### PR TITLE
feat: integrate Claude Code CLI native commands

### DIFF
--- a/ai-bridge/channel-manager.js
+++ b/ai-bridge/channel-manager.js
@@ -26,6 +26,7 @@
 import { readStdinData } from './utils/stdin-utils.js';
 import { handleClaudeCommand } from './channels/claude-channel.js';
 import { handleCodexCommand } from './channels/codex-channel.js';
+import { handleCLICommand } from './channels/cli-channel.js';
 import { getSdkStatus, isClaudeSdkAvailable, isCodexSdkAvailable } from './utils/sdk-loader.js';
 import { injectNetworkEnvVars } from './config/api-config.js';
 
@@ -112,6 +113,7 @@ async function handleSystemCommand(command, args, stdinData) {
 const providerHandlers = {
   claude: handleClaudeCommand,
   codex: handleCodexCommand,
+  cli: handleCLICommand,
   system: handleSystemCommand
 };
 

--- a/ai-bridge/channels/cli-channel.js
+++ b/ai-bridge/channels/cli-channel.js
@@ -1,0 +1,104 @@
+/**
+ * Claude Code CLI channel command handler.
+ * Handles CLI native commands like /plan, /review, /commit, etc.
+ */
+
+/**
+ * Execute a CLI native command.
+ * @param {string} command
+ * @param {string[]} args
+ * @param {object|null} stdinData
+ */
+export async function handleCLICommand(command, args, stdinData) {
+  switch (command) {
+    case 'execute': {
+      if (stdinData && stdinData.command !== undefined) {
+        const { command: cliCommand, args: cliArgs = [] } = stdinData;
+        await executeCLICommand(cliCommand, cliArgs);
+      } else {
+        // Legacy support for positional args
+        const cliCommand = args[0];
+        const cliArgs = args.slice(1);
+        await executeCLICommand(cliCommand, cliArgs);
+      }
+      break;
+    }
+
+    default:
+      throw new Error(`Unknown CLI command: ${command}`);
+  }
+}
+
+/**
+ * Execute a CLI command using the CLI daemon.
+ * @param {string} command - The CLI command to execute (e.g., "/plan")
+ * @param {string[]} args - Additional arguments for the command
+ */
+async function executeCLICommand(command, args = []) {
+  // Import the daemon service for CLI command execution
+  const { executeCliPersistent } = await import('../services/cli/cli-service.js');
+
+  // Execute the command through the persistent CLI service
+  await executeCliPersistent(command, args);
+}
+
+/**
+ * Get the list of supported CLI commands.
+ */
+export function getCLICommandList() {
+  return ['execute'];
+}
+
+/**
+ * Check if a command string is a CLI native command.
+ * @param {string} command - The command to check
+ * @returns {boolean} - true if the command is a CLI native command
+ */
+export function isCLINativeCommand(command) {
+  // CLI native commands start with '/' and are not plugin built-in commands
+  if (!command.startsWith('/')) {
+    return false;
+  }
+
+  // Known CLI native commands (this list should be kept in sync with Claude Code CLI)
+  const cliNativeCommands = [
+    '/plan',
+    '/review',
+    '/commit',
+    '/babysit',
+    '/loop',
+    '/help',
+    '/skills',
+    '/config',
+    '/providers',
+    '/mcp',
+    '/mode',
+    '/model',
+    '/temperature',
+    '/top-p',
+    '/top-k',
+    '/max-tokens'
+  ];
+
+  // Check if the command (without arguments) is a CLI native command
+  const commandName = command.split(' ')[0];
+  return cliNativeCommands.includes(commandName);
+}
+
+/**
+ * Extract command and arguments from a user input string.
+ * @param {string} input - User input (e.g., "/plan build a feature")
+ * @returns {object} - { command: string, args: string[] }
+ */
+export function parseCLICommand(input) {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith('/')) {
+    return null;
+  }
+
+  const parts = trimmed.split(/\s+/);
+  const command = parts[0];
+  const args = parts.slice(1);
+
+  return { command, args };
+}

--- a/ai-bridge/cli-daemon.js
+++ b/ai-bridge/cli-daemon.js
@@ -1,0 +1,470 @@
+#!/usr/bin/env node
+
+/**
+ * Claude Code CLI Daemon Process
+ *
+ * Long-running Node.js process that handles CLI native commands via
+ * stdin/stdout using NDJSON protocol.
+ *
+ * Protocol (stdin, one JSON per line):
+ *   {"id":"1","method":"cli.execute","params":{"command":"/plan","args":[]}}
+ *   {"id":"2","method":"heartbeat"}
+ *
+ * Protocol (stdout, one JSON per line):
+ *   {"type":"daemon","event":"ready","pid":12345}           // daemon lifecycle
+ *   {"id":"1","line":"[CLI OUTPUT]"}                       // command output
+ *   {"id":"1","done":true,"success":true}                   // command complete
+ *   {"id":"2","type":"heartbeat","ts":1234567890}           // heartbeat response
+ */
+
+import { createInterface } from 'readline';
+import { spawn } from 'child_process';
+import { injectNetworkEnvVars } from './config/api-config.js';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const DAEMON_VERSION = '1.0.0';
+
+// =============================================================================
+// State
+// =============================================================================
+
+let activeRequestId = null;
+let isDaemonMode = true;
+let cliPreloaded = false;
+let activeCliProcess = null;
+
+// Get CLI path from environment or use default
+const CLI_PATH = process.env.CLAUDE_CLI_PATH || 'claude';
+
+// =============================================================================
+// Output Interception
+// =============================================================================
+
+const _originalStdoutWrite = process.stdout.write.bind(process.stdout);
+const _originalStderrWrite = process.stderr.write.bind(process.stderr);
+const _originalConsoleLog = console.log.bind(console);
+const _originalConsoleError = console.error.bind(console);
+
+/**
+ * Write a raw NDJSON line to stdout.
+ */
+function writeRawLine(obj) {
+  _originalStdoutWrite(JSON.stringify(obj) + '\n', 'utf8');
+}
+
+/**
+ * Send a daemon lifecycle event.
+ */
+function sendDaemonEvent(event, data = {}) {
+  writeRawLine({ type: 'daemon', event, ...data });
+}
+
+/**
+ * Override process.stdout.write to tag output with request ID.
+ */
+process.stdout.write = function (chunk, encoding, callback) {
+  const text = typeof chunk === 'string' ? chunk : chunk.toString(encoding || 'utf8');
+
+  if (activeRequestId) {
+    const lines = text.split('\n');
+    for (const line of lines) {
+      if (line.length > 0) {
+        writeRawLine({ id: activeRequestId, line });
+      }
+    }
+    if (typeof callback === 'function') callback();
+    return true;
+  }
+
+  const trimmed = text.trim();
+  if (trimmed.startsWith('{')) {
+    return _originalStdoutWrite(chunk, encoding, callback);
+  }
+
+  if (trimmed.length > 0) {
+    const lines = text.split('\n');
+    for (const line of lines) {
+      if (line.trim().length > 0) {
+        writeRawLine({ type: 'daemon', event: 'log', message: line });
+      }
+    }
+  }
+  if (typeof callback === 'function') callback();
+  return true;
+};
+
+/**
+ * Override console.log to go through our tagged stdout.
+ */
+console.log = function (...args) {
+  const text = args
+    .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+    .join(' ');
+  process.stdout.write(text + '\n');
+};
+
+/**
+ * Override console.error to tag stderr output.
+ */
+console.error = function (...args) {
+  const text = args
+    .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+    .join(' ');
+  if (activeRequestId) {
+    writeRawLine({ id: activeRequestId, stderr: text });
+  } else {
+    _originalStderrWrite(text + '\n', 'utf8');
+  }
+};
+
+// =============================================================================
+// CLI Command Execution
+// =============================================================================
+
+/**
+ * Execute a CLI command and stream output.
+ */
+async function executeCliCommand(command, args = []) {
+  return new Promise((resolve, reject) => {
+    // Build CLI command arguments
+    const cliArgs = [...args];
+
+    // Spawn the CLI process
+    activeCliProcess = spawn(CLI_PATH, cliArgs, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env }
+    });
+
+    const stdoutChunks = [];
+    const stderrChunks = [];
+
+    // Handle stdout
+    activeCliProcess.stdout.on('data', (data) => {
+      const text = data.toString();
+      stdoutChunks.push(text);
+      // Stream each line
+      const lines = text.split('\n');
+      for (const line of lines) {
+        if (line.length > 0) {
+          writeRawLine({ id: activeRequestId, line });
+        }
+      }
+    });
+
+    // Handle stderr
+    activeCliProcess.stderr.on('data', (data) => {
+      const text = data.toString();
+      stderrChunks.push(text);
+      // Stream stderr lines
+      const lines = text.split('\n');
+      for (const line of lines) {
+        if (line.length > 0) {
+          writeRawLine({ id: activeRequestId, stderr: line });
+        }
+      }
+    });
+
+    // Handle process exit
+    activeCliProcess.on('close', (code) => {
+      activeCliProcess = null;
+      if (code === 0) {
+        const stdout = stdoutChunks.join('');
+        const stderr = stderrChunks.join('');
+        resolve({ stdout, stderr, exitCode: code });
+      } else {
+        const stdout = stdoutChunks.join('');
+        const stderr = stderrChunks.join('');
+        reject(new Error(`CLI process exited with code ${code}: ${stderr || stdout}`));
+      }
+    });
+
+    // Handle process error
+    activeCliProcess.on('error', (err) => {
+      activeCliProcess = null;
+      reject(new Error(`Failed to spawn CLI process: ${err.message}`));
+    });
+  });
+}
+
+/**
+ * Abort the currently running CLI command.
+ */
+function abortActiveCommand() {
+  if (activeCliProcess) {
+    activeCliProcess.kill('SIGTERM');
+    activeCliProcess = null;
+    return true;
+  }
+  return false;
+}
+
+// =============================================================================
+// Request Processing
+// =============================================================================
+
+/**
+ * Process a single request from stdin.
+ */
+async function processRequest(request) {
+  const { id, method, params = {} } = request;
+
+  // --- Heartbeat ---
+  if (method === 'heartbeat') {
+    writeRawLine({
+      id: id || '0',
+      type: 'heartbeat',
+      ts: Date.now(),
+      cliPreloaded,
+      memoryUsage: process.memoryUsage().heapUsed,
+    });
+    return;
+  }
+
+  // --- Status query ---
+  if (method === 'status') {
+    writeRawLine({
+      id,
+      type: 'status',
+      version: DAEMON_VERSION,
+      pid: process.pid,
+      uptime: process.uptime(),
+      cliPreloaded,
+      cliPath: CLI_PATH,
+      memoryUsage: process.memoryUsage(),
+    });
+    return;
+  }
+
+  // --- Graceful shutdown ---
+  if (method === 'shutdown') {
+    abortActiveCommand();
+    sendDaemonEvent('shutdown', { reason: 'requested' });
+    writeRawLine({ id: id || '0', done: true, success: true });
+    isDaemonMode = false;
+    setTimeout(() => process.exit(0), 100);
+    return;
+  }
+
+  // --- Abort command ---
+  if (method === 'abort') {
+    const aborted = abortActiveCommand();
+    writeRawLine({ id: id || '0', done: true, success: true, aborted });
+    return;
+  }
+
+  // --- Command execution ---
+  if (!id) {
+    _originalStderrWrite(
+      `[cli-daemon] Ignoring request without id: ${method}\n`,
+      'utf8'
+    );
+    return;
+  }
+
+  activeRequestId = id;
+
+  try {
+    if (method === 'cli.execute') {
+      const { command, args = [] } = params;
+      if (!command) {
+        throw new Error('Missing required parameter: command');
+      }
+      await executeCliCommand(command, args);
+      writeRawLine({ id, done: true, success: true });
+    } else {
+      throw new Error(`Unknown method: ${method}`);
+    }
+  } catch (error) {
+    if (activeRequestId !== null) {
+      writeRawLine({
+        id,
+        done: true,
+        success: false,
+        error: error.message || String(error),
+      });
+    }
+  } finally {
+    activeRequestId = null;
+  }
+}
+
+// =============================================================================
+// Main Entry Point
+// =============================================================================
+
+(async () => {
+  // Inject network environment variables
+  injectNetworkEnvVars();
+
+  // --- Error Handlers ---
+  process.on('uncaughtException', (error) => {
+    _originalStderrWrite(
+      `[cli-daemon] Uncaught exception: ${error.message}\n${error.stack}\n`,
+      'utf8'
+    );
+    if (activeRequestId) {
+      writeRawLine({
+        id: activeRequestId,
+        done: true,
+        success: false,
+        error: `Uncaught exception: ${error.message}`,
+      });
+      activeRequestId = null;
+    }
+  });
+
+  process.on('unhandledRejection', (reason) => {
+    _originalStderrWrite(
+      `[cli-daemon] Unhandled rejection: ${reason}\n`,
+      'utf8'
+    );
+    if (activeRequestId) {
+      writeRawLine({
+        id: activeRequestId,
+        done: true,
+        success: false,
+        error: `Unhandled rejection: ${String(reason)}`,
+      });
+      activeRequestId = null;
+    }
+  });
+
+  // --- Startup ---
+  sendDaemonEvent('starting', {
+    pid: process.pid,
+    version: DAEMON_VERSION,
+    nodeVersion: process.version,
+    platform: process.platform,
+    cliPath: CLI_PATH,
+  });
+
+  // Verify CLI is available
+  try {
+    const verifyProcess = spawn(CLI_PATH, ['--version'], {
+      stdio: 'pipe',
+      timeout: 5000
+    });
+
+    await new Promise((resolve, reject) => {
+      const outputChunks = [];
+      verifyProcess.stdout.on('data', (data) => {
+        outputChunks.push(data.toString());
+      });
+      verifyProcess.on('close', (code) => {
+        const output = outputChunks.join('');
+        if (code === 0) {
+          cliPreloaded = true;
+          sendDaemonEvent('cli_loaded', {
+            version: output.trim(),
+            path: CLI_PATH
+          });
+          resolve();
+        } else {
+          sendDaemonEvent('cli_load_error', {
+            error: `CLI verification failed with exit code ${code}`
+          });
+          resolve();
+        }
+      });
+      verifyProcess.on('error', (err) => {
+        sendDaemonEvent('cli_load_error', {
+          error: `Failed to spawn CLI: ${err.message}`
+        });
+        resolve();
+      });
+    });
+  } catch (e) {
+    sendDaemonEvent('cli_load_error', {
+      error: e.message
+    });
+  }
+
+  // Signal ready
+  sendDaemonEvent('ready', {
+    pid: process.pid,
+    cliPreloaded,
+  });
+
+  // --- Listen for requests on stdin ---
+  const rl = createInterface({
+    input: process.stdin,
+    crlfDelay: Infinity,
+  });
+
+  // Command requests must be serialized
+  let commandQueue = Promise.resolve();
+
+  rl.on('line', (line) => {
+    if (!line.trim()) return;
+
+    let request;
+    try {
+      request = JSON.parse(line);
+    } catch (e) {
+      _originalStderrWrite(
+        `[cli-daemon] Invalid JSON input: ${line.substring(0, 200)}\n`,
+        'utf8'
+      );
+      return;
+    }
+
+    // Heartbeats and status queries are safe to run immediately
+    if (request.method === 'heartbeat' || request.method === 'status') {
+      processRequest(request);
+      return;
+    }
+
+    // Abort bypasses the command queue
+    if (request.method === 'abort') {
+      abortActiveCommand();
+      writeRawLine({ id: request.id || '0', done: true, success: true });
+      return;
+    }
+
+    // Command requests are serialized
+    commandQueue = commandQueue
+      .then(() => processRequest(request))
+      .catch((e) => {
+        _originalStderrWrite(
+          `[cli-daemon] Request queue error: ${e.message}\n`,
+          'utf8'
+        );
+      });
+  });
+
+  rl.on('close', () => {
+    abortActiveCommand();
+    sendDaemonEvent('shutdown', { reason: 'stdin_closed' });
+    isDaemonMode = false;
+    process.exit(0);
+  });
+
+  // --- Parent process monitoring ---
+  const initialPpid = process.ppid;
+  const ppidMonitor = setInterval(() => {
+    const currentPpid = process.ppid;
+    const reparented = currentPpid !== initialPpid && currentPpid === 1;
+    let parentGone = false;
+    if (!reparented && currentPpid !== 1) {
+      try {
+        process.kill(currentPpid, 0);
+      } catch (err) {
+        if (err.code === 'ESRCH') {
+          parentGone = true;
+        }
+      }
+    }
+    if (reparented || parentGone) {
+      _originalStderrWrite(
+        `[cli-daemon] Parent process (ppid=${initialPpid}) is gone, exiting\n`,
+        'utf8'
+      );
+      isDaemonMode = false;
+      process.exit(0);
+    }
+  }, 10000);
+  ppidMonitor.unref();
+})();

--- a/ai-bridge/services/cli/cli-service.js
+++ b/ai-bridge/services/cli/cli-service.js
@@ -1,0 +1,118 @@
+/**
+ * Claude Code CLI Service
+ * Handles CLI native command execution through the CLI daemon.
+ */
+
+// In daemon mode, commands are executed by the cli-daemon.js process.
+// This service provides the interface for command execution.
+
+/**
+ * Execute a CLI native command in daemon mode.
+ * This function is called from cli-daemon.js when handling cli.execute requests.
+ *
+ * @param {string} command - The CLI command to execute (e.g., "/plan")
+ * @param {string[]} args - Additional arguments for the command
+ */
+export async function executeCliPersistent(command, args = []) {
+  const CLI_PATH = process.env.CLAUDE_CLI_PATH || 'claude';
+
+  // Build the command with arguments
+  const commandArgs = [command, ...args];
+
+  // Import spawn from child_process
+  const { spawn } = await import('child_process');
+
+  return new Promise((resolve, reject) => {
+    // Spawn the CLI process
+    const cliProcess = spawn(CLI_PATH, commandArgs, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env }
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    // Handle stdout - stream each line
+    cliProcess.stdout.on('data', (data) => {
+      const text = data.toString();
+      stdout += text;
+      // Output is automatically intercepted by the daemon's stdout override
+      // Just write to console.log which will be tagged with request ID
+      console.log(text);
+    });
+
+    // Handle stderr
+    cliProcess.stderr.on('data', (data) => {
+      const text = data.toString();
+      stderr += text;
+      // Stream stderr to console.error
+      console.error(text);
+    });
+
+    // Handle process exit
+    cliProcess.on('close', (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr, exitCode: code });
+      } else {
+        reject(new Error(`CLI process exited with code ${code}: ${stderr || stdout}`));
+      }
+    });
+
+    // Handle process error
+    cliProcess.on('error', (err) => {
+      reject(new Error(`Failed to spawn CLI process: ${err.message}`));
+    });
+  });
+}
+
+/**
+ * Check if a command is a CLI native command.
+ * @param {string} command - The command to check
+ * @returns {boolean} - true if the command is a CLI native command
+ */
+export function isCLINativeCommand(command) {
+  if (!command || !command.startsWith('/')) {
+    return false;
+  }
+
+  // Known CLI native commands
+  const cliNativeCommands = [
+    '/plan',
+    '/review',
+    '/commit',
+    '/babysit',
+    '/loop',
+    '/help',
+    '/skills',
+    '/config',
+    '/providers',
+    '/mcp',
+    '/mode',
+    '/model',
+    '/temperature',
+    '/top-p',
+    '/top-k',
+    '/max-tokens'
+  ];
+
+  const commandName = command.split(' ')[0];
+  return cliNativeCommands.includes(commandName);
+}
+
+/**
+ * Parse a CLI command string into command and arguments.
+ * @param {string} input - User input (e.g., "/plan build a feature")
+ * @returns {object|null} - { command: string, args: string[] } or null
+ */
+export function parseCLICommand(input) {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith('/')) {
+    return null;
+  }
+
+  const parts = trimmed.split(/\s+/);
+  const command = parts[0];
+  const args = parts.slice(1);
+
+  return { command, args };
+}

--- a/src/main/java/com/github/claudecodegui/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ClaudeChatWindow.java
@@ -1,6 +1,9 @@
 package com.github.claudecodegui;
 
 import com.github.claudecodegui.action.SendShortcutSync;
+import com.github.claudecodegui.bridge.BridgeDirectoryResolver;
+import com.github.claudecodegui.bridge.CLIDetector;
+import com.github.claudecodegui.bridge.EnvironmentConfigurator;
 import com.github.claudecodegui.handler.HandlerContext;
 import com.github.claudecodegui.handler.HistoryHandler;
 import com.github.claudecodegui.handler.MessageDispatcher;
@@ -8,7 +11,9 @@ import com.github.claudecodegui.handler.PermissionHandler;
 import com.github.claudecodegui.permission.PermissionService;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.provider.common.CLIDaemonBridge;
 import com.github.claudecodegui.provider.common.MessageCallback;
+import com.github.claudecodegui.settings.CLISettingsManager;
 import com.github.claudecodegui.session.SessionCallbackAdapter;
 import com.github.claudecodegui.session.SessionLifecycleManager;
 import com.github.claudecodegui.session.StreamMessageCoalescer;
@@ -41,6 +46,8 @@ public class ClaudeChatWindow {
     private final JPanel mainPanel;
     private final ClaudeSDKBridge claudeSDKBridge;
     private final CodexSDKBridge codexSDKBridge;
+    private final CLIDaemonBridge cliDaemonBridge;
+    private final CLISettingsManager cliSettingsManager;
     private final Project project;
     private final CodemossSettingsService settingsService;
     private final HtmlLoader htmlLoader;
@@ -80,6 +87,14 @@ public class ClaudeChatWindow {
         this.project = project;
         this.claudeSDKBridge = new ClaudeSDKBridge();
         this.codexSDKBridge = new CodexSDKBridge();
+
+        // Initialize CLI components
+        CLIDetector cliDetector = CLIDetector.getInstance();
+        BridgeDirectoryResolver directoryResolver = new BridgeDirectoryResolver();
+        EnvironmentConfigurator envConfigurator = new EnvironmentConfigurator();
+        this.cliDaemonBridge = new CLIDaemonBridge(cliDetector, directoryResolver, envConfigurator);
+        this.cliSettingsManager = new CLISettingsManager(cliDetector);
+
         this.settingsService = new CodemossSettingsService();
         this.htmlLoader = new HtmlLoader(getClass());
         this.mainPanel = new JPanel(new BorderLayout());
@@ -146,6 +161,16 @@ public class ClaudeChatWindow {
             @Override
             public CodexSDKBridge getCodexSDKBridge() {
                 return codexSDKBridge;
+            }
+
+            @Override
+            public CLIDaemonBridge getCliDaemonBridge() {
+                return cliDaemonBridge;
+            }
+
+            @Override
+            public CLISettingsManager getCliSettingsManager() {
+                return cliSettingsManager;
             }
 
             @Override
@@ -318,6 +343,14 @@ public class ClaudeChatWindow {
 
     public CodexSDKBridge getCodexSDKBridge() {
         return codexSDKBridge;
+    }
+
+    public CLIDaemonBridge getCliDaemonBridge() {
+        return cliDaemonBridge;
+    }
+
+    public CLISettingsManager getCliSettingsManager() {
+        return cliSettingsManager;
     }
 
     public String getSessionId() {
@@ -588,6 +621,15 @@ public class ClaudeChatWindow {
         }
 
         try {
+            if (cliDaemonBridge != null) {
+                LOG.info("Stopping CLI daemon bridge...");
+                cliDaemonBridge.stop();
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to stop CLI daemon bridge: " + e.getMessage());
+        }
+
+        try {
             if (browser != null) {
                 browser.dispose();
                 browser = null;
@@ -684,6 +726,16 @@ public class ClaudeChatWindow {
             public CodexSDKBridge getCodexSDKBridge() {
                 return codexSDKBridge;
             }   // Codex SDK bridge for AI communication
+
+            @Override
+            public CLIDaemonBridge getCliDaemonBridge() {
+                return cliDaemonBridge;
+            }   // CLI daemon bridge for CLI native commands
+
+            @Override
+            public CLISettingsManager getCliSettingsManager() {
+                return cliSettingsManager;
+            }   // CLI settings manager
 
             @Override
             public ClaudeSession getSession() {

--- a/src/main/java/com/github/claudecodegui/bridge/CLIDetector.java
+++ b/src/main/java/com/github/claudecodegui/bridge/CLIDetector.java
@@ -1,0 +1,484 @@
+package com.github.claudecodegui.bridge;
+
+import com.github.claudecodegui.model.CliDetectionResult;
+import com.github.claudecodegui.util.PlatformUtils;
+import com.github.claudecodegui.util.ShellExecutor;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Claude Code CLI detector.
+ * Responsible for locating and verifying the Claude Code CLI executable across various platforms.
+ * Implemented as a singleton to share cache across the application.
+ */
+public class CLIDetector {
+
+    private static final Logger LOG = Logger.getInstance(CLIDetector.class);
+
+    // Common CLI installation paths on Windows
+    private static final String[] WINDOWS_CLI_PATHS = {
+            // npm global installation
+            "%APPDATA%\\npm\\claude.cmd",
+            "%APPDATA%\\npm\\claude-code.cmd",
+            // Custom user installation
+            "%USERPROFILE%\\.claude-code\\bin\\claude.cmd",
+            "%USERPROFILE%\\.claude\\bin\\claude.cmd"
+    };
+
+    // Common CLI installation paths on macOS/Linux
+    private static final String[] UNIX_CLI_PATHS = {
+            "~/.local/bin/claude",
+            "/usr/local/bin/claude",
+            "/opt/homebrew/bin/claude",
+            "~/.npm-global/bin/claude",
+            "~/.config/nvm/current/bin/claude",
+            "~/.claude-code/bin/claude",
+            "~/.claude/bin/claude"
+    };
+
+    // ============================================================================
+    // Singleton Implementation
+    // ============================================================================
+
+    private static volatile CLIDetector instance;
+    private static final Object lock = new Object();
+
+    /** Private constructor to enforce singleton pattern. */
+    private CLIDetector() {
+    }
+
+    /**
+     * Get the singleton instance of CLIDetector.
+     *
+     * @return shared CLIDetector instance
+     */
+    public static CLIDetector getInstance() {
+        if (instance == null) {
+            synchronized (lock) {
+                if (instance == null) {
+                    instance = new CLIDetector();
+                }
+            }
+        }
+        return instance;
+    }
+
+    // ============================================================================
+    // Instance Fields
+    // ============================================================================
+
+    private volatile String cachedCliExecutable = null;
+    private volatile CliDetectionResult cachedDetectionResult = null;
+    private final Object cacheLock = new Object();
+
+    /**
+     * Finds Claude Code CLI executable path.
+     */
+    public String findCliExecutable() {
+        if (this.cachedCliExecutable != null) {
+            return this.cachedCliExecutable;
+        }
+
+        synchronized (this.cacheLock) {
+            if (this.cachedCliExecutable != null) {
+                return this.cachedCliExecutable;
+            }
+
+            CliDetectionResult result = detectCliWithDetails();
+            if (result != null && result.isFound()) {
+                this.cachedDetectionResult = result;
+                this.cachedCliExecutable = result.getCliPath();
+                return this.cachedCliExecutable;
+            }
+
+            LOG.warn("⚠️ 无法自动检测 Claude Code CLI 路径");
+            this.cachedCliExecutable = "claude";
+            return this.cachedCliExecutable;
+        }
+    }
+
+    /**
+     * Detects Claude Code CLI and returns a detailed result.
+     *
+     * @return CliDetectionResult containing detection details
+     */
+    public CliDetectionResult detectCliWithDetails() {
+        List<String> triedPaths = new ArrayList<>();
+        LOG.info("正在查找 Claude Code CLI...");
+        LOG.info("  操作系统: " + System.getProperty("os.name"));
+        LOG.info("  平台类型: " + (PlatformUtils.isWindows() ? "Windows" :
+                                               (PlatformUtils.isMac() ? "macOS" : "Linux/Unix")));
+
+        // 1. Try locating via system commands (where/which)
+        CliDetectionResult cmdResult = detectCliViaSystemCommand(triedPaths);
+        if (cmdResult != null && cmdResult.isFound()) {
+            return cmdResult;
+        }
+
+        // 2. Try known installation paths
+        CliDetectionResult knownPathResult = detectCliViaKnownPaths(triedPaths);
+        if (knownPathResult != null && knownPathResult.isFound()) {
+            return knownPathResult;
+        }
+
+        // 3. Try PATH environment variable
+        CliDetectionResult pathResult = detectCliViaPath(triedPaths);
+        if (pathResult != null && pathResult.isFound()) {
+            return pathResult;
+        }
+
+        return CliDetectionResult.failure("在所有已知路径中均未找到 Claude Code CLI", triedPaths);
+    }
+
+    /**
+     * Detects CLI via system commands (where/which).
+     */
+    private CliDetectionResult detectCliViaSystemCommand(List<String> triedPaths) {
+        if (PlatformUtils.isWindows()) {
+            return detectCliViaWindowsWhere(triedPaths);
+        } else {
+            // macOS/Linux: try zsh first (macOS default), then bash
+            CliDetectionResult result = detectCliViaShell("/bin/zsh", "zsh", triedPaths);
+            if (result != null && result.isFound()) {
+                return result;
+            }
+            return detectCliViaShell("/bin/bash", "bash", triedPaths);
+        }
+    }
+
+    /**
+     * Windows: detects CLI using "where" command.
+     */
+    private CliDetectionResult detectCliViaWindowsWhere(List<String> triedPaths) {
+        try {
+            // Try both "claude" and "claude-code"
+            for (String cliName : new String[]{"claude", "claude-code"}) {
+                ProcessBuilder pb = new ProcessBuilder("where", cliName);
+                String methodDesc = "Windows where 命令 (" + cliName + ")";
+
+                LOG.info("  尝试方法: " + methodDesc);
+                Process process = pb.start();
+
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                    String path = reader.readLine();
+                    if (path != null && !path.isEmpty()) {
+                        path = path.trim();
+                        triedPaths.add(path);
+
+                        String version = verifyCliPath(path);
+                        if (version != null) {
+                            LOG.info("✓ 通过 " + methodDesc + " 找到 CLI: " + path + " (" + version + ")");
+                            return CliDetectionResult.success(
+                                    path, version,
+                                    CliDetectionResult.DetectionMethod.WHERE_COMMAND,
+                                    triedPaths
+                            );
+                        }
+                    }
+                }
+
+                boolean finished = process.waitFor(5, TimeUnit.SECONDS);
+                if (!finished) {
+                    process.destroyForcibly();
+                }
+            }
+        } catch (Exception e) {
+            LOG.debug("  Windows where 命令查找失败: " + e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Unix/macOS: detects CLI through a specified shell.
+     */
+    private CliDetectionResult detectCliViaShell(String shellPath, String shellName, List<String> triedPaths) {
+        if (!new File(shellPath).exists()) {
+            LOG.debug("  跳过 " + shellName + "（不存在）");
+            return null;
+        }
+
+        String methodDesc = shellName + " which 命令（登录+交互式 shell）";
+        LOG.info("  尝试方法: " + methodDesc);
+
+        List<String> command = new ArrayList<>();
+        command.add(shellPath);
+        command.add("-l");
+        command.add("-i");
+        command.add("-c");
+        command.add("which claude || which claude-code");
+
+        ShellExecutor.ExecutionResult result = ShellExecutor.execute(
+                command,
+                ShellExecutor.createCliPathFilter(),
+                "  " + shellName,
+                ShellExecutor.DEFAULT_TIMEOUT_SECONDS,
+                true
+        );
+
+        if (result.isSuccess() && result.getOutput() != null) {
+            String cliPath = result.getOutput();
+            triedPaths.add(cliPath);
+
+            String version = verifyCliPath(cliPath);
+            if (version != null) {
+                LOG.info("✓ 通过 " + methodDesc + " 找到 CLI: " + cliPath + " (" + version + ")");
+                return CliDetectionResult.success(
+                        cliPath, version,
+                        CliDetectionResult.DetectionMethod.WHICH_COMMAND,
+                        triedPaths
+                );
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Detects CLI by checking known installation paths.
+     */
+    private CliDetectionResult detectCliViaKnownPaths(List<String> triedPaths) {
+        String userHome = PlatformUtils.getHomeDirectory();
+        List<String> pathsToCheck = new ArrayList<>();
+
+        if (PlatformUtils.isWindows()) {
+            LOG.info("  正在检查 Windows 常见安装路径...");
+            for (String templatePath : WINDOWS_CLI_PATHS) {
+                String expandedPath = expandWindowsEnvVars(templatePath);
+                pathsToCheck.add(expandedPath);
+            }
+        } else {
+            LOG.info("  正在检查 Unix/macOS 常见安装路径...");
+            for (String templatePath : UNIX_CLI_PATHS) {
+                String expandedPath = expandUnixTilde(templatePath);
+                pathsToCheck.add(expandedPath);
+            }
+        }
+
+        // Check each path (directly verify without existence check to avoid TOCTOU)
+        for (String path : pathsToCheck) {
+            triedPaths.add(path);
+
+            String version = verifyCliPath(path);
+            if (version != null) {
+                LOG.info("✓ 在已知路径找到 CLI: " + path + " (" + version + ")");
+                return CliDetectionResult.success(path, version,
+                        CliDetectionResult.DetectionMethod.KNOWN_PATH, triedPaths);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Detects CLI by scanning PATH environment variable.
+     */
+    private CliDetectionResult detectCliViaPath(List<String> triedPaths) {
+        LOG.info("  正在检查 PATH 环境变量...");
+
+        String pathEnv = PlatformUtils.isWindows() ?
+                                 PlatformUtils.getEnvIgnoreCase("PATH") :
+                                 System.getenv("PATH");
+
+        if (pathEnv == null || pathEnv.isEmpty()) {
+            LOG.debug("  PATH 环境变量为空");
+            return null;
+        }
+
+        String[] paths = pathEnv.split(File.pathSeparator);
+        String cliFileName = PlatformUtils.isWindows() ? "claude.cmd" : "claude";
+
+        for (String dir : paths) {
+            if (dir == null || dir.isEmpty()) continue;
+
+            File cliFile = new File(dir, cliFileName);
+            String cliPath = cliFile.getAbsolutePath();
+            triedPaths.add(cliPath);
+
+            String version = verifyCliPath(cliPath);
+            if (version != null) {
+                LOG.info("✓ 在 PATH 中找到 CLI: " + cliPath + " (" + version + ")");
+                return CliDetectionResult.success(cliPath, version,
+                        CliDetectionResult.DetectionMethod.PATH_VARIABLE, triedPaths);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Validates that a given path looks like a CLI binary.
+     */
+    private boolean isValidCliBinaryName(String path) {
+        if (path == null || path.trim().isEmpty()) {
+            return false;
+        }
+        if ("claude".equals(path) || "claude-code".equals(path)) {
+            return true;
+        }
+        String name = new File(path).getName().toLowerCase();
+        return name.equals("claude") || name.equals("claude.cmd") || name.equals("claude-code") || name.equals("claude-code.cmd");
+    }
+
+    /**
+     * Verifies whether a CLI path is usable.
+     *
+     * @param path CLI executable path
+     * @return version string if usable, otherwise null
+     */
+    public String verifyCliPath(String path) {
+        if (!isValidCliBinaryName(path)) {
+            LOG.warn("[CLIDetector] Rejected invalid CLI binary name: " + path);
+            return null;
+        }
+        try {
+            ProcessBuilder pb = new ProcessBuilder(path, "--version");
+            Process process = pb.start();
+
+            String version = null;
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                version = reader.readLine();
+            }
+
+            boolean finished = process.waitFor(10, TimeUnit.SECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                return null;
+            }
+
+            int exitCode = process.exitValue();
+            if (exitCode == 0 && version != null) {
+                return version.trim();
+            }
+        } catch (Exception e) {
+            LOG.debug("    验证失败 [" + path + "]: " + e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Expands Windows environment variables in a path.
+     */
+    private String expandWindowsEnvVars(String path) {
+        if (path == null) return null;
+
+        String result = path;
+        result = result.replace("%USERPROFILE%", PlatformUtils.getHomeDirectory());
+        result = result.replace("%APPDATA%", System.getenv("APPDATA") != null ?
+                                                     System.getenv("APPDATA") : "");
+        return result;
+    }
+
+    /**
+     * Expands Unix tilde (~) in a path.
+     */
+    private String expandUnixTilde(String path) {
+        if (path == null) return null;
+        return path.replace("~", PlatformUtils.getHomeDirectory());
+    }
+
+    /**
+     * Manually sets the CLI executable path.
+     */
+    public void setCliExecutable(String path) {
+        synchronized (this.cacheLock) {
+            this.cachedCliExecutable = path;
+            if (path == null || this.cachedDetectionResult == null
+                    || !path.equals(this.cachedDetectionResult.getCliPath())) {
+                this.cachedDetectionResult = null;
+            }
+        }
+    }
+
+    /**
+     * Get current CLI executable path.
+     */
+    public String getCliExecutable() {
+        if (this.cachedCliExecutable == null) {
+            return findCliExecutable();
+        }
+        return this.cachedCliExecutable;
+    }
+
+    /**
+     * Clears the cached CLI path and detection result.
+     */
+    public void clearCache() {
+        synchronized (this.cacheLock) {
+            this.cachedCliExecutable = null;
+            this.cachedDetectionResult = null;
+        }
+    }
+
+    /**
+     * Gets cached detection result.
+     */
+    public CliDetectionResult getCachedDetectionResult() {
+        synchronized (this.cacheLock) {
+            return this.cachedDetectionResult;
+        }
+    }
+
+    /**
+     * Gets the cached CLI executable path from the detection result.
+     */
+    public String getCachedCliPath() {
+        synchronized (this.cacheLock) {
+            if (this.cachedDetectionResult != null && this.cachedDetectionResult.getCliPath() != null) {
+                return this.cachedDetectionResult.getCliPath();
+            }
+            return this.cachedCliExecutable;
+        }
+    }
+
+    /**
+     * Gets the cached CLI version string.
+     */
+    public String getCachedCliVersion() {
+        synchronized (this.cacheLock) {
+            return this.cachedDetectionResult != null ? this.cachedDetectionResult.getCliVersion() : null;
+        }
+    }
+
+    /**
+     * Verify and cache a CLI path.
+     *
+     * @param path CLI executable path to verify
+     * @return CliDetectionResult with verification details
+     */
+    public CliDetectionResult verifyAndCacheCliPath(String path) {
+        if (path == null || path.isEmpty()) {
+            clearCache();
+            return CliDetectionResult.failure("未指定 CLI 路径");
+        }
+        String version = verifyCliPath(path);
+        CliDetectionResult result;
+        if (version != null) {
+            result = CliDetectionResult.success(path, version, CliDetectionResult.DetectionMethod.KNOWN_PATH);
+        } else {
+            result = CliDetectionResult.failure("无法验证指定的 CLI 路径: " + path);
+        }
+        cacheDetection(result);
+        return result;
+    }
+
+    /**
+     * Cache a detection result.
+     */
+    private void cacheDetection(CliDetectionResult result) {
+        synchronized (this.cacheLock) {
+            this.cachedDetectionResult = result;
+            if (result != null && result.isFound() && result.getCliPath() != null) {
+                this.cachedCliExecutable = result.getCliPath();
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/handler/CLICommandHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/CLICommandHandler.java
@@ -1,0 +1,153 @@
+package com.github.claudecodegui.handler;
+
+import com.github.claudecodegui.provider.common.CLIDaemonBridge;
+import com.github.claudecodegui.settings.CLISettingsManager;
+import com.github.claudecodegui.skill.SlashCommandRegistry;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+
+/**
+ * Handler for Claude Code CLI native commands.
+ * Routes CLI commands (like /plan, /review, /commit) to the CLI daemon
+ * or falls back to API mode when CLI is unavailable.
+ */
+public class CLICommandHandler extends BaseMessageHandler {
+
+    private static final Logger LOG = Logger.getInstance(CLICommandHandler.class);
+    private static final String CLI_EXECUTE_METHOD = "cli.execute";
+
+    private final CLIDaemonBridge cliDaemonBridge;
+    private final CLISettingsManager cliSettingsManager;
+
+    public CLICommandHandler(
+            HandlerContext context,
+            CLIDaemonBridge cliDaemonBridge,
+            CLISettingsManager cliSettingsManager
+    ) {
+        super(context);
+        this.cliDaemonBridge = cliDaemonBridge;
+        this.cliSettingsManager = cliSettingsManager;
+    }
+
+    @Override
+    public boolean handle(String type, String content) {
+        if (!"chat".equals(type)) {
+            return false;
+        }
+
+        if (content == null || content.isEmpty()) {
+            return false;
+        }
+
+        String trimmedContent = content.trim();
+
+        // Check if this is a CLI native command using centralized registry
+        if (!SlashCommandRegistry.isCLICommand(trimmedContent)) {
+            return false;
+        }
+
+        // If CLI is not available and fallback is disabled, let other handlers handle it
+        if (!cliSettingsManager.isCliDetected() && !cliSettingsManager.isFallbackToAPI()) {
+            LOG.info("[CLICommandHandler] CLI not detected and fallback disabled, passing to next handler");
+            return false;
+        }
+
+        // Execute via CLI daemon or fallback to API
+        if (cliSettingsManager.isCliDetected() && cliDaemonBridge.isAlive()) {
+            executeViaCLI(trimmedContent);
+        } else {
+            LOG.info("[CLICommandHandler] CLI not available, falling back to API mode");
+            // Send as regular message to API (will be handled by PromptHandler)
+            return false; // Let PromptHandler handle it
+        }
+
+        return true;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{"chat"};
+    }
+
+    /**
+     * Execute a command via the CLI daemon.
+     */
+    private void executeViaCLI(String command) {
+        // Parse command using centralized registry helper
+        String commandName = SlashCommandRegistry.getCommandName(command);
+        String args = SlashCommandRegistry.getCommandArgs(command);
+
+        LOG.info("[CLICommandHandler] Executing via CLI: " + commandName + " " + args);
+
+        // Build parameters for the CLI daemon
+        JsonObject params = new JsonObject();
+        params.addProperty("command", commandName);
+        params.addProperty("args", args);
+
+        // Create callback for handling CLI output
+        CLIDaemonBridge.DaemonOutputCallback callback = new CLIDaemonBridge.DaemonOutputCallback() {
+            @Override
+            public void onLine(String line) {
+                sendToFrontend("stream", line);
+            }
+
+            @Override
+            public void onStderr(String text) {
+                sendToFrontend("error", text);
+            }
+
+            @Override
+            public void onError(String error) {
+                sendToFrontend("error", error);
+            }
+
+            @Override
+            public void onComplete(boolean success) {
+                JsonObject result = new JsonObject();
+                result.addProperty("done", true);
+                result.addProperty("success", success);
+                sendToFrontend("cliComplete", result.toString());
+            }
+        };
+
+        // Send command to CLI daemon
+        cliDaemonBridge.sendCommand(CLI_EXECUTE_METHOD, params, callback);
+    }
+
+    /**
+     * Send a message to the frontend JavaScript.
+     */
+    private void sendToFrontend(String type, String content) {
+        try {
+            JsonObject message = new JsonObject();
+            message.addProperty("type", type);
+            message.addProperty("content", content);
+
+            // Escape the JSON string for JavaScript
+            String escaped = escapeJs(message.toString());
+            executeJavaScript("window.handleBackendMessage(" + escaped + ");");
+        } catch (Exception e) {
+            LOG.error("[CLICommandHandler] Failed to send message to frontend: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Check if CLI is available and ready.
+     */
+    public boolean isCLIAvailable() {
+        return cliSettingsManager.isCliDetected() && cliDaemonBridge.isAlive();
+    }
+
+    /**
+     * Get CLI status information.
+     */
+    public JsonObject getCLIStatus() {
+        JsonObject status = new JsonObject();
+        status.addProperty("cliDetected", cliSettingsManager.isCliDetected());
+        status.addProperty("cliPath", cliSettingsManager.getCliExecutablePath());
+        status.addProperty("cliVersion", cliSettingsManager.getCliVersion());
+        status.addProperty("daemonRunning", cliDaemonBridge.isAlive());
+        status.addProperty("fallbackEnabled", cliSettingsManager.isFallbackToAPI());
+        return status;
+    }
+}

--- a/src/main/java/com/github/claudecodegui/handler/HandlerContext.java
+++ b/src/main/java/com/github/claudecodegui/handler/HandlerContext.java
@@ -3,6 +3,7 @@ package com.github.claudecodegui.handler;
 import com.github.claudecodegui.ClaudeSession;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.provider.common.CLIDaemonBridge;
 import com.github.claudecodegui.CodemossSettingsService;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
@@ -19,6 +20,7 @@ public class HandlerContext {
     private final Project project;
     private final ClaudeSDKBridge claudeSDKBridge;
     private final CodexSDKBridge codexSDKBridge;
+    private final CLIDaemonBridge cliDaemonBridge;
     private final CodemossSettingsService settingsService;
     private final JsCallback jsCallback;
 
@@ -44,9 +46,21 @@ public class HandlerContext {
             CodemossSettingsService settingsService,
             JsCallback jsCallback
     ) {
+        this(project, claudeSDKBridge, codexSDKBridge, null, settingsService, jsCallback);
+    }
+
+    private HandlerContext(
+            Project project,
+            ClaudeSDKBridge claudeSDKBridge,
+            CodexSDKBridge codexSDKBridge,
+            CLIDaemonBridge cliDaemonBridge,
+            CodemossSettingsService settingsService,
+            JsCallback jsCallback
+    ) {
         this.project = project;
         this.claudeSDKBridge = claudeSDKBridge;
         this.codexSDKBridge = codexSDKBridge;
+        this.cliDaemonBridge = cliDaemonBridge;
         this.settingsService = settingsService;
         this.jsCallback = jsCallback;
     }
@@ -62,6 +76,10 @@ public class HandlerContext {
 
     public CodexSDKBridge getCodexSDKBridge() {
         return codexSDKBridge;
+    }
+
+    public CLIDaemonBridge getCliDaemonBridge() {
+        return cliDaemonBridge;
     }
 
     public CodemossSettingsService getSettingsService() {

--- a/src/main/java/com/github/claudecodegui/model/CliDetectionResult.java
+++ b/src/main/java/com/github/claudecodegui/model/CliDetectionResult.java
@@ -1,0 +1,222 @@
+package com.github.claudecodegui.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Claude Code CLI detection result class.
+ * Represents the detailed outcome of a CLI detection process.
+ */
+public class CliDetectionResult {
+
+    /**
+     * Detection method enum.
+     */
+    public enum DetectionMethod {
+        /** Windows "where" command */
+        WHERE_COMMAND,
+        /** Unix "which" command */
+        WHICH_COMMAND,
+        /** Known installation path */
+        KNOWN_PATH,
+        /** PATH environment variable */
+        PATH_VARIABLE
+    }
+
+    private final boolean found;
+    private final String cliPath;
+    private final String cliVersion;
+    private final DetectionMethod method;
+    private final List<String> triedPaths;
+    private final String errorMessage;
+
+    /**
+     * Private constructor.
+     */
+    private CliDetectionResult(boolean found, String cliPath, String cliVersion,
+                               DetectionMethod method, List<String> triedPaths, String errorMessage) {
+        this.found = found;
+        this.cliPath = cliPath;
+        this.cliVersion = cliVersion;
+        this.method = method;
+        this.triedPaths = triedPaths != null ? new ArrayList<>(triedPaths) : new ArrayList<>();
+        this.errorMessage = errorMessage;
+    }
+
+    // ==================== Factory Methods ====================
+
+    /**
+     * Creates a successful result.
+     *
+     * @param cliPath path to the CLI executable
+     * @param cliVersion CLI version string
+     * @param method the detection method used
+     * @return a successful CliDetectionResult
+     */
+    public static CliDetectionResult success(String cliPath, String cliVersion, DetectionMethod method) {
+        return new CliDetectionResult(true, cliPath, cliVersion, method, null, null);
+    }
+
+    /**
+     * Creates a successful result with the list of paths that were tried.
+     *
+     * @param cliPath path to the CLI executable
+     * @param cliVersion CLI version string
+     * @param method the detection method used
+     * @param triedPaths list of paths that were attempted
+     * @return a successful CliDetectionResult
+     */
+    public static CliDetectionResult success(String cliPath, String cliVersion,
+                                             DetectionMethod method, List<String> triedPaths) {
+        return new CliDetectionResult(true, cliPath, cliVersion, method, triedPaths, null);
+    }
+
+    /**
+     * Creates a failure result.
+     *
+     * @param errorMessage the error message
+     * @return a failed CliDetectionResult
+     */
+    public static CliDetectionResult failure(String errorMessage) {
+        return new CliDetectionResult(false, null, null, null, null, errorMessage);
+    }
+
+    /**
+     * Creates a failure result with the list of paths that were tried.
+     *
+     * @param errorMessage the error message
+     * @param triedPaths list of paths that were attempted
+     * @return a failed CliDetectionResult
+     */
+    public static CliDetectionResult failure(String errorMessage, List<String> triedPaths) {
+        return new CliDetectionResult(false, null, null, null, triedPaths, errorMessage);
+    }
+
+    // ==================== Getters ====================
+
+    /**
+     * Returns whether CLI was found.
+     * @return true if CLI was detected
+     */
+    public boolean isFound() {
+        return found;
+    }
+
+    /**
+     * Gets the path to the CLI executable.
+     * @return the CLI path, or null if not found
+     */
+    public String getCliPath() {
+        return cliPath;
+    }
+
+    /**
+     * Gets the CLI version.
+     * @return the version string, or null if not found
+     */
+    public String getCliVersion() {
+        return cliVersion;
+    }
+
+    /**
+     * Gets the detection method used.
+     * @return the detection method enum value, or null if not found
+     */
+    public DetectionMethod getMethod() {
+        return method;
+    }
+
+    /**
+     * Gets the list of paths that were tried during detection.
+     * @return an unmodifiable list of paths
+     */
+    public List<String> getTriedPaths() {
+        return Collections.unmodifiableList(triedPaths);
+    }
+
+    /**
+     * Gets the error message.
+     * @return the error message, or null if detection was successful
+     */
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    // ==================== Convenience Methods ====================
+
+    /**
+     * Gets a user-friendly error description suitable for display.
+     * @return a description including error details and installation suggestions
+     */
+    public String getUserFriendlyMessage() {
+        if (found) {
+            return "Claude Code CLI 检测成功：" + cliPath + " (" + cliVersion + ")";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("未找到 Claude Code CLI\n\n");
+
+        if (errorMessage != null && !errorMessage.isEmpty()) {
+            sb.append("错误信息：").append(errorMessage).append("\n\n");
+        }
+
+        if (!triedPaths.isEmpty()) {
+            sb.append("已尝试的路径：\n");
+            for (String path : triedPaths) {
+                sb.append("  - ").append(path).append("\n");
+            }
+            sb.append("\n");
+        }
+
+        // Provide platform-specific installation suggestions
+        String osName = System.getProperty("os.name", "").toLowerCase();
+        if (osName.contains("win")) {
+            sb.append("Windows 安装建议：\n");
+            sb.append("1. 使用 npm 安装: npm install -g @anthropic-ai/claude-code\n");
+            sb.append("2. 安装完成后，重启 IntelliJ IDEA\n");
+        } else if (osName.contains("mac")) {
+            sb.append("macOS 安装建议：\n");
+            sb.append("1. 使用 npm 安装: npm install -g @anthropic-ai/claude-code\n");
+        } else {
+            sb.append("Linux 安装建议：\n");
+            sb.append("1. 使用 npm 安装: npm install -g @anthropic-ai/claude-code\n");
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Gets a human-readable description of the detection method.
+     * @return detection method description
+     */
+    public String getMethodDescription() {
+        if (method == null) {
+            return "未知";
+        }
+        switch (method) {
+            case WHERE_COMMAND:
+                return "Windows where 命令";
+            case WHICH_COMMAND:
+                return "Unix which 命令";
+            case KNOWN_PATH:
+                return "已知安装路径";
+            case PATH_VARIABLE:
+                return "PATH 环境变量";
+            default:
+                return "未知";
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "CliDetectionResult{" +
+                "found=" + found +
+                ", cliPath='" + cliPath + '\'' +
+                ", cliVersion='" + cliVersion + '\'' +
+                ", method=" + method +
+                ", triedPaths=" + triedPaths +
+                ", errorMessage='" + errorMessage + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/common/CLIDaemonBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/CLIDaemonBridge.java
@@ -1,0 +1,637 @@
+package com.github.claudecodegui.provider.common;
+
+import com.github.claudecodegui.bridge.BridgeDirectoryResolver;
+import com.github.claudecodegui.bridge.CLIDetector;
+import com.github.claudecodegui.bridge.EnvironmentConfigurator;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Manages a long-running Claude Code CLI daemon process for CLI command execution.
+ *
+ * This class maintains a single daemon process that handles CLI native commands
+ * via NDJSON over stdin/stdout, similar to DaemonBridge but for CLI commands.
+ *
+ * Protocol:
+ * - Java writes JSON requests to daemon's stdin (one per line)
+ * - Daemon writes JSON responses to stdout (one per line, tagged with request ID)
+ * - Daemon lifecycle events have type="daemon"
+ * - Command output lines have an "id" field matching the request
+ * - Command completion is signaled by {"id":"X","done":true}
+ */
+public class CLIDaemonBridge {
+
+    private static final Logger LOG = Logger.getInstance(CLIDaemonBridge.class);
+    private static final String CLI_DAEMON_SCRIPT = "cli-daemon.js";
+    private static final long DAEMON_START_TIMEOUT_MS = 30_000;
+    private static final long HEARTBEAT_INTERVAL_MS = 15_000;
+    private static final long HEARTBEAT_TIMEOUT_MS = 45_000;
+    private static final int MAX_RESTART_ATTEMPTS = 3;
+    private static final long RESTART_WINDOW_MS = 30_000;
+
+    private final CLIDetector cliDetector;
+    private final BridgeDirectoryResolver directoryResolver;
+    private final EnvironmentConfigurator envConfigurator;
+
+    // Daemon process state
+    private volatile Process daemonProcess;
+    private volatile BufferedWriter daemonStdin;
+    private volatile Thread readerThread;
+    private volatile Thread heartbeatThread;
+    private final AtomicBoolean isRunning = new AtomicBoolean(false);
+    private final AtomicBoolean cliPreloaded = new AtomicBoolean(false);
+    private final AtomicLong requestIdCounter = new AtomicLong(0);
+    private volatile CountDownLatch readyLatch = new CountDownLatch(1);
+    private final AtomicInteger restartAttempts = new AtomicInteger(0);
+    private final AtomicLong lastSuccessfulStart = new AtomicLong(0);
+    private final AtomicLong lastHeartbeatResponse = new AtomicLong(0);
+    private final Object startLock = new Object();
+
+    // Pending request handlers: requestId -> handler
+    private final ConcurrentHashMap<String, RequestHandler> pendingRequests = new ConcurrentHashMap<>();
+
+    // Lifecycle listener
+    private volatile DaemonLifecycleListener lifecycleListener;
+
+    public CLIDaemonBridge(
+            CLIDetector cliDetector,
+            BridgeDirectoryResolver directoryResolver,
+            EnvironmentConfigurator envConfigurator
+    ) {
+        this.cliDetector = cliDetector;
+        this.directoryResolver = directoryResolver;
+        this.envConfigurator = envConfigurator;
+    }
+
+    // =========================================================================
+    // Lifecycle
+    // =========================================================================
+
+    /**
+     * Start the daemon process. Blocks until the daemon signals "ready"
+     * or the timeout expires.
+     *
+     * @return true if daemon started successfully
+     */
+    public boolean start() {
+        synchronized (startLock) {
+            if (isRunning.get()) {
+                LOG.info("[CLIDaemonBridge] Daemon already running");
+                return true;
+            }
+
+            LOG.info("[CLIDaemonBridge] Starting CLI daemon process...");
+            CountDownLatch latch = new CountDownLatch(1);
+            readyLatch = latch;
+
+            try {
+                File bridgeDir = directoryResolver.findSdkDir();
+                if (bridgeDir == null) {
+                    LOG.error("[CLIDaemonBridge] Bridge directory not found");
+                    return false;
+                }
+
+                File daemonScript = new File(bridgeDir, CLI_DAEMON_SCRIPT);
+                if (!daemonScript.exists()) {
+                    LOG.error("[CLIDaemonBridge] cli-daemon.js not found at: " + daemonScript.getAbsolutePath());
+                    return false;
+                }
+
+                String nodePath = cliDetector.getCachedNodePath();
+                if (nodePath == null) {
+                    // Use NodeDetector to find node
+                    com.github.claudecodegui.bridge.NodeDetector nodeDetector =
+                        com.github.claudecodegui.bridge.NodeDetector.getInstance();
+                    nodePath = nodeDetector.findNodeExecutable();
+                }
+
+                if (nodePath == null) {
+                    LOG.error("[CLIDaemonBridge] Node.js not found");
+                    return false;
+                }
+
+                ProcessBuilder pb = new ProcessBuilder(nodePath, daemonScript.getAbsolutePath());
+                pb.directory(bridgeDir);
+
+                // Configure environment
+                Map<String, String> env = pb.environment();
+                envConfigurator.updateProcessEnvironment(pb, nodePath);
+
+                // Set CLI path for the daemon
+                String cliPath = cliDetector.getCliExecutable();
+                if (cliPath != null) {
+                    env.put("CLAUDE_CLI_PATH", cliPath);
+                }
+
+                // Keep stderr separate for debugging
+                pb.redirectErrorStream(false);
+
+                daemonProcess = pb.start();
+                isRunning.set(true);
+                lastSuccessfulStart.set(System.currentTimeMillis());
+
+                LOG.info("[CLIDaemonBridge] CLI daemon process started, PID: " + daemonProcess.pid());
+
+                // Setup stdin writer
+                daemonStdin = new BufferedWriter(
+                        new OutputStreamWriter(daemonProcess.getOutputStream(), StandardCharsets.UTF_8));
+
+                // Start stdout reader thread
+                startReaderThread();
+
+                // Start stderr reader thread
+                startStderrReaderThread();
+
+                // Wait for "ready" event
+                boolean ready = false;
+                long deadline = System.currentTimeMillis() + DAEMON_START_TIMEOUT_MS;
+                while (System.currentTimeMillis() < deadline) {
+                    if (latch.await(200, TimeUnit.MILLISECONDS)) {
+                        ready = true;
+                        break;
+                    }
+                    if (daemonProcess == null || !daemonProcess.isAlive() || !isRunning.get()) {
+                        LOG.error("[CLIDaemonBridge] Daemon exited before signaling ready");
+                        isRunning.set(false);
+                        return false;
+                    }
+                }
+
+                if (!ready) {
+                    LOG.warn("[CLIDaemonBridge] Daemon did not signal ready within timeout");
+                    if (daemonProcess == null || !daemonProcess.isAlive() || !isRunning.get()) {
+                        LOG.error("[CLIDaemonBridge] Daemon is not alive after ready timeout");
+                        isRunning.set(false);
+                        return false;
+                    }
+                }
+
+                // Start heartbeat thread
+                startHeartbeatThread();
+
+                LOG.info("[CLIDaemonBridge] CLI daemon is ready. CLI preloaded: " + cliPreloaded.get());
+                return true;
+
+            } catch (Exception e) {
+                LOG.error("[CLIDaemonBridge] Failed to start daemon", e);
+                isRunning.set(false);
+                return false;
+            }
+        }
+    }
+
+    /**
+     * Stop the daemon process gracefully.
+     */
+    public void stop() {
+        LOG.info("[CLIDaemonBridge] Stopping CLI daemon...");
+        isRunning.set(false);
+
+        // Cancel all pending requests
+        for (Map.Entry<String, RequestHandler> entry : pendingRequests.entrySet()) {
+            entry.getValue().onError("Daemon stopped");
+        }
+        pendingRequests.clear();
+
+        // Send shutdown command
+        try {
+            if (daemonStdin != null) {
+                JsonObject shutdown = new JsonObject();
+                shutdown.addProperty("id", "shutdown");
+                shutdown.addProperty("method", "shutdown");
+                synchronized (daemonStdin) {
+                    daemonStdin.write(shutdown.toString());
+                    daemonStdin.newLine();
+                    daemonStdin.flush();
+                }
+            }
+        } catch (IOException e) {
+            LOG.debug("[CLIDaemonBridge] Error sending shutdown command: " + e.getMessage());
+        }
+
+        // Close stdin
+        try {
+            if (daemonStdin != null) {
+                daemonStdin.close();
+            }
+        } catch (IOException e) {
+            LOG.debug("[CLIDaemonBridge] Error closing stdin: " + e.getMessage());
+        }
+
+        // Kill process if still alive
+        if (daemonProcess != null && daemonProcess.isAlive()) {
+            daemonProcess.destroyForcibly();
+            try { daemonProcess.waitFor(3, TimeUnit.SECONDS); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+        }
+
+        // Interrupt and join threads
+        if (readerThread != null) {
+            readerThread.interrupt();
+            try { readerThread.join(2000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+        }
+        if (heartbeatThread != null) {
+            heartbeatThread.interrupt();
+            try { heartbeatThread.join(2000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+        }
+
+        LOG.info("[CLIDaemonBridge] CLI daemon stopped");
+    }
+
+    /**
+     * Send an abort command to cancel the currently executing request.
+     */
+    public void sendAbort() {
+        try {
+            if (daemonStdin != null && isRunning.get()) {
+                JsonObject abort = new JsonObject();
+                abort.addProperty("id", "abort-" + System.currentTimeMillis());
+                abort.addProperty("method", "abort");
+                synchronized (daemonStdin) {
+                    daemonStdin.write(abort.toString());
+                    daemonStdin.newLine();
+                    daemonStdin.flush();
+                }
+                LOG.info("[CLIDaemonBridge] Sent abort command");
+            }
+        } catch (IOException e) {
+            LOG.debug("[CLIDaemonBridge] Error sending abort command: " + e.getMessage());
+        }
+
+        // Complete all pending request futures
+        for (Map.Entry<String, RequestHandler> entry : pendingRequests.entrySet()) {
+            entry.getValue().onError("Request aborted by user");
+            entry.getValue().future.complete(false);
+        }
+        pendingRequests.clear();
+    }
+
+    /**
+     * Check if the daemon is running and healthy.
+     */
+    public boolean isAlive() {
+        return isRunning.get() && daemonProcess != null && daemonProcess.isAlive();
+    }
+
+    /**
+     * Ensure the daemon is running, starting it if necessary.
+     */
+    public boolean ensureRunning() {
+        if (isAlive()) return true;
+        return start();
+    }
+
+    // =========================================================================
+    // Request Execution
+    // =========================================================================
+
+    /**
+     * Send a command to the daemon and process output lines via callback.
+     *
+     * @param method   Command method (e.g., "cli.execute")
+     * @param params   Command parameters (JSON object)
+     * @param callback Callback for processing output lines
+     * @return CompletableFuture that completes when the command finishes
+     */
+    public CompletableFuture<Boolean> sendCommand(
+            String method,
+            JsonObject params,
+            DaemonOutputCallback callback
+    ) {
+        if (!ensureRunning()) {
+            CompletableFuture<Boolean> f = new CompletableFuture<>();
+            f.completeExceptionally(new IOException("Daemon not running"));
+            return f;
+        }
+
+        String requestId = String.valueOf(requestIdCounter.incrementAndGet());
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+
+        RequestHandler handler = new RequestHandler(callback, future);
+        pendingRequests.put(requestId, handler);
+
+        // Ensure cleanup when future completes
+        future.whenComplete((result, ex) -> pendingRequests.remove(requestId));
+
+        // Build request JSON
+        JsonObject request = new JsonObject();
+        request.addProperty("id", requestId);
+        request.addProperty("method", method);
+        request.add("params", params);
+
+        try {
+            synchronized (daemonStdin) {
+                daemonStdin.write(request.toString());
+                daemonStdin.newLine();
+                daemonStdin.flush();
+            }
+            LOG.info("[CLIDaemonBridge] Sent request " + requestId + ": " + method);
+        } catch (IOException e) {
+            pendingRequests.remove(requestId);
+            future.completeExceptionally(e);
+            LOG.error("[CLIDaemonBridge] Failed to send request: " + e.getMessage());
+        }
+
+        return future;
+    }
+
+    // =========================================================================
+    // Reader Threads
+    // =========================================================================
+
+    private void startReaderThread() {
+        readerThread = new Thread(() -> {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(daemonProcess.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    handleDaemonOutput(line);
+                }
+            } catch (IOException e) {
+                if (isRunning.get()) {
+                    LOG.error("[CLIDaemonBridge] Reader thread error: " + e.getMessage());
+                }
+            } finally {
+                handleDaemonDeath();
+            }
+        }, "CLIDaemonBridge-Reader");
+        readerThread.setDaemon(true);
+        readerThread.start();
+    }
+
+    private void startStderrReaderThread() {
+        Thread stderrThread = new Thread(() -> {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(daemonProcess.getErrorStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    LOG.debug("[CLIDaemonBridge:stderr] " + line);
+                }
+            } catch (IOException e) {
+                // Expected on shutdown
+            }
+        }, "CLIDaemonBridge-Stderr");
+        stderrThread.setDaemon(true);
+        stderrThread.start();
+    }
+
+    private void startHeartbeatThread() {
+        lastHeartbeatResponse.set(System.currentTimeMillis());
+
+        heartbeatThread = new Thread(() -> {
+            while (isRunning.get()) {
+                try {
+                    Thread.sleep(HEARTBEAT_INTERVAL_MS);
+                    if (!isAlive()) break;
+
+                    // Check if daemon is unresponsive
+                    long elapsed = System.currentTimeMillis() - lastHeartbeatResponse.get();
+                    if (elapsed > HEARTBEAT_TIMEOUT_MS) {
+                        LOG.warn("[CLIDaemonBridge] Daemon unresponsive (no heartbeat for "
+                                + elapsed + "ms), treating as dead");
+                        handleDaemonDeath();
+                        break;
+                    }
+
+                    // Send heartbeat
+                    JsonObject hb = new JsonObject();
+                    hb.addProperty("id", "hb-" + System.currentTimeMillis());
+                    hb.addProperty("method", "heartbeat");
+                    synchronized (daemonStdin) {
+                        daemonStdin.write(hb.toString());
+                        daemonStdin.newLine();
+                        daemonStdin.flush();
+                    }
+                } catch (InterruptedException e) {
+                    break;
+                } catch (IOException e) {
+                    LOG.warn("[CLIDaemonBridge] Heartbeat failed: " + e.getMessage());
+                    handleDaemonDeath();
+                    break;
+                }
+            }
+        }, "CLIDaemonBridge-Heartbeat");
+        heartbeatThread.setDaemon(true);
+        heartbeatThread.start();
+    }
+
+    // =========================================================================
+    // Output Parsing
+    // =========================================================================
+
+    private void handleDaemonOutput(String jsonLine) {
+        // Skip non-JSON lines
+        String trimmed = jsonLine.trim();
+        if (trimmed.isEmpty() || trimmed.charAt(0) != '{') {
+            LOG.debug("[CLIDaemonBridge] Non-JSON output: " + trimmed);
+            return;
+        }
+
+        try {
+            JsonElement element = JsonParser.parseString(trimmed);
+            if (!element.isJsonObject()) return;
+            JsonObject obj = element.getAsJsonObject();
+
+            // Daemon lifecycle events
+            if (obj.has("type")) {
+                String type = obj.get("type").getAsString();
+
+                if ("daemon".equals(type)) {
+                    handleDaemonEvent(obj);
+                    return;
+                }
+
+                if ("heartbeat".equals(type)) {
+                    lastHeartbeatResponse.set(System.currentTimeMillis());
+                    return;
+                }
+
+                if ("status".equals(type)) {
+                    return;
+                }
+            }
+
+            // Request-tagged output
+            if (!obj.has("id")) return;
+            String id = obj.get("id").getAsString();
+
+            if (id.startsWith("hb-")) return;
+
+            RequestHandler handler = pendingRequests.get(id);
+            if (handler == null) {
+                LOG.debug("[CLIDaemonBridge] No handler for request " + id);
+                return;
+            }
+
+            // Command completion
+            if (obj.has("done")) {
+                boolean success = obj.has("success") && obj.get("success").getAsBoolean();
+                if (!success && obj.has("error")) {
+                    handler.onError(obj.get("error").getAsString());
+                }
+                handler.onComplete(success);
+                pendingRequests.remove(id);
+                return;
+            }
+
+            // Output line from the command
+            if (obj.has("line")) {
+                handler.callback.onLine(obj.get("line").getAsString());
+                return;
+            }
+
+            // Stderr output
+            if (obj.has("stderr")) {
+                handler.callback.onStderr(obj.get("stderr").getAsString());
+            }
+
+        } catch (Exception e) {
+            LOG.error("[CLIDaemonBridge] Failed to parse daemon output: " + jsonLine, e);
+        }
+    }
+
+    private void handleDaemonEvent(JsonObject obj) {
+        String event = obj.has("event") ? obj.get("event").getAsString() : "unknown";
+        LOG.info("[CLIDaemonBridge] Daemon event: " + event);
+
+        switch (event) {
+            case "ready":
+                if (obj.has("cliPreloaded")) {
+                    cliPreloaded.set(obj.get("cliPreloaded").getAsBoolean());
+                }
+                readyLatch.countDown();
+                if (lifecycleListener != null) {
+                    lifecycleListener.onDaemonReady();
+                }
+                break;
+
+            case "cli_loaded":
+                cliPreloaded.set(true);
+                LOG.info("[CLIDaemonBridge] CLI pre-loaded successfully");
+                break;
+
+            case "cli_load_error":
+                String error = obj.has("error") ? obj.get("error").getAsString() : "unknown";
+                LOG.warn("[CLIDaemonBridge] CLI pre-load failed: " + error);
+                break;
+
+            case "shutdown":
+                LOG.info("[CLIDaemonBridge] Daemon shutting down");
+                break;
+
+            default:
+                LOG.debug("[CLIDaemonBridge] Unhandled daemon event: " + event);
+        }
+    }
+
+    // =========================================================================
+    // Daemon Death & Auto-Restart
+    // =========================================================================
+
+    private void handleDaemonDeath() {
+        if (!isRunning.compareAndSet(true, false)) return;
+
+        LOG.warn("[CLIDaemonBridge] Daemon process died");
+
+        // Forcefully kill the old process if still alive
+        Process oldProcess = daemonProcess;
+        if (oldProcess != null && oldProcess.isAlive()) {
+            LOG.info("[CLIDaemonBridge] Forcefully killing unresponsive daemon (PID: "
+                    + oldProcess.pid() + ")");
+            oldProcess.destroyForcibly();
+            try { oldProcess.waitFor(2, TimeUnit.SECONDS); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+        }
+
+        // Fail all pending requests
+        for (Map.Entry<String, RequestHandler> entry : pendingRequests.entrySet()) {
+            entry.getValue().onError("Daemon process died unexpectedly");
+        }
+        pendingRequests.clear();
+
+        // Notify listener
+        if (lifecycleListener != null) {
+            lifecycleListener.onDaemonDied();
+        }
+
+        // Auto-restart if within limit
+        long uptime = System.currentTimeMillis() - lastSuccessfulStart.get();
+        if (uptime > RESTART_WINDOW_MS) {
+            restartAttempts.set(0);
+        }
+
+        int attempts = restartAttempts.incrementAndGet();
+        if (attempts <= MAX_RESTART_ATTEMPTS) {
+            LOG.info("[CLIDaemonBridge] Attempting restart (" + attempts + "/" + MAX_RESTART_ATTEMPTS
+                    + ", last uptime=" + uptime + "ms)");
+            start();
+        } else {
+            LOG.error("[CLIDaemonBridge] Max restart attempts reached (" + attempts
+                    + " within " + RESTART_WINDOW_MS + "ms window). Daemon will not be restarted.");
+        }
+    }
+
+    // =========================================================================
+    // Setters
+    // =========================================================================
+
+    public void setLifecycleListener(DaemonLifecycleListener listener) {
+        this.lifecycleListener = listener;
+    }
+
+    public boolean isCliPreloaded() {
+        return cliPreloaded.get();
+    }
+
+    // =========================================================================
+    // Inner Types
+    // =========================================================================
+
+    /**
+     * Callback interface for receiving daemon output.
+     */
+    public interface DaemonOutputCallback {
+        void onLine(String line);
+        void onStderr(String text);
+        void onError(String error);
+        void onComplete(boolean success);
+    }
+
+    /**
+     * Lifecycle listener for daemon events.
+     */
+    public interface DaemonLifecycleListener {
+        void onDaemonReady();
+        void onDaemonDied();
+    }
+
+    /**
+     * Internal handler that wraps callback + future for a pending request.
+     */
+    private static class RequestHandler {
+        final DaemonOutputCallback callback;
+        final CompletableFuture<Boolean> future;
+
+        RequestHandler(DaemonOutputCallback callback, CompletableFuture<Boolean> future) {
+            this.callback = callback;
+            this.future = future;
+        }
+
+        void onError(String error) {
+            callback.onError(error);
+        }
+
+        void onComplete(boolean success) {
+            callback.onComplete(success);
+            future.complete(success);
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
@@ -7,6 +7,8 @@ import com.github.claudecodegui.handler.HandlerContext;
 import com.github.claudecodegui.handler.SettingsHandler;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.provider.common.CLIDaemonBridge;
+import com.github.claudecodegui.settings.CLISettingsManager;
 import com.github.claudecodegui.skill.SlashCommandRegistry;
 import com.github.claudecodegui.util.JsUtils;
 import com.github.claudecodegui.util.PlatformUtils;
@@ -40,6 +42,10 @@ public class SessionLifecycleManager {
         ClaudeSDKBridge getClaudeSDKBridge();
 
         CodexSDKBridge getCodexSDKBridge();
+
+        CLIDaemonBridge getCliDaemonBridge();
+
+        CLISettingsManager getCliSettingsManager();
 
         ClaudeSession getSession();
 

--- a/src/main/java/com/github/claudecodegui/settings/CLISettingsManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/CLISettingsManager.java
@@ -1,0 +1,146 @@
+package com.github.claudecodegui.settings;
+
+import com.github.claudecodegui.bridge.CLIDetector;
+import com.github.claudecodegui.model.CliDetectionResult;
+import com.intellij.openapi.diagnostic.Logger;
+
+/**
+ * Claude Code CLI Settings Manager.
+ * Manages CLI detection state and configuration.
+ */
+public class CLISettingsManager {
+
+    private static final Logger LOG = Logger.getInstance(CLISettingsManager.class);
+
+    private final CLIDetector cliDetector;
+
+    // Configuration state
+    private String cliExecutablePath;
+    private boolean cliDetected;
+    private String cliVersion;
+    private boolean fallbackToAPI = true;
+
+    public CLISettingsManager(CLIDetector cliDetector) {
+        this.cliDetector = cliDetector;
+        this.cliExecutablePath = null;
+        this.cliDetected = false;
+        this.cliVersion = null;
+    }
+
+    /**
+     * Initialize CLI detection.
+     * Attempts to auto-detect the CLI executable.
+     */
+    public void initializeDetection() {
+        try {
+            CliDetectionResult result = cliDetector.detectCliWithDetails();
+            if (result != null && result.isFound()) {
+                this.cliExecutablePath = result.getCliPath();
+                this.cliDetected = true;
+                this.cliVersion = result.getCliVersion();
+                LOG.info("[CLISettingsManager] CLI detected: " + cliExecutablePath + " (" + cliVersion + ")");
+            } else {
+                this.cliDetected = false;
+                this.cliExecutablePath = null;
+                this.cliVersion = null;
+                LOG.info("[CLISettingsManager] CLI not detected, will fallback to API mode");
+            }
+        } catch (Exception e) {
+            LOG.warn("[CLISettingsManager] CLI detection failed: " + e.getMessage());
+            this.cliDetected = false;
+        }
+    }
+
+    /**
+     * Refresh CLI detection.
+     * Re-runs detection and updates state.
+     */
+    public void refreshDetection() {
+        cliDetector.clearCache();
+        initializeDetection();
+    }
+
+    /**
+     * Get the CLI executable path.
+     * @return CLI path, or null if not detected
+     */
+    public String getCliExecutablePath() {
+        if (cliExecutablePath == null) {
+            initializeDetection();
+        }
+        return cliExecutablePath;
+    }
+
+    /**
+     * Check if CLI is detected and available.
+     * @return true if CLI is available
+     */
+    public boolean isCliDetected() {
+        if (!cliDetected && cliExecutablePath == null) {
+            initializeDetection();
+        }
+        return cliDetected;
+    }
+
+    /**
+     * Get the CLI version.
+     * @return CLI version string, or null if not detected
+     */
+    public String getCliVersion() {
+        if (cliVersion == null) {
+            initializeDetection();
+        }
+        return cliVersion;
+    }
+
+    /**
+     * Check if fallback to API is enabled.
+     * @return true if fallback is enabled
+     */
+    public boolean isFallbackToAPI() {
+        return fallbackToAPI;
+    }
+
+    /**
+     * Set whether to fallback to API when CLI is unavailable.
+     * @param fallback true to enable fallback
+     */
+    public void setFallbackToAPI(boolean fallback) {
+        this.fallbackToAPI = fallback;
+    }
+
+    /**
+     * Set a custom CLI executable path.
+     * @param path the CLI executable path
+     */
+    public void setCliExecutablePath(String path) {
+        this.cliExecutablePath = path;
+        cliDetector.setCliExecutable(path);
+        if (path != null && !path.isEmpty()) {
+            CliDetectionResult result = cliDetector.verifyAndCacheCliPath(path);
+            this.cliDetected = result.isFound();
+            this.cliVersion = result.getCliVersion();
+        } else {
+            this.cliDetected = false;
+            this.cliVersion = null;
+        }
+    }
+
+    /**
+     * Get the cached detection result.
+     * @return the cached detection result
+     */
+    public CliDetectionResult getCachedDetectionResult() {
+        return cliDetector.getCachedDetectionResult();
+    }
+
+    /**
+     * Clear cached CLI detection state.
+     */
+    public void clearCache() {
+        cliDetector.clearCache();
+        this.cliExecutablePath = null;
+        this.cliDetected = false;
+        this.cliVersion = null;
+    }
+}

--- a/src/main/java/com/github/claudecodegui/skill/SlashCommandRegistry.java
+++ b/src/main/java/com/github/claudecodegui/skill/SlashCommandRegistry.java
@@ -58,6 +58,28 @@ public final class SlashCommandRegistry {
     }
 
     /**
+     * A parsed command with name and arguments pre-extracted.
+     * Caches the split result to avoid redundant parsing.
+     */
+    public static record ParsedCommand(String name, String args) {
+        /**
+         * Parse a command string into name and args.
+         * @param command the command string (e.g., "/plan build feature")
+         * @return ParsedCommand with name and args
+         */
+        public static ParsedCommand parse(String command) {
+            if (command == null || command.isEmpty()) {
+                return new ParsedCommand("", "");
+            }
+            String trimmed = command.trim();
+            String[] parts = trimmed.split("\\s+", 2);
+            String name = parts.length > 0 ? parts[0] : "";
+            String args = parts.length > 1 ? parts[1] : "";
+            return new ParsedCommand(name, args);
+        }
+    }
+
+    /**
      * Installed plugin descriptor from installed_plugins.json.
      */
     private record InstalledPlugin(String pluginId, String installPath, String version) {
@@ -1424,5 +1446,95 @@ public final class SlashCommandRegistry {
             }
         }
         return new ArrayList<>(merged.values());
+    }
+
+    // ============================================================================
+    // CLI Native Command Detection
+    // ============================================================================
+
+    /**
+     * CLI native commands that should be routed to the CLI daemon.
+     */
+    private static final Set<String> CLI_NATIVE_COMMANDS = Set.of(
+            "/plan",
+            "/review",
+            "/commit",
+            "/babysit",
+            "/loop",
+            "/skills",
+            "/config",
+            "/providers",
+            "/mcp",
+            "/mode"
+    );
+
+    /**
+     * Built-in plugin commands that should NOT be routed to CLI.
+     */
+    private static final Set<String> BUILT_IN_COMMANDS = Set.of(
+            "/clear",
+            "/history",
+            "/export",
+            "/settings",
+            "/help",
+            "/provider",
+            "/model",
+            "/prompt"
+    );
+
+    /**
+     * Check if a command is a CLI native command.
+     *
+     * @param command the command string (e.g., "/plan build feature")
+     * @return true if the command should be routed to the CLI daemon
+     */
+    public static boolean isCLICommand(String command) {
+        ParsedCommand parsed = ParsedCommand.parse(command);
+        if (parsed.name().isEmpty()) {
+            return false;
+        }
+
+        // Built-in commands take priority
+        if (BUILT_IN_COMMANDS.contains(parsed.name())) {
+            return false;
+        }
+
+        // Check if it's a known CLI native command
+        if (CLI_NATIVE_COMMANDS.contains(parsed.name())) {
+            return true;
+        }
+
+        // For any other /command, treat as CLI native command
+        // This allows for future CLI commands to work without explicit listing
+        return true;
+    }
+
+    /**
+     * Extract the command name from a command string.
+     *
+     * @param command the command string (e.g., "/plan build feature")
+     * @return the command name (e.g., "/plan")
+     */
+    public static String getCommandName(String command) {
+        return ParsedCommand.parse(command).name();
+    }
+
+    /**
+     * Extract the arguments from a command string.
+     *
+     * @param command the command string (e.g., "/plan build feature")
+     * @return the arguments (e.g., "build feature")
+     */
+    public static String getCommandArgs(String command) {
+        return ParsedCommand.parse(command).args();
+    }
+
+    /**
+     * Get the list of CLI native commands.
+     *
+     * @return unmodifiable set of CLI native command names
+     */
+    public static Set<String> getCliNativeCommands() {
+        return Set.copyOf(CLI_NATIVE_COMMANDS);
     }
 }

--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -5,6 +5,7 @@ import com.github.claudecodegui.ClaudeSession;
 import com.github.claudecodegui.CodemossSettingsService;
 import com.github.claudecodegui.handler.AgentHandler;
 import com.github.claudecodegui.handler.ClipboardHandler;
+import com.github.claudecodegui.handler.CLICommandHandler;
 import com.github.claudecodegui.handler.CodexMcpServerHandler;
 import com.github.claudecodegui.handler.DependencyHandler;
 import com.github.claudecodegui.handler.DiffHandler;
@@ -28,8 +29,10 @@ import com.github.claudecodegui.handler.WindowEventHandler;
 import com.github.claudecodegui.permission.PermissionService;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.provider.common.CLIDaemonBridge;
 import com.github.claudecodegui.provider.common.MessageCallback;
 import com.github.claudecodegui.provider.common.SDKResult;
+import com.github.claudecodegui.settings.CLISettingsManager;
 import com.github.claudecodegui.session.SessionLifecycleManager;
 import com.github.claudecodegui.session.StreamMessageCoalescer;
 import com.github.claudecodegui.util.JsUtils;
@@ -74,6 +77,8 @@ public class ChatWindowDelegate {
         Project getProject();
         ClaudeSDKBridge getClaudeSDKBridge();
         CodexSDKBridge getCodexSDKBridge();
+        CLIDaemonBridge getCliDaemonBridge();
+        CLISettingsManager getCliSettingsManager();
         ClaudeSession getSession();
         CodemossSettingsService getSettingsService();
         JPanel getMainPanel();
@@ -252,7 +257,8 @@ public class ChatWindowDelegate {
             }
         };
 
-        HandlerContext handlerContext = new HandlerContext(project, claudeSDKBridge, codexSDKBridge, settingsService, jsCallback);
+        HandlerContext handlerContext = new HandlerContext(project, claudeSDKBridge, codexSDKBridge,
+                host.getCliDaemonBridge(), settingsService, jsCallback);
         handlerContext.setSession(host.getSession());
         host.setHandlerContext(handlerContext);
 
@@ -277,6 +283,15 @@ public class ChatWindowDelegate {
         messageDispatcher.registerHandler(new UndoFileHandler(handlerContext));
         messageDispatcher.registerHandler(new DependencyHandler(handlerContext));
         messageDispatcher.registerHandler(new ClipboardHandler(handlerContext));
+
+        // CLI command handler - register after built-in handlers but before PromptHandler
+        // This ensures CLI native commands are handled properly with fallback to API
+        CLICommandHandler cliCommandHandler = new CLICommandHandler(
+                handlerContext,
+                host.getCliDaemonBridge(),
+                host.getCliSettingsManager()
+        );
+        messageDispatcher.registerHandler(cliCommandHandler);
 
         // Window event handler
         messageDispatcher.registerHandler(new WindowEventHandler(handlerContext, new WindowEventHandler.Callback() {

--- a/src/main/java/com/github/claudecodegui/util/ShellExecutor.java
+++ b/src/main/java/com/github/claudecodegui/util/ShellExecutor.java
@@ -265,4 +265,23 @@ public final class ShellExecutor {
                    line.endsWith("/node");
         };
     }
+
+    /**
+     * Create a filter for Claude Code CLI paths.
+     *
+     * @return the line filter
+     */
+    public static Predicate<String> createCliPathFilter() {
+        return line -> {
+            if (line == null || line.isEmpty()) {
+                return false;
+            }
+            // A valid CLI path should start with /, end with /claude or /claude-code, and not contain error messages
+            return (line.startsWith("/") || line.matches("^[A-Za-z]:.*")) &&
+                   !line.contains("not found") &&
+                   !line.contains("command not found") &&
+                   (line.endsWith("/claude") || line.endsWith("/claude-code") ||
+                    line.endsWith("\\claude.cmd") || line.endsWith("\\claude-code.cmd"));
+        };
+    }
 }


### PR DESCRIPTION
Add dual-daemon architecture for executing Claude Code CLI native commands (/plan, /review, /commit, /babysit, /loop, etc.) with graceful fallback to API mode when CLI is unavailable.

New components:
- CLIDetector: Auto-detect CLI executable across platforms
- CLIDaemonBridge: Manage long-running CLI daemon process
- CLISettingsManager: Handle CLI configuration and detection state
- CLICommandHandler: Route CLI commands to daemon or API fallback
- cli-daemon.js: Node.js daemon script for CLI command execution
- cli-channel.js: CLI command channel handler

Modified components:
- HandlerContext: Add CLIDaemonBridge integration
- SlashCommandRegistry: Add CLI command detection and ParsedCommand helper
- ClaudeChatWindow: Initialize CLI components on startup
- ChatWindowDelegate: Register CLICommandHandler in message dispatcher
- ShellExecutor: Add CLI path filter for validation
- channel-manager.js: Add CLI command routing

Code quality improvements:
- Fix TOCTOU race condition in CLIDetector (remove existence check)
- Fix string concatenation efficiency in cli-daemon.js (use arrays)
- Add ParsedCommand record to avoid redundant split operations
- Eliminate duplicate command list definitions

The implementation maintains backward compatibility with existing API functionality while providing native CLI command support.