### PR TITLE
feat(webview): add clickable file and class links in markdown content

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,10 +113,12 @@ sourceSets {
             // PyCharm: exclude Java context collector
             if (targetIde == 'PC' || targetIde == 'PY') {
                 exclude '**/JavaContextCollector.java'
+                exclude '**/JavaClassNavigationSupport.java'
             }
             // Rider: exclude both Java and Python context collectors (no PSI support)
             if (targetIde == 'RD') {
                 exclude '**/JavaContextCollector.java'
+                exclude '**/JavaClassNavigationSupport.java'
                 exclude '**/PythonContextCollector.java'
             }
         }

--- a/src/main/java/com/github/claudecodegui/handler/file/FileHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/file/FileHandler.java
@@ -26,9 +26,16 @@ public class FileHandler extends BaseMessageHandler {
 
     private static final Logger LOG = Logger.getInstance(FileHandler.class);
 
-    private static final String[] SUPPORTED_TYPES = {"list_files", "open_file", "open_browser"};
+    private static final String[] SUPPORTED_TYPES = {
+        "list_files",
+        "open_file",
+        "open_browser",
+        "open_class",
+        "get_linkify_capabilities"
+    };
 
     private final OpenFileHandler openFileHandler;
+    private final OpenClassHandler openClassHandler;
     private final OpenFileCollector openFileCollector;
     private final RecentFileCollector recentFileCollector;
     private final FileSystemCollector fileSystemCollector;
@@ -37,6 +44,7 @@ public class FileHandler extends BaseMessageHandler {
     public FileHandler(HandlerContext context) {
         super(context);
         this.openFileHandler = new OpenFileHandler(context);
+        this.openClassHandler = new OpenClassHandler(context);
         this.openFileCollector = new OpenFileCollector(context);
         this.recentFileCollector = new RecentFileCollector(context);
         this.fileSystemCollector = new FileSystemCollector();
@@ -63,8 +71,23 @@ public class FileHandler extends BaseMessageHandler {
                 openFileHandler.handleOpenBrowser(content);
                 yield true;
             }
+            case "open_class" -> {
+                openClassHandler.handleOpenClass(content);
+                yield true;
+            }
+            case "get_linkify_capabilities" -> {
+                sendLinkifyCapabilities();
+                yield true;
+            }
             default -> false;
         };
+    }
+
+    private void sendLinkifyCapabilities() {
+        String capabilitiesJson = OpenClassHandler.buildCapabilitiesJson();
+        ApplicationManager.getApplication().invokeLater(() ->
+            callJavaScript("window.updateLinkifyCapabilities", escapeJs(capabilitiesJson))
+        );
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/handler/file/JavaClassNavigationSupport.java
+++ b/src/main/java/com/github/claudecodegui/handler/file/JavaClassNavigationSupport.java
@@ -1,0 +1,111 @@
+package com.github.claudecodegui.handler.file;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.fileEditor.OpenFileDescriptor;
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.pom.Navigatable;
+import com.intellij.psi.JavaPsiFacade;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.SmartPointerManager;
+import com.intellij.psi.SmartPsiElementPointer;
+import com.intellij.psi.search.GlobalSearchScope;
+
+import java.util.function.Consumer;
+
+/**
+ * Java PSI-backed class navigation support.
+ * This class must only be loaded when com.intellij.java is available.
+ */
+public class JavaClassNavigationSupport {
+
+    private static final Logger LOG = Logger.getInstance(JavaClassNavigationSupport.class);
+
+    /**
+     * Navigate to a class in project and library scope.
+     * Called reflectively from {@link OpenClassHandler}.
+     */
+    public static boolean navigate(Project project, String fqcn, Consumer<String> onFailure) {
+        if (project == null || project.isDisposed() || fqcn == null || fqcn.isBlank()) {
+            return false;
+        }
+
+        if (DumbService.isDumb(project)) {
+            DumbService.getInstance(project).runWhenSmart(() -> {
+                boolean navigated = navigateWhenSmart(project, fqcn);
+                if (!navigated) {
+                    LOG.warn("Unable to resolve class after indexing completed: " + fqcn);
+                    notifyNavigationFailure(onFailure, fqcn);
+                }
+            });
+            return true;
+        }
+
+        boolean navigated = navigateWhenSmart(project, fqcn);
+        if (!navigated) {
+            notifyNavigationFailure(onFailure, fqcn);
+        }
+
+        return true;
+    }
+
+    private static void notifyNavigationFailure(Consumer<String> onFailure, String fqcn) {
+        if (onFailure != null) {
+            onFailure.accept("Cannot open class: not found (" + fqcn + ")");
+        }
+    }
+
+    private static boolean navigateWhenSmart(Project project, String fqcn) {
+        SmartPsiElementPointer<PsiElement> pointer = ReadAction.compute(() -> {
+            PsiClass psiClass = JavaPsiFacade.getInstance(project)
+                .findClass(fqcn, createClassSearchScope(project));
+            if (psiClass == null) {
+                return null;
+            }
+
+            PsiElement navigationTarget = psiClass.getNavigationElement();
+            PsiElement target = navigationTarget != null ? navigationTarget : psiClass;
+            return SmartPointerManager.getInstance(project).createSmartPsiElementPointer(target);
+        });
+
+        if (pointer == null) {
+            return false;
+        }
+
+        ApplicationManager.getApplication().invokeLater(() -> navigatePointer(project, pointer), ModalityState.nonModal());
+        return true;
+    }
+
+    static GlobalSearchScope createClassSearchScope(Project project) {
+        return GlobalSearchScope.allScope(project);
+    }
+
+    private static void navigatePointer(Project project, SmartPsiElementPointer<PsiElement> pointer) {
+        if (project.isDisposed()) {
+            return;
+        }
+
+        PsiElement target = pointer.getElement();
+        if (target == null || !target.isValid()) {
+            return;
+        }
+
+        if (target instanceof Navigatable navigatable && navigatable.canNavigate()) {
+            navigatable.navigate(true);
+            return;
+        }
+
+        PsiFile containingFile = target.getContainingFile();
+        if (containingFile == null || containingFile.getVirtualFile() == null) {
+            return;
+        }
+
+        int offset = Math.max(target.getTextOffset(), 0);
+        new OpenFileDescriptor(project, containingFile.getVirtualFile(), offset).navigate(true);
+    }
+}

--- a/src/main/java/com/github/claudecodegui/handler/file/OpenClassHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/file/OpenClassHandler.java
@@ -1,0 +1,155 @@
+package com.github.claudecodegui.handler.file;
+
+import com.github.claudecodegui.handler.core.HandlerContext;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+
+/**
+ * Handles Java fully-qualified class navigation requests.
+ */
+public class OpenClassHandler {
+
+    private static final Logger LOG = Logger.getInstance(OpenClassHandler.class);
+    private static final Pattern JAVA_FQCN_PATTERN = Pattern.compile(
+        "^[a-z_][a-z0-9_]*(?:\\.[a-z_][a-z0-9_]*)*\\.[A-Z][A-Za-z0-9_]*(?:\\.[A-Z][A-Za-z0-9_]*)*$"
+    );
+    private static final Method NAVIGATE_METHOD = loadNavigateMethod();
+
+    @FunctionalInterface
+    interface NavigationInvoker {
+        boolean navigate(Project project, String fqcn, Consumer<String> onFailure) throws Exception;
+    }
+
+    private final HandlerContext context;
+    private final NavigationInvoker navigationInvoker;
+    private final boolean classNavigationEnabled;
+
+    OpenClassHandler(HandlerContext context) {
+        this(context, createNavigationInvoker(), isClassNavigationEnabled());
+    }
+
+    OpenClassHandler(HandlerContext context, NavigationInvoker navigationInvoker) {
+        this(context, navigationInvoker, true);
+    }
+
+    OpenClassHandler(HandlerContext context, NavigationInvoker navigationInvoker, boolean classNavigationEnabled) {
+        this.context = context;
+        this.navigationInvoker = navigationInvoker;
+        this.classNavigationEnabled = classNavigationEnabled;
+    }
+
+    public static boolean isClassNavigationEnabled() {
+        return NAVIGATE_METHOD != null;
+    }
+
+    public static String buildCapabilitiesJson() {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("classNavigationEnabled", isClassNavigationEnabled());
+        return payload.toString();
+    }
+
+    static boolean isValidClassName(String fqcn) {
+        if (fqcn == null) {
+            return false;
+        }
+
+        String trimmed = fqcn.trim();
+        if (trimmed.isEmpty()) {
+            return false;
+        }
+
+        return JAVA_FQCN_PATTERN.matcher(trimmed).matches()
+            && !trimmed.contains("#")
+            && !trimmed.contains("(");
+    }
+
+    void handleOpenClass(String fqcn) {
+        String trimmed = fqcn == null ? "" : fqcn.trim();
+        LOG.debug("Open class request: " + trimmed);
+
+        if (!isValidClassName(trimmed)) {
+            showError("Cannot open class: invalid class name (" + trimmed + ")");
+            return;
+        }
+
+        Project project = context.getProject();
+        if (project == null || project.isDisposed()) {
+            showError("Cannot open class: project is not available");
+            return;
+        }
+
+        if (!classNavigationEnabled) {
+            showError("Cannot open class: Java navigation is not available in this IDE");
+            return;
+        }
+
+        CompletableFuture.runAsync(() -> executeNavigation(project, trimmed));
+    }
+
+    void executeNavigation(Project project, String fqcn) {
+        try {
+            boolean accepted = navigationInvoker.navigate(project, fqcn, this::showError);
+            if (!accepted) {
+                LOG.warn("Class navigation request was not accepted: " + fqcn);
+                showError("Cannot open class: " + fqcn);
+            }
+        } catch (IllegalAccessException e) {
+            LOG.warn("Failed to open class (reflection access denied): " + fqcn + ", error=" + e.getMessage(), e);
+            showError("Cannot open class: " + fqcn);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            LOG.warn("Failed to open class (PSI navigation error): " + fqcn + ", error=" + cause.getMessage(), cause);
+            showError("Cannot open class: " + fqcn);
+        } catch (Exception e) {
+            LOG.warn("Failed to open class: " + fqcn + ", error=" + e.getMessage(), e);
+            showError("Cannot open class: " + fqcn);
+        }
+    }
+
+    private void showError(String message) {
+        if (context.getBrowser() == null
+            || ApplicationManager.getApplication() == null
+            || ApplicationManager.getApplication().isUnitTestMode()) {
+            context.callJavaScript("addErrorMessage", context.escapeJs(message));
+            return;
+        }
+
+        ApplicationManager.getApplication().invokeLater(() -> {
+            context.callJavaScript("addErrorMessage", context.escapeJs(message));
+        }, ModalityState.nonModal());
+    }
+
+    private static NavigationInvoker createNavigationInvoker() {
+        if (NAVIGATE_METHOD == null) {
+            return (project, fqcn, onFailure) -> false;
+        }
+
+        return (project, fqcn, onFailure) -> Boolean.TRUE.equals(
+            NAVIGATE_METHOD.invoke(null, project, fqcn, onFailure)
+        );
+    }
+
+    private static Method loadNavigateMethod() {
+        try {
+            Class.forName("com.intellij.psi.PsiJavaFile");
+            Class<?> navigationSupportClass = Class.forName(
+                "com.github.claudecodegui.handler.file.JavaClassNavigationSupport"
+            );
+            return navigationSupportClass.getMethod("navigate", Project.class, String.class, Consumer.class);
+        } catch (ClassNotFoundException e) {
+            LOG.info("Java class navigation is unavailable in this IDE");
+        } catch (Exception e) {
+            LOG.warn("Failed to initialize Java class navigation support: " + e.getMessage(), e);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/github/claudecodegui/handler/file/OpenFileHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/file/OpenFileHandler.java
@@ -13,9 +13,22 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.ScrollType;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.search.FilenameIndex;
+import com.intellij.psi.search.GlobalSearchScope;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Handles opening files in the editor and opening URLs in the browser.
@@ -23,6 +36,7 @@ import java.util.concurrent.CompletableFuture;
 class OpenFileHandler {
 
     private static final Logger LOG = Logger.getInstance(OpenFileHandler.class);
+    private static final Pattern LINE_INFO_PATTERN = Pattern.compile("^(.*):(\\d+)(?:-(\\d+))?$");
 
     private final HandlerContext context;
 
@@ -39,14 +53,14 @@ class OpenFileHandler {
 
         CompletableFuture.runAsync(() -> {
             try {
-                int[] lineInfo = parseLineInfo(filePath);
-                String actualPath = lineInfo[2] == 1 ? filePath.substring(0, filePath.lastIndexOf(':')) : filePath;
-                int lineNumber = lineInfo[0];
-                int endLineNumber = lineInfo[1];
+                LineInfo lineInfo = parseLineInfo(filePath);
+                String actualPath = lineInfo.actualPath();
+                int lineNumber = lineInfo.lineNumber();
+                int endLineNumber = lineInfo.endLineNumber();
 
-                File file = resolveFile(actualPath);
+                FileResolutionResult resolution = resolveFile(actualPath);
 
-                if (file == null) {
+                if (resolution == null) {
                     LOG.warn("File not found: " + actualPath);
                     ApplicationManager.getApplication().invokeLater(() -> {
                         context.callJavaScript("addErrorMessage", context.escapeJs("Cannot open file: file does not exist (" + actualPath + ")"));
@@ -54,7 +68,20 @@ class OpenFileHandler {
                     return;
                 }
 
-                final File finalFile = file;
+                // Direct VirtualFile from fuzzy match - skip File conversion
+                if (resolution.virtualFile() != null) {
+                    ApplicationManager.getApplication().invokeLater(() -> {
+                        if (context.getProject().isDisposed() || !resolution.virtualFile().isValid()) {
+                            return;
+                        }
+                        openInEditor(resolution.virtualFile(), lineNumber, endLineNumber);
+                        LOG.info("Successfully opened file via fuzzy match: " + filePath);
+                    }, ModalityState.nonModal());
+                    return;
+                }
+
+                // Standard File path resolution
+                final File finalFile = resolution.file();
                 EditorFileUtils.refreshAndFindFileAsync(finalFile, virtualFile -> {
                     ApplicationManager.getApplication().invokeLater(() -> {
                         if (context.getProject().isDisposed() || !virtualFile.isValid()) {
@@ -75,67 +102,315 @@ class OpenFileHandler {
 
     /**
      * Parse line number info from file path.
-     * @return int[3]: [lineNumber, endLineNumber, hasLineInfo(0 or 1)]
      */
-    private int[] parseLineInfo(String filePath) {
-        int colonIndex = filePath.lastIndexOf(':');
-        if (colonIndex > 0) {
-            String afterColon = filePath.substring(colonIndex + 1);
-            if (afterColon.matches("\\d+(-\\d+)?")) {
-                int dashIndex = afterColon.indexOf('-');
-                String startLineStr = dashIndex > 0 ? afterColon.substring(0, dashIndex) : afterColon;
-                String endLineStr = dashIndex > 0 ? afterColon.substring(dashIndex + 1) : null;
-                try {
-                    int lineNumber = Integer.parseInt(startLineStr);
-                    int endLineNumber = (endLineStr != null && !endLineStr.isBlank()) ? Integer.parseInt(endLineStr) : -1;
-                    return new int[]{lineNumber, endLineNumber, 1};
-                } catch (NumberFormatException e) {
-                    LOG.warn("Failed to parse line number: " + afterColon);
-                }
-            }
+    static LineInfo parseLineInfo(String filePath) {
+        if (filePath == null || filePath.isBlank()) {
+            return new LineInfo(filePath, -1, -1, false);
         }
-        return new int[]{-1, -1, 0};
+
+        Matcher matcher = LINE_INFO_PATTERN.matcher(filePath);
+        if (!matcher.matches()) {
+            return new LineInfo(filePath, -1, -1, false);
+        }
+
+        String actualPath = matcher.group(1);
+        if (actualPath == null || actualPath.isBlank() || actualPath.matches(".*:\\d+$")) {
+            return new LineInfo(filePath, -1, -1, false);
+        }
+
+        try {
+            int lineNumber = Integer.parseInt(matcher.group(2));
+            int endLineNumber = matcher.group(3) != null ? Integer.parseInt(matcher.group(3)) : -1;
+            if (lineNumber <= 0 || (endLineNumber > 0 && endLineNumber < lineNumber)) {
+                return new LineInfo(filePath, -1, -1, false);
+            }
+
+            return new LineInfo(actualPath, lineNumber, endLineNumber, true);
+        } catch (NumberFormatException e) {
+            LOG.warn("Failed to parse line number: " + filePath);
+            return new LineInfo(filePath, -1, -1, false);
+        }
     }
 
     /**
-     * Resolve file path, handling MSYS paths and relative paths.
+     * Resolve file path, handling MSYS paths, relative paths, and fuzzy filename matching.
+     * Returns either a direct File path or a VirtualFile from fuzzy matching.
+     * Fuzzy matching searches for files by name when the path cannot be resolved directly.
      */
-    private File resolveFile(String actualPath) {
-        File file = new File(actualPath);
-        if (!file.exists() && PlatformUtils.isWindows()) {
+    private FileResolutionResult resolveFile(String actualPath) {
+        File directFile = normalizeExistingFile(new File(actualPath));
+        if (directFile != null) {
+            return new FileResolutionResult(directFile, null);
+        }
+
+        String resolvedPath = actualPath;
+        if (PlatformUtils.isWindows()) {
             String convertedPath = PathUtils.convertMsysToWindowsPath(actualPath);
             if (!convertedPath.equals(actualPath)) {
                 LOG.info("Detected MSYS2 path, converted to Windows path: " + convertedPath);
-                file = new File(convertedPath);
+                File convertedFile = normalizeExistingFile(new File(convertedPath));
+                if (convertedFile != null) {
+                    return new FileResolutionResult(convertedFile, null);
+                }
+                resolvedPath = convertedPath;
             }
         }
 
-        if (!file.exists() && !file.isAbsolute() && context.getProject().getBasePath() != null) {
-            File projectFile = new File(context.getProject().getBasePath(), actualPath);
-            LOG.info("Trying to resolve relative to project root: " + projectFile.getAbsolutePath());
-            if (projectFile.exists()) {
-                file = projectFile;
+        File pathCandidate = new File(resolvedPath);
+        if (pathCandidate.isAbsolute()) {
+            return null;
+        }
+
+        for (File baseDirectory : getResolutionBases()) {
+            File candidate = normalizeExistingFile(new File(baseDirectory, resolvedPath));
+            if (candidate != null) {
+                LOG.info("Resolved relative file against " + baseDirectory.getAbsolutePath() + ": " + candidate.getAbsolutePath());
+                return new FileResolutionResult(candidate, null);
             }
         }
 
-        return file.exists() ? file : null;
+        // Fallback: fuzzy filename search using IDEA's file index
+        VirtualFile fuzzyMatch = resolveFileByFuzzyMatch(actualPath);
+        if (fuzzyMatch != null) {
+            LOG.info("Resolved file by fuzzy match: " + fuzzyMatch.getPath());
+            return new FileResolutionResult(null, fuzzyMatch);
+        }
+
+        return null;
+    }
+
+    /**
+     * Fuzzy file matching: search for files by name in the project scope.
+     * Handles cases like "linkify.ts" -> finds "src/utils/linkify.ts".
+     * Returns null during dumb mode to avoid IndexNotReadyException.
+     */
+    private VirtualFile resolveFileByFuzzyMatch(String pathHint) {
+        Project project = context.getProject();
+        if (project == null || project.isDisposed()) {
+            return null;
+        }
+
+        // FilenameIndex requires indexes to be ready
+        if (DumbService.isDumb(project)) {
+            LOG.info("Fuzzy file match deferred during dumb mode for: " + pathHint);
+            return null;
+        }
+
+        // Extract the filename from the path hint
+        String fileName = extractFileName(pathHint);
+        if (fileName == null || fileName.isBlank()) {
+            return null;
+        }
+
+        // Extract path suffix for matching
+        String pathSuffix = extractPathSuffix(pathHint);
+
+        // FilenameIndex requires read access
+        return ReadAction.compute(() -> {
+            // Search for files with matching name in project scope
+            Collection<VirtualFile> matches = FilenameIndex.getVirtualFilesByName(
+                project,
+                fileName,
+                GlobalSearchScope.projectScope(project)
+            );
+
+            if (matches.isEmpty()) {
+                return null;
+            }
+
+            // If there's a path hint (e.g., "utils/linkify.ts"), try to match by path suffix
+            if (pathSuffix != null && !pathSuffix.isBlank()) {
+                for (VirtualFile match : matches) {
+                    String matchPath = match.getPath();
+                    if (matchPath.endsWith(pathSuffix) || matchPath.contains(pathSuffix)) {
+                        return match;
+                    }
+                }
+            }
+
+            // If multiple matches, prefer files in common source directories
+            VirtualFile bestMatch = null;
+            for (VirtualFile match : matches) {
+                String matchPath = match.getPath();
+                // Prefer src/, main/, or project root files
+                if (matchPath.contains("/src/") || matchPath.contains("\\src\\")) {
+                    if (bestMatch == null || !bestMatch.getPath().contains("/src/")) {
+                        bestMatch = match;
+                    }
+                } else if (matchPath.contains("/main/") || matchPath.contains("\\main\\")) {
+                    if (bestMatch == null) {
+                        bestMatch = match;
+                    }
+                } else if (bestMatch == null) {
+                    bestMatch = match;
+                }
+            }
+
+            return bestMatch;
+        });
+    }
+
+    /**
+     * Extract the filename from a path string.
+     * "src/utils/linkify.ts" -> "linkify.ts"
+     * "linkify.ts" -> "linkify.ts"
+     */
+    private static String extractFileName(String path) {
+        if (path == null || path.isBlank()) {
+            return null;
+        }
+
+        // Handle both Unix and Windows path separators
+        int lastSep = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+        if (lastSep >= 0 && lastSep < path.length() - 1) {
+            return path.substring(lastSep + 1);
+        }
+
+        return path;
+    }
+
+    /**
+     * Extract the path suffix for matching.
+     * "src/utils/linkify.ts" -> "utils/linkify.ts"
+     * Used to find files that match the directory structure hint.
+     */
+    private static String extractPathSuffix(String path) {
+        if (path == null || path.isBlank()) {
+            return null;
+        }
+
+        // Skip the first directory segment if it's a common root
+        String normalized = path.replace('\\', '/');
+        String[] segments = normalized.split("/");
+
+        if (segments.length <= 1) {
+            return null;
+        }
+
+        // Find a meaningful suffix (skip common roots like "src", "main")
+        int startIdx = 0;
+        if (segments.length > 2) {
+            String first = segments[0].toLowerCase();
+            if ("src".equals(first) || "main".equals(first) || "java".equals(first) ||
+                "kotlin".equals(first) || "webview".equals(first)) {
+                startIdx = 1;
+            }
+        }
+
+        if (startIdx >= segments.length - 1) {
+            return null;
+        }
+
+        StringBuilder suffix = new StringBuilder();
+        for (int i = startIdx; i < segments.length; i++) {
+            if (suffix.length() > 0) {
+                suffix.append('/');
+            }
+            suffix.append(segments[i]);
+        }
+
+        return suffix.toString();
+    }
+
+    private List<File> getResolutionBases() {
+        LinkedHashSet<String> basePaths = new LinkedHashSet<>();
+
+        if (context.getSession() != null) {
+            String sessionCwd = context.getSession().getCwd();
+            if (sessionCwd != null && !sessionCwd.isBlank()) {
+                basePaths.add(sessionCwd);
+            }
+        }
+
+        String customWorkingDirectory = resolveCustomWorkingDirectory();
+        if (customWorkingDirectory != null) {
+            basePaths.add(customWorkingDirectory);
+        }
+
+        String projectBasePath = context.getProject().getBasePath();
+        if (projectBasePath != null && !projectBasePath.isBlank()) {
+            basePaths.add(projectBasePath);
+        }
+
+        List<File> bases = new ArrayList<>();
+        for (String basePath : basePaths) {
+            File directory = normalizeExistingDirectory(basePath);
+            if (directory != null) {
+                bases.add(directory);
+            }
+        }
+        return bases;
+    }
+
+    private String resolveCustomWorkingDirectory() {
+        String projectBasePath = context.getProject().getBasePath();
+        if (projectBasePath == null || projectBasePath.isBlank()) {
+            return null;
+        }
+
+        try {
+            String customWorkingDir = context.getSettingsService().getCustomWorkingDirectory(projectBasePath);
+            if (customWorkingDir == null || customWorkingDir.isBlank()) {
+                return null;
+            }
+
+            File workingDirectory = new File(customWorkingDir);
+            if (!workingDirectory.isAbsolute()) {
+                workingDirectory = new File(projectBasePath, customWorkingDir);
+            }
+
+            File canonicalDirectory = normalizeExistingDirectory(workingDirectory.getPath());
+            return canonicalDirectory != null ? canonicalDirectory.getAbsolutePath() : null;
+        } catch (Exception e) {
+            LOG.warn("Failed to resolve custom working directory: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private File normalizeExistingDirectory(String path) {
+        if (path == null || path.isBlank()) {
+            return null;
+        }
+
+        try {
+            File directory = new File(path).getCanonicalFile();
+            return directory.exists() && directory.isDirectory() ? directory : null;
+        } catch (IOException e) {
+            File directory = new File(path).getAbsoluteFile();
+            return directory.exists() && directory.isDirectory() ? directory : null;
+        }
+    }
+
+    private File normalizeExistingFile(File candidate) {
+        try {
+            File canonicalFile = candidate.getCanonicalFile();
+            return canonicalFile.exists() && canonicalFile.isFile() ? canonicalFile : null;
+        } catch (IOException e) {
+            File absoluteFile = candidate.getAbsoluteFile();
+            return absoluteFile.exists() && absoluteFile.isFile() ? absoluteFile : null;
+        }
     }
 
     /**
      * Open a virtual file in the editor, optionally navigating to a line range.
      */
-    private void openInEditor(com.intellij.openapi.vfs.VirtualFile virtualFile, int lineNumber, int endLineNumber) {
-        if (lineNumber <= 0) {
-            FileEditorManager.getInstance(context.getProject()).openFile(virtualFile, true);
+    private void openInEditor(VirtualFile virtualFile, int lineNumber, int endLineNumber) {
+        Project project = context.getProject();
+        if (project == null || project.isDisposed()) {
             return;
         }
 
-        OpenFileDescriptor descriptor = new OpenFileDescriptor(context.getProject(), virtualFile);
-        Editor editor = FileEditorManager.getInstance(context.getProject()).openTextEditor(descriptor, true);
+        if (lineNumber <= 0) {
+            FileEditorManager.getInstance(project).openFile(virtualFile, true);
+            return;
+        }
+
+        OpenFileDescriptor descriptor = new OpenFileDescriptor(project, virtualFile);
+        Editor editor = FileEditorManager.getInstance(project).openTextEditor(descriptor, true);
 
         if (editor == null) {
             LOG.warn("Cannot open text editor: " + virtualFile.getPath());
-            FileEditorManager.getInstance(context.getProject()).openFile(virtualFile, true);
+            FileEditorManager.getInstance(project).openFile(virtualFile, true);
             return;
         }
 
@@ -171,5 +446,15 @@ class OpenFileHandler {
                 LOG.error("Cannot open browser: " + e.getMessage(), e);
             }
         });
+    }
+
+    /**
+     * Result of file resolution: either a File path or a VirtualFile from fuzzy matching.
+     * At most one of the two fields will be non-null.
+     */
+    static record FileResolutionResult(File file, VirtualFile virtualFile) {
+    }
+
+    static record LineInfo(String actualPath, int lineNumber, int endLineNumber, boolean hasLineInfo) {
     }
 }

--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -24,6 +24,7 @@ import com.github.claudecodegui.handler.TabHandler;
 import com.github.claudecodegui.handler.WindowEventHandler;
 import com.github.claudecodegui.handler.file.FileExportHandler;
 import com.github.claudecodegui.handler.file.FileHandler;
+import com.github.claudecodegui.handler.file.OpenClassHandler;
 import com.github.claudecodegui.handler.file.UndoFileHandler;
 import com.github.claudecodegui.permission.PermissionService;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
@@ -447,6 +448,10 @@ public class ChatWindowDelegate {
         LOG.info("Received frontend_ready signal, frontend is now ready to receive data");
         host.setFrontendReady(true);
 
+        host.callJavaScript(
+            "window.updateLinkifyCapabilities",
+            JsUtils.escapeJs(OpenClassHandler.buildCapabilitiesJson())
+        );
         host.getSessionLifecycleManager().sendCurrentPermissionMode();
         replayCurrentSessionStateToFrontend();
         host.persistTabSessionState();

--- a/src/test/java/com/github/claudecodegui/handler/file/OpenClassHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/file/OpenClassHandlerTest.java
@@ -1,0 +1,182 @@
+package com.github.claudecodegui.handler.file;
+
+import com.github.claudecodegui.handler.core.HandlerContext;
+import com.intellij.openapi.project.Project;
+import org.junit.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class OpenClassHandlerTest {
+
+    @Test
+    public void acceptsJavaFullyQualifiedClassNames() {
+        assertTrue(OpenClassHandler.isValidClassName("com.github.foo.BarService"));
+        assertTrue(OpenClassHandler.isValidClassName("com.github.foo.Outer.Inner"));
+        assertTrue(OpenClassHandler.isValidClassName("com.github.claudecodegui.handler.file.OpenFileHandler"));
+    }
+
+    @Test
+    public void rejectsInvalidClassExpressions() {
+        assertFalse(OpenClassHandler.isValidClassName("com.example.api"));
+        assertFalse(OpenClassHandler.isValidClassName("org.junit.jupiter.api"));
+        assertFalse(OpenClassHandler.isValidClassName("com.github.foo.Bar#baz"));
+        assertFalse(OpenClassHandler.isValidClassName("com.github.foo.Bar.baz()"));
+        assertFalse(OpenClassHandler.isValidClassName("v1.2.3"));
+    }
+
+    @Test
+    public void reportsInvalidClassNamesWithoutInvokingNavigator() throws Exception {
+        CapturingJsCallback jsCallback = new CapturingJsCallback();
+        AtomicBoolean invoked = new AtomicBoolean(false);
+        OpenClassHandler handler = new OpenClassHandler(
+            createContext(createProject(), jsCallback),
+            (project, fqcn, onFailure) -> {
+                invoked.set(true);
+                return true;
+            }
+        );
+
+        handler.handleOpenClass("com.example.api");
+
+        assertFalse(invoked.get());
+        assertEquals(
+            "Cannot open class: invalid class name (com.example.api)",
+            jsCallback.awaitLastMessage()
+        );
+    }
+
+    @Test
+    public void reportsUnavailableProjectBeforeAsyncNavigation() throws Exception {
+        CapturingJsCallback jsCallback = new CapturingJsCallback();
+        OpenClassHandler handler = new OpenClassHandler(
+            createContext(null, jsCallback),
+            (project, fqcn, onFailure) -> true
+        );
+
+        handler.handleOpenClass("com.github.foo.BarService");
+
+        assertEquals("Cannot open class: project is not available", jsCallback.awaitLastMessage());
+    }
+
+    @Test
+    public void surfacesNavigatorReportedNotFoundErrors() throws Exception {
+        CapturingJsCallback jsCallback = new CapturingJsCallback();
+        OpenClassHandler handler = new OpenClassHandler(
+            createContext(createProject(), jsCallback),
+            (project, fqcn, onFailure) -> {
+                onFailure.accept("Cannot open class: not found (" + fqcn + ")");
+                return true;
+            }
+        );
+
+        handler.executeNavigation(createProject(), "com.github.foo.BarService");
+
+        assertEquals(
+            "Cannot open class: not found (com.github.foo.BarService)",
+            jsCallback.awaitLastMessage()
+        );
+    }
+
+    @Test
+    public void reportsNavigatorExceptionsAsGenericOpenErrors() throws Exception {
+        CapturingJsCallback jsCallback = new CapturingJsCallback();
+        OpenClassHandler handler = new OpenClassHandler(
+            createContext(createProject(), jsCallback),
+            (project, fqcn, onFailure) -> {
+                throw new IllegalStateException("boom");
+            }
+        );
+
+        handler.executeNavigation(createProject(), "com.github.foo.BarService");
+
+        assertEquals("Cannot open class: com.github.foo.BarService", jsCallback.awaitLastMessage());
+    }
+
+    private static HandlerContext createContext(Project project, CapturingJsCallback jsCallback) {
+        return new HandlerContext(project, null, null, null, jsCallback);
+    }
+
+    private static Project createProject() {
+        return (Project) Proxy.newProxyInstance(
+            OpenClassHandlerTest.class.getClassLoader(),
+            new Class<?>[]{Project.class},
+            (proxy, method, args) -> {
+                return switch (method.getName()) {
+                    case "isDisposed" -> false;
+                    case "getBasePath" -> null;
+                    case "getName" -> "test-project";
+                    case "toString" -> "test-project";
+                    case "hashCode" -> 1;
+                    case "equals" -> proxy == args[0];
+                    default -> defaultValue(method.getReturnType());
+                };
+            }
+        );
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+
+        if (boolean.class.equals(returnType)) {
+            return false;
+        }
+        if (int.class.equals(returnType)) {
+            return 0;
+        }
+        if (long.class.equals(returnType)) {
+            return 0L;
+        }
+        if (double.class.equals(returnType)) {
+            return 0D;
+        }
+        if (float.class.equals(returnType)) {
+            return 0F;
+        }
+        if (short.class.equals(returnType)) {
+            return (short) 0;
+        }
+        if (byte.class.equals(returnType)) {
+            return (byte) 0;
+        }
+        if (char.class.equals(returnType)) {
+            return (char) 0;
+        }
+        return null;
+    }
+
+    private static final class CapturingJsCallback implements HandlerContext.JsCallback {
+        private final List<String> messages = new ArrayList<>();
+        private final CountDownLatch latch = new CountDownLatch(1);
+
+        @Override
+        public synchronized void callJavaScript(String functionName, String... args) {
+            if (!"addErrorMessage".equals(functionName) || args.length == 0) {
+                return;
+            }
+
+            messages.add(args[0]);
+            latch.countDown();
+        }
+
+        @Override
+        public String escapeJs(String str) {
+            return str;
+        }
+
+        synchronized String awaitLastMessage() throws Exception {
+            assertTrue("Expected addErrorMessage callback", latch.await(2, TimeUnit.SECONDS));
+            return messages.get(messages.size() - 1);
+        }
+    }
+}

--- a/src/test/java/com/github/claudecodegui/handler/file/OpenFileHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/file/OpenFileHandlerTest.java
@@ -1,0 +1,40 @@
+package com.github.claudecodegui.handler.file;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class OpenFileHandlerTest {
+
+    @Test
+    public void parsesLineInfoForSimplePath() {
+        OpenFileHandler.LineInfo lineInfo = OpenFileHandler.parseLineInfo("src/foo/bar.ts:42");
+
+        assertEquals("src/foo/bar.ts", lineInfo.actualPath());
+        assertEquals(42, lineInfo.lineNumber());
+        assertEquals(-1, lineInfo.endLineNumber());
+        assertTrue(lineInfo.hasLineInfo());
+    }
+
+    @Test
+    public void parsesLineRangeInfo() {
+        OpenFileHandler.LineInfo lineInfo = OpenFileHandler.parseLineInfo("Main.java:128-140");
+
+        assertEquals("Main.java", lineInfo.actualPath());
+        assertEquals(128, lineInfo.lineNumber());
+        assertEquals(140, lineInfo.endLineNumber());
+        assertTrue(lineInfo.hasLineInfo());
+    }
+
+    @Test
+    public void rejectsColumnSyntax() {
+        OpenFileHandler.LineInfo lineInfo = OpenFileHandler.parseLineInfo("E:\\project\\src\\Foo.java:42:15");
+
+        assertEquals("E:\\project\\src\\Foo.java:42:15", lineInfo.actualPath());
+        assertEquals(-1, lineInfo.lineNumber());
+        assertEquals(-1, lineInfo.endLineNumber());
+        assertFalse(lineInfo.hasLineInfo());
+    }
+}

--- a/webview/src/components/MarkdownBlock.test.tsx
+++ b/webview/src/components/MarkdownBlock.test.tsx
@@ -1,0 +1,197 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import MarkdownBlock from './MarkdownBlock';
+import {
+  resetLinkifyCapabilities,
+  setLinkifyCapabilities,
+} from '../utils/linkifyCapabilities';
+
+const bridgeMocks = vi.hoisted(() => ({
+  openBrowser: vi.fn(),
+  openClass: vi.fn(),
+  openFile: vi.fn(),
+}));
+
+vi.mock('../utils/bridge', () => ({
+  openBrowser: bridgeMocks.openBrowser,
+  openClass: bridgeMocks.openClass,
+  openFile: bridgeMocks.openFile,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+describe('MarkdownBlock linkify integration', () => {
+  beforeEach(() => {
+    resetLinkifyCapabilities();
+    bridgeMocks.openBrowser.mockReset();
+    bridgeMocks.openClass.mockReset();
+    bridgeMocks.openFile.mockReset();
+  });
+
+  it('linkifies inline code content but not code fence blocks', () => {
+    render(
+      <MarkdownBlock
+        content={[
+          'Open src/components/App.tsx',
+          '',
+          '`src/inline-code.ts` should be linkified',
+          '',
+          '```ts',
+          'src/ignored-block.ts',
+          '```',
+        ].join('\n')}
+      />,
+    );
+
+    const fileLink = screen.getByRole('link', { name: 'src/components/App.tsx' });
+    expect(fileLink.getAttribute('data-linkify')).toBe('file');
+
+    // Inline code content should be linkified
+    const inlineCodeLink = screen.getByRole('link', { name: 'src/inline-code.ts' });
+    expect(inlineCodeLink.getAttribute('data-linkify')).toBe('file');
+    expect(inlineCodeLink.closest('code')).toBeTruthy();
+
+    // Code fence content should NOT be linkified
+    const fencedCode = document.querySelector('pre code');
+    expect(fencedCode?.textContent).toContain('src/ignored-block.ts');
+    expect(fencedCode?.querySelector('a')).toBeNull();
+  });
+
+  it('renders Java class links only when capability is enabled', () => {
+    const fqcn = 'com.github.claudecodegui.handler.file.OpenFileHandler';
+
+    const disabledRender = render(<MarkdownBlock content={fqcn} />);
+    expect(screen.queryByRole('link', { name: fqcn })).toBeNull();
+    disabledRender.unmount();
+
+    setLinkifyCapabilities({ classNavigationEnabled: true });
+    render(<MarkdownBlock content={fqcn} />);
+
+    const classLink = screen.getByRole('link', { name: fqcn });
+    expect(classLink.classList.contains('class-link')).toBe(true);
+    expect(classLink.getAttribute('data-linkify')).toBe('class');
+  });
+
+  it('adds url-link styling to plain URLs and markdown links', () => {
+    render(
+      <MarkdownBlock content={'Visit https://example.com/docs and [guide](https://example.com/guide)'} />,
+    );
+
+    const rawUrlLink = screen.getByRole('link', { name: 'https://example.com/docs' });
+    const markdownLink = screen.getByRole('link', { name: 'guide' });
+
+    expect(rawUrlLink.classList.contains('url-link')).toBe(true);
+    expect(markdownLink.classList.contains('url-link')).toBe(true);
+  });
+
+  it('strips unsafe markdown link protocols during sanitization', () => {
+    render(<MarkdownBlock content={'[bad](javascript:alert(1)) and [good](https://example.com/docs)'} />);
+
+    expect(screen.queryByRole('link', { name: 'bad' })).toBeNull();
+    expect(screen.getByRole('link', { name: 'good' }).getAttribute('href')).toBe('https://example.com/docs');
+  });
+
+  it('strips file: protocol links and does not route them to openFile', () => {
+    render(
+      <MarkdownBlock
+        content={'[click](https://example.com/docs) and [local](file:///tmp/demo.txt)'}
+      />,
+    );
+
+    // file: link should be stripped entirely by DOMPurify sanitization
+    expect(screen.queryByRole('link', { name: 'local' })).toBeNull();
+
+    // https link should still work
+    const httpsLink = screen.getByRole('link', { name: 'click' });
+    expect(httpsLink.getAttribute('href')).toBe('https://example.com/docs');
+
+    fireEvent.click(httpsLink);
+    expect(bridgeMocks.openBrowser).toHaveBeenCalledWith('https://example.com/docs');
+  });
+
+  it('renders windows, posix, and explicit relative paths as file links', () => {
+    render(
+      <MarkdownBlock
+        content={[
+          'Windows C:\\repo\\src\\Main.java',
+          '',
+          'POSIX /home/user/project/src/main.ts',
+          '',
+          'Relative ./foo.ts and ../shared/utils.ts',
+        ].join('\n')}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'C:\\repo\\src\\Main.java' }).getAttribute('data-linkify')).toBe('file');
+    expect(screen.getByRole('link', { name: '/home/user/project/src/main.ts' }).getAttribute('data-linkify')).toBe('file');
+    expect(screen.getByRole('link', { name: './foo.ts' }).getAttribute('data-linkify')).toBe('file');
+    expect(screen.getByRole('link', { name: '../shared/utils.ts' }).getAttribute('data-linkify')).toBe('file');
+  });
+
+  it('dispatches clicks to the correct bridge helpers', () => {
+    setLinkifyCapabilities({ classNavigationEnabled: true });
+
+    render(
+      <MarkdownBlock
+        content={[
+          'Open src/components/App.tsx',
+          '',
+          'See com.github.claudecodegui.handler.file.OpenFileHandler',
+          '',
+          'Visit https://example.com/docs',
+        ].join('\n')}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'src/components/App.tsx' }));
+    fireEvent.click(
+      screen.getByRole('link', {
+        name: 'com.github.claudecodegui.handler.file.OpenFileHandler',
+      }),
+    );
+    fireEvent.click(screen.getByRole('link', { name: 'https://example.com/docs' }));
+
+    expect(bridgeMocks.openFile).toHaveBeenCalledWith('src/components/App.tsx');
+    expect(bridgeMocks.openClass).toHaveBeenCalledWith(
+      'com.github.claudecodegui.handler.file.OpenFileHandler',
+    );
+    expect(bridgeMocks.openBrowser).toHaveBeenCalledWith('https://example.com/docs');
+  });
+
+  it('shows links during streaming and keeps final rendering consistent', () => {
+    setLinkifyCapabilities({ classNavigationEnabled: true });
+
+    const content = [
+      'Reading src/App.tsx',
+      '',
+      'Class com.github.claudecodegui.handler.file.OpenFileHandler',
+      '',
+      'Docs https://example.com/docs',
+    ].join('\n');
+
+    const { rerender } = render(<MarkdownBlock content={content} isStreaming />);
+
+    expect(screen.getByRole('link', { name: 'src/App.tsx' })).toBeTruthy();
+    expect(
+      screen.getByRole('link', {
+        name: 'com.github.claudecodegui.handler.file.OpenFileHandler',
+      }),
+    ).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'https://example.com/docs' })).toBeTruthy();
+
+    rerender(<MarkdownBlock content={content} isStreaming={false} />);
+
+    expect(screen.getByRole('link', { name: 'src/App.tsx' })).toBeTruthy();
+    expect(
+      screen.getByRole('link', {
+        name: 'com.github.claudecodegui.handler.file.OpenFileHandler',
+      }),
+    ).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'https://example.com/docs' })).toBeTruthy();
+  });
+});

--- a/webview/src/components/MarkdownBlock.tsx
+++ b/webview/src/components/MarkdownBlock.tsx
@@ -2,10 +2,62 @@ import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import { memo, useMemo, useState, useRef, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { openBrowser, openFile } from '../utils/bridge';
+import { openBrowser, openClass, openFile } from '../utils/bridge';
+import {
+  decorateExistingAnchors,
+  linkifyHtml,
+  linkifyPlainTextSegment,
+} from '../utils/linkify';
+import {
+  getLinkifyCapabilities,
+  subscribeLinkifyCapabilities,
+  type LinkifyCapabilities,
+} from '../utils/linkifyCapabilities';
 import hljs from 'highlight.js';
 import 'highlight.js/styles/github-dark.css';
 import { markedHighlight } from 'marked-highlight';
+
+const SAFE_HREF_PROTOCOL_REGEX = /^(?:https?|mailto):/i;
+const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/;
+const URI_SCHEME_REGEX = /^[A-Za-z][A-Za-z0-9+.-]*:/;
+let hrefSanitizerHookInstalled = false;
+
+function isAllowedHrefValue(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  if (WINDOWS_DRIVE_PATH_REGEX.test(trimmed)) {
+    return true;
+  }
+
+  if (!URI_SCHEME_REGEX.test(trimmed)) {
+    return true;
+  }
+
+  return SAFE_HREF_PROTOCOL_REGEX.test(trimmed);
+}
+
+function ensureSafeHrefSanitizerHook(): void {
+  if (hrefSanitizerHookInstalled) {
+    return;
+  }
+
+  DOMPurify.addHook('uponSanitizeAttribute', (_node, data) => {
+    if (data.attrName !== 'href' || typeof data.attrValue !== 'string') {
+      return;
+    }
+
+    if (!isAllowedHrefValue(data.attrValue)) {
+      data.keepAttr = false;
+    }
+  });
+
+  hrefSanitizerHookInstalled = true;
+}
+
+ensureSafeHrefSanitizerHook();
 // Lazy-loaded mermaid singleton (deferred until first diagram is encountered)
 let mermaidInstance: typeof import('mermaid').default | null = null;
 async function getMermaid() {
@@ -129,7 +181,62 @@ function safeLang(lang: string): string {
   return lang.replace(/[^a-zA-Z0-9_.-]/g, '');
 }
 
-function renderStreamingContent(content: string): string {
+function renderStreamingInlineText(
+  text: string,
+  capabilities: LinkifyCapabilities,
+): string {
+  return text
+    .split(/(`[^`\n]+`)/g)
+    .map((inlinePart) => {
+      const inlineCodeMatch = /^`([^`\n]+)`$/.exec(inlinePart);
+      if (inlineCodeMatch) {
+        // Inline code content should also be linkified
+        const linkifiedCode = linkifyPlainTextSegment(inlineCodeMatch[1], capabilities);
+        return `<code>${linkifiedCode}</code>`;
+      }
+
+      return inlinePart
+        .split(/(\*\*[^*]+\*\*)/g)
+        .map((part) => {
+          const boldMatch = /^\*\*([^*]+)\*\*$/.exec(part);
+          if (boldMatch) {
+            return `<strong>${linkifyPlainTextSegment(boldMatch[1], capabilities)}</strong>`;
+          }
+
+          return linkifyPlainTextSegment(part, capabilities);
+        })
+        .join('');
+    })
+    .join('');
+}
+
+function renderStreamingProseSegment(
+  segment: string,
+  capabilities: LinkifyCapabilities,
+): string {
+  return segment
+    .split(/\n{2,}/)
+    .filter((block) => block.length > 0)
+    .map((block) => {
+      const headingMatch = /^(#{1,6})\s+(.+)$/.exec(block);
+      if (headingMatch && !block.includes('\n')) {
+        const level = headingMatch[1].length;
+        return `<h${level}>${renderStreamingInlineText(headingMatch[2], capabilities)}</h${level}>`;
+      }
+
+      const lines = block
+        .split('\n')
+        .map((line) => renderStreamingInlineText(line, capabilities))
+        .join('<br/>');
+      return `<p>${lines}</p>`;
+    })
+    .join('');
+}
+
+function renderStreamingContent(
+  content: string,
+  capabilities: LinkifyCapabilities,
+): string {
   if (!content) return '';
 
   const safeContent = makeStreamSafe(content);
@@ -188,33 +295,14 @@ function renderStreamingContent(content: string): string {
       // Already wrapped in <pre> — pass through
       if (seg.startsWith('<pre>')) return seg;
 
-      let html = seg
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;');
-
-      // Inline code
-      html = html.replace(/`([^`\n]+)`/g, '<code>$1</code>');
-      // Bold
-      html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
-      // Headings (# ... ######)
-      html = html.replace(/^(#{1,6})\s+(.+)$/gm, (_m, hashes: string, text: string) => {
-        const level = hashes.length;
-        return `<h${level}>${text}</h${level}>`;
-      });
-      // Paragraph breaks
-      html = html.replace(/\n\n/g, '</p><p>');
-      // Single line breaks
-      html = html.replace(/\n/g, '<br/>');
-
-      return `<p>${html}</p>`;
+      return renderStreamingProseSegment(seg, capabilities);
     })
     .join('');
 
   // Sanitize the assembled HTML to prevent XSS even during streaming
   return DOMPurify.sanitize(raw, {
-    ALLOWED_TAGS: ['p', 'br', 'pre', 'code', 'strong', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
-    ALLOWED_ATTR: ['class'],
+    ALLOWED_TAGS: ['a', 'p', 'br', 'pre', 'code', 'strong', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+    ALLOWED_ATTR: ['class', 'href', 'data-linkify'],
   });
 }
 
@@ -231,6 +319,9 @@ const copyIconSvg = `
 
 const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps) => {
   const [previewSrc, setPreviewSrc] = useState<string | null>(null);
+  const [linkifyCapabilities, setLinkifyCapabilities] = useState<LinkifyCapabilities>(() =>
+    getLinkifyCapabilities(),
+  );
   const containerRef = useRef<HTMLDivElement>(null);
   const { t, i18n } = useTranslation();
 
@@ -240,6 +331,10 @@ const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps
   // Ref for tracking retry count
   const mermaidRetryRef = useRef(0);
   const MERMAID_MAX_RETRIES = 3;
+
+  useEffect(() => {
+    return subscribeLinkifyCapabilities(setLinkifyCapabilities);
+  }, []);
 
   // Render mermaid diagrams
   const renderMermaidDiagrams = useCallback(async () => {
@@ -387,7 +482,7 @@ const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps
 
       // During streaming, use lightweight renderer to avoid heavy parsing on every delta
       if (isStreaming) {
-        return renderStreamingContent(trimmedContent);
+        return renderStreamingContent(trimmedContent, linkifyCapabilities);
       }
 
       // Non-streaming: full markdown pipeline
@@ -403,6 +498,7 @@ const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps
       }
 
       const doc = new DOMParser().parseFromString(rawHtml, 'text/html');
+    decorateExistingAnchors(doc.body);
       const pres = doc.querySelectorAll('pre');
       const copySuccessText = t('markdown.copySuccess');
       const copyCodeTitle = t('markdown.copyCode');
@@ -439,11 +535,13 @@ const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps
         wrapper.appendChild(btn);
       });
 
+      linkifyHtml(doc.body, linkifyCapabilities);
+
       return doc.body.innerHTML.trim();
     } catch {
       return content;
     }
-  }, [content, isStreaming, i18n.language, t]);
+  }, [content, isStreaming, i18n.language, linkifyCapabilities, t]);
 
   // Force DOM refresh when streaming ends to fix potential layout corruption from streaming render
   useEffect(() => {
@@ -518,7 +616,19 @@ const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps
       return;
     }
 
-    if (/^(https?:|mailto:)/.test(href)) {
+    const linkType = anchor.getAttribute('data-linkify');
+
+    if (linkType === 'file') {
+      openFile(href);
+      return;
+    }
+
+    if (linkType === 'class') {
+      openClass(href);
+      return;
+    }
+
+    if (linkType === 'url' || /^(https?:|mailto:)/.test(href)) {
       openBrowser(href);
     } else {
       openFile(href);

--- a/webview/src/components/PermissionDialog.test.tsx
+++ b/webview/src/components/PermissionDialog.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PermissionDialog, { type PermissionRequest } from './PermissionDialog';
+import { resetLinkifyCapabilities, setLinkifyCapabilities } from '../utils/linkifyCapabilities';
+
+vi.mock('../hooks/useDialogResize', () => ({
+  useDialogResize: () => ({
+    dialogRef: { current: null },
+    dialogHeight: null,
+    setDialogHeight: vi.fn(),
+    handleResizeStart: vi.fn(),
+  }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallbackOrOptions?: unknown) => {
+      if (typeof fallbackOrOptions === 'string') {
+        return fallbackOrOptions;
+      }
+      return key;
+    },
+    i18n: { language: 'en' },
+  }),
+}));
+
+describe('PermissionDialog', () => {
+  beforeEach(() => {
+    resetLinkifyCapabilities();
+    setLinkifyCapabilities({ classNavigationEnabled: true });
+  });
+
+  it('reuses MarkdownBlock linkify inside the command content area', () => {
+    const request: PermissionRequest = {
+      channelId: 'perm-1',
+      toolName: 'bash',
+      inputs: {
+        cwd: 'src/components',
+        command: [
+          'Read src/components/App.tsx',
+          '',
+          'Inspect com.github.claudecodegui.handler.file.OpenFileHandler',
+          '',
+          'Reference https://example.com/docs',
+        ].join('\n'),
+      },
+    };
+
+    render(
+      <PermissionDialog
+        isOpen
+        request={request}
+        onApprove={() => {}}
+        onSkip={() => {}}
+        onApproveAlways={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'src/components/App.tsx' })).toBeTruthy();
+    expect(
+      screen.getByRole('link', {
+        name: 'com.github.claudecodegui.handler.file.OpenFileHandler',
+      }),
+    ).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'https://example.com/docs' })).toBeTruthy();
+  });
+});

--- a/webview/src/components/PlanApprovalDialog.test.tsx
+++ b/webview/src/components/PlanApprovalDialog.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PlanApprovalDialog, { type PlanApprovalRequest } from './PlanApprovalDialog';
+import { resetLinkifyCapabilities, setLinkifyCapabilities } from '../utils/linkifyCapabilities';
+
+vi.mock('../hooks/useDialogResize', () => ({
+  useDialogResize: () => ({
+    dialogRef: { current: null },
+    dialogHeight: null,
+    setDialogHeight: vi.fn(),
+    handleResizeStart: vi.fn(),
+  }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallbackOrOptions?: unknown) => {
+      if (typeof fallbackOrOptions === 'string') {
+        return fallbackOrOptions;
+      }
+      return key;
+    },
+    i18n: { language: 'en' },
+  }),
+}));
+
+describe('PlanApprovalDialog', () => {
+  beforeEach(() => {
+    resetLinkifyCapabilities();
+    setLinkifyCapabilities({ classNavigationEnabled: true });
+  });
+
+  it('reuses MarkdownBlock linkify inside the dialog content', () => {
+    const request: PlanApprovalRequest = {
+      requestId: 'req-1',
+      toolName: 'plan',
+      plan: [
+        'Review src/components/App.tsx',
+        '',
+        'Check com.github.claudecodegui.handler.file.OpenFileHandler',
+        '',
+        'Reference https://example.com/docs',
+      ].join('\n'),
+    };
+
+    render(
+      <PlanApprovalDialog
+        isOpen
+        request={request}
+        onApprove={() => {}}
+        onReject={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'src/components/App.tsx' })).toBeTruthy();
+    expect(
+      screen.getByRole('link', {
+        name: 'com.github.claudecodegui.handler.file.OpenFileHandler',
+      }),
+    ).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'https://example.com/docs' })).toBeTruthy();
+  });
+});

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -291,6 +291,11 @@ interface Window {
   updateWorkingDirectory?: (json: string) => void;
 
   /**
+   * Update linkify/navigation capabilities used by Markdown rendering.
+   */
+  updateLinkifyCapabilities?: (json: string) => void;
+
+  /**
    * Show success message
    */
   showSuccess?: (message: string) => void;

--- a/webview/src/main.tsx
+++ b/webview/src/main.tsx
@@ -7,6 +7,7 @@ import './i18n/config';
 import i18n from './i18n/config';
 import { setupSlashCommandsCallback } from './components/ChatInputBox/providers/slashCommandProvider';
 import { setupDollarCommandsCallback } from './components/ChatInputBox/providers/dollarCommandProvider';
+import { applyLinkifyCapabilitiesPayload } from './utils/linkifyCapabilities';
 import { sendBridgeEvent } from './utils/bridge';
 import type { UiFontConfig } from './types/uiFontConfig';
 
@@ -550,6 +551,12 @@ if (typeof window !== 'undefined' && !window.showPlanApprovalDialog) {
   };
 }
 
+if (typeof window !== 'undefined') {
+  window.updateLinkifyCapabilities = (json: string) => {
+    applyLinkifyCapabilitiesPayload(json);
+  };
+}
+
 // Render the React application
 ReactDOM.createRoot(document.getElementById('app') as HTMLElement).render(
   <ErrorBoundary>
@@ -596,4 +603,7 @@ waitForBridge(() => {
   // Ensure SDK dependency status is fetched on initial load (not only after opening Settings).
   console.log('[Main] Requesting dependency status');
   sendBridgeEvent('get_dependency_status');
+
+  console.log('[Main] Requesting linkify capabilities');
+  sendBridgeEvent('get_linkify_capabilities');
 });

--- a/webview/src/styles/less/components/message.less
+++ b/webview/src/styles/less/components/message.less
@@ -35,6 +35,11 @@
     min-width: 0; /* 允许内容缩小 */
     max-width: 100%; /* 防止超出容器 */
     contain: layout style; /* Isolate layout — prevents cross-message recalculation during scroll */
+
+    @supports (content-visibility: auto) {
+        content-visibility: auto;
+        contain-intrinsic-size: 0 160px;
+    }
 }
 
 .message:last-child {
@@ -606,16 +611,39 @@
 .markdown-content h3 { font-size: 1.2em; }
 
 .markdown-content a {
-    color: inherit;
-    text-decoration: none;
+    color: var(--accent-primary, #4ea1ff);
+    text-decoration-line: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+    text-decoration-color: currentColor;
     word-wrap: break-word;
     overflow-wrap: break-word;
-    pointer-events: none;
-    cursor: text;
+    pointer-events: auto;
+    cursor: pointer;
+    transition: color 0.15s ease, text-decoration-thickness 0.15s ease, opacity 0.15s ease;
 }
 
 .markdown-content a:hover {
-    text-decoration: none;
+    text-decoration-thickness: 2px;
+    opacity: 0.95;
+}
+
+.markdown-content a.file-link {
+    text-decoration-style: dotted;
+    color: var(--color-tool-file-link, var(--accent-primary, #4ea1ff));
+}
+
+.markdown-content a.class-link {
+    text-decoration-style: dashed;
+    color: var(--color-tool-class-link, var(--accent-primary, #4ea1ff));
+}
+
+.markdown-content a.url-link {
+    text-decoration-style: solid;
+}
+
+.message.user .markdown-content a {
+    color: inherit;
 }
 
 /* 表格容器 - 处理溢出 */

--- a/webview/src/styles/less/variables.less
+++ b/webview/src/styles/less/variables.less
@@ -71,6 +71,7 @@
     --color-tool-name: #90caf9;
     --color-tool-summary: #888;
     --color-tool-file-link: #a5d6a7;
+    --color-tool-class-link: #8ec5ff;
     --color-tool-param-text: #aaa;
     --color-tool-param-key: #78909c;
     --color-tool-param-value: #cfd8dc;
@@ -258,6 +259,7 @@
     --color-tool-name: #0066cc;
     --color-tool-summary: #666666;
     --color-tool-file-link: #107c10;
+    --color-tool-class-link: #0f6cbd;
     --color-tool-param-text: #666666;
     --color-tool-param-key: #666666;
     --color-tool-param-value: #333333;

--- a/webview/src/utils/bridge.test.ts
+++ b/webview/src/utils/bridge.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  openBrowser,
+  openClass,
+  openFile,
+  showEditableDiff,
+  showInteractiveDiff,
+  undoFileChanges,
+} from './bridge';
+
+describe('bridge navigation helpers', () => {
+  beforeEach(() => {
+    window.sendToJava = vi.fn();
+  });
+
+  it('allows relative navigation paths for openFile', () => {
+    openFile('../shared/utils.ts');
+    expect(window.sendToJava).toHaveBeenCalledWith('open_file:../shared/utils.ts');
+  });
+
+  it('sends openClass for valid Java FQCN values', () => {
+    openClass('com.github.claudecodegui.handler.file.OpenFileHandler');
+    expect(window.sendToJava).toHaveBeenCalledWith(
+      'open_class:com.github.claudecodegui.handler.file.OpenFileHandler',
+    );
+  });
+
+  it('shares the same trimmed FQCN validation rules as linkify', () => {
+    openClass(' com.github.foo.BarService ');
+    openClass('com.github.foo.Outer.Inner');
+    openClass('org.junit.jupiter.api');
+    openClass('com.github.foo.Bar.baz()');
+
+    expect(window.sendToJava).toHaveBeenNthCalledWith(1, 'open_class:com.github.foo.BarService');
+    expect(window.sendToJava).toHaveBeenNthCalledWith(2, 'open_class:com.github.foo.Outer.Inner');
+    expect(window.sendToJava).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects invalid Java class expressions', () => {
+    openClass('com.github.foo.Bar#baz');
+    expect(window.sendToJava).not.toHaveBeenCalled();
+  });
+
+  it('keeps traversal guards for mutating file APIs', () => {
+    showEditableDiff('../shared/utils.ts', [], 'M');
+    showInteractiveDiff('../shared/utils.ts', 'next');
+    undoFileChanges('../shared/utils.ts', 'M', []);
+
+    expect(window.sendToJava).not.toHaveBeenCalled();
+  });
+
+  it('allows http, https, and mailto protocols for openBrowser', () => {
+    openBrowser('https://example.com/docs');
+    openBrowser('http://example.com');
+    openBrowser('mailto:test@example.com');
+
+    expect(window.sendToJava).toHaveBeenNthCalledWith(1, 'open_browser:https://example.com/docs');
+    expect(window.sendToJava).toHaveBeenNthCalledWith(2, 'open_browser:http://example.com');
+    expect(window.sendToJava).toHaveBeenNthCalledWith(3, 'open_browser:mailto:test@example.com');
+  });
+
+  it('rejects file: and javascript: protocols in openBrowser', () => {
+    openBrowser('file:///etc/passwd');
+    openBrowser('javascript:alert(1)');
+
+    expect(window.sendToJava).not.toHaveBeenCalled();
+  });
+});

--- a/webview/src/utils/bridge.ts
+++ b/webview/src/utils/bridge.ts
@@ -1,21 +1,54 @@
+import { isJavaFqcnCandidate } from './linkify';
+
 const BRIDGE_UNAVAILABLE_WARNED = new Set<string>();
+const SAFE_BROWSER_PROTOCOLS = /^(https?|mailto):/i;
 
 /** Regex to detect path traversal: matches ".." as a path segment, not as part of filenames */
 const PATH_TRAVERSAL_REGEX = /(^|[\\/])\.\.($|[\\/])/;
+const CONTROL_CHAR_REGEX = /[\u0000-\u001f]/;
 
 /**
- * Validate file path doesn't contain path traversal patterns
- * Defense-in-depth: backend also validates using canonical paths
+ * Validate mutating file paths don't contain traversal patterns.
+ * Defense-in-depth: backend also validates using canonical paths.
  */
-const isValidPath = (filePath: string): boolean => {
+const isValidMutatingPath = (filePath: string): boolean => {
   if (!filePath) return false;
   let decodedPath: string;
   try {
     decodedPath = decodeURIComponent(filePath);
   } catch {
+    console.debug('[bridge] isValidMutatingPath: decodeURIComponent failed for:', filePath);
+    return false;
+  }
+  if (CONTROL_CHAR_REGEX.test(filePath) || CONTROL_CHAR_REGEX.test(decodedPath)) {
     return false;
   }
   return !PATH_TRAVERSAL_REGEX.test(filePath) && !PATH_TRAVERSAL_REGEX.test(decodedPath);
+};
+
+/**
+ * Navigation-only file opening supports relative paths like ../foo.ts and path:line.
+ */
+const isValidOpenFileTarget = (filePath: string): boolean => {
+  if (!filePath) return false;
+  let decodedPath: string;
+  try {
+    decodedPath = decodeURIComponent(filePath);
+  } catch {
+    console.debug('[bridge] isValidOpenFileTarget: decodeURIComponent failed for:', filePath);
+    return false;
+  }
+
+  return !CONTROL_CHAR_REGEX.test(filePath) && !CONTROL_CHAR_REGEX.test(decodedPath);
+};
+
+const isValidFqcn = (className: string): boolean => {
+  const trimmed = className?.trim();
+  if (!trimmed || CONTROL_CHAR_REGEX.test(trimmed)) {
+    return false;
+  }
+
+  return isJavaFqcnCandidate(trimmed);
 };
 
 const callBridge = (payload: string) => {
@@ -36,8 +69,7 @@ export const openFile = (filePath?: string, lineStart?: number, lineEnd?: number
   if (!filePath) {
     return;
   }
-  // Security: Validate base file path
-  if (!isValidPath(filePath)) {
+  if (!isValidOpenFileTarget(filePath)) {
     return;
   }
   let path = filePath;
@@ -49,8 +81,23 @@ export const openFile = (filePath?: string, lineStart?: number, lineEnd?: number
   sendBridgeEvent('open_file', path);
 };
 
+export const openClass = (className?: string) => {
+  const trimmed = className?.trim();
+  if (!trimmed || !isValidFqcn(trimmed)) {
+    return;
+  }
+
+  sendBridgeEvent('open_class', trimmed);
+};
+
 export const openBrowser = (url?: string) => {
   if (!url) {
+    return;
+  }
+  // Defense-in-depth: only allow http, https, and mailto protocols.
+  // file: and javascript: are explicitly rejected even though markdown
+  // sanitization should strip them before they reach this point.
+  if (!SAFE_BROWSER_PROTOCOLS.test(url)) {
     return;
   }
   sendBridgeEvent('open_browser', url);
@@ -67,6 +114,9 @@ export const refreshFile = (filePath: string) => {
 };
 
 export const showDiff = (filePath: string, oldContent: string, newContent: string, title?: string) => {
+  if (!isValidMutatingPath(filePath)) {
+    return;
+  }
   sendToJava('show_diff', { filePath, oldContent, newContent, title });
 };
 
@@ -75,6 +125,9 @@ export const showMultiEditDiff = (
   edits: Array<{ oldString: string; newString: string; replaceAll?: boolean }>,
   currentContent?: string
 ) => {
+  if (!isValidMutatingPath(filePath)) {
+    return;
+  }
   sendToJava('show_multi_edit_diff', { filePath, edits, currentContent });
 };
 
@@ -91,7 +144,7 @@ export const showEditableDiff = (
   status: 'A' | 'M'
 ) => {
   // Security: Validate file path (defense-in-depth, backend also validates)
-  if (!isValidPath(filePath)) {
+  if (!isValidMutatingPath(filePath)) {
     return;
   }
   sendToJava('show_editable_diff', { filePath, operations, status });
@@ -109,7 +162,7 @@ export const showEditPreviewDiff = (
   edits: Array<{ oldString: string; newString: string; replaceAll?: boolean }>,
   title?: string
 ) => {
-  if (!isValidPath(filePath)) {
+  if (!isValidMutatingPath(filePath)) {
     return;
   }
   sendToJava('show_edit_preview_diff', { filePath, edits, title });
@@ -133,7 +186,7 @@ export const showEditFullDiff = (
   replaceAll?: boolean,
   title?: string
 ) => {
-  if (!isValidPath(filePath)) {
+  if (!isValidMutatingPath(filePath)) {
     return;
   }
   sendToJava('show_edit_full_diff', { filePath, oldString, newString, originalContent, replaceAll, title });
@@ -153,7 +206,7 @@ export const showInteractiveDiff = (
   tabName?: string,
   isNewFile?: boolean
 ) => {
-  if (!isValidPath(filePath)) {
+  if (!isValidMutatingPath(filePath)) {
     return;
   }
   sendToJava('show_interactive_diff', { filePath, newFileContents, tabName, isNewFile: isNewFile ?? false });
@@ -180,7 +233,7 @@ export const undoFileChanges = (
   operations: Array<{ oldString: string; newString: string; replaceAll?: boolean }>
 ) => {
   // Security: Validate file path (defense-in-depth, backend also validates)
-  if (!isValidPath(filePath)) {
+  if (!isValidMutatingPath(filePath)) {
     return;
   }
   sendToJava('undo_file_changes', { filePath, status, operations });

--- a/webview/src/utils/linkify.test.ts
+++ b/webview/src/utils/linkify.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import {
+  decorateExistingAnchors,
+  isJavaFqcnCandidate,
+  linkifyHtml,
+  linkifyPlainTextSegment,
+  parseFileLinkTarget,
+} from './linkify';
+import { DEFAULT_LINKIFY_CAPABILITIES } from './linkifyCapabilities';
+
+describe('linkify', () => {
+  it('parses file targets with line numbers and rejects column suffixes', () => {
+    expect(parseFileLinkTarget('Main.java:128')).toEqual({
+      path: 'Main.java',
+      lineStart: 128,
+      lineEnd: undefined,
+    });
+
+    expect(parseFileLinkTarget('src/foo/bar.ts:42-50')).toEqual({
+      path: 'src/foo/bar.ts',
+      lineStart: 42,
+      lineEnd: 50,
+    });
+
+    expect(parseFileLinkTarget('E:\\project\\src\\Foo.java:42:15')).toBeNull();
+  });
+
+  it('recognizes valid Java FQCN values and rejects false positives', () => {
+    expect(isJavaFqcnCandidate('com.github.foo.BarService')).toBe(true);
+    expect(isJavaFqcnCandidate('com.github.foo.Outer.Inner')).toBe(true);
+    expect(isJavaFqcnCandidate('com.example.api')).toBe(false);
+    expect(isJavaFqcnCandidate('com.foo.Bar#baz')).toBe(false);
+    expect(isJavaFqcnCandidate('v1.2.3')).toBe(false);
+  });
+
+  it('linkifies plain text paths, URLs, and Java classes', () => {
+    const html = linkifyPlainTextSegment(
+      'Open src/foo/bar.ts:42 then visit https://example.com/docs and inspect com.github.foo.BarService',
+      { classNavigationEnabled: true },
+    );
+
+    expect(html).toContain('data-linkify="file"');
+    expect(html).toContain('src/foo/bar.ts:42');
+    expect(html).toContain('data-linkify="url"');
+    expect(html).toContain('https://example.com/docs');
+    expect(html).toContain('data-linkify="class"');
+    expect(html).toContain('com.github.foo.BarService');
+  });
+
+  it('linkifies windows, posix, and explicit relative file paths', () => {
+    const html = linkifyPlainTextSegment(
+      'Open C:\\repo\\src\\Main.java, /home/user/project/src/main.ts, ./foo.ts, and ../shared/utils.ts',
+      DEFAULT_LINKIFY_CAPABILITIES,
+    );
+
+    expect(html).toContain('C:\\repo\\src\\Main.java');
+    expect(html).toContain('/home/user/project/src/main.ts');
+    expect(html).toContain('./foo.ts');
+    expect(html).toContain('../shared/utils.ts');
+    expect((html.match(/data-linkify="file"/g) ?? []).length).toBe(4);
+  });
+
+  it('linkifies standalone source file names like linkify.ts', () => {
+    const html = linkifyPlainTextSegment(
+      'See linkify.ts and MarkdownBlock.test.tsx for implementation.',
+      DEFAULT_LINKIFY_CAPABILITIES,
+    );
+
+    expect(html).toContain('data-linkify="file"');
+    expect(html).toContain('linkify.ts');
+    expect(html).toContain('MarkdownBlock.test.tsx');
+    expect((html.match(/data-linkify="file"/g) ?? []).length).toBe(2);
+  });
+
+  it('does not linkify non-source file names like example.com', () => {
+    const html = linkifyPlainTextSegment(
+      'Visit example.com and read docs.pdf',
+      DEFAULT_LINKIFY_CAPABILITIES,
+    );
+
+    // .com and .pdf are not source file extensions, should not be linked
+    expect(html).not.toContain('href="example.com"');
+    expect(html).not.toContain('href="docs.pdf"');
+  });
+
+  it('detects multiple file paths in one segment, including unicode path segments', () => {
+    const html = linkifyPlainTextSegment(
+      'Compare src/foo.ts, src/bar.ts, and ./中文/utils.ts before shipping.',
+      DEFAULT_LINKIFY_CAPABILITIES,
+    );
+
+    expect((html.match(/data-linkify="file"/g) ?? []).length).toBe(3);
+    expect(html).toContain('./中文/utils.ts');
+  });
+
+  it('does not linkify weak signals or unsupported path:line:column values', () => {
+    const html = linkifyPlainTextSegment(
+      'Ignore foo/bar, 123:456, abc:def, com.example.api and E:\\project\\Foo.java:42:15',
+      { classNavigationEnabled: true },
+    );
+
+    expect(html).not.toContain('data-linkify="file"');
+    expect(html).not.toContain('data-linkify="class"');
+  });
+
+  it('does not confuse lowercase package-like text with URLs or class links', () => {
+    const html = linkifyPlainTextSegment(
+      'Visit https://com.example.http/docs but keep com.example.http as plain text.',
+      { classNavigationEnabled: true },
+    );
+
+    expect((html.match(/data-linkify="url"/g) ?? []).length).toBe(1);
+    expect(html).not.toContain('data-linkify="class"');
+    expect(html).toContain('com.example.http as plain text');
+  });
+
+  it('linkifies HTML text nodes while skipping anchors and code fences (pre blocks)', () => {
+    const root = document.createElement('div');
+    root.innerHTML = [
+      '<p>Open src/components/App.tsx and com.github.foo.BarService</p>',
+      '<p><a href="https://example.com/docs">docs</a></p>',
+      '<p><code>src/inline-code.ts</code> should be linkified</p>',
+      '<pre>com.github.foo.IgnoredService</pre>',
+    ].join('');
+
+    decorateExistingAnchors(root);
+    linkifyHtml(root, { classNavigationEnabled: true });
+
+    expect(root.querySelector('a.file-link')?.textContent).toBe('src/components/App.tsx');
+    expect(root.querySelector('a.class-link')?.textContent).toBe('com.github.foo.BarService');
+    expect(root.querySelector('a.url-link')?.getAttribute('data-linkify')).toBe('url');
+    // Inline code content should be linkified
+    expect(root.querySelector('code a.file-link')?.textContent).toBe('src/inline-code.ts');
+    // Code fence (pre) content should NOT be linkified
+    expect(root.querySelector('pre a')).toBeNull();
+  });
+
+  it('linkifies file paths that appear immediately after an existing anchor', () => {
+    const root = document.createElement('div');
+    root.innerHTML = '<p><a href="https://example.com/docs">docs</a>src/components/App.tsx</p>';
+
+    decorateExistingAnchors(root);
+    linkifyHtml(root, DEFAULT_LINKIFY_CAPABILITIES);
+
+    expect(root.querySelector('a.url-link')?.textContent).toBe('docs');
+    expect(root.querySelector('a.file-link')?.textContent).toBe('src/components/App.tsx');
+  });
+
+  it('keeps class links disabled when capability is off', () => {
+    const root = document.createElement('div');
+    root.innerHTML = '<p>com.github.foo.BarService</p>';
+
+    linkifyHtml(root, DEFAULT_LINKIFY_CAPABILITIES);
+
+    expect(root.querySelector('a.class-link')).toBeNull();
+  });
+});

--- a/webview/src/utils/linkify.ts
+++ b/webview/src/utils/linkify.ts
@@ -1,0 +1,517 @@
+import type { LinkifyCapabilities } from './linkifyCapabilities';
+
+export type LinkifyType = 'file' | 'class' | 'url';
+
+export interface FileLinkTarget {
+  path: string;
+  lineStart: number;
+  lineEnd?: number;
+}
+
+export interface LinkifyMatch {
+  type: LinkifyType;
+  value: string;
+  start: number;
+  end: number;
+}
+
+interface Detector {
+  type: LinkifyType;
+  priority: number;
+  matcher: RegExp;
+  enabled?: (capabilities: LinkifyCapabilities) => boolean;
+  validate?: (text: string, match: LinkifyMatch) => boolean;
+}
+
+interface RankedMatch extends LinkifyMatch {
+  priority: number;
+}
+
+const URL_REGEX = /https?:\/\/[^\s<>()]+[^\s<>().,!?;:'")\]]/g;
+const WINDOWS_ABSOLUTE_PATH_REGEX = /[A-Za-z]:\\(?:[^\\/:*?"<>|\r\n\s]+\\)*[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+(?!:\d)/g;
+const POSIX_ABSOLUTE_PATH_REGEX = /\/(?:[^/\s]+\/)*[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+(?!:\d)/g;
+const EXPLICIT_RELATIVE_PATH_REGEX = /(?:\.\/|(?:\.\.\/)+)(?:[^/\s]+\/)*[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+(?!:\d)/g;
+const PROJECT_RELATIVE_PATH_REGEX = /(?:[A-Za-z0-9_-]+\/)(?:[A-Za-z0-9._-]+\/)*[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+(?!:\d)/g;
+const FILE_WITH_LINE_REGEX = /(?:[A-Za-z]:\\(?:[^\\/:*?"<>|\r\n\s]+\\)*[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+|\/(?:[^/\s]+\/)*[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+|(?:\.\/|(?:\.\.\/)+)(?:[^/\s]+\/)*[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+|(?:[A-Za-z0-9_-]+\/)(?:[A-Za-z0-9._-]+\/)*[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+|[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+):\d+(?:-\d+)?(?!:\d)/g;
+const JAVA_FQCN_REGEX = /[a-z_][a-z0-9_]*(?:\.[a-z_][a-z0-9_]*)*\.[A-Z][A-Za-z0-9_]*(?:\.[A-Z][A-Za-z0-9_]*)*/g;
+const FILE_LINE_INFO_REGEX = /^(.*):(\d+)(?:-(\d+))?$/;
+const HTTP_LINK_REGEX = /^(https?:|mailto:)/i;
+const JAVA_FQCN_CANDIDATE_REGEX = /^[a-z_][a-z0-9_]*(?:\.[a-z_][a-z0-9_]*)*\.[A-Z][A-Za-z0-9_]*(?:\.[A-Z][A-Za-z0-9_]*)*$/;
+
+// Standalone filename regex: matches single filenames with common source file extensions
+// Must have at least one char before extension, and extension must be 2+ chars
+const STANDALONE_FILENAME_REGEX = /[A-Za-z0-9._-]+\.[A-Za-z]{2,}(?!:\d)/g;
+
+// Common source file extensions - used to validate standalone filenames
+const SOURCE_FILE_EXTENSIONS = new Set([
+  'ts', 'tsx', 'js', 'jsx', 'mjs', 'cjs',
+  'java', 'kt', 'kts', 'scala',
+  'py', 'pyw', 'pyi',
+  'go', 'rs', 'c', 'cpp', 'cc', 'cxx', 'h', 'hpp', 'hxx',
+  'cs', 'vb', 'fs', 'fsx',
+  'css', 'less', 'scss', 'sass',
+  'json', 'yaml', 'yml', 'toml', 'xml', 'ini', 'conf', 'config',
+  'md', 'markdown', 'rst', 'txt',
+  'sql', 'ddl', 'dml',
+  'sh', 'bash', 'zsh', 'fish', 'ps1', 'bat', 'cmd',
+  'dockerfile', 'makefile', 'cmake', 'gradle', 'maven',
+  'html', 'htm', 'vue', 'svelte', 'astro',
+  'graphql', 'gql',
+  'proto', 'thrift',
+  'lock', 'mod', 'sum',
+  'log', 'env', 'gitignore', 'dockerignore', 'editorconfig',
+]);
+
+// Validate standalone filename matches before linking them as file references.
+// Uses a multi-layered defense to avoid false positives on domain names,
+// package segments, and version strings:
+//  1. Source file extension whitelist (SOURCE_FILE_EXTENSIONS)
+//  2. Lowercase-only names check against common config filenames (commonLowercaseNames)
+//  3. Separator detection (_, -, .) for multi-word lowercase filenames
+//  4. Length threshold for single-word lowercase names (>10 chars rejected)
+function isSourceFileName(value: string): boolean {
+  if (!value || value.length < 3) {
+    return false;
+  }
+
+  // Extract extension first
+  const lastDot = value.lastIndexOf('.');
+  if (lastDot < 1 || lastDot >= value.length - 1) {
+    return false;
+  }
+
+  const namePart = value.slice(0, lastDot);
+  const extension = value.slice(lastDot + 1).toLowerCase();
+
+  // Must be a known source file extension
+  if (!SOURCE_FILE_EXTENSIONS.has(extension)) {
+    return false;
+  }
+
+  // Additional check for lowercase-only names:
+  // If name starts with lowercase and has no uppercase, be more cautious
+  // to avoid matching domain names or package segments like "example.com"
+  const firstChar = namePart[0];
+  if (firstChar >= 'a' && firstChar <= 'z' && !/[A-Z]/.test(namePart)) {
+    // Allow only if the name looks like a real filename:
+    // - Has underscores, dots, or hyphens (common in filenames)
+    // - Is a well-known lowercase file name
+    const lowerName = namePart.toLowerCase();
+    const commonLowercaseNames = ['readme', 'changelog', 'license', 'contributing',
+      'todo', 'notes', 'makefile', 'dockerfile', 'vagrantfile', 'gemfile',
+      'rakefile', 'procfile', 'bower', 'package', 'tsconfig', 'webpack',
+      'rollup', 'vite', 'eslint', 'prettier', 'stylelint', 'babel',
+      'jest', 'karma', 'mocha', 'nyc', 'istanbul', 'svgo', 'postcss'];
+
+    // If name contains typical filename separators, it's likely a filename
+    if (namePart.includes('_') || namePart.includes('-') || namePart.includes('.')) {
+      return true;
+    }
+
+    // If it's a common lowercase config/utility file name, allow it
+    if (commonLowercaseNames.some((n) => lowerName.startsWith(n) || lowerName.endsWith(n))) {
+      return true;
+    }
+
+    // Single lowercase word like "linkify" is acceptable for source files
+    // but reject things that look like package names (multiple dots in name part)
+    if (namePart.includes('.')) {
+      return false;
+    }
+
+    // Reject if it looks like a domain (no separators, just lowercase word)
+    // But allow short names (< 10 chars) as they're more likely to be filenames
+    if (namePart.length > 10 && /^[a-z]+$/.test(namePart)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+const HTML_ESCAPE_LOOKUP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+const GENERIC_LEADING_BOUNDARY_CHARS = /[\s([\]{}<>"'`=,:;!?]/;
+const GENERIC_TRAILING_BOUNDARY_CHARS = /[\s)\]}>"'`.,:;!?]/;
+
+function createGlobalRegex(regex: RegExp): RegExp {
+  const flags = regex.flags.includes('g') ? regex.flags : `${regex.flags}g`;
+  return new RegExp(regex.source, flags);
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => HTML_ESCAPE_LOOKUP[char] ?? char);
+}
+
+function hasLeadingBoundary(text: string, start: number, boundaryChars: RegExp): boolean {
+  if (start <= 0) {
+    return true;
+  }
+  return boundaryChars.test(text[start - 1]);
+}
+
+function hasTrailingBoundary(text: string, end: number, boundaryChars: RegExp): boolean {
+  if (end >= text.length) {
+    return true;
+  }
+  return boundaryChars.test(text[end]);
+}
+
+function isValidFileBoundary(text: string, match: LinkifyMatch): boolean {
+  if (!hasLeadingBoundary(text, match.start, GENERIC_LEADING_BOUNDARY_CHARS)) {
+    return false;
+  }
+
+  if (match.end < text.length && text[match.end] === ':') {
+    return false;
+  }
+
+  return hasTrailingBoundary(text, match.end, GENERIC_TRAILING_BOUNDARY_CHARS);
+}
+
+function isValidClassBoundary(text: string, match: LinkifyMatch): boolean {
+  if (!hasLeadingBoundary(text, match.start, GENERIC_LEADING_BOUNDARY_CHARS)) {
+    return false;
+  }
+
+  const nextChar = match.end < text.length ? text[match.end] : '';
+  if (!nextChar) {
+    return true;
+  }
+
+  if (/[A-Za-z0-9_]/.test(nextChar)) {
+    return false;
+  }
+
+  return nextChar !== '.' && nextChar !== '#' && nextChar !== '(';
+}
+
+function isValidUrlBoundary(text: string, match: LinkifyMatch): boolean {
+  return hasLeadingBoundary(text, match.start, GENERIC_LEADING_BOUNDARY_CHARS);
+}
+
+const DETECTORS: Detector[] = [
+  {
+    type: 'file',
+    priority: 1,
+    matcher: createGlobalRegex(FILE_WITH_LINE_REGEX),
+    validate: (text, match) => parseFileLinkTarget(match.value) !== null && isValidFileBoundary(text, match),
+  },
+  {
+    type: 'file',
+    priority: 2,
+    matcher: createGlobalRegex(WINDOWS_ABSOLUTE_PATH_REGEX),
+    validate: isValidFileBoundary,
+  },
+  {
+    type: 'file',
+    priority: 3,
+    matcher: createGlobalRegex(POSIX_ABSOLUTE_PATH_REGEX),
+    validate: isValidFileBoundary,
+  },
+  {
+    type: 'file',
+    priority: 4,
+    matcher: createGlobalRegex(EXPLICIT_RELATIVE_PATH_REGEX),
+    validate: isValidFileBoundary,
+  },
+  {
+    type: 'file',
+    priority: 5,
+    matcher: createGlobalRegex(PROJECT_RELATIVE_PATH_REGEX),
+    validate: isValidFileBoundary,
+  },
+  {
+    type: 'class',
+    priority: 6,
+    matcher: createGlobalRegex(JAVA_FQCN_REGEX),
+    enabled: (capabilities) => capabilities.classNavigationEnabled,
+    validate: (text, match) => isJavaFqcnCandidate(match.value) && isValidClassBoundary(text, match),
+  },
+  {
+    type: 'url',
+    priority: 7,
+    matcher: createGlobalRegex(URL_REGEX),
+    validate: isValidUrlBoundary,
+  },
+  {
+    // Standalone filename detector - lowest priority, only matches if nothing else matched
+    type: 'file',
+    priority: 8,
+    matcher: createGlobalRegex(STANDALONE_FILENAME_REGEX),
+    validate: (text, match) => isSourceFileName(match.value) && isValidFileBoundary(text, match),
+  },
+];
+
+const DETECTORS_WITH_URLS: ReadonlyArray<Detector> = Object.freeze(DETECTORS);
+const DETECTORS_NO_URLS: ReadonlyArray<Detector> = Object.freeze(
+  DETECTORS.filter((detector) => detector.type !== 'url'),
+);
+
+function getDetectors(includeUrls: boolean): ReadonlyArray<Detector> {
+  return includeUrls ? DETECTORS_WITH_URLS : DETECTORS_NO_URLS;
+}
+
+function createLinkElement(document: Document, match: LinkifyMatch): HTMLAnchorElement {
+  const anchor = document.createElement('a');
+  anchor.setAttribute('href', match.value);
+  anchor.setAttribute('data-linkify', match.type);
+  anchor.classList.add(`${match.type}-link`);
+  anchor.textContent = match.value;
+  return anchor;
+}
+
+function buildAnchorHtml(match: LinkifyMatch): string {
+  const escapedValue = escapeHtml(match.value);
+  return `<a class="${match.type}-link" data-linkify="${match.type}" href="${escapedValue}">${escapedValue}</a>`;
+}
+
+function findNextMatch(
+  text: string,
+  startIndex: number,
+  capabilities: LinkifyCapabilities,
+  includeUrls: boolean,
+): LinkifyMatch | null {
+  let bestMatch: RankedMatch | undefined;
+
+  for (const detector of getDetectors(includeUrls)) {
+    if (detector.enabled && !detector.enabled(capabilities)) {
+      continue;
+    }
+
+    const regex = detector.matcher;
+    regex.lastIndex = startIndex;
+
+    let candidate: RegExpExecArray | null = regex.exec(text);
+    while (candidate) {
+      const value = candidate[0];
+      const match: RankedMatch = {
+        type: detector.type,
+        value,
+        start: candidate.index,
+        end: candidate.index + value.length,
+        priority: detector.priority,
+      };
+
+      const isValid = detector.validate ? detector.validate(text, match) : true;
+      if (isValid) {
+        if (
+          !bestMatch
+          || match.start < bestMatch.start
+          || (match.start === bestMatch.start && match.priority < bestMatch.priority)
+        ) {
+          bestMatch = match;
+        }
+        break;
+      }
+
+      if (regex.lastIndex <= candidate.index) {
+        regex.lastIndex = candidate.index + 1;
+      }
+      candidate = regex.exec(text);
+    }
+
+    regex.lastIndex = 0;
+  }
+
+  if (bestMatch === undefined) {
+    return null;
+  }
+
+  const { type, value, start, end } = bestMatch;
+  return {
+    type,
+    value,
+    start,
+    end,
+  };
+}
+
+function collectLinkifyMatches(
+  text: string,
+  capabilities: LinkifyCapabilities,
+  includeUrls: boolean,
+): LinkifyMatch[] {
+  const matches: LinkifyMatch[] = [];
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const nextMatch = findNextMatch(text, cursor, capabilities, includeUrls);
+    if (!nextMatch) {
+      break;
+    }
+
+    matches.push(nextMatch);
+    cursor = nextMatch.end;
+  }
+
+  return matches;
+}
+
+function replaceTextNodeWithLinks(
+  textNode: Text,
+  matches: LinkifyMatch[],
+): void {
+  const document = textNode.ownerDocument;
+  if (!document) {
+    return;
+  }
+
+  const text = textNode.nodeValue ?? '';
+  const fragment = document.createDocumentFragment();
+  let cursor = 0;
+
+  matches.forEach((match) => {
+    if (match.start > cursor) {
+      fragment.appendChild(document.createTextNode(text.slice(cursor, match.start)));
+    }
+    fragment.appendChild(createLinkElement(document, match));
+    cursor = match.end;
+  });
+
+  if (cursor < text.length) {
+    fragment.appendChild(document.createTextNode(text.slice(cursor)));
+  }
+
+  textNode.parentNode?.replaceChild(fragment, textNode);
+}
+
+function shouldSkipTextNode(textNode: Text): boolean {
+  const parentElement = textNode.parentElement;
+  if (!parentElement) {
+    return true;
+  }
+
+  // Skip anchors (already linked) and code fences (pre blocks)
+  // Note: <code> is NOT skipped - inline code content should be linkified
+  return parentElement.closest('a, pre') !== null;
+}
+
+export function parseFileLinkTarget(value: string): FileLinkTarget | null {
+  const trimmedValue = value.trim();
+  if (!trimmedValue) {
+    return null;
+  }
+
+  const match = FILE_LINE_INFO_REGEX.exec(trimmedValue);
+  if (!match) {
+    return null;
+  }
+
+  const [, path, lineStartRaw, lineEndRaw] = match;
+  if (/:\d+$/.test(path)) {
+    return null;
+  }
+
+  const lineStart = Number.parseInt(lineStartRaw, 10);
+  const lineEnd = lineEndRaw ? Number.parseInt(lineEndRaw, 10) : undefined;
+
+  if (!Number.isInteger(lineStart) || lineStart <= 0) {
+    return null;
+  }
+
+  if (lineEnd !== undefined && (!Number.isInteger(lineEnd) || lineEnd < lineStart)) {
+    return null;
+  }
+
+  return {
+    path,
+    lineStart,
+    lineEnd,
+  };
+}
+
+export function isJavaFqcnCandidate(value: string): boolean {
+  if (!value) {
+    return false;
+  }
+
+  if (!JAVA_FQCN_CANDIDATE_REGEX.test(value)) {
+    return false;
+  }
+
+  return !value.includes('#') && !value.includes('(');
+}
+
+export function decorateExistingAnchors(root: Element): void {
+  root.querySelectorAll('a[href]').forEach((anchor) => {
+    const href = anchor.getAttribute('href')?.trim();
+    if (!href || !HTTP_LINK_REGEX.test(href)) {
+      return;
+    }
+
+    anchor.classList.add('url-link');
+    anchor.setAttribute('data-linkify', 'url');
+  });
+}
+
+export function linkifyHtml(root: Element, capabilities: LinkifyCapabilities): void {
+  const document = root.ownerDocument;
+  if (!document) {
+    return;
+  }
+
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const textNodes: Text[] = [];
+  let currentNode = walker.nextNode();
+
+  while (currentNode) {
+    textNodes.push(currentNode as Text);
+    currentNode = walker.nextNode();
+  }
+
+  textNodes.forEach((textNode) => {
+    if (shouldSkipTextNode(textNode)) {
+      return;
+    }
+
+    const text = textNode.nodeValue ?? '';
+    if (!text.trim()) {
+      return;
+    }
+
+    const matches = collectLinkifyMatches(text, capabilities, false);
+    if (matches.length === 0) {
+      return;
+    }
+
+    replaceTextNodeWithLinks(textNode, matches);
+  });
+}
+
+export function linkifyPlainTextSegment(
+  text: string,
+  capabilities: LinkifyCapabilities,
+): string {
+  if (!text) {
+    return '';
+  }
+
+  const matches = collectLinkifyMatches(text, capabilities, true);
+  if (matches.length === 0) {
+    return escapeHtml(text);
+  }
+
+  let html = '';
+  let cursor = 0;
+
+  matches.forEach((match) => {
+    if (match.start > cursor) {
+      html += escapeHtml(text.slice(cursor, match.start));
+    }
+    html += buildAnchorHtml(match);
+    cursor = match.end;
+  });
+
+  if (cursor < text.length) {
+    html += escapeHtml(text.slice(cursor));
+  }
+
+  return html;
+}

--- a/webview/src/utils/linkifyCapabilities.ts
+++ b/webview/src/utils/linkifyCapabilities.ts
@@ -1,0 +1,75 @@
+export type LinkifyCapabilities = {
+  classNavigationEnabled: boolean;
+};
+
+export const DEFAULT_LINKIFY_CAPABILITIES: LinkifyCapabilities = Object.freeze({
+  classNavigationEnabled: false,
+});
+
+type LinkifyCapabilitiesListener = (capabilities: LinkifyCapabilities) => void;
+
+let currentCapabilities: LinkifyCapabilities = { ...DEFAULT_LINKIFY_CAPABILITIES };
+const listeners = new Set<LinkifyCapabilitiesListener>();
+
+function normalizeLinkifyCapabilities(value: unknown): LinkifyCapabilities {
+  if (!value || typeof value !== 'object') {
+    return { ...DEFAULT_LINKIFY_CAPABILITIES };
+  }
+
+  const candidate = value as Partial<LinkifyCapabilities>;
+  return {
+    classNavigationEnabled: Boolean(candidate.classNavigationEnabled),
+  };
+}
+
+function cloneCapabilities(capabilities: LinkifyCapabilities): LinkifyCapabilities {
+  return { ...capabilities };
+}
+
+function emitCapabilitiesChanged(capabilities: LinkifyCapabilities): void {
+  const snapshot = cloneCapabilities(capabilities);
+  listeners.forEach((listener) => listener(snapshot));
+}
+
+function areCapabilitiesEqual(
+  left: LinkifyCapabilities,
+  right: LinkifyCapabilities,
+): boolean {
+  return left.classNavigationEnabled === right.classNavigationEnabled;
+}
+
+export function getLinkifyCapabilities(): LinkifyCapabilities {
+  return cloneCapabilities(currentCapabilities);
+}
+
+export function setLinkifyCapabilities(value: unknown): LinkifyCapabilities {
+  const nextCapabilities = normalizeLinkifyCapabilities(value);
+  if (areCapabilitiesEqual(currentCapabilities, nextCapabilities)) {
+    return cloneCapabilities(currentCapabilities);
+  }
+
+  currentCapabilities = nextCapabilities;
+  emitCapabilitiesChanged(currentCapabilities);
+  return cloneCapabilities(currentCapabilities);
+}
+
+export function applyLinkifyCapabilitiesPayload(json: string): LinkifyCapabilities {
+  try {
+    return setLinkifyCapabilities(JSON.parse(json));
+  } catch {
+    return setLinkifyCapabilities(DEFAULT_LINKIFY_CAPABILITIES);
+  }
+}
+
+export function subscribeLinkifyCapabilities(
+  listener: LinkifyCapabilitiesListener,
+): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function resetLinkifyCapabilities(): void {
+  setLinkifyCapabilities(DEFAULT_LINKIFY_CAPABILITIES);
+}


### PR DESCRIPTION
- Add linkify.ts for detecting file paths, Java FQCNs, and URLs in text
- Support multiple path formats: absolute, relative, project-style, with line numbers
- Add standalone source filename detection (e.g., linkify.ts, MarkdownBlock.tsx)
- Linkify inline code content while keeping code fences untouched
- Add fuzzy filename matching using IDEA's FilenameIndex when direct resolution fails
- Add classNavigationEnabled capability toggle for Java FQCN link rendering
- Add OpenClassHandler and JavaClassNavigationSupport for Java class navigation
- Add CSS styling with distinct underline styles for file/class/url links
- Add comprehensive unit tests for linkify detection and MarkdownBlock integration

Security: DOMPurify href protocol whitelist (https?, mailto, file:)
Performance: ReadAction wrapper for FilenameIndex, detector caching, RegExp pooling

Resolves #557
Resolves #853
Resolves #702
Resolves #514