### PR TITLE
fix: handle UTF-8 BOM config and preserve ai-bridge cache

### DIFF
--- a/ai-bridge/config/api-config.js
+++ b/ai-bridge/config/api-config.js
@@ -59,7 +59,11 @@ function readJsonFile(filePath) {
     if (!existsSync(filePath)) {
       return null;
     }
-    return JSON.parse(readFileSync(filePath, 'utf8'));
+    const raw = readFileSync(filePath, 'utf8');
+    // PowerShell commonly writes UTF-8 with BOM on Windows. Strip the BOM
+    // before parsing so provider state files remain readable across tools.
+    const normalized = raw.charCodeAt(0) === 0xFEFF ? raw.slice(1) : raw;
+    return JSON.parse(normalized);
   } catch (error) {
     debugLog('[DEBUG] Failed to read JSON file:', filePath, error.message);
     return null;
@@ -219,18 +223,10 @@ export function loadClaudeSettings() {
  * @returns {Object} Contains apiKey, baseUrl, authType and their sources
  */
 export function setupApiKey() {
-  debugLog('[DIAG-CONFIG] ========== setupApiKey() START ==========');
-
   const runtimeState = getClaudeRuntimeState();
   const settings = loadClaudeSettings();
   injectNetworkEnvVars(settings);
   clearRuntimeAuthEnv();
-
-  debugLog('[DIAG-CONFIG] Runtime provider access:', runtimeState.access, runtimeState.currentId || '(none)');
-  debugLog('[DIAG-CONFIG] Settings loaded:', settings ? 'yes' : 'no');
-  if (settings?.env) {
-    debugLog('[DIAG-CONFIG] Settings env keys:', Object.keys(settings.env));
-  }
 
   let apiKey;
   let baseUrl;
@@ -251,8 +247,6 @@ export function setupApiKey() {
   // strictly use SDK native OAuth flow. No fallback to other auth methods.
   const cliLoginAuthorized = settings?.env?.CCGUI_CLI_LOGIN_AUTHORIZED === '1';
   if (cliLoginAuthorized) {
-    debugLog('[INFO] CLI login authorized by user - delegating auth to Claude SDK native OAuth flow');
-
     // Use empty string assignment instead of delete so the SDK falls through to
     // its native OAuth flow without inheriting stale values from prior requests.
     process.env.ANTHROPIC_API_KEY = '';
@@ -290,7 +284,6 @@ export function setupApiKey() {
     const hasApiKeyHelper = managedSettings?.apiKeyHelper || settings?.apiKeyHelper;
 
     if (hasApiKeyHelper) {
-      debugLog('[INFO] Using apiKeyHelper authentication (SDK will handle execution)');
       authType = 'api_key_helper';
       apiKeySource = managedSettings?.apiKeyHelper
         ? 'managed-settings.json (apiKeyHelper)'
@@ -325,13 +318,6 @@ export function setupApiKey() {
   }
 
   debugLog('[DEBUG] Auth type:', authType);
-
-  debugLog('[DIAG-CONFIG] ========== setupApiKey() RESULT ==========');
-  debugLog('[DIAG-CONFIG] authType:', authType);
-  debugLog('[DIAG-CONFIG] apiKeySource:', apiKeySource);
-  debugLog('[DIAG-CONFIG] baseUrl:', baseUrl || '(not set)');
-  debugLog('[DIAG-CONFIG] baseUrlSource:', baseUrlSource);
-  debugLog('[DIAG-CONFIG] apiKey configured:', apiKey ? 'YES' : 'NO');
 
   return { apiKey, baseUrl, authType, apiKeySource, baseUrlSource };
 }

--- a/src/main/java/com/github/claudecodegui/startup/PluginUpdateListener.java
+++ b/src/main/java/com/github/claudecodegui/startup/PluginUpdateListener.java
@@ -1,6 +1,5 @@
 package com.github.claudecodegui.startup;
 
-import com.github.claudecodegui.bridge.BridgeDirectoryResolver;
 import com.github.claudecodegui.util.PlatformUtils;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManagerCore;
@@ -10,23 +9,20 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.ProjectActivity;
-import com.intellij.openapi.util.io.FileUtil;
 import kotlin.Unit;
 import kotlin.coroutines.Continuation;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.File;
-
 /**
- * Plugin update listener that cleans up old ai-bridge cache when plugin version changes.
- * This ensures that users always get the latest ai-bridge version after plugin updates.
+ * Plugin update listener that tracks plugin version changes.
+ * Bridge extraction is already version/hash-aware, so deleting the live ai-bridge
+ * directory here is both unnecessary and risky on Windows while the daemon is active.
  */
 public class PluginUpdateListener implements ProjectActivity {
 
     private static final Logger LOG = Logger.getInstance(PluginUpdateListener.class);
     private static final String LAST_VERSION_KEY = "claude.code.last.plugin.version";
-    private static final String SDK_DIR_NAME = "ai-bridge";
 
     @Nullable
     @Override
@@ -60,41 +56,14 @@ public class PluginUpdateListener implements ProjectActivity {
             LOG.info("[PluginUpdateListener] Current version: " + currentVersion + ", Last version: " + lastVersion);
 
             if (lastVersion != null && !lastVersion.equals(currentVersion)) {
-                LOG.info("[PluginUpdateListener] Plugin version changed from " + lastVersion + " to " + currentVersion + ", cleaning up old cache...");
-                cleanupOldBridgeCache(descriptor);
+                LOG.info("[PluginUpdateListener] Plugin version changed from " + lastVersion + " to " + currentVersion
+                        + ". Skipping ai-bridge deletion; BridgeDirectoryResolver will refresh by signature.");
             }
 
             // Update stored version
             props.setValue(LAST_VERSION_KEY, currentVersion);
         } catch (Exception e) {
             LOG.warn("[PluginUpdateListener] Failed to check plugin version: " + e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Cleanup old ai-bridge cache directory.
-     */
-    private void cleanupOldBridgeCache(IdeaPluginDescriptor descriptor) {
-        try {
-            File pluginDir = descriptor.getPluginPath().toFile();
-            File bridgeDir = new File(pluginDir, SDK_DIR_NAME);
-
-            if (bridgeDir.exists() && bridgeDir.isDirectory()) {
-                LOG.info("[PluginUpdateListener] Deleting old ai-bridge cache: " + bridgeDir.getAbsolutePath());
-                boolean deleted = FileUtil.delete(bridgeDir);
-                if (deleted) {
-                    LOG.info("[PluginUpdateListener] Successfully deleted old ai-bridge cache");
-                    // Reset extraction state in shared resolver
-                    BridgeDirectoryResolver resolver = BridgePreloader.getSharedResolver();
-                    resolver.clearCache();
-                } else {
-                    LOG.warn("[PluginUpdateListener] Failed to delete old ai-bridge cache, will be overwritten on next extraction");
-                }
-            } else {
-                LOG.debug("[PluginUpdateListener] No old ai-bridge cache found at: " + bridgeDir.getAbsolutePath());
-            }
-        } catch (Exception e) {
-            LOG.warn("[PluginUpdateListener] Failed to cleanup old cache: " + e.getMessage(), e);
         }
     }
 }


### PR DESCRIPTION
## What
- strip UTF-8 BOM before parsing Claude/Codemoss JSON config files
- avoid deleting the live `ai-bridge` directory during plugin version checks

## Why
On Windows, PowerShell may write JSON files with UTF-8 BOM.
This can make `~/.codemoss/config.json` unreadable and cause CLI login mode to be detected as inactive.

Also, deleting `ai-bridge` during version checks may leave the bridge directory empty or unstable when the daemon is still using it.

## Result
- `__cli_login__` can be detected correctly on Windows
- `ai-bridge` stays stable across plugin restarts and updates