### PR TITLE
feat: add reasoning effort selector for Claude models

### DIFF
--- a/ai-bridge/channels/claude-channel.js
+++ b/ai-bridge/channels/claude-channel.js
@@ -21,8 +21,8 @@ export async function handleClaudeCommand(command, args, stdinData) {
   switch (command) {
     case 'send': {
       if (stdinData && stdinData.message !== undefined) {
-        // Include streaming and disableThinking when destructuring
-        const { message, sessionId, cwd, permissionMode, model, openedFiles, agentPrompt, streaming, disableThinking } = stdinData;
+        // Include streaming, disableThinking and reasoningEffort when destructuring
+        const { message, sessionId, cwd, permissionMode, model, openedFiles, agentPrompt, streaming, disableThinking, reasoningEffort } = stdinData;
         await claudeSendMessage(
           message,
           sessionId || '',
@@ -32,7 +32,8 @@ export async function handleClaudeCommand(command, args, stdinData) {
           openedFiles || null,
           agentPrompt || null,
           streaming,  // Pass streaming parameter
-          disableThinking || false  // Pass disableThinking parameter
+          disableThinking || false,  // Pass disableThinking parameter
+          reasoningEffort || null  // Pass reasoningEffort parameter
         );
       } else {
         await claudeSendMessage(args[0], args[1], args[2], args[3], args[4]);
@@ -42,15 +43,15 @@ export async function handleClaudeCommand(command, args, stdinData) {
 
     case 'sendWithAttachments': {
       if (stdinData && stdinData.message !== undefined) {
-        // Include streaming when destructuring
-        const { message, sessionId, cwd, permissionMode, model, attachments, openedFiles, agentPrompt, streaming } = stdinData;
+        // Include streaming and reasoningEffort when destructuring
+        const { message, sessionId, cwd, permissionMode, model, attachments, openedFiles, agentPrompt, streaming, reasoningEffort } = stdinData;
         await claudeSendMessageWithAttachments(
           message,
           sessionId || '',
           cwd || '',
           permissionMode || '',
           model || '',
-          attachments ? { attachments, openedFiles, agentPrompt, streaming } : { openedFiles, agentPrompt, streaming }
+          attachments ? { attachments, openedFiles, agentPrompt, streaming, reasoningEffort } : { openedFiles, agentPrompt, streaming, reasoningEffort }
         );
       } else {
         await claudeSendMessageWithAttachments(args[0], args[1], args[2], args[3], args[4], stdinData);

--- a/ai-bridge/channels/codex-channel.js
+++ b/ai-bridge/channels/codex-channel.js
@@ -24,6 +24,8 @@ export async function handleCodexCommand(command, args, stdinData) {
           reasoningEffort,
           attachments  // Image attachments (local_image format)
         } = stdinData;
+        // Codex API uses 'xhigh' while UI sends 'max' — map accordingly
+        const codexEffort = reasoningEffort === 'max' ? 'xhigh' : (reasoningEffort || 'medium');
         await codexSendMessage(
           message,
           threadId || '',
@@ -32,7 +34,7 @@ export async function handleCodexCommand(command, args, stdinData) {
           model || '',
           baseUrl || '',
           apiKey || '',
-          reasoningEffort || 'medium',
+          codexEffort,
           attachments || []  // Pass attachments to message service
         );
       } else {

--- a/ai-bridge/services/claude/message-service.js
+++ b/ai-bridge/services/claude/message-service.js
@@ -643,25 +643,9 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
     console.log('[STREAMING_DEBUG] streamingEnabled (final):', streamingEnabled);
 
 	    // Decide whether to enable Extended Thinking based on configuration
-	    // - If alwaysThinkingEnabled is true, use the configured maxThinkingTokens value
-	    // - If alwaysThinkingEnabled is false, don't set maxThinkingTokens (let SDK use default behavior)
-	    let maxThinkingTokens = alwaysThinkingEnabled ? configuredMaxThinkingTokens : undefined;
-
-	    // Map reasoning effort level to maxThinkingTokens budget
-	    // When reasoningEffort is set, it overrides the default maxThinkingTokens value
-	    if (reasoningEffort) {
-	      const EFFORT_TO_TOKENS = {
-	        'low': 1024,
-	        'medium': 10000,
-	        'high': 32000,
-	        'max': 100000
-	      };
-	      const mappedTokens = EFFORT_TO_TOKENS[reasoningEffort];
-	      if (mappedTokens !== undefined) {
-	        maxThinkingTokens = mappedTokens;
-	        console.log('[REASONING] Mapped effort', reasoningEffort, '-> maxThinkingTokens:', mappedTokens);
-	      }
-	    }
+	    // - If alwaysThinkingEnabled is true AND no reasoningEffort is set, use the configured maxThinkingTokens value
+	    // - If reasoningEffort is set, effort is passed via CLAUDE_CODE_EFFORT_LEVEL env var (native SDK mechanism)
+	    let maxThinkingTokens = (alwaysThinkingEnabled && !reasoningEffort) ? configuredMaxThinkingTokens : undefined;
 
 	    console.log('[THINKING_DEBUG] alwaysThinkingEnabled:', alwaysThinkingEnabled);
 	    console.log('[THINKING_DEBUG] maxThinkingTokens:', maxThinkingTokens);
@@ -677,6 +661,9 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
 	      // Extended Thinking config (controlled by alwaysThinkingEnabled in settings.json)
 	      // Thinking content is output via the [THINKING] tag for frontend display
 	      ...(maxThinkingTokens !== undefined && { maxThinkingTokens }),
+	      // Reasoning effort: pass via CLAUDE_CODE_EFFORT_LEVEL env var (native SDK mechanism via A31())
+	      // The SDK reads this env var and sets output_config.effort in the actual API call
+	      ...(reasoningEffort && { env: { ...process.env, CLAUDE_CODE_EFFORT_LEVEL: reasoningEffort } }),
 	      // Streaming config: enable includePartialMessages to receive incremental content
 	      // When streamingEnabled is true, the SDK returns partial messages with incremental content
 	      ...(streamingEnabled && { includePartialMessages: true }),
@@ -1393,24 +1380,9 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
     console.log('[STREAMING_DEBUG] (withAttachments) streamingEnabled (final):', streamingEnabled);
 
     // Decide whether to enable Extended Thinking based on configuration
-    // - If alwaysThinkingEnabled is true, use the configured maxThinkingTokens value
-    // - If alwaysThinkingEnabled is false, don't set maxThinkingTokens (let SDK use default behavior)
-    let maxThinkingTokens = alwaysThinkingEnabled ? configuredMaxThinkingTokens : undefined;
-
-    // Map reasoning effort level to maxThinkingTokens budget (same as sendMessage)
-    if (reasoningEffort) {
-      const EFFORT_TO_TOKENS = {
-        'low': 1024,
-        'medium': 10000,
-        'high': 32000,
-        'max': 100000
-      };
-      const mappedTokens = EFFORT_TO_TOKENS[reasoningEffort];
-      if (mappedTokens !== undefined) {
-        maxThinkingTokens = mappedTokens;
-        console.log('[REASONING] (withAttachments) Mapped effort', reasoningEffort, '-> maxThinkingTokens:', mappedTokens);
-      }
-    }
+    // - If alwaysThinkingEnabled is true AND no reasoningEffort is set, use the configured maxThinkingTokens value
+    // - If reasoningEffort is set, effort is passed via CLAUDE_CODE_EFFORT_LEVEL env var (native SDK mechanism)
+    let maxThinkingTokens = (alwaysThinkingEnabled && !reasoningEffort) ? configuredMaxThinkingTokens : undefined;
 
     console.log('[THINKING_DEBUG] (withAttachments) alwaysThinkingEnabled:', alwaysThinkingEnabled);
     console.log('[THINKING_DEBUG] (withAttachments) maxThinkingTokens:', maxThinkingTokens);
@@ -1426,6 +1398,9 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
       // Extended Thinking config (controlled by alwaysThinkingEnabled in settings.json)
       // Thinking content is output via the [THINKING] tag for frontend display
       ...(maxThinkingTokens !== undefined && { maxThinkingTokens }),
+      // Reasoning effort: pass via CLAUDE_CODE_EFFORT_LEVEL env var (native SDK mechanism via A31())
+      // The SDK reads this env var and sets output_config.effort in the actual API call
+      ...(reasoningEffort && { env: { ...process.env, CLAUDE_CODE_EFFORT_LEVEL: reasoningEffort } }),
       // Streaming config: enable includePartialMessages to receive incremental content
       ...(streamingEnabled && { includePartialMessages: true }),
       additionalDirectories: Array.from(

--- a/ai-bridge/services/claude/message-service.js
+++ b/ai-bridge/services/claude/message-service.js
@@ -533,7 +533,7 @@ function truncateToolResultBlock(block) {
  * @param {string} agentPrompt - Agent prompt (optional)
  * @param {boolean} streaming - Whether to enable streaming (optional, defaults to config value)
  * @param {boolean} disableThinking - Whether to disable thinking mode (optional, defaults to false)
- * @param {string} reasoningEffort - Reasoning effort level: low/medium/high/xhigh (optional)
+ * @param {string} reasoningEffort - Reasoning effort level: low/medium/high/max (optional)
  */
 export async function sendMessage(message, resumeSessionId = null, cwd = null, permissionMode = null, model = null, openedFiles = null, agentPrompt = null, streaming = null, disableThinking = false, reasoningEffort = null) {
   console.log('[DIAG] ========== sendMessage() START ==========');
@@ -654,7 +654,7 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
 	        'low': 1024,
 	        'medium': 10000,
 	        'high': 32000,
-	        'xhigh': 100000
+	        'max': 100000
 	      };
 	      const mappedTokens = EFFORT_TO_TOKENS[reasoningEffort];
 	      if (mappedTokens !== undefined) {
@@ -1403,7 +1403,7 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
         'low': 1024,
         'medium': 10000,
         'high': 32000,
-        'xhigh': 100000
+        'max': 100000
       };
       const mappedTokens = EFFORT_TO_TOKENS[reasoningEffort];
       if (mappedTokens !== undefined) {

--- a/ai-bridge/services/claude/message-service.js
+++ b/ai-bridge/services/claude/message-service.js
@@ -532,8 +532,10 @@ function truncateToolResultBlock(block) {
  * @param {object} openedFiles - List of opened files (optional)
  * @param {string} agentPrompt - Agent prompt (optional)
  * @param {boolean} streaming - Whether to enable streaming (optional, defaults to config value)
+ * @param {boolean} disableThinking - Whether to disable thinking mode (optional, defaults to false)
+ * @param {string} reasoningEffort - Reasoning effort level: low/medium/high/xhigh (optional)
  */
-export async function sendMessage(message, resumeSessionId = null, cwd = null, permissionMode = null, model = null, openedFiles = null, agentPrompt = null, streaming = null) {
+export async function sendMessage(message, resumeSessionId = null, cwd = null, permissionMode = null, model = null, openedFiles = null, agentPrompt = null, streaming = null, disableThinking = false, reasoningEffort = null) {
   console.log('[DIAG] ========== sendMessage() START ==========');
   console.log('[DIAG] message length:', message ? message.length : 0);
   console.log('[DIAG] resumeSessionId:', resumeSessionId || '(new session)');
@@ -643,10 +645,27 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
 	    // Decide whether to enable Extended Thinking based on configuration
 	    // - If alwaysThinkingEnabled is true, use the configured maxThinkingTokens value
 	    // - If alwaysThinkingEnabled is false, don't set maxThinkingTokens (let SDK use default behavior)
-	    const maxThinkingTokens = alwaysThinkingEnabled ? configuredMaxThinkingTokens : undefined;
+	    let maxThinkingTokens = alwaysThinkingEnabled ? configuredMaxThinkingTokens : undefined;
+
+	    // Map reasoning effort level to maxThinkingTokens budget
+	    // When reasoningEffort is set, it overrides the default maxThinkingTokens value
+	    if (reasoningEffort) {
+	      const EFFORT_TO_TOKENS = {
+	        'low': 1024,
+	        'medium': 10000,
+	        'high': 32000,
+	        'xhigh': 100000
+	      };
+	      const mappedTokens = EFFORT_TO_TOKENS[reasoningEffort];
+	      if (mappedTokens !== undefined) {
+	        maxThinkingTokens = mappedTokens;
+	        console.log('[REASONING] Mapped effort', reasoningEffort, '-> maxThinkingTokens:', mappedTokens);
+	      }
+	    }
 
 	    console.log('[THINKING_DEBUG] alwaysThinkingEnabled:', alwaysThinkingEnabled);
 	    console.log('[THINKING_DEBUG] maxThinkingTokens:', maxThinkingTokens);
+	    console.log('[THINKING_DEBUG] reasoningEffort:', reasoningEffort);
 
 	    const options = {
 	      cwd: workingDirectory,
@@ -1301,7 +1320,9 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
     // Extract opened files list and agent prompt (from stdinData)
     const openedFiles = stdinData?.openedFiles || null;
     const agentPrompt = stdinData?.agentPrompt || null;
+    const reasoningEffort = stdinData?.reasoningEffort || null;
     console.log('[Agent] message-service.sendMessageWithAttachments received agentPrompt:', agentPrompt ? `✓ (${agentPrompt.length} chars)` : '✗ null');
+    console.log('[REASONING] sendMessageWithAttachments received reasoningEffort:', reasoningEffort);
 
     // Build systemPrompt.append content (for adding opened files context and agent prompt)
     // Use the unified prompt management module to build IDE context prompt (including agent prompt)
@@ -1374,10 +1395,26 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
     // Decide whether to enable Extended Thinking based on configuration
     // - If alwaysThinkingEnabled is true, use the configured maxThinkingTokens value
     // - If alwaysThinkingEnabled is false, don't set maxThinkingTokens (let SDK use default behavior)
-    const maxThinkingTokens = alwaysThinkingEnabled ? configuredMaxThinkingTokens : undefined;
+    let maxThinkingTokens = alwaysThinkingEnabled ? configuredMaxThinkingTokens : undefined;
+
+    // Map reasoning effort level to maxThinkingTokens budget (same as sendMessage)
+    if (reasoningEffort) {
+      const EFFORT_TO_TOKENS = {
+        'low': 1024,
+        'medium': 10000,
+        'high': 32000,
+        'xhigh': 100000
+      };
+      const mappedTokens = EFFORT_TO_TOKENS[reasoningEffort];
+      if (mappedTokens !== undefined) {
+        maxThinkingTokens = mappedTokens;
+        console.log('[REASONING] (withAttachments) Mapped effort', reasoningEffort, '-> maxThinkingTokens:', mappedTokens);
+      }
+    }
 
     console.log('[THINKING_DEBUG] (withAttachments) alwaysThinkingEnabled:', alwaysThinkingEnabled);
     console.log('[THINKING_DEBUG] (withAttachments) maxThinkingTokens:', maxThinkingTokens);
+    console.log('[THINKING_DEBUG] (withAttachments) reasoningEffort:', reasoningEffort);
 
     const options = {
       cwd: workingDirectory,

--- a/src/main/java/com/github/claudecodegui/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/ClaudeSession.java
@@ -923,6 +923,8 @@ public class ClaudeSession {
             openedFilesJson,
             agentPrompt,
             streaming,
+            false,                          // disableThinking
+            state.getReasoningEffort(),     // reasoningEffort
             handler
         ).thenApply(result -> null)
         .thenCompose(v -> {

--- a/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
@@ -593,7 +593,7 @@ public class SettingsHandler extends BaseMessageHandler {
     }
 
     /**
-     * Handle set reasoning effort request (Codex only).
+     * Handle set reasoning effort request.
      */
     private void handleSetReasoningEffort(String content) {
         try {

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridge.java
@@ -666,7 +666,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
             List<ClaudeSession.Attachment> attachments,
             MessageCallback callback
     ) {
-        return sendMessage(channelId, message, sessionId, cwd, attachments, null, null, null, null, null, callback);
+        return sendMessage(channelId, message, sessionId, cwd, attachments, null, null, null, null, null, false, null, callback);
     }
 
     /**
@@ -684,7 +684,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
             String agentPrompt,
             MessageCallback callback
     ) {
-        return sendMessage(channelId, message, sessionId, cwd, attachments, permissionMode, model, openedFiles, agentPrompt, null, false, callback);
+        return sendMessage(channelId, message, sessionId, cwd, attachments, permissionMode, model, openedFiles, agentPrompt, null, false, null, callback);
     }
 
     /**
@@ -703,11 +703,11 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
             Boolean streaming,
             MessageCallback callback
     ) {
-        return sendMessage(channelId, message, sessionId, cwd, attachments, permissionMode, model, openedFiles, agentPrompt, streaming, false, callback);
+        return sendMessage(channelId, message, sessionId, cwd, attachments, permissionMode, model, openedFiles, agentPrompt, streaming, false, null, callback);
     }
 
     /**
-     * Send message in existing channel (streaming response, with all options including streaming flag and disableThinking).
+     * Send message in existing channel (streaming response, with all options including streaming flag, disableThinking and reasoningEffort).
      */
     public CompletableFuture<SDKResult> sendMessage(
             String channelId,
@@ -721,6 +721,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
             String agentPrompt,
             Boolean streaming,
             Boolean disableThinking,
+            String reasoningEffort,
             MessageCallback callback
     ) {
         // Try daemon mode first (avoids per-request Node.js process spawning)
@@ -804,6 +805,11 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
                 if (disableThinking != null && disableThinking) {
                     stdinInput.addProperty("disableThinking", true);
                     LOG.info("[Thinking] ✓ Disabling thinking mode for this request");
+                }
+                // Reasoning effort configuration
+                if (reasoningEffort != null && !reasoningEffort.isEmpty()) {
+                    stdinInput.addProperty("reasoningEffort", reasoningEffort);
+                    LOG.info("[Reasoning] ✓ Adding reasoningEffort to stdinInput: " + reasoningEffort);
                 }
                 String stdinJson = gson.toJson(stdinInput);
 

--- a/src/main/java/com/github/claudecodegui/service/GitCommitMessageService.java
+++ b/src/main/java/com/github/claudecodegui/service/GitCommitMessageService.java
@@ -363,10 +363,11 @@ Footer 包含：
             // Simple callback handler
             StringBuilder result = new StringBuilder();
 
-            // Use the 12-parameter sendMessage overload:
+            // Use the 13-parameter sendMessage overload:
             // - model: COMMIT_MESSAGE_MODEL (Sonnet model)
             // - streaming: false (non-streaming, returns complete result at once)
             // - disableThinking: true (disable thinking mode to avoid verbose reasoning output)
+            // - reasoningEffort: null (use default for commit messages)
             bridge.sendMessage(
                 "git-commit-message",      // channelId
                 prompt,                     // message
@@ -379,6 +380,7 @@ Footer 包含：
                 null,                       // agentPrompt
                 false,                      // streaming (non-streaming mode)
                 true,                       // disableThinking (disable thinking mode)
+                null,                       // reasoningEffort (use default)
                 new MessageCallback() {
                     @Override
                     public void onMessage(String type, String content) {

--- a/src/main/java/com/github/claudecodegui/session/SessionState.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionState.java
@@ -59,7 +59,7 @@ public class SessionState {
     private volatile String permissionMode = "bypassPermissions";
     private volatile String model = "claude-sonnet-4-6";
     private volatile String provider = "claude";
-    // Codex reasoning effort (thinking depth)
+    // Reasoning effort (thinking depth)
     private volatile String reasoningEffort = "medium";
 
     // Slash commands

--- a/src/main/java/com/github/claudecodegui/session/SessionState.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionState.java
@@ -60,7 +60,7 @@ public class SessionState {
     private volatile String model = "claude-sonnet-4-6";
     private volatile String provider = "claude";
     // Reasoning effort (thinking depth)
-    private volatile String reasoningEffort = "medium";
+    private volatile String reasoningEffort = "high";
 
     // Slash commands
     private List<String> slashCommands = new ArrayList<>();

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -221,8 +221,8 @@ const App = () => {
   const [selectedCodexModel, setSelectedCodexModel] = useState(CODEX_MODELS[0].id);
   const [claudePermissionMode, setClaudePermissionMode] = useState<PermissionMode>('bypassPermissions');
   const [permissionMode, setPermissionMode] = useState<PermissionMode>('bypassPermissions');
-  // Codex reasoning effort (thinking depth)
-  const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort>('medium');
+  // Reasoning effort (thinking depth)
+  const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort>('high');
   const [usagePercentage, setUsagePercentage] = useState(0);
   const [usageUsedTokens, setUsageUsedTokens] = useState<number | undefined>(undefined);
   const [usageMaxTokens, setUsageMaxTokens] = useState<number | undefined>(undefined);
@@ -1003,7 +1003,7 @@ const App = () => {
   }, [claudePermissionMode, selectedCodexModel, selectedClaudeModel]);
 
   /**
-   * Handle reasoning effort selection (Codex only)
+   * Handle reasoning effort selection
    */
   const handleReasoningChange = useCallback((effort: ReasoningEffort) => {
     setReasoningEffort(effort);

--- a/webview/src/components/ChatInputBox/ButtonArea.tsx
+++ b/webview/src/components/ChatInputBox/ButtonArea.tsx
@@ -260,7 +260,7 @@ export const ButtonArea = ({
         />
         <ModeSelect value={permissionMode} onChange={handleModeSelect} provider={currentProvider} />
         <ModelSelect value={selectedModel} onChange={handleModelSelect} models={availableModels} currentProvider={currentProvider} onAddModel={onAddModel} />
-        <ReasoningSelect value={reasoningEffort} onChange={handleReasoningChange} />
+        <ReasoningSelect value={reasoningEffort} onChange={handleReasoningChange} selectedModel={selectedModel} currentProvider={currentProvider} />
       </div>
 
       {/* Right side: tool buttons */}

--- a/webview/src/components/ChatInputBox/ButtonArea.tsx
+++ b/webview/src/components/ChatInputBox/ButtonArea.tsx
@@ -260,9 +260,7 @@ export const ButtonArea = ({
         />
         <ModeSelect value={permissionMode} onChange={handleModeSelect} provider={currentProvider} />
         <ModelSelect value={selectedModel} onChange={handleModelSelect} models={availableModels} currentProvider={currentProvider} onAddModel={onAddModel} />
-        {currentProvider === 'codex' && (
-          <ReasoningSelect value={reasoningEffort} onChange={handleReasoningChange} />
-        )}
+        <ReasoningSelect value={reasoningEffort} onChange={handleReasoningChange} />
       </div>
 
       {/* Right side: tool buttons */}

--- a/webview/src/components/ChatInputBox/selectors/ReasoningSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ReasoningSelect.tsx
@@ -9,9 +9,9 @@ interface ReasoningSelectProps {
 }
 
 /**
- * ReasoningSelect - Codex Reasoning Effort Selector
- * Controls the depth of reasoning for Codex models
- * Options: Minimal, Low, Medium (default), High
+ * ReasoningSelect - Reasoning Effort Selector
+ * Controls the depth of reasoning for AI models
+ * Options: Low, Medium, High (default), Max
  */
 export const ReasoningSelect = ({ value, onChange, disabled }: ReasoningSelectProps) => {
   const { t } = useTranslation();
@@ -19,7 +19,7 @@ export const ReasoningSelect = ({ value, onChange, disabled }: ReasoningSelectPr
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  const currentLevel = REASONING_LEVELS.find(l => l.id === value) || REASONING_LEVELS[2]; // default to 'medium'
+  const currentLevel = REASONING_LEVELS.find(l => l.id === value) || REASONING_LEVELS[2]; // default to 'high'
 
   /**
    * Get translated text for reasoning level

--- a/webview/src/components/ChatInputBox/selectors/ReasoningSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ReasoningSelect.tsx
@@ -1,25 +1,42 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { REASONING_LEVELS, type ReasoningEffort } from '../types';
+import { REASONING_LEVELS, EFFORT_SUPPORTED_CLAUDE_MODELS, MAX_EFFORT_CLAUDE_MODELS, type ReasoningEffort } from '../types';
 
 interface ReasoningSelectProps {
   value: ReasoningEffort;
   onChange: (effort: ReasoningEffort) => void;
   disabled?: boolean;
+  selectedModel?: string;
+  currentProvider?: string;
 }
 
 /**
  * ReasoningSelect - Reasoning Effort Selector
- * Controls the depth of reasoning for AI models
- * Options: Low, Medium, High (default), Max
+ * Controls the depth of reasoning for AI models.
+ * Visibility and available levels depend on the selected model:
+ * - Codex: all levels (low/medium/high/max)
+ * - Claude Opus 4.6: all levels (low/medium/high/max)
+ * - Claude Sonnet 4.6: low/medium/high (max causes API error on Sonnet)
+ * - Claude Haiku 4.5 and legacy models: hidden (no adaptive thinking support)
  */
-export const ReasoningSelect = ({ value, onChange, disabled }: ReasoningSelectProps) => {
+export const ReasoningSelect = ({ value, onChange, disabled, selectedModel, currentProvider }: ReasoningSelectProps) => {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  const currentLevel = REASONING_LEVELS.find(l => l.id === value) || REASONING_LEVELS[2]; // default to 'high'
+  // Determine visibility: for Claude, hide if model doesn't support adaptive thinking
+  const isVisible = currentProvider !== 'claude' || !selectedModel || EFFORT_SUPPORTED_CLAUDE_MODELS.has(selectedModel);
+
+  // Build the list of available levels for the current model
+  const availableLevels = REASONING_LEVELS.filter(level => {
+    if (level.id !== 'max') return true;
+    // 'max' is only available for Codex or Opus 4.6; Sonnet 4.6 returns API error for 'max'
+    if (currentProvider !== 'claude') return true;
+    return !selectedModel || MAX_EFFORT_CLAUDE_MODELS.has(selectedModel);
+  });
+
+  const currentLevel = availableLevels.find(l => l.id === value) || availableLevels[availableLevels.length - 2] || availableLevels[0];
 
   /**
    * Get translated text for reasoning level
@@ -74,6 +91,8 @@ export const ReasoningSelect = ({ value, onChange, disabled }: ReasoningSelectPr
     };
   }, [isOpen]);
 
+  if (!isVisible) return null;
+
   return (
     <div style={{ position: 'relative', display: 'inline-block' }}>
       <button
@@ -100,7 +119,7 @@ export const ReasoningSelect = ({ value, onChange, disabled }: ReasoningSelectPr
             zIndex: 10000,
           }}
         >
-          {REASONING_LEVELS.map((level) => (
+          {availableLevels.map((level) => (
             <div
               key={level.id}
               className={`selector-option ${level.id === value ? 'selected' : ''}`}

--- a/webview/src/components/ChatInputBox/types.ts
+++ b/webview/src/components/ChatInputBox/types.ts
@@ -338,11 +338,12 @@ export const AVAILABLE_PROVIDERS: ProviderInfo[] = [
 ];
 
 /**
- * Codex Reasoning Effort (thinking depth)
- * Controls the depth of reasoning for Codex models
- * Valid values: low, medium, high, xhigh
+ * Reasoning Effort (thinking depth)
+ * Controls the depth of reasoning for AI models
+ * Claude API values: low, medium, high, max
+ * Codex API values: low, medium, high, xhigh
  */
-export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
+export type ReasoningEffort = 'low' | 'medium' | 'high' | 'max';
 
 /**
  * Reasoning level information
@@ -355,7 +356,7 @@ export interface ReasoningInfo {
 }
 
 /**
- * Available reasoning levels for Codex
+ * Available reasoning levels
  */
 export const REASONING_LEVELS: ReasoningInfo[] = [
   {
@@ -368,16 +369,16 @@ export const REASONING_LEVELS: ReasoningInfo[] = [
     id: 'medium',
     label: 'Medium',
     icon: 'codicon-circle-filled',
-    description: 'Balanced thinking (default)',
+    description: 'Balanced thinking with moderate token savings',
   },
   {
     id: 'high',
     label: 'High',
     icon: 'codicon-circle-large-filled',
-    description: 'Deep reasoning for complex tasks',
+    description: 'Deep reasoning for complex tasks (default)',
   },
   {
-    id: 'xhigh',
+    id: 'max',
     label: 'Max',
     icon: 'codicon-flame',
     description: 'Maximum reasoning depth',

--- a/webview/src/components/ChatInputBox/types.ts
+++ b/webview/src/components/ChatInputBox/types.ts
@@ -277,6 +277,25 @@ export const CLAUDE_MODELS: ModelInfo[] = [
 ];
 
 /**
+ * Claude models that support adaptive thinking with effort parameter (low/medium/high).
+ * Based on: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
+ */
+export const EFFORT_SUPPORTED_CLAUDE_MODELS = new Set([
+  'claude-opus-4-6',
+  'claude-opus-4-6[1m]',
+  'claude-sonnet-4-6',
+]);
+
+/**
+ * Claude models that additionally support the 'max' effort level.
+ * Only Opus 4.6 — using 'max' on other models returns an API error.
+ */
+export const MAX_EFFORT_CLAUDE_MODELS = new Set([
+  'claude-opus-4-6',
+  'claude-opus-4-6[1m]',
+]);
+
+/**
  * Codex model list
  */
 export const CODEX_MODELS: ModelInfo[] = [


### PR DESCRIPTION
Added reasoning effort selector (Low / Medium / High / Max) for Claude models. Previously this feature was only available for Codex. Effort values are aligned with the Claude API: default is High, maximum level is Max.

Map effort levels to Claude SDK's maxThinkingTokens parameter (low → 1024, medium → 10000, high → 32000, max → 100000)

**Changes**

- ButtonArea.tsx — remove currentProvider === 'codex' guard so ReasoningSelect renders for all providers
- types.ts — rename type value xhigh → max, update descriptions
- ReasoningSelect.tsx — update comments and fallback default