### PR TITLE
feat: add multi-project workspace context support for AI providers

### DIFF
--- a/ai-bridge/services/system-prompts.js
+++ b/ai-bridge/services/system-prompts.js
@@ -13,8 +13,8 @@ import { getWindowsPathConstraint } from '../utils/prompt-utils.js';
  * Build the IDE context system prompt.
  *
  * This function constructs a detailed system prompt based on the user's working environment
- * in the IDE (open files, selected code, etc.), helping the AI understand the user's current
- * code context.
+ * in the IDE (open files, selected code, workspace structure, etc.), helping the AI understand
+ * the user's current code context.
  *
  * @param {Object} openedFiles - Information about files open in the IDE
  * @param {string} openedFiles.active - Path of the currently active file (may include line markers #LX-Y)
@@ -23,6 +23,11 @@ import { getWindowsPathConstraint } from '../utils/prompt-utils.js';
  * @param {number} openedFiles.selection.endLine - Ending line number of the selection
  * @param {string} openedFiles.selection.selectedText - Content of the selected code
  * @param {string[]} openedFiles.others - List of other open file paths
+ * @param {boolean} openedFiles.isWorkspace - Whether this is a multi-project workspace
+ * @param {string} openedFiles.workspaceRoot - Root path of the workspace
+ * @param {Array} openedFiles.subprojects - List of subprojects in the workspace
+ * @param {Array} openedFiles.modules - List of modules in the project
+ * @param {string} openedFiles.activeSubproject - Name of the subproject containing the active file
  * @param {string} agentPrompt - Agent prompt (optional)
  * @returns {string} The constructed system prompt, or an empty string if there's no valid information
  */
@@ -49,28 +54,87 @@ function buildIDEContextPrompt(openedFiles, agentPrompt = null) {
     return prompt;
   }
 
-  const { active, selection, others } = openedFiles;
+  const { active, selection, others, isWorkspace, workspaceRoot, subprojects, modules, activeSubproject } = openedFiles;
   const hasActive = active && active.trim() !== '';
   const hasSelection = selection && selection.selectedText;
   const hasOthers = Array.isArray(others) && others.length > 0;
+  const hasWorkspace = !!isWorkspace;
+  const hasModules = Array.isArray(modules) && modules.length > 1;
 
   // If there's no valid information, return only the agent prompt (if any)
-  if (!hasActive && !hasOthers) {
+  if (!hasActive && !hasOthers && !hasWorkspace && !hasModules) {
     return prompt;
   }
 
   console.log('[SystemPrompts] Building IDE context prompt with active file:', active,
               'selection:', hasSelection ? 'yes' : 'no',
-              'other files:', others?.length || 0);
+              'other files:', others?.length || 0,
+              'workspace:', hasWorkspace ? 'yes' : 'no',
+              'modules:', modules?.length || 0);
 
   prompt += '\n\n## User\'s Current IDE Context\n\n';
   prompt += 'The user is working in an IDE. Below is their current workspace context, which provides critical information about what they are looking at and asking about:\n\n';
+
+  // Workspace/Multi-project context (highest priority for project structure understanding)
+  if (hasWorkspace) {
+    prompt += '### Multi-Project Workspace Structure\n\n';
+    prompt += 'You are working in a **multi-project workspace** environment. This is important for understanding project boundaries and dependencies:\n\n';
+
+    if (workspaceRoot) {
+      prompt += `**Workspace Root**: \`${workspaceRoot}\`\n\n`;
+    }
+
+    if (Array.isArray(subprojects) && subprojects.length > 0) {
+      prompt += '**Subprojects in this workspace**:\n';
+      for (const sp of subprojects) {
+        const name = sp.name || 'unknown';
+        const path = sp.path || '';
+        const type = sp.type || '';
+        const loaded = sp.loaded !== false; // Default to true if not specified
+
+        prompt += `- **${name}**`;
+        if (type) {
+          prompt += ` (${type})`;
+        }
+        if (!loaded) {
+          prompt += ' [not loaded]';
+        }
+        prompt += `: \`${path}\`\n`;
+      }
+      prompt += '\n';
+    }
+
+    if (activeSubproject) {
+      prompt += `**Current Context**: The active file belongs to subproject **${activeSubproject}**\n\n`;
+    }
+
+    prompt += '**Workspace Guidelines**:\n';
+    prompt += '- Each subproject may have its own build configuration, dependencies, and module structure\n';
+    prompt += '- When editing files, consider which subproject they belong to\n';
+    prompt += '- Cross-subproject references should be handled carefully (different package structures, etc.)\n';
+    prompt += '- Build commands should target the appropriate subproject\n\n';
+    prompt += '---\n\n';
+  } else if (hasModules) {
+    // Single project with multiple modules
+    prompt += '### Project Module Structure\n\n';
+    prompt += 'This project contains multiple modules:\n';
+    for (const mod of modules) {
+      const name = mod.name || 'unknown';
+      prompt += `- \`${name}\`\n`;
+    }
+    prompt += '\n**Note**: When editing files, consider which module they belong to and the module-specific configuration.\n\n';
+    prompt += '---\n\n';
+  }
 
   // Priority rules
   prompt += '**Context Priority Rules**:\n';
   prompt += '1. If code is selected → That specific code is the PRIMARY SUBJECT of the question\n';
   prompt += '2. If no code is selected → The currently active file is the PRIMARY SUBJECT\n';
-  prompt += '3. Other open files → Secondary context that MAY be relevant to the question\n\n';
+  prompt += '3. Other open files → Secondary context that MAY be relevant to the question\n';
+  if (hasWorkspace) {
+    prompt += '4. Workspace structure → Helps understand project boundaries and dependencies\n';
+  }
+  prompt += '\n';
 
   // File path format explanation
   prompt += '**File Path Format**: Paths may include line references: `#LX-Y` (lines X to Y) or `#LX` (single line X)\n\n';
@@ -120,7 +184,11 @@ function buildIDEContextPrompt(openedFiles, agentPrompt = null) {
   prompt += '- If the user asks a vague question (e.g., "what does this do?", "is this correct?"), apply it to the PRIMARY FOCUS (selected code or active file)\n';
   prompt += '- If the user mentions "this file", "this code", "here" → They mean the active file or selected code\n';
   prompt += '- If the user asks about relationships or dependencies → Consider the other open files as potential references\n';
-  prompt += '- Always prioritize the selected code > active file > other files when determining what the user is asking about\n\n';
+  prompt += '- Always prioritize the selected code > active file > other files when determining what the user is asking about\n';
+  if (hasWorkspace) {
+    prompt += '- For build/run commands, target the appropriate subproject (ask if unclear)\n';
+  }
+  prompt += '\n';
 
   return prompt;
 }

--- a/src/main/java/com/github/claudecodegui/handler/context/WorkspaceContextCollector.java
+++ b/src/main/java/com/github/claudecodegui/handler/context/WorkspaceContextCollector.java
@@ -25,6 +25,17 @@ public class WorkspaceContextCollector {
 
     private static final Logger LOG = Logger.getInstance(WorkspaceContextCollector.class);
 
+    private static final String CLASS_SUBPROJECT_MANAGER =
+        "com.intellij.ide.workspace.SubprojectManager";
+    private static final String CLASS_SUBPROJECT_MANAGER_KT =
+        "com.intellij.ide.workspace.SubprojectManagerKt";
+    private static final String CLASS_SUBPROJECT =
+        "com.intellij.ide.workspace.Subproject";
+    private static final String CLASS_WORKSPACE_SETTINGS =
+        "com.intellij.ide.workspace.WorkspaceSettings";
+    private static final String CLASS_SUBPROJECT_INFO_PROVIDER =
+        "com.intellij.openapi.project.workspace.SubprojectInfoProvider";
+
     private static final boolean WORKSPACE_PLUGIN_AVAILABLE = isWorkspacePluginAvailable();
     private static Method getSubprojectManagerMethod;
     private static Method getAllSubprojectsMethod;
@@ -32,18 +43,14 @@ public class WorkspaceContextCollector {
     private static Method getSubprojectNameMethod;
     private static Method getSubprojectByPathMethod;
     private static Method getHandlerMethod;
-    private static volatile Method isLoadedMethod;
     private static Class<?> subprojectClass;
 
     static {
         if (WORKSPACE_PLUGIN_AVAILABLE) {
             try {
-                Class<?> subprojectManagerClass = Class.forName(
-                    "com.intellij.ide.workspace.SubprojectManager");
-                Class<?> subprojectManagerKtClass = Class.forName(
-                    "com.intellij.ide.workspace.SubprojectManagerKt");
-                subprojectClass = Class.forName(
-                    "com.intellij.ide.workspace.Subproject");
+                Class<?> subprojectManagerClass = Class.forName(CLASS_SUBPROJECT_MANAGER);
+                Class<?> subprojectManagerKtClass = Class.forName(CLASS_SUBPROJECT_MANAGER_KT);
+                subprojectClass = Class.forName(CLASS_SUBPROJECT);
 
                 getSubprojectManagerMethod = subprojectManagerKtClass.getMethod(
                     "getSubprojectManager", Project.class);
@@ -68,8 +75,8 @@ public class WorkspaceContextCollector {
 
     private static boolean isWorkspacePluginAvailable() {
         try {
-            Class.forName("com.intellij.ide.workspace.SubprojectManager");
-            Class.forName("com.intellij.ide.workspace.WorkspaceSettings");
+            Class.forName(CLASS_SUBPROJECT_MANAGER);
+            Class.forName(CLASS_WORKSPACE_SETTINGS);
             return true;
         } catch (ClassNotFoundException e) {
             LOG.info("Workspace plugin not available - standard single-project mode");
@@ -140,8 +147,7 @@ public class WorkspaceContextCollector {
                 return false;
             }
 
-            Class<?> workspaceSettingsClass = Class.forName(
-                "com.intellij.ide.workspace.WorkspaceSettings");
+            Class<?> workspaceSettingsClass = Class.forName(CLASS_WORKSPACE_SETTINGS);
             Method getServiceMethod = workspaceSettingsClass.getMethod("getInstance", Project.class);
             Object settings = getServiceMethod.invoke(null, project);
 
@@ -238,6 +244,9 @@ public class WorkspaceContextCollector {
 
     /**
      * Check if a subproject is loaded.
+     * Resolves the isLoaded method against the actual handler class on each call,
+     * because different handlers (Gradle, Maven, etc.) may declare it on different classes.
+     * Method lookup is internally cached by the JVM, so the per-call cost is negligible.
      */
     private static boolean checkSubprojectLoaded(@NotNull Object subproject) {
         if (getHandlerMethod == null) {
@@ -248,9 +257,7 @@ public class WorkspaceContextCollector {
             Object handler = getHandlerMethod.invoke(subproject);
 
             if (handler != null) {
-                if (isLoadedMethod == null) {
-                    isLoadedMethod = handler.getClass().getMethod("isLoaded", subprojectClass);
-                }
+                Method isLoadedMethod = handler.getClass().getMethod("isLoaded", subprojectClass);
                 return Boolean.TRUE.equals(isLoadedMethod.invoke(handler, subproject));
             }
         } catch (Exception e) {
@@ -320,31 +327,49 @@ public class WorkspaceContextCollector {
             return null;
         }
 
-        // 1. Try using platform's SubprojectInfoProvider if available
+        // 1. Try using platform's SubprojectInfoProvider if available.
+        //    Prefer resolving the actual Subproject.getName() over deriving the name from
+        //    the path, because subproject display names may differ from their directory names.
         String subprojectPath = getSubprojectPathFromProvider(project, filePath);
         if (subprojectPath != null) {
+            String name = getSubprojectNameByPath(project, subprojectPath);
+            if (name != null) {
+                return name;
+            }
             return extractSubprojectNameFromPath(subprojectPath);
         }
 
-        // 2. Try using workspace plugin's SubprojectManager
-        if (WORKSPACE_PLUGIN_AVAILABLE && getSubprojectManagerMethod != null
-                && getSubprojectByPathMethod != null) {
-            try {
-                Object manager = getSubprojectManagerMethod.invoke(null, project);
-                if (manager != null) {
-                    Object subproject = getSubprojectByPathMethod.invoke(manager, filePath, false);
-
-                    if (subproject != null && subprojectClass.isInstance(subproject)) {
-                        return (String) getSubprojectNameMethod.invoke(subproject);
-                    }
-                }
-            } catch (Exception e) {
-                LOG.debug("Failed to get subproject for file via workspace plugin: " + e.getMessage());
-            }
+        // 2. Try using workspace plugin's SubprojectManager directly with the file path
+        String name = getSubprojectNameByPath(project, filePath);
+        if (name != null) {
+            return name;
         }
 
         // 3. Fallback: find module containing the file
         return getModuleForFile(project, filePath);
+    }
+
+    /**
+     * Look up a Subproject by path via the workspace plugin and return its name.
+     */
+    private static @Nullable String getSubprojectNameByPath(@NotNull Project project, @NotNull String path) {
+        if (!WORKSPACE_PLUGIN_AVAILABLE || getSubprojectManagerMethod == null
+                || getSubprojectByPathMethod == null || subprojectClass == null) {
+            return null;
+        }
+        try {
+            Object manager = getSubprojectManagerMethod.invoke(null, project);
+            if (manager == null) {
+                return null;
+            }
+            Object subproject = getSubprojectByPathMethod.invoke(manager, path, false);
+            if (subproject != null && subprojectClass.isInstance(subproject)) {
+                return (String) getSubprojectNameMethod.invoke(subproject);
+            }
+        } catch (Exception e) {
+            LOG.debug("Failed to get subproject name by path: " + e.getMessage());
+        }
+        return null;
     }
 
     /**
@@ -353,8 +378,7 @@ public class WorkspaceContextCollector {
      */
     private static @Nullable String getSubprojectPathFromProvider(@NotNull Project project, @NotNull String filePath) {
         try {
-            Class<?> subprojectInfoProviderClass = Class.forName(
-                "com.intellij.openapi.project.workspace.SubprojectInfoProvider");
+            Class<?> subprojectInfoProviderClass = Class.forName(CLASS_SUBPROJECT_INFO_PROVIDER);
             Method getServiceMethod = subprojectInfoProviderClass.getMethod("getInstance", Project.class);
             Object provider = getServiceMethod.invoke(null, project);
 
@@ -376,11 +400,18 @@ public class WorkspaceContextCollector {
 
     /**
      * Extract subproject name from path.
+     * Trims all trailing slashes before taking the last path segment.
      */
     private static @Nullable String extractSubprojectNameFromPath(@NotNull String path) {
-        String trimmed = path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
+        String trimmed = path;
+        while (trimmed.endsWith("/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+        if (trimmed.isEmpty()) {
+            return null;
+        }
         int lastSlash = trimmed.lastIndexOf('/');
-        if (lastSlash >= 0 && lastSlash < trimmed.length() - 1) {
+        if (lastSlash >= 0) {
             return trimmed.substring(lastSlash + 1);
         }
         return trimmed;

--- a/src/main/java/com/github/claudecodegui/handler/context/WorkspaceContextCollector.java
+++ b/src/main/java/com/github/claudecodegui/handler/context/WorkspaceContextCollector.java
@@ -1,0 +1,406 @@
+package com.github.claudecodegui.handler.context;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+
+/**
+ * Workspace context collector for multi-project workspace support.
+ * Dynamically detects and reads workspace plugin data to provide
+ * multi-directory/maven module information for AI context.
+ */
+public class WorkspaceContextCollector {
+
+    private static final Logger LOG = Logger.getInstance(WorkspaceContextCollector.class);
+
+    private static final boolean WORKSPACE_PLUGIN_AVAILABLE = isWorkspacePluginAvailable();
+    private static Method getSubprojectManagerMethod;
+    private static Method getAllSubprojectsMethod;
+    private static Method getSubprojectPathMethod;
+    private static Method getSubprojectNameMethod;
+    private static Method getSubprojectByPathMethod;
+    private static Method getHandlerMethod;
+    private static volatile Method isLoadedMethod;
+    private static Class<?> subprojectClass;
+
+    static {
+        if (WORKSPACE_PLUGIN_AVAILABLE) {
+            try {
+                Class<?> subprojectManagerClass = Class.forName(
+                    "com.intellij.ide.workspace.SubprojectManager");
+                Class<?> subprojectManagerKtClass = Class.forName(
+                    "com.intellij.ide.workspace.SubprojectManagerKt");
+                subprojectClass = Class.forName(
+                    "com.intellij.ide.workspace.Subproject");
+
+                getSubprojectManagerMethod = subprojectManagerKtClass.getMethod(
+                    "getSubprojectManager", Project.class);
+
+                getAllSubprojectsMethod = subprojectManagerClass.getMethod(
+                    "getAllSubprojects");
+
+                getSubprojectPathMethod = subprojectClass.getMethod("getProjectPath");
+                getSubprojectNameMethod = subprojectClass.getMethod("getName");
+
+                getHandlerMethod = subprojectClass.getMethod("getHandler");
+
+                getSubprojectByPathMethod = subprojectManagerClass.getMethod(
+                    "getSubprojectByPath", String.class, boolean.class);
+
+                LOG.info("Workspace plugin detected - multi-project context collection enabled");
+            } catch (Exception e) {
+                LOG.warn("Failed to load workspace plugin classes: " + e.getMessage());
+            }
+        }
+    }
+
+    private static boolean isWorkspacePluginAvailable() {
+        try {
+            Class.forName("com.intellij.ide.workspace.SubprojectManager");
+            Class.forName("com.intellij.ide.workspace.WorkspaceSettings");
+            return true;
+        } catch (ClassNotFoundException e) {
+            LOG.info("Workspace plugin not available - standard single-project mode");
+            return false;
+        }
+    }
+
+    /**
+     * Collect workspace context information for the given project.
+     *
+     * @param project The current project.
+     * @return JsonObject containing workspace information including subprojects.
+     */
+    public static @NotNull JsonObject collectWorkspaceContext(@Nullable Project project) {
+        JsonObject workspaceData = new JsonObject();
+
+        if (project == null) {
+            return workspaceData;
+        }
+
+        try {
+            // 1. Check if this is a multi-project workspace
+            boolean isWorkspace = checkIsWorkspace(project);
+            workspaceData.addProperty("isWorkspace", isWorkspace);
+
+            if (!isWorkspace) {
+                // If not a workspace, still collect module info for single project
+                collectModuleInfo(project, workspaceData);
+                return workspaceData;
+            }
+
+            // 2. Collect subprojects from workspace plugin
+            JsonArray subprojects = collectSubprojects(project);
+            workspaceData.add("subprojects", subprojects);
+            if (subprojects.size() > 0) {
+                LOG.debug("Collected " + subprojects.size() + " subprojects from workspace");
+            } else {
+                LOG.debug("No subprojects collected from workspace plugin");
+            }
+
+            // 3. Collect module information (may overlap with subprojects but provides more details)
+            collectModuleInfo(project, workspaceData);
+
+            // 4. Determine which subproject the active file belongs to
+            String projectBasePath = project.getBasePath();
+            if (projectBasePath != null) {
+                workspaceData.addProperty("workspaceRoot", projectBasePath);
+            }
+
+        } catch (Throwable t) {
+            LOG.warn("Failed to collect workspace context: " + t.getMessage(), t);
+        }
+
+        return workspaceData;
+    }
+
+    /**
+     * Check if the project is a multi-project workspace.
+     */
+    private static boolean checkIsWorkspace(@NotNull Project project) {
+        if (!WORKSPACE_PLUGIN_AVAILABLE || getSubprojectManagerMethod == null) {
+            return false;
+        }
+
+        try {
+            Object manager = getSubprojectManagerMethod.invoke(null, project);
+            if (manager == null) {
+                return false;
+            }
+
+            Class<?> workspaceSettingsClass = Class.forName(
+                "com.intellij.ide.workspace.WorkspaceSettings");
+            Method getServiceMethod = workspaceSettingsClass.getMethod("getInstance", Project.class);
+            Object settings = getServiceMethod.invoke(null, project);
+
+            if (settings != null) {
+                Method isWorkspaceMethod = workspaceSettingsClass.getMethod("isWorkspace");
+                return Boolean.TRUE.equals(isWorkspaceMethod.invoke(settings));
+            }
+        } catch (Exception e) {
+            LOG.debug("Failed to check isWorkspace: " + e.getMessage());
+        }
+
+        return false;
+    }
+
+    /**
+     * Collect subprojects from workspace plugin using reflection.
+     */
+    private static @NotNull JsonArray collectSubprojects(@NotNull Project project) {
+        JsonArray subprojectsArray = new JsonArray();
+
+        if (!WORKSPACE_PLUGIN_AVAILABLE || getSubprojectManagerMethod == null
+                || getAllSubprojectsMethod == null || subprojectClass == null) {
+            return subprojectsArray;
+        }
+
+        try {
+            Object manager = getSubprojectManagerMethod.invoke(null, project);
+            if (manager == null) {
+                return subprojectsArray;
+            }
+
+            Object subprojectsCollection = getAllSubprojectsMethod.invoke(manager);
+            if (!(subprojectsCollection instanceof Collection)) {
+                return subprojectsArray;
+            }
+
+            for (Object subproject : (Collection<?>) subprojectsCollection) {
+                if (subprojectClass.isInstance(subproject)) {
+                    JsonObject subprojectJson = new JsonObject();
+
+                    String name = (String) getSubprojectNameMethod.invoke(subproject);
+                    String path = (String) getSubprojectPathMethod.invoke(subproject);
+
+                    if (name != null && path != null) {
+                        subprojectJson.addProperty("name", name);
+                        subprojectJson.addProperty("path", path);
+
+                        String handlerType = getHandlerType(subproject);
+                        if (handlerType != null) {
+                            subprojectJson.addProperty("type", handlerType);
+                        }
+
+                        boolean isLoaded = checkSubprojectLoaded(subproject);
+                        subprojectJson.addProperty("loaded", isLoaded);
+
+                        subprojectsArray.add(subprojectJson);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to collect subprojects: " + e.getMessage());
+        }
+
+        return subprojectsArray;
+    }
+
+    /**
+     * Get the handler type for a subproject (Gradle, Maven, etc).
+     */
+    private static @Nullable String getHandlerType(@NotNull Object subproject) {
+        if (getHandlerMethod == null) {
+            return null;
+        }
+
+        try {
+            Object handler = getHandlerMethod.invoke(subproject);
+
+            if (handler != null) {
+                String handlerClassName = handler.getClass().getSimpleName();
+                if (handlerClassName.contains("Gradle")) {
+                    return "Gradle";
+                } else if (handlerClassName.contains("Maven")) {
+                    return "Maven";
+                } else if (handlerClassName.contains("Default")) {
+                    return "Default";
+                }
+                return handlerClassName.replace("SubprojectHandler", "");
+            }
+        } catch (Exception e) {
+            LOG.debug("Failed to get handler type: " + e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Check if a subproject is loaded.
+     */
+    private static boolean checkSubprojectLoaded(@NotNull Object subproject) {
+        if (getHandlerMethod == null) {
+            return true;
+        }
+
+        try {
+            Object handler = getHandlerMethod.invoke(subproject);
+
+            if (handler != null) {
+                if (isLoadedMethod == null) {
+                    isLoadedMethod = handler.getClass().getMethod("isLoaded", subprojectClass);
+                }
+                return Boolean.TRUE.equals(isLoadedMethod.invoke(handler, subproject));
+            }
+        } catch (Exception e) {
+            LOG.debug("Failed to check subproject loaded status: " + e.getMessage());
+        }
+        return true; // Assume loaded if we can't check
+    }
+
+    /**
+     * Collect module information from the project.
+     * This works even without workspace plugin.
+     */
+    private static void collectModuleInfo(@NotNull Project project, @NotNull JsonObject workspaceData) {
+        try {
+            Module[] modules = ModuleManager.getInstance(project).getModules();
+            JsonArray modulesArray = new JsonArray();
+
+            for (Module module : modules) {
+                JsonObject moduleJson = new JsonObject();
+                moduleJson.addProperty("name", module.getName());
+
+                VirtualFile[] contentRoots = ModuleRootManager.getInstance(module).getContentRoots();
+                if (contentRoots.length > 0) {
+                    JsonArray rootsArray = new JsonArray();
+                    for (VirtualFile root : contentRoots) {
+                        rootsArray.add(root.getPath());
+                    }
+                    moduleJson.add("contentRoots", rootsArray);
+                }
+
+                String moduleTypeName = getModuleTypeName(module);
+                if (moduleTypeName != null) {
+                    moduleJson.addProperty("type", moduleTypeName);
+                }
+
+                modulesArray.add(moduleJson);
+            }
+
+            if (modulesArray.size() > 0) {
+                workspaceData.add("modules", modulesArray);
+                LOG.debug("Collected " + modulesArray.size() + " modules");
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to collect module info: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Get module type name.
+     * Returns the module type identifier if set (non-standard module types like Maven, Gradle).
+     * Standard JAVA_MODULE types typically do not have this option set.
+     */
+    private static @Nullable String getModuleTypeName(@NotNull Module module) {
+        String moduleType = module.getOptionValue("moduleType");
+        return moduleType != null && !moduleType.isEmpty() ? moduleType : null;
+    }
+
+    /**
+     * Determine which subproject a file belongs to.
+     *
+     * @param project The project.
+     * @param filePath The file path to check.
+     * @return The subproject name if found, null otherwise.
+     */
+    public static @Nullable String getSubprojectForFile(@Nullable Project project, @Nullable String filePath) {
+        if (project == null || filePath == null) {
+            return null;
+        }
+
+        // 1. Try using platform's SubprojectInfoProvider if available
+        String subprojectPath = getSubprojectPathFromProvider(project, filePath);
+        if (subprojectPath != null) {
+            return extractSubprojectNameFromPath(subprojectPath);
+        }
+
+        // 2. Try using workspace plugin's SubprojectManager
+        if (WORKSPACE_PLUGIN_AVAILABLE && getSubprojectManagerMethod != null
+                && getSubprojectByPathMethod != null) {
+            try {
+                Object manager = getSubprojectManagerMethod.invoke(null, project);
+                if (manager != null) {
+                    Object subproject = getSubprojectByPathMethod.invoke(manager, filePath, false);
+
+                    if (subproject != null && subprojectClass.isInstance(subproject)) {
+                        return (String) getSubprojectNameMethod.invoke(subproject);
+                    }
+                }
+            } catch (Exception e) {
+                LOG.debug("Failed to get subproject for file via workspace plugin: " + e.getMessage());
+            }
+        }
+
+        // 3. Fallback: find module containing the file
+        return getModuleForFile(project, filePath);
+    }
+
+    /**
+     * Get subproject path using platform's SubprojectInfoProvider (if available).
+     * This class may not be available in all IntelliJ versions, so we use reflection.
+     */
+    private static @Nullable String getSubprojectPathFromProvider(@NotNull Project project, @NotNull String filePath) {
+        try {
+            Class<?> subprojectInfoProviderClass = Class.forName(
+                "com.intellij.openapi.project.workspace.SubprojectInfoProvider");
+            Method getServiceMethod = subprojectInfoProviderClass.getMethod("getInstance", Project.class);
+            Object provider = getServiceMethod.invoke(null, project);
+
+            if (provider != null) {
+                VirtualFile file = LocalFileSystem.getInstance().findFileByPath(filePath);
+                if (file != null) {
+                    Method getPathMethod = subprojectInfoProviderClass.getMethod(
+                        "getSubprojectPath", Project.class, VirtualFile.class);
+                    return (String) getPathMethod.invoke(provider, project, file);
+                }
+            }
+        } catch (ClassNotFoundException e) {
+            LOG.debug("SubprojectInfoProvider not available: " + e.getMessage());
+        } catch (Exception e) {
+            LOG.debug("Failed to get subproject path from provider: " + e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Extract subproject name from path.
+     */
+    private static @Nullable String extractSubprojectNameFromPath(@NotNull String path) {
+        String trimmed = path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
+        int lastSlash = trimmed.lastIndexOf('/');
+        if (lastSlash >= 0 && lastSlash < trimmed.length() - 1) {
+            return trimmed.substring(lastSlash + 1);
+        }
+        return trimmed;
+    }
+
+    /**
+     * Get the module name for a file.
+     */
+    private static @Nullable String getModuleForFile(@NotNull Project project, @NotNull String filePath) {
+        try {
+            VirtualFile file = LocalFileSystem.getInstance().findFileByPath(filePath);
+            if (file != null) {
+                Module module = ModuleUtilCore.findModuleForFile(file, project);
+                if (module != null) {
+                    return module.getName();
+                }
+            }
+        } catch (Exception e) {
+            LOG.debug("Failed to get module for file: " + e.getMessage());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/github/claudecodegui/session/EditorContextCollector.java
+++ b/src/main/java/com/github/claudecodegui/session/EditorContextCollector.java
@@ -1,6 +1,7 @@
 package com.github.claudecodegui.session;
 
 import com.github.claudecodegui.handler.context.ContextCollector;
+import com.github.claudecodegui.handler.context.WorkspaceContextCollector;
 import com.github.claudecodegui.util.EditorFileUtils;
 import com.github.claudecodegui.util.IgnoreRuleMatcher;
 import com.google.gson.JsonArray;
@@ -21,6 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Editor context collector.
  * Collects context information from the IDE editor (open files, selected code, etc.).
+ * Also collects workspace/multi-project information when the workspace plugin is available.
  */
 public class EditorContextCollector {
     private static final Logger LOG = Logger.getInstance(EditorContextCollector.class);
@@ -28,6 +30,7 @@ public class EditorContextCollector {
     private final Project project;
     private boolean psiContextEnabled = true;
     private boolean autoOpenFileEnabled = true;
+    private boolean workspaceContextEnabled = true;
 
     private boolean isQuickFix = false;
 
@@ -49,6 +52,14 @@ public class EditorContextCollector {
      */
     public void setAutoOpenFileEnabled(boolean enabled) {
         this.autoOpenFileEnabled = enabled;
+    }
+
+    /**
+     * Set whether workspace context collection is enabled.
+     * When enabled, multi-project workspace information is collected and added to context.
+     */
+    public void setWorkspaceContextEnabled(boolean enabled) {
+        this.workspaceContextEnabled = enabled;
     }
 
     /**
@@ -171,6 +182,34 @@ public class EditorContextCollector {
         if (othersArray.size() > 0) {
             openedFilesJson.add("others", othersArray);
             LOG.debug("Other opened files count: " + othersArray.size());
+        }
+
+        // Collect workspace/multi-project context
+        if (workspaceContextEnabled) {
+            try {
+                JsonObject workspaceContext = WorkspaceContextCollector.collectWorkspaceContext(project);
+                if (workspaceContext != null && workspaceContext.size() > 0) {
+                    // Merge workspace context into main object
+                    for (String key : workspaceContext.keySet()) {
+                        openedFilesJson.add(key, workspaceContext.get(key));
+                    }
+                    LOG.debug("Workspace context merged: isWorkspace="
+                        + (workspaceContext.has("isWorkspace")
+                            ? workspaceContext.get("isWorkspace").getAsBoolean() : false));
+
+                    // Determine which subproject the active file belongs to
+                    if (activeFile != null && workspaceContext.has("isWorkspace")
+                            && workspaceContext.get("isWorkspace").getAsBoolean()) {
+                        String subproject = WorkspaceContextCollector.getSubprojectForFile(project, activeFile);
+                        if (subproject != null) {
+                            openedFilesJson.addProperty("activeSubproject", subproject);
+                            LOG.debug("Active file belongs to subproject: " + subproject);
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to collect workspace context: " + e.getMessage());
+            }
         }
 
         if (isQuickFix) {

--- a/src/main/java/com/github/claudecodegui/session/SessionContextService.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionContextService.java
@@ -103,7 +103,8 @@ public class SessionContextService {
                     String name = sp.has("name") ? sp.get("name").getAsString() : "unknown";
                     String path = sp.has("path") ? sp.get("path").getAsString() : "";
                     String type = sp.has("type") ? sp.get("type").getAsString() : "";
-                    boolean loaded = sp.has("loaded") && sp.get("loaded").getAsBoolean();
+                    // Match the JS-side default in system-prompts.js: missing means loaded.
+                    boolean loaded = !sp.has("loaded") || sp.get("loaded").getAsBoolean();
 
                     sb.append("- **").append(name).append("**");
                     if (!type.isEmpty()) {
@@ -132,7 +133,7 @@ public class SessionContextService {
         if (openedFilesJson != null && openedFilesJson.has("modules")) {
             JsonArray modules = openedFilesJson.getAsJsonArray("modules");
             if (modules.size() > 1 && (!openedFilesJson.has("isWorkspace")
-                    || (openedFilesJson.has("isWorkspace") && !openedFilesJson.get("isWorkspace").getAsBoolean()))) {
+                    || !openedFilesJson.get("isWorkspace").getAsBoolean())) {
                 sb.append("\n\n## Project Modules\n\n");
                 sb.append("This project contains multiple modules:\n");
                 for (int i = 0; i < modules.size(); i++) {

--- a/src/main/java/com/github/claudecodegui/session/SessionContextService.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionContextService.java
@@ -85,6 +85,66 @@ public class SessionContextService {
         StringBuilder sb = new StringBuilder();
         boolean hasContent = false;
 
+        // 0. Workspace/Multi-project context (highest priority for project structure understanding)
+        if (openedFilesJson != null && openedFilesJson.has("isWorkspace")
+                && openedFilesJson.get("isWorkspace").getAsBoolean()) {
+            sb.append("\n\n## Workspace Context\n\n");
+            sb.append("You are working in a multi-project workspace environment.\n\n");
+
+            if (openedFilesJson.has("workspaceRoot")) {
+                sb.append("Workspace root: `").append(openedFilesJson.get("workspaceRoot").getAsString()).append("`\n\n");
+            }
+
+            if (openedFilesJson.has("subprojects")) {
+                JsonArray subprojects = openedFilesJson.getAsJsonArray("subprojects");
+                sb.append("Subprojects in this workspace:\n");
+                for (int i = 0; i < subprojects.size(); i++) {
+                    JsonObject sp = subprojects.get(i).getAsJsonObject();
+                    String name = sp.has("name") ? sp.get("name").getAsString() : "unknown";
+                    String path = sp.has("path") ? sp.get("path").getAsString() : "";
+                    String type = sp.has("type") ? sp.get("type").getAsString() : "";
+                    boolean loaded = sp.has("loaded") && sp.get("loaded").getAsBoolean();
+
+                    sb.append("- **").append(name).append("**");
+                    if (!type.isEmpty()) {
+                        sb.append(" (").append(type).append(")");
+                    }
+                    if (!loaded) {
+                        sb.append(" [not loaded]");
+                    }
+                    sb.append(": `").append(path).append("`\n");
+                }
+                sb.append("\n");
+            }
+
+            if (openedFilesJson.has("activeSubproject")) {
+                sb.append("The current file belongs to subproject: **")
+                    .append(openedFilesJson.get("activeSubproject").getAsString())
+                    .append("**\n\n");
+            }
+
+            sb.append("When working with files, consider which subproject they belong to. ")
+                .append("Each subproject may have its own build configuration, dependencies, and codebase structure.\n");
+            hasContent = true;
+        }
+
+        // Also show module info for single projects with multiple modules
+        if (openedFilesJson != null && openedFilesJson.has("modules")) {
+            JsonArray modules = openedFilesJson.getAsJsonArray("modules");
+            if (modules.size() > 1 && (!openedFilesJson.has("isWorkspace")
+                    || (openedFilesJson.has("isWorkspace") && !openedFilesJson.get("isWorkspace").getAsBoolean()))) {
+                sb.append("\n\n## Project Modules\n\n");
+                sb.append("This project contains multiple modules:\n");
+                for (int i = 0; i < modules.size(); i++) {
+                    JsonObject mod = modules.get(i).getAsJsonObject();
+                    String name = mod.has("name") ? mod.get("name").getAsString() : "unknown";
+                    sb.append("- `").append(name).append("`\n");
+                }
+                sb.append("\n");
+                hasContent = true;
+            }
+        }
+
         List<String> terminalPaths = new ArrayList<>();
         List<String> regularFilePaths = new ArrayList<>();
 

--- a/src/test/java/com/github/claudecodegui/handler/context/WorkspaceContextCollectorTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/context/WorkspaceContextCollectorTest.java
@@ -1,0 +1,120 @@
+package com.github.claudecodegui.handler.context;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for WorkspaceContextCollector.
+ * Tests the workspace context collection functionality for multi-project support.
+ */
+public class WorkspaceContextCollectorTest {
+
+    /**
+     * Test that collectWorkspaceContext returns empty JSON for null project.
+     */
+    @Test
+    public void collectWorkspaceContextReturnsEmptyForNullProject() {
+        JsonObject result = WorkspaceContextCollector.collectWorkspaceContext(null);
+
+        assertNotNull(result);
+        assertEquals(0, result.size());
+    }
+
+    /**
+     * Test that getSubprojectForFile returns null when project is null.
+     */
+    @Test
+    public void getSubprojectForFileReturnsNullForNullProject() {
+        assertNull(WorkspaceContextCollector.getSubprojectForFile(null, "/some/path"));
+    }
+
+    /**
+     * Test that getSubprojectForFile returns null when file path is null.
+     */
+    @Test
+    public void getSubprojectForFileReturnsNullForNullPath() {
+        assertNull(WorkspaceContextCollector.getSubprojectForFile(null, null));
+    }
+
+    /**
+     * Test that static methods produce consistent results across multiple calls.
+     */
+    @Test
+    public void staticMethodsProduceConsistentResults() {
+        JsonObject result1 = WorkspaceContextCollector.collectWorkspaceContext(null);
+        JsonObject result2 = WorkspaceContextCollector.collectWorkspaceContext(null);
+
+        assertEquals(result1.size(), result2.size());
+        assertEquals(0, result1.size());
+    }
+
+    /**
+     * Test extractSubprojectNameFromPath with normal paths.
+     */
+    @Test
+    public void extractSubprojectNameFromNormalPath() throws Exception {
+        String name = invokeExtractName("/home/user/projects/my-app");
+        assertEquals("my-app", name);
+    }
+
+    /**
+     * Test extractSubprojectNameFromPath with trailing slash.
+     */
+    @Test
+    public void extractSubprojectNameFromPathWithTrailingSlash() throws Exception {
+        String name = invokeExtractName("/home/user/projects/my-app/");
+        assertEquals("my-app", name);
+    }
+
+    /**
+     * Test extractSubprojectNameFromPath with simple name (no slash).
+     */
+    @Test
+    public void extractSubprojectNameFromSimpleName() throws Exception {
+        String name = invokeExtractName("my-app");
+        assertEquals("my-app", name);
+    }
+
+    /**
+     * Test extractSubprojectNameFromPath with multiple trailing slashes.
+     */
+    @Test
+    public void extractSubprojectNameFromPathWithMultipleTrailingSlashes() throws Exception {
+        // Only single trailing slash is trimmed
+        String name = invokeExtractName("/home/user/projects/my-app/");
+        assertEquals("my-app", name);
+    }
+
+    /**
+     * Test that subprojects array is always present when isWorkspace is true.
+     * Verifies the fix for the conditional subprojects key issue.
+     */
+    @Test
+    public void subprojectsAlwaysPresentWhenIsWorkspace() throws Exception {
+        // We can't easily test with a real workspace project in unit tests,
+        // but we can verify the JSON structure contract by checking that
+        // when collectWorkspaceContext returns isWorkspace=true, subprojects key exists
+        // This is validated indirectly - the static method always adds subprojects array
+        // when isWorkspace path is taken (verified via code review).
+        // Here we just ensure the method is callable and returns valid JSON.
+        JsonObject result = WorkspaceContextCollector.collectWorkspaceContext(null);
+        assertNotNull(result);
+        // For null project, we get an empty object (no isWorkspace key)
+        assertTrue(!result.has("isWorkspace"));
+    }
+
+    private static String invokeExtractName(String path) throws Exception {
+        Method method = WorkspaceContextCollector.class.getDeclaredMethod(
+            "extractSubprojectNameFromPath", String.class);
+        method.setAccessible(true);
+        return (String) method.invoke(null, path);
+    }
+}

--- a/src/test/java/com/github/claudecodegui/handler/context/WorkspaceContextCollectorTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/context/WorkspaceContextCollectorTest.java
@@ -1,15 +1,14 @@
 package com.github.claudecodegui.handler.context;
 
-import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test for WorkspaceContextCollector.
@@ -85,30 +84,31 @@ public class WorkspaceContextCollectorTest {
 
     /**
      * Test extractSubprojectNameFromPath with multiple trailing slashes.
+     * All trailing slashes should be trimmed before taking the last segment.
      */
     @Test
     public void extractSubprojectNameFromPathWithMultipleTrailingSlashes() throws Exception {
-        // Only single trailing slash is trimmed
-        String name = invokeExtractName("/home/user/projects/my-app/");
+        String name = invokeExtractName("/home/user/projects/my-app//");
         assertEquals("my-app", name);
     }
 
     /**
-     * Test that subprojects array is always present when isWorkspace is true.
-     * Verifies the fix for the conditional subprojects key issue.
+     * Test that extractSubprojectNameFromPath returns null for an all-slashes path.
      */
     @Test
-    public void subprojectsAlwaysPresentWhenIsWorkspace() throws Exception {
-        // We can't easily test with a real workspace project in unit tests,
-        // but we can verify the JSON structure contract by checking that
-        // when collectWorkspaceContext returns isWorkspace=true, subprojects key exists
-        // This is validated indirectly - the static method always adds subprojects array
-        // when isWorkspace path is taken (verified via code review).
-        // Here we just ensure the method is callable and returns valid JSON.
+    public void extractSubprojectNameFromAllSlashes() throws Exception {
+        String name = invokeExtractName("///");
+        assertNull(name);
+    }
+
+    /**
+     * Test that null project results in a JSON object without an isWorkspace key.
+     */
+    @Test
+    public void nullProjectProducesEmptyContextWithoutIsWorkspaceKey() {
         JsonObject result = WorkspaceContextCollector.collectWorkspaceContext(null);
         assertNotNull(result);
-        // For null project, we get an empty object (no isWorkspace key)
-        assertTrue(!result.has("isWorkspace"));
+        assertFalse(result.has("isWorkspace"));
     }
 
     private static String invokeExtractName(String path) throws Exception {


### PR DESCRIPTION
Add workspace/multi-project context collection to improve AI understanding of project structure when working in IntelliJ's workspace mode (multiple projects in a single window).

Changes across three layers:

Java Plugin Layer:
- Add WorkspaceContextCollector that dynamically detects the Workspace Plugin via reflection and collects subproject/module information. Gracefully falls back to module-only collection when the plugin is unavailable (e.g. in PyCharm, WebStorm).
- Integrate workspace context into EditorContextCollector as a reusable member field, with a toggle to enable/disable collection.
- Add workspace and module context sections to SessionContextService's Codex context builder, providing Codex with the same structural awareness that Claude receives via system-prompts.js.

AI Bridge Layer (Node.js):
- Extend buildIDEContextPrompt() in system-prompts.js to render workspace subproject listings, module structure, and workspace-specific guidelines into the Claude system prompt when multi-project data is present.
- Add context priority rules for workspace structure and subproject-aware build command targeting.

Tests:
- Add WorkspaceContextCollectorTest covering null-safety and static state sharing across instances.
- Rename mergeAssistantMessageKeepsMoreCompleteThinkingBlock to mergeAssistantMessageKeepsMoreCompleteThinkingBlockWithToolUse to resolve test name collision.