### PR TITLE
Support subagent edits in status panel

### DIFF
--- a/ai-bridge/services/codex/codex-event-handler.js
+++ b/ai-bridge/services/codex/codex-event-handler.js
@@ -13,7 +13,7 @@
 
 import { randomUUID } from 'crypto';
 import { existsSync } from 'fs';
-import { readFile } from 'fs/promises';
+import { readFile, stat } from 'fs/promises';
 import { requestPermissionFromJava } from '../../permission-handler.js';
 import { findSessionFileByThreadId } from './codex-agents-loader.js';
 import {
@@ -45,6 +45,7 @@ import {
 export { emitSyntheticPatchOperations, findUniqueRollbackIndex };
 
 const COMMAND_DENIED_ABORT_ERROR = '__CODEX_COMMAND_DENIED_ABORT__';
+const SESSION_LINES_CACHE_MAX_BYTES = 4 * 1024 * 1024;
 
 const LIFECYCLE_TOOL_NAMES = new Set(['spawn_agent', 'wait_agent', 'close_agent', 'send_input', 'resume_agent']);
 
@@ -203,6 +204,9 @@ export function createInitialEventState(emitMessage) {
     deniedCommandToolUseIds: new Set(),
     emittedDeniedCommandToolResultIds: new Set(),
     sessionFilePath: null,
+    sessionLinesCachePath: null,
+    sessionLinesCacheKey: null,
+    sessionLinesCache: [],
     sessionLineCursor: 0,
     sessionFunctionCursor: 0,
     sessionTurnStartCursor: 0,
@@ -263,20 +267,43 @@ function splitSessionJsonlEntries(content) {
   return content.split('\n').filter((line) => line.trim());
 }
 
-function countSessionJsonlLines(content) {
-  return splitSessionJsonlEntries(content).length;
+async function readSessionJsonlLines(state, threadId, debugScope = 'SESSION') {
+  const sessionPath = ensureSessionFilePath(state, threadId);
+  if (!sessionPath) return [];
+  let fileStat;
+  try {
+    fileStat = await stat(sessionPath);
+  } catch (error) {
+    logDebug(debugScope, 'Failed to stat session file:', error?.message || error);
+    return [];
+  }
+  const cacheKey = `${fileStat.mtimeMs}:${fileStat.size}`;
+  if (state.sessionLinesCachePath === sessionPath && state.sessionLinesCacheKey === cacheKey) {
+    return state.sessionLinesCache;
+  }
+  let content = '';
+  try {
+    content = await readFile(sessionPath, 'utf8');
+  } catch (error) {
+    logDebug(debugScope, 'Failed to read session file:', error?.message || error);
+    return [];
+  }
+  const lines = splitSessionJsonlEntries(content);
+  if (fileStat.size <= SESSION_LINES_CACHE_MAX_BYTES) {
+    state.sessionLinesCachePath = sessionPath;
+    state.sessionLinesCacheKey = cacheKey;
+    state.sessionLinesCache = lines;
+  } else {
+    state.sessionLinesCachePath = null;
+    state.sessionLinesCacheKey = null;
+    state.sessionLinesCache = [];
+  }
+  return lines;
 }
 
 async function readLatestTurnContextFromSession(state, threadId) {
-  const sessionPath = ensureSessionFilePath(state, threadId);
-  if (!sessionPath) return null;
-  let content = '';
-  try { content = await readFile(sessionPath, 'utf8'); } catch (error) {
-    logDebug('PERM_DEBUG', 'Failed to read session for turn_context:', error?.message || error);
-    return null;
-  }
-  if (!content.trim()) return null;
-  const lines = splitSessionJsonlEntries(content);
+  const lines = await readSessionJsonlLines(state, threadId, 'PERM_DEBUG');
+  if (lines.length === 0) return null;
   const startIndex = Math.max(0, lines.length - SESSION_CONTEXT_SCAN_MAX_LINES);
   for (let i = lines.length - 1; i >= startIndex; i--) {
     const line = lines[i];
@@ -291,17 +318,8 @@ async function readLatestTurnContextFromSession(state, threadId) {
 }
 
 async function replayMissingFunctionCallsFromSession(state, config) {
-  const sessionPath = ensureSessionFilePath(state, config.threadId);
-  if (!sessionPath) return { toolUses: 0, toolResults: 0 };
-
-  let content = '';
-  try { content = await readFile(sessionPath, 'utf8'); } catch (error) {
-    logDebug('SESSION_REPLAY', 'Failed to read session file for function replay:', error?.message || error);
-    return { toolUses: 0, toolResults: 0 };
-  }
-  if (!content.trim()) return { toolUses: 0, toolResults: 0 };
-
-  const lines = splitSessionJsonlEntries(content);
+  const lines = await readSessionJsonlLines(state, config.threadId, 'SESSION_REPLAY');
+  if (lines.length === 0) return { toolUses: 0, toolResults: 0 };
   const candidateStartIndexes = [
     state.sessionFunctionCursor > 0 ? state.sessionFunctionCursor : null,
     state.sessionTurnStartCursor > 0 ? state.sessionTurnStartCursor : null,
@@ -603,6 +621,9 @@ export async function processCodexEventStream(events, state, config) {
           config.threadId = state.currentThreadId;
         }
         state.sessionFilePath = null;
+        state.sessionLinesCachePath = null;
+        state.sessionLinesCacheKey = null;
+        state.sessionLinesCache = [];
         state.sessionLineCursor = 0;
         state.sessionFunctionCursor = 0;
         state.sessionTurnStartCursor = 0;
@@ -618,17 +639,8 @@ export async function processCodexEventStream(events, state, config) {
       case 'turn.started': {
         state.turnWorkspaceSnapshot = null;
         state.emittedFileChangePaths.clear();
-        const sessionPath = ensureSessionFilePath(state, config.threadId);
-        if (sessionPath && existsSync(sessionPath)) {
-          try {
-            const content = await readFile(sessionPath, 'utf8');
-            state.sessionTurnStartCursor = countSessionJsonlLines(content);
-          } catch {
-            state.sessionTurnStartCursor = state.sessionFunctionCursor;
-          }
-        } else {
-          state.sessionTurnStartCursor = state.sessionFunctionCursor;
-        }
+        const lines = await readSessionJsonlLines(state, config.threadId, 'SESSION_REPLAY');
+        state.sessionTurnStartCursor = lines.length > 0 ? lines.length : state.sessionFunctionCursor;
         await captureTurnWorkspaceSnapshot(state, config);
         logDebug('CODEX_EVENT', 'Turn started');
         break;

--- a/ai-bridge/services/codex/codex-event-handler.js
+++ b/ai-bridge/services/codex/codex-event-handler.js
@@ -13,14 +13,13 @@
 
 import { randomUUID } from 'crypto';
 import { existsSync } from 'fs';
-import { readFile, unlink, writeFile } from 'fs/promises';
+import { readFile } from 'fs/promises';
 import { requestPermissionFromJava } from '../../permission-handler.js';
 import { findSessionFileByThreadId } from './codex-agents-loader.js';
-import { extractPatchFromResponseItemPayload, parseApplyPatchToOperations } from './codex-patch-parser.js';
 import {
   truncateForDisplay, getStableItemId, extractCommand,
   smartToolName, smartDescription, mapCommandToolNameToPermissionToolName,
-  resolveFilePath, stringifyRawEvent, isApprovalRelatedRawEvent
+  stringifyRawEvent, isApprovalRelatedRawEvent
 } from './codex-command-utils.js';
 import {
   DEBUG_LEVEL, MAX_TOOL_RESULT_CHARS,
@@ -31,10 +30,105 @@ import {
 import {
   normalizeMcpToolName, normalizeMcpToolInput,
   parseFunctionCallArguments, normalizeFunctionCallTool,
-  rememberToolInvocation, findMatchingToolUseId,
+  rememberToolInvocation, buildToolInvocationSignature,
 } from './codex-tool-normalization.js';
+import {
+  captureTurnWorkspaceSnapshot,
+  collectPatchOperationsFromSession,
+  emitSyntheticPatchOperations,
+  emitTurnWorkspaceDiff,
+  findUniqueRollbackIndex,
+  requestPatchApprovalsViaBridge,
+  rollbackDeniedPatchBatches,
+} from './codex-event-patch-tracking.js';
+
+export { emitSyntheticPatchOperations, findUniqueRollbackIndex };
 
 const COMMAND_DENIED_ABORT_ERROR = '__CODEX_COMMAND_DENIED_ABORT__';
+
+const LIFECYCLE_TOOL_NAMES = new Set(['spawn_agent', 'wait_agent', 'close_agent', 'send_input', 'resume_agent']);
+
+function isLifecycleTool(toolName) {
+  return typeof toolName === 'string' && LIFECYCLE_TOOL_NAMES.has(toolName);
+}
+
+function nextLifecycleToolUseId(state, toolName, stableHint = '') {
+  state.lifecycleToolSequence = (state.lifecycleToolSequence || 0) + 1;
+  const prefix = state.eventStateId || 'state';
+  const suffix = stableHint ? String(stableHint).replace(/[^a-zA-Z0-9_.:-]/g, '_') : state.lifecycleToolSequence;
+  return `codex_lifecycle_${toolName}_${prefix}_${suffix}`;
+}
+
+function rememberPendingFunctionCall(state, toolUseId) {
+  if (!toolUseId || state.emittedToolResultIds.has(toolUseId)) return;
+  if (!Array.isArray(state.pendingFunctionCallToolUseIds)) {
+    state.pendingFunctionCallToolUseIds = [];
+  }
+  if (!state.pendingFunctionCallToolUseIds.includes(toolUseId)) {
+    state.pendingFunctionCallToolUseIds.push(toolUseId);
+  }
+}
+
+function resolveFunctionCallOutputToolUseId(payload, state) {
+  const rawCallId = typeof payload.call_id === 'string' && payload.call_id ? payload.call_id : '';
+  if (rawCallId) return rawCallId;
+  const rawPayloadId = typeof payload.id === 'string' && payload.id ? payload.id : '';
+  if (rawPayloadId && state.emittedToolUseIds.has(rawPayloadId)) {
+    return state.emittedToolResultIds.has(rawPayloadId) ? '' : rawPayloadId;
+  }
+
+  const pending = (Array.isArray(state.pendingFunctionCallToolUseIds) ? state.pendingFunctionCallToolUseIds : [])
+    .filter((toolUseId) => state.emittedToolUseIds.has(toolUseId) && !state.emittedToolResultIds.has(toolUseId));
+  state.pendingFunctionCallToolUseIds = pending;
+  return pending.length > 0 ? pending[0] : '';
+}
+
+function markFunctionCallOutputCompleted(state, toolUseId) {
+  if (!Array.isArray(state.pendingFunctionCallToolUseIds)) return;
+  state.pendingFunctionCallToolUseIds = state.pendingFunctionCallToolUseIds.filter((pendingId) => pendingId !== toolUseId);
+}
+
+function sanitizeIdPart(value) {
+  return String(value || '').replace(/[^a-zA-Z0-9_.:-]/g, '_');
+}
+
+function generatedFunctionToolUseId(state, stableHint = '') {
+  if (stableHint) {
+    return `codex_function_${state.eventStateId || 'state'}_${sanitizeIdPart(stableHint)}`;
+  }
+  return randomUUID();
+}
+
+function rememberPendingMcpToolUseId(state, signature, toolUseId) {
+  if (!signature || !toolUseId) return;
+  if (!(state.pendingMcpToolUseIdsBySignature instanceof Map)) {
+    state.pendingMcpToolUseIdsBySignature = new Map();
+  }
+  const queue = state.pendingMcpToolUseIdsBySignature.get(signature) ?? [];
+  queue.push(toolUseId);
+  state.pendingMcpToolUseIdsBySignature.set(signature, queue);
+}
+
+function consumePendingMcpToolUseId(state, signature) {
+  if (!signature || !(state.pendingMcpToolUseIdsBySignature instanceof Map)) return null;
+  const queue = state.pendingMcpToolUseIdsBySignature.get(signature);
+  if (!Array.isArray(queue) || queue.length === 0) return null;
+  while (queue.length > 0) {
+    const candidate = queue.shift();
+    if (candidate && state.emittedToolUseIds.has(candidate) && !state.emittedToolResultIds.has(candidate)) {
+      if (queue.length === 0) state.pendingMcpToolUseIdsBySignature.delete(signature);
+      return candidate;
+    }
+  }
+  state.pendingMcpToolUseIdsBySignature.delete(signature);
+  return null;
+}
+
+function syntheticPatchSafeToRollback(operation, rollbackResult = null, deniedByUser = false) {
+  if (!operation || typeof operation.newString !== 'string' || operation.newString.length === 0) return false;
+  if (deniedByUser && rollbackResult?.success === false) return false;
+  return true;
+}
 
 function toolUseMsg(id, name, input) {
   return { type: 'assistant', message: { role: 'assistant', content: [{ type: 'tool_use', id, name, input }] } };
@@ -48,7 +142,7 @@ function textMsg(text) {
   return { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text }] } };
 }
 
-function handleFunctionCallPayload(payload, state) {
+export function handleFunctionCallPayload(payload, state, options = {}) {
   if (!payload || payload.type !== 'function_call') return false;
 
   const rawToolName = typeof payload.name === 'string' ? payload.name : '';
@@ -58,24 +152,26 @@ function handleFunctionCallPayload(payload, state) {
   const normalizedTool = normalizeFunctionCallTool(rawToolName, parsedArguments);
   const toolName = normalizedTool.name;
   const toolInput = normalizedTool.input;
-  const matchedToolUseId = findMatchingToolUseId(state, toolName, toolInput);
-  const toolUseId = matchedToolUseId || (typeof payload.call_id === 'string' && payload.call_id ? payload.call_id : randomUUID());
+  const rawCallId = typeof payload.call_id === 'string' && payload.call_id ? payload.call_id : null;
+  const rawPayloadId = typeof payload.id === 'string' && payload.id ? payload.id : null;
+  const stableHint = options.stableHint || rawPayloadId || '';
+  const lifecycleTool = isLifecycleTool(toolName);
+  const toolUseId = rawCallId || rawPayloadId || (lifecycleTool
+    ? nextLifecycleToolUseId(state, toolName, stableHint)
+    : generatedFunctionToolUseId(state, stableHint));
 
   if (!state.emittedToolUseIds.has(toolUseId)) {
     state.emitMessage(toolUseMsg(toolUseId, toolName, toolInput));
     state.emittedToolUseIds.add(toolUseId);
   }
   rememberToolInvocation(state, toolUseId, toolName, toolInput);
-  state.lastFunctionCallToolUseId = toolUseId;
+  rememberPendingFunctionCall(state, toolUseId);
   return true;
 }
 
-function handleFunctionCallOutputPayload(payload, state) {
+export function handleFunctionCallOutputPayload(payload, state) {
   if (!payload || payload.type !== 'function_call_output') return false;
-  let toolUseId = typeof payload.call_id === 'string' ? payload.call_id : '';
-  if ((!toolUseId || !state.emittedToolUseIds.has(toolUseId)) && state.lastFunctionCallToolUseId) {
-    toolUseId = state.lastFunctionCallToolUseId;
-  }
+  const toolUseId = resolveFunctionCallOutputToolUseId(payload, state);
   if (!toolUseId || state.emittedToolResultIds.has(toolUseId) || !state.emittedToolUseIds.has(toolUseId)) return false;
 
   const output = typeof payload.output === 'string' ? payload.output : JSON.stringify(payload.output ?? '(no output)');
@@ -84,6 +180,7 @@ function handleFunctionCallOutputPayload(payload, state) {
   const truncatedResult = truncateForDisplay(output, MAX_TOOL_RESULT_CHARS);
   state.emitMessage(toolResultMsg(toolUseId, isError, truncatedResult && truncatedResult.trim() ? truncatedResult : '(no output)'));
   state.emittedToolResultIds.add(toolUseId);
+  markFunctionCallOutputCompleted(state, toolUseId);
   return true;
 }
 
@@ -96,7 +193,13 @@ export function createInitialEventState(emitMessage) {
     emittedToolResultIds: new Set(),
     toolCallSignatureById: new Map(),
     toolUseIdBySignature: new Map(),
-    lastFunctionCallToolUseId: null,
+    pendingFunctionCallToolUseIds: [],
+    pendingMcpToolUseIdsBySignature: new Map(),
+    lifecycleToolSequence: 0,
+    eventStateId: randomUUID(),
+    syntheticEditSequence: 0,
+    turnWorkspaceSnapshot: null,
+    emittedFileChangePaths: new Set(),
     deniedCommandToolUseIds: new Set(),
     emittedDeniedCommandToolResultIds: new Set(),
     sessionFilePath: null,
@@ -149,8 +252,9 @@ function ensureToolUseId(state, phase, item) {
 
 function ensureSessionFilePath(state, threadId) {
   if (state.sessionFilePath && existsSync(state.sessionFilePath)) return state.sessionFilePath;
-  if (!threadId) return null;
-  state.sessionFilePath = findSessionFileByThreadId(threadId);
+  const effectiveThreadId = threadId || state.currentThreadId;
+  if (!effectiveThreadId) return null;
+  state.sessionFilePath = findSessionFileByThreadId(effectiveThreadId);
   return state.sessionFilePath;
 }
 
@@ -184,47 +288,6 @@ async function readLatestTurnContextFromSession(state, threadId) {
     }
   }
   return null;
-}
-
-async function collectPatchOperationsFromSession(state, config) {
-  const sessionPath = ensureSessionFilePath(state, config.threadId);
-  if (!sessionPath) return [];
-  let content = '';
-  try { content = await readFile(sessionPath, 'utf8'); } catch (error) {
-    console.warn('[DEBUG] Failed to read session file:', sessionPath, error?.message || error);
-    return [];
-  }
-  if (!content.trim()) return [];
-
-  const lines = splitSessionJsonlEntries(content);
-  const startIndex = state.sessionLineCursor > 0
-    ? state.sessionLineCursor
-    : Math.max(0, lines.length - SESSION_PATCH_SCAN_MAX_LINES);
-  const batches = [];
-
-  for (let i = startIndex; i < lines.length; i++) {
-    const line = lines[i];
-    if (!line || !line.trim()) continue;
-    let parsed;
-    try { parsed = JSON.parse(line); } catch { continue; }
-    if (parsed?.type !== 'response_item' || !parsed.payload) continue;
-
-    const payload = parsed.payload;
-    const callId = String(payload.call_id ?? payload.id ?? `line_${i}`);
-    if (state.processedPatchCallIds.has(callId)) continue;
-
-    const patchText = extractPatchFromResponseItemPayload(payload);
-    if (!patchText) continue;
-
-    const operations = parseApplyPatchToOperations(patchText)
-      .map((op) => ({ ...op, filePath: resolveFilePath(op.filePath, config.cwd) }))
-      .filter((op) => op.filePath && (op.oldString !== '' || op.newString !== ''));
-    state.processedPatchCallIds.add(callId);
-    if (operations.length === 0) continue;
-    batches.push({ callId, operations });
-  }
-  state.sessionLineCursor = lines.length;
-  return batches;
 }
 
 async function replayMissingFunctionCallsFromSession(state, config) {
@@ -262,17 +325,17 @@ async function replayMissingFunctionCallsFromSession(state, config) {
     const payload = parsed.payload;
     const payloadType = payload.type;
     if (payloadType === 'function_call') {
-      const callId = typeof payload.call_id === 'string' && payload.call_id ? payload.call_id : `line_${i}`;
+      const callId = typeof payload.call_id === 'string' && payload.call_id ? payload.call_id : (typeof payload.id === 'string' && payload.id ? payload.id : `line_${i}`);
       if (state.processedSessionFunctionCallIds.has(callId)) continue;
       state.processedSessionFunctionCallIds.add(callId);
-      if (handleFunctionCallPayload(payload, state)) {
+      if (handleFunctionCallPayload(payload, state, { stableHint: callId })) {
         toolUses += 1;
       }
       continue;
     }
 
     if (payloadType === 'function_call_output') {
-      const callId = typeof payload.call_id === 'string' && payload.call_id ? payload.call_id : `line_${i}`;
+      const callId = typeof payload.call_id === 'string' && payload.call_id ? payload.call_id : (typeof payload.id === 'string' && payload.id ? payload.id : `line_${i}`);
       if (state.processedSessionFunctionOutputIds.has(callId)) continue;
       state.processedSessionFunctionOutputIds.add(callId);
       if (handleFunctionCallOutputPayload(payload, state)) {
@@ -287,119 +350,6 @@ async function replayMissingFunctionCallsFromSession(state, config) {
 
 async function replayMissingFunctionCallsDuringStream(state, config) {
   await replayMissingFunctionCallsFromSession(state, config);
-}
-
-function buildPermissionInputForPatchOperation(operation) {
-  if (!operation || typeof operation !== 'object') return null;
-  const isWrite = operation.toolName === 'write' || operation.kind === 'add';
-  if (isWrite) {
-    return { toolName: 'Write', input: { file_path: operation.filePath, content: operation.newString ?? '' } };
-  }
-  return {
-    toolName: 'Edit',
-    input: { file_path: operation.filePath, old_string: operation.oldString ?? '', new_string: operation.newString ?? '', replace_all: false }
-  };
-}
-
-async function requestPatchApprovalsViaBridge(patchBatches) {
-  const deniedCallIds = new Set();
-  if (!Array.isArray(patchBatches) || patchBatches.length === 0) return deniedCallIds;
-  for (const batch of patchBatches) {
-    if (!batch || !Array.isArray(batch.operations) || batch.operations.length === 0) continue;
-    const previewOp = batch.operations[0];
-    const requestPayload = buildPermissionInputForPatchOperation(previewOp);
-    if (!requestPayload) continue;
-    try {
-      logInfo('PERM_DEBUG', `Patch approval request: callId=${batch.callId}, tool=${requestPayload.toolName}, file=${previewOp?.filePath || ''}`);
-      const allowed = await requestPermissionFromJava(requestPayload.toolName, requestPayload.input);
-      logInfo('PERM_DEBUG', `Patch approval decision: callId=${batch.callId}, allowed=${allowed ? 'true' : 'false'}`);
-      if (!allowed) deniedCallIds.add(batch.callId);
-    } catch (error) {
-      logWarn('PERM_DEBUG', `Patch approval bridge failed (callId=${batch.callId}): ${error?.message || error}`);
-      deniedCallIds.add(batch.callId);
-    }
-  }
-  return deniedCallIds;
-}
-
-async function rollbackSinglePatchOperation(operation) {
-  if (!operation || typeof operation !== 'object' || !operation.filePath) {
-    return { ok: false, reason: 'invalid-operation' };
-  }
-  const { filePath } = operation;
-  const oldString = typeof operation.oldString === 'string' ? operation.oldString : '';
-  const newString = typeof operation.newString === 'string' ? operation.newString : '';
-  const isAddedFile = operation.kind === 'add' || (operation.toolName === 'write' && oldString === '');
-
-  if (isAddedFile) {
-    if (!existsSync(filePath)) return { ok: true, reason: 'file-already-missing' };
-    try { await unlink(filePath); return { ok: true, reason: 'file-deleted' }; }
-    catch (error) { return { ok: false, reason: error?.message || String(error) }; }
-  }
-  if (!existsSync(filePath)) return { ok: false, reason: 'file-missing' };
-  let currentContent = '';
-  try { currentContent = await readFile(filePath, 'utf8'); }
-  catch (error) { return { ok: false, reason: error?.message || String(error) }; }
-  if (newString === oldString) return { ok: true, reason: 'noop' };
-  if (!newString) return { ok: false, reason: 'unsupported-empty-new-string' };
-  const index = currentContent.indexOf(newString);
-  if (index < 0) return { ok: false, reason: 'new-string-not-found' };
-  const revertedContent = currentContent.slice(0, index) + oldString + currentContent.slice(index + newString.length);
-  try { await writeFile(filePath, revertedContent, 'utf8'); return { ok: true, reason: 'replaced' }; }
-  catch (error) { return { ok: false, reason: error?.message || String(error) }; }
-}
-
-async function rollbackDeniedPatchBatches(patchBatches, deniedCallIds) {
-  const resultByCallId = new Map();
-  if (!Array.isArray(patchBatches) || patchBatches.length === 0) return resultByCallId;
-  if (!(deniedCallIds instanceof Set) || deniedCallIds.size === 0) return resultByCallId;
-  for (const batch of patchBatches) {
-    if (!batch || !deniedCallIds.has(batch.callId)) continue;
-    const operations = Array.isArray(batch.operations) ? [...batch.operations].reverse() : [];
-    const failures = [];
-    for (const op of operations) {
-      const result = await rollbackSinglePatchOperation(op);
-      if (!result.ok) failures.push({ filePath: op?.filePath || '', reason: result.reason });
-    }
-    resultByCallId.set(batch.callId, { success: failures.length === 0, failures });
-  }
-  return resultByCallId;
-}
-
-function emitSyntheticPatchOperations(state, patchBatches, isError, deniedCallIds = new Set(), rollbackByCallId = new Map()) {
-  if (!Array.isArray(patchBatches) || patchBatches.length === 0) return 0;
-  let emittedCount = 0;
-  for (const batch of patchBatches) {
-    if (!batch || !Array.isArray(batch.operations)) continue;
-    batch.operations.forEach((op, index) => {
-      const toolUseId = `codex_patch_${batch.callId}_${index}`;
-      const toolName = op.toolName === 'write' ? 'write' : 'edit';
-      if (!state.emittedToolUseIds.has(toolUseId)) {
-        state.emitMessage(toolUseMsg(toolUseId, toolName, {
-          file_path: op.filePath,
-          old_string: op.oldString,
-          new_string: op.newString,
-          start_line: op.startLine,
-          end_line: op.endLine,
-          replace_all: false,
-          source: 'codex_session_patch'
-        }));
-        state.emittedToolUseIds.add(toolUseId);
-      }
-      const deniedByUser = deniedCallIds instanceof Set && deniedCallIds.has(batch.callId);
-      const rollbackResult = rollbackByCallId instanceof Map ? rollbackByCallId.get(batch.callId) : null;
-      const rollbackSucceeded = !deniedByUser || rollbackResult?.success !== false;
-      const opIsError = !!isError || deniedByUser;
-      let resultText = 'Patch applied';
-      if (isError) resultText = 'Patch apply failed';
-      else if (deniedByUser) {
-        resultText = rollbackSucceeded ? 'Patch denied by user and rolled back' : 'Patch denied by user but rollback failed';
-      }
-      state.emitMessage(toolResultMsg(toolUseId, opIsError, resultText));
-      emittedCount += 1;
-    });
-  }
-  return emittedCount;
 }
 
 function emitDeniedCommandToolResultOnce(state, toolUseId, messageText = 'Command denied by user') {
@@ -451,7 +401,7 @@ function extractAppendedDelta(previousText, nextText) {
 }
 
 function emitThinkingBlock(state, text) {
-  console.log('[THINKING]', text);
+  logDebug('CODEX_EVENT', `Thinking: ${text}`);
   state.emitMessage({
     type: 'assistant',
     message: { role: 'assistant', content: [{ type: 'thinking', thinking: text, text }] }
@@ -500,9 +450,9 @@ async function maybeLogRuntimePolicy(state, config) {
  * file_change, and mcp_tool_call.
  */
 async function handleItemCompleted(item, state, config) {
-  console.log('[DEBUG] item.completed - type:', item.type);
-  console.log('[DEBUG] item.completed - has text:', !!item.text);
-  console.log('[DEBUG] item.completed - has agent_message:', !!item.agent_message);
+  logDebug('CODEX_EVENT', `item.completed type=${item.type}`);
+  logDebug('CODEX_EVENT', `item.completed hasText=${!!item.text}`);
+  logDebug('CODEX_EVENT', `item.completed hasAgentMessage=${!!item.agent_message}`);
   maybeEmitReasoning(state, item);
 
   if (item.type === 'agent_message') {
@@ -514,14 +464,14 @@ async function handleItemCompleted(item, state, config) {
   } else if (item.type === 'mcp_tool_call') {
     handleMcpToolCall(item, state);
   } else {
-    console.log('[DEBUG] Unhandled item.completed item type:', item.type);
+    logDebug('CODEX_EVENT', `Unhandled item.completed item type=${item.type}`);
   }
 }
 
 function handleAgentMessage(item, state, { emitSnapshot = true } = {}) {
   const text = item.text || '';
-  console.log('[DEBUG] agent_message text length:', text.length);
-  console.log('[DEBUG] agent_message text (first 100 chars):', text.substring(0, 100));
+  logDebug('CODEX_EVENT', `agent_message text length=${text.length}`);
+  logDebug('CODEX_EVENT', `agent_message text=${text.substring(0, 100)}`);
   const stableId = getStableItemId(item) ?? 'agent_message';
   const previousText = state.assistantTextCache.get(stableId) ?? '';
   const delta = extractAppendedDelta(previousText, text);
@@ -541,7 +491,7 @@ function handleCommandExecution(item, state) {
   const command = extractCommand(item);
   if (state.deniedCommandToolUseIds.has(toolUseId)) {
     emitDeniedCommandToolResultOnce(state, toolUseId);
-    console.log('[DEBUG] Skip command output because approval denied:', command);
+    logDebug('CODEX_EVENT', `Skip command output because approval denied: ${command}`);
     return;
   }
   const output = item.aggregated_output ?? item.output ?? item.stdout ?? item.result ?? '';
@@ -561,10 +511,15 @@ function handleCommandExecution(item, state) {
 async function handleFileChange(item, state, config) {
   const status = item.status || 'completed';
   const isError = status !== 'completed';
-  try { console.log('[DEBUG] file_change raw item:', JSON.stringify(item)); }
-  catch (error) { console.log('[DEBUG] file_change raw item stringify failed:', error?.message || error); }
+  try { logDebug('CODEX_EVENT', `file_change raw item: ${JSON.stringify(item)}`); }
+  catch (error) { logDebug('CODEX_EVENT', `file_change raw item stringify failed: ${error?.message || error}`); }
 
-  const patchBatches = await collectPatchOperationsFromSession(state, config);
+  const patchBatches = await collectPatchOperationsFromSession(
+    state,
+    config,
+    ensureSessionFilePath,
+    splitSessionJsonlEntries
+  );
   let deniedCallIds = new Set();
   let rollbackByCallId = new Map();
 
@@ -586,17 +541,18 @@ async function handleFileChange(item, state, config) {
     }
   }
   const emitted = emitSyntheticPatchOperations(state, patchBatches, isError, deniedCallIds, rollbackByCallId);
-  if (emitted > 0) console.log('[DEBUG] file_change synthesized operations:', emitted);
-  else console.log('[DEBUG] file_change: no patch operations found in session log');
+  if (emitted > 0) logDebug('CODEX_EVENT', `file_change synthesized operations=${emitted}`);
+  else logDebug('CODEX_EVENT', 'file_change: no patch operations found in session log');
 }
 
 function handleMcpToolCall(item, state) {
   const toolName = normalizeMcpToolName(item.server, item.tool);
   const toolInput = normalizeMcpToolInput(item.server, item.tool, item.arguments || {});
-  const matchedToolUseId = findMatchingToolUseId(state, toolName, toolInput);
-  const toolUseId = matchedToolUseId || item.id || randomUUID();
+  const rawItemId = typeof item.id === 'string' && item.id ? item.id : null;
+  const signature = buildToolInvocationSignature(toolName, toolInput);
+  const toolUseId = rawItemId || consumePendingMcpToolUseId(state, signature) || randomUUID();
   const isError = item.status === 'failed' || !!item.error;
-  console.log('[DEBUG] MCP tool call completed:', toolName, 'id:', toolUseId, 'error:', isError);
+  logDebug('CODEX_EVENT', `MCP tool call completed tool=${toolName} id=${toolUseId} error=${isError}`);
   if (!state.emittedToolUseIds.has(toolUseId)) {
     state.emitMessage(toolUseMsg(toolUseId, toolName, toolInput));
     state.emittedToolUseIds.add(toolUseId);
@@ -615,6 +571,7 @@ function handleMcpToolCall(item, state) {
       resultContent = JSON.stringify(item.result);
     }
   }
+  if (state.emittedToolResultIds.has(toolUseId)) return;
   const truncatedResult = truncateForDisplay(resultContent, MAX_TOOL_RESULT_CHARS);
   state.emitMessage(toolResultMsg(toolUseId, isError, truncatedResult && truncatedResult.trim() ? truncatedResult : '(no output)'));
   state.emittedToolResultIds.add(toolUseId);
@@ -632,28 +589,35 @@ export async function processCodexEventStream(events, state, config) {
     for await (const event of events) {
       rawEventIndex += 1;
       const rawEventJson = stringifyRawEvent(event);
-      if (rawEventJson && DEBUG_LEVEL >= 5) console.log(`[RAW_EVENT][${rawEventIndex}]`, rawEventJson);
+      if (rawEventJson && DEBUG_LEVEL >= 5) logDebug('CODEX_RAW_EVENT', `[${rawEventIndex}] ${rawEventJson}`);
       if (rawEventJson && DEBUG_LEVEL >= 4 && isApprovalRelatedRawEvent(rawEventJson)) {
-        console.log(`[RAW_EVENT_APPROVAL_HINT][${rawEventIndex}]`, rawEventJson);
+        logDebug('CODEX_RAW_EVENT', `[APPROVAL_HINT][${rawEventIndex}] ${rawEventJson}`);
       }
       await maybeLogRuntimePolicy(state, config);
-      console.log('[DEBUG] Codex event:', event.type);
+      logDebug('CODEX_EVENT', `Codex event=${event.type}`);
 
       switch (event.type) {
       case 'thread.started': {
         state.currentThreadId = event.thread_id;
+        if (state.currentThreadId && !config.threadId) {
+          config.threadId = state.currentThreadId;
+        }
         state.sessionFilePath = null;
         state.sessionLineCursor = 0;
         state.sessionFunctionCursor = 0;
         state.sessionTurnStartCursor = 0;
+        state.turnWorkspaceSnapshot = null;
+        state.emittedFileChangePaths.clear();
         state.processedPatchCallIds.clear();
         state.processedSessionFunctionCallIds.clear();
         state.processedSessionFunctionOutputIds.clear();
-        console.log('[THREAD_ID]', state.currentThreadId);
+        logInfo('CODEX_EVENT', `Thread id=${state.currentThreadId}`);
         break;
       }
 
       case 'turn.started': {
+        state.turnWorkspaceSnapshot = null;
+        state.emittedFileChangePaths.clear();
         const sessionPath = ensureSessionFilePath(state, config.threadId);
         if (sessionPath && existsSync(sessionPath)) {
           try {
@@ -665,7 +629,8 @@ export async function processCodexEventStream(events, state, config) {
         } else {
           state.sessionTurnStartCursor = state.sessionFunctionCursor;
         }
-        console.log('[DEBUG] Turn started');
+        await captureTurnWorkspaceSnapshot(state, config);
+        logDebug('CODEX_EVENT', 'Turn started');
         break;
       }
 
@@ -677,6 +642,7 @@ export async function processCodexEventStream(events, state, config) {
       case 'item.started': {
         maybeEmitReasoning(state, event.item);
         if (event.item && event.item.type === 'command_execution') {
+          await captureTurnWorkspaceSnapshot(state, config);
           const toolUseId = ensureToolUseId(state, 'started', event.item);
           const command = extractCommand(event.item);
           const toolName = smartToolName(command);
@@ -694,14 +660,17 @@ export async function processCodexEventStream(events, state, config) {
         } else if (event.item && event.item.type === 'mcp_tool_call') {
           const toolName = normalizeMcpToolName(event.item.server, event.item.tool);
           const toolInput = normalizeMcpToolInput(event.item.server, event.item.tool, event.item.arguments || {});
-          const matchedToolUseId = findMatchingToolUseId(state, toolName, toolInput);
-          const toolUseId = matchedToolUseId || event.item.id || randomUUID();
-          console.log('[DEBUG] MCP tool call started:', toolName, 'id:', toolUseId);
+          const rawItemId = typeof event.item.id === 'string' && event.item.id ? event.item.id : null;
+          const toolUseId = rawItemId || randomUUID();
+          logDebug('CODEX_EVENT', `MCP tool call started tool=${toolName} id=${toolUseId}`);
           if (!state.emittedToolUseIds.has(toolUseId)) {
             state.emitMessage(toolUseMsg(toolUseId, toolName, toolInput));
             state.emittedToolUseIds.add(toolUseId);
           }
           rememberToolInvocation(state, toolUseId, toolName, toolInput);
+          if (!rawItemId) {
+            rememberPendingMcpToolUseId(state, buildToolInvocationSignature(toolName, toolInput), toolUseId);
+          }
         }
         await replayMissingFunctionCallsDuringStream(state, config);
         break;
@@ -723,13 +692,14 @@ export async function processCodexEventStream(events, state, config) {
       }
 
       case 'turn.completed': {
-        console.log('[DEBUG] Turn completed');
+        logDebug('CODEX_EVENT', 'Turn completed');
         const replayed = await replayMissingFunctionCallsFromSession(state, config);
         if (replayed.toolUses > 0 || replayed.toolResults > 0) {
-          console.log('[DEBUG] Replayed session function calls:', JSON.stringify(replayed));
+          logDebug('CODEX_EVENT', `Replayed session function calls: ${JSON.stringify(replayed)}`);
         }
+        await emitTurnWorkspaceDiff(state, config);
         if (event.usage) {
-          console.log('[DEBUG] Token usage:', event.usage);
+          logDebug('CODEX_EVENT', `Token usage: ${JSON.stringify(event.usage)}`);
           const claudeUsage = {
             input_tokens: event.usage.input_tokens || 0,
             output_tokens: event.usage.output_tokens || 0,
@@ -740,7 +710,7 @@ export async function processCodexEventStream(events, state, config) {
             type: 'result', subtype: 'usage', is_error: false,
             usage: claudeUsage, session_id: state.currentThreadId, uuid: randomUUID()
           });
-          console.log('[DEBUG] Emitted usage statistics (Claude-compatible format):', claudeUsage);
+          logDebug('CODEX_EVENT', `Emitted usage statistics: ${JSON.stringify(claudeUsage)}`);
         }
         if (typeof config.onTurnCompleted === 'function') {
           config.onTurnCompleted(event, state);
@@ -751,7 +721,7 @@ export async function processCodexEventStream(events, state, config) {
       case 'turn.failed': {
         const errorMsg = event.error?.message || 'Turn failed';
         if (isReconnectNotice(errorMsg)) {
-          console.warn('[DEBUG] Codex reconnect notice:', errorMsg);
+          logWarn('CODEX_EVENT', `Codex reconnect notice: ${errorMsg}`);
           emitStatusMessage(state.emitMessage, errorMsg);
           break;
         }
@@ -762,14 +732,14 @@ export async function processCodexEventStream(events, state, config) {
         if (typeof config.onTurnFailed === 'function') {
           config.onTurnFailed(event, state);
         }
-        console.error('[DEBUG] Turn failed:', errorMsg);
+        logWarn('CODEX_EVENT', `Turn failed: ${errorMsg}`);
         throw new Error(errorMsg);
       }
 
       case 'error': {
         const generalError = event.message || 'Unknown error';
         if (isReconnectNotice(generalError)) {
-          console.warn('[DEBUG] Codex reconnect notice:', generalError);
+          logWarn('CODEX_EVENT', `Codex reconnect notice: ${generalError}`);
           emitStatusMessage(state.emitMessage, generalError);
           break;
         }
@@ -780,35 +750,37 @@ export async function processCodexEventStream(events, state, config) {
         if (typeof config.onTurnFailed === 'function') {
           config.onTurnFailed(event, state);
         }
-        console.error('[DEBUG] Codex error:', generalError);
+        logWarn('CODEX_EVENT', `Codex error: ${generalError}`);
         throw new Error(generalError);
       }
 
       default: {
         const payloadType = event.payload?.type;
-        console.log('[DEBUG] Unknown event type:', event.type, 'payload.type:', payloadType);
+        logDebug('CODEX_EVENT', `Unknown event type=${event.type} payload.type=${payloadType}`);
 
         if (event.type === 'response_item') {
           const payload = event.payload;
           const payloadCallId = typeof payload?.call_id === 'string' && payload.call_id
             ? payload.call_id
             : null;
-          if (handleFunctionCallPayload(payload, state)) {
-            if (payloadCallId) {
-              state.processedSessionFunctionCallIds.add(payloadCallId);
+          const payloadStableId = typeof payload?.id === 'string' && payload.id ? payload.id : null;
+          const payloadKey = payloadCallId || payloadStableId;
+          if (handleFunctionCallPayload(payload, state, { stableHint: payloadKey || `stream_${rawEventIndex}` })) {
+            if (payloadKey) {
+              state.processedSessionFunctionCallIds.add(payloadKey);
             }
             break;
           }
           if (handleFunctionCallOutputPayload(payload, state)) {
-            if (payloadCallId) {
-              state.processedSessionFunctionOutputIds.add(payloadCallId);
+            if (payloadKey) {
+              state.processedSessionFunctionOutputIds.add(payloadKey);
             }
             break;
           }
         }
 
         if (event.type === 'event_msg' || payloadType === 'function_call' || payloadType === 'function_call_output') {
-          console.log('[DEBUG] Full event:', JSON.stringify(event).substring(0, 500));
+          logDebug('CODEX_EVENT', `Full event: ${JSON.stringify(event).substring(0, 500)}`);
         }
       }
       }

--- a/ai-bridge/services/codex/codex-event-handler.lifecycle.test.mjs
+++ b/ai-bridge/services/codex/codex-event-handler.lifecycle.test.mjs
@@ -1,10 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { createInitialEventState, emitSyntheticPatchOperations, findUniqueRollbackIndex, handleFunctionCallPayload, handleFunctionCallOutputPayload, processCodexEventStream } from './codex-event-handler.js';
+import { collectPatchOperationsFromSession, rollbackDeniedPatchBatches } from './codex-event-patch-tracking.js';
 
 test('function call payload prefers raw call_id over matching signature for repeated lifecycle tools', () => {
   const emitted = [];
@@ -77,6 +78,39 @@ test('denied patch rollback index is line-aware and rejects ambiguous global mat
   const content = 'same\nneedle\nsame\nneedle\n';
   assert.equal(findUniqueRollbackIndex(content, 'needle', { startLine: 2, endLine: 2 }), 5);
   assert.equal(findUniqueRollbackIndex(content, 'needle', {}), -1);
+});
+
+test('collectPatchOperationsFromSession reads jsonl patch operations', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'codex-session-patch-'));
+  const sessionPath = join(cwd, 'session.jsonl');
+  const patch = '*** Begin Patch\n*** Update File: src/a.txt\n@@ -1 +1 @@\n-old\n+new\n*** End Patch';
+  const payload = {
+    type: 'response_item',
+    payload: {
+      type: 'function_call',
+      name: 'apply_patch',
+      call_id: 'patch-1',
+      arguments: JSON.stringify({ patch }),
+    },
+  };
+  try {
+    await writeFile(sessionPath, `${JSON.stringify(payload)}\n`, 'utf8');
+    const state = { sessionLineCursor: 0, processedPatchCallIds: new Set() };
+    const batches = await collectPatchOperationsFromSession(
+      state,
+      { cwd, threadId: 'thread-1' },
+      () => sessionPath,
+      (content) => content.split('\n').filter((line) => line.trim()),
+    );
+
+    assert.equal(batches.length, 1);
+    assert.equal(batches[0].operations.length, 1);
+    assert.equal(batches[0].operations[0].oldString, 'old');
+    assert.equal(batches[0].operations[0].newString, 'new');
+    assert.equal(batches[0].operations[0].workspaceRoot, cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
 });
 
 
@@ -173,11 +207,70 @@ test('denied patch rollback failure remains visible as a file change', () => {
   assert.equal(result.message.content[0].is_error, false);
 });
 
+test('denied patch rollback refuses symlink paths', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'codex-denied-patch-'));
+  try {
+    await writeFile(join(cwd, 'target.txt'), 'after\n', 'utf8');
+    await symlink(join(cwd, 'target.txt'), join(cwd, 'link.txt'));
+
+    const resultByCallId = await rollbackDeniedPatchBatches([
+      {
+        callId: 'patch-1',
+        operations: [{
+          filePath: join(cwd, 'link.txt'),
+          workspaceRoot: cwd,
+          oldString: 'before\n',
+          newString: 'after\n',
+          toolName: 'edit',
+          kind: 'update',
+        }],
+      },
+    ], new Set(['patch-1']));
+
+    const result = resultByCallId.get('patch-1');
+    assert.equal(result.success, false);
+    assert.equal(result.failures[0].reason, 'refuse-symlink-path');
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test('denied patch rollback refuses symlink parent paths', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'codex-denied-patch-root-'));
+  const outside = await mkdtemp(join(tmpdir(), 'codex-denied-patch-outside-'));
+  try {
+    await writeFile(join(outside, 'target.txt'), 'after\n', 'utf8');
+    await symlink(outside, join(cwd, 'linked-dir'));
+
+    const resultByCallId = await rollbackDeniedPatchBatches([
+      {
+        callId: 'patch-1',
+        operations: [{
+          filePath: join(cwd, 'linked-dir', 'target.txt'),
+          workspaceRoot: cwd,
+          oldString: 'before\n',
+          newString: 'after\n',
+          toolName: 'edit',
+          kind: 'update',
+        }],
+      },
+    ], new Set(['patch-1']));
+
+    const result = resultByCallId.get('patch-1');
+    assert.equal(result.success, false);
+    assert.equal(result.failures[0].reason, 'refuse-symlink-path');
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  }
+});
+
 
 test('command-created files are emitted as rollback-safe synthetic file changes', async () => {
   const cwd = await mkdtemp(join(tmpdir(), 'codex-fs-snapshot-'));
   const emitted = [];
   const state = createInitialEventState((message) => emitted.push(message));
+  let expectedTextPath = '';
 
   async function* events() {
     yield { type: 'turn.started' };
@@ -190,6 +283,7 @@ test('command-created files are emitted as rollback-safe synthetic file changes'
 
   try {
     await processCodexEventStream(events(), state, { cwd, threadId: 'thread-1', threadOptions: {}, normalizedPermissionMode: 'default' });
+    expectedTextPath = await realpath(join(cwd, 'src/text.js'));
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }
@@ -198,7 +292,7 @@ test('command-created files are emitted as rollback-safe synthetic file changes'
   const fileResult = emitted.find((message) => message.message?.content?.[0]?.type === 'tool_result' && message.message.content[0].tool_use_id === fileUse?.message.content[0].id);
 
   assert.ok(fileUse, 'expected synthetic write tool use');
-  assert.equal(fileUse.message.content[0].input.file_path, join(cwd, 'src/text.js'));
+  assert.equal(fileUse.message.content[0].input.file_path, expectedTextPath);
   assert.equal(fileUse.message.content[0].input.old_string, '');
   assert.equal(fileUse.message.content[0].input.new_string, 'export const hello = "world";\n');
   assert.equal(fileUse.message.content[0].input.safe_to_rollback, true);

--- a/ai-bridge/services/codex/codex-event-handler.lifecycle.test.mjs
+++ b/ai-bridge/services/codex/codex-event-handler.lifecycle.test.mjs
@@ -1,0 +1,208 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { createInitialEventState, emitSyntheticPatchOperations, findUniqueRollbackIndex, handleFunctionCallPayload, handleFunctionCallOutputPayload, processCodexEventStream } from './codex-event-handler.js';
+
+test('function call payload prefers raw call_id over matching signature for repeated lifecycle tools', () => {
+  const emitted = [];
+  const state = createInitialEventState((message) => emitted.push(message));
+  const args = JSON.stringify({ target: 'agent-1' });
+
+  assert.equal(handleFunctionCallPayload({ type: 'function_call', name: 'wait_agent', call_id: 'call-1', arguments: args }, state), true);
+  assert.equal(handleFunctionCallPayload({ type: 'function_call', name: 'wait_agent', call_id: 'call-2', arguments: args }, state), true);
+
+  assert.equal(emitted.length, 2);
+  assert.equal(emitted[0].message.content[0].id, 'call-1');
+  assert.equal(emitted[1].message.content[0].id, 'call-2');
+});
+
+test('function call payload creates unique ids for repeated lifecycle tools without raw call_id', () => {
+  const emitted = [];
+  const state = createInitialEventState((message) => emitted.push(message));
+  const args = JSON.stringify({ target: 'agent-1' });
+
+  assert.equal(handleFunctionCallPayload({ type: 'function_call', name: 'wait_agent', arguments: args }, state), true);
+  assert.equal(handleFunctionCallPayload({ type: 'function_call', name: 'wait_agent', arguments: args }, state), true);
+
+  assert.equal(emitted.length, 2);
+  assert.notEqual(emitted[0].message.content[0].id, emitted[1].message.content[0].id);
+  assert.match(emitted[0].message.content[0].id, /^codex_lifecycle_wait_agent_/);
+  assert.match(emitted[1].message.content[0].id, /^codex_lifecycle_wait_agent_/);
+});
+
+
+test('function call output without call_id matches only a single pending function call', () => {
+  const emitted = [];
+  const state = createInitialEventState((message) => emitted.push(message));
+
+  handleFunctionCallPayload({ type: 'function_call', name: 'wait_agent', arguments: JSON.stringify({ target: 'agent-1' }) }, state);
+  assert.equal(handleFunctionCallOutputPayload({ type: 'function_call_output', output: 'done' }, state), true);
+
+  assert.equal(emitted.length, 2);
+  assert.equal(emitted[1].message.content[0].tool_use_id, emitted[0].message.content[0].id);
+});
+
+test('function call output without call_id resolves pending calls in FIFO order', () => {
+  const emitted = [];
+  const state = createInitialEventState((message) => emitted.push(message));
+
+  handleFunctionCallPayload({ type: 'function_call', name: 'wait_agent', arguments: JSON.stringify({ target: 'agent-1' }) }, state);
+  handleFunctionCallPayload({ type: 'function_call', name: 'send_input', arguments: JSON.stringify({ target: 'agent-1', message: 'continue' }) }, state);
+
+  assert.equal(handleFunctionCallOutputPayload({ type: 'function_call_output', output: 'done-1' }, state), true);
+  assert.equal(handleFunctionCallOutputPayload({ type: 'function_call_output', output: 'done-2' }, state), true);
+  const results = emitted.filter((message) => message.message?.content?.[0]?.type === 'tool_result');
+  assert.equal(results.length, 2);
+  assert.equal(results[0].message.content[0].tool_use_id, emitted[0].message.content[0].id);
+  assert.equal(results[1].message.content[0].tool_use_id, emitted[1].message.content[0].id);
+});
+
+test('lifecycle ids without call_id do not collide across event states', () => {
+  const emittedA = [];
+  const emittedB = [];
+  const stateA = createInitialEventState((message) => emittedA.push(message));
+  const stateB = createInitialEventState((message) => emittedB.push(message));
+
+  handleFunctionCallPayload({ type: 'function_call', name: 'spawn_agent', arguments: JSON.stringify({}) }, stateA);
+  handleFunctionCallPayload({ type: 'function_call', name: 'spawn_agent', arguments: JSON.stringify({}) }, stateB);
+
+  assert.notEqual(emittedA[0].message.content[0].id, emittedB[0].message.content[0].id);
+});
+
+
+test('denied patch rollback index is line-aware and rejects ambiguous global matches', () => {
+  const content = 'same\nneedle\nsame\nneedle\n';
+  assert.equal(findUniqueRollbackIndex(content, 'needle', { startLine: 2, endLine: 2 }), 5);
+  assert.equal(findUniqueRollbackIndex(content, 'needle', {}), -1);
+});
+
+
+
+test('response_item function_call without call_id is handled without undefined callId', async () => {
+  const emitted = [];
+  const state = createInitialEventState((message) => emitted.push(message));
+  const events = [
+    { type: 'response_item', payload: { type: 'function_call', name: 'spawn_agent', id: 'item-1', arguments: '{}' } },
+  ];
+
+  await processCodexEventStream(events, state, { threadId: 'thread-1', threadOptions: {}, normalizedPermissionMode: 'default' });
+
+  assert.equal(emitted.length, 1);
+  assert.equal(emitted[0].message.content[0].id, 'item-1');
+});
+
+
+test('non-lifecycle function calls without ids do not reuse signature ids', () => {
+  const emitted = [];
+  const state = createInitialEventState((message) => emitted.push(message));
+  const payload = { type: 'function_call', name: 'update_plan', arguments: JSON.stringify({ plan: [{ step: 'x', status: 'pending' }] }) };
+
+  assert.equal(handleFunctionCallPayload(payload, state), true);
+  assert.equal(handleFunctionCallPayload(payload, state), true);
+
+  const uses = emitted.filter((message) => message.message?.content?.[0]?.type === 'tool_use');
+  assert.equal(uses.length, 2);
+  assert.notEqual(uses[0].message.content[0].id, uses[1].message.content[0].id);
+});
+
+test('function_call_output with payload id does not consume the next pending call twice', () => {
+  const emitted = [];
+  const state = createInitialEventState((message) => emitted.push(message));
+
+  handleFunctionCallPayload({ type: 'function_call', id: 'item-1', name: 'update_plan', arguments: JSON.stringify({ plan: [{ step: 'a', status: 'pending' }] }) }, state);
+  handleFunctionCallPayload({ type: 'function_call', id: 'item-2', name: 'update_plan', arguments: JSON.stringify({ plan: [{ step: 'b', status: 'pending' }] }) }, state);
+
+  assert.equal(handleFunctionCallOutputPayload({ type: 'function_call_output', id: 'item-1', output: 'done-1' }, state), true);
+  assert.equal(handleFunctionCallOutputPayload({ type: 'function_call_output', id: 'item-1', output: 'duplicate' }, state), false);
+
+  const results = emitted.filter((message) => message.message?.content?.[0]?.type === 'tool_result');
+  assert.equal(results.length, 1);
+  assert.equal(results[0].message.content[0].tool_use_id, 'item-1');
+});
+
+
+
+test('function_call_output with nonmatching payload id falls back to FIFO pending call', () => {
+  const emitted = [];
+  const state = createInitialEventState((message) => emitted.push(message));
+
+  handleFunctionCallPayload({ type: 'function_call', id: 'call-1', name: 'update_plan', arguments: JSON.stringify({ plan: [{ step: 'a', status: 'pending' }] }) }, state);
+
+  assert.equal(handleFunctionCallOutputPayload({ type: 'function_call_output', id: 'output-item-1', output: 'done' }, state), true);
+
+  const results = emitted.filter((message) => message.message?.content?.[0]?.type === 'tool_result');
+  assert.equal(results.length, 1);
+  assert.equal(results[0].message.content[0].tool_use_id, 'call-1');
+});
+
+test('identical mcp calls without ids remain separate invocations', async () => {
+  const emitted = [];
+  const state = createInitialEventState((message) => emitted.push(message));
+  const item = { type: 'mcp_tool_call', server: 'filesystem', tool: 'read_text_file', arguments: { path: '/tmp/a.txt' }, output: 'ok' };
+
+  await processCodexEventStream([
+    { type: 'item.started', item },
+    { type: 'item.started', item },
+    { type: 'item.completed', item },
+    { type: 'item.completed', item },
+  ], state, { threadId: 'thread-1', threadOptions: {}, normalizedPermissionMode: 'default' });
+
+  assert.equal(emitted[0].message.content[0].type, 'tool_use');
+  assert.equal(emitted[1].message.content[0].type, 'tool_use');
+  const uses = emitted.filter((message) => message.message?.content?.[0]?.type === 'tool_use');
+  const results = emitted.filter((message) => message.message?.content?.[0]?.type === 'tool_result');
+  assert.equal(uses.length, 2);
+  assert.equal(results.length, 2);
+  assert.notEqual(uses[0].message.content[0].id, uses[1].message.content[0].id);
+});
+
+test('denied patch rollback failure remains visible as a file change', () => {
+  const emitted = [];
+  const state = createInitialEventState((message) => emitted.push(message));
+  const patchBatches = [{ callId: 'patch-1', operations: [{ filePath: '/repo/a.ts', oldString: 'before', newString: 'after', toolName: 'edit', kind: 'update' }] }];
+  const rollbackByCallId = new Map([['patch-1', { success: false, failures: [{ filePath: '/repo/a.ts', reason: 'ambiguous_match' }] }]]);
+
+  emitSyntheticPatchOperations(state, patchBatches, false, new Set(['patch-1']), rollbackByCallId);
+
+  const use = emitted.find((message) => message.message?.content?.[0]?.type === 'tool_use');
+  const result = emitted.find((message) => message.message?.content?.[0]?.type === 'tool_result');
+  assert.equal(use.message.content[0].input.safe_to_rollback, false);
+  assert.equal(result.message.content[0].is_error, false);
+});
+
+
+test('command-created files are emitted as rollback-safe synthetic file changes', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'codex-fs-snapshot-'));
+  const emitted = [];
+  const state = createInitialEventState((message) => emitted.push(message));
+
+  async function* events() {
+    yield { type: 'turn.started' };
+    yield { type: 'item.started', item: { type: 'command_execution', id: 'cmd-1', command: 'cat > src/text.js' } };
+    await mkdir(join(cwd, 'src'), { recursive: true });
+    await writeFile(join(cwd, 'src/text.js'), 'export const hello = "world";\n', 'utf8');
+    yield { type: 'item.completed', item: { type: 'command_execution', id: 'cmd-1', command: 'cat > src/text.js', exit_code: 0, output: '' } };
+    yield { type: 'turn.completed' };
+  }
+
+  try {
+    await processCodexEventStream(events(), state, { cwd, threadId: 'thread-1', threadOptions: {}, normalizedPermissionMode: 'default' });
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+
+  const fileUse = emitted.find((message) => message.message?.content?.[0]?.type === 'tool_use' && message.message.content[0].name === 'write');
+  const fileResult = emitted.find((message) => message.message?.content?.[0]?.type === 'tool_result' && message.message.content[0].tool_use_id === fileUse?.message.content[0].id);
+
+  assert.ok(fileUse, 'expected synthetic write tool use');
+  assert.equal(fileUse.message.content[0].input.file_path, join(cwd, 'src/text.js'));
+  assert.equal(fileUse.message.content[0].input.old_string, '');
+  assert.equal(fileUse.message.content[0].input.new_string, 'export const hello = "world";\n');
+  assert.equal(fileUse.message.content[0].input.safe_to_rollback, true);
+  assert.equal(fileUse.message.content[0].input.existed_before, false);
+  assert.equal(fileUse.message.content[0].input.source, 'codex_session_patch');
+  assert.equal(fileResult?.message.content?.[0]?.is_error, false);
+});

--- a/ai-bridge/services/codex/codex-event-patch-tracking.js
+++ b/ai-bridge/services/codex/codex-event-patch-tracking.js
@@ -1,0 +1,285 @@
+import { existsSync } from 'fs';
+import { readFile, unlink, writeFile } from 'fs/promises';
+import { requestPermissionFromJava } from '../../permission-handler.js';
+import { extractPatchFromResponseItemPayload, parseApplyPatchToOperations } from './codex-patch-parser.js';
+import { captureWorkspaceSnapshot, diffWorkspaceSnapshots } from './codex-workspace-snapshot.js';
+import { resolveFilePath } from './codex-command-utils.js';
+import { SESSION_PATCH_SCAN_MAX_LINES, logDebug, logInfo, logWarn } from './codex-utils.js';
+
+function toolUseMsg(id, name, input) {
+  return { type: 'assistant', message: { role: 'assistant', content: [{ type: 'tool_use', id, name, input }] } };
+}
+
+function toolResultMsg(toolUseId, isError, content) {
+  return { type: 'user', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: toolUseId, is_error: isError, content }] } };
+}
+
+function syntheticPatchSafeToRollback(operation, rollbackResult = null, deniedByUser = false) {
+  if (!operation || typeof operation.newString !== 'string' || operation.newString.length === 0) return false;
+  if (deniedByUser && rollbackResult?.success === false) return false;
+  return true;
+}
+
+export async function collectPatchOperationsFromSession(state, config, ensureSessionFilePath, splitSessionJsonlEntries) {
+  const sessionPath = ensureSessionFilePath(state, config.threadId);
+  if (!sessionPath) return [];
+  let content = '';
+  try { content = await readFile(sessionPath, 'utf8'); } catch (error) {
+    logDebug('PERM_DEBUG', `Failed to read session file for patch replay: ${sessionPath} ${error?.message || error}`);
+    return [];
+  }
+  if (!content.trim()) return [];
+
+  const lines = splitSessionJsonlEntries(content);
+  const startIndex = state.sessionLineCursor > 0
+    ? state.sessionLineCursor
+    : Math.max(0, lines.length - SESSION_PATCH_SCAN_MAX_LINES);
+  const batches = [];
+
+  for (let i = startIndex; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line || !line.trim()) continue;
+    let parsed;
+    try { parsed = JSON.parse(line); } catch { continue; }
+    if (parsed?.type !== 'response_item' || !parsed.payload) continue;
+
+    const payload = parsed.payload;
+    const callId = String(payload.call_id ?? payload.id ?? `line_${i}`);
+    if (state.processedPatchCallIds.has(callId)) continue;
+
+    const patchText = extractPatchFromResponseItemPayload(payload);
+    if (!patchText) continue;
+
+    const operations = parseApplyPatchToOperations(patchText)
+      .map((op) => ({ ...op, filePath: resolveFilePath(op.filePath, config.cwd) }))
+      .filter((op) => op.filePath && (op.kind === 'delete' || op.oldString !== '' || op.newString !== ''));
+    state.processedPatchCallIds.add(callId);
+    if (operations.length === 0) continue;
+    batches.push({ callId, operations });
+  }
+  state.sessionLineCursor = lines.length;
+  return batches;
+}
+
+function buildPermissionInputForPatchOperation(operation) {
+  if (!operation || typeof operation !== 'object') return null;
+  const isWrite = operation.toolName === 'write' || operation.kind === 'add';
+  if (isWrite) {
+    return { toolName: 'Write', input: { file_path: operation.filePath, content: operation.newString ?? '' } };
+  }
+  return {
+    toolName: 'Edit',
+    input: { file_path: operation.filePath, old_string: operation.oldString ?? '', new_string: operation.newString ?? '', replace_all: false }
+  };
+}
+
+export async function requestPatchApprovalsViaBridge(patchBatches) {
+  const deniedCallIds = new Set();
+  if (!Array.isArray(patchBatches) || patchBatches.length === 0) return deniedCallIds;
+  for (const batch of patchBatches) {
+    if (!batch || !Array.isArray(batch.operations) || batch.operations.length === 0) continue;
+    const previewOp = batch.operations[0];
+    const requestPayload = buildPermissionInputForPatchOperation(previewOp);
+    if (!requestPayload) continue;
+    try {
+      logInfo('PERM_DEBUG', `Patch approval request: callId=${batch.callId}, tool=${requestPayload.toolName}, file=${previewOp?.filePath || ''}`);
+      const allowed = await requestPermissionFromJava(requestPayload.toolName, requestPayload.input);
+      logInfo('PERM_DEBUG', `Patch approval decision: callId=${batch.callId}, allowed=${allowed ? 'true' : 'false'}`);
+      if (!allowed) deniedCallIds.add(batch.callId);
+    } catch (error) {
+      logWarn('PERM_DEBUG', `Patch approval bridge failed (callId=${batch.callId}): ${error?.message || error}`);
+      deniedCallIds.add(batch.callId);
+    }
+  }
+  return deniedCallIds;
+}
+
+function normalizeLineRange(startLine, endLine, content) {
+  const lines = content.split('\n');
+  const start = Number.isInteger(startLine) && startLine > 0 ? startLine : 1;
+  const end = Number.isInteger(endLine) && endLine >= start ? endLine : start;
+  const offsets = [0];
+  for (let i = 0; i < lines.length - 1; i++) {
+    offsets.push(offsets[offsets.length - 1] + lines[i].length + 1);
+  }
+  const startOffset = offsets[Math.min(start - 1, offsets.length - 1)] ?? 0;
+  const endLineIndex = Math.min(end - 1, lines.length - 1);
+  const endOffset = (offsets[endLineIndex] ?? content.length) + (lines[endLineIndex]?.length ?? 0);
+  return { startOffset, endOffset: Math.min(endOffset, content.length) };
+}
+
+export function findUniqueRollbackIndex(currentContent, newString, operation) {
+  if (!newString) return -1;
+  if (Number.isInteger(operation.startLine) && operation.startLine > 0) {
+    const { startOffset, endOffset } = normalizeLineRange(operation.startLine, operation.endLine, currentContent);
+    const exactWindow = currentContent.slice(startOffset, endOffset);
+    const exactIndex = exactWindow.indexOf(newString);
+    if (exactIndex >= 0 && exactWindow.indexOf(newString, exactIndex + 1) < 0) {
+      return startOffset + exactIndex;
+    }
+    const expansion = Math.max(newString.length, 256);
+    const windowStart = Math.max(0, startOffset - expansion);
+    const windowEnd = Math.min(currentContent.length, endOffset + expansion);
+    const local = currentContent.slice(windowStart, windowEnd);
+    const localIndex = local.indexOf(newString);
+    if (localIndex >= 0 && local.indexOf(newString, localIndex + 1) < 0) {
+      return windowStart + localIndex;
+    }
+  }
+  const first = currentContent.indexOf(newString);
+  if (first < 0) return -1;
+  return currentContent.indexOf(newString, first + 1) < 0 ? first : -1;
+}
+
+async function rollbackSinglePatchOperation(operation) {
+  if (!operation || typeof operation !== 'object' || !operation.filePath) {
+    return { ok: false, reason: 'invalid-operation' };
+  }
+  const { filePath } = operation;
+  const oldString = typeof operation.oldString === 'string' ? operation.oldString : '';
+  const newString = typeof operation.newString === 'string' ? operation.newString : '';
+  const isAddedFile = operation.kind === 'add' || (operation.toolName === 'write' && oldString === '');
+
+  if (isAddedFile) {
+    if (!existsSync(filePath)) return { ok: true, reason: 'file-already-missing' };
+    try { await unlink(filePath); return { ok: true, reason: 'file-deleted' }; }
+    catch (error) { return { ok: false, reason: error?.message || String(error) }; }
+  }
+  if (!existsSync(filePath)) return { ok: false, reason: 'file-missing' };
+  let currentContent = '';
+  try { currentContent = await readFile(filePath, 'utf8'); }
+  catch (error) { return { ok: false, reason: error?.message || String(error) }; }
+  if (newString === oldString) return { ok: true, reason: 'noop' };
+  if (!newString) return { ok: false, reason: 'unsupported-empty-new-string' };
+  const index = findUniqueRollbackIndex(currentContent, newString, operation);
+  if (index < 0) return { ok: false, reason: 'new-string-not-found-or-ambiguous' };
+  const revertedContent = currentContent.slice(0, index) + oldString + currentContent.slice(index + newString.length);
+  try { await writeFile(filePath, revertedContent, 'utf8'); return { ok: true, reason: 'replaced' }; }
+  catch (error) { return { ok: false, reason: error?.message || String(error) }; }
+}
+
+export async function rollbackDeniedPatchBatches(patchBatches, deniedCallIds) {
+  const resultByCallId = new Map();
+  if (!Array.isArray(patchBatches) || patchBatches.length === 0) return resultByCallId;
+  if (!(deniedCallIds instanceof Set) || deniedCallIds.size === 0) return resultByCallId;
+  for (const batch of patchBatches) {
+    if (!batch || !deniedCallIds.has(batch.callId)) continue;
+    const operations = Array.isArray(batch.operations) ? [...batch.operations].reverse() : [];
+    const failures = [];
+    for (const op of operations) {
+      const result = await rollbackSinglePatchOperation(op);
+      if (!result.ok) failures.push({ filePath: op?.filePath || '', reason: result.reason });
+    }
+    resultByCallId.set(batch.callId, { success: failures.length === 0, failures });
+  }
+  return resultByCallId;
+}
+
+export function emitSyntheticPatchOperations(state, patchBatches, isError, deniedCallIds = new Set(), rollbackByCallId = new Map()) {
+  if (!Array.isArray(patchBatches) || patchBatches.length === 0) return 0;
+  let emittedCount = 0;
+  for (const batch of patchBatches) {
+    if (!batch || !Array.isArray(batch.operations)) continue;
+    batch.operations.forEach((op, index) => {
+      const toolUseId = `codex_patch_${batch.callId}_${index}`;
+      const toolName = op.toolName === 'write' ? 'write' : 'edit';
+      if (!state.emittedToolUseIds.has(toolUseId)) {
+        state.syntheticEditSequence = (state.syntheticEditSequence || 0) + 1;
+        const editSequence = state.syntheticEditSequence;
+        state.emitMessage(toolUseMsg(toolUseId, toolName, {
+          file_path: op.filePath,
+          old_string: op.oldString,
+          new_string: op.newString,
+          start_line: op.startLine,
+          end_line: op.endLine,
+          replace_all: false,
+          source: 'codex_session_patch',
+          operation_id: toolUseId,
+          safe_to_rollback: syntheticPatchSafeToRollback(op, rollbackByCallId instanceof Map ? rollbackByCallId.get(batch.callId) : null, deniedCallIds instanceof Set && deniedCallIds.has(batch.callId)),
+          edit_sequence: editSequence,
+          existed_before: op.kind !== 'add',
+          expected_after_content_hash: op.expectedAfterContentHash
+        }));
+        state.emittedToolUseIds.add(toolUseId);
+      }
+      if (op.filePath) state.emittedFileChangePaths.add(op.filePath);
+      const deniedByUser = deniedCallIds instanceof Set && deniedCallIds.has(batch.callId);
+      const rollbackResult = rollbackByCallId instanceof Map ? rollbackByCallId.get(batch.callId) : null;
+      const rollbackSucceeded = !deniedByUser || rollbackResult?.success !== false;
+      const opIsError = !!isError || (deniedByUser && rollbackSucceeded);
+      let resultText = 'Patch applied';
+      if (isError) resultText = 'Patch apply failed';
+      else if (deniedByUser) {
+        resultText = rollbackSucceeded ? 'Patch denied by user and rolled back' : 'Patch denied by user but rollback failed';
+      }
+      state.emitMessage(toolResultMsg(toolUseId, opIsError, resultText));
+      emittedCount += 1;
+    });
+  }
+  return emittedCount;
+}
+
+export async function captureTurnWorkspaceSnapshot(state, config) {
+  if (state.turnWorkspaceSnapshot || !config?.cwd) return;
+  state.turnWorkspaceSnapshot = await captureWorkspaceSnapshot(config.cwd);
+  if (state.turnWorkspaceSnapshot?.truncated) {
+    logWarn('PERM_DEBUG', `Codex workspace snapshot truncated for cwd=${config.cwd}`);
+  }
+}
+
+function emitSyntheticWorkspaceSnapshotOperations(state, operations) {
+  if (!Array.isArray(operations) || operations.length === 0) return 0;
+
+  const operationsByPath = new Map();
+  for (const operation of operations) {
+    if (!operation?.filePath) continue;
+    const list = operationsByPath.get(operation.filePath) ?? [];
+    list.push(operation);
+    operationsByPath.set(operation.filePath, list);
+  }
+
+  let emittedCount = 0;
+  for (const [filePath, fileOperations] of operationsByPath.entries()) {
+    if (state.emittedFileChangePaths.has(filePath)) continue;
+
+    fileOperations.forEach((operation) => {
+      state.syntheticEditSequence = (state.syntheticEditSequence || 0) + 1;
+      const editSequence = state.syntheticEditSequence;
+      const toolUseId = `codex_fs_${state.eventStateId || 'state'}_${editSequence}`;
+      const toolName = operation.toolName === 'write' ? 'write' : 'edit';
+
+      if (!state.emittedToolUseIds.has(toolUseId)) {
+        state.emitMessage(toolUseMsg(toolUseId, toolName, {
+          file_path: operation.filePath,
+          old_string: operation.oldString,
+          new_string: operation.newString,
+          start_line: operation.startLine,
+          end_line: operation.endLine,
+          replace_all: operation.replaceAll === true,
+          source: 'codex_session_patch',
+          operation_id: toolUseId,
+          safe_to_rollback: operation.safeToRollback === true,
+          edit_sequence: editSequence,
+          existed_before: operation.existedBefore !== false,
+          expected_after_content_hash: operation.expectedAfterContentHash
+        }));
+        state.emittedToolUseIds.add(toolUseId);
+      }
+      state.emitMessage(toolResultMsg(toolUseId, false, 'Filesystem change detected'));
+      state.emittedToolResultIds.add(toolUseId);
+      emittedCount += 1;
+    });
+
+    state.emittedFileChangePaths.add(filePath);
+  }
+  return emittedCount;
+}
+
+export async function emitTurnWorkspaceDiff(state, config) {
+  if (!state.turnWorkspaceSnapshot || !config?.cwd) return 0;
+  const afterSnapshot = await captureWorkspaceSnapshot(config.cwd);
+  const operations = diffWorkspaceSnapshots(state.turnWorkspaceSnapshot, afterSnapshot);
+  const emitted = emitSyntheticWorkspaceSnapshotOperations(state, operations);
+  if (emitted > 0) logDebug('CODEX_EVENT', `workspace snapshot synthesized operations=${emitted}`);
+  return emitted;
+}

--- a/ai-bridge/services/codex/codex-event-patch-tracking.js
+++ b/ai-bridge/services/codex/codex-event-patch-tracking.js
@@ -1,5 +1,6 @@
-import { existsSync } from 'fs';
-import { readFile, unlink, writeFile } from 'fs/promises';
+import { constants, existsSync } from 'fs';
+import { lstat, open, readFile, realpath, unlink } from 'fs/promises';
+import { isAbsolute, relative, resolve, sep } from 'path';
 import { requestPermissionFromJava } from '../../permission-handler.js';
 import { extractPatchFromResponseItemPayload, parseApplyPatchToOperations } from './codex-patch-parser.js';
 import { captureWorkspaceSnapshot, diffWorkspaceSnapshots } from './codex-workspace-snapshot.js';
@@ -51,7 +52,7 @@ export async function collectPatchOperationsFromSession(state, config, ensureSes
     if (!patchText) continue;
 
     const operations = parseApplyPatchToOperations(patchText)
-      .map((op) => ({ ...op, filePath: resolveFilePath(op.filePath, config.cwd) }))
+      .map((op) => ({ ...op, filePath: resolveFilePath(op.filePath, config.cwd), workspaceRoot: config.cwd || '' }))
       .filter((op) => op.filePath && (op.kind === 'delete' || op.oldString !== '' || op.newString !== ''));
     state.processedPatchCallIds.add(callId);
     if (operations.length === 0) continue;
@@ -131,6 +132,78 @@ export function findUniqueRollbackIndex(currentContent, newString, operation) {
   return currentContent.indexOf(newString, first + 1) < 0 ? first : -1;
 }
 
+function isPathWithinRoot(root, candidate) {
+  const relativePath = relative(root, candidate);
+  return relativePath === '' || (!!relativePath && !relativePath.startsWith(`..${sep}`) && relativePath !== '..' && !isAbsolute(relativePath));
+}
+
+function noFollowOpenFlag() {
+  if (typeof constants.O_NOFOLLOW !== 'number' || constants.O_NOFOLLOW === 0) {
+    throw new Error('nofollow-open-unsupported');
+  }
+  return constants.O_NOFOLLOW;
+}
+
+async function validateRollbackPath(filePath, workspaceRoot, allowMissingFile) {
+  if (!workspaceRoot || typeof workspaceRoot !== 'string') {
+    return { ok: false, reason: 'missing-workspace-root' };
+  }
+  let realRoot;
+  try {
+    realRoot = await realpath(resolve(workspaceRoot));
+  } catch (error) {
+    return { ok: false, reason: error?.message || String(error) };
+  }
+  const lexicalRoot = resolve(workspaceRoot);
+  const lexicalPath = resolve(filePath);
+  if (!isPathWithinRoot(lexicalRoot, lexicalPath)) {
+    return { ok: false, reason: 'path-outside-workspace' };
+  }
+  const absolutePath = resolve(realRoot, relative(lexicalRoot, lexicalPath));
+  if (!isPathWithinRoot(realRoot, absolutePath)) {
+    return { ok: false, reason: 'path-outside-workspace' };
+  }
+  const relativePath = relative(realRoot, absolutePath);
+  const parts = relativePath ? relativePath.split(sep).filter(Boolean) : [];
+  let current = realRoot;
+  for (let index = 0; index < parts.length; index += 1) {
+    current = resolve(current, parts[index]);
+    try {
+      const currentStat = await lstat(current);
+      if (currentStat.isSymbolicLink()) {
+        return { ok: false, reason: 'refuse-symlink-path' };
+      }
+      if (index < parts.length - 1 && !currentStat.isDirectory()) {
+        return { ok: false, reason: 'parent-not-directory' };
+      }
+    } catch (error) {
+      if (allowMissingFile && index === parts.length - 1) {
+        return { ok: true };
+      }
+      return { ok: false, reason: error?.message || String(error) };
+    }
+  }
+  return { ok: true };
+}
+
+async function readTextNoFollow(filePath) {
+  const handle = await open(filePath, constants.O_RDONLY | noFollowOpenFlag());
+  try {
+    return await handle.readFile('utf8');
+  } finally {
+    await handle.close();
+  }
+}
+
+async function writeTextNoFollow(filePath, content) {
+  const handle = await open(filePath, constants.O_WRONLY | constants.O_TRUNC | noFollowOpenFlag());
+  try {
+    await handle.writeFile(content, 'utf8');
+  } finally {
+    await handle.close();
+  }
+}
+
 async function rollbackSinglePatchOperation(operation) {
   if (!operation || typeof operation !== 'object' || !operation.filePath) {
     return { ok: false, reason: 'invalid-operation' };
@@ -139,22 +212,38 @@ async function rollbackSinglePatchOperation(operation) {
   const oldString = typeof operation.oldString === 'string' ? operation.oldString : '';
   const newString = typeof operation.newString === 'string' ? operation.newString : '';
   const isAddedFile = operation.kind === 'add' || (operation.toolName === 'write' && oldString === '');
+  const validation = await validateRollbackPath(filePath, operation.workspaceRoot, isAddedFile);
+  if (!validation.ok) {
+    return { ok: false, reason: validation.reason };
+  }
+  try {
+    const fileStatus = await lstat(filePath);
+    if (fileStatus.isSymbolicLink()) {
+      return { ok: false, reason: 'refuse-symlink-path' };
+    }
+  } catch (error) {
+    if (!isAddedFile) {
+      return { ok: false, reason: error?.message || String(error) };
+    }
+  }
 
   if (isAddedFile) {
     if (!existsSync(filePath)) return { ok: true, reason: 'file-already-missing' };
+    const deleteValidation = await validateRollbackPath(filePath, operation.workspaceRoot, false);
+    if (!deleteValidation.ok) return { ok: false, reason: deleteValidation.reason };
     try { await unlink(filePath); return { ok: true, reason: 'file-deleted' }; }
     catch (error) { return { ok: false, reason: error?.message || String(error) }; }
   }
   if (!existsSync(filePath)) return { ok: false, reason: 'file-missing' };
   let currentContent = '';
-  try { currentContent = await readFile(filePath, 'utf8'); }
+  try { currentContent = await readTextNoFollow(filePath); }
   catch (error) { return { ok: false, reason: error?.message || String(error) }; }
   if (newString === oldString) return { ok: true, reason: 'noop' };
   if (!newString) return { ok: false, reason: 'unsupported-empty-new-string' };
   const index = findUniqueRollbackIndex(currentContent, newString, operation);
   if (index < 0) return { ok: false, reason: 'new-string-not-found-or-ambiguous' };
   const revertedContent = currentContent.slice(0, index) + oldString + currentContent.slice(index + newString.length);
-  try { await writeFile(filePath, revertedContent, 'utf8'); return { ok: true, reason: 'replaced' }; }
+  try { await writeTextNoFollow(filePath, revertedContent); return { ok: true, reason: 'replaced' }; }
   catch (error) { return { ok: false, reason: error?.message || String(error) }; }
 }
 

--- a/ai-bridge/services/codex/codex-patch-parser.js
+++ b/ai-bridge/services/codex/codex-patch-parser.js
@@ -149,12 +149,24 @@ export function parseApplyPatchToOperations(patchText) {
     });
   };
 
+  const flushDelete = () => {
+    if (!currentPath || currentKind !== 'delete') return;
+    operations.push({
+      filePath: currentPath,
+      kind: currentKind,
+      oldString: '',
+      newString: '',
+      toolName: 'edit'
+    });
+  };
+
   for (const rawLine of lines) {
     const line = rawLine ?? '';
 
     if (line.startsWith('*** Update File: ')) {
       flushUpdate();
       flushAdd();
+      flushDelete();
       currentPath = line.slice('*** Update File: '.length).trim();
       currentKind = 'update';
       currentHunkHeader = null;
@@ -167,6 +179,7 @@ export function parseApplyPatchToOperations(patchText) {
     if (line.startsWith('*** Add File: ')) {
       flushUpdate();
       flushAdd();
+      flushDelete();
       currentPath = line.slice('*** Add File: '.length).trim();
       currentKind = 'add';
       currentHunkHeader = null;
@@ -179,6 +192,7 @@ export function parseApplyPatchToOperations(patchText) {
     if (line.startsWith('*** Delete File: ')) {
       flushUpdate();
       flushAdd();
+      flushDelete();
       currentPath = line.slice('*** Delete File: '.length).trim();
       currentKind = 'delete';
       currentHunkHeader = null;
@@ -199,6 +213,7 @@ export function parseApplyPatchToOperations(patchText) {
     if (line.startsWith('*** End Patch')) {
       flushUpdate();
       flushAdd();
+      flushDelete();
       currentPath = null;
       currentKind = null;
       currentHunkHeader = null;
@@ -249,6 +264,7 @@ export function parseApplyPatchToOperations(patchText) {
 
   flushUpdate();
   flushAdd();
+  flushDelete();
 
   return operations;
 }

--- a/ai-bridge/services/codex/codex-patch-parser.test.mjs
+++ b/ai-bridge/services/codex/codex-patch-parser.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createInitialEventState, emitSyntheticPatchOperations } from './codex-event-handler.js';
+import { parseApplyPatchToOperations } from './codex-patch-parser.js';
+
+test('parseApplyPatchToOperations emits delete file operations', () => {
+  const operations = parseApplyPatchToOperations(`*** Begin Patch
+*** Delete File: src/obsolete.ts
+*** End Patch`);
+
+  assert.equal(operations.length, 1);
+  assert.equal(operations[0].filePath, 'src/obsolete.ts');
+  assert.equal(operations[0].kind, 'delete');
+  assert.equal(operations[0].toolName, 'edit');
+  assert.equal(operations[0].oldString, '');
+  assert.equal(operations[0].newString, '');
+});
+
+test('delete file patch operations are emitted as visible unsafe file changes', () => {
+  const emitted = [];
+  const state = createInitialEventState((message) => emitted.push(message));
+  const operations = parseApplyPatchToOperations(`*** Begin Patch
+*** Delete File: src/obsolete.ts
+*** End Patch`);
+
+  const count = emitSyntheticPatchOperations(state, [{ callId: 'delete-1', operations }], false);
+
+  assert.equal(count, 1);
+  const use = emitted.find((message) => message.message?.content?.[0]?.type === 'tool_use');
+  const result = emitted.find((message) => message.message?.content?.[0]?.type === 'tool_result');
+  assert.equal(use.message.content[0].name, 'edit');
+  assert.equal(use.message.content[0].input.file_path, 'src/obsolete.ts');
+  assert.equal(use.message.content[0].input.safe_to_rollback, false);
+  assert.equal(result.message.content[0].is_error, false);
+});

--- a/ai-bridge/services/codex/codex-utils.js
+++ b/ai-bridge/services/codex/codex-utils.js
@@ -32,11 +32,24 @@ export const logDebug = (tag, ...args) => debugLog(4, tag, ...args);
 export const VALID_SANDBOX_MODES = new Set(['read-only', 'workspace-write', 'danger-full-access']);
 export const VALID_APPROVAL_POLICIES = new Set(['never', 'on-request', 'on-failure', 'untrusted']);
 export const CODEX_CLI_ENV_BLOCKLIST = new Set([
+  // Runtime behavior is mapped explicitly from plugin permission settings.
   'CODEX_APPROVAL_POLICY',
   'CODEX_SANDBOX_MODE',
   'CODEX_SANDBOX',
   'CODEX_SANDBOX_NETWORK_DISABLED',
-  'CODEX_CI'
+  'CODEX_CI',
+
+  // Authentication and endpoint settings must come from the active plugin
+  // provider / ~/.codex files, not from the IDE launcher environment.
+  'CODEX_API_KEY',
+  'CODEX_API_BASE',
+  'CODEX_BASE_URL',
+  'OPENAI_API_KEY',
+  'OPENAI_API_BASE',
+  'OPENAI_BASE_URL',
+  'OPENAI_ORG_ID',
+  'OPENAI_ORGANIZATION',
+  'OPENAI_PROJECT'
 ]);
 
 /**

--- a/ai-bridge/services/codex/codex-utils.js
+++ b/ai-bridge/services/codex/codex-utils.js
@@ -52,6 +52,10 @@ export const CODEX_CLI_ENV_BLOCKLIST = new Set([
   'OPENAI_PROJECT'
 ]);
 
+function isBlockedCodexCliEnvKey(key) {
+  return CODEX_CLI_ENV_BLOCKLIST.has(String(key || '').toUpperCase());
+}
+
 /**
  * Reads sandbox mode override from environment variables.
  * Returns an empty string when no override should be applied.
@@ -100,7 +104,7 @@ export function buildCodexCliEnvironment(baseEnv) {
     if (typeof rawValue !== 'string' || rawValue.length === 0) {
       continue;
     }
-    if (CODEX_CLI_ENV_BLOCKLIST.has(key)) {
+    if (isBlockedCodexCliEnvKey(key)) {
       removedKeys.push(key);
       continue;
     }

--- a/ai-bridge/services/codex/codex-utils.test.mjs
+++ b/ai-bridge/services/codex/codex-utils.test.mjs
@@ -43,3 +43,21 @@ test('buildCodexCliEnvironment removes inherited Codex/OpenAI auth and endpoint 
     ])
   );
 });
+
+test('buildCodexCliEnvironment removes inherited auth variables case-insensitively', () => {
+  const { cliEnv, removedKeys } = buildCodexCliEnvironment({
+    PATH: '/usr/bin',
+    openai_api_key: 'sk-lowercase-openai',
+    OpenAI_Base_URL: 'https://wrong.example/v1',
+    codex_api_key: 'sk-lowercase-codex',
+  });
+
+  assert.equal(cliEnv.PATH, '/usr/bin');
+  assert.equal(cliEnv.openai_api_key, undefined);
+  assert.equal(cliEnv.OpenAI_Base_URL, undefined);
+  assert.equal(cliEnv.codex_api_key, undefined);
+  assert.deepEqual(
+    new Set(removedKeys),
+    new Set(['openai_api_key', 'OpenAI_Base_URL', 'codex_api_key'])
+  );
+});

--- a/ai-bridge/services/codex/codex-utils.test.mjs
+++ b/ai-bridge/services/codex/codex-utils.test.mjs
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildCodexCliEnvironment } from './codex-utils.js';
+
+test('buildCodexCliEnvironment removes inherited Codex/OpenAI auth and endpoint variables', () => {
+  const { cliEnv, removedKeys } = buildCodexCliEnvironment({
+    PATH: '/usr/bin',
+    HOME: '/tmp/home',
+    CODEX_API_KEY: 'sk-old-codex',
+    CODEX_API_BASE: 'https://old-codex.example/v1',
+    CODEX_BASE_URL: 'https://old-codex-base.example/v1',
+    OPENAI_API_KEY: 'sk-old-openai',
+    OPENAI_API_BASE: 'https://old-openai-api-base.example/v1',
+    OPENAI_BASE_URL: 'https://old-openai-base.example/v1',
+    OPENAI_ORG_ID: 'org-old',
+    OPENAI_ORGANIZATION: 'org-old-name',
+    OPENAI_PROJECT: 'proj-old',
+    CODEX_APPROVAL_POLICY: 'never',
+    CODEX_SANDBOX_MODE: 'danger-full-access',
+  });
+
+  assert.equal(cliEnv.PATH, '/usr/bin');
+  assert.equal(cliEnv.HOME, '/tmp/home');
+  assert.equal(cliEnv.CODEX_API_KEY, undefined);
+  assert.equal(cliEnv.OPENAI_API_KEY, undefined);
+  assert.equal(cliEnv.CODEX_API_BASE, undefined);
+  assert.equal(cliEnv.OPENAI_BASE_URL, undefined);
+  assert.deepEqual(
+    new Set(removedKeys),
+    new Set([
+      'CODEX_API_KEY',
+      'CODEX_API_BASE',
+      'CODEX_BASE_URL',
+      'OPENAI_API_KEY',
+      'OPENAI_API_BASE',
+      'OPENAI_BASE_URL',
+      'OPENAI_ORG_ID',
+      'OPENAI_ORGANIZATION',
+      'OPENAI_PROJECT',
+      'CODEX_APPROVAL_POLICY',
+      'CODEX_SANDBOX_MODE',
+    ])
+  );
+});

--- a/ai-bridge/services/codex/codex-workspace-snapshot.js
+++ b/ai-bridge/services/codex/codex-workspace-snapshot.js
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
-import { readdir, readFile, stat } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { lstat, open, readdir, realpath, stat } from 'node:fs/promises';
 import { isAbsolute, relative, resolve, sep } from 'node:path';
 
 const DEFAULT_MAX_FILES = 5000;
@@ -24,6 +25,15 @@ function isPathWithinRoot(root, candidate) {
   return relativePath === '' || (!!relativePath && !relativePath.startsWith(`..${sep}`) && relativePath !== '..' && !isAbsolute(relativePath));
 }
 
+async function safeRealPathWithinRoot(root, candidate) {
+  try {
+    const realCandidate = await realpath(candidate);
+    return isPathWithinRoot(root, realCandidate) ? realCandidate : '';
+  } catch {
+    return '';
+  }
+}
+
 function isIgnoredDirectory(name) {
   return IGNORED_DIRECTORY_NAMES.has(name);
 }
@@ -44,13 +54,33 @@ function sha256(content) {
   return createHash('sha256').update(typeof content === 'string' ? content : '').digest('hex');
 }
 
+function noFollowOpenFlag() {
+  if (typeof constants.O_NOFOLLOW !== 'number' || constants.O_NOFOLLOW === 0) {
+    return null;
+  }
+  return constants.O_NOFOLLOW;
+}
+
 async function readSnapshotFile(filePath, fileStat, limits) {
   if (!fileStat.isFile()) return null;
   if (fileStat.size > limits.maxFileBytes) return null;
-  const buffer = await readFile(filePath);
+  const noFollowStat = await lstat(filePath);
+  if (!noFollowStat.isFile() || noFollowStat.isSymbolicLink()) return null;
+  const noFollow = noFollowOpenFlag();
+  if (noFollow === null) return null;
+  const handle = await open(filePath, constants.O_RDONLY | noFollow);
+  let buffer;
+  try {
+    const openStat = await handle.stat();
+    if (!openStat.isFile() || openStat.size > limits.maxFileBytes) return null;
+    buffer = await handle.readFile();
+  } finally {
+    await handle.close();
+  }
+  if (buffer.length > limits.maxFileBytes) return null;
   if (isLikelyBinary(buffer)) return null;
   return {
-    path: resolve(filePath),
+    path: filePath,
     existed: true,
     binary: false,
     content: buffer.toString('utf8'),
@@ -76,8 +106,15 @@ export async function captureWorkspaceSnapshot(cwd, options = {}) {
     return null;
   }
 
+  let realRoot = '';
+  try {
+    realRoot = await realpath(root);
+  } catch {
+    return null;
+  }
+
   const files = new Map();
-  const directories = [root];
+  const directories = [realRoot];
   let totalBytes = 0;
   let truncated = false;
 
@@ -95,47 +132,46 @@ export async function captureWorkspaceSnapshot(cwd, options = {}) {
     entries.sort((left, right) => left.name.localeCompare(right.name));
 
     for (const entry of entries) {
+      if (files.size >= limits.maxFiles || totalBytes >= limits.maxTotalBytes) {
+        truncated = true;
+        directories.length = 0;
+        break;
+      }
       const absolutePath = resolve(directory, entry.name);
-      if (!isPathWithinRoot(root, absolutePath)) continue;
+      if (!isPathWithinRoot(realRoot, absolutePath)) continue;
       if (entry.isSymbolicLink()) continue;
 
       if (entry.isDirectory()) {
         if (!isIgnoredDirectory(entry.name)) {
-          if (!isPathWithinRoot(root, absolutePath)) continue;
-          directories.push(absolutePath);
+          const realDirectory = await safeRealPathWithinRoot(realRoot, absolutePath);
+          if (!realDirectory) continue;
+          directories.push(realDirectory);
         }
         continue;
       }
 
       if (!entry.isFile() || isIgnoredFile(entry.name)) continue;
-      if (files.size >= limits.maxFiles || totalBytes >= limits.maxTotalBytes) {
-        truncated = true;
-        continue;
-      }
-
       let fileStat;
       try {
-        fileStat = await stat(absolutePath);
-      } catch {
-        continue;
-      }
-      if (totalBytes + fileStat.size > limits.maxTotalBytes) {
-        truncated = true;
-        continue;
-      }
-
-      try {
-        const snapshot = await readSnapshotFile(absolutePath, fileStat, limits);
+        const realFile = await safeRealPathWithinRoot(realRoot, absolutePath);
+        if (!realFile) continue;
+        fileStat = await stat(realFile);
+        if (realFile !== absolutePath && !isPathWithinRoot(realRoot, realFile)) continue;
+        if (totalBytes + fileStat.size > limits.maxTotalBytes) {
+          truncated = true;
+          continue;
+        }
+        const snapshot = await readSnapshotFile(realFile, fileStat, limits);
         if (!snapshot) continue;
         files.set(snapshot.path, snapshot);
         totalBytes += snapshot.length;
       } catch {
-        // File may disappear or become unreadable while Codex is running.
+        continue;
       }
     }
   }
 
-  return { root, files, totalBytes, truncated };
+  return { root: realRoot, files, totalBytes, truncated };
 }
 
 function countLines(content) {

--- a/ai-bridge/services/codex/codex-workspace-snapshot.js
+++ b/ai-bridge/services/codex/codex-workspace-snapshot.js
@@ -1,0 +1,346 @@
+import { createHash } from 'node:crypto';
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
+
+const DEFAULT_MAX_FILES = 5000;
+const DEFAULT_MAX_FILE_BYTES = 1024 * 1024;
+const DEFAULT_MAX_TOTAL_BYTES = 32 * 1024 * 1024;
+
+const IGNORED_DIRECTORY_NAMES = new Set([
+  '.git', '.idea', '.gradle', '.m2', '.m2_repo', '.next', '.nuxt', '.turbo', '.cache',
+  '.pytest_cache', '.mypy_cache', '.ruff_cache', '.venv', '__pycache__', 'build', 'coverage',
+  'dist', 'env', 'logs', 'node_modules', 'out', 'target', 'temp', 'tmp', 'venv'
+]);
+
+const IGNORED_FILE_NAMES = new Set(['.DS_Store']);
+
+function normalizeRoot(cwd) {
+  if (typeof cwd !== 'string' || !cwd.trim()) return '';
+  return resolve(cwd);
+}
+
+function isPathWithinRoot(root, candidate) {
+  const relativePath = relative(root, candidate);
+  return relativePath === '' || (!!relativePath && !relativePath.startsWith(`..${sep}`) && relativePath !== '..' && !isAbsolute(relativePath));
+}
+
+function isIgnoredDirectory(name) {
+  return IGNORED_DIRECTORY_NAMES.has(name);
+}
+
+function isIgnoredFile(name) {
+  return IGNORED_FILE_NAMES.has(name);
+}
+
+function isLikelyBinary(buffer) {
+  const limit = Math.min(buffer.length, 8192);
+  for (let index = 0; index < limit; index += 1) {
+    if (buffer[index] === 0) return true;
+  }
+  return false;
+}
+
+function sha256(content) {
+  return createHash('sha256').update(typeof content === 'string' ? content : '').digest('hex');
+}
+
+async function readSnapshotFile(filePath, fileStat, limits) {
+  if (!fileStat.isFile()) return null;
+  if (fileStat.size > limits.maxFileBytes) return null;
+  const buffer = await readFile(filePath);
+  if (isLikelyBinary(buffer)) return null;
+  return {
+    path: resolve(filePath),
+    existed: true,
+    binary: false,
+    content: buffer.toString('utf8'),
+    length: fileStat.size,
+    modifiedAtMillis: fileStat.mtimeMs,
+  };
+}
+
+export async function captureWorkspaceSnapshot(cwd, options = {}) {
+  const root = normalizeRoot(cwd);
+  if (!root) return null;
+
+  const limits = {
+    maxFiles: options.maxFiles ?? DEFAULT_MAX_FILES,
+    maxFileBytes: options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES,
+    maxTotalBytes: options.maxTotalBytes ?? DEFAULT_MAX_TOTAL_BYTES,
+  };
+
+  try {
+    const rootStat = await stat(root);
+    if (!rootStat.isDirectory()) return null;
+  } catch {
+    return null;
+  }
+
+  const files = new Map();
+  const directories = [root];
+  let totalBytes = 0;
+  let truncated = false;
+
+  while (directories.length > 0) {
+    const directory = directories.shift();
+    if (!directory) continue;
+
+    let entries;
+    try {
+      entries = await readdir(directory, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+
+    for (const entry of entries) {
+      const absolutePath = resolve(directory, entry.name);
+      if (!isPathWithinRoot(root, absolutePath)) continue;
+      if (entry.isSymbolicLink()) continue;
+
+      if (entry.isDirectory()) {
+        if (!isIgnoredDirectory(entry.name)) {
+          if (!isPathWithinRoot(root, absolutePath)) continue;
+          directories.push(absolutePath);
+        }
+        continue;
+      }
+
+      if (!entry.isFile() || isIgnoredFile(entry.name)) continue;
+      if (files.size >= limits.maxFiles || totalBytes >= limits.maxTotalBytes) {
+        truncated = true;
+        continue;
+      }
+
+      let fileStat;
+      try {
+        fileStat = await stat(absolutePath);
+      } catch {
+        continue;
+      }
+      if (totalBytes + fileStat.size > limits.maxTotalBytes) {
+        truncated = true;
+        continue;
+      }
+
+      try {
+        const snapshot = await readSnapshotFile(absolutePath, fileStat, limits);
+        if (!snapshot) continue;
+        files.set(snapshot.path, snapshot);
+        totalBytes += snapshot.length;
+      } catch {
+        // File may disappear or become unreadable while Codex is running.
+      }
+    }
+  }
+
+  return { root, files, totalBytes, truncated };
+}
+
+function countLines(content) {
+  if (!content) return 1;
+  let lines = 1;
+  for (let index = 0; index < content.length; index += 1) {
+    if (content[index] === '\n') lines += 1;
+  }
+  return lines;
+}
+
+function splitLinesPreserveEndings(content) {
+  if (!content) return [];
+  const lines = [];
+  let start = 0;
+  for (let index = 0; index < content.length; index += 1) {
+    if (content[index] === '\n') {
+      lines.push(content.slice(start, index + 1));
+      start = index + 1;
+    }
+  }
+  if (start < content.length) {
+    lines.push(content.slice(start));
+  }
+  return lines;
+}
+
+function joinLines(lines, fromInclusive, toExclusive) {
+  let result = '';
+  for (let index = fromInclusive; index < toExclusive; index += 1) {
+    result += lines[index];
+  }
+  return result;
+}
+
+function singleHunk(beforeLines, afterLines, oldChangeStart, oldChangeEnd, newChangeStart, newChangeEnd) {
+  const contextLines = 2;
+  return {
+    oldFrom: Math.max(0, oldChangeStart - contextLines),
+    oldTo: Math.min(beforeLines.length, oldChangeEnd + contextLines),
+    newFrom: Math.max(0, newChangeStart - contextLines),
+    newTo: Math.min(afterLines.length, newChangeEnd + contextLines),
+  };
+}
+
+function buildHunkRanges(beforeLines, afterLines) {
+  const beforeSize = beforeLines.length;
+  const afterSize = afterLines.length;
+  if (beforeSize * afterSize > 200000) {
+    return [singleHunk(beforeLines, afterLines, 0, beforeSize, 0, afterSize)];
+  }
+
+  const lcs = Array.from({ length: beforeSize + 1 }, () => Array(afterSize + 1).fill(0));
+  for (let oldIndex = beforeSize - 1; oldIndex >= 0; oldIndex -= 1) {
+    for (let newIndex = afterSize - 1; newIndex >= 0; newIndex -= 1) {
+      if (beforeLines[oldIndex] === afterLines[newIndex]) {
+        lcs[oldIndex][newIndex] = lcs[oldIndex + 1][newIndex + 1] + 1;
+      } else {
+        lcs[oldIndex][newIndex] = Math.max(lcs[oldIndex + 1][newIndex], lcs[oldIndex][newIndex + 1]);
+      }
+    }
+  }
+
+  const rawRanges = [];
+  let oldIndex = 0;
+  let newIndex = 0;
+  let oldStart = -1;
+  let newStart = -1;
+
+  while (oldIndex < beforeSize || newIndex < afterSize) {
+    if (oldIndex < beforeSize && newIndex < afterSize && beforeLines[oldIndex] === afterLines[newIndex]) {
+      if (oldStart >= 0) {
+        rawRanges.push({ oldStart, oldEnd: oldIndex, newStart, newEnd: newIndex });
+        oldStart = -1;
+        newStart = -1;
+      }
+      oldIndex += 1;
+      newIndex += 1;
+      continue;
+    }
+
+    if (oldStart < 0) {
+      oldStart = oldIndex;
+      newStart = newIndex;
+    }
+
+    if (newIndex < afterSize && (oldIndex === beforeSize || lcs[oldIndex][newIndex + 1] >= lcs[oldIndex + 1][newIndex])) {
+      newIndex += 1;
+    } else if (oldIndex < beforeSize) {
+      oldIndex += 1;
+    }
+  }
+
+  if (oldStart >= 0) {
+    rawRanges.push({ oldStart, oldEnd: oldIndex, newStart, newEnd: newIndex });
+  }
+
+  const hunks = [];
+  for (const raw of rawRanges) {
+    const next = singleHunk(beforeLines, afterLines, raw.oldStart, raw.oldEnd, raw.newStart, raw.newEnd);
+    const previous = hunks[hunks.length - 1];
+    if (previous && (next.oldFrom <= previous.oldTo || next.newFrom <= previous.newTo)) {
+      hunks[hunks.length - 1] = {
+        oldFrom: previous.oldFrom,
+        oldTo: Math.max(previous.oldTo, next.oldTo),
+        newFrom: previous.newFrom,
+        newTo: Math.max(previous.newTo, next.newTo),
+      };
+    } else {
+      hunks.push(next);
+    }
+  }
+  return hunks;
+}
+
+export function buildEditOperationsFromSnapshots(filePath, existedBefore, beforeContent, afterContent) {
+  const before = typeof beforeContent === 'string' ? beforeContent : '';
+  const after = typeof afterContent === 'string' ? afterContent : '';
+  if (before.includes('\0') || after.includes('\0')) return [];
+
+  if (!existedBefore) {
+    if (!after) return [];
+    return [{
+      toolName: 'write',
+      filePath,
+      oldString: '',
+      newString: after,
+      replaceAll: false,
+      startLine: 1,
+      endLine: Math.max(1, countLines(after)),
+      safeToRollback: true,
+      existedBefore: false,
+      expectedAfterContentHash: sha256(after),
+    }];
+  }
+
+  if (before === after) return [];
+
+  const beforeLines = splitLinesPreserveEndings(before);
+  const afterLines = splitLinesPreserveEndings(after);
+  const hunks = buildHunkRanges(beforeLines, afterLines);
+  const operations = [];
+
+  for (const hunk of hunks) {
+    const oldString = joinLines(beforeLines, hunk.oldFrom, hunk.oldTo);
+    const newString = joinLines(afterLines, hunk.newFrom, hunk.newTo);
+    if (oldString === newString) continue;
+    const startLine = hunk.newFrom + 1;
+    operations.push({
+      toolName: 'edit',
+      filePath,
+      oldString,
+      newString,
+      replaceAll: false,
+      startLine,
+      endLine: Math.max(startLine, hunk.newTo),
+      safeToRollback: newString.length > 0,
+      existedBefore: true,
+      expectedAfterContentHash: sha256(after),
+    });
+  }
+
+  return operations;
+}
+
+export function diffWorkspaceSnapshots(beforeSnapshot, afterSnapshot) {
+  if (!beforeSnapshot || !afterSnapshot) return [];
+
+  const paths = new Set([
+    ...beforeSnapshot.files.keys(),
+    ...afterSnapshot.files.keys(),
+  ]);
+  const operations = [];
+
+  for (const filePath of Array.from(paths).sort((left, right) => left.localeCompare(right))) {
+    const before = beforeSnapshot.files.get(filePath);
+    const after = afterSnapshot.files.get(filePath);
+
+    if (!before && after) {
+      operations.push(...buildEditOperationsFromSnapshots(filePath, false, '', after.content));
+      continue;
+    }
+
+    if (before && !after) {
+      if (!before.binary && before.existed) {
+        operations.push({
+          toolName: 'edit',
+          filePath,
+          oldString: before.content,
+          newString: '',
+          replaceAll: false,
+          startLine: 1,
+          endLine: 1,
+          safeToRollback: false,
+          existedBefore: true,
+          expectedAfterContentHash: '',
+        });
+      }
+      continue;
+    }
+
+    if (!before || !after || before.binary || after.binary) continue;
+    if (before.content === after.content) continue;
+    operations.push(...buildEditOperationsFromSnapshots(filePath, true, before.content, after.content));
+  }
+
+  return operations;
+}

--- a/ai-bridge/services/codex/codex-workspace-snapshot.test.mjs
+++ b/ai-bridge/services/codex/codex-workspace-snapshot.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -57,9 +57,30 @@ test('captureWorkspaceSnapshot skips dependency folders while keeping project fi
 
     const captured = await captureWorkspaceSnapshot(cwd);
 
-    assert.ok(captured.files.has(join(cwd, 'src/app.js')));
+    assert.ok(captured.files.has(await realpath(join(cwd, 'src/app.js'))));
     assert.equal(captured.files.has(join(cwd, 'node_modules/pkg/index.js')), false);
   } finally {
     await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test('captureWorkspaceSnapshot skips symlinked files and directories outside workspace', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'codex-workspace-snapshot-'));
+  const outside = await mkdtemp(join(tmpdir(), 'codex-workspace-outside-'));
+  try {
+    await mkdir(join(cwd, 'src'), { recursive: true });
+    await writeFile(join(cwd, 'src/app.js'), 'export const app = true;\n', 'utf8');
+    await writeFile(join(outside, 'secret.txt'), 'secret\n', 'utf8');
+    await symlink(join(outside, 'secret.txt'), join(cwd, 'src/secret-link.txt'));
+    await symlink(outside, join(cwd, 'linked-outside-dir'));
+
+    const captured = await captureWorkspaceSnapshot(cwd);
+
+    assert.ok(captured.files.has(await realpath(join(cwd, 'src/app.js'))));
+    assert.equal(captured.files.has(join(cwd, 'src/secret-link.txt')), false);
+    assert.equal(captured.files.has(join(outside, 'secret.txt')), false);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
   }
 });

--- a/ai-bridge/services/codex/codex-workspace-snapshot.test.mjs
+++ b/ai-bridge/services/codex/codex-workspace-snapshot.test.mjs
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { buildEditOperationsFromSnapshots, captureWorkspaceSnapshot, diffWorkspaceSnapshots } from './codex-workspace-snapshot.js';
+
+function snapshot(files) {
+  return {
+    root: '/repo',
+    files: new Map(Object.entries(files).map(([filePath, content]) => [filePath, {
+      path: filePath,
+      existed: true,
+      binary: false,
+      content,
+      length: Buffer.byteLength(content),
+      modifiedAtMillis: 0,
+    }])),
+    totalBytes: 0,
+    truncated: false,
+  };
+}
+
+test('buildEditOperationsFromSnapshots emits rollback-safe write for new text files', () => {
+  const operations = buildEditOperationsFromSnapshots('/repo/src/new.js', false, '', 'export const value = 1;\n');
+
+  assert.equal(operations.length, 1);
+  assert.equal(operations[0].toolName, 'write');
+  assert.equal(operations[0].oldString, '');
+  assert.equal(operations[0].newString, 'export const value = 1;\n');
+  assert.equal(operations[0].safeToRollback, true);
+  assert.equal(operations[0].existedBefore, false);
+});
+
+test('diffWorkspaceSnapshots emits focused edit hunks for modified files', () => {
+  const before = snapshot({ '/repo/src/app.js': 'one\ntwo\nthree\n' });
+  const after = snapshot({ '/repo/src/app.js': 'one\nTWO\nthree\n' });
+
+  const operations = diffWorkspaceSnapshots(before, after);
+
+  assert.equal(operations.length, 1);
+  assert.equal(operations[0].toolName, 'edit');
+  assert.equal(operations[0].oldString, 'one\ntwo\nthree\n');
+  assert.equal(operations[0].newString, 'one\nTWO\nthree\n');
+  assert.equal(operations[0].safeToRollback, true);
+  assert.equal(operations[0].existedBefore, true);
+});
+
+test('captureWorkspaceSnapshot skips dependency folders while keeping project files', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'codex-workspace-snapshot-'));
+  try {
+    await mkdir(join(cwd, 'src'), { recursive: true });
+    await mkdir(join(cwd, 'node_modules', 'pkg'), { recursive: true });
+    await writeFile(join(cwd, 'src/app.js'), 'export const app = true;\n', 'utf8');
+    await writeFile(join(cwd, 'node_modules/pkg/index.js'), 'ignored\n', 'utf8');
+
+    const captured = await captureWorkspaceSnapshot(cwd);
+
+    assert.ok(captured.files.has(join(cwd, 'src/app.js')));
+    assert.equal(captured.files.has(join(cwd, 'node_modules/pkg/index.js')), false);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
+
 plugins {
     id 'java'
     id 'checkstyle'
@@ -33,12 +35,12 @@ group = 'com.github.idea-claude-code-gui'
 version = '0.4.3-Alpha1'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 
     // Use Java Toolchain for consistent JDK across all tasks
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
@@ -58,7 +60,7 @@ if (localJavaHome) {
             // Skip runIde task to use JBR for JCEF support
             if (it.name != 'runIde') {
                 javaLauncher = javaToolchains.launcherFor {
-                    languageVersion = JavaLanguageVersion.of(17)
+                    languageVersion = JavaLanguageVersion.of(21)
                 }
             }
         }
@@ -106,6 +108,15 @@ dependencies {
     }
 }
 
+
+intellijPlatform {
+    pluginVerification {
+        ides {
+            create(IntelliJPlatformType.IntellijIdeaCommunity, '2024.3.1')
+        }
+    }
+}
+
 sourceSets {
     main {
         java {
@@ -128,14 +139,13 @@ sourceSets {
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
     // Ensure consistent source/target compatibility
-    options.release.set(17)
+    options.release.set(21)
 }
 
 // Ensure plugin.xml is patched with the correct since/until build and change notes
 patchPluginXml {
     // plugin compatibility range
-    sinceBuild = '233'
-    untilBuild = '263.*'
+    sinceBuild = '243'
 
     // Release notes shown in plugin repositories
     // Dynamically load the latest changelog entry from CHANGELOG.md and convert to simple HTML.
@@ -351,8 +361,64 @@ tasks.named('processResources') {
     mustRunAfter('buildWebview')
 }
 
+// Install runtime dependencies needed by the embedded bridge before packaging it.
+tasks.register('installAiBridgeDependencies', Exec) {
+    onlyIf { aiBridgeDir.exists() }
+    workingDir aiBridgeDir
+
+    inputs.files(new File(aiBridgeDir, 'package.json'), new File(aiBridgeDir, 'package-lock.json'))
+    outputs.dir(new File(aiBridgeDir, 'node_modules'))
+
+    def npmCommand = 'npm'
+    if (localNodePath) {
+        def nodeFile = file(localNodePath)
+        def npmExecutable = null
+        def pathToAdd = null
+
+        if (nodeFile.isFile()) {
+            def binDir = nodeFile.parentFile
+            def npmInSameDir = new File(binDir, 'npm')
+            if (npmInSameDir.exists()) {
+                npmExecutable = npmInSameDir
+                pathToAdd = binDir.absolutePath
+            }
+        } else if (nodeFile.isDirectory()) {
+            def npmInBin = new File(nodeFile, 'bin/npm')
+            def npmInDir = new File(nodeFile, 'npm')
+
+            if (npmInBin.exists()) {
+                npmExecutable = npmInBin
+                pathToAdd = new File(nodeFile, 'bin').absolutePath
+            } else if (npmInDir.exists()) {
+                npmExecutable = npmInDir
+                pathToAdd = nodeFile.absolutePath
+            }
+        }
+
+        if (npmExecutable != null) {
+            npmCommand = npmExecutable.absolutePath
+            println "Using npm executable for ai-bridge: ${npmCommand}"
+        }
+
+        if (pathToAdd != null) {
+            def currentPath = System.getenv('PATH') ?: ''
+            environment 'PATH', "${pathToAdd}${File.pathSeparator}${currentPath}"
+        }
+    }
+
+    if (System.getProperty('os.name').toLowerCase().contains('windows')) {
+        commandLine 'cmd', '/c', npmCommand, 'ci', '--omit=dev'
+    } else {
+        commandLine npmCommand, 'ci', '--omit=dev'
+    }
+
+    doFirst { println 'Installing ai-bridge runtime dependencies...' }
+    doLast { println 'ai-bridge runtime dependencies are ready.' }
+}
+
 // Use system zip command to package ai-bridge, preserving file permissions
 tasks.register('packageAiBridge', Exec) {
+    dependsOn('installAiBridgeDependencies')
     onlyIf { aiBridgeDir.exists() }
 
     // Switch to ai-bridge directory for packaging, avoiding inclusion of top-level directory
@@ -360,6 +426,11 @@ tasks.register('packageAiBridge', Exec) {
 
     // Ensure output directory exists and dependencies are installed
     doFirst {
+        def nodeModules = new File(aiBridgeDir, 'node_modules')
+        if (!nodeModules.isDirectory()) {
+            throw new GradleException('ai-bridge node_modules is missing. Run ./gradlew installAiBridgeDependencies or cd ai-bridge && npm ci --omit=dev.')
+        }
+
         aiBridgePackDir.mkdirs()
         // Delete old zip file
         if (aiBridgeArchive.exists()) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
-
 plugins {
     id 'java'
     id 'checkstyle'
@@ -35,12 +33,12 @@ group = 'com.github.idea-claude-code-gui'
 version = '0.4.3-Alpha1'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 
     // Use Java Toolchain for consistent JDK across all tasks
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 
@@ -60,7 +58,7 @@ if (localJavaHome) {
             // Skip runIde task to use JBR for JCEF support
             if (it.name != 'runIde') {
                 javaLauncher = javaToolchains.launcherFor {
-                    languageVersion = JavaLanguageVersion.of(21)
+                    languageVersion = JavaLanguageVersion.of(17)
                 }
             }
         }
@@ -108,15 +106,6 @@ dependencies {
     }
 }
 
-
-intellijPlatform {
-    pluginVerification {
-        ides {
-            create(IntelliJPlatformType.IntellijIdeaCommunity, '2024.3.1')
-        }
-    }
-}
-
 sourceSets {
     main {
         java {
@@ -139,13 +128,14 @@ sourceSets {
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
     // Ensure consistent source/target compatibility
-    options.release.set(21)
+    options.release.set(17)
 }
 
 // Ensure plugin.xml is patched with the correct since/until build and change notes
 patchPluginXml {
     // plugin compatibility range
-    sinceBuild = '243'
+    sinceBuild = '233'
+    untilBuild = '263.*'
 
     // Release notes shown in plugin repositories
     // Dynamically load the latest changelog entry from CHANGELOG.md and convert to simple HTML.

--- a/docs/plans/2026-04-26-subagent-edits-status-panel.md
+++ b/docs/plans/2026-04-26-subagent-edits-status-panel.md
@@ -1,0 +1,1140 @@
+# Sub-agent Edits Status Panel 实现计划
+
+> **For Claude:** REQUIRED SUB-SKILL：使用 `superpowers:executing-plans` 按任务逐步执行本计划。
+
+**目标：** 让 Claude 和 Codex 的 sub-agent 产生的文件改动，能够出现在现有 `Edits` 状态面板中，并且与主 agent 改动具备同样的 diff、单文件回滚、全部丢弃、全部接受能力。
+
+**架构：** 在 Java session 消息流水线中新增一个 provider-neutral 的 sub-agent edit 捕获层。该层在 sub-agent 启动时开启文件改动作用域，记录作用域内被触碰文件的修改前快照，在 sub-agent 完成后生成标准 `edit`/`write` 工具调用消息，再交给现有 React `useFileChanges` hook、Java diff handler 和 undo handler 处理。因为多 Agent 复审确认现有 diff/undo 成功语义存在硬风险，所以第一阶段必须同时修正 rollback、batch rollback、diff reject 的失败可观测性，不能只做展示。
+
+**技术栈：** IntelliJ Platform Java 17 插件 API、Gson、Claude/Codex session handlers、React/TypeScript webview hooks、现有 editable diff/undo handlers、Gradle/JUnit、Vitest。
+
+---
+
+## 1. 当前架构分析结论
+
+经过代码分析，现有 `Edits` 能力的核心链路如下：
+
+1. Java provider 层把 Claude/Codex 输出转换为 `ClaudeSession.Message`，并存入 `SessionState`。
+2. Java 通过已有 callback 把完整消息列表推给 webview。
+3. 前端 `webview/src/hooks/useFileChanges.ts` 从 assistant message 的 `tool_use` block 中解析文件改动。
+4. `useFileChanges` 只认 `FILE_MODIFY_TOOL_NAMES` 中的文件修改工具，例如 `edit`、`write`、`edit_file`、`write_file`。
+5. `webview/src/components/StatusPanel/FileChangesList.tsx` 把解析出的 `FileChangeSummary.operations` 传给 diff/undo bridge。
+6. `src/main/java/com/github/claudecodegui/handler/diff/EditableDiffHandler.java` 根据 operations 反推修改前内容并打开交互式 diff。
+7. `src/main/java/com/github/claudecodegui/handler/file/UndoFileHandler.java` 用同一组 operations 执行单文件或批量回滚。
+8. `webview/src/hooks/useFileChangesManagement.ts` 的 Keep All 只移动 `baseMessageIndex`，不会改磁盘文件。
+
+关键结论：
+
+- `Edits` 当前不是 VCS dirty files 视图，而是“从聊天消息里的文件修改工具调用解析出的可操作改动列表”。
+- 因此，正确改造点不是重写 `Edits` 面板，而是让 sub-agent 改动变成同样格式的 `edit`/`write` 工具调用消息。
+- 仅合成消息不足以达成“和主 agent 一样可 diff / 回滚 / 接受”。现有 `UndoFileHandler`、`ContentRebuildUtil`、`EditableDiffHandler` 对失败和 partial success 的处理必须先变成可观测、可阻断、可返回给前端的结构化结果。
+- Codex 已有 `codex_session_patch` 合成链路，新增 VFS tracker 后会形成“双真源”。必须在后端定义权威来源和去重策略，不能把 correctness 押在前端字符串 dedupe 上。
+- Claude 当前可能通过 `[MESSAGE]` user tool_result 和 `[TOOL_RESULT]` 双路径触发 completion；Codex tool id 也可能因 signature 复用而不具备“每次调用唯一”语义。因此 lifecycle finalize 必须幂等，并且 provider-specific 完成信号必须经过真实 fixture 验证。
+
+### 1.1 多 Agent 复审收敛结论
+
+本方案经过三路 sub-agent 交叉 review 后，收敛出以下必须修正项。以下条目是本计划的阻塞验收门槛；任一未满足，都不能宣称“sub-agent 改动与主 agent 改动完全一致支持 Edits 操作”。
+
+1. **核心捕获链路是硬阻塞。** 必须新增 session-owned `SubagentLifecycleDetector`、`SubagentEditScopeTracker`、VFS before/after snapshot、`SyntheticFileChangeMessageFactory`，并接入 Claude/Codex handlers；只修前端展示或只加 metadata 不算完成。
+2. **Undo 成功语义是硬阻塞。** 单文件 rollback 找不到 `newString`、定位歧义、`safeToRollback=false`、写入/删除失败时不能 silent success；`undo_all` 部分失败时不能向前端报告整体成功并隐藏全部 Edits。
+3. **Codex 双来源是硬阻塞。** 当 `codex_session_patch` 已覆盖某个文件/operation 时，VFS tracker 只能补缺，不能再生成并列权威 operation；后端必须有 operation registry/source priority，前端 dedupe 只能兜底。
+4. **Lifecycle completion 必须幂等。** Claude 双通道 tool_result、Codex wait/close 重复或缺失信号都必须被 `scopeId + completionToken` 去重处理；同一次 finalize 只能 append 一批 synthetic messages。
+5. **Claude mixed tool_result 必须过滤。** 一个 user message 同时包含“已处理 tool_result”和“新 tool_result”时，不能把整条 raw message 原样再次加入历史；必须只保留未处理 blocks 或拆分后追加。
+6. **Codex lifecycle id 必须唯一。** `spawn_agent` / `wait_agent` / `close_agent` / `send_input` / `resume_agent` 等 lifecycle tools 必须优先使用 raw `payload.call_id` 或 MCP `item.id`；缺少唯一 id 时必须生成 sequence id 或 fail-closed，不能用 signature 复用吞掉重复调用。
+7. **不明确就失败关闭。** 无法可靠归属 agent、无法获取 before snapshot、文本重复且无法安全定位、文件已被用户改写时，不生成可 rollback operation。
+8. **Keep All 不能跨 pending scope 生效。** 前端可以用 message boundary 隐藏已展示 edits，但必须在 streaming 或 Codex/Claude pending sub-agent scope 未 flush 时禁用；不得使用跨来源不可比的单一 `edit_sequence` 水位过滤未来消息。
+9. **Discard All 必须按请求快照隐藏。** `undo_all` 成功或 partial success 后，前端只能隐藏后端返回的 `succeededFiles` 或请求发起时的文件快照，不能按“当前面板最新列表”全量隐藏，否则会误处理延迟 synthetic injection。
+10. **新增文件删除必须验证真实磁盘状态。** 回滚 added file 时必须 refresh VFS，并在 VFS 找不到时使用 filesystem fallback；如果磁盘文件仍存在且删除失败，必须返回失败。
+11. **Simple diff 也必须使用结构化失败。** 不只 editable diff，`SimpleDiffDisplayHandler` / `ContentRebuildUtil` 的 before-content rebuild 失败也必须可观测，不能 silent skip。
+
+---
+
+## 2. 非目标
+
+本功能不做以下事情：
+
+- 不把 `Edits` 改成单纯读取 `git diff` 或 IDE dirty files。
+- 不为 Claude 和 Codex 做两套不同 UI。
+- 不依赖 sub-agent 最终总结文本来猜测改了哪些文件。
+- 不在缺少 before snapshot 的情况下强行生成可回滚操作。
+- 不在第一阶段新增删除文件状态 `D`，因为当前主 agent pipeline 也没有完整支持删除文件展示/恢复。
+- 不改变现有主 agent edit/write 的行为。
+
+---
+
+## 3. 推荐总体方案
+
+### 3.1 核心思路
+
+新增一个 `SubagentEditScopeTracker`。注意：当前 `SessionSendService` 每次发送都会创建新的 `ClaudeMessageHandler` 或 `CodexMessageHandler`，所以 tracker 不能是 handler-local 对象。它必须是 session-owned collaborator，由 `SessionSendService` 持有并注入 Claude/Codex handlers，或者挂在 `SessionState` 附近由 session 生命周期统一管理。否则 Codex `spawn_agent` 跨 `wait_agent`、跨消息阶段时会丢 scope。
+
+```text
+Claude/Codex 消息流
+        |
+        v
+ClaudeMessageHandler / CodexMessageHandler
+        |
+        +-- SubagentLifecycleDetector 识别 Task/agent/spawn_agent 启动与完成
+        |
+        v
+SubagentEditScopeTracker
+        |
+        +-- sub-agent 启动时打开 scope
+        +-- scope 活跃期间记录文件 before snapshot
+        +-- scope 完成时刷新并读取 after content
+        +-- before/after 生成 edit/write operations
+        |
+        v
+Synthetic assistant tool_use + user tool_result messages
+        |
+        v
+现有 useFileChanges -> StatusPanel Edits
+        |
+        +-- 加固后的 diff
+        +-- 加固后的单文件回滚
+        +-- 加固后的全部丢弃
+        +-- pending-scope gate + message boundary 版全部接受
+```
+
+### 3.2 为什么要合成消息
+
+现有 `Edits` 的数据契约是：
+
+```json
+{
+  "type": "tool_use",
+  "name": "edit",
+  "input": {
+    "file_path": "/absolute/path/File.java",
+    "old_string": "before hunk",
+    "new_string": "after hunk",
+    "replace_all": false
+  }
+}
+```
+
+如果 sub-agent 改动也被转换成这种结构，现有前端和后端几乎不需要知道“这是 sub-agent 改的”。它只会把这些操作当成普通文件改动。
+
+推荐 synthetic edit message 格式：
+
+```json
+{
+  "type": "assistant",
+  "content": "",
+  "raw": {
+    "isMeta": true,
+    "message": {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "subagent_edit_<scopeId>_<sequence>_<index>",
+          "name": "edit",
+          "input": {
+            "file_path": "/absolute/path/File.java",
+            "old_string": "before hunk",
+            "new_string": "after hunk",
+            "replace_all": false,
+            "start_line": 42,
+            "end_line": 48,
+            "source": "subagent",
+            "scope_id": "<scopeId>",
+            "agent_handle": "<provider-stable-handle-if-known>",
+            "parent_tool_use_id": "<task-or-spawn-tool-id>",
+            "operation_id": "<globally-unique-operation-id>",
+            "safe_to_rollback": true
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+并追加匹配的 synthetic tool result：
+
+```json
+{
+  "type": "user",
+  "content": "",
+  "raw": {
+    "isMeta": true,
+    "message": {
+      "role": "user",
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "subagent_edit_<scopeId>_<sequence>_<index>",
+          "is_error": false,
+          "content": "Sub-agent edit captured"
+        }
+      ]
+    }
+  }
+}
+```
+
+新文件使用 `write`：
+
+```json
+{
+  "type": "tool_use",
+  "id": "subagent_write_<scopeId>_<sequence>_<index>",
+  "name": "write",
+  "input": {
+    "file_path": "/absolute/path/NewFile.java",
+    "content": "full file content",
+    "new_string": "full file content",
+    "source": "subagent",
+    "scope_id": "<scopeId>",
+    "agent_handle": "<provider-stable-handle-if-known>",
+    "operation_id": "<globally-unique-operation-id>",
+    "safe_to_rollback": true
+  }
+}
+```
+
+注意事项：
+
+- `ClaudeSession.Message.content` 必须为空字符串；不要写 `Tool: edit` 之类可见文本，否则会污染聊天区并干扰 tool-only message 判定。
+- synthetic messages 的 `raw.isMeta` 必须为 `true`，用于和真实模型输出区分；metadata 同时必须放在 `tool_use.input` 内，因为前端 `useFileChanges` 只从 normalized tool input 读取文件改动元数据。
+- 同一个 scope finalize 时，推荐生成一条 assistant message，内部包含多个 `tool_use` block；再生成一条 user message，内部包含对应多个 `tool_result` block。这样能减少消息数量，也能让同一批 synthetic operations 更稳定。
+- `tool_use.id` 必须全局唯一，不能只依赖 provider 原始 `tool_use_id`；建议包含 `scopeId + finalizeSequence + operationIndex`。
+
+---
+
+## 4. Claude 和 Codex 支持策略
+
+### 4.1 Claude
+
+Claude sub-agent 通常通过 `Task` 或 `agent` 工具调用体现。
+
+生命周期规则：
+
+- assistant `tool_use` 的 normalized name 为 `task` 或 `agent` 时，开启一个 sub-agent scope。
+- 收到匹配 `tool_use_id` 的 user `tool_result` 时，完成该 scope。
+- completion 处理必须按 `scopeId + parentToolUseId + completionToken` 幂等；同一个 completion 被 `[MESSAGE]` user tool_result 和 `[TOOL_RESULT]` tag 同时送达时，只能 finalize 一次。
+- 如果 streaming/turn 结束时还有未完成 scope，只能 finalize 明确可关闭的 Claude scope；无法确认结束语义的 scope 应保留 pending 或 fail-closed，不生成可 rollback operation。
+
+Claude raw message 去重规则：
+
+- `ClaudeMessageHandler` 不能只维护一个 `processedToolResultIds` 后直接跳过整条消息。user message 可能同时包含多个 `tool_result` block，其中一部分已通过 `[TOOL_RESULT]` 通道处理，另一部分是新的。
+- 处理 user raw message 前先按 block 过滤：已处理 `tool_result.id/tool_use_id` 从 raw content 中移除；未处理 blocks 保留并继续触发 lifecycle completion。
+- 如果过滤后 raw content 为空，不追加该 user message；如果仍有普通文本或未处理 blocks，则追加过滤后的 clone，不能把已处理 block 再暴露给前端。
+- synthetic append 必须由统一 completion 入口触发，不能分别在 `[MESSAGE]` 和 `[TOOL_RESULT]` 两条路径各自 append。
+
+Claude 主 agent 的 `Edit`/`Write` 工具调用不需要改造，继续走现有链路。
+
+### 4.2 Codex
+
+Codex 有两个相关路径：
+
+1. 主 agent 的 `apply_patch`/file_change：当前 `ai-bridge/services/codex/codex-event-handler.js` 已经能从 session patch 合成 `edit`/`write` 操作，并标记为 `source=codex_session_patch`。
+2. sub-agent：通常通过 `spawn_agent` 启动，再通过 `wait_agent` 或 `close_agent` 等待/关闭。
+
+Codex 生命周期规则：
+
+- 看到 assistant `tool_use` name 为 `spawn_agent` 时，创建 provisional scope。
+- scope 关联字段不要命名为单一 `agentId`。应使用 provider-neutral 的 `agentHandle`，并从 `agent_id`、`agentId`、`agent_path`、`agentPath`、文本 UUID、返回对象 id 等真实输出里提取。
+- scope 在 `spawn_agent` 返回后继续保持 active，因为 worker 后续还可能继续修改文件；不能沿用当前 `useSubagents` “spawn tool_result 就 completed”的 UI 语义来判断文件 scope 完成。
+- 看到 `wait_agent` 或 `close_agent` 的成功结果时：
+  - 如果能通过 `target` / `agentHandle` / `parent_tool_use_id` 匹配 active scope，则 finalize 对应 scope。
+  - 如果无法可靠匹配，不能 finalize 最早 active scope；必须 fail-closed，保留 pending 诊断日志，或者只生成不可 rollback 的展示项。
+- detector 必须维护 session-owned `toolUseId -> toolName/input` 映射，因为 user `tool_result` 只有 `tool_use_id`，不包含原始工具名；这个映射不能放在 `CodexMessageHandler` 实例上。
+- 如果 lifecycle 依赖 `wait_agent`/`close_agent` 的每次调用唯一性，必须先修正 `ai-bridge` 对这些 lifecycle tools 的 `tool_use_id` signature 复用 / `tool_result` 去重策略，或者新增不被去重吞掉的 lifecycle sequence event。
+- turn completion 只能作为“flush 明确已完成 scope”的机会，不能无条件 finalize 所有 active Codex scope。
+
+Codex Node bridge lifecycle 契约：
+
+- 对 `spawn_agent`、`wait_agent`、`close_agent`、`send_input`、`resume_agent`，`ai-bridge` 必须优先使用 raw `payload.call_id`；MCP item/event path 必须优先使用 `item.id`，不能先用 `findMatchingToolUseId` 做 signature 匹配。
+- 只有非 lifecycle 普通工具才允许 signature fallback。lifecycle tool 缺少 raw id 时，必须生成包含 monotonic sequence 的 synthetic id，例如 `codex_lifecycle_<toolName>_<sequence>`，并把 sequence 透传给 Java；不能把相同 args 的重复 `wait_agent` 合并成同一个 tool_use。
+- lifecycle `tool_result` 必须可追溯到唯一 tool_use。空结果、错误结果、重复 wait/close 都要发出可诊断 event；Java 层根据 result 成败决定 finalize / fail-closed。
+- 必须用 fixture 覆盖 raw `call_id`、无 `call_id`、MCP `item.id`、重复 `wait_agent` 同 args、重复 `close_agent`、缺失 result、错误 result 这七类场景。
+
+Codex 双来源规则：
+
+- 不要删除现有 Codex main patch synthesis。
+- 后端必须定义单一权威来源：同一文件已有 `codex_session_patch` 覆盖时，VFS tracker 默认不再生成同文件 operations，只允许补充 session patch 缺失的文件。
+- 新增 session-owned `EditOperationRegistry`，在 synthetic message append 前登记 `operationId`、`filePath`、normalized hunk hash、line range、source、scopeId、finalizeSequence。
+- source priority 固定为：`codex_session_patch` > `main_tool_use` > `subagent_vfs`。priority 只用于折叠同一路径/同一 hunk 的重复来源；不同 hunk 不得互相覆盖。
+- VFS tracker 发现与高优先级 operation 同路径同 hunk 时，只写 diagnostic，不生成第二个可回滚 operation；发现同路径不同 hunk 时可以生成补充 operation，但必须带独立 `operationId`。
+- dedupe 应先在后端按 `operationId` / normalized hunk / file path / source priority 完成；前端 dedupe 只能作为防御层，不能承担 correctness。
+- 必须用真实 Codex event/session fixture 验证：主 agent patch 不重复、worker patch 归属正确、wait/close 重复或缺失时不会错误 finalize。
+
+---
+
+## 5. 文件改动捕获策略
+
+### 5.1 主策略：作用域内 VFS 快照
+
+实现 `SubagentEditScopeTracker`，在有 active scope 时订阅 IntelliJ VFS 事件。
+
+推荐使用：
+
+- `project.getMessageBus().connect()`
+- `VirtualFileManager.VFS_CHANGES`
+- `BulkFileListener.before(...)`
+- `BulkFileListener.after(...)`
+
+线程与性能约束：VFS 回调可能发生在敏感线程或写动作附近，读取 before content 时必须设置文件大小上限，跳过二进制/超大文件，并避免在 EDT 上做昂贵 diff。diff 构建和 synthetic message 生成应放在 finalize 阶段的后台流程中完成；最终 append message 再回到 session 消息处理链路。
+
+scope 数据结构建议：
+
+```java
+final class SubagentEditScope {
+    String scopeId;
+    String provider; // claude | codex
+    String parentToolUseId;
+    String agentHandle;
+    long finalizeSequence;
+    Set<String> completedTokens;
+    long startedAtMillis;
+    boolean finalizing;
+    Map<String, FileSnapshot> beforeByPath;
+    Set<String> touchedPaths;
+    Set<String> skippedPaths;
+}
+
+final class FileSnapshot {
+    String path;
+    boolean existed;
+    boolean binary;
+    String content;
+    long length;
+    long modifiedAtMillis;
+    String contentHash;
+}
+
+final class RegisteredEditOperation {
+    String operationId;
+    String filePath;
+    String source; // main_tool_use | subagent_vfs | codex_session_patch
+    String scopeId;
+    long finalizeSequence;
+    int lineStart;
+    int lineEnd;
+    String normalizedHunkHash;
+}
+```
+
+处理规则：
+
+- scope start 时立即捕获 project snapshot，作为后续 before content 的唯一可信基线。
+- scope start 后开始监听 VFS touched path。
+- 文件创建时，优先使用 scope-start snapshot 判断 `existed=false`；如果无法证明 before content，则 fail-closed 跳过可回滚 operation。
+- 文件修改后，仅记录 touched path，不在事件发生后反读磁盘作为 before content，避免把 after content 误当作 before content。
+- finalize 前主动刷新 project root，避免外部 Node/Codex 进程写入后 VFS 还没同步。
+- completion signal 到达后不要立即同步读文件；应做稳定性探测：刷新 VFS 后读取 size/mtime，间隔短延迟再次读取，连续两次稳定或达到超时后再读取 after content。固定 300-1000ms debounce 只能作为兜底，不应是唯一机制。
+- finalize 时读取 after content，并用 before/after 生成 operations。
+- finalize 生成 operation 前先查询 session-owned `EditOperationRegistry`：只有同一路径、同一 normalized hunk、同一 before/after 语义的 operation 才按 source priority 去重；同路径不同 hunk 必须保留为独立 operation。
+- registry 不允许做 path-level suppression；否则主 agent 和 sub-agent 修改同一文件不同区域时会误丢合法改动。
+- 如果文件在 finalize 前又被用户手动修改、IDE document 仍有未保存内容，或同一文件被多个 active scopes 同时触碰且无法区分归属，则跳过可 rollback operation。
+- 对 Codex，`codex_session_patch` 只压制同 hunk 的重复 VFS operation；同一路径不同 hunk 仍可由 VFS tracker 补充。
+- 所有 skipped path 必须进入 diagnostic log，包含 `scopeId`、`agentHandle`、`path`、`reason`，便于后续排查“sub-agent 明明改了文件但 Edits 没显示”的情况。
+
+### 5.2 兜底策略：dirty file reconciliation
+
+VFS 是主策略，但为了处理外部进程写入未及时触发 VFS 的情况，可以加一个保守兜底：
+
+1. scope start 时，如果项目是 Git repo，记录当前 dirty file set。
+2. scope finalize 时，再记录一次 dirty file set。
+3. 只处理“scope 期间从 clean 变 dirty”的文件。
+4. tracked 文件可以从 `HEAD` 读取 before content，但仅限 scope start 时确实 clean 的文件。
+5. untracked 新文件 before content 为空。
+6. 如果文件在 scope start 时已经 dirty，且 VFS 没有捕获 before snapshot，则跳过，不生成可回滚操作。
+
+这个兜底策略的原则是：宁可不展示，也不要生成可能误回滚用户已有改动的危险操作。
+
+---
+
+## 6. Operation 生成规则
+
+新增 `EditOperationBuilder`，输入 before/after content，输出可被现有 `useFileChanges`、`EditableDiffHandler`、`UndoFileHandler` 消费的 operations。
+
+### 6.1 支持场景
+
+- 已存在文本文件被修改：生成一个或多个 `edit` operations。
+- 新文本文件被创建：生成一个 `write` operation。
+- 文件创建后又在 scope 结束前被删除：不生成 operation。
+- 文件修改后又恢复原样：不生成 operation。
+- 二进制文件：跳过并写 debug log。
+- 超大文件：默认跳过，除非能安全生成小范围 hunk。
+
+### 6.2 Diff 算法
+
+建议实现 line-based diff：
+
+1. 按行切分 before/after，同时保留行尾换行信息。
+2. 对合理大小文件使用 LCS 或 Myers diff。
+3. 合并距离很近的 hunks。
+4. 每个 hunk 带 2-3 行上下文，降低 `newString` 在文件中重复匹配导致回滚错位置的概率。
+5. 记录 `start_line`、`end_line`，用于文件跳转和后续 line-aware rollback。
+
+不要默认对修改文件生成 whole-file operation。whole-file operation 虽然简单，但会让回滚风险显著变高，尤其是文件在 scope 前已经 dirty 或用户同时编辑时。
+
+### 6.3 删除文件
+
+当前 `FileChangeStatus` 只有 `A` 和 `M`。删除文件应作为后续增强，不放入第一阶段：
+
+- 增加 `D` 状态。
+- 前端 `FileChangesList` 支持删除状态展示。
+- `showEditableDiff` 支持 deleted file diff。
+- `UndoFileHandler` 支持把删除文件恢复为 old content。
+
+第一阶段遇到删除文件时：记录日志并跳过，不展示危险操作。
+
+---
+
+## 7. Synthetic Message 生成规则
+
+新增 `SyntheticFileChangeMessageFactory`。
+
+职责：把 `EditOperationBuilder` 输出的 operations 转换为 `ClaudeSession.Message` 列表。
+
+每个 finalized scope 生成两条隐藏 meta 消息：
+
+1. 一条 assistant message，`content=""`，`raw.isMeta=true`，`raw.message.content` 中包含多个 `tool_use` blocks。
+2. 一条 user message，`content=""`，`raw.isMeta=true`，`raw.message.content` 中包含对应多个 `tool_result` blocks。
+
+要求：
+
+- raw 结构要兼容 `webview/src/utils/messageUtils.ts` 的 `normalizeBlocks`。
+- `tool_use.id` 与 `tool_result.tool_use_id` 必须一一对应且全局唯一。
+- `tool_result.is_error` 必须为 `false`；如果 operation 不安全，不生成 successful tool result，而是在 diagnostic log 中说明跳过原因。
+- metadata 必须保留在 `tool_use.input` 中，包括 `source`、`scope_id`、`agent_handle`、`parent_tool_use_id`、`operation_id`、`safe_to_rollback`、`edit_sequence`。
+- `edit_sequence` 仅作为同一来源内的诊断/排序 metadata；前端 Keep All 不得把 Java tracker、Codex bridge、不同 turn 的 sequence 当成全局可比较水位。
+- 同一个 scope finalize 时批量 append messages；`SubagentEditScopeTracker.complete(...)` 必须幂等，即使 handler 收到重复 completion signal，也只能返回同一批 messages 一次。
+- `callbackHandler.notifyMessageUpdate(state.getMessages())` 不要求全链路只发生一次，但 synthetic append 与 completion 状态更新必须是原子语义，不能出现重复 synthetic messages。
+- 不要把 metadata 只放在 `raw` 顶层；当前前端 Edits 解析不读取顶层 raw metadata。
+
+---
+
+## 8. 前端改造
+
+前端应尽量保持小改动，但必须把现有操作结果协议补齐，否则 “Discard All / Reject / Undo” 会错误隐藏失败项。
+
+### 8.1 必需改动
+
+修改 `webview/src/types/fileChanges.ts`：
+
+```ts
+export interface EditOperation {
+  toolName: string;
+  oldString: string;
+  newString: string;
+  additions: number;
+  deletions: number;
+  replaceAll?: boolean;
+  lineStart?: number;
+  lineEnd?: number;
+  source?: 'main' | 'subagent' | 'codex_session_patch';
+  scopeId?: string;
+  agentHandle?: string;
+  parentToolUseId?: string;
+  operationId?: string;
+  safeToRollback?: boolean;
+  editSequence?: number;
+}
+```
+
+修改 `webview/src/hooks/useFileChanges.ts`：
+
+- 从 normalized input 中读取：
+  - `source`
+  - `scope_id`
+  - `agent_handle`
+  - `parent_tool_use_id`
+  - `operation_id`
+  - `safe_to_rollback`
+  - `edit_sequence`
+- 构建 `EditOperation` 时保留这些字段。
+- 保留现有 `lineStart/lineEnd` 解析，并在 diff / undo bridge payload 中继续传给 Java。
+- 加防御性 operation dedupe，但只作为兜底。
+
+前端 processed/dedupe key 的优先级必须是：
+
+```text
+operationId > toolUseId > occurrenceId > filePath + toolName + oldString + newString + lineStart + lineEnd
+```
+
+其中 `operationId` 和 `toolUseId` 表示后端/bridge 已声明的唯一 operation，不得被纯文本 hunk 指纹合并；这样才能保留同一文件同一 hunk 的多次合法重复编辑。只有缺少稳定 id 的历史消息才退回到 hunk 指纹兜底。Codex session patch 与 VFS tracker 的同 hunk 重复必须主要由后端 `EditOperationRegistry` 处理，前端 dedupe 不能承担正确性职责。
+
+修改 `webview/src/components/StatusPanel/FileChangesList.tsx`、`webview/src/components/StatusPanel/StatusPanel.tsx` 与 bridge 类型：
+
+- `showEditableDiff`、单文件 undo、`undo_all_file_changes` 都必须传完整 operations，包括 `lineStart`、`lineEnd`、`operationId`、`source`、`scopeId`、`safeToRollback`、`editSequence`。
+- `undo_all` 发起前必须捕获请求快照：`requestId + filePaths + operationIds`。后端返回 success 时也应返回 `succeededFiles`；前端只隐藏 `succeededFiles`，如果老后端未返回该字段，最多隐藏请求快照内文件，不能隐藏当前最新 Edits 列表。
+- `undo_all` 返回 partial result 时，前端只把成功文件对应的 operation keys 加入 processed set；失败文件/失败 operations 继续留在 `Edits` 并展示错误提示。
+- `Keep All` 设置 `baseMessageIndex = messages.length` 前必须确认没有 streaming/pending sub-agent；如果仍有 pending scope，禁用 Keep All 或先完成 synthetic injection，避免后续注入被错误接受或错误隐藏。
+- `Keep All` 只移动接受边界，不修改磁盘文件，也不能复用 undo/discard 的 operation-level processed keys；不要用单一 edit sequence 阈值过滤未来 edits。
+
+### 8.2 可选 UI
+
+默认不显示来源标识，以满足“和主 agent 完全一样”的诉求。
+
+如果产品上需要解释来源，可在后续增加轻量 badge：当文件任一 operation 的 `source === 'subagent'` 时显示 `Sub-agent`，但这不是 MVP 必需项。
+
+---
+
+## 9. 后端改造文件清单
+
+新增：
+
+- `src/main/java/com/github/claudecodegui/session/SubagentLifecycleDetector.java`
+- `src/main/java/com/github/claudecodegui/session/SubagentEditScopeTracker.java`
+- `src/main/java/com/github/claudecodegui/session/SyntheticFileChangeMessageFactory.java`
+- `src/main/java/com/github/claudecodegui/session/EditOperationRegistry.java`
+- `src/main/java/com/github/claudecodegui/util/EditOperationBuilder.java`
+- `src/main/java/com/github/claudecodegui/util/FileSnapshotUtil.java`
+- `src/main/java/com/github/claudecodegui/util/UndoOperationApplier.java`
+- `webview/src/components/StatusPanel/fileChangeActions.ts`
+
+修改：
+
+- `src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java`
+- `src/main/java/com/github/claudecodegui/session/CodexMessageHandler.java`
+- `src/main/java/com/github/claudecodegui/session/SessionSendService.java`，创建并注入 session-owned tracker 与 session-owned tool registry。
+- `src/main/java/com/github/claudecodegui/session/SessionState.java`，仅在需要提供批量追加 helper 或 pending scope 状态时修改。
+- `src/main/java/com/github/claudecodegui/handler/file/UndoFileHandler.java`，修正单文件/批量回滚成功语义，added file 删除必须 refresh VFS + filesystem fallback。
+- `src/main/java/com/github/claudecodegui/util/ContentRebuildUtil.java`，返回结构化 rebuild 结果，不再 silent skip。
+- `src/main/java/com/github/claudecodegui/handler/diff/EditableDiffHandler.java`、`src/main/java/com/github/claudecodegui/handler/diff/SimpleDiffDisplayHandler.java` 和 `src/main/java/com/github/claudecodegui/handler/diff/DiffFileOperations.java`，让 diff rebuild/reject/apply 写入失败可返回。
+- `webview/src/components/StatusPanel/FileChangesList.tsx`、`webview/src/components/StatusPanel/StatusPanel.tsx`、`webview/src/hooks/useFileChanges.ts`、`webview/src/hooks/useFileChangesManagement.ts` 以及 bridge 类型，传递完整 operation、做防御性 dedupe、处理 partial result 与 Keep All pending-scope gate。
+
+Node bridge 原则上不承载跨 provider 核心逻辑，但 Codex lifecycle 信号可靠性可能必须小幅修改：
+
+- `ai-bridge/services/codex/codex-event-handler.js`
+- `ai-bridge/services/codex/codex-tool-normalization.js`
+
+如果确认 `wait_agent`/`close_agent` 的 `tool_use_id` 会被 signature 复用或 tool_result 去重吞掉，必须针对 lifecycle tools 保留 raw `payload.call_id` 或发出额外 sequence metadata；否则 Java 层不能安全 finalize Codex scope。
+
+---
+
+## 10. 安全规则
+
+实现时必须满足：
+
+1. 只处理 project base path 下的文件。
+2. 忽略目录、`.git`、build 输出目录、二进制文件和超大文件。
+3. 没有 before content 时，不生成可回滚 operation。
+4. 文件在 scope start 前已经 dirty 且 VFS 没捕获 before snapshot 时，不生成 operation。
+5. scope finalize 必须幂等，并按 `scopeId + completionToken` 去重。
+6. 并行 sub-agent 存在多个 active scope 且 VFS 事件无法精确归属时，fail-closed，不生成可 rollback operation。
+7. diff 打开前如果 `newString` 已经无法在当前文件中安全定位，应提示并保留在 `Edits`，不要展示错误 diff，也不要自动移除。
+8. 回滚匹配不得 fallback 到第一个全局 `indexOf(newString)`；行范围附近没有唯一匹配时，如果全文件存在多处匹配，必须返回 `ambiguous_match`。
+9. 显式 `safeToRollback=false` 的 operation，Java undo/reject 路径必须拒绝执行；前端应禁用 discard/reject 或把该 operation 从可回滚列表中排除。
+10. 回滚失败时不能把文件从 `Edits` 中移除。
+11. added file 回滚必须验证真实磁盘删除结果；VFS 未命中时要 refresh 并 fallback 到 filesystem delete，失败则返回失败。
+12. `undo_all` partial success 必须返回逐文件结果；前端只能隐藏 succeeded files。
+13. `Discard All` full success 也必须基于返回的 `succeededFiles` 或请求快照隐藏，不能清空当前最新列表。
+14. `Keep All` 必须在 pending sub-agent flush 后才能执行；执行后仅移动 message boundary，不得用跨来源单一 edit sequence 阈值过滤未来 edits。
+15. Codex `codex_session_patch` 与 VFS tracker 冲突时，以后端 source priority 决定唯一 operation。
+16. 不安全或归属不明确的 operation 必须 skipped + diagnostic，不得显示为可回滚项。
+17. Codex denied patch 如果 rollback 失败，必须把残留文件改动作为成功 tool_result 暴露给 Edits，但标记 `safe_to_rollback=false`，避免静默丢失真实磁盘改动。
+18. 并行 sub-agent 的 VFS 事件缺少可靠 owner 信号时必须 fail-closed；多个 active scope 下不能猜 latest 归属，宁可跳过 ambiguous operation 也不能错归属。
+19. `write/write_file` 只有在 `existed_before=false` 或无法证明已存在时才可按新增处理；`existed_before=true` 必须是修改。
+17. `SimpleDiffDisplayHandler` 与 `EditableDiffHandler` 必须共享结构化 rebuild 失败语义；只修 editable path 不算完成。
+
+---
+
+## 11. 实现任务拆解
+
+### Task 0：修正现有 Edits 操作语义
+
+**Files:**
+
+- Modify: `src/main/java/com/github/claudecodegui/handler/file/UndoFileHandler.java`
+- Create/Modify: `src/main/java/com/github/claudecodegui/util/UndoOperationApplier.java`
+- Modify: `src/main/java/com/github/claudecodegui/util/ContentRebuildUtil.java`
+- Modify: `src/main/java/com/github/claudecodegui/handler/diff/EditableDiffHandler.java`
+- Modify: `src/main/java/com/github/claudecodegui/handler/diff/SimpleDiffDisplayHandler.java`
+- Modify: `src/main/java/com/github/claudecodegui/handler/diff/DiffFileOperations.java`
+- Modify: `webview/src/components/StatusPanel/FileChangesList.tsx`
+- Modify: `webview/src/components/StatusPanel/StatusPanel.tsx`
+- Modify: `webview/src/components/StatusPanel/fileChangeActions.ts`
+- Modify: `webview/src/hooks/useFileChangesManagement.ts`
+- Create/Modify: Java 与 webview 相关测试。
+
+**Step 1：写失败测试**
+
+覆盖：
+
+- 单文件 undo 找不到 `newString` 时返回失败，前端不移除该 file change。
+- 单文件 undo 遇到重复 `newString` 且 line range 不能唯一定位时返回 `ambiguous_match`，不能 fallback 到第一个全局匹配。
+- 显式 `safeToRollback=false` 时 undo/reject 返回失败，前端保留该 file change。
+- added file undo 在 VFS 未刷新时仍能通过 filesystem fallback 删除；如果磁盘文件仍存在则返回失败。
+- `undo_all` 一部分文件成功、一部分文件失败时返回 `succeededFiles` 与 `failedFiles`，前端只隐藏成功项。
+- `undo_all` 全成功时也返回 `succeededFiles`；前端按请求快照或返回列表隐藏，不能清空当前最新 Edits。
+- `ContentRebuildUtil` 找不到 operation 时返回 skipped/failed 结构化结果，而不是 silent skip。
+- `SimpleDiffDisplayHandler` 和 `EditableDiffHandler` 都消费结构化 rebuild result；失败时不展示错误 diff，也不移除 Edits。
+- diff reject/apply 写入失败时不发送 remove-from-edits。
+- bridge payload 保留 `lineStart`、`lineEnd`、`operationId`、`source`、`scopeId`、`safeToRollback`、`editSequence`。
+
+**Step 2：实现后端结果协议**
+
+建议协议：
+
+```json
+{
+  "success": false,
+  "partial": true,
+  "succeededFiles": ["/path/A.java"],
+  "failedFiles": [
+    { "filePath": "/path/B.java", "reason": "new_string_not_found" }
+  ]
+}
+```
+
+单文件 undo 必须在 `newString` 无法定位、写入失败、文件不存在等情况下返回失败；批量 undo 不能把 partial success 包装成整体 success。
+
+**Step 3：实现前端 partial handling**
+
+- `StatusPanel` 对 `undo_all` partial success 只调用 per-file discard。
+- 失败文件保留在 `Edits` 并显示错误 toast / message。
+- `Keep All` 不复用 undo 的 operation-level processed key 语义；应移动 message boundary，并依赖 pending-scope gate 防止延迟 injection。
+- `Discard All` 发起时保存 `requestId + filePaths + operationIds`，成功/partial 回调只处理该快照内且后端确认成功的文件。
+
+**Step 4：运行测试**
+
+Run:
+
+```bash
+./gradlew test --tests com.github.claudecodegui.util.UndoOperationApplierTest --tests com.github.claudecodegui.handler.diff.EditableDiffHandlerTest --tests com.github.claudecodegui.session.SubagentEditScopeTrackerTest --tests com.github.claudecodegui.session.SubagentLifecycleDetectorTest
+cd webview && npx vitest run src/components/StatusPanel/fileChangeActions.test.ts src/hooks/useFileChanges.test.ts src/hooks/useFileChangesManagement.test.ts
+node --test ai-bridge/services/codex/codex-event-handler.lifecycle.test.mjs
+```
+
+Expected: PASS。
+
+---
+
+### Task 1：新增 EditOperationBuilder 测试和实现
+
+**Files:**
+
+- Create: `src/test/java/com/github/claudecodegui/util/EditOperationBuilderTest.java`
+- Create: `src/main/java/com/github/claudecodegui/util/EditOperationBuilder.java`
+
+**Step 1：写失败测试**
+
+覆盖：
+
+- 单行替换生成一个 edit operation。
+- 多 hunk 修改生成多个 operations。
+- 新文件生成一个 write operation。
+- before/after 相同不生成 operation。
+- 重复文本场景带上下文，降低误回滚风险。
+- CRLF/LF 场景生成可用 operation。
+- 二进制或超大文件跳过。
+
+**Step 2：运行测试确认失败**
+
+Run:
+
+```bash
+./gradlew test --tests com.github.claudecodegui.util.EditOperationBuilderTest
+```
+
+Expected: FAIL，因为 `EditOperationBuilder` 尚未实现。
+
+**Step 3：实现最小功能**
+
+实现 line-based diff、hunk 合并、上下文生成、line range 记录。
+
+**Step 4：运行测试确认通过**
+
+Run:
+
+```bash
+./gradlew test --tests com.github.claudecodegui.util.EditOperationBuilderTest
+```
+
+Expected: PASS。
+
+---
+
+### Task 2：新增 SyntheticFileChangeMessageFactory
+
+**Files:**
+
+- Create: `src/test/java/com/github/claudecodegui/session/SyntheticFileChangeMessageFactoryTest.java`
+- Create: `src/main/java/com/github/claudecodegui/session/SyntheticFileChangeMessageFactory.java`
+
+**Step 1：写失败测试**
+
+断言：
+
+- modified file 生成 `name=edit` 的 assistant `tool_use`。
+- new file 生成 `name=write` 的 assistant `tool_use`。
+- user `tool_result` 的 `tool_use_id` 正确匹配。
+- `source=subagent`、`scope_id`、`agent_handle`、`parent_tool_use_id`、`operation_id` 被保留。
+- raw message shape 能被前端 `normalizeBlocks` 识别。
+- `ClaudeSession.Message.content` 为空，`raw.isMeta=true`，不会在聊天区显示 `Tool: edit`。
+- 同一 scope 的多个 operations 被批量放入同一对 assistant/user meta messages。
+
+**Step 2：实现 factory**
+
+使用 `ClaudeSession.Message`、`JsonObject`、`JsonArray` 生成消息。tool id 使用 `scopeId + finalizeSequence + operationIndex` 生成全局唯一值。
+
+**Step 3：运行测试**
+
+Run:
+
+```bash
+./gradlew test --tests com.github.claudecodegui.session.SyntheticFileChangeMessageFactoryTest
+```
+
+Expected: PASS。
+
+---
+
+### Task 3：新增 SubagentLifecycleDetector
+
+**Files:**
+
+- Create: `src/test/java/com/github/claudecodegui/session/SubagentLifecycleDetectorTest.java`
+- Create: `src/main/java/com/github/claudecodegui/session/SubagentLifecycleDetector.java`
+
+**Step 1：写失败测试**
+
+覆盖：
+
+- Claude `Task` tool_use 识别为 start。
+- Claude `agent` tool_use 识别为 start。
+- Claude matching tool_result 识别为 completion。
+- Codex `spawn_agent` 识别为 start。
+- Codex spawn result 从 JSON content 提取 `agentHandle`。
+- Codex spawn result 从 text content / UUID / agent path 提取 `agentHandle`。
+- Codex `wait_agent`/`close_agent` 识别为 completion signal。
+- Codex lifecycle tool 使用 raw `call_id` / MCP `item.id` / sequence id 形成唯一 completion token，重复同 args 调用不会被合并。
+- Codex 无法匹配 `agentHandle` 时 fail-closed，不 finalize oldest。
+- Claude 同一 `tool_result` 通过双通道到达时只产生一个 completion event。
+- Claude mixed user message 中已处理与未处理 `tool_result` 共存时，只对未处理 block 生成 completion event。
+
+**Step 2：实现 detector**
+
+输出 provider-neutral event：
+
+```java
+public final class SubagentLifecycleEvent {
+    enum Kind { STARTED, SPAWN_RESOLVED, COMPLETED }
+    Kind kind;
+    String provider;
+    String toolUseId;
+    String parentToolUseId;
+    String agentHandle;
+    String completionToken;
+}
+```
+
+**Step 3：运行测试**
+
+Run:
+
+```bash
+./gradlew test --tests com.github.claudecodegui.session.SubagentLifecycleDetectorTest
+```
+
+Expected: PASS。
+
+---
+
+### Task 4：实现 SubagentEditScopeTracker
+
+**Files:**
+
+- Create: `src/test/java/com/github/claudecodegui/session/SubagentEditScopeTrackerTest.java`
+- Create: `src/test/java/com/github/claudecodegui/session/EditOperationRegistryTest.java`
+- Create: `src/main/java/com/github/claudecodegui/session/SubagentEditScopeTracker.java`
+- Create: `src/main/java/com/github/claudecodegui/session/EditOperationRegistry.java`
+- Create: `src/main/java/com/github/claudecodegui/util/FileSnapshotUtil.java`
+
+**Step 1：先写不依赖 VFS 的状态机测试**
+
+覆盖：
+
+- start scope 创建 active scope。
+- before snapshot 每个文件只保存一次。
+- finalize scope 生成 synthetic messages。
+- finalize 幂等：相同 `scopeId + completionToken` 只输出一次 synthetic messages。
+- 存在多个 active scopes 且 VFS 事件无法可靠归属时 fail-closed，不生成可 rollback operation。
+- Codex `codex_session_patch` 已覆盖的文件不会再被 VFS tracker 生成重复 operation。
+- 同路径不同 hunk 可以生成补充 operation，同路径同 hunk 必须被 registry 去重。
+- registry source priority 固定且可测试，不能靠前端 dedupe 才避免重复展示。
+- project base path 外文件被忽略。
+- 缺少 before snapshot 的已有 dirty 文件被跳过。
+
+**Step 2：实现核心 tracker**
+
+建议接口：
+
+```java
+public final class SubagentEditScopeTracker {
+    public void startScope(...);
+    public void resolveAgentHandle(...);
+    public List<ClaudeSession.Message> completeScope(String scopeId, String completionToken);
+    public List<ClaudeSession.Message> completeEligibleScopes(...);
+    public void recordBeforeSnapshot(String path, FileSnapshot snapshot);
+    public void recordTouchedPath(String path);
+}
+```
+
+**Step 3：接入 VFS listener**
+
+- 第一个 scope 开启时 subscribe。
+- 最后一个 scope 完成后 disconnect。
+- finalize 前 refresh project root，并执行 size/mtime 稳定性探测。
+
+**Step 4：运行测试**
+
+Run:
+
+```bash
+./gradlew test --tests com.github.claudecodegui.session.SubagentEditScopeTrackerTest --tests com.github.claudecodegui.session.EditOperationRegistryTest
+```
+
+Expected: PASS。
+
+---
+
+### Task 5：接入 ClaudeMessageHandler
+
+**Files:**
+
+- Modify: `src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java`
+- Modify: `src/main/java/com/github/claudecodegui/session/SessionSendService.java`
+- Modify/Test: `src/test/java/com/github/claudecodegui/session/ClaudeMessageHandlerRawConsistencyTest.java`
+- Modify/Test: `src/test/java/com/github/claudecodegui/session/ClaudeMessageHandlerDedupTest.java`
+
+**Step 1：新增测试场景**
+
+模拟：
+
+1. assistant `Task` tool_use 到达。
+2. tracker 开启 scope。
+3. 测试中注入一个 before/after 文件 delta。
+4. matching tool_result 到达。
+5. handler 在正常 tool_result 后追加 synthetic edit messages。
+6. 同一个 tool_result 通过 `[MESSAGE]` 与 `[TOOL_RESULT]` 双路径到达时，handler 只追加一批 synthetic edit messages。
+7. 同一 user raw message 同时包含已处理 tool_result 与新 tool_result 时，追加到 history 的 raw message 只保留新 block，已处理 block 不再暴露。
+
+**Step 2：接入 start**
+
+在 `handleAssistantMessage` 中，对 parsed raw assistant message 调用 `SubagentLifecycleDetector`。识别到 start 后，在通知前端前开启 scope。
+
+**Step 3：接入 completion**
+
+在 `handleUserMessage` 和 `handleToolResult` 两条路径中统一调用幂等 completion 入口；保留现有 tool_result message 行为，但 synthetic append 只能发生一次。
+
+**Step 4：增加兜底**
+
+在 stream end 或 onComplete 处只 finalize 明确已完成但尚未 flush 的 Claude scopes；仍不明确的 scope 保留 pending 或跳过可 rollback operation。
+
+**Step 5：运行测试**
+
+Run:
+
+```bash
+./gradlew test --tests com.github.claudecodegui.session.ClaudeMessageHandlerRawConsistencyTest --tests com.github.claudecodegui.session.ClaudeMessageHandlerDedupTest
+```
+
+Expected: PASS。
+
+---
+
+### Task 6：接入 CodexMessageHandler
+
+**Files:**
+
+- Modify: `src/main/java/com/github/claudecodegui/session/CodexMessageHandler.java`
+- Modify: `src/main/java/com/github/claudecodegui/session/SessionSendService.java`
+- Modify: `ai-bridge/services/codex/codex-event-handler.js`
+- Modify: `ai-bridge/services/codex/codex-tool-normalization.js`
+- Create: `src/test/java/com/github/claudecodegui/session/CodexMessageHandlerSubagentEditsTest.java`
+- Create/Modify: `ai-bridge/services/codex/codex-event-handler.lifecycle.test.mjs`
+
+**Step 1：新增测试场景**
+
+模拟：
+
+1. Codex assistant message 中出现 `spawn_agent` tool_use。
+2. tracker 创建 provisional scope。
+3. spawn tool_result 解析出 `agentHandle`。
+4. `wait_agent` 或 `close_agent` 成功结果 finalize 对应 scope。
+5. 无 `agentHandle` 或无法可靠匹配时 fail-closed，不 finalize oldest active scope。
+6. turn completion 只 flush eligible scopes，不无条件 finalize remaining active scopes。
+7. 重复 wait/close 或 tool id 复用场景不会重复/错误 finalize。
+8. raw `payload.call_id`、MCP `item.id`、无 call_id sequence fallback 三条 Node bridge 路径都产生唯一 tool_use id。
+9. lifecycle `tool_result` 缺失或失败时不 finalize，只记录 diagnostic。
+
+**Step 2：修正 Node bridge lifecycle id**
+
+先修 `ai-bridge`，保证 lifecycle tools 的 tool_use/tool_result id 具备每次调用唯一性，再接入 Java detector。否则 Java 侧无法区分重复 `wait_agent` 与同一调用的重复 result。
+
+**Step 3：接入 lifecycle detector**
+
+在 `handleAssistantMessage` 和 `handleUserMessage` parse 后调用 detector。
+
+**Step 4：保留 Codex direct patch 路径**
+
+不要移除 `ai-bridge/services/codex/codex-event-handler.js` 中现有 patch synthesis。重复问题必须由后端 source priority / operation registry 解决：`codex_session_patch` 覆盖的同一路径，VFS tracker 默认只记录诊断，不生成重复 operation。前端 dedupe 只是防御层。
+
+**Step 5：运行测试**
+
+Run:
+
+```bash
+node --test ai-bridge/services/codex/codex-event-handler.lifecycle.test.mjs
+./gradlew test --tests com.github.claudecodegui.session.CodexMessageHandlerSubagentEditsTest
+```
+
+Expected: PASS。
+
+---
+
+### Task 7：前端保留 metadata 并去重
+
+**Files:**
+
+- Modify: `webview/src/types/fileChanges.ts`
+- Modify: `webview/src/hooks/useFileChanges.ts`
+- Create: `webview/src/hooks/useFileChanges.test.ts`
+
+**Step 1：写测试**
+
+构造 synthetic sub-agent `edit` 和 `write` messages，断言：
+
+- modified file 显示为 `M`。
+- new file 显示为 `A`。
+- operation metadata 被保留，包括 `agentHandle`、`operationId`、`safeToRollback`、`editSequence`。
+- 重复 operation 被折叠，dedupe key 不包含 `source/scopeId`。
+- `codex_session_patch` 与 `subagent_vfs` 同 hunk 重复时前端只显示一个兜底项。
+- failed tool_result 不会进入 `Edits`。
+- hidden meta synthetic message 不显示为聊天文本，但能被 `useFileChanges` 解析。
+
+**Step 2：实现 metadata extraction**
+
+从 normalized input 读取 `source`、`scope_id`、`agent_handle`、`parent_tool_use_id`、`operation_id`、`safe_to_rollback`、`edit_sequence`。
+
+**Step 3：实现 dedupe**
+
+在 push 到 `fileOperationsMap` 前做 operation signature 去重；同时确保后续 diff/undo bridge payload 不丢 `lineStart/lineEnd/operationId/source/scopeId/safeToRollback/editSequence`。
+
+**Step 4：运行测试**
+
+Run:
+
+```bash
+cd webview && npx vitest run src/hooks/useFileChanges.test.ts && npx tsc -p tsconfig.test.json --noEmit
+```
+
+Expected: PASS。
+
+---
+
+### Task 8：可选来源标识
+
+**Files:**
+
+- Modify: `webview/src/components/StatusPanel/FileChangesList.tsx`
+- Modify: `webview/src/components/StatusPanel/StatusPanel.less`
+- Modify: `webview/src/i18n/locales/en.json`
+- Modify: `webview/src/i18n/locales/zh.json`
+
+**Step 1：确认是否需要**
+
+如果要求“和主 agent 完全一样”，跳过本任务。
+
+**Step 2：如需要，增加 badge**
+
+当文件任一 operation 的 `source === 'subagent'` 时显示轻量 `Sub-agent` 标识。
+
+**Step 3：运行测试**
+
+Run:
+
+```bash
+cd webview && npm test
+```
+
+Expected: PASS。
+
+---
+
+### Task 9：增强定位安全性
+
+**Files:**
+
+- Modify: `src/main/java/com/github/claudecodegui/handler/file/UndoFileHandler.java`
+- Modify: `src/main/java/com/github/claudecodegui/util/UndoOperationApplier.java`
+- Modify: `src/main/java/com/github/claudecodegui/util/ContentRebuildUtil.java`
+- Modify: `src/main/java/com/github/claudecodegui/handler/diff/SimpleDiffDisplayHandler.java`
+- Modify: `src/main/java/com/github/claudecodegui/handler/diff/EditableDiffHandler.java`
+- Modify: `webview/src/components/StatusPanel/FileChangesList.tsx`
+- Modify: `webview/src/components/StatusPanel/StatusPanel.tsx`
+- Create/Modify: `src/test/java/com/github/claudecodegui/util/UndoOperationApplierTest.java`
+- Create/Modify: `src/test/java/com/github/claudecodegui/handler/diff/EditableDiffHandlerTest.java`
+- Create/Modify: `webview/src/hooks/useFileChangesManagement.test.ts`
+- Create/Modify: `ai-bridge/services/codex/codex-event-handler.lifecycle.test.mjs`
+
+**Step 1：新增重复 newString 场景测试**
+
+当前 rollback 使用第一次 `content.indexOf(newString)`，重复文本可能定位错误。用测试覆盖：
+
+- 同一 `newString` 在文件中出现多次时，优先使用 `lineStart/lineEnd` 附近匹配。
+- 行范围附近找不到时，如果全文件存在多处匹配，返回 `ambiguous_match` failure，不自动回滚。
+- 行范围缺失时保持主 agent 既有单一匹配行为，但遇到多处匹配时返回 `ambiguous_match`，不能 fallback 到第一个全局匹配。
+- `safeToRollback=false` 时 undo/reject 明确失败。
+- added file 删除必须 refresh VFS；VFS 找不到时 fallback 到 `java.nio.file.Files.deleteIfExists`，并验证删除后文件不存在。
+- `SimpleDiffDisplayHandler` rebuild 失败时返回/展示错误，不打开可能错误的 diff。
+
+**Step 2：传递完整 operation**
+
+确保前端 diff、单文件 undo、batch undo 都把 `lineStart`、`lineEnd`、`operationId`、`safeToRollback` 带到 Java；后端优先用这些字段缩小匹配范围并执行安全检查。
+
+**Step 3：运行测试**
+
+Run targeted Java 和 webview tests。
+
+Expected: 主 agent 既有 rollback 行为不回归，sub-agent synthetic operations 具备 line-aware 安全定位。
+
+---
+
+### Task 10：手工集成验证清单
+
+**Files:**
+
+- Create: `docs/testing/subagent-edits-status-panel-checklist.md`
+
+**Step 1：创建验证清单**
+
+覆盖场景：
+
+- Claude 主 agent edit 仍然进入 `Edits`。
+- Claude `Task` sub-agent 修改一个文件，文件进入 `Edits`。
+- Claude `Task` sub-agent 新建一个文件，文件显示为 added。
+- Codex 主 agent patch 仍然只显示一次。
+- Codex `spawn_agent` worker 修改一个文件，文件进入 `Edits`。
+- Codex worker 新建一个文件，文件显示为 added。
+- synthetic sub-agent 文件可以打开 diff。
+- diff 中 Reject 写入成功后才移出 `Edits`；写入失败时保留。
+- 单文件 rollback 能恢复文件并移出 `Edits`；找不到 `newString`、定位歧义或 `safeToRollback=false` 时失败且保留。
+- 新增文件 rollback 在 VFS 未刷新时仍能删除真实磁盘文件；删除失败时保留 `Edits`。
+- Discard All 能恢复所有 sub-agent 文件；partial failure 时只隐藏成功文件；full success 也只隐藏请求快照/后端返回的成功文件。
+- Keep All 只隐藏执行时 message boundary 之前且已经 flush 的 files，不修改磁盘内容；pending sub-agent 未完成时按钮保持禁用。
+- 并行 sub-agents 在缺少可靠 VFS owner 信号时 fail-closed，不产生错归属的危险 rollback operation。
+- 并行 sub-agents 修改同一文件且无法归属时不生成危险 rollback。
+- Claude 双通道 tool_result 不会产生重复 synthetic messages；mixed user message 只保留未处理 tool_result blocks。
+- Codex 主 patch 与 VFS tracker 不会重复显示同一操作，后端 registry 记录 source priority 命中。
+- Codex `wait_agent`/`close_agent` 重复、缺失、错误结果或无法匹配时 fail-closed。
+- Codex Node bridge raw `call_id`、MCP `item.id`、无 call_id sequence fallback 都不会复用 lifecycle tool id。
+- 已有 dirty 文件在缺少 before snapshot 时不会生成不安全 rollback。
+
+**Step 2：运行完整验证命令**
+
+Run:
+
+```bash
+node --test ai-bridge/config/api-config.test.js ai-bridge/services/claude/persistent-query-service.helpers.test.mjs ai-bridge/services/claude/persistent-query-service.test.mjs ai-bridge/services/codex/codex-event-handler.lifecycle.test.mjs
+cd webview && npm test
+./gradlew test
+git diff --check
+```
+
+Expected: all pass。
+
+---
+
+## 12. 工作量评估
+
+### MVP：可展示且操作语义可信
+
+范围：
+
+- Task 0 现有 undo / batch undo / diff reject 成功语义修正。
+- Claude/Codex lifecycle detection 与 session-owned tracker。
+- VFS-scoped before/after snapshot。
+- Codex `codex_session_patch` 与 VFS tracker 后端单一权威来源策略。
+- hidden meta synthetic edit/write messages。
+- frontend metadata + 防御性 dedupe + partial undo result handling。
+- Keep All pending-scope gate + message boundary acceptance。
+- 不支持 agent 删除已有文件状态 `D`；但 added file rollback 必须支持真实删除新增文件。
+- 不加来源 badge。
+
+估算：**10-15 人日**。其中 2-3 人日用于先修 Edits 操作语义与 lifecycle id 安全底座，5-7 人日用于核心捕获/synthetic 链路，3-5 人日用于 Codex 双来源 registry、Keep All pending-scope gate 与测试补齐。
+
+### 生产级增强
+
+额外范围：
+
+- dirty file reconciliation 兜底。
+- 大文件/二进制跳过处理与性能压测。
+- 更完整的 line-aware rollback / ambiguous match 处理。
+- Codex real event fixture 覆盖 wait/close id 复用、tool_result 去重、worker patch 归属。
+- Claude/Codex、streaming/non-streaming 手工验证。
+- Subagents UI lifecycle 语义从 “spawn completed” 调整为 “worker completed”。
+
+估算：**总计 15-22 人日**，包含 MVP。
+
+### 完整增强版
+
+额外范围：
+
+- 新增删除文件状态 `D`。
+- 删除文件 diff 展示。
+- rollback 恢复删除文件。
+- 并行 sub-agent 更精确归属。
+- 如果 Codex SDK 暴露 child session path，则优先解析 child session patch。
+- 更细的 conflict UI：展示 skipped/unsafe operations 的原因。
+
+估算：**总计 3-4 周**。
+
+---
+
+## 13. 推荐发布节奏
+
+建议拆成三个 PR 级别的阶段：
+
+1. **Edits 操作语义加固**
+   - 单文件 rollback 失败可见，ambiguous match fail-closed
+   - added file delete refresh + filesystem fallback
+   - `undo_all` partial/full success 都基于 `succeededFiles` 或请求快照
+   - editable/simple diff rebuild 与 reject/apply 写入确认
+   - 前端 partial handling、完整 operation payload、Discard All 快照
+
+2. **核心捕获与 synthetic messages**
+   - session-owned tracker / tool registry / operation registry
+   - lifecycle detector 与 Claude mixed tool_result 过滤
+   - Codex lifecycle raw id / MCP item id / sequence fallback
+   - operation builder
+   - hidden meta synthetic messages
+   - Codex 后端单一权威来源策略
+   - frontend metadata/dedupe 与 Keep All pending-scope gate
+
+3. **可靠性与 UX polish**
+   - dirty file reconciliation
+   - 更完整的 line-aware diff/rollback 诊断
+   - Subagents UI lifecycle 语义修正
+   - 可选来源 badge
+   - 手工验证清单
+
+第一阶段不要做“被 agent 删除的文件”状态 `D` 支持。注意这不影响 added file rollback：新增文件的 discard 本质是删除该新增文件，必须在第一阶段保证真实磁盘删除成功语义。
+
+---
+
+## 14. 成功标准
+
+实现完成后必须满足：
+
+- Claude sub-agent 改动进入 `Edits`，行为与主 agent 改动一致。
+- Codex sub-agent 改动进入 `Edits`，行为与主 agent 改动一致。
+- Claude 主 agent 既有 edit/write 展示不回归。
+- Codex 主 agent patch 展示不重复，`codex_session_patch` 与 VFS tracker 不产生双份 operation。
+- sub-agent 文件能打开正确 before/after diff，且 hidden synthetic messages 不污染聊天内容。
+- 单文件 rollback 找不到 `newString`、定位歧义、`safeToRollback=false` 或写入失败时返回失败并保留 `Edits`。
+- added file rollback 必须真实删除磁盘文件；VFS 未刷新或删除失败时不能 silent success。
+- Discard All partial failure 时只隐藏成功文件，失败文件仍可重试或查看原因；full success 也不能误隐藏请求后新注入的 synthetic Edits。
+- Keep All 基于 pending-scope gate + message boundary，延迟 synthetic injection 不会让已接受项被错误处理。
+- Claude 双通道 tool_result 只 finalize 一次；mixed raw message 不会重新暴露已处理 tool_result block。
+- Codex `wait_agent`/`close_agent` 重复、缺失、tool id 复用或无法匹配时 fail-closed，不错误归属到最早 active scope。
+- Codex Node bridge lifecycle id 在 raw `call_id`、MCP `item.id`、无 call_id fallback 场景下均保持每次调用唯一。
+- 不安全 operation 被跳过并记录 diagnostic，而不是展示错误 diff 或执行危险 rollback。
+- Java、Node 和 webview 测试覆盖 lifecycle、operation registry、operation builder、synthetic message、frontend parsing/dedupe、rollback result protocol、partial undo、Discard All 快照、Keep All pending-scope gate。

--- a/src/main/java/com/github/claudecodegui/handler/CodexMessageConverter.java
+++ b/src/main/java/com/github/claudecodegui/handler/CodexMessageConverter.java
@@ -311,6 +311,20 @@ public class CodexMessageConverter {
                contentStr.startsWith("<environment_context>");
     }
 
+    private static String stableCodexToolId(JsonObject payload, String timestamp) {
+        if (payload != null) {
+            if (payload.has("call_id") && !payload.get("call_id").isJsonNull()) {
+                return payload.get("call_id").getAsString();
+            }
+            if (payload.has("id") && !payload.get("id").isJsonNull()) {
+                return payload.get("id").getAsString();
+            }
+        }
+        String seed = (payload != null ? payload.toString() : "") + "|" + (timestamp != null ? timestamp : "");
+        return "codex_history_" + Integer.toHexString(seed.hashCode());
+    }
+
+
     /**
      * Strip internal instruction blocks that are prepended before sending to Codex.
      * These blocks are useful model context, but should not be rendered as user history.
@@ -351,7 +365,7 @@ public class CodexMessageConverter {
         // Build tool_use format
         JsonObject toolUse = new JsonObject();
         toolUse.addProperty("type", "tool_use");
-        toolUse.addProperty("id", payload.has("call_id") ? payload.get("call_id").getAsString() : "unknown");
+        toolUse.addProperty("id", stableCodexToolId(payload, timestamp));
         toolUse.addProperty("name", toolName);
 
         if (toolInput != null) {
@@ -510,7 +524,7 @@ public class CodexMessageConverter {
 
         JsonObject toolResult = new JsonObject();
         toolResult.addProperty("type", "tool_result");
-        toolResult.addProperty("tool_use_id", payload.has("call_id") ? payload.get("call_id").getAsString() : "unknown");
+        toolResult.addProperty("tool_use_id", stableCodexToolId(payload, timestamp));
 
         String output = safeGetAsString(payload.get("output"), "");
         toolResult.addProperty("content", output);
@@ -546,7 +560,7 @@ public class CodexMessageConverter {
 
         JsonObject toolUse = new JsonObject();
         toolUse.addProperty("type", "tool_use");
-        toolUse.addProperty("id", payload.has("call_id") ? payload.get("call_id").getAsString() : "unknown");
+        toolUse.addProperty("id", stableCodexToolId(payload, timestamp));
         toolUse.addProperty("name", toolName);
 
         JsonObject input = new JsonObject();

--- a/src/main/java/com/github/claudecodegui/handler/DiffHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/DiffHandler.java
@@ -30,7 +30,7 @@ public class DiffHandler extends BaseMessageHandler {
         DiffFileOperations fileOperations = new DiffFileOperations(context);
         this.dispatcher = new DiffRequestDispatcher(List.of(
                 new RefreshFileHandler(context, gson, fileOperations),
-                new SimpleDiffDisplayHandler(context, gson, fileOperations),
+                new SimpleDiffDisplayHandler(context, gson, fileOperations, browserBridge),
                 new EditableDiffHandler(context, gson, browserBridge, fileOperations),
                 new InteractiveDiffMessageHandler(context, gson, browserBridge, fileOperations)
         ));

--- a/src/main/java/com/github/claudecodegui/handler/diff/DiffBrowserBridge.java
+++ b/src/main/java/com/github/claudecodegui/handler/diff/DiffBrowserBridge.java
@@ -45,6 +45,10 @@ public class DiffBrowserBridge {
      * Notify the frontend to remove a file from the edits list.
      */
     public void sendRemoveFileFromEdits(String filePath) {
+        sendRemoveFileFromEdits(filePath, null);
+    }
+
+    public void sendRemoveFileFromEdits(String filePath, String requestId) {
         ApplicationManager.getApplication().invokeLater(() -> {
             try {
                 if (context.getBrowser() == null || context.isDisposed()) {
@@ -53,6 +57,9 @@ public class DiffBrowserBridge {
                 }
                 JsonObject payload = new JsonObject();
                 payload.addProperty("filePath", filePath);
+                if (requestId != null && !requestId.isEmpty()) {
+                    payload.addProperty("requestId", requestId);
+                }
                 String payloadJson = gson.toJson(payload);
                 String js = "(function() {" +
                         "  if (typeof window.handleRemoveFileFromEdits === 'function') {" +
@@ -70,6 +77,10 @@ public class DiffBrowserBridge {
      * Send diff result to the frontend.
      */
     public void sendDiffResult(String filePath, String action, String content, String error) {
+        sendDiffResult(filePath, action, content, error, null);
+    }
+
+    public void sendDiffResult(String filePath, String action, String content, String error, String requestId) {
         ApplicationManager.getApplication().invokeLater(() -> {
             try {
                 if (context.getBrowser() == null || context.isDisposed()) {
@@ -85,6 +96,9 @@ public class DiffBrowserBridge {
                 }
                 if (error != null) {
                     payload.addProperty("error", error);
+                }
+                if (requestId != null && !requestId.isEmpty()) {
+                    payload.addProperty("requestId", requestId);
                 }
 
                 String payloadJson = gson.toJson(payload);

--- a/src/main/java/com/github/claudecodegui/handler/diff/DiffFileOperations.java
+++ b/src/main/java/com/github/claudecodegui/handler/diff/DiffFileOperations.java
@@ -5,12 +5,17 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.encoding.EncodingProjectManager;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Shared file-system operations for diff handlers.
@@ -30,78 +35,166 @@ public class DiffFileOperations {
      * Uses canonical paths to prevent path traversal attacks.
      */
     public boolean isPathWithinProject(String filePath) {
-        if (filePath == null || filePath.isEmpty()) {
-            return false;
+        return resolveProjectPath(filePath).isPresent();
+    }
+
+    private Optional<Path> resolveProjectPath(String filePath) {
+        if (filePath == null || filePath.isBlank()) {
+            return Optional.empty();
         }
         String projectBasePath = context.getProject().getBasePath();
         if (projectBasePath == null) {
             LOG.warn("Security: Cannot validate path - project base path is null");
-            return false;
+            return Optional.empty();
         }
         try {
-            String canonicalFilePath = new File(filePath).getCanonicalPath();
-            String canonicalBasePath = new File(projectBasePath).getCanonicalPath();
-            return canonicalFilePath.startsWith(canonicalBasePath + File.separator)
-                    || canonicalFilePath.equals(canonicalBasePath);
+            Path base = Path.of(projectBasePath).toRealPath().normalize();
+            Path input = Path.of(filePath);
+            Path requested = input.isAbsolute() ? input.normalize() : base.resolve(input).normalize();
+            Path resolved = resolveExistingOrParent(requested);
+            if (!isWithin(base, resolved)) {
+                LOG.warn("Security: File path outside project directory: " + filePath + " (resolved: " + resolved + ")");
+                return Optional.empty();
+            }
+            return Optional.of(resolved);
         } catch (IOException e) {
             LOG.error("Failed to validate file path: " + filePath, e);
-            return false;
+            return Optional.empty();
+        } catch (Exception e) {
+            LOG.warn("Failed to validate file path: " + filePath, e);
+            return Optional.empty();
         }
+    }
+
+    private static Path resolveExistingOrParent(Path requested) throws IOException {
+        if (Files.exists(requested)) {
+            return requested.toRealPath().normalize();
+        }
+        Path parent = requested.getParent();
+        if (parent != null && Files.exists(parent)) {
+            return parent.toRealPath().resolve(requested.getFileName()).normalize();
+        }
+        return requested.toAbsolutePath().normalize();
+    }
+
+    private static boolean isWithin(Path base, Path candidate) {
+        Path normalizedBase = base.normalize();
+        Path normalizedCandidate = candidate.normalize();
+        if (isWindows()) {
+            String baseText = normalizedBase.toString().toLowerCase(java.util.Locale.ROOT);
+            String candidateText = normalizedCandidate.toString().toLowerCase(java.util.Locale.ROOT);
+            return candidateText.equals(baseText) || candidateText.startsWith(baseText + java.io.File.separator);
+        }
+        return normalizedCandidate.startsWith(normalizedBase);
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase(java.util.Locale.ROOT).contains("win");
     }
 
     /**
      * Delete a file and refresh VFS.
      * Used when rejecting a newly created file to fully undo the creation.
      */
-    public void deleteFile(String filePath) {
-        if (!isPathWithinProject(filePath)) {
+    public boolean deleteFile(String filePath) {
+        Optional<Path> safePath = resolveProjectPath(filePath);
+        if (safePath.isEmpty()) {
             LOG.warn("Security: Attempted to delete file outside project directory: " + filePath);
-            return;
+            return false;
         }
+        String resolvedFilePath = safePath.get().toString();
 
-        ApplicationManager.getApplication().invokeLater(() -> {
+        AtomicBoolean success = new AtomicBoolean(false);
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        runOnDispatchThreadAndWait(() -> {
             try {
                 VirtualFile file = LocalFileSystem.getInstance()
-                        .refreshAndFindFileByPath(filePath.replace('\\', '/'));
+                        .refreshAndFindFileByPath(resolvedFilePath.replace('\\', '/'));
                 if (file != null) {
                     ApplicationManager.getApplication().runWriteAction(() -> {
                         try {
                             file.delete(this);
-                            LOG.info("File deleted (reject new file): " + filePath);
+                            success.set(true);
+                            LOG.info("File deleted (reject new file): " + resolvedFilePath);
                         } catch (IOException e) {
-                            LOG.error("Failed to delete file: " + filePath, e);
+                            failure.set(e);
                         }
                     });
                 } else {
-                    File javaFile = new File(filePath);
-                    if (javaFile.exists() && javaFile.delete()) {
-                        LOG.info("File deleted via fallback (reject new file): " + filePath);
+                    Path nioPath = safePath.get();
+                    if (!Files.exists(nioPath)) {
+                        success.set(true);
+                    } else if (Files.deleteIfExists(nioPath)) {
+                        success.set(true);
+                        LOG.info("File deleted via fallback (reject new file): " + resolvedFilePath);
+                    } else {
+                        failure.set(new IOException("Failed to delete file"));
                     }
                 }
             } catch (Exception e) {
-                LOG.error("Failed to delete file: " + filePath, e);
+                failure.set(e);
             }
         });
+
+        if (failure.get() != null) {
+            LOG.error("Failed to delete file: " + resolvedFilePath, failure.get());
+        }
+        return success.get() && failure.get() == null;
+    }
+
+
+    public Optional<String> readContentFromFile(String filePath) {
+        Optional<Path> safePath = resolveProjectPath(filePath);
+        if (safePath.isEmpty()) {
+            LOG.warn("Security: Attempted to read file outside project directory: " + filePath);
+            return Optional.empty();
+        }
+        String resolvedFilePath = safePath.get().toString();
+        try {
+            VirtualFile file = LocalFileSystem.getInstance()
+                    .refreshAndFindFileByPath(resolvedFilePath.replace('\\', '/'));
+            if (file != null) {
+                Charset charset = file.getCharset() != null ? file.getCharset() : StandardCharsets.UTF_8;
+                return Optional.of(new String(file.contentsToByteArray(), charset));
+            }
+            Path nioPath = safePath.get();
+            if (!Files.exists(nioPath)) {
+                return Optional.empty();
+            }
+            return Optional.of(Files.readString(nioPath, fallbackCharset()));
+        } catch (Exception e) {
+            LOG.error("Failed to read content from file: " + resolvedFilePath, e);
+            return Optional.empty();
+        }
+    }
+
+    public boolean contentEquals(String filePath, String expectedContent) {
+        Optional<String> current = readContentFromFile(filePath);
+        return current.isPresent() && current.get().equals(expectedContent != null ? expectedContent : "");
     }
 
     /**
      * Write content to file and refresh VFS.
      * Validates that the file path is within the project directory for security.
      */
-    public void writeContentToFile(String filePath, String content) {
+    public boolean writeContentToFile(String filePath, String content) {
         if (content == null) {
-            return;
+            return false;
         }
 
-        if (!isPathWithinProject(filePath)) {
+        Optional<Path> safePath = resolveProjectPath(filePath);
+        if (safePath.isEmpty()) {
             LOG.warn("Security: Attempted to write file outside project directory: " + filePath);
-            return;
+            return false;
         }
+        String resolvedFilePath = safePath.get().toString();
 
-        ApplicationManager.getApplication().invokeLater(() -> {
+        AtomicBoolean success = new AtomicBoolean(false);
+        AtomicReference<Exception> failure = new AtomicReference<>();
+        runOnDispatchThreadAndWait(() -> {
             try {
                 VirtualFile file = LocalFileSystem.getInstance()
-                        .refreshAndFindFileByPath(filePath.replace('\\', '/'));
+                        .refreshAndFindFileByPath(resolvedFilePath.replace('\\', '/'));
 
                 if (file != null) {
                     Charset charset = file.getCharset() != null ? file.getCharset() : StandardCharsets.UTF_8;
@@ -110,25 +203,58 @@ public class DiffFileOperations {
                         try {
                             file.setBinaryContent(content.getBytes(charset));
                             file.refresh(false, false);
-                            LOG.info("File content written successfully: " + filePath);
+                            success.set(true);
+                            LOG.info("File content written successfully: " + resolvedFilePath);
                         } catch (IOException e) {
-                            LOG.error("Failed to write file content: " + filePath, e);
+                            failure.set(e);
                         }
                     });
                 } else {
-                    File javaFile = new File(filePath);
-                    File parentDir = javaFile.getParentFile();
-                    if (parentDir != null && !parentDir.exists() && !parentDir.mkdirs()) {
-                        LOG.error("Failed to create parent directories: " + parentDir.getAbsolutePath());
+                    Path nioPath = safePath.get();
+                    Path parentDir = nioPath.getParent();
+                    if (parentDir != null) {
+                        Files.createDirectories(parentDir);
+                    }
+                    Optional<Path> validatedAfterParent = resolveProjectPath(nioPath.toString());
+                    if (validatedAfterParent.isEmpty()) {
+                        failure.set(new IOException("Resolved path escaped project after creating parent directories"));
                         return;
                     }
-                    Files.write(javaFile.toPath(), content.getBytes(StandardCharsets.UTF_8));
-                    LocalFileSystem.getInstance().refreshAndFindFileByPath(filePath.replace('\\', '/'));
-                    LOG.info("New file created: " + filePath);
+                    Path target = validatedAfterParent.get();
+                    Path temp = Files.createTempFile(target.getParent(), target.getFileName().toString(), ".tmp");
+                    try {
+                        Files.write(temp, content.getBytes(fallbackCharset()));
+                        Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+                    } catch (IOException atomicMoveFailure) {
+                        Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING);
+                    } finally {
+                        Files.deleteIfExists(temp);
+                    }
+                    LocalFileSystem.getInstance().refreshAndFindFileByPath(target.toString().replace('\\', '/'));
+                    success.set(true);
+                    LOG.info("New file created: " + target);
                 }
             } catch (Exception e) {
-                LOG.error("Failed to write content to file: " + filePath, e);
+                failure.set(e);
             }
         });
+
+        if (failure.get() != null) {
+            LOG.error("Failed to write content to file: " + resolvedFilePath, failure.get());
+        }
+        return success.get() && failure.get() == null;
+    }
+
+    private void runOnDispatchThreadAndWait(Runnable runnable) {
+        if (ApplicationManager.getApplication().isDispatchThread()) {
+            runnable.run();
+        } else {
+            ApplicationManager.getApplication().invokeAndWait(runnable);
+        }
+    }
+
+    private Charset fallbackCharset() {
+        Charset charset = EncodingProjectManager.getInstance(context.getProject()).getDefaultCharset();
+        return charset != null ? charset : StandardCharsets.UTF_8;
     }
 }

--- a/src/main/java/com/github/claudecodegui/handler/diff/DiffFileOperations.java
+++ b/src/main/java/com/github/claudecodegui/handler/diff/DiffFileOperations.java
@@ -8,9 +8,11 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.encoding.EncodingProjectManager;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Optional;
@@ -50,7 +52,11 @@ public class DiffFileOperations {
         try {
             Path base = Path.of(projectBasePath).toRealPath().normalize();
             Path input = Path.of(filePath);
-            Path requested = input.isAbsolute() ? input.normalize() : base.resolve(input).normalize();
+            Path requested = (input.isAbsolute() ? input : base.resolve(input)).toAbsolutePath().normalize();
+            if (!isWithin(base, requested) || hasSymlinkSegment(base, requested)) {
+                LOG.warn("Security: Refusing unsafe file path: " + filePath + " (requested: " + requested + ")");
+                return Optional.empty();
+            }
             Path resolved = resolveExistingOrParent(requested);
             if (!isWithin(base, resolved)) {
                 LOG.warn("Security: File path outside project directory: " + filePath + " (resolved: " + resolved + ")");
@@ -75,6 +81,22 @@ public class DiffFileOperations {
             return parent.toRealPath().resolve(requested.getFileName()).normalize();
         }
         return requested.toAbsolutePath().normalize();
+    }
+
+    private static boolean hasSymlinkSegment(Path base, Path requested) {
+        try {
+            Path relative = base.relativize(requested);
+            Path current = base;
+            for (Path part : relative) {
+                current = current.resolve(part);
+                if (Files.exists(current, LinkOption.NOFOLLOW_LINKS) && Files.isSymbolicLink(current)) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            return true;
+        }
+        return false;
     }
 
     private static boolean isWithin(Path base, Path candidate) {
@@ -151,6 +173,10 @@ public class DiffFileOperations {
         }
         String resolvedFilePath = safePath.get().toString();
         try {
+            if (Files.isSymbolicLink(safePath.get())) {
+                LOG.warn("Security: Refusing to read symlink path: " + resolvedFilePath);
+                return Optional.empty();
+            }
             VirtualFile file = LocalFileSystem.getInstance()
                     .refreshAndFindFileByPath(resolvedFilePath.replace('\\', '/'));
             if (file != null) {
@@ -161,7 +187,9 @@ public class DiffFileOperations {
             if (!Files.exists(nioPath)) {
                 return Optional.empty();
             }
-            return Optional.of(Files.readString(nioPath, fallbackCharset()));
+            try (InputStream inputStream = Files.newInputStream(nioPath, LinkOption.NOFOLLOW_LINKS)) {
+                return Optional.of(new String(inputStream.readAllBytes(), fallbackCharset()));
+            }
         } catch (Exception e) {
             LOG.error("Failed to read content from file: " + resolvedFilePath, e);
             return Optional.empty();
@@ -193,6 +221,10 @@ public class DiffFileOperations {
         AtomicReference<Exception> failure = new AtomicReference<>();
         runOnDispatchThreadAndWait(() -> {
             try {
+                if (Files.isSymbolicLink(safePath.get())) {
+                    failure.set(new IOException("Refusing to write symlink path"));
+                    return;
+                }
                 VirtualFile file = LocalFileSystem.getInstance()
                         .refreshAndFindFileByPath(resolvedFilePath.replace('\\', '/'));
 

--- a/src/main/java/com/github/claudecodegui/handler/diff/EditableDiffHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/diff/EditableDiffHandler.java
@@ -54,9 +54,12 @@ public class EditableDiffHandler implements DiffActionHandler {
             String filePath = json.has("filePath") ? json.get("filePath").getAsString() : "";
             JsonArray operations = json.has("operations") ? json.getAsJsonArray("operations") : new JsonArray();
             String status = json.has("status") ? json.get("status").getAsString() : "M";
+            String requestId = json.has("requestId") && !json.get("requestId").isJsonNull() ? json.get("requestId").getAsString() : null;
 
             if (!fileOperations.isPathWithinProject(filePath)) {
+                String message = "Invalid file path: path must be within project directory";
                 LOG.warn("Security: file path outside project directory: " + filePath);
+                browserBridge.sendDiffResult(filePath, "ERROR", null, message, requestId);
                 return;
             }
 
@@ -68,18 +71,18 @@ public class EditableDiffHandler implements DiffActionHandler {
                 if (!file.exists()) {
                     LOG.warn("File does not exist: " + filePath);
                     browserBridge.showErrorToast(ClaudeCodeGuiBundle.message("diff.fileNotFoundDetail", filePath));
-                    browserBridge.sendRemoveFileFromEdits(filePath);
+                    browserBridge.sendDiffResult(filePath, "ERROR", null, "File not found", requestId);
                     return;
                 }
             }
 
-            ApplicationManager.getApplication().invokeLater(() -> showEditableDiff(filePath, operations, isNewFile));
+            ApplicationManager.getApplication().executeOnPooledThread(() -> showEditableDiff(filePath, operations, isNewFile, requestId));
         } catch (Exception e) {
             LOG.error("Failed to parse show_editable_diff request: " + e.getMessage(), e);
         }
     }
 
-    private void showEditableDiff(String filePath, JsonArray operations, boolean isNewFile) {
+    private void showEditableDiff(String filePath, JsonArray operations, boolean isNewFile, String requestId) {
         try {
             String currentContent = "";
             Charset charset = StandardCharsets.UTF_8;
@@ -93,28 +96,46 @@ public class EditableDiffHandler implements DiffActionHandler {
                 } catch (IOException e) {
                     LOG.error("Failed to read file content: " + filePath, e);
                     browserBridge.showErrorToast(ClaudeCodeGuiBundle.message("diff.fileReadFailedDetail", e.getMessage()));
+                    browserBridge.sendDiffResult(filePath, "ERROR", null, e.getMessage(), requestId);
                     return;
                 }
             }
 
-            String originalContent = isNewFile
-                    ? ""
-                    : ContentRebuildUtil.rebuildBeforeContent(currentContent, operations);
+            if (!areOperationsSafeToRollback(operations)) {
+                String message = "Unable to open editable diff because one or more operations are marked unsafe to rollback";
+                LOG.warn(message + ": " + filePath);
+                browserBridge.showErrorToast(message);
+                browserBridge.sendDiffResult(filePath, "ERROR", null, message, requestId);
+                return;
+            }
+
+            ContentRebuildUtil.RebuildResult rebuildResult = isNewFile
+                    ? new ContentRebuildUtil.RebuildResult(true, "", new JsonArray())
+                    : ContentRebuildUtil.rebuildBeforeContentResult(currentContent, operations);
+            if (!rebuildResult.success()) {
+                String message = "Unable to rebuild original content for diff; one or more operations no longer match current file content";
+                LOG.warn(message + ": " + filePath);
+                browserBridge.showErrorToast(message);
+                browserBridge.sendDiffResult(filePath, "ERROR", null, message, requestId);
+                return;
+            }
+            String originalContent = rebuildResult.content();
 
             String fileName = new File(filePath).getName();
             String tabName = ClaudeCodeGuiBundle.message("diff.tabName", fileName, operations.size());
 
+            String expectedCurrentContent = currentContent;
             InteractiveDiffRequest request = isNewFile
-                    ? InteractiveDiffRequest.forNewFile(filePath, currentContent, tabName)
-                    : InteractiveDiffRequest.forModifiedFile(filePath, originalContent, currentContent, tabName);
+                    ? InteractiveDiffRequest.forNewFile(filePath, expectedCurrentContent, tabName)
+                    : InteractiveDiffRequest.forModifiedFile(filePath, originalContent, expectedCurrentContent, tabName);
 
-            LOG.info("Diff request created - original length: " + originalContent.length() + ", current length: " + currentContent.length());
+            LOG.info("Diff request created - original length: " + originalContent.length() + ", current length: " + expectedCurrentContent.length());
 
             InteractiveDiffManager.showInteractiveDiff(context.getProject(), request)
-                    .thenAccept(result -> handleDiffResult(result, filePath, originalContent, isNewFile))
+                    .thenAccept(result -> handleDiffResult(result, filePath, originalContent, expectedCurrentContent, isNewFile, requestId))
                     .exceptionally(e -> {
                         LOG.error("Error in interactive diff: " + e.getMessage(), e);
-                        browserBridge.sendDiffResult(filePath, "REJECT", null, e.getMessage());
+                        browserBridge.sendDiffResult(filePath, "REJECT", null, e.getMessage(), requestId);
                         return null;
                     });
 
@@ -122,28 +143,70 @@ public class EditableDiffHandler implements DiffActionHandler {
         } catch (Exception e) {
             LOG.error("Failed to show editable diff: " + e.getMessage(), e);
             browserBridge.showErrorToast(ClaudeCodeGuiBundle.message("diff.openFailedDetail", e.getMessage()));
+            browserBridge.sendDiffResult(filePath, "ERROR", null, e.getMessage(), requestId);
         }
     }
 
-    private void handleDiffResult(DiffResult result, String filePath, String originalContent, boolean isNewFile) {
+    public static boolean areOperationsSafeToRollback(JsonArray operations) {
+        if (operations == null) {
+            return true;
+        }
+        for (int i = 0; i < operations.size(); i++) {
+            if (!operations.get(i).isJsonObject()) {
+                continue;
+            }
+            JsonObject operation = operations.get(i).getAsJsonObject();
+            if (hasFalseBoolean(operation, "safeToRollback") || hasFalseBoolean(operation, "safe_to_rollback")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean hasFalseBoolean(JsonObject object, String key) {
+        if (!object.has(key) || object.get(key).isJsonNull()) {
+            return false;
+        }
+        try {
+            return !object.get(key).getAsBoolean();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private void handleDiffResult(DiffResult result, String filePath, String originalContent, String expectedCurrentContent, boolean isNewFile, String requestId) {
         if (result.isApplied()) {
-            fileOperations.writeContentToFile(filePath, result.getFinalContent());
-            browserBridge.sendDiffResult(filePath, "APPLY", result.getFinalContent(), null);
+            if (!fileOperations.contentEquals(filePath, expectedCurrentContent)) {
+                browserBridge.sendDiffResult(filePath, "ERROR", null, "File changed while diff was open", requestId);
+                return;
+            }
+            boolean written = fileOperations.writeContentToFile(filePath, result.getFinalContent());
+            if (written) {
+                browserBridge.sendDiffResult(filePath, "APPLY", result.getFinalContent(), null, requestId);
+            } else {
+                browserBridge.sendDiffResult(filePath, "ERROR", null, "Failed to write applied diff content", requestId);
+            }
             return;
         }
 
         if (result.isRejected()) {
-            if (isNewFile) {
-                fileOperations.deleteFile(filePath);
-            } else {
-                fileOperations.writeContentToFile(filePath, originalContent);
+            if (!fileOperations.contentEquals(filePath, expectedCurrentContent)) {
+                browserBridge.sendDiffResult(filePath, "ERROR", null, "File changed while diff was open", requestId);
+                return;
             }
-            browserBridge.sendRemoveFileFromEdits(filePath);
-            browserBridge.sendDiffResult(filePath, "REJECT", null, null);
+            boolean reverted = isNewFile
+                    ? fileOperations.deleteFile(filePath)
+                    : fileOperations.writeContentToFile(filePath, originalContent);
+            if (reverted) {
+                browserBridge.sendRemoveFileFromEdits(filePath, requestId);
+                browserBridge.sendDiffResult(filePath, "REJECT", null, null, requestId);
+            } else {
+                browserBridge.sendDiffResult(filePath, "ERROR", null, "Failed to revert diff changes", requestId);
+            }
             return;
         }
 
         LOG.info("Diff dismissed for: " + filePath);
-        browserBridge.sendDiffResult(filePath, "DISMISS", null, null);
+        browserBridge.sendDiffResult(filePath, "DISMISS", null, null, requestId);
     }
 }

--- a/src/main/java/com/github/claudecodegui/handler/diff/SimpleDiffDisplayHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/diff/SimpleDiffDisplayHandler.java
@@ -33,11 +33,17 @@ public class SimpleDiffDisplayHandler implements DiffActionHandler {
     private final HandlerContext context;
     private final Gson gson;
     private final DiffFileOperations fileOperations;
+    private final DiffBrowserBridge browserBridge;
 
     public SimpleDiffDisplayHandler(HandlerContext context, Gson gson, DiffFileOperations fileOperations) {
+        this(context, gson, fileOperations, new DiffBrowserBridge(context, gson));
+    }
+
+    public SimpleDiffDisplayHandler(HandlerContext context, Gson gson, DiffFileOperations fileOperations, DiffBrowserBridge browserBridge) {
         this.context = context;
         this.gson = gson;
         this.fileOperations = fileOperations;
+        this.browserBridge = browserBridge;
     }
 
     private static final String[] TYPES = {
@@ -66,6 +72,13 @@ public class SimpleDiffDisplayHandler implements DiffActionHandler {
                 break;
             default:
                 break;
+        }
+    }
+
+    private void notifyDiffFailure(String filePath, String message) {
+        LOG.warn(message + (filePath == null || filePath.isBlank() ? "" : ": " + filePath));
+        if (browserBridge != null) {
+            browserBridge.showErrorToast(message);
         }
     }
 
@@ -143,11 +156,16 @@ public class SimpleDiffDisplayHandler implements DiffActionHandler {
                     }
 
                     if (afterContent == null) {
-                        LOG.warn("Could not read file content: " + filePath);
+                        notifyDiffFailure(filePath, "Could not read file content for diff");
                         return;
                     }
 
-                    String beforeContent = ContentRebuildUtil.rebuildBeforeContent(afterContent, edits);
+                    ContentRebuildUtil.RebuildResult rebuildResult = ContentRebuildUtil.rebuildBeforeContentResult(afterContent, edits);
+                    if (!rebuildResult.success()) {
+                        notifyDiffFailure(filePath, "Could not safely rebuild before content for diff");
+                        return;
+                    }
+                    String beforeContent = rebuildResult.content();
 
                     String fileName = new File(filePath).getName();
                     FileType fileType = FileTypeManager.getInstance().getFileTypeByFileName(fileName);
@@ -212,26 +230,12 @@ public class SimpleDiffDisplayHandler implements DiffActionHandler {
                         }
                     }
 
-                    String afterContent = currentContent;
-                    for (int i = 0; i < edits.size(); i++) {
-                        JsonObject edit = edits.get(i).getAsJsonObject();
-                        String oldString = edit.has("oldString") ? edit.get("oldString").getAsString() : "";
-                        String newString = edit.has("newString") ? edit.get("newString").getAsString() : "";
-                        boolean replaceAll = edit.has("replaceAll") && edit.get("replaceAll").getAsBoolean();
-
-                        if (replaceAll) {
-                            afterContent = afterContent.replace(oldString, newString);
-                        } else {
-                            int index = afterContent.indexOf(oldString);
-                            if (index >= 0) {
-                                afterContent = afterContent.substring(0, index)
-                                        + newString
-                                        + afterContent.substring(index + oldString.length());
-                            } else {
-                                LOG.warn("oldString not found in file, skipping edit");
-                            }
-                        }
+                    ForwardApplyResult applyResult = applyForwardEditsForPreview(currentContent, edits);
+                    if (!applyResult.success()) {
+                        notifyDiffFailure(filePath, "Could not safely build edit preview diff: " + applyResult.reason());
+                        return;
                     }
+                    String afterContent = applyResult.content();
 
                     String fileName = new File(filePath).getName();
                     FileType fileType = FileTypeManager.getInstance().getFileTypeByFileName(fileName);
@@ -259,6 +263,47 @@ public class SimpleDiffDisplayHandler implements DiffActionHandler {
         } catch (Exception e) {
             LOG.error("Failed to parse show_edit_preview_diff request: " + e.getMessage(), e);
         }
+    }
+
+    static ForwardApplyResult applyForwardEditsForPreview(String originalContent, JsonArray edits) {
+        String content = originalContent != null ? originalContent : "";
+        if (edits == null || edits.isEmpty()) {
+            return new ForwardApplyResult(true, content, null);
+        }
+        for (int i = 0; i < edits.size(); i++) {
+            JsonObject edit = edits.get(i).getAsJsonObject();
+            String oldString = edit.has("oldString") && !edit.get("oldString").isJsonNull()
+                    ? edit.get("oldString").getAsString()
+                    : "";
+            String newString = edit.has("newString") && !edit.get("newString").isJsonNull()
+                    ? edit.get("newString").getAsString()
+                    : "";
+            boolean replaceAll = edit.has("replaceAll") && !edit.get("replaceAll").isJsonNull()
+                    && edit.get("replaceAll").getAsBoolean();
+            if (oldString.isEmpty()) {
+                return new ForwardApplyResult(false, content, "empty_old_string");
+            }
+            if (replaceAll) {
+                if (!content.contains(oldString)) {
+                    return new ForwardApplyResult(false, content, "old_string_not_found");
+                }
+                content = content.replace(oldString, newString);
+                continue;
+            }
+            int first = content.indexOf(oldString);
+            if (first < 0) {
+                return new ForwardApplyResult(false, content, "old_string_not_found");
+            }
+            int second = content.indexOf(oldString, first + Math.max(1, oldString.length()));
+            if (second >= 0) {
+                return new ForwardApplyResult(false, content, "ambiguous_old_string");
+            }
+            content = content.substring(0, first) + newString + content.substring(first + oldString.length());
+        }
+        return new ForwardApplyResult(true, content, null);
+    }
+
+    record ForwardApplyResult(boolean success, String content, String reason) {
     }
 
     private void handleShowEditFullDiff(String content) {
@@ -296,24 +341,18 @@ public class SimpleDiffDisplayHandler implements DiffActionHandler {
                         LOG.info("Using cached original content for full file diff");
                         beforeContent = originalContent;
 
-                        if (replaceAll) {
-                            afterContent = beforeContent.replace(oldString, newString);
-                        } else {
-                            int index = beforeContent.indexOf(oldString);
-                            if (index >= 0) {
-                                afterContent = beforeContent.substring(0, index)
-                                        + newString
-                                        + beforeContent.substring(index + oldString.length());
-                            } else if (file != null) {
-                                try {
-                                    afterContent = new String(file.contentsToByteArray(), file.getCharset());
-                                } catch (IOException e) {
-                                    afterContent = "";
-                                }
-                            } else {
-                                afterContent = "";
-                            }
+                        JsonArray singleEdit = new JsonArray();
+                        JsonObject edit = new JsonObject();
+                        edit.addProperty("oldString", oldString);
+                        edit.addProperty("newString", newString);
+                        edit.addProperty("replaceAll", replaceAll);
+                        singleEdit.add(edit);
+                        ForwardApplyResult applyResult = applyForwardEditsForPreview(beforeContent, singleEdit);
+                        if (!applyResult.success()) {
+                            notifyDiffFailure(filePath, "Could not safely build full edit diff: " + applyResult.reason());
+                            return;
                         }
+                        afterContent = applyResult.content();
                     } else {
                         LOG.info("No cached content, showing edit-only diff");
                         beforeContent = oldString;

--- a/src/main/java/com/github/claudecodegui/handler/file/UndoFileHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/file/UndoFileHandler.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -49,6 +50,9 @@ public class UndoFileHandler extends BaseMessageHandler {
 
     interface BatchUndoAction {
         String filePath();
+        default String requestFilePath() {
+            return filePath();
+        }
         void apply() throws Exception;
         void rollback() throws Exception;
         default void afterCommit() throws Exception {
@@ -100,7 +104,11 @@ public class UndoFileHandler extends BaseMessageHandler {
         try {
             Path basePath = Path.of(projectBasePath).toRealPath().normalize();
             Path inputPath = Path.of(filePath);
-            Path requestedPath = inputPath.isAbsolute() ? inputPath.normalize() : basePath.resolve(inputPath).normalize();
+            Path requestedPath = (inputPath.isAbsolute() ? inputPath : basePath.resolve(inputPath)).toAbsolutePath().normalize();
+            if (!isWithin(basePath, requestedPath) || hasSymlinkSegment(basePath, requestedPath)) {
+                LOG.warn("[UndoFileHandler] Refusing unsafe file path: " + filePath + " (requested: " + requestedPath + ")");
+                return java.util.Optional.empty();
+            }
             Path resolvedPath = resolveExistingOrParent(requestedPath);
             if (!isWithin(basePath, resolvedPath)) {
                 LOG.warn("[UndoFileHandler] File path outside project directory: " + filePath
@@ -126,6 +134,22 @@ public class UndoFileHandler extends BaseMessageHandler {
             return parent.toRealPath().resolve(requestedPath.getFileName()).normalize();
         }
         return requestedPath.toAbsolutePath().normalize();
+    }
+
+    private static boolean hasSymlinkSegment(Path basePath, Path requestedPath) {
+        try {
+            Path relative = basePath.relativize(requestedPath);
+            Path current = basePath;
+            for (Path part : relative) {
+                current = current.resolve(part);
+                if (Files.exists(current, LinkOption.NOFOLLOW_LINKS) && Files.isSymbolicLink(current)) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            return true;
+        }
+        return false;
     }
 
     private static boolean isWithin(Path basePath, Path candidatePath) {
@@ -164,6 +188,7 @@ public class UndoFileHandler extends BaseMessageHandler {
             }
 
             LOG.info("[UndoFileHandler] Undoing changes for file: " + resolvedFilePath + ", status: " + status);
+            String requestFilePath = filePath;
 
             ApplicationManager.getApplication().invokeLater(() -> {
                 try {
@@ -188,7 +213,7 @@ public class UndoFileHandler extends BaseMessageHandler {
                     }
 
                     // Send success callback
-                    sendSuccess(resolvedFilePath);
+                    sendSuccess(resolvedFilePath, requestFilePath);
 
                 } catch (Exception e) {
                     LOG.error("[UndoFileHandler] Failed to undo file changes: " + e.getMessage(), e);
@@ -258,7 +283,7 @@ public class UndoFileHandler extends BaseMessageHandler {
             String resolvedFilePath = safePath.get().toString();
 
             try {
-                actions.add(createBatchUndoAction(resolvedFilePath, status, operations));
+                actions.add(createBatchUndoAction(resolvedFilePath, filePath, status, operations));
             } catch (Exception e) {
                 failCount++;
                 String reason = e instanceof UnsafeRollbackException ? "unsafe_to_rollback" : "undo_failed";
@@ -277,7 +302,7 @@ public class UndoFileHandler extends BaseMessageHandler {
         JsonArray succeededFiles = new JsonArray();
         if (execution.success()) {
             for (BatchUndoAction action : actions) {
-                succeededFiles.add(action.filePath());
+                succeededFiles.add(action.requestFilePath());
             }
             sendAllResult(true, false, actions.size(), succeededFiles, failedFiles, null);
         } else {
@@ -432,6 +457,9 @@ public class UndoFileHandler extends BaseMessageHandler {
         LocalFileSystem localFileSystem = LocalFileSystem.getInstance();
         VirtualFile file = localFileSystem.refreshAndFindFileByPath(normalizedPath);
         Path nioPath = Path.of(filePath);
+        if (Files.isSymbolicLink(nioPath)) {
+            throw new Exception("Refusing to delete symlink path");
+        }
         if (file == null || !file.exists()) {
             if (!Files.exists(nioPath)) {
                 LOG.warn("[UndoFileHandler] File not found for deletion: " + filePath);
@@ -470,7 +498,12 @@ public class UndoFileHandler extends BaseMessageHandler {
         }
     }
 
-    private BatchUndoAction createBatchUndoAction(String filePath, String status, JsonArray operations) throws Exception {
+    private BatchUndoAction createBatchUndoAction(
+            String filePath,
+            String requestFilePath,
+            String status,
+            JsonArray operations
+    ) throws Exception {
         if ("A".equals(status)) {
             if (hasUnsafeOperation(operations)) {
                 throw new UnsafeRollbackException("Operation is marked unsafe to rollback");
@@ -484,8 +517,16 @@ public class UndoFileHandler extends BaseMessageHandler {
                 }
 
                 @Override
+                public String requestFilePath() {
+                    return requestFilePath != null ? requestFilePath : filePath;
+                }
+
+                @Override
                 public void apply() throws Exception {
                     validateExpectedAfterHash(filePath, operations);
+                    if (Files.isSymbolicLink(path)) {
+                        throw new Exception("Refusing to undo symlink path");
+                    }
                     if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
                         return;
                     }
@@ -524,6 +565,9 @@ public class UndoFileHandler extends BaseMessageHandler {
             if (operations == null || operations.isEmpty()) {
                 throw new Exception("No operations to undo");
             }
+            if (Files.isSymbolicLink(Path.of(filePath))) {
+                throw new Exception("Refusing to undo symlink path");
+            }
             DocumentSnapshot snapshot = callOnEdtAndWait(() -> {
                 VirtualFile file = LocalFileSystem.getInstance().refreshAndFindFileByPath(filePath.replace('\\', '/'));
                 if (file == null || !file.exists()) {
@@ -545,6 +589,11 @@ public class UndoFileHandler extends BaseMessageHandler {
                 @Override
                 public String filePath() {
                     return filePath;
+                }
+
+                @Override
+                public String requestFilePath() {
+                    return requestFilePath != null ? requestFilePath : filePath;
                 }
 
                 @Override
@@ -620,7 +669,15 @@ public class UndoFileHandler extends BaseMessageHandler {
             return documentText;
         }
         Path path = Path.of(filePath);
-        return Files.exists(path, LinkOption.NOFOLLOW_LINKS) ? Files.readString(path, StandardCharsets.UTF_8) : "";
+        if (Files.isSymbolicLink(path)) {
+            throw new Exception("Refusing to read symlink path");
+        }
+        if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+            return "";
+        }
+        try (InputStream inputStream = Files.newInputStream(path, LinkOption.NOFOLLOW_LINKS)) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
     }
 
     private static String firstExpectedAfterHash(JsonArray operations) {
@@ -703,10 +760,11 @@ public class UndoFileHandler extends BaseMessageHandler {
         LOG.info("[UndoFileHandler] Successfully reversed edits for file: " + filePath);
     }
 
-    private void sendSuccess(String filePath) {
+    private void sendSuccess(String filePath, String requestFilePath) {
         JsonObject result = new JsonObject();
         result.addProperty("success", true);
         result.addProperty("filePath", filePath != null ? filePath : "");
+        result.addProperty("requestFilePath", requestFilePath != null ? requestFilePath : "");
 
         String json = gson.toJson(result);
         LOG.info("[UndoFileHandler] Sending success callback: " + json);

--- a/src/main/java/com/github/claudecodegui/handler/file/UndoFileHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/file/UndoFileHandler.java
@@ -2,6 +2,7 @@ package com.github.claudecodegui.handler.file;
 
 import com.github.claudecodegui.handler.core.BaseMessageHandler;
 import com.github.claudecodegui.handler.core.HandlerContext;
+import com.github.claudecodegui.util.UndoOperationApplier;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -11,10 +12,26 @@ import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Handler for undoing single file changes.
@@ -29,6 +46,17 @@ public class UndoFileHandler extends BaseMessageHandler {
         "undo_file_changes",
         "undo_all_file_changes"
     };
+
+    interface BatchUndoAction {
+        String filePath();
+        void apply() throws Exception;
+        void rollback() throws Exception;
+        default void afterCommit() throws Exception {
+        }
+    }
+
+    record BatchUndoExecution(boolean success, int appliedCount, String error) {
+    }
 
     public UndoFileHandler(HandlerContext context) {
         super(context);
@@ -59,39 +87,56 @@ public class UndoFileHandler extends BaseMessageHandler {
      * @param filePath The file path to validate
      * @return true if path is valid and safe, false otherwise
      */
-    private boolean isValidFilePath(String filePath) {
-        if (filePath == null || filePath.isEmpty()) {
-            return false;
+    private java.util.Optional<Path> resolveProjectPath(String filePath) {
+        if (filePath == null || filePath.isBlank()) {
+            return java.util.Optional.empty();
         }
-
         String projectBasePath = context.getProject() != null ? context.getProject().getBasePath() : null;
         if (projectBasePath == null) {
             LOG.warn("[UndoFileHandler] Cannot validate path: project base path is null");
-            return false;
+            return java.util.Optional.empty();
         }
 
         try {
-            // Use canonical path to resolve symlinks, "..", encoded chars, etc.
-            java.io.File file = new java.io.File(filePath);
-            java.io.File baseDir = new java.io.File(projectBasePath);
-
-            String canonicalFilePath = file.getCanonicalPath();
-            String canonicalBasePath = baseDir.getCanonicalPath();
-
-            // Ensure the file is within the project directory
-            boolean isValid = canonicalFilePath.startsWith(canonicalBasePath + java.io.File.separator)
-                || canonicalFilePath.equals(canonicalBasePath);
-
-            if (!isValid) {
-                LOG.warn("[UndoFileHandler] File path outside project directory: " + filePath +
-                    " (canonical: " + canonicalFilePath + ", base: " + canonicalBasePath + ")");
+            Path basePath = Path.of(projectBasePath).toRealPath().normalize();
+            Path inputPath = Path.of(filePath);
+            Path requestedPath = inputPath.isAbsolute() ? inputPath.normalize() : basePath.resolve(inputPath).normalize();
+            Path resolvedPath = resolveExistingOrParent(requestedPath);
+            if (!isWithin(basePath, resolvedPath)) {
+                LOG.warn("[UndoFileHandler] File path outside project directory: " + filePath
+                    + " (resolved: " + resolvedPath + ", base: " + basePath + ")");
+                return java.util.Optional.empty();
             }
-
-            return isValid;
-        } catch (java.io.IOException e) {
+            return java.util.Optional.of(resolvedPath);
+        } catch (IOException e) {
             LOG.warn("[UndoFileHandler] Failed to validate path: " + e.getMessage());
-            return false;
+            return java.util.Optional.empty();
+        } catch (Exception e) {
+            LOG.warn("[UndoFileHandler] Failed to validate path: " + filePath, e);
+            return java.util.Optional.empty();
         }
+    }
+
+    private static Path resolveExistingOrParent(Path requestedPath) throws IOException {
+        if (Files.exists(requestedPath)) {
+            return requestedPath.toRealPath().normalize();
+        }
+        Path parent = requestedPath.getParent();
+        if (parent != null && Files.exists(parent)) {
+            return parent.toRealPath().resolve(requestedPath.getFileName()).normalize();
+        }
+        return requestedPath.toAbsolutePath().normalize();
+    }
+
+    private static boolean isWithin(Path basePath, Path candidatePath) {
+        Path normalizedBase = basePath.normalize();
+        Path normalizedCandidate = candidatePath.normalize();
+        if (System.getProperty("os.name", "").toLowerCase(java.util.Locale.ROOT).contains("win")) {
+            String baseText = normalizedBase.toString().toLowerCase(java.util.Locale.ROOT);
+            String candidateText = normalizedCandidate.toString().toLowerCase(java.util.Locale.ROOT);
+            return candidateText.equals(baseText) || candidateText.startsWith(baseText + java.io.File.separator);
+        }
+        return normalizedCandidate.startsWith(normalizedBase);
     }
 
     private void handleUndoFileChanges(String content) {
@@ -106,42 +151,48 @@ public class UndoFileHandler extends BaseMessageHandler {
                 return;
             }
 
-            // Security: Validate file path
-            if (!isValidFilePath(filePath)) {
+            java.util.Optional<Path> safePath = resolveProjectPath(filePath);
+            if (safePath.isEmpty()) {
                 sendError(filePath, "Invalid file path: path must be within project directory");
                 return;
             }
+            String resolvedFilePath = safePath.get().toString();
 
             if (status == null || status.isEmpty()) {
-                sendError(filePath, "File status is required");
+                sendError(resolvedFilePath, "File status is required");
                 return;
             }
 
-            LOG.info("[UndoFileHandler] Undoing changes for file: " + filePath + ", status: " + status);
+            LOG.info("[UndoFileHandler] Undoing changes for file: " + resolvedFilePath + ", status: " + status);
 
             ApplicationManager.getApplication().invokeLater(() -> {
                 try {
                     if ("A".equals(status)) {
-                        // Added file: delete it
-                        deleteFile(filePath);
+                        // Added file: delete it only when every operation is rollback-safe
+                        if (hasUnsafeOperation(operations)) {
+                            sendError(resolvedFilePath, "Operation is marked unsafe to rollback");
+                            return;
+                        }
+                        validateExpectedAfterHash(resolvedFilePath, operations);
+                        deleteFile(resolvedFilePath);
                     } else if ("M".equals(status)) {
                         // Modified file: reverse the edits
                         if (operations == null || operations.isEmpty()) {
-                            sendError(filePath, "No operations to undo");
+                            sendError(resolvedFilePath, "No operations to undo");
                             return;
                         }
-                        reverseEdits(filePath, operations);
+                        reverseEdits(resolvedFilePath, operations);
                     } else {
-                        sendError(filePath, "Unknown file status: " + status);
+                        sendError(resolvedFilePath, "Unknown file status: " + status);
                         return;
                     }
 
                     // Send success callback
-                    sendSuccess(filePath);
+                    sendSuccess(resolvedFilePath);
 
                 } catch (Exception e) {
                     LOG.error("[UndoFileHandler] Failed to undo file changes: " + e.getMessage(), e);
-                    sendError(filePath, e.getMessage());
+                    sendError(resolvedFilePath, e.getMessage());
                 }
             });
 
@@ -163,56 +214,10 @@ public class UndoFileHandler extends BaseMessageHandler {
 
             LOG.info("[UndoFileHandler] Undoing changes for " + files.size() + " files");
 
-            ApplicationManager.getApplication().invokeLater(() -> {
-                int successCount = 0;
-                int failCount = 0;
-                StringBuilder errors = new StringBuilder();
-
-                for (int i = 0; i < files.size(); i++) {
-                    JsonObject fileObj = files.get(i).getAsJsonObject();
-                    String filePath = fileObj.has("filePath") ? fileObj.get("filePath").getAsString() : null;
-                    String status = fileObj.has("status") ? fileObj.get("status").getAsString() : null;
-                    JsonArray operations = fileObj.has("operations") ? fileObj.getAsJsonArray("operations") : null;
-
-                    if (filePath == null || filePath.isEmpty()) {
-                        failCount++;
-                        errors.append("File ").append(i).append(": Missing path; ");
-                        continue;
-                    }
-
-                    // Security: Validate file path
-                    if (!isValidFilePath(filePath)) {
-                        failCount++;
-                        errors.append(filePath).append(": Invalid path (outside project); ");
-                        continue;
-                    }
-
-                    try {
-                        if ("A".equals(status)) {
-                            // Added file: delete it
-                            deleteFile(filePath);
-                        } else if ("M".equals(status)) {
-                            // Modified file: reverse the edits
-                            if (operations != null && !operations.isEmpty()) {
-                                reverseEdits(filePath, operations);
-                            }
-                        }
-                        successCount++;
-                        LOG.info("[UndoFileHandler] Successfully undone: " + filePath);
-                    } catch (Exception e) {
-                        failCount++;
-                        errors.append(filePath).append(": ").append(e.getMessage()).append("; ");
-                        LOG.error("[UndoFileHandler] Failed to undo " + filePath + ": " + e.getMessage(), e);
-                    }
-                }
-
-                if (failCount == 0) {
-                    sendAllSuccess(successCount);
-                } else if (successCount > 0) {
-                    // Partial success
-                    sendAllSuccess(successCount);
-                } else {
-                    sendAllError(errors.toString());
+            ProgressManager.getInstance().run(new Task.Backgroundable(context.getProject(), "Undo Claude Changes", false) {
+                @Override
+                public void run(@NotNull ProgressIndicator indicator) {
+                    executeUndoAllFileChanges(files, indicator);
                 }
             });
 
@@ -222,15 +227,229 @@ public class UndoFileHandler extends BaseMessageHandler {
         }
     }
 
-    private void deleteFile(String filePath) throws Exception {
-        VirtualFile file = LocalFileSystem.getInstance().findFileByPath(filePath);
-        if (file == null || !file.exists()) {
-            LOG.warn("[UndoFileHandler] File not found for deletion: " + filePath);
-            // File already doesn't exist, treat as success
+    private void executeUndoAllFileChanges(JsonArray files, ProgressIndicator indicator) {
+        int failCount = 0;
+        JsonArray failedFiles = new JsonArray();
+        StringBuilder errors = new StringBuilder();
+        List<BatchUndoAction> actions = new ArrayList<>();
+
+        for (int i = 0; i < files.size(); i++) {
+            JsonObject fileObj = files.get(i).getAsJsonObject();
+            String filePath = fileObj.has("filePath") ? fileObj.get("filePath").getAsString() : null;
+            String status = fileObj.has("status") ? fileObj.get("status").getAsString() : null;
+            JsonArray operations = fileObj.has("operations") ? fileObj.getAsJsonArray("operations") : null;
+
+            if (filePath == null || filePath.isEmpty()) {
+                failCount++;
+                String message = "Missing path";
+                errors.append("File ").append(i).append(": ").append(message).append("; ");
+                failedFiles.add(failureObject(filePath, "missing_path", message));
+                continue;
+            }
+
+            java.util.Optional<Path> safePath = resolveProjectPath(filePath);
+            if (safePath.isEmpty()) {
+                failCount++;
+                String message = "Invalid path (outside project)";
+                errors.append(filePath).append(": ").append(message).append("; ");
+                failedFiles.add(failureObject(filePath, "invalid_path", message));
+                continue;
+            }
+            String resolvedFilePath = safePath.get().toString();
+
+            try {
+                actions.add(createBatchUndoAction(resolvedFilePath, status, operations));
+            } catch (Exception e) {
+                failCount++;
+                String reason = e instanceof UnsafeRollbackException ? "unsafe_to_rollback" : "undo_failed";
+                errors.append(resolvedFilePath).append(": ").append(e.getMessage()).append("; ");
+                failedFiles.add(failureObject(resolvedFilePath, reason, e.getMessage()));
+                LOG.error("[UndoFileHandler] Failed to prepare undo " + resolvedFilePath + ": " + e.getMessage(), e);
+            }
+        }
+
+        if (failCount > 0) {
+            sendAllResult(false, false, 0, new JsonArray(), failedFiles, errors.toString());
             return;
         }
 
-        // Use AtomicReference to capture exception from lambda
+        BatchUndoExecution execution = executeBatchUndoActions(actions, indicator);
+        JsonArray succeededFiles = new JsonArray();
+        if (execution.success()) {
+            for (BatchUndoAction action : actions) {
+                succeededFiles.add(action.filePath());
+            }
+            sendAllResult(true, false, actions.size(), succeededFiles, failedFiles, null);
+        } else {
+            String message = execution.error() != null ? execution.error() : "Batch undo failed";
+            failedFiles.add(failureObject("", "undo_failed", message));
+            sendAllResult(false, execution.appliedCount() > 0, execution.appliedCount(), succeededFiles, failedFiles, message);
+        }
+    }
+
+    static boolean hasUnsafeOperation(JsonArray operations) {
+        if (operations == null || operations.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < operations.size(); i++) {
+            if (!operations.get(i).isJsonObject()) {
+                continue;
+            }
+            JsonObject operation = operations.get(i).getAsJsonObject();
+            Boolean safeToRollback = getOptionalBoolean(operation, "safeToRollback", "safe_to_rollback");
+            if (Boolean.FALSE.equals(safeToRollback)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static BatchUndoExecution executeBatchUndoActions(List<? extends BatchUndoAction> actions, ProgressIndicator indicator) {
+        if (actions == null || actions.isEmpty()) {
+            return new BatchUndoExecution(true, 0, null);
+        }
+        List<BatchUndoAction> applied = new ArrayList<>();
+        try {
+            int total = actions.size();
+            for (int i = 0; i < total; i++) {
+                if (indicator != null) {
+                    indicator.checkCanceled();
+                    indicator.setText("Undoing file changes");
+                    indicator.setText2(actions.get(i).filePath());
+                    indicator.setFraction((double) i / total);
+                }
+                BatchUndoAction action = actions.get(i);
+                action.apply();
+                applied.add(action);
+            }
+            if (indicator != null) {
+                indicator.setFraction(1.0);
+            }
+        } catch (Exception applyError) {
+            List<String> rollbackErrors = new ArrayList<>();
+            for (int i = applied.size() - 1; i >= 0; i--) {
+                BatchUndoAction action = applied.get(i);
+                try {
+                    action.rollback();
+                } catch (Exception rollbackError) {
+                    rollbackErrors.add(action.filePath() + ": " + rollbackError.getMessage());
+                    LOG.warn("[UndoFileHandler] Failed to rollback batch undo action for " + action.filePath(), rollbackError);
+                }
+            }
+            String message = applyError.getMessage();
+            if (!rollbackErrors.isEmpty()) {
+                message += "; rollback failures: " + String.join("; ", rollbackErrors);
+            }
+            return new BatchUndoExecution(false, applied.size(), message);
+        }
+        for (BatchUndoAction action : applied) {
+            try {
+                action.afterCommit();
+            } catch (Exception cleanupError) {
+                LOG.warn("[UndoFileHandler] Failed to cleanup after batch undo action for " + action.filePath(), cleanupError);
+            }
+        }
+        return new BatchUndoExecution(true, applied.size(), null);
+    }
+
+    private static Boolean getOptionalBoolean(JsonObject object, String camelName, String snakeName) {
+        if (object == null) {
+            return null;
+        }
+        try {
+            if (object.has(camelName) && !object.get(camelName).isJsonNull()) {
+                return object.get(camelName).getAsBoolean();
+            }
+            if (object.has(snakeName) && !object.get(snakeName).isJsonNull()) {
+                return object.get(snakeName).getAsBoolean();
+            }
+        } catch (Exception ignored) {
+            return null;
+        }
+        return null;
+    }
+
+    private static final class UnsafeRollbackException extends Exception {
+        private UnsafeRollbackException(String message) {
+            super(message);
+        }
+    }
+
+    private record DocumentSnapshot(VirtualFile file, Document document, String content) {
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    @FunctionalInterface
+    private interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+
+    private static void runOnEdtAndWait(ThrowingRunnable runnable) throws Exception {
+        if (ApplicationManager.getApplication().isDispatchThread()) {
+            runnable.run();
+            return;
+        }
+        AtomicReference<Exception> exceptionRef = new AtomicReference<>();
+        ApplicationManager.getApplication().invokeAndWait(() -> {
+            try {
+                runnable.run();
+            } catch (Exception e) {
+                exceptionRef.set(e);
+            }
+        });
+        Exception exception = exceptionRef.get();
+        if (exception != null) {
+            throw exception;
+        }
+    }
+
+    private static <T> T callOnEdtAndWait(ThrowingSupplier<T> supplier) throws Exception {
+        if (ApplicationManager.getApplication().isDispatchThread()) {
+            return supplier.get();
+        }
+        AtomicReference<T> resultRef = new AtomicReference<>();
+        AtomicReference<Exception> exceptionRef = new AtomicReference<>();
+        ApplicationManager.getApplication().invokeAndWait(() -> {
+            try {
+                resultRef.set(supplier.get());
+            } catch (Exception e) {
+                exceptionRef.set(e);
+            }
+        });
+        Exception exception = exceptionRef.get();
+        if (exception != null) {
+            throw exception;
+        }
+        return resultRef.get();
+    }
+
+    private void deleteFile(String filePath) throws Exception {
+        String normalizedPath = filePath.replace('\\', '/');
+        LocalFileSystem localFileSystem = LocalFileSystem.getInstance();
+        VirtualFile file = localFileSystem.refreshAndFindFileByPath(normalizedPath);
+        Path nioPath = Path.of(filePath);
+        if (file == null || !file.exists()) {
+            if (!Files.exists(nioPath)) {
+                LOG.warn("[UndoFileHandler] File not found for deletion: " + filePath);
+                return;
+            }
+            try {
+                Files.delete(nioPath);
+                localFileSystem.refreshAndFindFileByPath(normalizedPath);
+                if (Files.exists(nioPath)) {
+                    throw new IOException("File still exists after delete");
+                }
+                LOG.info("[UndoFileHandler] Successfully deleted file via filesystem fallback: " + filePath);
+                return;
+            } catch (IOException e) {
+                throw new Exception("Failed to delete file: " + e.getMessage(), e);
+            }
+        }
+
         final java.util.concurrent.atomic.AtomicReference<Exception> exceptionRef = new java.util.concurrent.atomic.AtomicReference<>();
 
         WriteCommandAction.runWriteCommandAction(context.getProject(), "Undo Claude: Delete File", null, () -> {
@@ -242,15 +461,213 @@ public class UndoFileHandler extends BaseMessageHandler {
             }
         });
 
-        // Check if exception occurred during write action
         Exception ex = exceptionRef.get();
         if (ex != null) {
             throw new Exception("Failed to delete file: " + ex.getMessage(), ex);
         }
+        if (Files.exists(nioPath)) {
+            throw new Exception("Failed to delete file: file still exists after deletion");
+        }
+    }
+
+    private BatchUndoAction createBatchUndoAction(String filePath, String status, JsonArray operations) throws Exception {
+        if ("A".equals(status)) {
+            if (hasUnsafeOperation(operations)) {
+                throw new UnsafeRollbackException("Operation is marked unsafe to rollback");
+            }
+            Path path = Path.of(filePath);
+            AtomicReference<Path> backupPathRef = new AtomicReference<>();
+            return new BatchUndoAction() {
+                @Override
+                public String filePath() {
+                    return filePath;
+                }
+
+                @Override
+                public void apply() throws Exception {
+                    validateExpectedAfterHash(filePath, operations);
+                    if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+                        return;
+                    }
+                    Path backupPath = createBackupTempPath();
+                    Files.deleteIfExists(backupPath);
+                    movePath(path, backupPath);
+                    backupPathRef.set(backupPath);
+                    LocalFileSystem.getInstance().refreshAndFindFileByPath(filePath.replace('\\', '/'));
+                }
+
+                @Override
+                public void rollback() throws Exception {
+                    Path backupPath = backupPathRef.get();
+                    if (backupPath == null || !Files.exists(backupPath, LinkOption.NOFOLLOW_LINKS)
+                            || Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+                        return;
+                    }
+                    Path parent = path.getParent();
+                    if (parent != null) {
+                        Files.createDirectories(parent);
+                    }
+                    movePath(backupPath, path);
+                    LocalFileSystem.getInstance().refreshAndFindFileByPath(filePath.replace('\\', '/'));
+                }
+
+                @Override
+                public void afterCommit() throws Exception {
+                    Path backupPath = backupPathRef.get();
+                    if (backupPath != null) {
+                        Files.deleteIfExists(backupPath);
+                    }
+                }
+            };
+        }
+        if ("M".equals(status)) {
+            if (operations == null || operations.isEmpty()) {
+                throw new Exception("No operations to undo");
+            }
+            DocumentSnapshot snapshot = callOnEdtAndWait(() -> {
+                VirtualFile file = LocalFileSystem.getInstance().refreshAndFindFileByPath(filePath.replace('\\', '/'));
+                if (file == null || !file.exists()) {
+                    throw new Exception("File not found: " + filePath);
+                }
+                Document document = FileDocumentManager.getInstance().getDocument(file);
+                if (document == null) {
+                    throw new Exception("Cannot get document for: " + filePath);
+                }
+                return new DocumentSnapshot(file, document, document.getText());
+            });
+            String originalContent = snapshot.content();
+            UndoOperationApplier.Result result = UndoOperationApplier.reverseEdits(originalContent, operations);
+            if (!result.isSuccess()) {
+                throw new Exception(result.toErrorMessage());
+            }
+            String revertedContent = result.getContent();
+            return new BatchUndoAction() {
+                @Override
+                public String filePath() {
+                    return filePath;
+                }
+
+                @Override
+                public void apply() throws Exception {
+                    runOnEdtAndWait(() ->
+                            WriteCommandAction.runWriteCommandAction(context.getProject(), "Undo Claude Changes", null, () ->
+                                    snapshot.document().setText(revertedContent)
+                            )
+                    );
+                }
+
+                @Override
+                public void rollback() throws Exception {
+                    runOnEdtAndWait(() -> {
+                        WriteCommandAction.runWriteCommandAction(context.getProject(), "Rollback Claude Batch Undo", null, () ->
+                                snapshot.document().setText(originalContent)
+                        );
+                        FileDocumentManager.getInstance().saveDocument(snapshot.document());
+                        snapshot.file().refresh(false, false);
+                    }
+                    );
+                }
+
+                @Override
+                public void afterCommit() throws Exception {
+                    runOnEdtAndWait(() -> {
+                        FileDocumentManager.getInstance().saveDocument(snapshot.document());
+                        snapshot.file().refresh(false, false);
+                    });
+                }
+            };
+        }
+        throw new Exception("Unknown file status: " + status);
+    }
+
+    private static Path createBackupTempPath() throws IOException {
+        return Files.createTempFile("cc-gui-undo-", ".bak");
+    }
+
+    private static void movePath(Path source, Path target) throws IOException {
+        try {
+            Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException e) {
+            Files.move(source, target);
+        }
+    }
+
+    private void validateExpectedAfterHash(String filePath, JsonArray operations) throws Exception {
+        String expectedHash = firstExpectedAfterHash(operations);
+        if (expectedHash == null) {
+            return;
+        }
+        String content = readCurrentContentForHash(filePath);
+        if (!expectedHash.equals(sha256(content))) {
+            throw new Exception("content_changed: Current content no longer matches the captured LLM result");
+        }
+    }
+
+    private String readCurrentContentForHash(String filePath) throws Exception {
+        AtomicReference<String> documentTextRef = new AtomicReference<>();
+        runOnEdtAndWait(() -> {
+            VirtualFile file = LocalFileSystem.getInstance().refreshAndFindFileByPath(filePath.replace('\\', '/'));
+            if (file == null) {
+                return;
+            }
+            Document document = FileDocumentManager.getInstance().getDocument(file);
+            if (document != null) {
+                documentTextRef.set(document.getText());
+            }
+        });
+        String documentText = documentTextRef.get();
+        if (documentText != null) {
+            return documentText;
+        }
+        Path path = Path.of(filePath);
+        return Files.exists(path, LinkOption.NOFOLLOW_LINKS) ? Files.readString(path, StandardCharsets.UTF_8) : "";
+    }
+
+    private static String firstExpectedAfterHash(JsonArray operations) {
+        if (operations == null) {
+            return null;
+        }
+        for (int i = 0; i < operations.size(); i++) {
+            if (!operations.get(i).isJsonObject()) {
+                continue;
+            }
+            JsonObject operation = operations.get(i).getAsJsonObject();
+            String hash = getOptionalString(operation, "expectedAfterContentHash", "expected_after_content_hash");
+            if (hash != null && !hash.isBlank()) {
+                return hash;
+            }
+        }
+        return null;
+    }
+
+    private static String getOptionalString(JsonObject object, String camelName, String snakeName) {
+        if (object == null) {
+            return null;
+        }
+        try {
+            if (object.has(camelName) && !object.get(camelName).isJsonNull()) {
+                return object.get(camelName).getAsString();
+            }
+            if (object.has(snakeName) && !object.get(snakeName).isJsonNull()) {
+                return object.get(snakeName).getAsString();
+            }
+        } catch (Exception ignored) {
+            return null;
+        }
+        return null;
+    }
+
+    private static String sha256(String content) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest((content != null ? content : "").getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            return Integer.toHexString((content != null ? content : "").hashCode());
+        }
     }
 
     private void reverseEdits(String filePath, JsonArray operations) throws Exception {
-        VirtualFile file = LocalFileSystem.getInstance().findFileByPath(filePath);
+        VirtualFile file = LocalFileSystem.getInstance().refreshAndFindFileByPath(filePath.replace('\\', '/'));
         if (file == null || !file.exists()) {
             throw new Exception("File not found: " + filePath);
         }
@@ -260,46 +677,22 @@ public class UndoFileHandler extends BaseMessageHandler {
             throw new Exception("Cannot get document for: " + filePath);
         }
 
+        final java.util.concurrent.atomic.AtomicReference<Exception> exceptionRef = new java.util.concurrent.atomic.AtomicReference<>();
+
         WriteCommandAction.runWriteCommandAction(context.getProject(), "Undo Claude Changes", null, () -> {
             String content = document.getText();
-
-            // Reverse iterate through operations to undo in correct order
-            // Each operation: replace newString back to oldString
-            for (int i = operations.size() - 1; i >= 0; i--) {
-                JsonObject op = operations.get(i).getAsJsonObject();
-                String oldString = op.has("oldString") && !op.get("oldString").isJsonNull()
-                    ? op.get("oldString").getAsString()
-                    : "";
-                String newString = op.has("newString") && !op.get("newString").isJsonNull()
-                    ? op.get("newString").getAsString()
-                    : "";
-                boolean replaceAll = op.has("replaceAll") && op.get("replaceAll").getAsBoolean();
-
-                if (newString.isEmpty()) {
-                    // newString is empty means content was deleted, we need to restore oldString
-                    // This case is tricky - we'd need position info which we don't have
-                    // For now, skip these cases as they're rare in typical edit operations
-                    LOG.warn("[UndoFileHandler] Skipping operation with empty newString (deletion case)");
-                    continue;
-                }
-
-                if (replaceAll) {
-                    // Replace all occurrences
-                    content = content.replace(newString, oldString);
-                } else {
-                    // Replace first occurrence only
-                    int index = content.indexOf(newString);
-                    if (index != -1) {
-                        content = content.substring(0, index) + oldString + content.substring(index + newString.length());
-                    } else {
-                        LOG.warn("[UndoFileHandler] Could not find newString to replace: " +
-                            newString.substring(0, Math.min(50, newString.length())) + "...");
-                    }
-                }
+            UndoOperationApplier.Result result = UndoOperationApplier.reverseEdits(content, operations);
+            if (!result.isSuccess()) {
+                exceptionRef.set(new Exception(result.toErrorMessage()));
+                return;
             }
-
-            document.setText(content);
+            document.setText(result.getContent());
         });
+
+        Exception ex = exceptionRef.get();
+        if (ex != null) {
+            throw ex;
+        }
 
         // Save the document
         FileDocumentManager.getInstance().saveDocument(document);
@@ -337,13 +730,34 @@ public class UndoFileHandler extends BaseMessageHandler {
         });
     }
 
-    private void sendAllSuccess(int count) {
+    private JsonObject failureObject(String filePath, String reason, String message) {
+        JsonObject failure = new JsonObject();
+        failure.addProperty("filePath", filePath != null ? filePath : "");
+        failure.addProperty("reason", reason);
+        failure.addProperty("message", message);
+        return failure;
+    }
+
+    private void sendAllResult(
+        boolean success,
+        boolean partial,
+        int count,
+        JsonArray succeededFiles,
+        JsonArray failedFiles,
+        String error
+    ) {
         JsonObject result = new JsonObject();
-        result.addProperty("success", true);
+        result.addProperty("success", success);
+        result.addProperty("partial", partial);
         result.addProperty("count", count);
+        result.add("succeededFiles", succeededFiles);
+        result.add("failedFiles", failedFiles);
+        if (error != null && !error.isEmpty()) {
+            result.addProperty("error", error);
+        }
 
         String json = gson.toJson(result);
-        LOG.info("[UndoFileHandler] Sending batch success callback: " + json);
+        LOG.info("[UndoFileHandler] Sending batch undo callback: " + json);
 
         ApplicationManager.getApplication().invokeLater(() -> {
             callJavaScript("onUndoAllFileResult", escapeJs(json));
@@ -351,15 +765,6 @@ public class UndoFileHandler extends BaseMessageHandler {
     }
 
     private void sendAllError(String error) {
-        JsonObject result = new JsonObject();
-        result.addProperty("success", false);
-        result.addProperty("error", error);
-
-        String json = gson.toJson(result);
-        LOG.warn("[UndoFileHandler] Sending batch error callback: " + json);
-
-        ApplicationManager.getApplication().invokeLater(() -> {
-            callJavaScript("onUndoAllFileResult", escapeJs(json));
-        });
+        sendAllResult(false, false, 0, new JsonArray(), new JsonArray(), error);
     }
 }

--- a/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
@@ -13,7 +13,9 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Claude message callback handler.
@@ -29,6 +31,8 @@ public class ClaudeMessageHandler implements MessageCallback {
     private final MessageMerger messageMerger;
     private final ReplayDeduplicator replayDedup = new ReplayDeduplicator();
     private final Gson gson;
+    private final SubagentLifecycleDetector subagentLifecycleDetector;
+    private final SubagentEditScopeTracker subagentEditScopeTracker;
 
     // Content accumulator for the current assistant message
     private final StringBuilder assistantContent = new StringBuilder();
@@ -54,6 +58,17 @@ public class ClaudeMessageHandler implements MessageCallback {
     private volatile boolean textSegmentActive = false;
     private volatile boolean thinkingSegmentActive = false;
 
+    // Offset tracking for deduplication after conservative sync.
+    // Volatile: same threading pattern as textSegmentActive/thinkingSegmentActive
+    // (read/written across SDK callback threads and EDT).
+    private volatile int syncedContentOffset = 0;
+    private volatile int syncedThinkingOffset = 0;
+
+    // Claude bridge can deliver the same tool_result via both a full user message and a
+    // standalone tool_result tag. Keep this idempotent so downstream edit/lifecycle handling
+    // does not see duplicate completion signals.
+    private final Set<String> processedToolResultIds = new HashSet<>();
+
     /**
      * Constructor.
      */
@@ -65,12 +80,28 @@ public class ClaudeMessageHandler implements MessageCallback {
             MessageMerger messageMerger,
             Gson gson
     ) {
+        this(project, state, callbackHandler, messageParser, messageMerger, gson,
+                new SubagentLifecycleDetector(), new SubagentEditScopeTracker(project, new EditOperationRegistry()));
+    }
+
+    public ClaudeMessageHandler(
+            Project project,
+            SessionState state,
+            CallbackHandler callbackHandler,
+            MessageParser messageParser,
+            MessageMerger messageMerger,
+            Gson gson,
+            SubagentLifecycleDetector subagentLifecycleDetector,
+            SubagentEditScopeTracker subagentEditScopeTracker
+    ) {
         this.project = project;
         this.state = state;
         this.callbackHandler = callbackHandler;
         this.messageParser = messageParser;
         this.messageMerger = messageMerger;
         this.gson = gson;
+        this.subagentLifecycleDetector = subagentLifecycleDetector;
+        this.subagentEditScopeTracker = subagentEditScopeTracker;
     }
 
     /**
@@ -167,6 +198,7 @@ public class ClaudeMessageHandler implements MessageCallback {
 
         Message errorMessage = new Message(Message.Type.ERROR, error);
         state.addMessage(errorMessage);
+        subagentEditScopeTracker.cancelAll();
         callbackHandler.notifyMessageUpdate(state.getMessages());
         if (wasStreaming) {
             callbackHandler.notifyStreamEnd();
@@ -275,6 +307,8 @@ public class ClaudeMessageHandler implements MessageCallback {
                 replayDedup.beginContentReplay(streamingText, ReplayDeduplicator.replayOffset(previousAssistantContent.length(), replayDedup.contentOffset()));
             }
             currentAssistantMessage.raw = mergedRaw;
+            subagentEditScopeTracker.registerExternalOperations(messageJson);
+            processSubagentLifecycleEvents(subagentLifecycleDetector.handleAssistant("claude", messageJson));
 
             if (isStreaming) {
                 String mergedThinkingContent = ReplayDeduplicator.extractThinkingContent(mergedRaw);
@@ -468,9 +502,16 @@ public class ClaudeMessageHandler implements MessageCallback {
 
             // Check if the message contains a tool_result
             if (messageParser.hasToolResult(userMsg)) {
+                JsonObject filteredUserMsg = filterUnprocessedToolResults(userMsg);
+                if (filteredUserMsg == null) {
+                    LOG.debug("Skipping duplicate tool_result user message");
+                    return;
+                }
                 // This is a user message with tool_result; add it to the message list
-                Message toolResultMessage = new Message(Message.Type.USER, "[tool_result]", userMsg);
+                Message toolResultMessage = new Message(Message.Type.USER, "[tool_result]", filteredUserMsg);
                 state.addMessage(toolResultMessage);
+                subagentEditScopeTracker.registerExternalResults(filteredUserMsg);
+                processSubagentLifecycleEvents(subagentLifecycleDetector.handleUser("claude", filteredUserMsg));
                 LOG.debug("Added tool_result user message to state");
                 callbackHandler.notifyMessageUpdate(state.getMessages());
                 return;
@@ -530,6 +571,10 @@ public class ClaudeMessageHandler implements MessageCallback {
                     : null;
 
             if (toolUseId != null) {
+                if (!markToolResultProcessed(toolUseId)) {
+                    LOG.debug("Skipping duplicate tool_result for tool_use_id: " + toolUseId);
+                    return;
+                }
                 // Build a user message containing the tool_result
                 JsonArray contentArray = new JsonArray();
                 contentArray.add(toolResultBlock);
@@ -544,12 +589,100 @@ public class ClaudeMessageHandler implements MessageCallback {
                 // Create the user message and add it to the message list
                 Message toolResultMessage = new Message(Message.Type.USER, "[tool_result]", rawUser);
                 state.addMessage(toolResultMessage);
+                subagentEditScopeTracker.registerExternalResults(rawUser);
+                processSubagentLifecycleEvents(subagentLifecycleDetector.handleUser("claude", rawUser));
 
                 LOG.debug("Tool result received for tool_use_id: " + toolUseId);
                 callbackHandler.notifyMessageUpdate(state.getMessages());
             }
         } catch (Exception e) {
             LOG.warn("Failed to parse tool_result JSON: " + e.getMessage());
+        }
+    }
+
+
+    private void processSubagentLifecycleEvents(List<SubagentLifecycleEvent> events) {
+        for (SubagentLifecycleEvent event : events) {
+            if (event.kind() == SubagentLifecycleEvent.Kind.STARTED) {
+                subagentEditScopeTracker.startScope(event.provider(), event.parentToolUseId(), event.agentHandle());
+            } else if (event.kind() == SubagentLifecycleEvent.Kind.SPAWN_RESOLVED) {
+                subagentEditScopeTracker.resolveAgentHandle(event.parentToolUseId(), event.agentHandle());
+            } else if (event.kind() == SubagentLifecycleEvent.Kind.CANCELLED) {
+                if (event.agentHandle() != null) {
+                    subagentEditScopeTracker.cancelByAgentHandle(event.agentHandle());
+                } else {
+                    subagentEditScopeTracker.cancelByParentToolUseId(event.parentToolUseId());
+                }
+            } else if (event.kind() == SubagentLifecycleEvent.Kind.COMPLETED) {
+                List<Message> syntheticMessages = subagentEditScopeTracker.completeByParentToolUseId(
+                        event.parentToolUseId(), event.completionToken());
+                for (Message syntheticMessage : syntheticMessages) {
+                    state.addMessage(syntheticMessage);
+                }
+            }
+        }
+    }
+
+
+    private JsonObject filterUnprocessedToolResults(JsonObject userMsg) {
+        if (!userMsg.has("message") || !userMsg.get("message").isJsonObject()) {
+            return userMsg;
+        }
+        JsonObject message = userMsg.getAsJsonObject("message");
+        if (!message.has("content") || !message.get("content").isJsonArray()) {
+            return userMsg;
+        }
+
+        JsonArray originalContent = message.getAsJsonArray("content");
+        JsonArray filteredContent = new JsonArray();
+        boolean sawToolResult = false;
+        boolean keptAnyToolResult = false;
+
+        for (int i = 0; i < originalContent.size(); i++) {
+            if (!originalContent.get(i).isJsonObject()) {
+                filteredContent.add(originalContent.get(i).deepCopy());
+                continue;
+            }
+            JsonObject block = originalContent.get(i).getAsJsonObject();
+            if (!block.has("type") || !"tool_result".equals(block.get("type").getAsString())) {
+                filteredContent.add(block.deepCopy());
+                continue;
+            }
+
+            sawToolResult = true;
+            if (!block.has("tool_use_id") || block.get("tool_use_id").isJsonNull()) {
+                filteredContent.add(block.deepCopy());
+                keptAnyToolResult = true;
+                continue;
+            }
+
+            String toolUseId = block.get("tool_use_id").getAsString();
+            if (markToolResultProcessed(toolUseId)) {
+                filteredContent.add(block.deepCopy());
+                keptAnyToolResult = true;
+            }
+        }
+
+        if (!sawToolResult) {
+            return userMsg;
+        }
+        if (!keptAnyToolResult && filteredContent.size() == 0) {
+            return null;
+        }
+
+        JsonObject filtered = userMsg.deepCopy();
+        JsonObject filteredMessage = filtered.getAsJsonObject("message");
+        filteredMessage.add("content", filteredContent);
+        return filtered;
+    }
+
+    private boolean markToolResultProcessed(String toolUseId) {
+        synchronized (processedToolResultIds) {
+            if (processedToolResultIds.contains(toolUseId)) {
+                return false;
+            }
+            processedToolResultIds.add(toolUseId);
+            return true;
         }
     }
 

--- a/src/main/java/com/github/claudecodegui/session/CodexMessageHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/CodexMessageHandler.java
@@ -30,6 +30,8 @@ public class CodexMessageHandler implements MessageCallback {
      * message merger.
      */
     private final MessageMerger messageMerger = new MessageMerger();
+    private final SubagentLifecycleDetector subagentLifecycleDetector;
+    private final SubagentEditScopeTracker subagentEditScopeTracker;
 
     /**
      * assistant content.
@@ -58,8 +60,19 @@ public class CodexMessageHandler implements MessageCallback {
      * @since 1.0.0
      */
     public CodexMessageHandler(SessionState state, CallbackHandler callbackHandler) {
+        this(state, callbackHandler, new SubagentLifecycleDetector(), new SubagentEditScopeTracker(null, new EditOperationRegistry()));
+    }
+
+    public CodexMessageHandler(
+            SessionState state,
+            CallbackHandler callbackHandler,
+            SubagentLifecycleDetector subagentLifecycleDetector,
+            SubagentEditScopeTracker subagentEditScopeTracker
+    ) {
         this.state = state;
         this.callbackHandler = callbackHandler;
+        this.subagentLifecycleDetector = subagentLifecycleDetector;
+        this.subagentEditScopeTracker = subagentEditScopeTracker;
     }
 
     /**
@@ -130,6 +143,7 @@ public class CodexMessageHandler implements MessageCallback {
 
         Message errorMessage = new Message(Message.Type.ERROR, error);
         state.addMessage(errorMessage);
+        subagentEditScopeTracker.cancelAll();
         callbackHandler.notifyMessageUpdate(state.getMessages());
         if (wasStreaming) {
             callbackHandler.notifyStreamEnd();
@@ -195,6 +209,8 @@ public class CodexMessageHandler implements MessageCallback {
             } else {
                 state.addMessage(parsed);
             }
+            subagentEditScopeTracker.registerExternalOperations(msgJson);
+            processSubagentLifecycleEvents(subagentLifecycleDetector.handleAssistant("codex", msgJson));
             callbackHandler.notifyMessageUpdate(state.getMessages());
 
             LOG.debug("Codex assistant message synchronized with raw JSON");
@@ -222,11 +238,39 @@ public class CodexMessageHandler implements MessageCallback {
             }
 
             state.addMessage(parsed);
+            subagentEditScopeTracker.registerExternalResults(msgJson);
+            processSubagentLifecycleEvents(subagentLifecycleDetector.handleUser("codex", msgJson));
             callbackHandler.notifyMessageUpdate(state.getMessages());
 
             LOG.debug("Codex user message (tool_result) added");
         } catch (Exception e) {
             LOG.warn("Failed to parse user message: " + e.getMessage());
+        }
+    }
+
+    private void processSubagentLifecycleEvents(java.util.List<SubagentLifecycleEvent> events) {
+        for (SubagentLifecycleEvent event : events) {
+            if (event.kind() == SubagentLifecycleEvent.Kind.STARTED) {
+                subagentEditScopeTracker.startScope(event.provider(), event.parentToolUseId(), event.agentHandle());
+            } else if (event.kind() == SubagentLifecycleEvent.Kind.SPAWN_RESOLVED) {
+                subagentEditScopeTracker.resolveAgentHandle(event.parentToolUseId(), event.agentHandle());
+            } else if (event.kind() == SubagentLifecycleEvent.Kind.CANCELLED) {
+                if (event.agentHandle() != null) {
+                    subagentEditScopeTracker.cancelByAgentHandle(event.agentHandle());
+                } else {
+                    subagentEditScopeTracker.cancelByParentToolUseId(event.parentToolUseId());
+                }
+            } else if (event.kind() == SubagentLifecycleEvent.Kind.COMPLETED) {
+                java.util.List<Message> syntheticMessages;
+                if (event.agentHandle() != null) {
+                    syntheticMessages = subagentEditScopeTracker.completeByAgentHandle(event.agentHandle(), event.completionToken());
+                } else {
+                    syntheticMessages = subagentEditScopeTracker.completeByParentToolUseId(event.parentToolUseId(), event.completionToken());
+                }
+                for (Message syntheticMessage : syntheticMessages) {
+                    state.addMessage(syntheticMessage);
+                }
+            }
         }
     }
 

--- a/src/main/java/com/github/claudecodegui/session/EditOperationRegistry.java
+++ b/src/main/java/com/github/claudecodegui/session/EditOperationRegistry.java
@@ -1,0 +1,45 @@
+package com.github.claudecodegui.session;
+
+import com.github.claudecodegui.util.EditOperationBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Session-owned dedupe registry for generated edit operations. */
+public final class EditOperationRegistry {
+
+    private final Map<String, RegisteredOperation> operationBySignature = new HashMap<>();
+
+    public synchronized boolean register(EditOperationBuilder.Operation operation, String source, String scopeId, long editSequence) {
+        String signature = signature(operation);
+        int priority = priority(source);
+        RegisteredOperation existing = operationBySignature.get(signature);
+        if (existing != null && existing.priority() >= priority) {
+            return false;
+        }
+        RegisteredOperation next = new RegisteredOperation(source, scopeId, editSequence, priority);
+        operationBySignature.put(signature, next);
+        return true;
+    }
+
+    private static String signature(EditOperationBuilder.Operation operation) {
+        return operation.filePath() + "\u0000" + operation.oldString() + "\u0000" + operation.newString()
+                + "\u0000" + operation.lineStart() + "\u0000" + operation.lineEnd();
+    }
+
+    private static int priority(String source) {
+        if ("codex_session_patch".equals(source)) {
+            return 300;
+        }
+        if ("main_tool_use".equals(source) || "main".equals(source)) {
+            return 200;
+        }
+        if ("subagent_vfs".equals(source) || "subagent".equals(source)) {
+            return 100;
+        }
+        return 0;
+    }
+
+    private record RegisteredOperation(String source, String scopeId, long editSequence, int priority) {
+    }
+}

--- a/src/main/java/com/github/claudecodegui/session/SessionSendService.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionSendService.java
@@ -29,6 +29,8 @@ public class SessionSendService {
     private final ClaudeSDKBridge claudeSDKBridge;
     private final CodexSDKBridge codexSDKBridge;
     private final SessionContextService contextService;
+    private final SubagentLifecycleDetector subagentLifecycleDetector;
+    private final SubagentEditScopeTracker subagentEditScopeTracker;
 
     public SessionSendService(
             Project project,
@@ -50,6 +52,9 @@ public class SessionSendService {
         this.claudeSDKBridge = claudeSDKBridge;
         this.codexSDKBridge = codexSDKBridge;
         this.contextService = contextService;
+        EditOperationRegistry editOperationRegistry = new EditOperationRegistry();
+        this.subagentLifecycleDetector = new SubagentLifecycleDetector();
+        this.subagentEditScopeTracker = new SubagentEditScopeTracker(project, editOperationRegistry);
     }
 
     public void prepareContextCollector(EditorContextCollector contextCollector) {
@@ -173,7 +178,12 @@ public class SessionSendService {
             List<String> fileTagPaths,
             String effectivePermissionMode
     ) {
-        CodexMessageHandler handler = new CodexMessageHandler(state, callbackFacade.getCallbackHandler());
+        CodexMessageHandler handler = new CodexMessageHandler(
+                state,
+                callbackFacade.getCallbackHandler(),
+                subagentLifecycleDetector,
+                subagentEditScopeTracker
+        );
         String accessMode = CodemossSettingsService.CODEX_RUNTIME_ACCESS_INACTIVE;
         try {
             accessMode = new CodemossSettingsService().getCodexRuntimeAccessMode();
@@ -218,7 +228,9 @@ public class SessionSendService {
                 callbackFacade.getCallbackHandler(),
                 messageParser,
                 messageMerger,
-                gson
+                gson,
+                subagentLifecycleDetector,
+                subagentEditScopeTracker
         );
 
         Boolean streaming = readStreamingEnabled();

--- a/src/main/java/com/github/claudecodegui/session/SubagentEditScopeTracker.java
+++ b/src/main/java/com/github/claudecodegui/session/SubagentEditScopeTracker.java
@@ -20,6 +20,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
 /** Session-owned tracker that captures file deltas produced inside sub-agent scopes. */
@@ -53,8 +57,16 @@ public final class SubagentEditScopeTracker {
                 return existingAgentScope.scopeId;
             }
         }
+        List<Scope> activeScopes = activeScopes();
+        for (Scope activeScope : activeScopes) {
+            activeScope.disableBaselineOnlyDiff = true;
+        }
         String scopeId = provider + "_" + (parentToolUseId != null ? parentToolUseId : UUID.randomUUID());
-        Scope scope = new Scope(scopeId, provider, parentToolUseId, agentHandle, Map.of());
+        CompletableFuture<Map<String, FileSnapshotUtil.FileSnapshot>> baselineFuture = activeScopes.isEmpty()
+                ? captureBaselineAsync(project)
+                : CompletableFuture.completedFuture(Map.of());
+        Scope scope = new Scope(scopeId, provider, parentToolUseId, agentHandle, baselineFuture);
+        scope.disableBaselineOnlyDiff = !activeScopes.isEmpty();
         latestScope = scope;
         if (parentToolUseId != null) {
             scopeByParentToolUseId.put(parentToolUseId, scope);
@@ -77,18 +89,18 @@ public final class SubagentEditScopeTracker {
         scopeByAgentHandle.put(agentHandle, scope);
     }
 
-    public synchronized List<ClaudeSession.Message> completeByParentToolUseId(String parentToolUseId, String completionToken) {
+    public List<ClaudeSession.Message> completeByParentToolUseId(String parentToolUseId, String completionToken) {
         if (parentToolUseId == null) {
             return List.of();
         }
-        return complete(scopeByParentToolUseId.get(parentToolUseId), completionToken);
+        return complete(lookupByParentToolUseId(parentToolUseId), completionToken);
     }
 
-    public synchronized List<ClaudeSession.Message> completeByAgentHandle(String agentHandle, String completionToken) {
+    public List<ClaudeSession.Message> completeByAgentHandle(String agentHandle, String completionToken) {
         if (agentHandle == null) {
             return List.of();
         }
-        return complete(scopeByAgentHandle.get(agentHandle), completionToken);
+        return complete(lookupByAgentHandle(agentHandle), completionToken);
     }
 
     public synchronized void cancelByParentToolUseId(String parentToolUseId) {
@@ -157,6 +169,21 @@ public final class SubagentEditScopeTracker {
 
     public synchronized void recordAfterSnapshotForTest(Map<String, FileSnapshotUtil.FileSnapshot> snapshots) {
         afterSnapshotForTest = snapshots;
+    }
+
+    synchronized void recordBaselineForTest(Map<String, FileSnapshotUtil.FileSnapshot> snapshots) {
+        Scope scope = latestActiveScope();
+        if (scope != null) {
+            scope.baselineByPath = snapshots != null ? snapshots : Map.of();
+            scope.baselineFuture = CompletableFuture.completedFuture(scope.baselineByPath);
+        }
+    }
+
+    private static CompletableFuture<Map<String, FileSnapshotUtil.FileSnapshot>> captureBaselineAsync(Project project) {
+        if (project == null || project.isDisposed() || project.getBasePath() == null) {
+            return CompletableFuture.completedFuture(Map.of());
+        }
+        return CompletableFuture.supplyAsync(() -> FileSnapshotUtil.captureProjectSnapshot(project));
     }
 
     private void installVfsListener() {
@@ -277,7 +304,7 @@ public final class SubagentEditScopeTracker {
     }
 
     private FileSnapshotUtil.FileSnapshot readBeforeSnapshot(Scope scope, VFileEvent event, String path) {
-        FileSnapshotUtil.FileSnapshot baseline = scope.baselineByPath.get(path);
+        FileSnapshotUtil.FileSnapshot baseline = scope.currentBaseline().get(path);
         if (baseline != null) {
             return baseline;
         }
@@ -309,12 +336,9 @@ public final class SubagentEditScopeTracker {
     }
 
     private List<ClaudeSession.Message> complete(Scope scope, String completionToken) {
-        if (scope == null || completionToken == null || scope.completed || scope.completedTokens.contains(completionToken)) {
+        if (completionToken == null || !markCompleted(scope, completionToken)) {
             return List.of();
         }
-        scope.completed = true;
-        scope.completedTokens.add(completionToken);
-        removeScope(scope);
 
         long sequence = editSequence.incrementAndGet();
         List<EditOperationBuilder.Operation> operations = buildOperations(scope, sequence);
@@ -323,6 +347,24 @@ public final class SubagentEditScopeTracker {
         }
         ScopeDescriptor descriptor = new ScopeDescriptor(scope.scopeId, scope.provider, scope.parentToolUseId, scope.agentHandle, sequence);
         return SyntheticFileChangeMessageFactory.build(descriptor, operations);
+    }
+
+    private synchronized Scope lookupByParentToolUseId(String parentToolUseId) {
+        return scopeByParentToolUseId.get(parentToolUseId);
+    }
+
+    private synchronized Scope lookupByAgentHandle(String agentHandle) {
+        return scopeByAgentHandle.get(agentHandle);
+    }
+
+    private synchronized boolean markCompleted(Scope scope, String completionToken) {
+        if (scope == null || completionToken == null || scope.completed || scope.completedTokens.contains(completionToken)) {
+            return false;
+        }
+        scope.completed = true;
+        scope.completedTokens.add(completionToken);
+        removeScope(scope);
+        return true;
     }
 
     private void cancel(Scope scope) {
@@ -346,7 +388,11 @@ public final class SubagentEditScopeTracker {
     }
 
     private List<EditOperationBuilder.Operation> buildOperations(Scope scope, long sequence) {
+        Map<String, FileSnapshotUtil.FileSnapshot> baselineByPath = scope.baselineForCompletion();
         Set<String> paths = new LinkedHashSet<>(scope.beforeByPath.keySet());
+        if (!scope.disableBaselineOnlyDiff) {
+            paths.addAll(baselineByPath.keySet());
+        }
 
         List<EditOperationBuilder.Operation> operations = new ArrayList<>();
         for (String path : paths) {
@@ -354,7 +400,7 @@ public final class SubagentEditScopeTracker {
                 LOG.warn("Skipping ambiguous sub-agent edit path touched by multiple active scopes: " + path);
                 continue;
             }
-            FileSnapshotUtil.FileSnapshot before = scope.beforeByPath.get(path);
+            FileSnapshotUtil.FileSnapshot before = scope.beforeByPath.getOrDefault(path, baselineByPath.get(path));
             FileSnapshotUtil.FileSnapshot after = readAfterSnapshot(path);
             if (after == null) {
                 if (before != null && before.existed() && !before.binary()) {
@@ -401,15 +447,39 @@ public final class SubagentEditScopeTracker {
         private final Map<String, FileSnapshotUtil.FileSnapshot> beforeByPath = new HashMap<>();
         private final Set<String> conflictedPaths = new HashSet<>();
         private final Set<String> completedTokens = new HashSet<>();
-        private final Map<String, FileSnapshotUtil.FileSnapshot> baselineByPath;
+        private boolean disableBaselineOnlyDiff;
+        private Map<String, FileSnapshotUtil.FileSnapshot> baselineByPath;
+        private CompletableFuture<Map<String, FileSnapshotUtil.FileSnapshot>> baselineFuture;
 
         private Scope(String scopeId, String provider, String parentToolUseId, String agentHandle,
-                      Map<String, FileSnapshotUtil.FileSnapshot> baselineByPath) {
+                      CompletableFuture<Map<String, FileSnapshotUtil.FileSnapshot>> baselineFuture) {
             this.scopeId = scopeId;
             this.provider = provider;
             this.parentToolUseId = parentToolUseId;
             this.agentHandle = agentHandle;
-            this.baselineByPath = baselineByPath != null ? baselineByPath : Map.of();
+            this.baselineByPath = Map.of();
+            this.baselineFuture = baselineFuture != null ? baselineFuture : CompletableFuture.completedFuture(Map.of());
+        }
+
+        private Map<String, FileSnapshotUtil.FileSnapshot> currentBaseline() {
+            if (baselineByPath.isEmpty() && baselineFuture != null && baselineFuture.isDone() && !baselineFuture.isCompletedExceptionally()) {
+                baselineByPath = baselineFuture.getNow(Map.of());
+            }
+            return baselineByPath != null ? baselineByPath : Map.of();
+        }
+
+        private Map<String, FileSnapshotUtil.FileSnapshot> baselineForCompletion() {
+            if (!baselineByPath.isEmpty() || baselineFuture == null) {
+                return currentBaseline();
+            }
+            try {
+                baselineByPath = baselineFuture.get(3, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (ExecutionException | TimeoutException e) {
+                LOG.warn("Sub-agent baseline snapshot unavailable at completion", e);
+            }
+            return baselineByPath != null ? baselineByPath : Map.of();
         }
     }
 

--- a/src/main/java/com/github/claudecodegui/session/SubagentEditScopeTracker.java
+++ b/src/main/java/com/github/claudecodegui/session/SubagentEditScopeTracker.java
@@ -1,0 +1,423 @@
+package com.github.claudecodegui.session;
+
+import com.github.claudecodegui.util.EditOperationBuilder;
+import com.github.claudecodegui.util.FileSnapshotUtil;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.openapi.vfs.newvfs.BulkFileListener;
+import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent;
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** Session-owned tracker that captures file deltas produced inside sub-agent scopes. */
+public final class SubagentEditScopeTracker {
+
+    private static final Logger LOG = Logger.getInstance(SubagentEditScopeTracker.class);
+
+    private final Project project;
+    private final EditOperationRegistry registry;
+    private final AtomicLong editSequence = new AtomicLong();
+    private final Map<String, Scope> scopeByParentToolUseId = new HashMap<>();
+    private final Map<String, Scope> scopeByAgentHandle = new HashMap<>();
+    private final Map<String, PendingExternalOperation> pendingExternalOperationsByToolUseId = new HashMap<>();
+    private Scope latestScope;
+    private Map<String, FileSnapshotUtil.FileSnapshot> afterSnapshotForTest;
+
+    public SubagentEditScopeTracker(Project project, EditOperationRegistry registry) {
+        this.project = project;
+        this.registry = registry != null ? registry : new EditOperationRegistry();
+        installVfsListener();
+    }
+
+    public synchronized String startScope(String provider, String parentToolUseId, String agentHandle) {
+        if (parentToolUseId != null && scopeByParentToolUseId.containsKey(parentToolUseId)) {
+            return scopeByParentToolUseId.get(parentToolUseId).scopeId;
+        }
+        if (agentHandle != null) {
+            Scope existingAgentScope = scopeByAgentHandle.get(agentHandle);
+            if (existingAgentScope != null && !existingAgentScope.completed) {
+                latestScope = existingAgentScope;
+                return existingAgentScope.scopeId;
+            }
+        }
+        String scopeId = provider + "_" + (parentToolUseId != null ? parentToolUseId : UUID.randomUUID());
+        Scope scope = new Scope(scopeId, provider, parentToolUseId, agentHandle, Map.of());
+        latestScope = scope;
+        if (parentToolUseId != null) {
+            scopeByParentToolUseId.put(parentToolUseId, scope);
+        }
+        if (agentHandle != null) {
+            scopeByAgentHandle.put(agentHandle, scope);
+        }
+        return scopeId;
+    }
+
+    public synchronized void resolveAgentHandle(String parentToolUseId, String agentHandle) {
+        if (parentToolUseId == null || agentHandle == null) {
+            return;
+        }
+        Scope scope = scopeByParentToolUseId.get(parentToolUseId);
+        if (scope == null || scope.completed) {
+            return;
+        }
+        scope.agentHandle = agentHandle;
+        scopeByAgentHandle.put(agentHandle, scope);
+    }
+
+    public synchronized List<ClaudeSession.Message> completeByParentToolUseId(String parentToolUseId, String completionToken) {
+        if (parentToolUseId == null) {
+            return List.of();
+        }
+        return complete(scopeByParentToolUseId.get(parentToolUseId), completionToken);
+    }
+
+    public synchronized List<ClaudeSession.Message> completeByAgentHandle(String agentHandle, String completionToken) {
+        if (agentHandle == null) {
+            return List.of();
+        }
+        return complete(scopeByAgentHandle.get(agentHandle), completionToken);
+    }
+
+    public synchronized void cancelByParentToolUseId(String parentToolUseId) {
+        if (parentToolUseId == null) {
+            return;
+        }
+        cancel(scopeByParentToolUseId.get(parentToolUseId));
+    }
+
+    public synchronized void cancelByAgentHandle(String agentHandle) {
+        if (agentHandle == null) {
+            return;
+        }
+        cancel(scopeByAgentHandle.get(agentHandle));
+    }
+
+    public synchronized void cancelAll() {
+        for (Scope scope : new ArrayList<>(activeScopes())) {
+            cancel(scope);
+        }
+    }
+
+    public synchronized void registerExternalOperations(JsonObject raw) {
+        for (SubagentToolOperationParser.ParsedToolOperation parsed : SubagentToolOperationParser.toolOperations(raw)) {
+            String source = parsed.source();
+            EditOperationBuilder.Operation operation = parsed.operation();
+            if ("subagent".equals(source) || "subagent_vfs".equals(source)) {
+                registry.register(
+                        operation,
+                        source,
+                        parsed.scopeId(),
+                        parsed.editSequence()
+                );
+                continue;
+            }
+            markPathConflicted(activeScopes(), operation.filePath());
+            PendingExternalOperation pending = new PendingExternalOperation(
+                    operation,
+                    source != null ? source : "main",
+                    parsed.scopeId(),
+                    parsed.editSequence()
+            );
+            if (parsed.toolUseId() == null) {
+                registry.register(pending.operation(), pending.source(), pending.scopeId(), pending.editSequence());
+            } else {
+                pendingExternalOperationsByToolUseId.put(parsed.toolUseId(), pending);
+            }
+        }
+    }
+
+    public synchronized void registerExternalResults(JsonObject raw) {
+        for (String toolUseId : SubagentToolOperationParser.successfulToolResultIds(raw)) {
+            PendingExternalOperation pending = pendingExternalOperationsByToolUseId.remove(toolUseId);
+            if (pending != null) {
+                registry.register(pending.operation(), pending.source(), pending.scopeId(), pending.editSequence());
+            }
+        }
+    }
+
+    public synchronized void recordBeforeSnapshot(String path, FileSnapshotUtil.FileSnapshot snapshot) {
+        Scope scope = latestActiveScope();
+        if (scope != null && path != null && snapshot != null) {
+            scope.beforeByPath.put(path, snapshot);
+        }
+    }
+
+    public synchronized void recordAfterSnapshotForTest(Map<String, FileSnapshotUtil.FileSnapshot> snapshots) {
+        afterSnapshotForTest = snapshots;
+    }
+
+    private void installVfsListener() {
+        if (project == null || project.isDisposed()) {
+            return;
+        }
+        project.getMessageBus().connect(project).subscribe(VirtualFileManager.VFS_CHANGES, new BulkFileListener() {
+            @Override
+            public void before(@NotNull List<? extends VFileEvent> events) {
+                recordVfsBeforeEvents(events);
+            }
+        });
+    }
+
+    private void recordVfsBeforeEvents(List<? extends VFileEvent> events) {
+        if (events == null || events.isEmpty()) {
+            return;
+        }
+        synchronized (this) {
+            List<Scope> activeScopes = activeScopes();
+            if (activeScopes.isEmpty()) {
+                return;
+            }
+            for (VFileEvent event : events) {
+                String path = normalizeProjectPath(event.getPath());
+                if (path == null) {
+                    continue;
+                }
+                Scope owner = chooseOwnerScope(activeScopes, path);
+                if (owner == null) {
+                    markPathAmbiguous(activeScopes, path);
+                    continue;
+                }
+                markConflictsIfPathAlreadyOwned(activeScopes, owner, path);
+                owner.beforeByPath.computeIfAbsent(path, currentPath -> readBeforeSnapshot(owner, event, currentPath));
+            }
+        }
+    }
+
+
+
+    synchronized void recordVfsBeforePathForTest(String path, FileSnapshotUtil.FileSnapshot snapshot) {
+        List<Scope> activeScopes = activeScopes();
+        Scope owner = chooseOwnerScope(activeScopes, path);
+        if (owner == null || path == null || snapshot == null) {
+            markPathAmbiguous(activeScopes, path);
+            return;
+        }
+        markConflictsIfPathAlreadyOwned(activeScopes, owner, path);
+        owner.beforeByPath.putIfAbsent(path, snapshot);
+    }
+
+    private Scope chooseOwnerScope(List<Scope> activeScopes, String path) {
+        if (activeScopes == null || activeScopes.isEmpty()) {
+            return null;
+        }
+        if (activeScopes.size() == 1) {
+            return activeScopes.get(0);
+        }
+        Scope existingOwner = null;
+        for (Scope scope : activeScopes) {
+            if (scope.beforeByPath.containsKey(path)) {
+                if (existingOwner != null) {
+                    return null;
+                }
+                existingOwner = scope;
+            }
+        }
+        if (existingOwner != null) {
+            return existingOwner;
+        }
+        return null;
+    }
+
+    private void markPathConflicted(List<Scope> activeScopes, String path) {
+        if (path == null || activeScopes == null || activeScopes.isEmpty()) {
+            return;
+        }
+        for (Scope scope : activeScopes) {
+            scope.conflictedPaths.add(path);
+        }
+    }
+
+    private void markPathAmbiguous(List<Scope> activeScopes, String path) {
+        if (path == null || activeScopes == null || activeScopes.size() <= 1) {
+            return;
+        }
+        markPathConflicted(activeScopes, path);
+    }
+
+    private void markConflictsIfPathAlreadyOwned(List<Scope> activeScopes, Scope owner, String path) {
+        for (Scope scope : activeScopes) {
+            if (scope != owner && scope.beforeByPath.containsKey(path)) {
+                scope.conflictedPaths.add(path);
+                owner.conflictedPaths.add(path);
+            }
+        }
+    }
+
+    private Scope latestActiveScope() {
+        if (latestScope != null && !latestScope.completed) {
+            return latestScope;
+        }
+        for (Scope scope : scopeByParentToolUseId.values()) {
+            if (!scope.completed) {
+                return scope;
+            }
+        }
+        return null;
+    }
+
+    private List<Scope> activeScopes() {
+        LinkedHashSet<Scope> scopes = new LinkedHashSet<>();
+        scopes.addAll(scopeByParentToolUseId.values());
+        scopes.addAll(scopeByAgentHandle.values());
+        scopes.removeIf(scope -> scope == null || scope.completed);
+        return new ArrayList<>(scopes);
+    }
+
+    private FileSnapshotUtil.FileSnapshot readBeforeSnapshot(Scope scope, VFileEvent event, String path) {
+        FileSnapshotUtil.FileSnapshot baseline = scope.baselineByPath.get(path);
+        if (baseline != null) {
+            return baseline;
+        }
+        if (event instanceof VFileCreateEvent) {
+            return FileSnapshotUtil.nonExistingSnapshot(path);
+        }
+        return FileSnapshotUtil.readSnapshot(Path.of(path)).orElseGet(() -> FileSnapshotUtil.nonExistingSnapshot(path));
+    }
+
+    private String normalizeProjectPath(String rawPath) {
+        if (rawPath == null || rawPath.isBlank() || project == null || project.getBasePath() == null) {
+            return null;
+        }
+        try {
+            Path basePath = Path.of(project.getBasePath()).toRealPath().normalize();
+            Path raw = Path.of(rawPath).toAbsolutePath().normalize();
+            Path path = java.nio.file.Files.exists(raw)
+                    ? raw.toRealPath().normalize()
+                    : (raw.getParent() != null && java.nio.file.Files.exists(raw.getParent())
+                            ? raw.getParent().toRealPath().resolve(raw.getFileName()).normalize()
+                            : raw);
+            if (!path.startsWith(basePath)) {
+                return null;
+            }
+            return path.toString();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private List<ClaudeSession.Message> complete(Scope scope, String completionToken) {
+        if (scope == null || completionToken == null || scope.completed || scope.completedTokens.contains(completionToken)) {
+            return List.of();
+        }
+        scope.completed = true;
+        scope.completedTokens.add(completionToken);
+        removeScope(scope);
+
+        long sequence = editSequence.incrementAndGet();
+        List<EditOperationBuilder.Operation> operations = buildOperations(scope, sequence);
+        if (operations.isEmpty()) {
+            return List.of();
+        }
+        ScopeDescriptor descriptor = new ScopeDescriptor(scope.scopeId, scope.provider, scope.parentToolUseId, scope.agentHandle, sequence);
+        return SyntheticFileChangeMessageFactory.build(descriptor, operations);
+    }
+
+    private void cancel(Scope scope) {
+        if (scope == null || scope.completed) {
+            return;
+        }
+        scope.completed = true;
+        removeScope(scope);
+    }
+
+    private void removeScope(Scope scope) {
+        if (scope.parentToolUseId != null) {
+            scopeByParentToolUseId.remove(scope.parentToolUseId);
+        }
+        if (scope.agentHandle != null) {
+            scopeByAgentHandle.remove(scope.agentHandle);
+        }
+        if (latestScope == scope) {
+            latestScope = null;
+        }
+    }
+
+    private List<EditOperationBuilder.Operation> buildOperations(Scope scope, long sequence) {
+        Set<String> paths = new LinkedHashSet<>(scope.beforeByPath.keySet());
+
+        List<EditOperationBuilder.Operation> operations = new ArrayList<>();
+        for (String path : paths) {
+            if (scope.conflictedPaths.contains(path)) {
+                LOG.warn("Skipping ambiguous sub-agent edit path touched by multiple active scopes: " + path);
+                continue;
+            }
+            FileSnapshotUtil.FileSnapshot before = scope.beforeByPath.get(path);
+            FileSnapshotUtil.FileSnapshot after = readAfterSnapshot(path);
+            if (after == null) {
+                if (before != null && before.existed() && !before.binary()) {
+                    EditOperationBuilder.Operation deleteOperation = new EditOperationBuilder.Operation(
+                            "edit", path, before.content(), "", false, 1, 1, false, ""
+                    );
+                    if (registry.register(deleteOperation, "subagent_vfs", scope.scopeId, sequence)) {
+                        operations.add(deleteOperation);
+                    }
+                }
+                continue;
+            }
+            if (after.binary() || (before != null && before.binary())) {
+                continue;
+            }
+            boolean existedBefore = before != null && before.existed();
+            String beforeContent = before != null ? before.content() : "";
+            String afterContent = after.content();
+            for (EditOperationBuilder.Operation operation : EditOperationBuilder.build(path, existedBefore, beforeContent, afterContent)) {
+                if (registry.register(operation, "subagent_vfs", scope.scopeId, sequence)) {
+                    operations.add(operation);
+                }
+            }
+        }
+        return operations;
+    }
+
+    private FileSnapshotUtil.FileSnapshot readAfterSnapshot(String path) {
+        if (afterSnapshotForTest != null) {
+            return afterSnapshotForTest.get(path);
+        }
+        return FileSnapshotUtil.readSnapshot(Path.of(path)).orElse(null);
+    }
+
+    public record ScopeDescriptor(String scopeId, String provider, String parentToolUseId, String agentHandle, long editSequence) {
+    }
+
+    private static final class Scope {
+        private final String scopeId;
+        private final String provider;
+        private final String parentToolUseId;
+        private String agentHandle;
+        private boolean completed;
+        private final Map<String, FileSnapshotUtil.FileSnapshot> beforeByPath = new HashMap<>();
+        private final Set<String> conflictedPaths = new HashSet<>();
+        private final Set<String> completedTokens = new HashSet<>();
+        private final Map<String, FileSnapshotUtil.FileSnapshot> baselineByPath;
+
+        private Scope(String scopeId, String provider, String parentToolUseId, String agentHandle,
+                      Map<String, FileSnapshotUtil.FileSnapshot> baselineByPath) {
+            this.scopeId = scopeId;
+            this.provider = provider;
+            this.parentToolUseId = parentToolUseId;
+            this.agentHandle = agentHandle;
+            this.baselineByPath = baselineByPath != null ? baselineByPath : Map.of();
+        }
+    }
+
+    private record PendingExternalOperation(
+            EditOperationBuilder.Operation operation,
+            String source,
+            String scopeId,
+            long editSequence
+    ) {
+    }
+}

--- a/src/main/java/com/github/claudecodegui/session/SubagentLifecycleDetector.java
+++ b/src/main/java/com/github/claudecodegui/session/SubagentLifecycleDetector.java
@@ -1,0 +1,332 @@
+package com.github.claudecodegui.session;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Detects provider-neutral sub-agent lifecycle events from normalized messages. */
+public final class SubagentLifecycleDetector {
+
+    private static final Pattern UUID_PATTERN = Pattern.compile("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+    private static final int MAX_TRACKED_TOOL_IDS = 1000;
+    private final Map<String, ToolUseInfo> toolUseById = new HashMap<>();
+    private final Set<String> startedToolUseIds = new HashSet<>();
+    private final Set<String> terminalToolUseIds = new HashSet<>();
+
+    public List<SubagentLifecycleEvent> handleAssistant(String provider, JsonObject raw) {
+        List<SubagentLifecycleEvent> events = new ArrayList<>();
+        for (JsonObject block : contentBlocks(raw)) {
+            if (!isType(block, "tool_use")) {
+                continue;
+            }
+            String id = getString(block, "id");
+            String name = normalizeName(getString(block, "name"));
+            JsonObject input = block.has("input") && block.get("input").isJsonObject()
+                    ? block.getAsJsonObject("input")
+                    : new JsonObject();
+            if (id == null || name == null || terminalToolUseIds.contains(id)) {
+                continue;
+            }
+            toolUseById.put(id, new ToolUseInfo(name, input));
+            if (isStartTool(provider, name) && startedToolUseIds.add(id)) {
+                events.add(new SubagentLifecycleEvent(
+                        SubagentLifecycleEvent.Kind.STARTED,
+                        provider,
+                        id,
+                        id,
+                        extractAgentHandle(input),
+                        "start:" + id
+                ));
+            }
+        }
+        return events;
+    }
+
+    public List<SubagentLifecycleEvent> handleUser(String provider, JsonObject raw) {
+        List<SubagentLifecycleEvent> events = new ArrayList<>();
+        for (JsonObject block : contentBlocks(raw)) {
+            if (!isType(block, "tool_result")) {
+                continue;
+            }
+            String toolUseId = getString(block, "tool_use_id");
+            if (toolUseId == null) {
+                continue;
+            }
+            ToolUseInfo info = toolUseById.get(toolUseId);
+            if (info == null) {
+                continue;
+            }
+            if (isErroredToolResult(block)) {
+                toolUseById.remove(toolUseId);
+                markTerminal(toolUseId);
+                if (shouldCancelScope(provider, info.name())) {
+                    events.add(new SubagentLifecycleEvent(
+                            SubagentLifecycleEvent.Kind.CANCELLED,
+                            provider,
+                            toolUseId,
+                            toolUseId,
+                            resolveTerminalAgentHandle(info.name(), info.input(), block),
+                            "cancel:" + toolUseId
+                    ));
+                }
+                continue;
+            }
+            if ("claude".equals(provider) && ("task".equals(info.name()) || "agent".equals(info.name()))) {
+                events.add(new SubagentLifecycleEvent(
+                        SubagentLifecycleEvent.Kind.COMPLETED,
+                        provider,
+                        toolUseId,
+                        toolUseId,
+                        extractAgentHandle(info.input()),
+                        "complete:" + toolUseId
+                ));
+                toolUseById.remove(toolUseId);
+                markTerminal(toolUseId);
+            } else if ("codex".equals(provider) && "spawn_agent".equals(info.name())) {
+                String agentHandle = firstNonBlank(extractAgentHandleFromSpawnResult(block), extractAgentHandle(info.input()));
+                if (agentHandle != null) {
+                    events.add(new SubagentLifecycleEvent(
+                            SubagentLifecycleEvent.Kind.SPAWN_RESOLVED,
+                            provider,
+                            toolUseId,
+                            toolUseId,
+                            agentHandle,
+                            "spawn_resolved:" + toolUseId
+                    ));
+                } else {
+                    events.add(new SubagentLifecycleEvent(
+                            SubagentLifecycleEvent.Kind.CANCELLED,
+                            provider,
+                            toolUseId,
+                            toolUseId,
+                            null,
+                            "spawn_unresolved:" + toolUseId
+                    ));
+                }
+                toolUseById.remove(toolUseId);
+                markTerminal(toolUseId);
+            } else if ("codex".equals(provider) && ("wait_agent".equals(info.name()) || "close_agent".equals(info.name()))) {
+                String agentHandle = resolveTerminalAgentHandle(info.name(), info.input(), block);
+                if (agentHandle != null) {
+                    events.add(new SubagentLifecycleEvent(
+                            SubagentLifecycleEvent.Kind.COMPLETED,
+                            provider,
+                            toolUseId,
+                            null,
+                            agentHandle,
+                            "complete:" + toolUseId
+                    ));
+                }
+                toolUseById.remove(toolUseId);
+                markTerminal(toolUseId);
+            } else {
+                markTerminal(toolUseId);
+            }
+        }
+        return events;
+    }
+
+    private static boolean isErroredToolResult(JsonObject block) {
+        if (block == null || !block.has("is_error") || block.get("is_error").isJsonNull()) {
+            return false;
+        }
+        try {
+            return block.get("is_error").getAsBoolean();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private void markTerminal(String toolUseId) {
+        if (toolUseId == null) {
+            return;
+        }
+        toolUseById.remove(toolUseId);
+        startedToolUseIds.remove(toolUseId);
+        terminalToolUseIds.add(toolUseId);
+        if (terminalToolUseIds.size() > MAX_TRACKED_TOOL_IDS) {
+            terminalToolUseIds.clear();
+        }
+    }
+
+    private static boolean isStartTool(String provider, String name) {
+        return ("claude".equals(provider) && ("task".equals(name) || "agent".equals(name)))
+                || ("codex".equals(provider) && ("spawn_agent".equals(name)
+                || "resume_agent".equals(name) || "send_input".equals(name)));
+    }
+
+    private static boolean shouldCancelScope(String provider, String name) {
+        return ("claude".equals(provider) && ("task".equals(name) || "agent".equals(name)))
+                || ("codex".equals(provider) && ("spawn_agent".equals(name)
+                || "wait_agent".equals(name) || "close_agent".equals(name)
+                || "resume_agent".equals(name) || "send_input".equals(name)));
+    }
+
+    private static List<JsonObject> contentBlocks(JsonObject raw) {
+        if (raw == null) {
+            return List.of();
+        }
+        JsonObject message = raw.has("message") && raw.get("message").isJsonObject()
+                ? raw.getAsJsonObject("message")
+                : raw;
+        if (!message.has("content") || !message.get("content").isJsonArray()) {
+            return List.of();
+        }
+        JsonArray content = message.getAsJsonArray("content");
+        List<JsonObject> blocks = new ArrayList<>();
+        for (JsonElement element : content) {
+            if (element.isJsonObject()) {
+                blocks.add(element.getAsJsonObject());
+            }
+        }
+        return blocks;
+    }
+
+    private static boolean isType(JsonObject block, String type) {
+        return type.equals(getString(block, "type"));
+    }
+
+    private static String getString(JsonObject object, String key) {
+        if (object == null || !object.has(key) || object.get(key).isJsonNull()) {
+            return null;
+        }
+        try {
+            return object.get(key).getAsString();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String normalizeName(String name) {
+        return name == null ? null : name.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static String extractAgentHandle(JsonObject input) {
+        if (input == null) {
+            return null;
+        }
+        return firstNonBlank(
+                getString(input, "agentHandle"),
+                getString(input, "agent_handle"),
+                getString(input, "agentId"),
+                getString(input, "agent_id"),
+                getString(input, "agentPath"),
+                getString(input, "agent_path"),
+                getString(input, "target")
+        );
+    }
+
+    private static String extractSingleTargetArrayHandle(JsonObject input) {
+        if (input == null || !input.has("targets") || !input.get("targets").isJsonArray()) {
+            return null;
+        }
+        JsonArray targets = input.getAsJsonArray("targets");
+        String handle = null;
+        for (JsonElement target : targets) {
+            if (!target.isJsonPrimitive()) {
+                continue;
+            }
+            String value;
+            try {
+                value = target.getAsString();
+            } catch (Exception e) {
+                continue;
+            }
+            if (value == null || value.isBlank()) {
+                continue;
+            }
+            if (handle != null) {
+                return null;
+            }
+            handle = value;
+        }
+        return handle;
+    }
+
+    private static String resolveTerminalAgentHandle(String toolName, JsonObject input, JsonObject resultBlock) {
+        String directInputHandle = extractAgentHandle(input);
+        String resultHandle = extractAgentHandleFromToolResult(resultBlock);
+        if ("wait_agent".equals(toolName)) {
+            return firstNonBlank(resultHandle, directInputHandle, extractSingleTargetArrayHandle(input));
+        }
+        return firstNonBlank(directInputHandle, resultHandle);
+    }
+
+    private static String extractAgentHandleFromToolResult(JsonObject block) {
+        String content = getString(block, "content");
+        if (content == null || content.isBlank()) {
+            return null;
+        }
+        try {
+            JsonElement parsed = JsonParser.parseString(content);
+            if (parsed.isJsonObject()) {
+                return extractAgentHandle(parsed.getAsJsonObject());
+            }
+        } catch (Exception ignored) {
+            // Fall back to text extraction.
+        }
+        Matcher matcher = UUID_PATTERN.matcher(content);
+        String match = null;
+        while (matcher.find()) {
+            if (match != null) {
+                return null;
+            }
+            match = matcher.group();
+        }
+        return match;
+    }
+
+
+    private static String extractAgentHandleFromSpawnResult(JsonObject block) {
+        String structured = extractAgentHandleFromToolResult(block);
+        if (structured != null) {
+            return structured;
+        }
+        String content = getString(block, "content");
+        if (content == null) {
+            return null;
+        }
+        String trimmed = content.trim();
+        if (!isPlausiblePlainTextHandle(trimmed)) {
+            return null;
+        }
+        return trimmed;
+    }
+
+    private static boolean isPlausiblePlainTextHandle(String value) {
+        if (value == null || value.isBlank() || value.length() > 512 || value.contains("\n")) {
+            return false;
+        }
+        if (value.startsWith("/") || value.startsWith("~/") || value.matches("^[A-Za-z]:[\\/].*")) {
+            return true;
+        }
+        if (value.matches("^[A-Za-z0-9._:-]+$")) {
+            String lower = value.toLowerCase(Locale.ROOT);
+            return lower.contains("agent") || lower.contains("codex") || value.matches(".*[0-9a-fA-F]{6,}.*");
+        }
+        return false;
+    }
+
+    private static String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private record ToolUseInfo(String name, JsonObject input) {
+    }
+}

--- a/src/main/java/com/github/claudecodegui/session/SubagentLifecycleDetector.java
+++ b/src/main/java/com/github/claudecodegui/session/SubagentLifecycleDetector.java
@@ -127,6 +127,17 @@ public final class SubagentLifecycleDetector {
                             agentHandle,
                             "complete:" + toolUseId
                     ));
+                } else if ("wait_agent".equals(info.name())) {
+                    for (String targetHandle : extractTargetArrayHandles(info.input())) {
+                        events.add(new SubagentLifecycleEvent(
+                                SubagentLifecycleEvent.Kind.COMPLETED,
+                                provider,
+                                toolUseId,
+                                null,
+                                targetHandle,
+                                "complete:" + toolUseId + ":" + targetHandle
+                        ));
+                    }
                 }
                 toolUseById.remove(toolUseId);
                 markTerminal(toolUseId);
@@ -228,11 +239,16 @@ public final class SubagentLifecycleDetector {
     }
 
     private static String extractSingleTargetArrayHandle(JsonObject input) {
+        List<String> handles = extractTargetArrayHandles(input);
+        return handles.size() == 1 ? handles.get(0) : null;
+    }
+
+    private static List<String> extractTargetArrayHandles(JsonObject input) {
         if (input == null || !input.has("targets") || !input.get("targets").isJsonArray()) {
-            return null;
+            return List.of();
         }
         JsonArray targets = input.getAsJsonArray("targets");
-        String handle = null;
+        List<String> handles = new ArrayList<>();
         for (JsonElement target : targets) {
             if (!target.isJsonPrimitive()) {
                 continue;
@@ -246,12 +262,9 @@ public final class SubagentLifecycleDetector {
             if (value == null || value.isBlank()) {
                 continue;
             }
-            if (handle != null) {
-                return null;
-            }
-            handle = value;
+            handles.add(value);
         }
-        return handle;
+        return handles;
     }
 
     private static String resolveTerminalAgentHandle(String toolName, JsonObject input, JsonObject resultBlock) {

--- a/src/main/java/com/github/claudecodegui/session/SubagentLifecycleEvent.java
+++ b/src/main/java/com/github/claudecodegui/session/SubagentLifecycleEvent.java
@@ -1,0 +1,12 @@
+package com.github.claudecodegui.session;
+
+public record SubagentLifecycleEvent(
+        Kind kind,
+        String provider,
+        String toolUseId,
+        String parentToolUseId,
+        String agentHandle,
+        String completionToken
+) {
+    public enum Kind { STARTED, SPAWN_RESOLVED, COMPLETED, CANCELLED }
+}

--- a/src/main/java/com/github/claudecodegui/session/SubagentToolOperationParser.java
+++ b/src/main/java/com/github/claudecodegui/session/SubagentToolOperationParser.java
@@ -1,0 +1,174 @@
+package com.github.claudecodegui.session;
+
+import com.github.claudecodegui.util.EditOperationBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class SubagentToolOperationParser {
+
+    private SubagentToolOperationParser() {
+    }
+
+    static List<ParsedToolOperation> toolOperations(JsonObject raw) {
+        List<ParsedToolOperation> operations = new ArrayList<>();
+        for (JsonObject block : contentBlocks(raw)) {
+            if (!isToolUse(block) || !block.has("input") || !block.get("input").isJsonObject()) {
+                continue;
+            }
+            JsonObject input = block.getAsJsonObject("input");
+            EditOperationBuilder.Operation operation = operationFromToolInput(block, input);
+            if (operation == null) {
+                continue;
+            }
+            operations.add(new ParsedToolOperation(
+                    operation,
+                    getString(input, "source"),
+                    getString(input, "scope_id"),
+                    getLong(input, "edit_sequence"),
+                    getString(block, "id")
+            ));
+        }
+        return operations;
+    }
+
+    static List<String> successfulToolResultIds(JsonObject raw) {
+        List<String> ids = new ArrayList<>();
+        for (JsonObject block : contentBlocks(raw)) {
+            if (!"tool_result".equals(getString(block, "type")) || isErroredToolResult(block)) {
+                continue;
+            }
+            String toolUseId = getString(block, "tool_use_id");
+            if (toolUseId != null) {
+                ids.add(toolUseId);
+            }
+        }
+        return ids;
+    }
+
+    private static List<JsonObject> contentBlocks(JsonObject raw) {
+        if (raw == null || !raw.has("message") || !raw.get("message").isJsonObject()) {
+            return List.of();
+        }
+        JsonObject message = raw.getAsJsonObject("message");
+        if (!message.has("content") || !message.get("content").isJsonArray()) {
+            return List.of();
+        }
+        JsonArray content = message.getAsJsonArray("content");
+        List<JsonObject> blocks = new ArrayList<>();
+        for (JsonElement element : content) {
+            if (element.isJsonObject()) {
+                blocks.add(element.getAsJsonObject());
+            }
+        }
+        return blocks;
+    }
+
+    private static boolean isErroredToolResult(JsonObject block) {
+        if (block == null || !block.has("is_error") || block.get("is_error").isJsonNull()) {
+            return false;
+        }
+        try {
+            return block.get("is_error").getAsBoolean();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static boolean isToolUse(JsonObject block) {
+        return "tool_use".equals(getString(block, "type"));
+    }
+
+    private static EditOperationBuilder.Operation operationFromToolInput(JsonObject block, JsonObject input) {
+        String toolName = getString(block, "name");
+        if (toolName == null) {
+            return null;
+        }
+        String normalizedToolName = toolName.toLowerCase(java.util.Locale.ROOT);
+        if (!normalizedToolName.equals("edit") && !normalizedToolName.equals("write")
+                && !normalizedToolName.equals("edit_file") && !normalizedToolName.equals("write_file")) {
+            return null;
+        }
+        String filePath = firstNonBlank(getString(input, "file_path"), getString(input, "filePath"), getString(input, "path"));
+        if (filePath == null) {
+            return null;
+        }
+        String oldString = firstNonBlank(getString(input, "old_string"), getString(input, "oldString"));
+        String newString = firstNonBlank(getString(input, "new_string"), getString(input, "newString"), getString(input, "content"));
+        boolean replaceAll = getBoolean(input, "replace_all") || getBoolean(input, "replaceAll");
+        int lineStart = getInt(input, "start_line", getInt(input, "lineStart", 1));
+        int lineEnd = getInt(input, "end_line", getInt(input, "lineEnd", lineStart));
+        boolean safeToRollback = !input.has("safe_to_rollback") || !input.get("safe_to_rollback").isJsonPrimitive()
+                || input.get("safe_to_rollback").getAsBoolean();
+        String operationToolName = normalizedToolName.contains("write") ? "write" : "edit";
+        return new EditOperationBuilder.Operation(
+                operationToolName,
+                filePath,
+                oldString != null ? oldString : "",
+                newString != null ? newString : "",
+                replaceAll,
+                lineStart,
+                lineEnd,
+                safeToRollback,
+                firstNonBlank(getString(input, "expected_after_content_hash"), getString(input, "expectedAfterContentHash"))
+        );
+    }
+
+    private static String getString(JsonObject object, String key) {
+        if (object == null || !object.has(key) || object.get(key).isJsonNull()) {
+            return null;
+        }
+        try {
+            return object.get(key).getAsString();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static boolean getBoolean(JsonObject object, String key) {
+        return object != null && object.has(key) && !object.get(key).isJsonNull() && object.get(key).getAsBoolean();
+    }
+
+    private static int getInt(JsonObject object, String key, int fallback) {
+        if (object == null || !object.has(key) || object.get(key).isJsonNull()) {
+            return fallback;
+        }
+        try {
+            return object.get(key).getAsInt();
+        } catch (Exception e) {
+            return fallback;
+        }
+    }
+
+    private static long getLong(JsonObject object, String key) {
+        if (object == null || !object.has(key) || object.get(key).isJsonNull()) {
+            return 0L;
+        }
+        try {
+            return object.get(key).getAsLong();
+        } catch (Exception e) {
+            return 0L;
+        }
+    }
+
+    private static String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    record ParsedToolOperation(
+            EditOperationBuilder.Operation operation,
+            String source,
+            String scopeId,
+            long editSequence,
+            String toolUseId
+    ) {
+    }
+}

--- a/src/main/java/com/github/claudecodegui/session/SyntheticFileChangeMessageFactory.java
+++ b/src/main/java/com/github/claudecodegui/session/SyntheticFileChangeMessageFactory.java
@@ -1,0 +1,93 @@
+package com.github.claudecodegui.session;
+
+import com.github.claudecodegui.util.EditOperationBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/** Builds hidden synthetic edit/write messages consumable by the existing Edits pipeline. */
+public final class SyntheticFileChangeMessageFactory {
+
+    private SyntheticFileChangeMessageFactory() {
+    }
+
+    public static List<ClaudeSession.Message> build(
+            SubagentEditScopeTracker.ScopeDescriptor scope,
+            List<EditOperationBuilder.Operation> operations
+    ) {
+        if (operations == null || operations.isEmpty()) {
+            return List.of();
+        }
+
+        JsonArray toolUses = new JsonArray();
+        JsonArray toolResults = new JsonArray();
+        int index = 0;
+        for (EditOperationBuilder.Operation operation : operations) {
+            String toolUseId = "subagent_" + operation.toolName() + "_" + scope.scopeId() + "_" + scope.editSequence() + "_" + index;
+            String operationId = scope.scopeId() + ":" + scope.editSequence() + ":" + index + ":"
+                    + UUID.nameUUIDFromBytes((operation.filePath() + operation.oldString() + operation.newString()).getBytes(StandardCharsets.UTF_8));
+
+            JsonObject input = new JsonObject();
+            input.addProperty("file_path", operation.filePath());
+            input.addProperty("old_string", operation.oldString());
+            input.addProperty("new_string", operation.newString());
+            input.addProperty("oldString", operation.oldString());
+            input.addProperty("newString", operation.newString());
+            input.addProperty("replace_all", operation.replaceAll());
+            input.addProperty("replaceAll", operation.replaceAll());
+            input.addProperty("start_line", operation.lineStart());
+            input.addProperty("end_line", operation.lineEnd());
+            input.addProperty("source", "subagent");
+            input.addProperty("scope_id", scope.scopeId());
+            input.addProperty("parent_tool_use_id", scope.parentToolUseId());
+            input.addProperty("operation_id", operationId);
+            input.addProperty("safe_to_rollback", operation.safeToRollback());
+            input.addProperty("edit_sequence", scope.editSequence());
+            input.addProperty("existed_before", !"write".equals(operation.toolName()));
+            input.addProperty("expected_after_content_hash", operation.expectedAfterContentHash());
+            input.addProperty("expectedAfterContentHash", operation.expectedAfterContentHash());
+            if (scope.agentHandle() != null) {
+                input.addProperty("agent_handle", scope.agentHandle());
+            }
+            if ("write".equals(operation.toolName())) {
+                input.addProperty("content", operation.newString());
+            }
+
+            JsonObject toolUse = new JsonObject();
+            toolUse.addProperty("type", "tool_use");
+            toolUse.addProperty("id", toolUseId);
+            toolUse.addProperty("name", operation.toolName());
+            toolUse.add("input", input);
+            toolUses.add(toolUse);
+
+            JsonObject toolResult = new JsonObject();
+            toolResult.addProperty("type", "tool_result");
+            toolResult.addProperty("tool_use_id", toolUseId);
+            toolResult.addProperty("is_error", false);
+            toolResult.addProperty("content", "Sub-agent edit captured");
+            toolResults.add(toolResult);
+            index++;
+        }
+
+        List<ClaudeSession.Message> messages = new ArrayList<>();
+        messages.add(new ClaudeSession.Message(ClaudeSession.Message.Type.ASSISTANT, "", rawMessage("assistant", toolUses)));
+        messages.add(new ClaudeSession.Message(ClaudeSession.Message.Type.USER, "", rawMessage("user", toolResults)));
+        return messages;
+    }
+
+    private static JsonObject rawMessage(String role, JsonArray content) {
+        JsonObject message = new JsonObject();
+        message.addProperty("role", role);
+        message.add("content", content);
+
+        JsonObject raw = new JsonObject();
+        raw.addProperty("type", role);
+        raw.addProperty("isMeta", true);
+        raw.add("message", message);
+        return raw;
+    }
+}

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeSDKToolWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeSDKToolWindow.java
@@ -1,5 +1,6 @@
 package com.github.claudecodegui.ui.toolwindow;
 
+import com.github.claudecodegui.bridge.BridgeDirectoryResolver;
 import com.github.claudecodegui.i18n.ClaudeCodeGuiBundle;
 import com.github.claudecodegui.settings.TabStateService;
 import com.github.claudecodegui.startup.BridgePreloader;
@@ -22,6 +23,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.*;
+import java.io.File;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -211,9 +213,7 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
 
             ApplicationManager.getApplication().executeOnPooledThread(() -> {
                 try {
-                    BridgePreloader.getSharedResolver().findSdkDir();
-                    CompletableFuture<Boolean> future = BridgePreloader.waitForBridgeAsync();
-                    Boolean ready = future.get(60, TimeUnit.SECONDS);
+                    Boolean ready = waitForBridgeReady();
 
                     if (project.isDisposed()) { return; }
 
@@ -348,6 +348,29 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
         }
 
         LOG.debug("[TabManager] Updated tab closeable state: count=" + tabCount + ", closeable=" + closeable);
+    }
+
+    private boolean waitForBridgeReady() throws Exception {
+        BridgeDirectoryResolver resolver = BridgePreloader.getSharedResolver();
+        File bridgeDir = resolver.findSdkDir();
+        if (bridgeDir != null && resolver.isValidBridgeDir(bridgeDir)) {
+            return true;
+        }
+
+        CompletableFuture<Boolean> future = BridgePreloader.waitForBridgeAsync();
+        Boolean ready = future.get(60, TimeUnit.SECONDS);
+        if (Boolean.TRUE.equals(ready)) {
+            return true;
+        }
+
+        bridgeDir = resolver.findSdkDir();
+        if (bridgeDir != null && resolver.isValidBridgeDir(bridgeDir)) {
+            return true;
+        }
+
+        resolver.clearCache();
+        bridgeDir = resolver.findSdkDir();
+        return bridgeDir != null && resolver.isValidBridgeDir(bridgeDir);
     }
 
     private JPanel createLoadingPanel() {

--- a/src/main/java/com/github/claudecodegui/util/ContentRebuildUtil.java
+++ b/src/main/java/com/github/claudecodegui/util/ContentRebuildUtil.java
@@ -17,158 +17,34 @@ public final class ContentRebuildUtil {
 
     /**
      * Reverse-rebuild the pre-edit content from the post-edit content.
-     *
-     * Note: if the file was modified by a linter/formatter, newString may not match exactly.
-     * In that case, whitespace-normalized matching is attempted; if that also fails, the
-     * operation is skipped and processing continues.
+     * Uses the fail-closed UndoOperationApplier; if any operation cannot be matched safely,
+     * the returned content remains the post-edit content via rebuildBeforeContentResult.
      */
     public static String rebuildBeforeContent(String afterContent, JsonArray edits) {
-        String content = afterContent;
-
-        // Iterate over edit operations in reverse order
-        for (int i = edits.size() - 1; i >= 0; i--) {
-            JsonObject edit = edits.get(i).getAsJsonObject();
-            String oldString = edit.has("oldString") ? edit.get("oldString").getAsString() : "";
-            String newString = edit.has("newString") ? edit.get("newString").getAsString() : "";
-            boolean replaceAll = edit.has("replaceAll") && edit.get("replaceAll").getAsBoolean();
-
-            if (replaceAll) {
-                content = reverseReplaceAll(content, oldString, newString);
-            } else {
-                content = reverseReplaceSingle(content, oldString, newString);
-            }
-        }
-
-        LOG.info("Successfully rebuilt before content (" + edits.size() + " operations)");
-        return content;
-    }
-
-    private static String reverseReplaceAll(String content, String oldString, String newString) {
-        // First try exact match
-        if (content.contains(newString)) {
-            return content.replace(newString, oldString);
-        }
-
-        // Try matching with normalized line separators (CRLF vs LF)
-        String normalizedNewString = LineSeparatorUtil.normalizeToMatch(newString, content);
-        if (!normalizedNewString.equals(newString) && content.contains(normalizedNewString)) {
-            String normalizedOldString = LineSeparatorUtil.normalizeToMatch(oldString, content);
-            return content.replace(normalizedNewString, normalizedOldString);
-        }
-
-        // Try matching with normalized whitespace
-        String normalizedNew = normalizeWhitespace(newString);
-        String normalizedContent = normalizeWhitespace(content);
-        if (normalizedContent.contains(normalizedNew)) {
-            return replaceNormalized(content, newString, oldString);
-        }
-        LOG.warn("rebuildBeforeContent: newString not found (replace_all), skipping operation");
-        return content;
-    }
-
-    private static String reverseReplaceSingle(String content, String oldString, String newString) {
-        // First try exact match
-        int index = content.indexOf(newString);
-        if (index >= 0) {
-            return content.substring(0, index) + oldString + content.substring(index + newString.length());
-        }
-
-        // Try matching with normalized line separators (CRLF vs LF)
-        String normalizedNewString = LineSeparatorUtil.normalizeToMatch(newString, content);
-        if (!normalizedNewString.equals(newString)) {
-            index = content.indexOf(normalizedNewString);
-            if (index >= 0) {
-                String normalizedOldString = LineSeparatorUtil.normalizeToMatch(oldString, content);
-                return content.substring(0, index) + normalizedOldString
-                        + content.substring(index + normalizedNewString.length());
-            }
-        }
-
-        // Try matching with normalized whitespace
-        int fuzzyIndex = findNormalizedIndex(content, newString);
-        if (fuzzyIndex >= 0) {
-            int actualEnd = findActualEndIndex(content, fuzzyIndex, newString);
-            return content.substring(0, fuzzyIndex) + oldString + content.substring(actualEnd);
-        }
-        LOG.warn("rebuildBeforeContent: newString not found, skipping operation");
-        return content;
+        return rebuildBeforeContentResult(afterContent, edits).content();
     }
 
     /**
-     * Normalize whitespace characters (for fuzzy matching).
+     * Reverse-rebuild the pre-edit content and report skipped operations.
      */
-    static String normalizeWhitespace(String s) {
-        if (s == null) { return ""; }
-        return s.replaceAll("\\s+", " ").trim();
+    public static RebuildResult rebuildBeforeContentResult(String afterContent, JsonArray edits) {
+        UndoOperationApplier.Result result = UndoOperationApplier.reverseEdits(afterContent, edits);
+        JsonArray skippedOperations = new JsonArray();
+        if (!result.isSuccess()) {
+            for (UndoOperationApplier.Failure failure : result.getFailures()) {
+                JsonObject skipped = new JsonObject();
+                skipped.addProperty("operationIndex", failure.operationIndex());
+                skipped.addProperty("reason", failure.reason());
+                skipped.addProperty("message", failure.message());
+                skippedOperations.add(skipped);
+            }
+            LOG.warn("rebuildBeforeContent failed: " + skippedOperations);
+            return new RebuildResult(false, afterContent, skippedOperations);
+        }
+        LOG.info("Rebuilt before content (" + edits.size() + " operations, 0 skipped)");
+        return new RebuildResult(true, result.getContent(), skippedOperations);
     }
 
-    /**
-     * Find the position of a substring after normalizing whitespace.
-     */
-    static int findNormalizedIndex(String content, String target) {
-        String normalizedTarget = normalizeWhitespace(target);
-        // Normalize line separators to LF for consistent processing
-        String normalizedContent = LineSeparatorUtil.normalizeToLF(content);
-        String[] lines = normalizedContent.split("\n", -1);
-        int charIndex = 0;
-
-        for (int lineIdx = 0; lineIdx < lines.length; lineIdx++) {
-            StringBuilder remainingBuilder = new StringBuilder();
-            for (int j = lineIdx; j < lines.length; j++) {
-                if (j > lineIdx) { remainingBuilder.append("\n"); }
-                remainingBuilder.append(lines[j]);
-            }
-            String normalizedRemaining = normalizeWhitespace(remainingBuilder.toString());
-
-            if (normalizedRemaining.startsWith(normalizedTarget) ||
-                normalizedRemaining.contains(normalizedTarget)) {
-                // Map back to original content position
-                return LineSeparatorUtil.mapToOriginalPosition(content, normalizedContent, charIndex);
-            }
-            charIndex += lines[lineIdx].length() + 1;
-        }
-        return -1;
-    }
-
-    /**
-     * Find the actual end index, accounting for whitespace differences.
-     */
-    static int findActualEndIndex(String content, int startIndex, String target) {
-        String normalizedTarget = normalizeWhitespace(target);
-        int targetNormalizedLen = normalizedTarget.length();
-
-        int normalizedCount = 0;
-        int actualIndex = startIndex;
-
-        while (actualIndex < content.length() && normalizedCount < targetNormalizedLen) {
-            char c = content.charAt(actualIndex);
-            if (!Character.isWhitespace(c) ||
-                (normalizedCount > 0 && normalizedCount < normalizedTarget.length() &&
-                 normalizedTarget.charAt(normalizedCount) == ' ')) {
-                normalizedCount++;
-            }
-            actualIndex++;
-        }
-
-        // Skip trailing whitespace (but not line breaks, including \r and \n)
-        while (actualIndex < content.length() &&
-               Character.isWhitespace(content.charAt(actualIndex)) &&
-               content.charAt(actualIndex) != '\n' &&
-               content.charAt(actualIndex) != '\r') {
-            actualIndex++;
-        }
-
-        return actualIndex;
-    }
-
-    /**
-     * Perform a replacement using normalized matching.
-     */
-    static String replaceNormalized(String content, String target, String replacement) {
-        int index = findNormalizedIndex(content, target);
-        if (index < 0) { return content; }
-
-        int endIndex = findActualEndIndex(content, index, target);
-        return content.substring(0, index) + replacement + content.substring(endIndex);
+    public record RebuildResult(boolean success, String content, JsonArray skippedOperations) {
     }
 }

--- a/src/main/java/com/github/claudecodegui/util/EditOperationBuilder.java
+++ b/src/main/java/com/github/claudecodegui/util/EditOperationBuilder.java
@@ -1,0 +1,212 @@
+package com.github.claudecodegui.util;
+
+import java.util.ArrayList;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+
+/**
+ * Builds Claude-compatible edit/write operations from before/after text snapshots.
+ */
+public final class EditOperationBuilder {
+
+    private static final com.intellij.openapi.diagnostic.Logger LOG =
+            com.intellij.openapi.diagnostic.Logger.getInstance(EditOperationBuilder.class);
+    private static final int CONTEXT_LINES = 2;
+
+    private EditOperationBuilder() {
+    }
+
+    public static List<Operation> build(String filePath, boolean existedBefore, String beforeContent, String afterContent) {
+        String before = beforeContent != null ? beforeContent : "";
+        String after = afterContent != null ? afterContent : "";
+        if (containsNullByte(before) || containsNullByte(after)) {
+            return List.of();
+        }
+        if (!existedBefore) {
+            if (after.isEmpty()) {
+                return List.of();
+            }
+            return List.of(new Operation("write", filePath, "", after, false, 1, Math.max(1, countLines(after)), true, sha256(after)));
+        }
+        if (before.equals(after)) {
+            return List.of();
+        }
+
+        List<String> beforeLines = splitLinesPreserveEndings(before);
+        List<String> afterLines = splitLinesPreserveEndings(after);
+        List<HunkRange> hunks = buildHunkRanges(beforeLines, afterLines);
+        if (hunks.isEmpty()) {
+            return List.of();
+        }
+
+        List<Operation> operations = new ArrayList<>();
+        for (HunkRange hunk : hunks) {
+            String oldString = join(beforeLines, hunk.oldFrom(), hunk.oldTo());
+            String newString = join(afterLines, hunk.newFrom(), hunk.newTo());
+            if (oldString.equals(newString)) {
+                continue;
+            }
+            int lineStart = hunk.newFrom() + 1;
+            int lineEnd = Math.max(lineStart, hunk.newTo());
+            operations.add(new Operation("edit", filePath, oldString, newString, false, lineStart, lineEnd, !newString.isEmpty(), sha256(after)));
+        }
+        return operations;
+    }
+
+    private static List<HunkRange> buildHunkRanges(List<String> beforeLines, List<String> afterLines) {
+        int beforeSize = beforeLines.size();
+        int afterSize = afterLines.size();
+        if ((long) beforeSize * (long) afterSize > 200_000L) {
+            LOG.warn("EditOperationBuilder LCS threshold exceeded; falling back to a single large hunk"
+                    + " beforeLines=" + beforeSize + " afterLines=" + afterSize);
+            return List.of(singleHunk(beforeLines, afterLines, 0, beforeSize, 0, afterSize));
+        }
+
+        int[][] lcs = new int[beforeSize + 1][afterSize + 1];
+        for (int i = beforeSize - 1; i >= 0; i--) {
+            for (int j = afterSize - 1; j >= 0; j--) {
+                if (beforeLines.get(i).equals(afterLines.get(j))) {
+                    lcs[i][j] = lcs[i + 1][j + 1] + 1;
+                } else {
+                    lcs[i][j] = Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+                }
+            }
+        }
+
+        List<RawRange> rawRanges = new ArrayList<>();
+        int i = 0;
+        int j = 0;
+        int oldStart = -1;
+        int newStart = -1;
+        while (i < beforeSize || j < afterSize) {
+            if (i < beforeSize && j < afterSize && beforeLines.get(i).equals(afterLines.get(j))) {
+                if (oldStart >= 0) {
+                    rawRanges.add(new RawRange(oldStart, i, newStart, j));
+                    oldStart = -1;
+                    newStart = -1;
+                }
+                i++;
+                j++;
+                continue;
+            }
+            if (oldStart < 0) {
+                oldStart = i;
+                newStart = j;
+            }
+            if (j < afterSize && (i == beforeSize || lcs[i][j + 1] >= lcs[i + 1][j])) {
+                j++;
+            } else if (i < beforeSize) {
+                i++;
+            }
+        }
+        if (oldStart >= 0) {
+            rawRanges.add(new RawRange(oldStart, i, newStart, j));
+        }
+
+        List<HunkRange> hunks = new ArrayList<>();
+        for (RawRange raw : rawRanges) {
+            HunkRange next = singleHunk(beforeLines, afterLines, raw.oldStart(), raw.oldEnd(), raw.newStart(), raw.newEnd());
+            if (!hunks.isEmpty()) {
+                HunkRange previous = hunks.get(hunks.size() - 1);
+                if (next.oldFrom() <= previous.oldTo() || next.newFrom() <= previous.newTo()) {
+                    hunks.set(hunks.size() - 1, new HunkRange(
+                            previous.oldFrom(), Math.max(previous.oldTo(), next.oldTo()),
+                            previous.newFrom(), Math.max(previous.newTo(), next.newTo())
+                    ));
+                    continue;
+                }
+            }
+            hunks.add(next);
+        }
+        return hunks;
+    }
+
+    private static HunkRange singleHunk(
+            List<String> beforeLines,
+            List<String> afterLines,
+            int oldChangeStart,
+            int oldChangeEnd,
+            int newChangeStart,
+            int newChangeEnd
+    ) {
+        int oldFrom = Math.max(0, oldChangeStart - CONTEXT_LINES);
+        int newFrom = Math.max(0, newChangeStart - CONTEXT_LINES);
+        int oldTo = Math.min(beforeLines.size(), oldChangeEnd + CONTEXT_LINES);
+        int newTo = Math.min(afterLines.size(), newChangeEnd + CONTEXT_LINES);
+        return new HunkRange(oldFrom, oldTo, newFrom, newTo);
+    }
+
+    private static boolean containsNullByte(String content) {
+        return content.indexOf('\0') >= 0;
+    }
+
+    private static int countLines(String content) {
+        if (content.isEmpty()) {
+            return 1;
+        }
+        int lines = 1;
+        for (int i = 0; i < content.length(); i++) {
+            if (content.charAt(i) == '\n') {
+                lines++;
+            }
+        }
+        return lines;
+    }
+
+    private static List<String> splitLinesPreserveEndings(String content) {
+        List<String> lines = new ArrayList<>();
+        if (content.isEmpty()) {
+            return lines;
+        }
+        int start = 0;
+        for (int i = 0; i < content.length(); i++) {
+            if (content.charAt(i) == '\n') {
+                lines.add(content.substring(start, i + 1));
+                start = i + 1;
+            }
+        }
+        if (start < content.length()) {
+            lines.add(content.substring(start));
+        }
+        return lines;
+    }
+
+    private static String join(List<String> lines, int fromInclusive, int toExclusive) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = fromInclusive; i < toExclusive; i++) {
+            builder.append(lines.get(i));
+        }
+        return builder.toString();
+    }
+
+    private static String sha256(String content) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest((content != null ? content : "").getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            return Integer.toHexString((content != null ? content : "").hashCode());
+        }
+    }
+
+    private record RawRange(int oldStart, int oldEnd, int newStart, int newEnd) {
+    }
+
+    private record HunkRange(int oldFrom, int oldTo, int newFrom, int newTo) {
+    }
+
+    public record Operation(
+            String toolName,
+            String filePath,
+            String oldString,
+            String newString,
+            boolean replaceAll,
+            int lineStart,
+            int lineEnd,
+            boolean safeToRollback,
+            String expectedAfterContentHash
+    ) {
+    }
+}

--- a/src/main/java/com/github/claudecodegui/util/FileSnapshotUtil.java
+++ b/src/main/java/com/github/claudecodegui/util/FileSnapshotUtil.java
@@ -1,0 +1,171 @@
+package com.github.claudecodegui.util;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Conservative project text snapshot utilities for sub-agent edit scopes.
+ */
+public final class FileSnapshotUtil {
+
+    private static final long MAX_FILE_BYTES = 1024 * 1024;
+    private static final int MAX_FILES = 5000;
+
+    private FileSnapshotUtil() {
+    }
+
+    public static Map<String, FileSnapshot> captureProjectSnapshot(Project project) {
+        if (project == null || project.getBasePath() == null) {
+            return Map.of();
+        }
+        return captureDirectorySnapshot(Path.of(project.getBasePath()));
+    }
+
+    public static Map<String, FileSnapshot> captureDirectorySnapshot(Path root) {
+        if (root == null || !Files.isDirectory(root)) {
+            return Map.of();
+        }
+        Map<String, FileSnapshot> snapshots = new HashMap<>();
+        try {
+            Path realRoot = root.toRealPath().normalize();
+            try (Stream<Path> stream = Files.walk(realRoot)) {
+                stream
+                        .filter(path -> !Files.isSymbolicLink(path))
+                        .filter(path -> Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS))
+                        .filter(path -> isWithin(realRoot, path))
+                        .filter(path -> !isExcluded(realRoot, path))
+                        .limit(MAX_FILES)
+                        .forEach(path -> readSnapshot(realRoot, path).ifPresent(snapshot -> snapshots.put(snapshot.path(), snapshot)));
+            }
+        } catch (IOException e) {
+            return snapshots;
+        }
+        return snapshots;
+    }
+
+    public static java.util.Optional<FileSnapshot> readSnapshot(Path path) {
+        return readSnapshot(null, path);
+    }
+
+    private static java.util.Optional<FileSnapshot> readSnapshot(Path root, Path path) {
+        try {
+            if (path == null || Files.isSymbolicLink(path) || !Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
+                return java.util.Optional.empty();
+            }
+            if (root != null && !isWithin(root, path)) {
+                return java.util.Optional.empty();
+            }
+            long length = Files.size(path);
+            if (length > MAX_FILE_BYTES) {
+                return java.util.Optional.empty();
+            }
+            byte[] bytes = Files.readAllBytes(path);
+            boolean binary = isBinary(bytes);
+            Charset charset = resolveCharset(path);
+            String content = binary ? "" : new String(bytes, charset);
+            return java.util.Optional.of(new FileSnapshot(
+                    path.toAbsolutePath().normalize().toString(),
+                    true,
+                    binary,
+                    content,
+                    length,
+                    Files.getLastModifiedTime(path).toMillis(),
+                    sha256(bytes)
+            ));
+        } catch (IOException e) {
+            return java.util.Optional.empty();
+        }
+    }
+
+    public static FileSnapshot nonExistingSnapshot(String path) {
+        String normalizedPath;
+        try {
+            normalizedPath = Path.of(path).toAbsolutePath().normalize().toString();
+        } catch (Exception e) {
+            normalizedPath = path;
+        }
+        return new FileSnapshot(normalizedPath, false, false, "", 0L, 0L, "");
+    }
+
+    private static Charset resolveCharset(Path path) {
+        try {
+            VirtualFile virtualFile = LocalFileSystem.getInstance().findFileByNioFile(path);
+            if (virtualFile != null && virtualFile.getCharset() != null) {
+                return virtualFile.getCharset();
+            }
+        } catch (Exception ignored) {
+        }
+        return StandardCharsets.UTF_8;
+    }
+
+    private static boolean isExcluded(Path root, Path path) {
+        Path relative;
+        try {
+            relative = root.relativize(path);
+        } catch (IllegalArgumentException e) {
+            return true;
+        }
+        for (Path part : relative) {
+            String name = part.toString();
+            if (name.equals(".git") || name.equals(".idea") || name.equals("build")
+                    || name.equals("out") || name.equals("node_modules") || name.equals("dist")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isWithin(Path root, Path path) {
+        try {
+            Path normalizedRoot = root.normalize();
+            Path normalizedPath = path.toAbsolutePath().normalize();
+            return normalizedPath.startsWith(normalizedRoot);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static boolean isBinary(byte[] bytes) {
+        int limit = Math.min(bytes.length, 8192);
+        for (int i = 0; i < limit; i++) {
+            if (bytes[i] == 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String sha256(byte[] bytes) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(bytes));
+        } catch (NoSuchAlgorithmException e) {
+            return Integer.toHexString(java.util.Arrays.hashCode(bytes));
+        }
+    }
+
+    public record FileSnapshot(
+            String path,
+            boolean existed,
+            boolean binary,
+            String content,
+            long length,
+            long modifiedAtMillis,
+            String contentHash
+    ) {
+    }
+}

--- a/src/main/java/com/github/claudecodegui/util/FileSnapshotUtil.java
+++ b/src/main/java/com/github/claudecodegui/util/FileSnapshotUtil.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -15,6 +16,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.HexFormat;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
 /**
@@ -23,6 +25,7 @@ import java.util.stream.Stream;
 public final class FileSnapshotUtil {
 
     private static final long MAX_FILE_BYTES = 1024 * 1024;
+    private static final long MAX_TOTAL_BYTES = 32L * 1024L * 1024L;
     private static final int MAX_FILES = 5000;
 
     private FileSnapshotUtil() {
@@ -42,6 +45,7 @@ public final class FileSnapshotUtil {
         Map<String, FileSnapshot> snapshots = new HashMap<>();
         try {
             Path realRoot = root.toRealPath().normalize();
+            AtomicLong totalBytes = new AtomicLong();
             try (Stream<Path> stream = Files.walk(realRoot)) {
                 stream
                         .filter(path -> !Files.isSymbolicLink(path))
@@ -49,7 +53,12 @@ public final class FileSnapshotUtil {
                         .filter(path -> isWithin(realRoot, path))
                         .filter(path -> !isExcluded(realRoot, path))
                         .limit(MAX_FILES)
-                        .forEach(path -> readSnapshot(realRoot, path).ifPresent(snapshot -> snapshots.put(snapshot.path(), snapshot)));
+                        .forEach(path -> readSnapshot(realRoot, path).ifPresent(snapshot -> {
+                            if (totalBytes.get() + snapshot.length() <= MAX_TOTAL_BYTES) {
+                                snapshots.put(snapshot.path(), snapshot);
+                                totalBytes.addAndGet(snapshot.length());
+                            }
+                        }));
             }
         } catch (IOException e) {
             return snapshots;
@@ -66,24 +75,34 @@ public final class FileSnapshotUtil {
             if (path == null || Files.isSymbolicLink(path) || !Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)) {
                 return java.util.Optional.empty();
             }
-            if (root != null && !isWithin(root, path)) {
+            Path realPath = path.toRealPath(LinkOption.NOFOLLOW_LINKS).normalize();
+            if (root != null && !isWithin(root, realPath)) {
                 return java.util.Optional.empty();
             }
-            long length = Files.size(path);
+            if (Files.isSymbolicLink(realPath) || !Files.isRegularFile(realPath, LinkOption.NOFOLLOW_LINKS)) {
+                return java.util.Optional.empty();
+            }
+            long length = Files.size(realPath);
             if (length > MAX_FILE_BYTES) {
                 return java.util.Optional.empty();
             }
-            byte[] bytes = Files.readAllBytes(path);
+            byte[] bytes;
+            try (InputStream inputStream = Files.newInputStream(realPath, LinkOption.NOFOLLOW_LINKS)) {
+                bytes = inputStream.readNBytes((int) MAX_FILE_BYTES + 1);
+            }
+            if (bytes.length > MAX_FILE_BYTES) {
+                return java.util.Optional.empty();
+            }
             boolean binary = isBinary(bytes);
-            Charset charset = resolveCharset(path);
+            Charset charset = resolveCharset(realPath);
             String content = binary ? "" : new String(bytes, charset);
             return java.util.Optional.of(new FileSnapshot(
-                    path.toAbsolutePath().normalize().toString(),
+                    realPath.toAbsolutePath().normalize().toString(),
                     true,
                     binary,
                     content,
                     length,
-                    Files.getLastModifiedTime(path).toMillis(),
+                    Files.getLastModifiedTime(realPath).toMillis(),
                     sha256(bytes)
             ));
         } catch (IOException e) {

--- a/src/main/java/com/github/claudecodegui/util/UndoOperationApplier.java
+++ b/src/main/java/com/github/claudecodegui/util/UndoOperationApplier.java
@@ -1,0 +1,249 @@
+package com.github.claudecodegui.util;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HexFormat;
+import java.util.List;
+
+/**
+ * Applies reverse edit operations to in-memory text.
+ */
+public final class UndoOperationApplier {
+
+    private UndoOperationApplier() {
+    }
+
+    public static Result reverseEdits(String originalContent, JsonArray operations) {
+        String content = originalContent != null ? originalContent : "";
+        List<Failure> failures = new ArrayList<>();
+
+        if (operations == null || operations.isEmpty()) {
+            return Result.failure(content, List.of(new Failure(-1, "no_operations", "No operations to undo")));
+        }
+
+        String expectedAfterContentHash = firstExpectedAfterContentHash(operations);
+        if (expectedAfterContentHash != null && !expectedAfterContentHash.equals(sha256(content))) {
+            return Result.failure(content, List.of(new Failure(-1, "content_changed", "Current content no longer matches the captured LLM result")));
+        }
+
+        for (int i = operations.size() - 1; i >= 0; i--) {
+            JsonObject op = operations.get(i).getAsJsonObject();
+            String oldString = getString(op, "oldString", "old_string");
+            String newString = getString(op, "newString", "new_string");
+            boolean replaceAll = getBoolean(op, "replaceAll", "replace_all");
+            Boolean safeToRollback = getOptionalBoolean(op, "safeToRollback", "safe_to_rollback");
+
+            if (Boolean.FALSE.equals(safeToRollback)) {
+                failures.add(new Failure(i, "unsafe_to_rollback", "Operation is marked unsafe to rollback"));
+                continue;
+            }
+
+            if (newString.isEmpty()) {
+                failures.add(new Failure(i, "empty_new_string_unsupported", "Cannot safely undo an operation with an empty newString"));
+                continue;
+            }
+
+            if (replaceAll) {
+                if (!content.contains(newString)) {
+                    failures.add(new Failure(i, "new_string_not_found", "Could not find newString to replace"));
+                    continue;
+                }
+                content = content.replace(newString, oldString);
+                continue;
+            }
+
+            MatchResult match = findReplacementMatch(content, newString, op);
+            if (!match.success()) {
+                failures.add(new Failure(i, match.reason(), match.message()));
+                continue;
+            }
+            int index = match.index();
+            content = content.substring(0, index) + oldString + content.substring(index + newString.length());
+        }
+
+        if (!failures.isEmpty()) {
+            return Result.failure(originalContent != null ? originalContent : "", failures);
+        }
+        return Result.success(content);
+    }
+
+    private static MatchResult findReplacementMatch(String content, String newString, JsonObject op) {
+        Integer lineStart = getInteger(op, "lineStart", "start_line");
+        Integer lineEnd = getInteger(op, "lineEnd", "end_line");
+        if (lineStart != null && lineStart > 0) {
+            int searchStartLine = Math.max(1, lineStart - 1);
+            int searchEndLine = lineEnd != null && lineEnd >= lineStart ? lineEnd + 1 : lineStart + 1;
+            int searchStart = charOffsetForLine(content, searchStartLine);
+            int searchEnd = charOffsetForLine(content, searchEndLine + 1);
+            List<Integer> nearbyMatches = findOccurrences(content, newString, searchStart, searchEnd);
+            if (nearbyMatches.size() == 1) {
+                return MatchResult.success(nearbyMatches.get(0));
+            }
+            if (nearbyMatches.size() > 1) {
+                return MatchResult.failure("ambiguous_match", "Multiple nearby matches for newString");
+            }
+        }
+
+        List<Integer> allMatches = findOccurrences(content, newString, 0, content.length());
+        if (allMatches.isEmpty()) {
+            return MatchResult.failure("new_string_not_found", "Could not find newString to replace");
+        }
+        if (allMatches.size() > 1) {
+            return MatchResult.failure("ambiguous_match", "Multiple matches for newString");
+        }
+        return MatchResult.success(allMatches.get(0));
+    }
+
+    private static List<Integer> findOccurrences(String content, String needle, int startInclusive, int endExclusive) {
+        List<Integer> indexes = new ArrayList<>();
+        if (needle.isEmpty()) {
+            return indexes;
+        }
+        int fromIndex = Math.max(0, startInclusive);
+        int limit = Math.min(content.length(), Math.max(startInclusive, endExclusive));
+        while (fromIndex <= limit) {
+            int index = content.indexOf(needle, fromIndex);
+            if (index < 0 || index + needle.length() > limit) {
+                break;
+            }
+            indexes.add(index);
+            fromIndex = index + Math.max(1, needle.length());
+        }
+        return indexes;
+    }
+
+    private static int charOffsetForLine(String content, int oneBasedLine) {
+        if (oneBasedLine <= 1) {
+            return 0;
+        }
+        int currentLine = 1;
+        for (int i = 0; i < content.length(); i++) {
+            if (content.charAt(i) == '\n') {
+                currentLine++;
+                if (currentLine == oneBasedLine) {
+                    return i + 1;
+                }
+            }
+        }
+        return content.length();
+    }
+
+    private static String getString(JsonObject op, String camelName, String snakeName) {
+        if (op.has(camelName) && !op.get(camelName).isJsonNull()) {
+            return op.get(camelName).getAsString();
+        }
+        if (op.has(snakeName) && !op.get(snakeName).isJsonNull()) {
+            return op.get(snakeName).getAsString();
+        }
+        return "";
+    }
+
+    private static boolean getBoolean(JsonObject op, String camelName, String snakeName) {
+        if (op.has(camelName) && !op.get(camelName).isJsonNull()) {
+            return op.get(camelName).getAsBoolean();
+        }
+        return op.has(snakeName) && !op.get(snakeName).isJsonNull() && op.get(snakeName).getAsBoolean();
+    }
+
+    private static Boolean getOptionalBoolean(JsonObject op, String camelName, String snakeName) {
+        if (op.has(camelName) && !op.get(camelName).isJsonNull()) {
+            return op.get(camelName).getAsBoolean();
+        }
+        if (op.has(snakeName) && !op.get(snakeName).isJsonNull()) {
+            return op.get(snakeName).getAsBoolean();
+        }
+        return null;
+    }
+
+    private static Integer getInteger(JsonObject op, String camelName, String snakeName) {
+        if (op.has(camelName) && !op.get(camelName).isJsonNull()) {
+            return op.get(camelName).getAsInt();
+        }
+        if (op.has(snakeName) && !op.get(snakeName).isJsonNull()) {
+            return op.get(snakeName).getAsInt();
+        }
+        return null;
+    }
+
+    private static String firstExpectedAfterContentHash(JsonArray operations) {
+        for (int i = 0; i < operations.size(); i++) {
+            if (!operations.get(i).isJsonObject()) {
+                continue;
+            }
+            JsonObject op = operations.get(i).getAsJsonObject();
+            String hash = getString(op, "expectedAfterContentHash", "expected_after_content_hash");
+            if (!hash.isBlank()) {
+                return hash;
+            }
+        }
+        return null;
+    }
+
+    private static String sha256(String content) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest((content != null ? content : "").getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            return Integer.toHexString((content != null ? content : "").hashCode());
+        }
+    }
+
+    private record MatchResult(boolean success, int index, String reason, String message) {
+        static MatchResult success(int index) {
+            return new MatchResult(true, index, null, null);
+        }
+
+        static MatchResult failure(String reason, String message) {
+            return new MatchResult(false, -1, reason, message);
+        }
+    }
+
+    public static final class Result {
+        private final boolean success;
+        private final String content;
+        private final List<Failure> failures;
+
+        private Result(boolean success, String content, List<Failure> failures) {
+            this.success = success;
+            this.content = content;
+            this.failures = Collections.unmodifiableList(new ArrayList<>(failures));
+        }
+
+        public static Result success(String content) {
+            return new Result(true, content, List.of());
+        }
+
+        public static Result failure(String content, List<Failure> failures) {
+            return new Result(false, content, failures);
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public String getContent() {
+            return content;
+        }
+
+        public List<Failure> getFailures() {
+            return failures;
+        }
+
+        public String toErrorMessage() {
+            if (failures.isEmpty()) {
+                return "Undo failed";
+            }
+            Failure first = failures.get(0);
+            return first.reason() + ": " + first.message();
+        }
+    }
+
+    public record Failure(int operationIndex, String reason, String message) {
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
     <id>com.github.idea-claude-code-gui</id>
-    <name>CC GUI（Claude or Codex）</name>
+    <name>CC GUI (Claude or Codex)</name>
     <vendor>MossX</vendor>
 
     <!-- Resource bundle for i18n -->

--- a/src/test/java/com/github/claudecodegui/handler/CodexMessageConverterTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/CodexMessageConverterTest.java
@@ -100,7 +100,7 @@ public class CodexMessageConverterTest {
         JsonObject result = CodexMessageConverter.convertFunctionCallOutputToToolResult(payload, null);
 
         JsonObject toolResult = extractFirstToolResult(result);
-        assertEquals("unknown", toolResult.get("tool_use_id").getAsString());
+        assertTrue(toolResult.get("tool_use_id").getAsString().startsWith("codex_history_"));
     }
 
     @Test
@@ -233,7 +233,7 @@ public class CodexMessageConverterTest {
 
         JsonObject toolUse = extractFirstBlock(result);
         assertEquals("unknown", toolUse.get("name").getAsString());
-        assertEquals("unknown", toolUse.get("id").getAsString());
+        assertTrue(toolUse.get("id").getAsString().startsWith("codex_history_"));
     }
 
     // ---- helpers ----

--- a/src/test/java/com/github/claudecodegui/handler/diff/EditableDiffHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/diff/EditableDiffHandlerTest.java
@@ -1,0 +1,38 @@
+package com.github.claudecodegui.handler.diff;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class EditableDiffHandlerTest {
+
+    @Test
+    public void operationsAreUnsafeWhenAnyOperationDisallowsRollback() {
+        JsonArray operations = new JsonArray();
+        operations.add(operation(true));
+        operations.add(operation(false));
+
+        assertFalse(EditableDiffHandler.areOperationsSafeToRollback(operations));
+    }
+
+    @Test
+    public void operationsAreSafeWhenSafetyFlagIsMissingOrTrue() {
+        JsonArray operations = new JsonArray();
+        operations.add(operation(true));
+        JsonObject missingFlag = new JsonObject();
+        missingFlag.addProperty("newString", "content");
+        operations.add(missingFlag);
+
+        assertTrue(EditableDiffHandler.areOperationsSafeToRollback(operations));
+    }
+
+    private static JsonObject operation(boolean safe) {
+        JsonObject operation = new JsonObject();
+        operation.addProperty("newString", "content");
+        operation.addProperty("safeToRollback", safe);
+        return operation;
+    }
+}

--- a/src/test/java/com/github/claudecodegui/handler/diff/SimpleDiffDisplayHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/diff/SimpleDiffDisplayHandlerTest.java
@@ -1,0 +1,44 @@
+package com.github.claudecodegui.handler.diff;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SimpleDiffDisplayHandlerTest {
+
+    @Test
+    public void applyForwardEditsForPreviewFailsClosedOnAmbiguousOldString() {
+        JsonArray edits = new JsonArray();
+        edits.add(edit("same", "changed", false));
+
+        SimpleDiffDisplayHandler.ForwardApplyResult result = SimpleDiffDisplayHandler.applyForwardEditsForPreview(
+                "same\nother\nsame\n", edits);
+
+        assertFalse(result.success());
+        assertEquals("ambiguous_old_string", result.reason());
+    }
+
+    @Test
+    public void applyForwardEditsForPreviewAppliesUniqueEdit() {
+        JsonArray edits = new JsonArray();
+        edits.add(edit("before", "after", false));
+
+        SimpleDiffDisplayHandler.ForwardApplyResult result = SimpleDiffDisplayHandler.applyForwardEditsForPreview(
+                "line\nbefore\n", edits);
+
+        assertTrue(result.success());
+        assertEquals("line\nafter\n", result.content());
+    }
+
+    private static JsonObject edit(String oldString, String newString, boolean replaceAll) {
+        JsonObject edit = new JsonObject();
+        edit.addProperty("oldString", oldString);
+        edit.addProperty("newString", newString);
+        edit.addProperty("replaceAll", replaceAll);
+        return edit;
+    }
+}

--- a/src/test/java/com/github/claudecodegui/handler/file/UndoFileHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/file/UndoFileHandlerTest.java
@@ -1,0 +1,104 @@
+package com.github.claudecodegui.handler.file;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class UndoFileHandlerTest {
+
+    @Test
+    public void detectsUnsafeSnakeCaseRollbackOperation() {
+        JsonArray operations = new JsonArray();
+        JsonObject operation = new JsonObject();
+        operation.addProperty("safe_to_rollback", false);
+        operations.add(operation);
+
+        assertTrue(UndoFileHandler.hasUnsafeOperation(operations));
+    }
+
+    @Test
+    public void detectsUnsafeCamelCaseRollbackOperation() {
+        JsonArray operations = new JsonArray();
+        JsonObject operation = new JsonObject();
+        operation.addProperty("safeToRollback", false);
+        operations.add(operation);
+
+        assertTrue(UndoFileHandler.hasUnsafeOperation(operations));
+    }
+
+    @Test
+    public void missingRollbackSafetyFlagDefaultsToSafeForLegacyRequests() {
+        JsonArray operations = new JsonArray();
+        operations.add(new JsonObject());
+
+        assertFalse(UndoFileHandler.hasUnsafeOperation(operations));
+        assertFalse(UndoFileHandler.hasUnsafeOperation(null));
+    }
+
+    @Test
+    public void batchUndoRollsBackAppliedActionsWhenLaterActionFails() {
+        List<String> events = new ArrayList<>();
+        UndoFileHandler.BatchUndoAction first = new RecordingAction("first", events, false);
+        UndoFileHandler.BatchUndoAction second = new RecordingAction("second", events, true);
+
+        UndoFileHandler.BatchUndoExecution execution = UndoFileHandler.executeBatchUndoActions(List.of(first, second), null);
+
+        assertFalse(execution.success());
+        assertEquals(List.of("apply:first", "apply:second", "rollback:first"), events);
+        assertEquals(1, execution.appliedCount());
+    }
+
+    @Test
+    public void batchUndoDoesNotRollbackWhenCleanupFailsAfterAllActionsApplied() {
+        List<String> events = new ArrayList<>();
+        UndoFileHandler.BatchUndoAction first = new CleanupFailingAction("first", events);
+
+        UndoFileHandler.BatchUndoExecution execution = UndoFileHandler.executeBatchUndoActions(List.of(first), null);
+
+        assertTrue(execution.success());
+        assertEquals(List.of("apply:first", "afterCommit:first"), events);
+        assertEquals(1, execution.appliedCount());
+    }
+
+    private record RecordingAction(String filePath, List<String> events, boolean fail)
+            implements UndoFileHandler.BatchUndoAction {
+        @Override
+        public void apply() throws Exception {
+            events.add("apply:" + filePath);
+            if (fail) {
+                throw new Exception("failed:" + filePath);
+            }
+        }
+
+        @Override
+        public void rollback() {
+            events.add("rollback:" + filePath);
+        }
+    }
+
+    private record CleanupFailingAction(String filePath, List<String> events)
+            implements UndoFileHandler.BatchUndoAction {
+        @Override
+        public void apply() {
+            events.add("apply:" + filePath);
+        }
+
+        @Override
+        public void rollback() {
+            events.add("rollback:" + filePath);
+        }
+
+        @Override
+        public void afterCommit() throws Exception {
+            events.add("afterCommit:" + filePath);
+            throw new Exception("cleanup failed");
+        }
+    }
+}

--- a/src/test/java/com/github/claudecodegui/session/ClaudeMessageHandlerDedupTest.java
+++ b/src/test/java/com/github/claudecodegui/session/ClaudeMessageHandlerDedupTest.java
@@ -2,6 +2,8 @@ package com.github.claudecodegui.session;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -18,12 +20,13 @@ import static org.junit.Assert.assertTrue;
 public class ClaudeMessageHandlerDedupTest {
 
     private RecordingCallbackHandler callbackHandler;
+    private SessionState state;
     private ClaudeMessageHandler handler;
 
     @Before
     public void setUp() {
         callbackHandler = new RecordingCallbackHandler();
-        SessionState state = new SessionState();
+        state = new SessionState();
         MessageParser messageParser = new MessageParser();
         MessageMerger messageMerger = new MessageMerger();
         Gson gson = new GsonBuilder().create();
@@ -36,6 +39,46 @@ public class ClaudeMessageHandlerDedupTest {
                 messageMerger,
                 gson
         );
+    }
+
+
+    @Test
+    public void toolResultDeliveredThroughUserAndToolResultChannelsIsAddedOnce() {
+        String userToolResult = """
+                {"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tool-1","content":"done"}]}}
+                """;
+        String toolResultBlock = """
+                {"type":"tool_result","tool_use_id":"tool-1","content":"done"}
+                """;
+
+        handler.onMessage("user", userToolResult);
+        handler.onMessage("tool_result", toolResultBlock);
+
+        assertEquals("Duplicate tool_result should only be stored once", 1, state.getMessages().size());
+        assertEquals("Only one message update should be emitted", 1, callbackHandler.messageUpdateCount);
+    }
+
+
+    @Test
+    public void mixedToolResultUserMessageKeepsOnlyUnprocessedBlocks() {
+        String standaloneToolResult = """
+                {"type":"tool_result","tool_use_id":"tool-1","content":"done"}
+                """;
+        String mixedUserMessage = """
+                {"type":"user","message":{"content":[
+                  {"type":"tool_result","tool_use_id":"tool-1","content":"done"},
+                  {"type":"tool_result","tool_use_id":"tool-2","content":"new"}
+                ]}}
+                """;
+
+        handler.onMessage("tool_result", standaloneToolResult);
+        handler.onMessage("user", mixedUserMessage);
+
+        assertEquals(2, state.getMessages().size());
+        JsonObject raw = state.getMessages().get(1).raw;
+        JsonArray blocks = raw.getAsJsonObject("message").getAsJsonArray("content");
+        assertEquals("Only the unprocessed tool_result block should remain", 1, blocks.size());
+        assertEquals("tool-2", blocks.get(0).getAsJsonObject().get("tool_use_id").getAsString());
     }
 
     /**
@@ -302,10 +345,17 @@ public class ClaudeMessageHandlerDedupTest {
         final List<String> thinkingDeltas = new ArrayList<>();
         int streamStartCount = 0;
         int streamEndCount = 0;
+        int messageUpdateCount = 0;
 
         void clear() {
             contentDeltas.clear();
             thinkingDeltas.clear();
+            messageUpdateCount = 0;
+        }
+
+        @Override
+        public void notifyMessageUpdate(List<ClaudeSession.Message> messages) {
+            messageUpdateCount++;
         }
 
         @Override

--- a/src/test/java/com/github/claudecodegui/session/ClaudeMessageHandlerSubagentEditsTest.java
+++ b/src/test/java/com/github/claudecodegui/session/ClaudeMessageHandlerSubagentEditsTest.java
@@ -1,0 +1,63 @@
+package com.github.claudecodegui.session;
+
+import com.github.claudecodegui.util.FileSnapshotUtil;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ClaudeMessageHandlerSubagentEditsTest {
+    private SessionState state;
+    private RecordingCallbackHandler callbackHandler;
+    private SubagentEditScopeTracker tracker;
+    private ClaudeMessageHandler handler;
+
+    @Before
+    public void setUp() {
+        state = new SessionState();
+        callbackHandler = new RecordingCallbackHandler();
+        tracker = new SubagentEditScopeTracker(null, new EditOperationRegistry());
+        Gson gson = new GsonBuilder().create();
+        handler = new ClaudeMessageHandler(
+                null,
+                state,
+                callbackHandler,
+                new MessageParser(),
+                new MessageMerger(),
+                gson,
+                new SubagentLifecycleDetector(),
+                tracker
+        );
+    }
+
+    @Test
+    public void taskCompletionAppendsSyntheticEditMessages() {
+        handler.onMessage("assistant", """
+                {"type":"assistant","message":{"content":[{"type":"tool_use","id":"task-1","name":"Task","input":{}}]}}
+                """);
+        tracker.recordBeforeSnapshot("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "old\n", 4, 1L, "h1"));
+        tracker.recordAfterSnapshotForTest(Map.of("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "new\n", 4, 2L, "h2")));
+
+        handler.onMessage("user", """
+                {"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"task-1","content":"done"}]}}
+                """);
+
+        assertEquals(4, state.getMessages().size());
+        assertEquals(ClaudeSession.Message.Type.ASSISTANT, state.getMessages().get(2).type);
+        assertTrue(state.getMessages().get(2).raw.get("isMeta").getAsBoolean());
+    }
+
+    private static class RecordingCallbackHandler extends CallbackHandler {
+        int messageUpdateCount = 0;
+
+        @Override
+        public void notifyMessageUpdate(java.util.List<ClaudeSession.Message> messages) {
+            messageUpdateCount++;
+        }
+    }
+}

--- a/src/test/java/com/github/claudecodegui/session/CodexMessageHandlerSubagentEditsTest.java
+++ b/src/test/java/com/github/claudecodegui/session/CodexMessageHandlerSubagentEditsTest.java
@@ -1,0 +1,53 @@
+package com.github.claudecodegui.session;
+
+import com.github.claudecodegui.util.FileSnapshotUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CodexMessageHandlerSubagentEditsTest {
+    private SessionState state;
+    private RecordingCallbackHandler callbackHandler;
+    private SubagentEditScopeTracker tracker;
+    private CodexMessageHandler handler;
+
+    @Before
+    public void setUp() {
+        state = new SessionState();
+        callbackHandler = new RecordingCallbackHandler();
+        tracker = new SubagentEditScopeTracker(null, new EditOperationRegistry());
+        handler = new CodexMessageHandler(state, callbackHandler, new SubagentLifecycleDetector(), tracker);
+    }
+
+    @Test
+    public void waitAgentCompletionAppendsSyntheticEditMessages() {
+        handler.onMessage("assistant", """
+                {"type":"assistant","message":{"content":[{"type":"tool_use","id":"spawn-1","name":"spawn_agent","input":{}}]}}
+                """);
+        handler.onMessage("user", """
+                {"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"spawn-1","content":"{\\"agent_id\\":\\"agent-1\\"}"}]}}
+                """);
+        tracker.recordBeforeSnapshot("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "old", 3, 1L, "h1"));
+        tracker.recordAfterSnapshotForTest(Map.of("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "new", 3, 2L, "h2")));
+        handler.onMessage("assistant", """
+                {"type":"assistant","message":{"content":[{"type":"tool_use","id":"wait-1","name":"wait_agent","input":{"target":"agent-1"}}]}}
+                """);
+
+        handler.onMessage("user", """
+                {"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"wait-1","content":"done"}]}}
+                """);
+
+        assertEquals(6, state.getMessages().size());
+        assertTrue(state.getMessages().get(4).raw.get("isMeta").getAsBoolean());
+    }
+
+    private static class RecordingCallbackHandler extends CallbackHandler {
+        @Override
+        public void notifyMessageUpdate(java.util.List<ClaudeSession.Message> messages) {
+        }
+    }
+}

--- a/src/test/java/com/github/claudecodegui/session/SubagentEditScopeTrackerTest.java
+++ b/src/test/java/com/github/claudecodegui/session/SubagentEditScopeTrackerTest.java
@@ -55,6 +55,23 @@ public class SubagentEditScopeTrackerTest {
     }
 
     @Test
+    public void completeScopeBuildsSyntheticMessagesFromBaselineWithoutVfsBeforeEvent() {
+        SubagentEditScopeTracker tracker = new SubagentEditScopeTracker(null, new EditOperationRegistry());
+        tracker.startScope("claude", "task-baseline", null);
+        tracker.recordBaselineForTest(Map.of(
+                "/tmp/Baseline.java", new FileSnapshotUtil.FileSnapshot("/tmp/Baseline.java", true, false, "old", 3, 1L, "h1")
+        ));
+        tracker.recordAfterSnapshotForTest(Map.of(
+                "/tmp/Baseline.java", new FileSnapshotUtil.FileSnapshot("/tmp/Baseline.java", true, false, "new", 3, 2L, "h2")
+        ));
+
+        List<ClaudeSession.Message> messages = tracker.completeByParentToolUseId("task-baseline", "token-baseline");
+
+        assertEquals(2, messages.size());
+        assertTrue(messages.get(0).raw.toString().contains("Baseline.java"));
+    }
+
+    @Test
     public void completeScopeFinalizesOnlyOnceAcrossDifferentTokens() {
         SubagentEditScopeTracker tracker = new SubagentEditScopeTracker(null, new EditOperationRegistry());
         tracker.startScope("codex", "spawn-1", "agent-1");
@@ -157,6 +174,21 @@ public class SubagentEditScopeTrackerTest {
 
         assertEquals(2, tracker.completeByAgentHandle("agent-1", "wait-1").size());
         assertTrue(tracker.completeByAgentHandle("agent-2", "wait-2").isEmpty());
+    }
+
+    @Test
+    public void overlappingScopesDoNotAttributeBaselineOnlyChanges() {
+        SubagentEditScopeTracker tracker = new SubagentEditScopeTracker(null, new EditOperationRegistry());
+        tracker.startScope("codex", "spawn-1", "agent-1");
+        tracker.recordBaselineForTest(Map.of(
+                "/tmp/A.java", new FileSnapshotUtil.FileSnapshot("/tmp/A.java", true, false, "a1", 2, 1L, "a1")
+        ));
+        tracker.startScope("codex", "spawn-2", "agent-2");
+        tracker.recordAfterSnapshotForTest(Map.of(
+                "/tmp/A.java", new FileSnapshotUtil.FileSnapshot("/tmp/A.java", true, false, "a2", 2, 2L, "a2")
+        ));
+
+        assertTrue(tracker.completeByAgentHandle("agent-1", "wait-1").isEmpty());
     }
 
 

--- a/src/test/java/com/github/claudecodegui/session/SubagentEditScopeTrackerTest.java
+++ b/src/test/java/com/github/claudecodegui/session/SubagentEditScopeTrackerTest.java
@@ -1,0 +1,198 @@
+package com.github.claudecodegui.session;
+
+import com.github.claudecodegui.util.FileSnapshotUtil;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SubagentEditScopeTrackerTest {
+
+    @Test
+    public void completeScopeBuildsSyntheticMessagesForManualDelta() {
+        SubagentEditScopeTracker tracker = new SubagentEditScopeTracker(null, new EditOperationRegistry());
+        tracker.startScope("claude", "task-1", null);
+        tracker.recordBeforeSnapshot("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "old\n", 4, 1L, "h1"));
+        tracker.recordAfterSnapshotForTest(Map.of("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "new\n", 4, 2L, "h2")));
+
+        List<ClaudeSession.Message> messages = tracker.completeByParentToolUseId("task-1", "token-1");
+
+        assertEquals(2, messages.size());
+        assertTrue(messages.get(0).raw.getAsJsonObject("message").getAsJsonArray("content").size() > 0);
+    }
+
+    @Test
+    public void completeScopeIsIdempotentForSameToken() {
+        SubagentEditScopeTracker tracker = new SubagentEditScopeTracker(null, new EditOperationRegistry());
+        tracker.startScope("claude", "task-1", null);
+        tracker.recordBeforeSnapshot("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "old", 3, 1L, "h1"));
+        tracker.recordAfterSnapshotForTest(Map.of("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "new", 3, 2L, "h2")));
+
+        assertEquals(2, tracker.completeByParentToolUseId("task-1", "token-1").size());
+        assertTrue(tracker.completeByParentToolUseId("task-1", "token-1").isEmpty());
+    }
+
+    @Test
+    public void completeScopeIgnoresUnrecordedAfterOnlyPaths() {
+        SubagentEditScopeTracker tracker = new SubagentEditScopeTracker(null, new EditOperationRegistry());
+        tracker.startScope("claude", "task-1", null);
+        tracker.recordBeforeSnapshot("/tmp/Tracked.java", new FileSnapshotUtil.FileSnapshot("/tmp/Tracked.java", true, false, "old", 3, 1L, "h1"));
+        tracker.recordAfterSnapshotForTest(Map.of(
+                "/tmp/Tracked.java", new FileSnapshotUtil.FileSnapshot("/tmp/Tracked.java", true, false, "new", 3, 2L, "h2"),
+                "/tmp/Untracked.java", new FileSnapshotUtil.FileSnapshot("/tmp/Untracked.java", true, false, "created elsewhere", 17, 2L, "h3")
+        ));
+
+        List<ClaudeSession.Message> messages = tracker.completeByParentToolUseId("task-1", "token-1");
+        String raw = messages.get(0).raw.toString();
+
+        assertTrue(raw.contains("Tracked.java"));
+        assertTrue(!raw.contains("Untracked.java"));
+    }
+
+    @Test
+    public void completeScopeFinalizesOnlyOnceAcrossDifferentTokens() {
+        SubagentEditScopeTracker tracker = new SubagentEditScopeTracker(null, new EditOperationRegistry());
+        tracker.startScope("codex", "spawn-1", "agent-1");
+        tracker.recordBeforeSnapshot("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "old", 3, 1L, "h1"));
+        tracker.recordAfterSnapshotForTest(Map.of("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "new", 3, 2L, "h2")));
+
+        assertEquals(2, tracker.completeByAgentHandle("agent-1", "wait-1").size());
+
+        tracker.recordAfterSnapshotForTest(Map.of("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "newer", 5, 3L, "h3")));
+        assertTrue(tracker.completeByAgentHandle("agent-1", "close-1").isEmpty());
+        assertTrue(tracker.completeByParentToolUseId("spawn-1", "wait-2").isEmpty());
+    }
+
+
+    @Test
+    public void cancelledScopeDoesNotFinalizeOrConflictWithLaterScope() {
+        SubagentEditScopeTracker tracker = new SubagentEditScopeTracker(null, new EditOperationRegistry());
+        tracker.startScope("claude", "task-1", null);
+        tracker.recordBeforeSnapshot("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "old", 3, 1L, "h1"));
+        tracker.cancelByParentToolUseId("task-1");
+        tracker.recordAfterSnapshotForTest(Map.of("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "new", 3, 2L, "h2")));
+
+        assertTrue(tracker.completeByParentToolUseId("task-1", "token-1").isEmpty());
+
+        tracker.startScope("claude", "task-2", null);
+        tracker.recordBeforeSnapshot("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "new", 3, 2L, "h2"));
+        tracker.recordAfterSnapshotForTest(Map.of("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "newer", 5, 3L, "h3")));
+
+        assertEquals(2, tracker.completeByParentToolUseId("task-2", "token-2").size());
+    }
+
+    @Test
+    public void highPriorityOperationOnSamePathDoesNotSuppressDifferentSubagentHunk() {
+        EditOperationRegistry registry = new EditOperationRegistry();
+        registry.register(new com.github.claudecodegui.util.EditOperationBuilder.Operation(
+                "edit", "/tmp/File.java", "alpha", "beta", false, 1, 1, true, "hash"
+        ), "codex_session_patch", null, 1L);
+        SubagentEditScopeTracker tracker = new SubagentEditScopeTracker(null, registry);
+        tracker.startScope("claude", "task-1", null);
+        tracker.recordBeforeSnapshot("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "one\ntwo\n", 8, 1L, "h1"));
+        tracker.recordAfterSnapshotForTest(Map.of("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "one\nthree\n", 10, 2L, "h2")));
+
+        assertEquals(2, tracker.completeByParentToolUseId("task-1", "token-1").size());
+    }
+
+
+    @Test
+    public void deletedFileProducesVisibleUnsafeOperation() {
+        SubagentEditScopeTracker tracker = new SubagentEditScopeTracker(null, new EditOperationRegistry());
+        tracker.startScope("claude", "task-delete", null);
+        tracker.recordBeforeSnapshot("/tmp/DeleteMe.java", new FileSnapshotUtil.FileSnapshot("/tmp/DeleteMe.java", true, false, "old content", 11, 1L, "h1"));
+        tracker.recordAfterSnapshotForTest(Map.of());
+
+        List<ClaudeSession.Message> messages = tracker.completeByParentToolUseId("task-delete", "token-delete");
+
+        assertEquals(2, messages.size());
+        String raw = messages.get(0).raw.toString();
+        assertTrue(raw.contains("DeleteMe.java"));
+        assertTrue(raw.contains("safe_to_rollback\":false"));
+    }
+
+
+    @Test
+    public void overlappingScopesFailClosedForAmbiguousVfsEvents() {
+        SubagentEditScopeTracker tracker = new SubagentEditScopeTracker(null, new EditOperationRegistry());
+        tracker.startScope("codex", "spawn-1", "agent-1");
+        tracker.recordVfsBeforePathForTest("/tmp/A.java", new FileSnapshotUtil.FileSnapshot("/tmp/A.java", true, false, "a1", 2, 1L, "a1"));
+        tracker.startScope("codex", "spawn-2", "agent-2");
+        tracker.recordVfsBeforePathForTest("/tmp/B.java", new FileSnapshotUtil.FileSnapshot("/tmp/B.java", true, false, "b1", 2, 1L, "b1"));
+        tracker.recordAfterSnapshotForTest(Map.of(
+                "/tmp/A.java", new FileSnapshotUtil.FileSnapshot("/tmp/A.java", true, false, "a2", 2, 2L, "a2"),
+                "/tmp/B.java", new FileSnapshotUtil.FileSnapshot("/tmp/B.java", true, false, "b2", 2, 2L, "b2")
+        ));
+
+        assertEquals(2, tracker.completeByAgentHandle("agent-1", "wait-1").size());
+        assertTrue(tracker.completeByAgentHandle("agent-2", "wait-2").isEmpty());
+
+        SubagentEditScopeTracker ambiguous = new SubagentEditScopeTracker(null, new EditOperationRegistry());
+        ambiguous.startScope("codex", "spawn-3", "agent-3");
+        ambiguous.startScope("codex", "spawn-4", "agent-4");
+        ambiguous.recordVfsBeforePathForTest("/tmp/FirstTouch.java", new FileSnapshotUtil.FileSnapshot("/tmp/FirstTouch.java", true, false, "s1", 2, 1L, "s1"));
+        ambiguous.recordAfterSnapshotForTest(Map.of(
+                "/tmp/FirstTouch.java", new FileSnapshotUtil.FileSnapshot("/tmp/FirstTouch.java", true, false, "s2", 2, 2L, "s2")
+        ));
+
+        assertTrue(ambiguous.completeByAgentHandle("agent-3", "wait-3").isEmpty());
+        assertTrue(ambiguous.completeByAgentHandle("agent-4", "wait-4").isEmpty());
+    }
+
+    @Test
+    public void overlappingScopesKeepExistingPathOwner() {
+        SubagentEditScopeTracker tracker = new SubagentEditScopeTracker(null, new EditOperationRegistry());
+        tracker.startScope("codex", "spawn-1", "agent-1");
+        tracker.recordVfsBeforePathForTest("/tmp/A.java", new FileSnapshotUtil.FileSnapshot("/tmp/A.java", true, false, "a1", 2, 1L, "a1"));
+        tracker.startScope("codex", "spawn-2", "agent-2");
+        tracker.recordVfsBeforePathForTest("/tmp/A.java", new FileSnapshotUtil.FileSnapshot("/tmp/A.java", true, false, "a1", 2, 1L, "a1"));
+        tracker.recordAfterSnapshotForTest(Map.of(
+                "/tmp/A.java", new FileSnapshotUtil.FileSnapshot("/tmp/A.java", true, false, "a2", 2, 2L, "a2")
+        ));
+
+        assertEquals(2, tracker.completeByAgentHandle("agent-1", "wait-1").size());
+        assertTrue(tracker.completeByAgentHandle("agent-2", "wait-2").isEmpty());
+    }
+
+
+
+    @Test
+    public void externalOperationConflictsActiveScopeOnSamePath() {
+        SubagentEditScopeTracker tracker = new SubagentEditScopeTracker(null, new EditOperationRegistry());
+        tracker.startScope("codex", "spawn-1", "agent-1");
+        tracker.recordBeforeSnapshot("/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "old", 3, 1L, "h1"));
+
+        tracker.registerExternalOperations(toolUseRaw("tool-main", "/tmp/File.java", "old", "main change", "codex_session_patch"));
+        tracker.recordAfterSnapshotForTest(Map.of(
+                "/tmp/File.java", new FileSnapshotUtil.FileSnapshot("/tmp/File.java", true, false, "subagent change", 15, 2L, "h2")
+        ));
+
+        assertTrue(tracker.completeByAgentHandle("agent-1", "wait-1").isEmpty());
+    }
+
+    private static JsonObject toolUseRaw(String id, String filePath, String oldString, String newString, String source) {
+        JsonObject raw = new JsonObject();
+        JsonObject message = new JsonObject();
+        JsonArray content = new JsonArray();
+        JsonObject block = new JsonObject();
+        JsonObject input = new JsonObject();
+        input.addProperty("file_path", filePath);
+        input.addProperty("old_string", oldString);
+        input.addProperty("new_string", newString);
+        input.addProperty("source", source);
+        block.addProperty("type", "tool_use");
+        block.addProperty("id", id);
+        block.addProperty("name", "edit");
+        block.add("input", input);
+        content.add(block);
+        message.add("content", content);
+        raw.add("message", message);
+        return raw;
+    }
+
+}

--- a/src/test/java/com/github/claudecodegui/session/SubagentLifecycleDetectorTest.java
+++ b/src/test/java/com/github/claudecodegui/session/SubagentLifecycleDetectorTest.java
@@ -188,7 +188,7 @@ public class SubagentLifecycleDetectorTest {
     }
 
     @Test
-    public void waitAgentMultipleTargetsWithoutResultHandleDoesNotGuess() {
+    public void waitAgentMultipleTargetsWithoutResultHandleCompletesAllTargets() {
         SubagentLifecycleDetector detector = new SubagentLifecycleDetector();
         detector.handleAssistant("codex", gson.fromJson("""
                 {"message":{"content":[{"type":"tool_use","id":"wait-1","name":"wait_agent","input":{"targets":["agent-1","agent-2"]}}]}}
@@ -198,7 +198,10 @@ public class SubagentLifecycleDetectorTest {
                 {"message":{"content":[{"type":"tool_result","tool_use_id":"wait-1","content":"{\\"targets\\":[\\"agent-1\\",\\"agent-2\\"]}"}]}}
                 """, com.google.gson.JsonObject.class));
 
-        assertTrue(events.isEmpty());
+        assertEquals(2, events.size());
+        assertEquals(SubagentLifecycleEvent.Kind.COMPLETED, events.get(0).kind());
+        assertEquals("agent-1", events.get(0).agentHandle());
+        assertEquals("agent-2", events.get(1).agentHandle());
     }
 
     @Test

--- a/src/test/java/com/github/claudecodegui/session/SubagentLifecycleDetectorTest.java
+++ b/src/test/java/com/github/claudecodegui/session/SubagentLifecycleDetectorTest.java
@@ -1,0 +1,238 @@
+package com.github.claudecodegui.session;
+
+import com.google.gson.Gson;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+public class SubagentLifecycleDetectorTest {
+    private final Gson gson = new Gson();
+
+    @Test
+    public void detectsClaudeTaskStartAndCompletion() {
+        SubagentLifecycleDetector detector = new SubagentLifecycleDetector();
+        List<SubagentLifecycleEvent> starts = detector.handleAssistant("claude", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_use","id":"task-1","name":"Task","input":{}}]}}
+                """, com.google.gson.JsonObject.class));
+        assertEquals(1, starts.size());
+        assertEquals(SubagentLifecycleEvent.Kind.STARTED, starts.get(0).kind());
+
+        List<SubagentLifecycleEvent> completions = detector.handleUser("claude", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_result","tool_use_id":"task-1","content":"done"}]}}
+                """, com.google.gson.JsonObject.class));
+        assertEquals(1, completions.size());
+        assertEquals(SubagentLifecycleEvent.Kind.COMPLETED, completions.get(0).kind());
+        assertEquals("task-1", completions.get(0).parentToolUseId());
+    }
+
+    @Test
+    public void detectsCodexSpawnResolveAndWaitCompletion() {
+        SubagentLifecycleDetector detector = new SubagentLifecycleDetector();
+        List<SubagentLifecycleEvent> starts = detector.handleAssistant("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_use","id":"spawn-1","name":"spawn_agent","input":{}}]}}
+                """, com.google.gson.JsonObject.class));
+        assertEquals(1, starts.size());
+
+        List<SubagentLifecycleEvent> resolved = detector.handleUser("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_result","tool_use_id":"spawn-1","content":"{\\"agent_id\\":\\"agent-1\\"}"}]}}
+                """, com.google.gson.JsonObject.class));
+        assertEquals(SubagentLifecycleEvent.Kind.SPAWN_RESOLVED, resolved.get(0).kind());
+        assertEquals("agent-1", resolved.get(0).agentHandle());
+
+        detector.handleAssistant("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_use","id":"wait-1","name":"wait_agent","input":{"target":"agent-1"}}]}}
+                """, com.google.gson.JsonObject.class));
+        List<SubagentLifecycleEvent> completed = detector.handleUser("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_result","tool_use_id":"wait-1","content":"done"}]}}
+                """, com.google.gson.JsonObject.class));
+        assertEquals(1, completed.size());
+        assertEquals(SubagentLifecycleEvent.Kind.COMPLETED, completed.get(0).kind());
+        assertEquals("agent-1", completed.get(0).agentHandle());
+    }
+
+
+    @Test
+    public void emitsCancelledForErroredStartedLifecycleTool() {
+        SubagentLifecycleDetector detector = new SubagentLifecycleDetector();
+        detector.handleAssistant("claude", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_use","id":"task-1","name":"Task","input":{}}]}}
+                """, com.google.gson.JsonObject.class));
+
+        List<SubagentLifecycleEvent> events = detector.handleUser("claude", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_result","tool_use_id":"task-1","is_error":true,"content":"failed"}]}}
+                """, com.google.gson.JsonObject.class));
+
+        assertEquals(1, events.size());
+        assertEquals(SubagentLifecycleEvent.Kind.CANCELLED, events.get(0).kind());
+        assertEquals("task-1", events.get(0).parentToolUseId());
+    }
+
+    @Test
+    public void doesNotRestartCompletedToolUseWhenMergedRawIsReprocessed() {
+        SubagentLifecycleDetector detector = new SubagentLifecycleDetector();
+        com.google.gson.JsonObject assistant = gson.fromJson("""
+                {"message":{"content":[{"type":"tool_use","id":"task-1","name":"Task","input":{}}]}}
+                """, com.google.gson.JsonObject.class);
+
+        assertFalse(detector.handleAssistant("claude", assistant).isEmpty());
+        assertFalse(detector.handleUser("claude", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_result","tool_use_id":"task-1","content":"done"}]}}
+                """, com.google.gson.JsonObject.class)).isEmpty());
+
+        assertTrue(detector.handleAssistant("claude", assistant).isEmpty());
+    }
+
+    @Test
+    public void startsCodexScopeForResumeAgent() {
+        SubagentLifecycleDetector detector = new SubagentLifecycleDetector();
+        List<SubagentLifecycleEvent> events = detector.handleAssistant("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_use","id":"resume-1","name":"resume_agent","input":{"target":"agent-1"}}]}}
+                """, com.google.gson.JsonObject.class));
+
+        assertEquals(1, events.size());
+        assertEquals(SubagentLifecycleEvent.Kind.STARTED, events.get(0).kind());
+        assertEquals("agent-1", events.get(0).agentHandle());
+    }
+
+    @Test
+    public void ignoresErroredClaudeTaskResult() {
+        SubagentLifecycleDetector detector = new SubagentLifecycleDetector();
+        detector.handleAssistant("claude", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_use","id":"task-1","name":"Task","input":{}}]}}
+                """, com.google.gson.JsonObject.class));
+
+        List<SubagentLifecycleEvent> completions = detector.handleUser("claude", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_result","tool_use_id":"task-1","is_error":true,"content":"failed"}]}}
+                """, com.google.gson.JsonObject.class));
+
+        assertEquals(1, completions.size());
+        assertEquals(SubagentLifecycleEvent.Kind.CANCELLED, completions.get(0).kind());
+    }
+
+    @Test
+    public void ignoresErroredCodexLifecycleResults() {
+        SubagentLifecycleDetector detector = new SubagentLifecycleDetector();
+        detector.handleAssistant("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_use","id":"spawn-1","name":"spawn_agent","input":{}}]}}
+                """, com.google.gson.JsonObject.class));
+
+        List<SubagentLifecycleEvent> resolved = detector.handleUser("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_result","tool_use_id":"spawn-1","is_error":true,"content":"spawn failed"}]}}
+                """, com.google.gson.JsonObject.class));
+        assertEquals(1, resolved.size());
+        assertEquals(SubagentLifecycleEvent.Kind.CANCELLED, resolved.get(0).kind());
+
+        detector.handleAssistant("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_use","id":"wait-1","name":"wait_agent","input":{"target":"agent-1"}}]}}
+                """, com.google.gson.JsonObject.class));
+        List<SubagentLifecycleEvent> completed = detector.handleUser("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_result","tool_use_id":"wait-1","is_error":true,"content":"timeout agent-1"}]}}
+                """, com.google.gson.JsonObject.class));
+
+        assertEquals(1, completed.size());
+        assertEquals(SubagentLifecycleEvent.Kind.CANCELLED, completed.get(0).kind());
+    }
+
+
+    @Test
+    public void cancelsErroredSendInputLifecycleResult() {
+        SubagentLifecycleDetector detector = new SubagentLifecycleDetector();
+        detector.handleAssistant("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_use","id":"send-1","name":"send_input","input":{"target":"agent-1"}}]}}
+                """, com.google.gson.JsonObject.class));
+
+        List<SubagentLifecycleEvent> events = detector.handleUser("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_result","tool_use_id":"send-1","is_error":true,"content":"send failed"}]}}
+                """, com.google.gson.JsonObject.class));
+
+        assertEquals(1, events.size());
+        assertEquals(SubagentLifecycleEvent.Kind.CANCELLED, events.get(0).kind());
+        assertEquals("agent-1", events.get(0).agentHandle());
+    }
+
+
+    @Test
+    public void waitAgentSingleTargetArrayCompletesThatHandle() {
+        SubagentLifecycleDetector detector = new SubagentLifecycleDetector();
+        detector.handleAssistant("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_use","id":"wait-1","name":"wait_agent","input":{"targets":["agent-1"]}}]}}
+                """, com.google.gson.JsonObject.class));
+
+        List<SubagentLifecycleEvent> events = detector.handleUser("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_result","tool_use_id":"wait-1","content":"done"}]}}
+                """, com.google.gson.JsonObject.class));
+
+        assertEquals(1, events.size());
+        assertEquals(SubagentLifecycleEvent.Kind.COMPLETED, events.get(0).kind());
+        assertEquals("agent-1", events.get(0).agentHandle());
+    }
+
+    @Test
+    public void waitAgentMultipleTargetsUsesResultHandleOnly() {
+        SubagentLifecycleDetector detector = new SubagentLifecycleDetector();
+        detector.handleAssistant("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_use","id":"wait-1","name":"wait_agent","input":{"targets":["agent-1","agent-2"]}}]}}
+                """, com.google.gson.JsonObject.class));
+
+        List<SubagentLifecycleEvent> events = detector.handleUser("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_result","tool_use_id":"wait-1","content":"{\\"agent_id\\":\\"agent-2\\"}"}]}}
+                """, com.google.gson.JsonObject.class));
+
+        assertEquals(1, events.size());
+        assertEquals(SubagentLifecycleEvent.Kind.COMPLETED, events.get(0).kind());
+        assertEquals("agent-2", events.get(0).agentHandle());
+    }
+
+    @Test
+    public void waitAgentMultipleTargetsWithoutResultHandleDoesNotGuess() {
+        SubagentLifecycleDetector detector = new SubagentLifecycleDetector();
+        detector.handleAssistant("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_use","id":"wait-1","name":"wait_agent","input":{"targets":["agent-1","agent-2"]}}]}}
+                """, com.google.gson.JsonObject.class));
+
+        List<SubagentLifecycleEvent> events = detector.handleUser("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_result","tool_use_id":"wait-1","content":"{\\"targets\\":[\\"agent-1\\",\\"agent-2\\"]}"}]}}
+                """, com.google.gson.JsonObject.class));
+
+        assertTrue(events.isEmpty());
+    }
+
+    @Test
+    public void resolvesCodexSpawnAgentFromPlainTextPath() {
+        SubagentLifecycleDetector detector = new SubagentLifecycleDetector();
+        detector.handleAssistant("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_use","id":"spawn-plain","name":"spawn_agent","input":{}}]}}
+                """, com.google.gson.JsonObject.class));
+
+        List<SubagentLifecycleEvent> events = detector.handleUser("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_result","tool_use_id":"spawn-plain","content":"/tmp/codex-agent-abc.md"}]}}
+                """, com.google.gson.JsonObject.class));
+
+        assertEquals(1, events.size());
+        assertEquals(SubagentLifecycleEvent.Kind.SPAWN_RESOLVED, events.get(0).kind());
+        assertEquals("/tmp/codex-agent-abc.md", events.get(0).agentHandle());
+    }
+
+
+    @Test
+    public void spawnAgentPlainTextErrorCancelsUnresolvedScope() {
+        SubagentLifecycleDetector detector = new SubagentLifecycleDetector();
+        detector.handleAssistant("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_use","id":"spawn-invalid","name":"spawn_agent","input":{}}]}}
+                """, com.google.gson.JsonObject.class));
+
+        List<SubagentLifecycleEvent> events = detector.handleUser("codex", gson.fromJson("""
+                {"message":{"content":[{"type":"tool_result","tool_use_id":"spawn-invalid","content":"Full-history forked agents inherit the parent agent type, model, and reasoning effort; omit agent_type, model, and reasoning_effort."}]}}
+                """, com.google.gson.JsonObject.class));
+
+        assertEquals(1, events.size());
+        assertEquals(SubagentLifecycleEvent.Kind.CANCELLED, events.get(0).kind());
+        assertEquals("spawn-invalid", events.get(0).parentToolUseId());
+        assertEquals(null, events.get(0).agentHandle());
+    }
+
+}

--- a/src/test/java/com/github/claudecodegui/session/SyntheticFileChangeMessageFactoryTest.java
+++ b/src/test/java/com/github/claudecodegui/session/SyntheticFileChangeMessageFactoryTest.java
@@ -1,0 +1,45 @@
+package com.github.claudecodegui.session;
+
+import com.github.claudecodegui.util.EditOperationBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SyntheticFileChangeMessageFactoryTest {
+
+    @Test
+    public void buildsHiddenAssistantAndUserMessagesWithMetadata() {
+        EditOperationBuilder.Operation operation = new EditOperationBuilder.Operation(
+                "edit", "/tmp/File.java", "old", "new", false, 3, 3, true, "hash"
+        );
+        SubagentEditScopeTracker.ScopeDescriptor scope = new SubagentEditScopeTracker.ScopeDescriptor(
+                "scope-1", "claude", "task-1", "agent-a", 7
+        );
+
+        List<ClaudeSession.Message> messages = SyntheticFileChangeMessageFactory.build(scope, List.of(operation));
+
+        assertEquals(2, messages.size());
+        assertEquals(ClaudeSession.Message.Type.ASSISTANT, messages.get(0).type);
+        assertEquals("", messages.get(0).content);
+        assertTrue(messages.get(0).raw.get("isMeta").getAsBoolean());
+
+        JsonArray toolUses = messages.get(0).raw.getAsJsonObject("message").getAsJsonArray("content");
+        JsonObject toolUse = toolUses.get(0).getAsJsonObject();
+        assertEquals("edit", toolUse.get("name").getAsString());
+        JsonObject input = toolUse.getAsJsonObject("input");
+        assertEquals("subagent", input.get("source").getAsString());
+        assertEquals("scope-1", input.get("scope_id").getAsString());
+        assertEquals("agent-a", input.get("agent_handle").getAsString());
+        assertEquals(7, input.get("edit_sequence").getAsInt());
+        assertNotNull(input.get("operation_id").getAsString());
+
+        JsonArray toolResults = messages.get(1).raw.getAsJsonObject("message").getAsJsonArray("content");
+        assertEquals(toolUse.get("id").getAsString(), toolResults.get(0).getAsJsonObject().get("tool_use_id").getAsString());
+    }
+}

--- a/src/test/java/com/github/claudecodegui/util/EditOperationBuilderTest.java
+++ b/src/test/java/com/github/claudecodegui/util/EditOperationBuilderTest.java
@@ -1,0 +1,86 @@
+package com.github.claudecodegui.util;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class EditOperationBuilderTest {
+
+    @Test
+    public void buildsSingleEditForModifiedText() {
+        List<EditOperationBuilder.Operation> operations = EditOperationBuilder.build("/tmp/File.java", true, "one\ntwo\n", "one\nthree\n");
+
+        assertEquals(1, operations.size());
+        EditOperationBuilder.Operation operation = operations.get(0);
+        assertEquals("edit", operation.toolName());
+        assertTrue(operation.oldString().contains("two"));
+        assertTrue(operation.newString().contains("three"));
+        assertEquals(1, operation.lineStart());
+    }
+
+    @Test
+    public void buildsWriteForNewTextFile() {
+        List<EditOperationBuilder.Operation> operations = EditOperationBuilder.build("/tmp/New.java", false, "", "class New {}\n");
+
+        assertEquals(1, operations.size());
+        EditOperationBuilder.Operation operation = operations.get(0);
+        assertEquals("write", operation.toolName());
+        assertEquals("", operation.oldString());
+        assertEquals("class New {}\n", operation.newString());
+        assertTrue(operation.safeToRollback());
+    }
+
+    @Test
+    public void returnsEmptyWhenContentDidNotChange() {
+        assertTrue(EditOperationBuilder.build("/tmp/File.java", true, "same", "same").isEmpty());
+    }
+
+    @Test
+    public void skipsBinaryContent() {
+        List<EditOperationBuilder.Operation> operations = EditOperationBuilder.build("/tmp/File.bin", true, "a\u0000b", "a\u0000c");
+        assertTrue(operations.isEmpty());
+    }
+
+    @Test
+    public void lineStartPointsToContextHunkStartForSafeRollback() {
+        String before = "a\nb\nc\nd\ne\n";
+        String after = "a\nb\nchanged\nd\ne\n";
+
+        EditOperationBuilder.Operation operation = EditOperationBuilder.build("/tmp/File.java", true, before, after).get(0);
+
+        assertTrue(operation.newString().startsWith("a\nb\n"));
+        assertEquals(1, operation.lineStart());
+    }
+
+
+    @Test
+    public void buildsSeparateOperationsForDistantHunks() {
+        String before = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\n";
+        String after = "a\nB\nc\nd\ne\nf\ng\nh\nI\nj\n";
+
+        List<EditOperationBuilder.Operation> operations = EditOperationBuilder.build("/tmp/File.java", true, before, after);
+
+        assertEquals(2, operations.size());
+        assertTrue(operations.get(0).newString().contains("B"));
+        assertFalse(operations.get(0).newString().contains("F"));
+        assertTrue(operations.get(1).newString().contains("I"));
+        assertFalse(operations.get(1).newString().contains("B"));
+    }
+
+
+
+    @Test
+    public void marksEmptyAfterContentUnsafe() {
+        List<EditOperationBuilder.Operation> operations = EditOperationBuilder.build("/tmp/File.java", true, "old content", "");
+
+        assertEquals(1, operations.size());
+        EditOperationBuilder.Operation operation = operations.get(0);
+        assertEquals("", operation.newString());
+        assertFalse(operation.safeToRollback());
+    }
+
+}

--- a/src/test/java/com/github/claudecodegui/util/FileSnapshotUtilTest.java
+++ b/src/test/java/com/github/claudecodegui/util/FileSnapshotUtilTest.java
@@ -1,0 +1,43 @@
+package com.github.claudecodegui.util;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FileSnapshotUtilTest {
+
+    @Test
+    public void captureDirectorySnapshotSkipsSymlinkedFiles() throws Exception {
+        Path root = Files.createTempDirectory("cc-gui-snapshot-root");
+        Path outside = Files.createTempDirectory("cc-gui-snapshot-outside");
+        try {
+            Path source = root.resolve("source.txt");
+            Path secret = outside.resolve("secret.txt");
+            Path link = root.resolve("secret-link.txt");
+            Files.writeString(source, "safe");
+            Files.writeString(secret, "secret");
+            try {
+                Files.createSymbolicLink(link, secret);
+            } catch (UnsupportedOperationException | SecurityException e) {
+                Assume.assumeNoException(e);
+            }
+
+            var snapshots = FileSnapshotUtil.captureDirectorySnapshot(root);
+
+            assertTrue(snapshots.containsKey(source.toRealPath().toString()));
+            assertFalse(snapshots.containsKey(link.toAbsolutePath().normalize().toString()));
+            assertFalse(snapshots.containsKey(secret.toRealPath().toString()));
+        } finally {
+            Files.deleteIfExists(root.resolve("secret-link.txt"));
+            Files.deleteIfExists(root.resolve("source.txt"));
+            Files.deleteIfExists(outside.resolve("secret.txt"));
+            Files.deleteIfExists(root);
+            Files.deleteIfExists(outside);
+        }
+    }
+}

--- a/src/test/java/com/github/claudecodegui/util/UndoOperationApplierTest.java
+++ b/src/test/java/com/github/claudecodegui/util/UndoOperationApplierTest.java
@@ -1,0 +1,123 @@
+package com.github.claudecodegui.util;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class UndoOperationApplierTest {
+
+    @Test
+    public void reverseEditsFailsWhenNewStringIsMissing() {
+        JsonArray operations = new JsonArray();
+        operations.add(operation("before", "after"));
+
+        UndoOperationApplier.Result result = UndoOperationApplier.reverseEdits("current content", operations);
+
+        assertFalse(result.isSuccess());
+        assertEquals("current content", result.getContent());
+        assertEquals("new_string_not_found", result.getFailures().get(0).reason());
+    }
+
+    @Test
+    public void reverseEditsReplacesNewStringWithOldString() {
+        JsonArray operations = new JsonArray();
+        operations.add(operation("before", "after"));
+
+        UndoOperationApplier.Result result = UndoOperationApplier.reverseEdits("one after two", operations);
+
+        assertTrue(result.isSuccess());
+        assertEquals("one before two", result.getContent());
+    }
+
+    @Test
+    public void reverseEditsFailsForEmptyNewString() {
+        JsonArray operations = new JsonArray();
+        operations.add(operation("restored", ""));
+
+        UndoOperationApplier.Result result = UndoOperationApplier.reverseEdits("current content", operations);
+
+        assertFalse(result.isSuccess());
+        assertEquals("empty_new_string_unsupported", result.getFailures().get(0).reason());
+    }
+
+
+    @Test
+    public void reverseEditsFailsWhenNewStringAppearsMultipleTimesWithoutLineInfo() {
+        JsonArray operations = new JsonArray();
+        operations.add(operation("before", "same"));
+
+        UndoOperationApplier.Result result = UndoOperationApplier.reverseEdits("same\nother\nsame", operations);
+
+        assertFalse(result.isSuccess());
+        assertEquals("ambiguous_match", result.getFailures().get(0).reason());
+    }
+
+    @Test
+    public void reverseEditsUsesLineInfoToChooseUniqueNearbyMatch() {
+        JsonArray operations = new JsonArray();
+        JsonObject op = operation("before", "same");
+        op.addProperty("lineStart", 3);
+        op.addProperty("lineEnd", 3);
+        operations.add(op);
+
+        UndoOperationApplier.Result result = UndoOperationApplier.reverseEdits("same\nother\nsame", operations);
+
+        assertTrue(result.isSuccess());
+        assertEquals("same\nother\nbefore", result.getContent());
+    }
+
+    @Test
+    public void reverseEditsFailsWhenSafeToRollbackIsFalse() {
+        JsonArray operations = new JsonArray();
+        JsonObject op = operation("before", "after");
+        op.addProperty("safeToRollback", false);
+        operations.add(op);
+
+        UndoOperationApplier.Result result = UndoOperationApplier.reverseEdits("after", operations);
+
+        assertFalse(result.isSuccess());
+        assertEquals("unsafe_to_rollback", result.getFailures().get(0).reason());
+    }
+
+    @Test
+    public void reverseEditsFailsWhenExpectedAfterHashDiffers() {
+        JsonArray operations = new JsonArray();
+        JsonObject op = operation("before", "after");
+        op.addProperty("expectedAfterContentHash", "not-the-current-content-hash");
+        operations.add(op);
+
+        UndoOperationApplier.Result result = UndoOperationApplier.reverseEdits("after", operations);
+
+        assertFalse(result.isSuccess());
+        assertEquals("content_changed", result.getFailures().get(0).reason());
+    }
+
+
+    @Test
+    public void reverseEditsUsesContextHunkLineStartToAvoidDuplicateAmbiguity() {
+        JsonArray operations = new JsonArray();
+        JsonObject op = operation("a\nb\nc\nd\ne\n", "a\nb\nchanged\nd\ne\n");
+        op.addProperty("lineStart", 1);
+        op.addProperty("lineEnd", 5);
+        operations.add(op);
+
+        String content = "a\nb\nchanged\nd\ne\n---\na\nb\nchanged\nd\ne\n";
+        UndoOperationApplier.Result result = UndoOperationApplier.reverseEdits(content, operations);
+
+        assertTrue(result.isSuccess());
+        assertEquals("a\nb\nc\nd\ne\n---\na\nb\nchanged\nd\ne\n", result.getContent());
+    }
+
+
+    private static JsonObject operation(String oldString, String newString) {
+        JsonObject op = new JsonObject();
+        op.addProperty("oldString", oldString);
+        op.addProperty("newString", newString);
+        op.addProperty("replaceAll", false);
+        return op;
+    }
+}

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -1,9 +1,12 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import HistoryView from './components/history/HistoryView';
-import SettingsView from './components/settings';
-import { sendBridgeEvent } from './utils/bridge';
-import { preloadSlashCommands, forceRefreshPrompts } from './components/ChatInputBox/providers';
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import HistoryView from "./components/history/HistoryView";
+import SettingsView from "./components/settings";
+import { sendBridgeEvent } from "./utils/bridge";
+import {
+  preloadSlashCommands,
+  forceRefreshPrompts,
+} from "./components/ChatInputBox/providers";
 import {
   useScrollBehavior,
   useSessionManagement,
@@ -18,24 +21,27 @@ import {
   useMessageSender,
   useModelProviderState,
   useChatComputations,
-} from './hooks';
+} from "./hooks";
 import {
   NEW_SESSION_COMMANDS,
   RESUME_COMMANDS,
   PLAN_COMMANDS,
   CONTEXT_COMMANDS,
-} from './hooks/useMessageSender';
-import { applyDiffTheme, getStoredDiffTheme } from './utils/diffTheme';
-import type { Attachment, ChatInputBoxHandle } from './components/ChatInputBox/types';
-import { ToastContainer } from './components/Toast';
-import { ChatHeader } from './components/ChatHeader';
-import { ChatScreen } from './components/ChatScreen';
-import { useSubagentContextValues } from './contexts/SubagentContext';
-import { useMessages } from './contexts/MessagesContext';
-import { useSession } from './contexts/SessionContext';
-import { useUIState } from './contexts/UIStateContext';
-import { useDialogs } from './contexts/DialogContext';
-import { AppDialogs } from './components/AppDialogs';
+} from "./hooks/useMessageSender";
+import { applyDiffTheme, getStoredDiffTheme } from "./utils/diffTheme";
+import type {
+  Attachment,
+  ChatInputBoxHandle,
+} from "./components/ChatInputBox/types";
+import { ToastContainer } from "./components/Toast";
+import { ChatHeader } from "./components/ChatHeader";
+import { ChatScreen } from "./components/ChatScreen";
+import { useSubagentContextValues } from "./contexts/SubagentContext";
+import { useMessages } from "./contexts/MessagesContext";
+import { useSession } from "./contexts/SessionContext";
+import { useUIState } from "./contexts/UIStateContext";
+import { useDialogs } from "./contexts/DialogContext";
+import { AppDialogs } from "./components/AppDialogs";
 
 const App = () => {
   const { t } = useTranslation();
@@ -51,35 +57,52 @@ const App = () => {
     openContextUsageDialog,
     updateContextUsageData,
     closeContextUsageDialog,
-    setRewindDialogOpen, setCurrentRewindRequest,
-    isRewinding, setIsRewinding, setRewindSelectDialogOpen,
+    setRewindDialogOpen,
+    setCurrentRewindRequest,
+    isRewinding,
+    setIsRewinding,
+    setRewindSelectDialogOpen,
   } = useDialogs();
 
   // ── Messages flow state (extracted to MessagesContext, stage 1 of TASK-P1-01) ──
   // Display state (loadingStartTime / isThinking) is consumed inside <ChatScreen>.
   const {
-    messages, setMessages,
-    subagentHistories, setSubagentHistories,
+    messages,
+    setMessages,
+    subagentHistories,
+    setSubagentHistories,
     setStatus,
-    loading, setLoading, setLoadingStartTime,
+    loading,
+    setLoading,
+    setLoadingStartTime,
     setIsThinking,
-    streamingActive, setStreamingActive,
+    streamingActive,
+    setStreamingActive,
   } = useMessages();
 
   // ── Session state (extracted to SessionContext, stage 2 of TASK-P1-01) ──
   const {
-    currentSessionId, setCurrentSessionId,
-    customSessionTitle, setCustomSessionTitle,
-    historyData, setHistoryData,
-    currentSessionIdRef, customSessionTitleRef,
+    currentSessionId,
+    setCurrentSessionId,
+    customSessionTitle,
+    setCustomSessionTitle,
+    historyData,
+    setHistoryData,
+    currentSessionIdRef,
+    customSessionTitleRef,
   } = useSession();
 
   // ── UI state (extracted to UIStateContext, stage 3 of TASK-P1-01) ──
   // Dialog visibility (addModelDialog / changelog) is consumed inside AppDialogs.
   const {
-    currentView, setCurrentView,
-    settingsInitialTab, setSettingsInitialTab,
-    toasts, addToast, dismissToast, clearToasts,
+    currentView,
+    setCurrentView,
+    settingsInitialTab,
+    setSettingsInitialTab,
+    toasts,
+    addToast,
+    dismissToast,
+    clearToasts,
     setContextInfo,
   } = useUIState();
 
@@ -95,10 +118,16 @@ const App = () => {
   // Message anchor node registry for anchor rail navigation
   const messageNodeMapRef = useRef<Map<string, HTMLDivElement>>(new Map());
   const [anchorCollapsedCount, setAnchorCollapsedCount] = useState(0);
-  const handleMessageNodeRef = useCallback((id: string, node: HTMLDivElement | null) => {
-    if (node) { messageNodeMapRef.current.set(id, node); }
-    else { messageNodeMapRef.current.delete(id); }
-  }, []);
+  const handleMessageNodeRef = useCallback(
+    (id: string, node: HTMLDivElement | null) => {
+      if (node) {
+        messageNodeMapRef.current.set(id, node);
+      } else {
+        messageNodeMapRef.current.delete(id);
+      }
+    },
+    [],
+  );
 
   // ── Theme & context actions ──
   useThemeInit();
@@ -112,62 +141,101 @@ const App = () => {
 
   // ── Scroll behavior ──
   const {
-    messagesContainerRef, messagesEndRef, inputAreaRef,
-    isUserAtBottomRef, userPausedRef,
+    messagesContainerRef,
+    messagesEndRef,
+    inputAreaRef,
+    isUserAtBottomRef,
+    userPausedRef,
   } = useScrollBehavior({ currentView, messages, loading, streamingActive });
 
   // ── Streaming messages ──
   const {
-    streamingContentRef, streamingThinkingRef, isStreamingRef, useBackendStreamingRenderRef,
-    streamingMessageIndexRef, contentUpdateTimeoutRef, thinkingUpdateTimeoutRef,
-    lastContentUpdateRef, lastThinkingUpdateRef, autoExpandedThinkingKeysRef,
-    streamingTurnIdRef, turnIdCounterRef,
-    findLastAssistantIndex, extractRawBlocks,
-    getOrCreateStreamingAssistantIndex, patchAssistantForStreaming,
+    streamingContentRef,
+    streamingThinkingRef,
+    isStreamingRef,
+    useBackendStreamingRenderRef,
+    streamingMessageIndexRef,
+    contentUpdateTimeoutRef,
+    thinkingUpdateTimeoutRef,
+    lastContentUpdateRef,
+    lastThinkingUpdateRef,
+    autoExpandedThinkingKeysRef,
+    streamingTurnIdRef,
+    turnIdCounterRef,
+    findLastAssistantIndex,
+    extractRawBlocks,
+    getOrCreateStreamingAssistantIndex,
+    patchAssistantForStreaming,
   } = useStreamingMessages();
 
   // (Toast helpers moved to UIStateContext)
 
   // ── Model/Provider state ──
   const {
-    currentProvider, selectedModel, permissionMode,
-    selectedAgent, sdkStatusLoaded, currentSdkInstalled,
+    currentProvider,
+    selectedModel,
+    permissionMode,
+    selectedAgent,
+    sdkStatusLoaded,
+    currentSdkInstalled,
     currentProviderRef,
-    activeProviderConfig, claudeSettingsAlwaysThinkingEnabled,
-    reasoningEffort, streamingEnabledSetting, sendShortcut, autoOpenFileEnabled,
+    activeProviderConfig,
+    claudeSettingsAlwaysThinkingEnabled,
+    reasoningEffort,
+    streamingEnabledSetting,
+    sendShortcut,
+    autoOpenFileEnabled,
     longContextEnabled,
-    usagePercentage, usageUsedTokens, usageMaxTokens,
+    usagePercentage,
+    usageUsedTokens,
+    usageMaxTokens,
     setPermissionMode,
-    setClaudePermissionMode, setCodexPermissionMode,
-    setSelectedClaudeModel, setSelectedCodexModel,
-    setProviderConfigVersion, setActiveProviderConfig,
-    setClaudeSettingsAlwaysThinkingEnabled, setStreamingEnabledSetting,
-    setSendShortcut, setAutoOpenFileEnabled,
-    setSdkStatus, setSdkStatusLoaded, setSelectedAgent,
-    setUsagePercentage, setUsageUsedTokens, setUsageMaxTokens,
+    setClaudePermissionMode,
+    setCodexPermissionMode,
+    setSelectedClaudeModel,
+    setSelectedCodexModel,
+    setProviderConfigVersion,
+    setActiveProviderConfig,
+    setClaudeSettingsAlwaysThinkingEnabled,
+    setStreamingEnabledSetting,
+    setSendShortcut,
+    setAutoOpenFileEnabled,
+    setSdkStatus,
+    setSdkStatusLoaded,
+    setSelectedAgent,
+    setUsagePercentage,
+    setUsageUsedTokens,
+    setUsageMaxTokens,
     syncActiveProviderModelMapping,
-    handleModeSelect, handleModelSelect, handleProviderSelect,
-    handleReasoningChange, handleAgentSelect, handleToggleThinking,
-    handleStreamingEnabledChange, handleSendShortcutChange,
-    handleAutoOpenFileEnabledChange, handleLongContextChange,
+    handleModeSelect,
+    handleModelSelect,
+    handleProviderSelect,
+    handleReasoningChange,
+    handleAgentSelect,
+    handleToggleThinking,
+    handleStreamingEnabledChange,
+    handleSendShortcutChange,
+    handleAutoOpenFileEnabledChange,
+    handleLongContextChange,
   } = useModelProviderState({ addToast, t });
 
   // ── Global drag event interception ──
   useEffect(() => {
     const preventExternalDrop = (e: DragEvent) => {
       const types = Array.from(e.dataTransfer?.types ?? []);
-      const isExternalDrop = types.includes('Files') || types.includes('text/uri-list');
+      const isExternalDrop =
+        types.includes("Files") || types.includes("text/uri-list");
       if (!isExternalDrop) return;
       e.preventDefault();
       e.stopPropagation();
     };
-    document.addEventListener('dragover', preventExternalDrop);
-    document.addEventListener('drop', preventExternalDrop);
-    document.addEventListener('dragenter', preventExternalDrop);
+    document.addEventListener("dragover", preventExternalDrop);
+    document.addEventListener("drop", preventExternalDrop);
+    document.addEventListener("dragenter", preventExternalDrop);
     return () => {
-      document.removeEventListener('dragover', preventExternalDrop);
-      document.removeEventListener('drop', preventExternalDrop);
-      document.removeEventListener('dragenter', preventExternalDrop);
+      document.removeEventListener("dragover", preventExternalDrop);
+      document.removeEventListener("drop", preventExternalDrop);
+      document.removeEventListener("dragenter", preventExternalDrop);
     };
   }, []);
 
@@ -175,94 +243,177 @@ const App = () => {
   useEffect(() => {
     preloadSlashCommands();
     forceRefreshPrompts();
-    const retryTimer = setTimeout(() => { forceRefreshPrompts(); }, 1000);
+    const retryTimer = setTimeout(() => {
+      forceRefreshPrompts();
+    }, 1000);
     return () => clearTimeout(retryTimer);
   }, []);
 
   useEffect(() => {
-    if (isFirstMountRef.current) { isFirstMountRef.current = false; return; }
-    if (currentView === 'chat') { forceRefreshPrompts(); }
+    if (isFirstMountRef.current) {
+      isFirstMountRef.current = false;
+      return;
+    }
+    if (currentView === "chat") {
+      forceRefreshPrompts();
+    }
   }, [currentView]);
 
   // ── Session management ──
   const {
-    showNewSessionConfirm, showInterruptConfirm,
+    showNewSessionConfirm,
+    showInterruptConfirm,
     suppressNextStatusToastRef,
-    createNewSession, forceCreateNewSession,
+    createNewSession,
+    forceCreateNewSession,
     forceCreateNewSessionWithProvider,
-    handleConfirmNewSession, handleCancelNewSession,
-    handleConfirmInterrupt, handleCancelInterrupt,
-    loadHistorySession, deleteHistorySession, deleteHistorySessions, exportHistorySession,
-    toggleFavoriteSession, updateHistoryTitle,
+    handleConfirmNewSession,
+    handleCancelNewSession,
+    handleConfirmInterrupt,
+    handleCancelInterrupt,
+    loadHistorySession,
+    deleteHistorySession,
+    deleteHistorySessions,
+    exportHistorySession,
+    toggleFavoriteSession,
+    updateHistoryTitle,
   } = useSessionManagement({
-    messages, loading, historyData, currentSessionId,
-    setHistoryData, setMessages, setCurrentView, setCurrentSessionId,
-    setCustomSessionTitle, setUsagePercentage, setUsageUsedTokens, setUsageMaxTokens,
-    setStatus, setLoading, setIsThinking, setStreamingActive,
-    clearToasts, addToast, t,
+    messages,
+    loading,
+    historyData,
+    currentSessionId,
+    setHistoryData,
+    setMessages,
+    setCurrentView,
+    setCurrentSessionId,
+    setCustomSessionTitle,
+    setUsagePercentage,
+    setUsageUsedTokens,
+    setUsageMaxTokens,
+    setStatus,
+    setLoading,
+    setIsThinking,
+    setStreamingActive,
+    clearToasts,
+    addToast,
+    t,
   });
 
   useHistoryLoader({ currentView, currentProvider });
 
   // ── Window callbacks (bridge communication) ──
   useWindowCallbacks({
-    t, addToast, clearToasts,
-    setMessages, setStatus, setLoading, setLoadingStartTime,
-    setIsThinking, setStreamingActive, setHistoryData,
-    setCurrentSessionId, setUsagePercentage, setUsageUsedTokens, setUsageMaxTokens,
-    setPermissionMode, setClaudePermissionMode, setCodexPermissionMode,
-    setSelectedClaudeModel, setSelectedCodexModel,
-    setProviderConfigVersion, setActiveProviderConfig,
-    setClaudeSettingsAlwaysThinkingEnabled, setStreamingEnabledSetting,
-    setSendShortcut, setAutoOpenFileEnabled,
-    setSdkStatus, setSdkStatusLoaded,
-    setIsRewinding, setRewindDialogOpen, setCurrentRewindRequest,
-    setContextInfo, setSelectedAgent,
+    t,
+    addToast,
+    clearToasts,
+    setMessages,
+    setStatus,
+    setLoading,
+    setLoadingStartTime,
+    setIsThinking,
+    setStreamingActive,
+    setHistoryData,
+    setCurrentSessionId,
+    setUsagePercentage,
+    setUsageUsedTokens,
+    setUsageMaxTokens,
+    setPermissionMode,
+    setClaudePermissionMode,
+    setCodexPermissionMode,
+    setSelectedClaudeModel,
+    setSelectedCodexModel,
+    setProviderConfigVersion,
+    setActiveProviderConfig,
+    setClaudeSettingsAlwaysThinkingEnabled,
+    setStreamingEnabledSetting,
+    setSendShortcut,
+    setAutoOpenFileEnabled,
+    setSdkStatus,
+    setSdkStatusLoaded,
+    setIsRewinding,
+    setRewindDialogOpen,
+    setCurrentRewindRequest,
+    setContextInfo,
+    setSelectedAgent,
     setSubagentHistories,
-    currentProviderRef, messagesContainerRef, isUserAtBottomRef, userPausedRef,
+    currentProviderRef,
+    messagesContainerRef,
+    isUserAtBottomRef,
+    userPausedRef,
     suppressNextStatusToastRef,
-    streamingContentRef, streamingThinkingRef, isStreamingRef, useBackendStreamingRenderRef,
+    streamingContentRef,
+    streamingThinkingRef,
+    isStreamingRef,
+    useBackendStreamingRenderRef,
     autoExpandedThinkingKeysRef,
     streamingMessageIndexRef,
-    streamingTurnIdRef, turnIdCounterRef,
-    lastContentUpdateRef, contentUpdateTimeoutRef,
-    lastThinkingUpdateRef, thinkingUpdateTimeoutRef,
-    findLastAssistantIndex, extractRawBlocks,
-    getOrCreateStreamingAssistantIndex, patchAssistantForStreaming,
+    streamingTurnIdRef,
+    turnIdCounterRef,
+    lastContentUpdateRef,
+    contentUpdateTimeoutRef,
+    lastThinkingUpdateRef,
+    thinkingUpdateTimeoutRef,
+    findLastAssistantIndex,
+    extractRawBlocks,
+    getOrCreateStreamingAssistantIndex,
+    patchAssistantForStreaming,
     syncActiveProviderModelMapping,
-    openPermissionDialog, openAskUserQuestionDialog, openPlanApprovalDialog,
-    openContextUsageDialog, updateContextUsageData,
+    openPermissionDialog,
+    openAskUserQuestionDialog,
+    openPlanApprovalDialog,
+    openContextUsageDialog,
+    updateContextUsageData,
     closeContextUsageDialog,
-    customSessionTitleRef, currentSessionIdRef, updateHistoryTitle,
+    customSessionTitleRef,
+    currentSessionIdRef,
+    updateHistoryTitle,
     setCustomSessionTitle,
   });
 
   // ── Message processing ──
   const {
-    getMessageText, getContentBlocks,
-    mergedMessages, sentAttachmentsRef,
+    getMessageText,
+    getContentBlocks,
+    mergedMessages,
+    sentAttachmentsRef,
   } = useMessageProcessing({ messages, currentSessionId, t });
 
   // ── Message sender ──
   // Wrap handleProviderSelect to also clear messages and input (like creating a new session)
-  const wrappedHandleProviderSelect = useCallback((providerId: string) => {
-    chatInputRef.current?.clear();
-    handleProviderSelect(providerId);
-    forceCreateNewSessionWithProvider(providerId);
-  }, [forceCreateNewSessionWithProvider, handleProviderSelect]);
+  const wrappedHandleProviderSelect = useCallback(
+    (providerId: string) => {
+      chatInputRef.current?.clear();
+      handleProviderSelect(providerId);
+      forceCreateNewSessionWithProvider(providerId);
+    },
+    [forceCreateNewSessionWithProvider, handleProviderSelect],
+  );
 
   const {
     handleSubmit: hookHandleSubmit,
     executeMessage,
     interruptSession,
   } = useMessageSender({
-    t, addToast,
-    currentProvider, selectedModel, permissionMode, selectedAgent,
-    sdkStatusLoaded, currentSdkInstalled,
-    sentAttachmentsRef, chatInputRef, messagesContainerRef,
-    isUserAtBottomRef, userPausedRef, isStreamingRef,
-    setMessages, setLoading, setLoadingStartTime, setStreamingActive,
-    setSettingsInitialTab, setCurrentView,
+    t,
+    addToast,
+    currentProvider,
+    selectedModel,
+    permissionMode,
+    selectedAgent,
+    sdkStatusLoaded,
+    currentSdkInstalled,
+    sentAttachmentsRef,
+    chatInputRef,
+    messagesContainerRef,
+    isUserAtBottomRef,
+    userPausedRef,
+    isStreamingRef,
+    setMessages,
+    setLoading,
+    setLoadingStartTime,
+    setStreamingActive,
+    setSettingsInitialTab,
+    setCurrentView,
     forceCreateNewSession,
     handleModeSelect,
     longContextEnabled,
@@ -278,76 +429,118 @@ const App = () => {
   } = useMessageQueue({ isLoading: loading, onExecute: executeMessage });
 
   // handleSubmit with queue support (new session and local commands bypass loading check)
-  const handleSubmit = useCallback((content: string, attachments?: Attachment[]) => {
-    const text = content.replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
-    const hasAttachments = Array.isArray(attachments) && attachments.length > 0;
-    if (!text && !hasAttachments) return;
-    // Local commands work even while loading
-    if (text.startsWith('/')) {
-      const command = text.split(/\s+/)[0].toLowerCase();
-      // New session commands
-      if (NEW_SESSION_COMMANDS.has(command)) {
-        forceCreateNewSession();
+  const handleSubmit = useCallback(
+    (content: string, attachments?: Attachment[]) => {
+      const text = content.replace(/[\u200B-\u200D\uFEFF]/g, "").trim();
+      const hasAttachments =
+        Array.isArray(attachments) && attachments.length > 0;
+      if (!text && !hasAttachments) return;
+      // Local commands work even while loading
+      if (text.startsWith("/")) {
+        const command = text.split(/\s+/)[0].toLowerCase();
+        // New session commands
+        if (NEW_SESSION_COMMANDS.has(command)) {
+          forceCreateNewSession();
+          return;
+        }
+        // /resume - open history view
+        if (RESUME_COMMANDS.has(command)) {
+          setCurrentView("history");
+          return;
+        }
+        // /plan - switch to plan mode (Claude only; Codex sends as normal text)
+        if (PLAN_COMMANDS.has(command) && currentProvider === "claude") {
+          handleModeSelect("plan");
+          addToast(
+            t("chat.planModeEnabled", { defaultValue: "Plan mode enabled" }),
+            "info",
+          );
+          return;
+        }
+        // /context - handled locally even while loading
+        if (CONTEXT_COMMANDS.has(command)) {
+          hookHandleSubmit(content, attachments);
+          return;
+        }
+      }
+      // If loading, add to queue
+      if (loading) {
+        enqueueMessage(content, attachments);
         return;
       }
-      // /resume - open history view
-      if (RESUME_COMMANDS.has(command)) {
-        setCurrentView('history');
-        return;
-      }
-      // /plan - switch to plan mode (Claude only; Codex sends as normal text)
-      if (PLAN_COMMANDS.has(command) && currentProvider === 'claude') {
-        handleModeSelect('plan');
-        addToast(t('chat.planModeEnabled', { defaultValue: 'Plan mode enabled' }), 'info');
-        return;
-      }
-      // /context - handled locally even while loading
-      if (CONTEXT_COMMANDS.has(command)) {
-        hookHandleSubmit(content, attachments);
-        return;
-      }
-    }
-    // If loading, add to queue
-    if (loading) {
-      enqueueMessage(content, attachments);
-      return;
-    }
-    hookHandleSubmit(content, attachments);
-  }, [loading, enqueueMessage, hookHandleSubmit, forceCreateNewSession, currentProvider, handleModeSelect, setCurrentView, addToast, t]);
+      hookHandleSubmit(content, attachments);
+    },
+    [
+      loading,
+      enqueueMessage,
+      hookHandleSubmit,
+      forceCreateNewSession,
+      currentProvider,
+      handleModeSelect,
+      setCurrentView,
+      addToast,
+      t,
+    ],
+  );
 
   // ── Chat-view computations (stage 5 of TASK-P1-01) ──
   const {
-    findToolResult, getToolResultRaw,
+    findToolResult,
+    getToolResultRaw,
     fileChangeMgmt,
-    filteredFileChanges, subagents, globalTodos, rewindableMessages, sessionTitle,
+    filteredFileChanges,
+    subagents,
+    hasPendingSubagent,
+    globalTodos,
+    rewindableMessages,
+    sessionTitle,
   } = useChatComputations({
-    t, messages, mergedMessages, customSessionTitle, streamingActive, currentProvider,
-    currentSessionId, currentSessionIdRef,
-    getMessageText, getContentBlocks,
+    t,
+    messages,
+    mergedMessages,
+    customSessionTitle,
+    streamingActive,
+    currentProvider,
+    currentSessionId,
+    currentSessionIdRef,
+    getMessageText,
+    getContentBlocks,
   });
 
-  const { handleUndoFile, handleDiscardAll: handleDiscardAllRaw, handleKeepAll } = fileChangeMgmt;
-  const onDiscardAll = useCallback(
-    () => { handleDiscardAllRaw(filteredFileChanges); },
-    [handleDiscardAllRaw, filteredFileChanges],
-  );
+  const {
+    handleUndoFile,
+    handleKeepAll,
+    registerPendingFileChangeAction,
+    clearPendingFileChangeAction,
+  } = fileChangeMgmt;
 
   // Stabilize context value references for SubagentContext consumers.
-  const { subagentHistoryCtxValue, sessionIdCtxValue } = useSubagentContextValues(subagentHistories, currentSessionId);
+  const { subagentHistoryCtxValue, sessionIdCtxValue } =
+    useSubagentContextValues(subagentHistories, currentSessionId);
 
   const handleNavigateToProviderSettings = useCallback(() => {
-    setSettingsInitialTab('providers');
-    setCurrentView('settings');
+    setSettingsInitialTab("providers");
+    setCurrentView("settings");
   }, [setSettingsInitialTab, setCurrentView]);
 
   // ── Rewind handlers ──
   const {
-    handleRewindConfirm, handleRewindCancel,
-    handleOpenRewindSelectDialog, handleRewindSelect, handleRewindSelectCancel,
+    handleRewindConfirm,
+    handleRewindCancel,
+    handleOpenRewindSelectDialog,
+    handleRewindSelect,
+    handleRewindSelectCancel,
   } = useRewindHandlers({
-    t, addToast, currentSessionId, mergedMessages, getMessageText,
-    setCurrentRewindRequest, setRewindDialogOpen, setRewindSelectDialogOpen,
-    setIsRewinding, isRewinding,
+    t,
+    addToast,
+    currentSessionId,
+    mergedMessages,
+    getMessageText,
+    setCurrentRewindRequest,
+    setRewindDialogOpen,
+    setRewindSelectDialogOpen,
+    setIsRewinding,
+    isRewinding,
   });
 
   const statusPanelExpanded = !userCollapsedRef.current;
@@ -360,13 +553,13 @@ const App = () => {
         currentView={currentView}
         sessionTitle={sessionTitle}
         t={t}
-        onBack={() => setCurrentView('chat')}
+        onBack={() => setCurrentView("chat")}
         onNewSession={createNewSession}
-        onNewTab={() => sendBridgeEvent('create_new_tab')}
-        onHistory={() => setCurrentView('history')}
+        onNewTab={() => sendBridgeEvent("create_new_tab")}
+        onHistory={() => setCurrentView("history")}
         onSettings={() => {
           setSettingsInitialTab(undefined);
-          setCurrentView('settings');
+          setCurrentView("settings");
         }}
         titleEditable
         onTitleChange={(newTitle) => {
@@ -377,9 +570,9 @@ const App = () => {
         }}
       />
 
-      {currentView === 'settings' ? (
+      {currentView === "settings" ? (
         <SettingsView
-          onClose={() => setCurrentView('chat')}
+          onClose={() => setCurrentView("chat")}
           initialTab={settingsInitialTab}
           currentProvider={currentProvider}
           streamingEnabled={streamingEnabledSetting}
@@ -389,7 +582,7 @@ const App = () => {
           autoOpenFileEnabled={autoOpenFileEnabled}
           onAutoOpenFileEnabledChange={handleAutoOpenFileEnabledChange}
         />
-      ) : currentView === 'chat' ? (
+      ) : currentView === "chat" ? (
         <ChatScreen
           mergedMessages={mergedMessages}
           getMessageText={getMessageText}
@@ -412,9 +605,11 @@ const App = () => {
           onMessageNodeRef={handleMessageNodeRef}
           statusPanelExpanded={statusPanelExpanded}
           forceStatusUpdate={forceStatusUpdate}
+          hasPendingSubagent={hasPendingSubagent}
           onUndoFile={handleUndoFile}
-          onDiscardAll={onDiscardAll}
           onKeepAll={handleKeepAll}
+          onRegisterFileChangeAction={registerPendingFileChangeAction}
+          onClearFileChangeAction={clearPendingFileChangeAction}
           onSubmit={handleSubmit}
           onInterrupt={interruptSession}
           onRewind={handleOpenRewindSelectDialog}
@@ -427,7 +622,9 @@ const App = () => {
           sdkStatusLoaded={sdkStatusLoaded}
           currentSdkInstalled={currentSdkInstalled}
           activeProviderConfig={activeProviderConfig}
-          claudeSettingsAlwaysThinkingEnabled={claudeSettingsAlwaysThinkingEnabled}
+          claudeSettingsAlwaysThinkingEnabled={
+            claudeSettingsAlwaysThinkingEnabled
+          }
           reasoningEffort={reasoningEffort}
           streamingEnabledSetting={streamingEnabledSetting}
           sendShortcut={sendShortcut}

--- a/webview/src/components/ChatScreen.tsx
+++ b/webview/src/components/ChatScreen.tsx
@@ -1,31 +1,37 @@
-import { type RefObject } from 'react';
-import { useTranslation } from 'react-i18next';
-import { ChatInputBox } from './ChatInputBox';
-import type {
-  Attachment,
-  ChatInputBoxHandle,
-} from './ChatInputBox/types';
-import { MessageAnchorRail } from './MessageAnchorRail';
-import { MessageList } from './MessageList';
-import { ScrollControl } from './ScrollControl';
-import { StatusPanel, StatusPanelErrorBoundary } from './StatusPanel';
-import { WelcomeScreen } from './WelcomeScreen';
+import { type RefObject } from "react";
+import { useTranslation } from "react-i18next";
+import { ChatInputBox } from "./ChatInputBox";
+import type { Attachment, ChatInputBoxHandle } from "./ChatInputBox/types";
+import { MessageAnchorRail } from "./MessageAnchorRail";
+import { MessageList } from "./MessageList";
+import { ScrollControl } from "./ScrollControl";
+import { StatusPanel, StatusPanelErrorBoundary } from "./StatusPanel";
+import { WelcomeScreen } from "./WelcomeScreen";
 import {
   SessionIdContext,
   SubagentHistoryContext,
   ToolResultRawContext,
-} from '../contexts/SubagentContext';
-import { useMessages } from '../contexts/MessagesContext';
-import { useSession } from '../contexts/SessionContext';
-import { useUIState } from '../contexts/UIStateContext';
-import { extractMarkdownContent } from '../utils/copyUtils';
-import type { ClaudeMessage, TodoItem, ToolResultBlock } from '../types';
-import type { useMessageProcessing, useFileChanges, useSubagents, useFileChangesManagement, useModelProviderState, useMessageQueue } from '../hooks';
-import type { GetToolResultRawFn } from '../contexts/SubagentContext';
+} from "../contexts/SubagentContext";
+import { useMessages } from "../contexts/MessagesContext";
+import { useSession } from "../contexts/SessionContext";
+import { useUIState } from "../contexts/UIStateContext";
+import { extractMarkdownContent } from "../utils/copyUtils";
+import type { ClaudeMessage, TodoItem, ToolResultBlock } from "../types";
+import type {
+  useMessageProcessing,
+  useFileChanges,
+  useSubagents,
+  useFileChangesManagement,
+  useModelProviderState,
+  useMessageQueue,
+} from "../hooks";
+import type { GetToolResultRawFn } from "../contexts/SubagentContext";
 
-type SubagentHistoryGetter = (key: string) => ReturnType<typeof useMessages>['subagentHistories'][string] | undefined;
+type SubagentHistoryGetter = (
+  key: string,
+) => ReturnType<typeof useMessages>["subagentHistories"][string] | undefined;
 type ProviderState = ReturnType<typeof useModelProviderState>;
-type MessageQueueValue = ReturnType<typeof useMessageQueue>['queue'];
+type MessageQueueValue = ReturnType<typeof useMessageQueue>["queue"];
 type SubagentList = ReturnType<typeof useSubagents>;
 type FileChangeList = ReturnType<typeof useFileChanges>;
 type FileChangeMgmt = ReturnType<typeof useFileChangesManagement>;
@@ -34,8 +40,11 @@ export interface ChatScreenProps {
   // Computed message data
   mergedMessages: ClaudeMessage[];
   getMessageText: (message: ClaudeMessage) => string;
-  getContentBlocks: ReturnType<typeof useMessageProcessing>['getContentBlocks'];
-  findToolResult: (toolUseId?: string, messageIndex?: number) => ToolResultBlock | null;
+  getContentBlocks: ReturnType<typeof useMessageProcessing>["getContentBlocks"];
+  findToolResult: (
+    toolUseId?: string,
+    messageIndex?: number,
+  ) => ToolResultBlock | null;
   getToolResultRaw: GetToolResultRawFn;
 
   // Subagent / status panel data
@@ -61,9 +70,11 @@ export interface ChatScreenProps {
   // Status panel
   statusPanelExpanded: boolean;
   forceStatusUpdate: React.Dispatch<React.SetStateAction<number>>;
-  onUndoFile: FileChangeMgmt['handleUndoFile'];
-  onDiscardAll: () => void;
-  onKeepAll: FileChangeMgmt['handleKeepAll'];
+  hasPendingSubagent: boolean;
+  onUndoFile: FileChangeMgmt["handleUndoFile"];
+  onKeepAll: FileChangeMgmt["handleKeepAll"];
+  onRegisterFileChangeAction: FileChangeMgmt["registerPendingFileChangeAction"];
+  onClearFileChangeAction: FileChangeMgmt["clearPendingFileChangeAction"];
 
   // Submit / interrupt / nav
   onSubmit: (content: string, attachments?: Attachment[]) => void;
@@ -73,32 +84,32 @@ export interface ChatScreenProps {
   onProviderSelect: (providerId: string) => void;
 
   // Model / provider state (slice from useModelProviderState)
-  currentProvider: ProviderState['currentProvider'];
-  selectedModel: ProviderState['selectedModel'];
-  permissionMode: ProviderState['permissionMode'];
-  selectedAgent: ProviderState['selectedAgent'];
-  sdkStatusLoaded: ProviderState['sdkStatusLoaded'];
-  currentSdkInstalled: ProviderState['currentSdkInstalled'];
-  activeProviderConfig: ProviderState['activeProviderConfig'];
-  claudeSettingsAlwaysThinkingEnabled: ProviderState['claudeSettingsAlwaysThinkingEnabled'];
-  reasoningEffort: ProviderState['reasoningEffort'];
-  streamingEnabledSetting: ProviderState['streamingEnabledSetting'];
-  sendShortcut: ProviderState['sendShortcut'];
-  autoOpenFileEnabled: ProviderState['autoOpenFileEnabled'];
-  longContextEnabled: ProviderState['longContextEnabled'];
-  usagePercentage: ProviderState['usagePercentage'];
-  usageUsedTokens: ProviderState['usageUsedTokens'];
-  usageMaxTokens: ProviderState['usageMaxTokens'];
+  currentProvider: ProviderState["currentProvider"];
+  selectedModel: ProviderState["selectedModel"];
+  permissionMode: ProviderState["permissionMode"];
+  selectedAgent: ProviderState["selectedAgent"];
+  sdkStatusLoaded: ProviderState["sdkStatusLoaded"];
+  currentSdkInstalled: ProviderState["currentSdkInstalled"];
+  activeProviderConfig: ProviderState["activeProviderConfig"];
+  claudeSettingsAlwaysThinkingEnabled: ProviderState["claudeSettingsAlwaysThinkingEnabled"];
+  reasoningEffort: ProviderState["reasoningEffort"];
+  streamingEnabledSetting: ProviderState["streamingEnabledSetting"];
+  sendShortcut: ProviderState["sendShortcut"];
+  autoOpenFileEnabled: ProviderState["autoOpenFileEnabled"];
+  longContextEnabled: ProviderState["longContextEnabled"];
+  usagePercentage: ProviderState["usagePercentage"];
+  usageUsedTokens: ProviderState["usageUsedTokens"];
+  usageMaxTokens: ProviderState["usageMaxTokens"];
 
   // Model handlers
-  onModeSelect: ProviderState['handleModeSelect'];
-  onModelSelect: ProviderState['handleModelSelect'];
-  onAgentSelect: ProviderState['handleAgentSelect'];
-  onReasoningChange: ProviderState['handleReasoningChange'];
-  onToggleThinking: ProviderState['handleToggleThinking'];
-  onStreamingEnabledChange: ProviderState['handleStreamingEnabledChange'];
-  onAutoOpenFileEnabledChange: ProviderState['handleAutoOpenFileEnabledChange'];
-  onLongContextChange: ProviderState['handleLongContextChange'];
+  onModeSelect: ProviderState["handleModeSelect"];
+  onModelSelect: ProviderState["handleModelSelect"];
+  onAgentSelect: ProviderState["handleAgentSelect"];
+  onReasoningChange: ProviderState["handleReasoningChange"];
+  onToggleThinking: ProviderState["handleToggleThinking"];
+  onStreamingEnabledChange: ProviderState["handleStreamingEnabledChange"];
+  onAutoOpenFileEnabledChange: ProviderState["handleAutoOpenFileEnabledChange"];
+  onLongContextChange: ProviderState["handleLongContextChange"];
 
   // Message queue
   messageQueue: MessageQueueValue;
@@ -114,35 +125,83 @@ export interface ChatScreenProps {
  * Stage 5 of TASK-P1-01.
  */
 export const ChatScreen = ({
-  mergedMessages, getMessageText, getContentBlocks, findToolResult, getToolResultRaw,
-  subagents, globalTodos, filteredFileChanges,
-  subagentHistoryCtxValue, sessionIdCtxValue,
-  chatInputRef, messagesContainerRef, messagesEndRef, inputAreaRef,
-  messageNodeMapRef, userCollapsedRef,
-  anchorCollapsedCount, setAnchorCollapsedCount, onMessageNodeRef,
-  statusPanelExpanded, forceStatusUpdate,
-  onUndoFile, onDiscardAll, onKeepAll,
-  onSubmit, onInterrupt, onRewind,
-  onNavigateToProviderSettings, onProviderSelect,
-  currentProvider, selectedModel, permissionMode, selectedAgent,
-  sdkStatusLoaded, currentSdkInstalled,
-  activeProviderConfig, claudeSettingsAlwaysThinkingEnabled,
-  reasoningEffort, streamingEnabledSetting, sendShortcut, autoOpenFileEnabled,
-  longContextEnabled, usagePercentage, usageUsedTokens, usageMaxTokens,
-  onModeSelect, onModelSelect, onAgentSelect, onReasoningChange, onToggleThinking,
+  mergedMessages,
+  getMessageText,
+  getContentBlocks,
+  findToolResult,
+  getToolResultRaw,
+  subagents,
+  globalTodos,
+  filteredFileChanges,
+  subagentHistoryCtxValue,
+  sessionIdCtxValue,
+  chatInputRef,
+  messagesContainerRef,
+  messagesEndRef,
+  inputAreaRef,
+  messageNodeMapRef,
+  userCollapsedRef,
+  anchorCollapsedCount,
+  setAnchorCollapsedCount,
+  onMessageNodeRef,
+  statusPanelExpanded,
+  forceStatusUpdate,
+  hasPendingSubagent,
+  onUndoFile,
+  onKeepAll,
+  onRegisterFileChangeAction,
+  onClearFileChangeAction,
+  onSubmit,
+  onInterrupt,
+  onRewind,
+  onNavigateToProviderSettings,
+  onProviderSelect,
+  currentProvider,
+  selectedModel,
+  permissionMode,
+  selectedAgent,
+  sdkStatusLoaded,
+  currentSdkInstalled,
+  activeProviderConfig,
+  claudeSettingsAlwaysThinkingEnabled,
+  reasoningEffort,
+  streamingEnabledSetting,
+  sendShortcut,
+  autoOpenFileEnabled,
+  longContextEnabled,
+  usagePercentage,
+  usageUsedTokens,
+  usageMaxTokens,
+  onModeSelect,
+  onModelSelect,
+  onAgentSelect,
+  onReasoningChange,
+  onToggleThinking,
   onStreamingEnabledChange,
-  onAutoOpenFileEnabledChange, onLongContextChange,
-  messageQueue, onRemoveFromQueue,
+  onAutoOpenFileEnabledChange,
+  onLongContextChange,
+  messageQueue,
+  onRemoveFromQueue,
 }: ChatScreenProps) => {
   const { t } = useTranslation();
-  const { messages, loading, isThinking, streamingActive, loadingStartTime, subagentHistories } = useMessages();
+  const {
+    messages,
+    loading,
+    isThinking,
+    streamingActive,
+    loadingStartTime,
+    subagentHistories,
+  } = useMessages();
   const { currentSessionId } = useSession();
   const {
-    setSettingsInitialTab, setCurrentView,
-    contextInfo, setContextInfo,
+    setSettingsInitialTab,
+    setCurrentView,
+    contextInfo,
+    setContextInfo,
     setAddModelDialogOpen,
     addToast,
-    draftInput, setDraftInput,
+    draftInput,
+    setDraftInput,
     openChangelogDialog,
   } = useUIState();
 
@@ -192,7 +251,10 @@ export const ChatScreen = ({
         </div>
       </div>
 
-      <ScrollControl containerRef={messagesContainerRef} inputAreaRef={inputAreaRef} />
+      <ScrollControl
+        containerRef={messagesContainerRef}
+        inputAreaRef={inputAreaRef}
+      />
 
       <StatusPanelErrorBoundary>
         <StatusPanel
@@ -203,9 +265,11 @@ export const ChatScreen = ({
           currentSessionId={currentSessionId}
           expanded={statusPanelExpanded}
           isStreaming={streamingActive}
+          hasPendingSubagent={hasPendingSubagent}
           onUndoFile={onUndoFile}
-          onDiscardAll={onDiscardAll}
           onKeepAll={onKeepAll}
+          onRegisterFileChangeAction={onRegisterFileChangeAction}
+          onClearFileChangeAction={onClearFileChangeAction}
         />
       </StatusPanelErrorBoundary>
 
@@ -220,13 +284,20 @@ export const ChatScreen = ({
           usageUsedTokens={usageUsedTokens}
           usageMaxTokens={usageMaxTokens}
           showUsage={true}
-          alwaysThinkingEnabled={activeProviderConfig?.settingsConfig?.alwaysThinkingEnabled ?? claudeSettingsAlwaysThinkingEnabled}
-          placeholder={sendShortcut === 'cmdEnter' ? t('chat.inputPlaceholderCmdEnter') : t('chat.inputPlaceholderEnter')}
+          alwaysThinkingEnabled={
+            activeProviderConfig?.settingsConfig?.alwaysThinkingEnabled ??
+            claudeSettingsAlwaysThinkingEnabled
+          }
+          placeholder={
+            sendShortcut === "cmdEnter"
+              ? t("chat.inputPlaceholderCmdEnter")
+              : t("chat.inputPlaceholderEnter")
+          }
           sdkInstalled={currentSdkInstalled}
           sdkStatusLoading={!sdkStatusLoaded}
           onInstallSdk={() => {
-            setSettingsInitialTab('dependencies');
-            setCurrentView('settings');
+            setSettingsInitialTab("dependencies");
+            setCurrentView("settings");
           }}
           value={draftInput}
           onInput={setDraftInput}
@@ -244,19 +315,22 @@ export const ChatScreen = ({
           selectedAgent={selectedAgent}
           onAgentSelect={onAgentSelect}
           activeFile={contextInfo?.file}
-          selectedLines={contextInfo?.startLine !== undefined && contextInfo?.endLine !== undefined
-            ? (contextInfo.startLine === contextInfo.endLine
+          selectedLines={
+            contextInfo?.startLine !== undefined &&
+            contextInfo?.endLine !== undefined
+              ? contextInfo.startLine === contextInfo.endLine
                 ? `L${contextInfo.startLine}`
-                : `L${contextInfo.startLine}-${contextInfo.endLine}`)
-            : undefined}
+                : `L${contextInfo.startLine}-${contextInfo.endLine}`
+              : undefined
+          }
           onClearContext={() => setContextInfo(null)}
           onOpenAgentSettings={() => {
-            setSettingsInitialTab('agents');
-            setCurrentView('settings');
+            setSettingsInitialTab("agents");
+            setCurrentView("settings");
           }}
           onOpenPromptSettings={() => {
-            setSettingsInitialTab('prompts');
-            setCurrentView('settings');
+            setSettingsInitialTab("prompts");
+            setCurrentView("settings");
           }}
           onOpenModelSettings={() => {
             setAddModelDialogOpen(true);
@@ -280,4 +354,3 @@ export const ChatScreen = ({
     </>
   );
 };
-

--- a/webview/src/components/StatusPanel/FileChangesList.tsx
+++ b/webview/src/components/StatusPanel/FileChangesList.tsx
@@ -14,6 +14,8 @@ interface FileChangesListProps {
   onShowDiff: (fileChange: FileChangeSummary) => void;
   onDiscardAllClick: () => void;
   onKeepAllClick: () => void;
+  keepAllDisabled?: boolean;
+  actionsDisabled?: boolean;
 }
 
 interface FileChangeRowProps {
@@ -23,6 +25,7 @@ interface FileChangeRowProps {
   onOpen: (fileChange: FileChangeSummary) => void;
   onShowDiff: (fileChange: FileChangeSummary) => void;
   onUndo: (fileChange: FileChangeSummary) => void;
+  actionsDisabled: boolean;
   t: TFunction;
 }
 
@@ -34,6 +37,7 @@ const FileChangeRow = memo(
     onOpen,
     onShowDiff,
     onUndo,
+    actionsDisabled,
     t,
   }: FileChangeRowProps) => {
     const status = String(fileChange.status || "M");
@@ -104,7 +108,7 @@ const FileChangeRow = memo(
             className="file-change-action-btn diff-btn"
             onClick={handleShowDiff}
             title={t("statusPanel.showDiff")}
-            disabled={isDiscardingAll || unsafeRollback}
+            disabled={actionsDisabled || isDiscardingAll || unsafeRollback}
           >
             <span className="codicon codicon-diff" />
           </button>
@@ -112,7 +116,7 @@ const FileChangeRow = memo(
             className="file-change-action-btn undo-btn"
             onClick={handleUndo}
             title={t("statusPanel.undoChanges")}
-            disabled={isDiscardingAll || isUndoing || unsafeRollback}
+            disabled={actionsDisabled || isDiscardingAll || isUndoing || unsafeRollback}
           >
             {isUndoing ? (
               <span className="codicon codicon-loading codicon-modifier-spin" />
@@ -137,6 +141,8 @@ const FileChangesList = memo(
     onShowDiff,
     onDiscardAllClick,
     onKeepAllClick,
+    keepAllDisabled = false,
+    actionsDisabled = false,
   }: FileChangesListProps) => {
     const { t } = useTranslation();
 
@@ -159,7 +165,7 @@ const FileChangesList = memo(
           <button
             className="file-changes-action-btn discard-all-btn"
             onClick={onDiscardAllClick}
-            disabled={isDiscardingAll}
+            disabled={actionsDisabled || isDiscardingAll}
             title={t("statusPanel.discardAll")}
           >
             {isDiscardingAll ? (
@@ -172,6 +178,7 @@ const FileChangesList = memo(
           <button
             className="file-changes-action-btn keep-all-btn"
             onClick={onKeepAllClick}
+            disabled={keepAllDisabled}
             title={t("statusPanel.keepAll")}
           >
             <span className="codicon codicon-check-all" />
@@ -187,6 +194,7 @@ const FileChangesList = memo(
               fileChange={fileChange}
               isUndoing={undoingFile === fileChange.filePath}
               isDiscardingAll={isDiscardingAll}
+              actionsDisabled={actionsDisabled}
               onOpen={handleOpenFile}
               onShowDiff={onShowDiff}
               onUndo={onUndoClick}

--- a/webview/src/components/StatusPanel/FileChangesList.tsx
+++ b/webview/src/components/StatusPanel/FileChangesList.tsx
@@ -1,16 +1,17 @@
-import { memo, useCallback } from 'react';
-import type React from 'react';
-import { useTranslation } from 'react-i18next';
-import type { TFunction } from 'i18next';
-import type { FileChangeSummary } from '../../types';
-import { showEditableDiff, openFile } from '../../utils/bridge';
-import FileIcon from './FileIcon';
+import { memo, useCallback } from "react";
+import type React from "react";
+import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
+import type { FileChangeSummary } from "../../types";
+import { openFile } from "../../utils/bridge";
+import FileIcon from "./FileIcon";
 
 interface FileChangesListProps {
   fileChanges: FileChangeSummary[];
   undoingFile: string | null;
   isDiscardingAll: boolean;
   onUndoClick: (fileChange: FileChangeSummary) => void;
+  onShowDiff: (fileChange: FileChangeSummary) => void;
   onDiscardAllClick: () => void;
   onKeepAllClick: () => void;
 }
@@ -18,167 +19,186 @@ interface FileChangesListProps {
 interface FileChangeRowProps {
   fileChange: FileChangeSummary;
   isUndoing: boolean;
+  isDiscardingAll: boolean;
   onOpen: (fileChange: FileChangeSummary) => void;
   onShowDiff: (fileChange: FileChangeSummary) => void;
   onUndo: (fileChange: FileChangeSummary) => void;
   t: TFunction;
 }
 
-const FileChangeRow = memo(({ fileChange, isUndoing, onOpen, onShowDiff, onUndo, t }: FileChangeRowProps) => {
-  const status = String(fileChange.status || 'M');
-  const statusClass = status === 'A' ? 'added' : 'modified';
+const FileChangeRow = memo(
+  ({
+    fileChange,
+    isUndoing,
+    isDiscardingAll,
+    onOpen,
+    onShowDiff,
+    onUndo,
+    t,
+  }: FileChangeRowProps) => {
+    const status = String(fileChange.status || "M");
+    const statusClass = status === "A" ? "added" : "modified";
+    const unsafeRollback = fileChange.operations.some(
+      (operation) => operation.safeToRollback === false,
+    );
 
-  const handleOpen = useCallback(() => {
-    onOpen(fileChange);
-  }, [onOpen, fileChange]);
-
-  const handleOpenKeyDown = useCallback((event: React.KeyboardEvent<HTMLSpanElement>) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
+    const handleOpen = useCallback(() => {
       onOpen(fileChange);
-    }
-  }, [onOpen, fileChange]);
+    }, [onOpen, fileChange]);
 
-  const handleShowDiff = useCallback(() => {
-    onShowDiff(fileChange);
-  }, [onShowDiff, fileChange]);
+    const handleOpenKeyDown = useCallback(
+      (event: React.KeyboardEvent<HTMLSpanElement>) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onOpen(fileChange);
+        }
+      },
+      [onOpen, fileChange],
+    );
 
-  const handleUndo = useCallback(() => {
-    onUndo(fileChange);
-  }, [onUndo, fileChange]);
+    const handleShowDiff = useCallback(() => {
+      onShowDiff(fileChange);
+    }, [onShowDiff, fileChange]);
 
-  return (
-    <div className="file-change-item">
-      {/* Status indicator (A/M) */}
-      <span className={`file-change-status status-${statusClass}`}>
-        {status}
-      </span>
+    const handleUndo = useCallback(() => {
+      onUndo(fileChange);
+    }, [onUndo, fileChange]);
 
-      {/* File icon */}
-      <FileIcon filePath={fileChange.filePath} />
-
-      {/* File name — keyboard accessible since it acts as a button */}
-      <span
-        className="file-change-name"
-        role="button"
-        tabIndex={0}
-        onClick={handleOpen}
-        onKeyDown={handleOpenKeyDown}
-        title={fileChange.filePath}
-      >
-        {fileChange.fileName}
-      </span>
-
-      {/* Stats */}
-      {(fileChange.additions > 0 || fileChange.deletions > 0) && (
-        <span className="file-change-stats">
-          {fileChange.additions > 0 && <span className="additions">+{fileChange.additions}</span>}
-          {fileChange.deletions > 0 && <span className="deletions">-{fileChange.deletions}</span>}
+    return (
+      <div className="file-change-item">
+        {/* Status indicator (A/M) */}
+        <span className={`file-change-status status-${statusClass}`}>
+          {status}
         </span>
-      )}
 
-      {/* Actions */}
-      <div className="file-change-actions">
-        <button
-          className="file-change-action-btn diff-btn"
-          onClick={handleShowDiff}
-          title={t('statusPanel.showDiff')}
+        {/* File icon */}
+        <FileIcon filePath={fileChange.filePath} />
+
+        {/* File name — keyboard accessible since it acts as a button */}
+        <span
+          className="file-change-name"
+          role="button"
+          tabIndex={0}
+          onClick={handleOpen}
+          onKeyDown={handleOpenKeyDown}
+          title={fileChange.filePath}
         >
-          <span className="codicon codicon-diff" />
-        </button>
-        <button
-          className="file-change-action-btn undo-btn"
-          onClick={handleUndo}
-          title={t('statusPanel.undoChanges')}
-          disabled={isUndoing}
-        >
-          {isUndoing ? (
-            <span className="codicon codicon-loading codicon-modifier-spin" />
-          ) : (
-            <span className="codicon codicon-discard" />
-          )}
-        </button>
+          {fileChange.fileName}
+        </span>
+
+        {/* Stats */}
+        {(fileChange.additions > 0 || fileChange.deletions > 0) && (
+          <span className="file-change-stats">
+            {fileChange.additions > 0 && (
+              <span className="additions">+{fileChange.additions}</span>
+            )}
+            {fileChange.deletions > 0 && (
+              <span className="deletions">-{fileChange.deletions}</span>
+            )}
+          </span>
+        )}
+
+        {/* Actions */}
+        <div className="file-change-actions">
+          <button
+            className="file-change-action-btn diff-btn"
+            onClick={handleShowDiff}
+            title={t("statusPanel.showDiff")}
+            disabled={isDiscardingAll || unsafeRollback}
+          >
+            <span className="codicon codicon-diff" />
+          </button>
+          <button
+            className="file-change-action-btn undo-btn"
+            onClick={handleUndo}
+            title={t("statusPanel.undoChanges")}
+            disabled={isDiscardingAll || isUndoing || unsafeRollback}
+          >
+            {isUndoing ? (
+              <span className="codicon codicon-loading codicon-modifier-spin" />
+            ) : (
+              <span className="codicon codicon-discard" />
+            )}
+          </button>
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  },
+);
 
-FileChangeRow.displayName = 'FileChangeRow';
+FileChangeRow.displayName = "FileChangeRow";
 
-const FileChangesList = memo(({
-  fileChanges,
-  undoingFile,
-  isDiscardingAll,
-  onUndoClick,
-  onDiscardAllClick,
-  onKeepAllClick,
-}: FileChangesListProps) => {
-  const { t } = useTranslation();
+const FileChangesList = memo(
+  ({
+    fileChanges,
+    undoingFile,
+    isDiscardingAll,
+    onUndoClick,
+    onShowDiff,
+    onDiscardAllClick,
+    onKeepAllClick,
+  }: FileChangesListProps) => {
+    const { t } = useTranslation();
 
-  const handleOpenFile = useCallback((fileChange: FileChangeSummary) => {
-    openFile(fileChange.filePath, fileChange.lineStart, fileChange.lineEnd);
-  }, []);
+    const handleOpenFile = useCallback((fileChange: FileChangeSummary) => {
+      openFile(fileChange.filePath, fileChange.lineStart, fileChange.lineEnd);
+    }, []);
 
-  const handleShowDiff = useCallback((fileChange: FileChangeSummary) => {
-    const operations = fileChange.operations.map((op) => ({
-      oldString: op.oldString,
-      newString: op.newString,
-      replaceAll: op.replaceAll,
-    }));
-    // Use editable diff view for selective accept/reject of changes
-    const status = fileChange.status === 'A' ? 'A' : 'M';
-    showEditableDiff(fileChange.filePath, operations, status);
-  }, []);
+    if (fileChanges.length === 0) {
+      return (
+        <div className="status-panel-empty">
+          {t("statusPanel.noFileChanges")}
+        </div>
+      );
+    }
 
-  if (fileChanges.length === 0) {
-    return <div className="status-panel-empty">{t('statusPanel.noFileChanges')}</div>;
-  }
+    return (
+      <div className="file-changes-container">
+        {/* Batch action buttons */}
+        <div className="file-changes-actions-bar">
+          <button
+            className="file-changes-action-btn discard-all-btn"
+            onClick={onDiscardAllClick}
+            disabled={isDiscardingAll}
+            title={t("statusPanel.discardAll")}
+          >
+            {isDiscardingAll ? (
+              <span className="codicon codicon-loading codicon-modifier-spin" />
+            ) : (
+              <span className="codicon codicon-trash" />
+            )}
+            <span>{t("statusPanel.discardAll")}</span>
+          </button>
+          <button
+            className="file-changes-action-btn keep-all-btn"
+            onClick={onKeepAllClick}
+            title={t("statusPanel.keepAll")}
+          >
+            <span className="codicon codicon-check-all" />
+            <span>{t("statusPanel.keepAll")}</span>
+          </button>
+        </div>
 
-  return (
-    <div className="file-changes-container">
-      {/* Batch action buttons */}
-      <div className="file-changes-actions-bar">
-        <button
-          className="file-changes-action-btn discard-all-btn"
-          onClick={onDiscardAllClick}
-          disabled={isDiscardingAll}
-          title={t('statusPanel.discardAll')}
-        >
-          {isDiscardingAll ? (
-            <span className="codicon codicon-loading codicon-modifier-spin" />
-          ) : (
-            <span className="codicon codicon-trash" />
-          )}
-          <span>{t('statusPanel.discardAll')}</span>
-        </button>
-        <button
-          className="file-changes-action-btn keep-all-btn"
-          onClick={onKeepAllClick}
-          title={t('statusPanel.keepAll')}
-        >
-          <span className="codicon codicon-check-all" />
-          <span>{t('statusPanel.keepAll')}</span>
-        </button>
+        {/* File list */}
+        <div className="file-changes-list">
+          {fileChanges.map((fileChange) => (
+            <FileChangeRow
+              key={fileChange.filePath}
+              fileChange={fileChange}
+              isUndoing={undoingFile === fileChange.filePath}
+              isDiscardingAll={isDiscardingAll}
+              onOpen={handleOpenFile}
+              onShowDiff={onShowDiff}
+              onUndo={onUndoClick}
+              t={t}
+            />
+          ))}
+        </div>
       </div>
+    );
+  },
+);
 
-      {/* File list */}
-      <div className="file-changes-list">
-        {fileChanges.map((fileChange) => (
-          <FileChangeRow
-            key={fileChange.filePath}
-            fileChange={fileChange}
-            isUndoing={undoingFile === fileChange.filePath}
-            onOpen={handleOpenFile}
-            onShowDiff={handleShowDiff}
-            onUndo={onUndoClick}
-            t={t}
-          />
-        ))}
-      </div>
-    </div>
-  );
-});
-
-FileChangesList.displayName = 'FileChangesList';
+FileChangesList.displayName = "FileChangesList";
 
 export default FileChangesList;

--- a/webview/src/components/StatusPanel/StatusPanel.test.tsx
+++ b/webview/src/components/StatusPanel/StatusPanel.test.tsx
@@ -56,16 +56,19 @@ function getKeepAllButton() {
 }
 
 describe('StatusPanel', () => {
-  it('allows Keep All while a session-level subagent is pending', () => {
+  it('disables Keep All while a session-level subagent is pending', () => {
     renderFilesPanel({ hasPendingSubagent: true });
 
-    expect(getKeepAllButton().disabled).toBe(false);
+    expect(getKeepAllButton().disabled).toBe(true);
+    expect((screen.getByTitle('statusPanel.discardAll') as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTitle('statusPanel.showDiff') as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTitle('statusPanel.undoChanges') as HTMLButtonElement).disabled).toBe(true);
   });
 
-  it('allows Keep All while a response is still streaming', () => {
+  it('disables Keep All while a response is still streaming', () => {
     renderFilesPanel({ isStreaming: true });
 
-    expect(getKeepAllButton().disabled).toBe(false);
+    expect(getKeepAllButton().disabled).toBe(true);
   });
 
   it('allows Keep All when no stream or subagent scope is pending', () => {

--- a/webview/src/components/StatusPanel/StatusPanel.test.tsx
+++ b/webview/src/components/StatusPanel/StatusPanel.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import StatusPanel from './StatusPanel';
+import type { FileChangeSummary, SubagentInfo } from '../../types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../../utils/bridge', () => ({
+  openFile: vi.fn(),
+  showEditableDiff: vi.fn(() => true),
+  undoFileChanges: vi.fn(),
+  sendToJava: vi.fn(),
+}));
+
+const fileChange: FileChangeSummary = {
+  filePath: '/tmp/example.ts',
+  fileName: 'example.ts',
+  status: 'M',
+  additions: 1,
+  deletions: 1,
+  operations: [
+    {
+      toolName: 'Edit',
+      oldString: 'old',
+      newString: 'new',
+      additions: 1,
+      deletions: 1,
+    },
+  ],
+};
+
+function renderFilesPanel(props: Partial<React.ComponentProps<typeof StatusPanel>> = {}) {
+  render(
+    <StatusPanel
+      todos={[]}
+      fileChanges={[fileChange]}
+      subagents={[]}
+      expanded
+      isStreaming={false}
+      {...props}
+    />,
+  );
+
+  fireEvent.click(screen.getByText('statusPanel.editsTab'));
+}
+
+function getKeepAllButton() {
+  const button = screen.getByText('statusPanel.keepAll').closest('button');
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error('Keep All button not found');
+  }
+  return button;
+}
+
+describe('StatusPanel', () => {
+  it('allows Keep All while a session-level subagent is pending', () => {
+    renderFilesPanel({ hasPendingSubagent: true });
+
+    expect(getKeepAllButton().disabled).toBe(false);
+  });
+
+  it('allows Keep All while a response is still streaming', () => {
+    renderFilesPanel({ isStreaming: true });
+
+    expect(getKeepAllButton().disabled).toBe(false);
+  });
+
+  it('allows Keep All when no stream or subagent scope is pending', () => {
+    renderFilesPanel({ hasPendingSubagent: false });
+
+    expect(getKeepAllButton().disabled).toBe(false);
+  });
+
+  it('counts error subagents as settled in the progress badge', () => {
+    const subagents: SubagentInfo[] = [
+      { id: 'a', type: 'worker', description: 'done 1', status: 'completed', messageIndex: 0 },
+      { id: 'b', type: 'worker', description: 'done 2', status: 'completed', messageIndex: 0 },
+      { id: 'c', type: 'worker', description: 'done 3', status: 'completed', messageIndex: 0 },
+      { id: 'd', type: 'worker', description: 'invalid spawn', status: 'error', messageIndex: 0 },
+    ];
+
+    render(
+      <StatusPanel
+        todos={[]}
+        fileChanges={[]}
+        subagents={subagents}
+        expanded
+        isStreaming={false}
+      />,
+    );
+
+    expect(screen.getByText('4/4')).toBeTruthy();
+  });
+
+});

--- a/webview/src/components/StatusPanel/StatusPanel.tsx
+++ b/webview/src/components/StatusPanel/StatusPanel.tsx
@@ -29,6 +29,7 @@ const StatusPanel = ({
   currentSessionId,
   expanded = true,
   isStreaming = false,
+  hasPendingSubagent = false,
   onUndoFile,
   onKeepAll,
   onRegisterFileChangeAction,
@@ -55,6 +56,8 @@ const StatusPanel = ({
   const hasTodos = todos.length > 0;
   const hasFileChanges = fileChanges.length > 0;
   const hasSubagents = subagents.length > 0;
+  const keepAllDisabled = isStreaming || hasPendingSubagent;
+  const fileActionsDisabled = isStreaming || hasPendingSubagent;
 
   // Calculate todo stats
   const { completedCount, totalCount, hasInProgressTodo } = useMemo(() => {
@@ -125,11 +128,16 @@ const StatusPanel = ({
 
   // Undo handlers
   const handleUndoClick = useCallback((fileChange: FileChangeSummary) => {
+    if (fileActionsDisabled) return;
     setConfirmUndoFile(fileChange);
-  }, []);
+  }, [fileActionsDisabled]);
 
   const handleConfirmUndo = useCallback(() => {
     if (!confirmUndoFile) return;
+    if (fileActionsDisabled) {
+      setConfirmUndoFile(null);
+      return;
+    }
 
     const { filePath, operations } = confirmUndoFile;
     const safeStatus = confirmUndoFile.status === "A" ? "A" : "M";
@@ -139,7 +147,7 @@ const StatusPanel = ({
     setConfirmUndoFile(null);
 
     undoFileChanges(filePath, safeStatus, toBridgeOperations(operations));
-  }, [confirmUndoFile]);
+  }, [confirmUndoFile, fileActionsDisabled]);
 
   const handleCancelUndo = useCallback(() => {
     setConfirmUndoFile(null);
@@ -147,11 +155,16 @@ const StatusPanel = ({
 
   // Discard All handlers
   const handleDiscardAllClick = useCallback(() => {
+    if (fileActionsDisabled) return;
     setConfirmDiscardAll(true);
-  }, []);
+  }, [fileActionsDisabled]);
 
   const handleConfirmDiscardAll = useCallback(() => {
     if (fileChanges.length === 0) return;
+    if (fileActionsDisabled) {
+      setConfirmDiscardAll(false);
+      return;
+    }
 
     setIsDiscardingAll(true);
     setConfirmDiscardAll(false);
@@ -167,7 +180,7 @@ const StatusPanel = ({
     );
 
     sendToJava("undo_all_file_changes", { files });
-  }, [fileChanges]);
+  }, [fileChanges, fileActionsDisabled]);
 
   const handleCancelDiscardAll = useCallback(() => {
     setConfirmDiscardAll(false);
@@ -175,6 +188,7 @@ const StatusPanel = ({
 
   const handleShowDiff = useCallback(
     (fileChange: FileChangeSummary) => {
+      if (fileActionsDisabled) return;
       const status = fileChange.status === "A" ? "A" : "M";
       const requestId = onRegisterFileChangeAction?.(fileChange);
       const dispatched = showEditableDiff(
@@ -187,14 +201,15 @@ const StatusPanel = ({
         onClearFileChangeAction?.(requestId);
       }
     },
-    [onRegisterFileChangeAction, onClearFileChangeAction],
+    [fileActionsDisabled, onRegisterFileChangeAction, onClearFileChangeAction],
   );
 
   // Keep All handler
   const handleKeepAllClick = useCallback(() => {
+    if (keepAllDisabled) return;
     onKeepAll?.();
     window.addToast?.(t("statusPanel.keepAllSuccess"), "success");
-  }, [onKeepAll, t]);
+  }, [keepAllDisabled, onKeepAll, t]);
 
   // Register undo result callback
   useEffect(() => {
@@ -204,19 +219,21 @@ const StatusPanel = ({
         setUndoingFile(null);
 
         if (result.success) {
+          const completedFilePath = result.requestFilePath || result.filePath;
           const requested = undoRequestByFilePathRef.current.get(
-            result.filePath,
+            completedFilePath,
           );
-          undoRequestByFilePathRef.current.delete(result.filePath);
-          onUndoFile?.(result.filePath, requested?.operations);
+          undoRequestByFilePathRef.current.delete(completedFilePath);
+          onUndoFile?.(completedFilePath, requested?.operations);
           window.addToast?.(
             t("statusPanel.undoSuccess", {
-              fileName: getFileName(result.filePath),
+              fileName: getFileName(completedFilePath),
             }),
             "success",
           );
         } else {
-          undoRequestByFilePathRef.current.delete(result.filePath);
+          const completedFilePath = result.requestFilePath || result.filePath;
+          undoRequestByFilePathRef.current.delete(completedFilePath);
           window.addToast?.(
             t("statusPanel.undoFailed", {
               error: result.error || "Unknown error",
@@ -224,8 +241,8 @@ const StatusPanel = ({
             "error",
           );
         }
-      } catch {
-        // JSON parse failed, reset state silently
+      } catch (error) {
+        console.error("Failed to handle undo file result", error);
         setUndoingFile(null);
       }
     };
@@ -283,8 +300,8 @@ const StatusPanel = ({
             "error",
           );
         }
-      } catch {
-        // JSON parse failed, reset state silently
+      } catch (error) {
+        console.error("Failed to handle undo all file result", error);
         setIsDiscardingAll(false);
       }
     };
@@ -322,6 +339,8 @@ const StatusPanel = ({
             onShowDiff={handleShowDiff}
             onDiscardAllClick={handleDiscardAllClick}
             onKeepAllClick={handleKeepAllClick}
+            keepAllDisabled={keepAllDisabled}
+            actionsDisabled={fileActionsDisabled}
           />
         );
       default:

--- a/webview/src/components/StatusPanel/StatusPanel.tsx
+++ b/webview/src/components/StatusPanel/StatusPanel.tsx
@@ -1,28 +1,56 @@
-import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
-import { useTranslation } from 'react-i18next';
-import type { FileChangeSummary } from '../../types';
-import { undoFileChanges, sendToJava } from '../../utils/bridge';
-import { getFileName } from '../../utils/helpers';
-import TodoList from './TodoList';
-import SubagentList from './SubagentList';
-import FileChangesList from './FileChangesList';
-import UndoConfirmDialog from './UndoConfirmDialog';
-import DiscardAllDialog from './DiscardAllDialog';
-import type { TabType, StatusPanelProps } from './types';
-import './StatusPanel.less';
+import { useState, useMemo, useEffect, useRef, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import type { FileChangeSummary } from "../../types";
+import {
+  showEditableDiff,
+  undoFileChanges,
+  sendToJava,
+} from "../../utils/bridge";
+import { getFileName } from "../../utils/helpers";
+import TodoList from "./TodoList";
+import SubagentList from "./SubagentList";
+import FileChangesList from "./FileChangesList";
+import UndoConfirmDialog from "./UndoConfirmDialog";
+import DiscardAllDialog from "./DiscardAllDialog";
+import type { TabType, StatusPanelProps } from "./types";
+import {
+  getFilesToDiscardAfterUndoAll,
+  getSucceededFilesFromUndoAllResult,
+  getUndoAllFailureMessage,
+  toBridgeOperations,
+} from "./fileChangeActions";
+import "./StatusPanel.less";
 
-const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, currentSessionId, expanded = true, isStreaming = false, onUndoFile, onDiscardAll, onKeepAll }: StatusPanelProps) => {
+const StatusPanel = ({
+  todos,
+  fileChanges,
+  subagents,
+  subagentHistories,
+  currentSessionId,
+  expanded = true,
+  isStreaming = false,
+  onUndoFile,
+  onKeepAll,
+  onRegisterFileChangeAction,
+  onClearFileChangeAction,
+}: StatusPanelProps) => {
   const { t } = useTranslation();
   const [openPopover, setOpenPopover] = useState<TabType | null>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
 
   // Undo related state
   const [undoingFile, setUndoingFile] = useState<string | null>(null);
-  const [confirmUndoFile, setConfirmUndoFile] = useState<FileChangeSummary | null>(null);
+  const [confirmUndoFile, setConfirmUndoFile] =
+    useState<FileChangeSummary | null>(null);
 
   // Discard All confirmation state
   const [confirmDiscardAll, setConfirmDiscardAll] = useState(false);
   const [isDiscardingAll, setIsDiscardingAll] = useState(false);
+  const discardAllRequestFilesRef = useRef<string[]>([]);
+  const undoRequestByFilePathRef = useRef(new Map<string, FileChangeSummary>());
+  const discardAllRequestByFilePathRef = useRef(
+    new Map<string, FileChangeSummary>(),
+  );
 
   const hasTodos = todos.length > 0;
   const hasFileChanges = fileChanges.length > 0;
@@ -30,17 +58,30 @@ const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, current
 
   // Calculate todo stats
   const { completedCount, totalCount, hasInProgressTodo } = useMemo(() => {
-    const completed = todos.filter((todo) => todo.status === 'completed').length;
-    const inProgress = todos.some((todo) => todo.status === 'in_progress');
-    return { completedCount: completed, totalCount: todos.length, hasInProgressTodo: inProgress };
+    const completed = todos.filter(
+      (todo) => todo.status === "completed",
+    ).length;
+    const inProgress = todos.some((todo) => todo.status === "in_progress");
+    return {
+      completedCount: completed,
+      totalCount: todos.length,
+      hasInProgressTodo: inProgress,
+    };
   }, [todos]);
 
   // Calculate subagent stats
-  const { subagentCompletedCount, subagentTotalCount, hasRunningSubagent } = useMemo(() => {
-    const completed = subagents.filter((s) => s.status === 'completed').length;
-    const running = subagents.some((s) => s.status === 'running');
-    return { subagentCompletedCount: completed, subagentTotalCount: subagents.length, hasRunningSubagent: running };
-  }, [subagents]);
+  const { subagentCompletedCount, subagentTotalCount, hasRunningSubagent } =
+    useMemo(() => {
+      const completed = subagents.filter(
+        (s) => s.status === "completed" || s.status === "error",
+      ).length;
+      const running = subagents.some((s) => s.status === "running");
+      return {
+        subagentCompletedCount: completed,
+        subagentTotalCount: subagents.length,
+        hasRunningSubagent: running,
+      };
+    }, [subagents]);
 
   // Calculate total file changes stats
   const { totalAdditions, totalDeletions } = useMemo(() => {
@@ -49,7 +90,7 @@ const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, current
         totalAdditions: acc.totalAdditions + file.additions,
         totalDeletions: acc.totalDeletions + file.deletions,
       }),
-      { totalAdditions: 0, totalDeletions: 0 }
+      { totalAdditions: 0, totalDeletions: 0 },
     );
   }, [fileChanges]);
 
@@ -63,14 +104,18 @@ const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, current
   // Close popover when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (popoverRef.current && !popoverRef.current.contains(event.target as Node)) {
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(event.target as Node)
+      ) {
         setOpenPopover(null);
       }
     };
 
     if (openPopover) {
-      document.addEventListener('mousedown', handleClickOutside);
-      return () => document.removeEventListener('mousedown', handleClickOutside);
+      document.addEventListener("mousedown", handleClickOutside);
+      return () =>
+        document.removeEventListener("mousedown", handleClickOutside);
     }
   }, [openPopover]);
 
@@ -87,18 +132,13 @@ const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, current
     if (!confirmUndoFile) return;
 
     const { filePath, operations } = confirmUndoFile;
-    const safeStatus = confirmUndoFile.status === 'A' ? 'A' : 'M';
+    const safeStatus = confirmUndoFile.status === "A" ? "A" : "M";
 
     setUndoingFile(filePath);
+    undoRequestByFilePathRef.current.set(filePath, confirmUndoFile);
     setConfirmUndoFile(null);
 
-    const ops = operations.map((op) => ({
-      oldString: op.oldString,
-      newString: op.newString,
-      replaceAll: op.replaceAll,
-    }));
-
-    undoFileChanges(filePath, safeStatus, ops);
+    undoFileChanges(filePath, safeStatus, toBridgeOperations(operations));
   }, [confirmUndoFile]);
 
   const handleCancelUndo = useCallback(() => {
@@ -118,25 +158,42 @@ const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, current
 
     const files = fileChanges.map((fc) => ({
       filePath: fc.filePath,
-      status: fc.status === 'A' ? 'A' : 'M',
-      operations: fc.operations.map((op) => ({
-        oldString: op.oldString,
-        newString: op.newString,
-        replaceAll: op.replaceAll,
-      })),
+      status: fc.status === "A" ? "A" : "M",
+      operations: toBridgeOperations(fc.operations),
     }));
+    discardAllRequestFilesRef.current = files.map((file) => file.filePath);
+    discardAllRequestByFilePathRef.current = new Map(
+      fileChanges.map((fileChange) => [fileChange.filePath, fileChange]),
+    );
 
-    sendToJava('undo_all_file_changes', { files });
+    sendToJava("undo_all_file_changes", { files });
   }, [fileChanges]);
 
   const handleCancelDiscardAll = useCallback(() => {
     setConfirmDiscardAll(false);
   }, []);
 
+  const handleShowDiff = useCallback(
+    (fileChange: FileChangeSummary) => {
+      const status = fileChange.status === "A" ? "A" : "M";
+      const requestId = onRegisterFileChangeAction?.(fileChange);
+      const dispatched = showEditableDiff(
+        fileChange.filePath,
+        toBridgeOperations(fileChange.operations),
+        status,
+        requestId,
+      );
+      if (!dispatched) {
+        onClearFileChangeAction?.(requestId);
+      }
+    },
+    [onRegisterFileChangeAction, onClearFileChangeAction],
+  );
+
   // Keep All handler
   const handleKeepAllClick = useCallback(() => {
     onKeepAll?.();
-    window.addToast?.(t('statusPanel.keepAllSuccess'), 'success');
+    window.addToast?.(t("statusPanel.keepAllSuccess"), "success");
   }, [onKeepAll, t]);
 
   // Register undo result callback
@@ -147,15 +204,24 @@ const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, current
         setUndoingFile(null);
 
         if (result.success) {
-          onUndoFile?.(result.filePath);
+          const requested = undoRequestByFilePathRef.current.get(
+            result.filePath,
+          );
+          undoRequestByFilePathRef.current.delete(result.filePath);
+          onUndoFile?.(result.filePath, requested?.operations);
           window.addToast?.(
-            t('statusPanel.undoSuccess', { fileName: getFileName(result.filePath) }),
-            'success'
+            t("statusPanel.undoSuccess", {
+              fileName: getFileName(result.filePath),
+            }),
+            "success",
           );
         } else {
+          undoRequestByFilePathRef.current.delete(result.filePath);
           window.addToast?.(
-            t('statusPanel.undoFailed', { error: result.error || 'Unknown error' }),
-            'error'
+            t("statusPanel.undoFailed", {
+              error: result.error || "Unknown error",
+            }),
+            "error",
           );
         }
       } catch {
@@ -177,13 +243,44 @@ const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, current
         const result = JSON.parse(resultJson);
         setIsDiscardingAll(false);
 
+        const succeededFiles = getSucceededFilesFromUndoAllResult(result);
+
         if (result.success) {
-          onDiscardAll?.();
-          window.addToast?.(t('statusPanel.discardAllSuccess'), 'success');
-        } else {
+          getFilesToDiscardAfterUndoAll(
+            result,
+            discardAllRequestFilesRef.current,
+          ).forEach((filePath) => {
+            const requested =
+              discardAllRequestByFilePathRef.current.get(filePath);
+            onUndoFile?.(filePath, requested?.operations);
+          });
+          discardAllRequestFilesRef.current = [];
+          discardAllRequestByFilePathRef.current.clear();
+          window.addToast?.(t("statusPanel.discardAllSuccess"), "success");
+        } else if (result.partial && succeededFiles.length > 0) {
+          succeededFiles.forEach((filePath) => {
+            const requested =
+              discardAllRequestByFilePathRef.current.get(filePath);
+            onUndoFile?.(filePath, requested?.operations);
+          });
+          discardAllRequestFilesRef.current = [];
+          discardAllRequestByFilePathRef.current.clear();
           window.addToast?.(
-            t('statusPanel.discardAllFailed', { error: result.error || 'Unknown error' }),
-            'error'
+            t("statusPanel.discardAllFailed", {
+              error: getUndoAllFailureMessage(
+                result,
+                "Some files could not be discarded",
+              ),
+            }),
+            "error",
+          );
+        } else {
+          discardAllRequestByFilePathRef.current.clear();
+          window.addToast?.(
+            t("statusPanel.discardAllFailed", {
+              error: getUndoAllFailureMessage(result, "Unknown error"),
+            }),
+            "error",
           );
         }
       } catch {
@@ -196,7 +293,7 @@ const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, current
     return () => {
       delete window.onUndoAllFileResult;
     };
-  }, [onDiscardAll, t]);
+  }, [onUndoFile, t]);
 
   if (!expanded) {
     return null;
@@ -204,17 +301,25 @@ const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, current
 
   const renderPopoverContent = () => {
     switch (openPopover) {
-      case 'todo':
+      case "todo":
         return <TodoList todos={todos} />;
-      case 'subagent':
-        return <SubagentList subagents={subagents} histories={subagentHistories} currentSessionId={currentSessionId} isStreaming={isStreaming} />;
-      case 'files':
+      case "subagent":
+        return (
+          <SubagentList
+            subagents={subagents}
+            histories={subagentHistories}
+            currentSessionId={currentSessionId}
+            isStreaming={isStreaming}
+          />
+        );
+      case "files":
         return (
           <FileChangesList
             fileChanges={fileChanges}
             undoingFile={undoingFile}
             isDiscardingAll={isDiscardingAll}
             onUndoClick={handleUndoClick}
+            onShowDiff={handleShowDiff}
             onDiscardAllClick={handleDiscardAllClick}
             onKeepAllClick={handleKeepAllClick}
           />
@@ -230,11 +335,11 @@ const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, current
       <div className="status-panel-tabs">
         {/* Todo Tab */}
         <div
-          className={`status-panel-tab ${openPopover === 'todo' ? 'active' : ''}`}
-          onClick={() => handleTabClick('todo')}
+          className={`status-panel-tab ${openPopover === "todo" ? "active" : ""}`}
+          onClick={() => handleTabClick("todo")}
         >
           <span className="codicon codicon-checklist" />
-          <span className="tab-label">{t('statusPanel.tasksTab')}</span>
+          <span className="tab-label">{t("statusPanel.tasksTab")}</span>
           {hasTodos && (
             <span className="tab-progress">
               {completedCount}/{totalCount}
@@ -247,11 +352,11 @@ const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, current
 
         {/* Subagent Tab */}
         <div
-          className={`status-panel-tab ${openPopover === 'subagent' ? 'active' : ''}`}
-          onClick={() => handleTabClick('subagent')}
+          className={`status-panel-tab ${openPopover === "subagent" ? "active" : ""}`}
+          onClick={() => handleTabClick("subagent")}
         >
           <span className="codicon codicon-hubot" />
-          <span className="tab-label">{t('statusPanel.subagentTab')}</span>
+          <span className="tab-label">{t("statusPanel.subagentTab")}</span>
           {hasSubagents && (
             <span className="tab-progress">
               {subagentCompletedCount}/{subagentTotalCount}
@@ -264,11 +369,11 @@ const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, current
 
         {/* File Changes Tab */}
         <div
-          className={`status-panel-tab ${openPopover === 'files' ? 'active' : ''}`}
-          onClick={() => handleTabClick('files')}
+          className={`status-panel-tab ${openPopover === "files" ? "active" : ""}`}
+          onClick={() => handleTabClick("files")}
         >
           <span className="codicon codicon-edit" />
-          <span className="tab-label">{t('statusPanel.editsTab')}</span>
+          <span className="tab-label">{t("statusPanel.editsTab")}</span>
           {hasFileChanges && (
             <span className="tab-stats">
               <span className="stat-additions">+{totalAdditions}</span>
@@ -280,9 +385,7 @@ const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, current
 
       {/* Popover Content */}
       {openPopover && (
-        <div className="status-panel-popover">
-          {renderPopoverContent()}
-        </div>
+        <div className="status-panel-popover">{renderPopoverContent()}</div>
       )}
 
       {/* Dialogs */}

--- a/webview/src/components/StatusPanel/fileChangeActions.test.ts
+++ b/webview/src/components/StatusPanel/fileChangeActions.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import { filterProcessedFileChanges, getFilesToDiscardAfterUndoAll, getProcessedOperationKeys, getSucceededFilesFromUndoAllResult, toBridgeOperations } from './fileChangeActions';
+import type { EditOperation } from '../../types';
+
+describe('fileChangeActions', () => {
+  it('preserves operation metadata for Java bridge payloads', () => {
+    const operations: EditOperation[] = [{
+      toolName: 'edit',
+      oldString: 'before',
+      newString: 'after',
+      additions: 1,
+      deletions: 1,
+      replaceAll: false,
+      lineStart: 10,
+      lineEnd: 12,
+      operationId: 'op-1',
+      source: 'subagent',
+      scopeId: 'scope-1',
+      agentHandle: 'agent-1',
+      parentToolUseId: 'parent-1',
+      safeToRollback: true,
+      editSequence: 9,
+    }];
+
+    expect(toBridgeOperations(operations)).toEqual([{
+      oldString: 'before',
+      newString: 'after',
+      replaceAll: false,
+      lineStart: 10,
+      lineEnd: 12,
+      operationId: 'op-1',
+      source: 'subagent',
+      scopeId: 'scope-1',
+      agentHandle: 'agent-1',
+      parentToolUseId: 'parent-1',
+      safeToRollback: true,
+      editSequence: 9,
+    }]);
+  });
+
+
+  it('uses request snapshot when undo all succeeds without succeededFiles', () => {
+    expect(getFilesToDiscardAfterUndoAll({ success: true }, ['/repo/a.ts', '/repo/b.ts'])).toEqual([
+      '/repo/a.ts',
+      '/repo/b.ts',
+    ]);
+  });
+
+  it('uses backend succeededFiles before request snapshot', () => {
+    expect(getFilesToDiscardAfterUndoAll({ success: true, succeededFiles: ['/repo/a.ts'] }, ['/repo/a.ts', '/repo/b.ts'])).toEqual([
+      '/repo/a.ts',
+    ]);
+  });
+
+  it('returns only succeeded files for partial undo all result', () => {
+    const result = {
+      success: false,
+      partial: true,
+      succeededFiles: ['/repo/a.ts'],
+      failedFiles: [{ filePath: '/repo/b.ts', reason: 'new_string_not_found' }],
+    };
+
+    expect(getSucceededFilesFromUndoAllResult(result)).toEqual(['/repo/a.ts']);
+  });
+
+  it('filters processed operations without hiding future operations on the same file', () => {
+    const oldOperation: EditOperation = {
+      toolName: 'edit',
+      oldString: 'before',
+      newString: 'after',
+      additions: 1,
+      deletions: 1,
+      operationId: 'op-old',
+      editSequence: 1,
+    };
+    const futureOperation: EditOperation = {
+      toolName: 'edit',
+      oldString: 'after',
+      newString: 'future',
+      additions: 1,
+      deletions: 1,
+      operationId: 'op-future',
+      editSequence: 2,
+    };
+    const fileChange = {
+      filePath: '/repo/a.ts',
+      fileName: 'a.ts',
+      status: 'M' as const,
+      additions: 2,
+      deletions: 2,
+      operations: [oldOperation, futureOperation],
+    };
+
+    const processedKeys = getProcessedOperationKeys('/repo/a.ts', [oldOperation]);
+    const filtered = filterProcessedFileChanges([fileChange], processedKeys);
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].operations).toEqual([futureOperation]);
+    expect(filtered[0].additions).toBe(1);
+    expect(filtered[0].deletions).toBe(1);
+  });
+
+  it('uses operation fingerprint when operationId is missing', () => {
+    const operation: EditOperation = {
+      toolName: 'edit',
+      oldString: 'before',
+      newString: 'after',
+      additions: 1,
+      deletions: 1,
+      lineStart: 3,
+      lineEnd: 4,
+    };
+
+    expect(getProcessedOperationKeys('/repo/a.ts', [operation])).toEqual([
+      'fp:/repo/a.ts\u0000edit\u0000before\u0000after\u00003\u00004',
+    ]);
+  });
+
+
+  it('recomputes status after filtering processed added operation from same file', () => {
+    const writeOperation: EditOperation = {
+      toolName: 'write',
+      oldString: '',
+      newString: 'initial',
+      additions: 1,
+      deletions: 0,
+      operationId: 'op-write',
+    };
+    const editOperation: EditOperation = {
+      toolName: 'edit',
+      oldString: 'initial',
+      newString: 'changed',
+      additions: 1,
+      deletions: 1,
+      operationId: 'op-edit',
+    };
+    const fileChange = {
+      filePath: '/repo/a.ts',
+      fileName: 'a.ts',
+      status: 'A' as const,
+      additions: 2,
+      deletions: 1,
+      operations: [writeOperation, editOperation],
+    };
+
+    const filtered = filterProcessedFileChanges([fileChange], getProcessedOperationKeys('/repo/a.ts', [writeOperation]));
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].status).toBe('M');
+    expect(filtered[0].operations).toEqual([editOperation]);
+  });
+
+  it('processed key fallback includes tool occurrence when operation id is missing', () => {
+    const operation: EditOperation = {
+      toolName: 'edit',
+      oldString: 'before',
+      newString: 'after',
+      additions: 1,
+      deletions: 1,
+      lineStart: 3,
+      lineEnd: 4,
+      toolUseId: 'tool-1',
+    };
+
+    expect(getProcessedOperationKeys('/repo/a.ts', [operation])).toEqual([
+      'tool:tool-1',
+    ]);
+  });
+
+});

--- a/webview/src/components/StatusPanel/fileChangeActions.ts
+++ b/webview/src/components/StatusPanel/fileChangeActions.ts
@@ -1,0 +1,82 @@
+import type { EditOperation } from '../../types';
+
+export interface BridgeEditOperation {
+  oldString: string;
+  newString: string;
+  replaceAll?: boolean;
+  lineStart?: number;
+  lineEnd?: number;
+  operationId?: string;
+  source?: string;
+  scopeId?: string;
+  agentHandle?: string;
+  parentToolUseId?: string;
+  safeToRollback?: boolean;
+  expectedAfterContentHash?: string;
+  editSequence?: number;
+  existedBefore?: boolean;
+  toolUseId?: string;
+}
+
+export interface UndoAllResult {
+  success?: boolean;
+  partial?: boolean;
+  succeededFiles?: string[];
+  failedFiles?: Array<{ filePath?: string; reason?: string; message?: string }>;
+  error?: string;
+}
+
+export const toBridgeOperations = (operations: EditOperation[]): BridgeEditOperation[] =>
+  operations.map((op) => ({
+    oldString: op.oldString,
+    newString: op.newString,
+    replaceAll: op.replaceAll,
+    lineStart: op.lineStart,
+    lineEnd: op.lineEnd,
+    operationId: op.operationId,
+    source: op.source,
+    scopeId: op.scopeId,
+    agentHandle: op.agentHandle,
+    parentToolUseId: op.parentToolUseId,
+    safeToRollback: op.safeToRollback,
+    expectedAfterContentHash: op.expectedAfterContentHash,
+    editSequence: op.editSequence,
+    existedBefore: op.existedBefore,
+    toolUseId: op.toolUseId,
+  }));
+
+export { filterProcessedFileChanges, getProcessedOperationKey, getProcessedOperationKeys } from '../../utils/fileChangeProcessing';
+
+export const getSucceededFilesFromUndoAllResult = (result: UndoAllResult): string[] => {
+  if (!Array.isArray(result.succeededFiles)) {
+    return [];
+  }
+  return result.succeededFiles.filter((filePath): filePath is string => typeof filePath === 'string' && filePath.length > 0);
+};
+
+export const getUndoAllFailureMessage = (result: UndoAllResult, fallback: string): string => {
+  if (typeof result.error === 'string' && result.error.length > 0) {
+    return result.error;
+  }
+  if (Array.isArray(result.failedFiles) && result.failedFiles.length > 0) {
+    return result.failedFiles
+      .map((failure) => {
+        const filePath = failure.filePath || 'unknown';
+        const reason = failure.message || failure.reason || 'Unknown error';
+        return `${filePath}: ${reason}`;
+      })
+      .join('; ');
+  }
+  return fallback;
+};
+
+export const getFilesToDiscardAfterUndoAll = (result: UndoAllResult, requestedFiles: string[]): string[] => {
+  const succeededFiles = getSucceededFilesFromUndoAllResult(result);
+  if (succeededFiles.length > 0) {
+    return succeededFiles;
+  }
+  if (result.success) {
+    return requestedFiles.filter((filePath): filePath is string => typeof filePath === 'string' && filePath.length > 0);
+  }
+  return [];
+};

--- a/webview/src/components/StatusPanel/types.ts
+++ b/webview/src/components/StatusPanel/types.ts
@@ -12,12 +12,16 @@ export interface StatusPanelProps {
   expanded?: boolean;
   /** Whether the conversation is currently streaming (active) */
   isStreaming?: boolean;
-  /** Callback when a file is successfully undone */
-  onUndoFile?: (filePath: string) => void;
-  /** Callback when all files are successfully discarded */
-  onDiscardAll?: () => void;
+  /** Whether any session-level subagent scope is still pending */
+  hasPendingSubagent?: boolean;
+  /** Callback when file operations are successfully processed */
+  onUndoFile?: (filePath: string, operations?: FileChangeSummary['operations']) => void;
   /** Callback when user clicks Keep All (accept changes as new baseline) */
   onKeepAll?: () => void;
+  /** Register a pending diff/apply/reject request and return its request id */
+  onRegisterFileChangeAction?: (fileChange: FileChangeSummary) => string;
+  /** Clear a pending diff/apply/reject request when bridge dispatch fails */
+  onClearFileChangeAction?: (requestId?: string) => void;
 }
 
 export const statusClassMap: Record<TodoItem['status'], string> = {

--- a/webview/src/components/shared/ProviderModelIcon.tsx
+++ b/webview/src/components/shared/ProviderModelIcon.tsx
@@ -42,8 +42,7 @@ import GrokMono from '@lobehub/icons/es/Grok/components/Mono';
 import OpenRouterMono from '@lobehub/icons/es/OpenRouter/components/Mono';
 import YiColor from '@lobehub/icons/es/Yi/components/Color';
 import YiMono from '@lobehub/icons/es/Yi/components/Mono';
-import XiaomiMiMoMono from '@lobehub/icons/es/XiaomiMiMo/components/Mono';
-import type { ReactElement } from 'react';
+import type { CSSProperties, ReactElement } from 'react';
 import { resolveIconVendor, type ModelVendor } from '../../utils/modelIconMapping';
 
 export interface ProviderModelIconProps {
@@ -57,7 +56,7 @@ export interface ProviderModelIconProps {
   colored?: boolean;
 }
 
-function getXiaomiWrapperStyle(size: number): React.CSSProperties {
+function getXiaomiWrapperStyle(size: number): CSSProperties {
   return {
     alignItems: 'center',
     background: '#000',
@@ -68,22 +67,24 @@ function getXiaomiWrapperStyle(size: number): React.CSSProperties {
     height: size,
     justifyContent: 'center',
     lineHeight: 1,
+    fontSize: Math.max(8, Math.round(size * 0.42)),
+    fontWeight: 700,
     width: size,
   };
 }
 
 const XiaomiMiMoIcon = (size: number, colored: boolean): ReactElement => {
-  if (!colored) {
-    return <XiaomiMiMoMono size={size} />;
-  }
-
   return (
     <span
       aria-label="XiaomiMiMo"
       role="img"
-      style={getXiaomiWrapperStyle(size)}
+      style={{
+        ...getXiaomiWrapperStyle(size),
+        background: colored ? '#ff6900' : 'transparent',
+        color: colored ? '#fff' : 'currentColor',
+      }}
     >
-      <XiaomiMiMoMono size={Math.max(1, Math.round(size * 0.72))} />
+      Mi
     </span>
   );
 };

--- a/webview/src/hooks/useChatComputations.ts
+++ b/webview/src/hooks/useChatComputations.ts
@@ -1,24 +1,25 @@
-import { type RefObject, useCallback, useMemo, useRef } from 'react';
-import type { TFunction } from 'i18next';
+import { type RefObject, useCallback, useMemo, useRef } from "react";
+import type { TFunction } from "i18next";
 import type {
   ClaudeMessage,
   ClaudeRawMessage,
   ToolResultBlock,
-} from '../types';
-import type { GetToolResultRawFn } from '../contexts/SubagentContext';
-import type { RewindableMessage } from '../components/RewindSelectDialog';
-import { formatTime } from '../utils/helpers';
-import { extractTodosFromToolUse } from '../utils/todoToolNormalization';
+} from "../types";
+import type { GetToolResultRawFn } from "../contexts/SubagentContext";
+import type { RewindableMessage } from "../components/RewindSelectDialog";
+import { formatTime } from "../utils/helpers";
+import { extractTodosFromToolUse } from "../utils/todoToolNormalization";
 import {
   finalizeSubagentsForSettledTurn,
   finalizeTodosForSettledTurn,
   sliceLatestConversationTurn,
-} from '../utils/turnScope';
-import { FILE_MODIFY_TOOL_NAMES, isToolName } from '../utils/toolConstants';
-import { useSubagents } from './useSubagents';
-import { useFileChanges } from './useFileChanges';
-import { useFileChangesManagement } from './useFileChangesManagement';
-import type { useMessageProcessing } from './useMessageProcessing';
+} from "../utils/turnScope";
+import { FILE_MODIFY_TOOL_NAMES, isToolName } from "../utils/toolConstants";
+import { filterProcessedFileChanges } from "../utils/fileChangeProcessing";
+import { useSubagents } from "./useSubagents";
+import { useFileChanges } from "./useFileChanges";
+import { useFileChangesManagement } from "./useFileChangesManagement";
+import type { useMessageProcessing } from "./useMessageProcessing";
 
 interface UseChatComputationsParams {
   t: TFunction;
@@ -29,8 +30,8 @@ interface UseChatComputationsParams {
   currentProvider: string;
   currentSessionId: string | null;
   currentSessionIdRef: RefObject<string | null>;
-  getMessageText: ReturnType<typeof useMessageProcessing>['getMessageText'];
-  getContentBlocks: ReturnType<typeof useMessageProcessing>['getContentBlocks'];
+  getMessageText: ReturnType<typeof useMessageProcessing>["getMessageText"];
+  getContentBlocks: ReturnType<typeof useMessageProcessing>["getContentBlocks"];
 }
 
 /**
@@ -57,37 +58,44 @@ export function useChatComputations({
   messagesRef.current = messages;
   const toolResultRawMapRef = useRef<Map<string, ClaudeRawMessage>>(new Map());
 
-  const findToolResult = useCallback((toolUseId?: string, messageIndex?: number): ToolResultBlock | null => {
-    if (!toolUseId || typeof messageIndex !== 'number') return null;
-    const currentMessages = messagesRef.current;
-    const cachedRaw = toolResultRawMapRef.current.get(toolUseId);
-    if (cachedRaw != null) {
-      const content = cachedRaw.content ?? cachedRaw.message?.content;
-      if (Array.isArray(content)) {
-        const hit = content.find(
+  const findToolResult = useCallback(
+    (toolUseId?: string, messageIndex?: number): ToolResultBlock | null => {
+      if (!toolUseId || typeof messageIndex !== "number") return null;
+      const currentMessages = messagesRef.current;
+      const cachedRaw = toolResultRawMapRef.current.get(toolUseId);
+      if (cachedRaw != null) {
+        const content = cachedRaw.content ?? cachedRaw.message?.content;
+        if (Array.isArray(content)) {
+          const hit = content.find(
+            (block): block is ToolResultBlock =>
+              Boolean(block) &&
+              block.type === "tool_result" &&
+              block.tool_use_id === toolUseId,
+          );
+          if (hit) return hit;
+        }
+      }
+      for (let i = 0; i < currentMessages.length; i += 1) {
+        const candidate = currentMessages[i];
+        const raw = candidate.raw;
+        if (!raw || typeof raw === "string") continue;
+        const content = raw.content ?? raw.message?.content;
+        if (!Array.isArray(content)) continue;
+        const resultBlock = content.find(
           (block): block is ToolResultBlock =>
-            Boolean(block) && block.type === 'tool_result' && block.tool_use_id === toolUseId,
+            Boolean(block) &&
+            block.type === "tool_result" &&
+            block.tool_use_id === toolUseId,
         );
-        if (hit) return hit;
+        if (resultBlock) {
+          toolResultRawMapRef.current.set(toolUseId, raw);
+          return resultBlock;
+        }
       }
-    }
-    for (let i = 0; i < currentMessages.length; i += 1) {
-      const candidate = currentMessages[i];
-      const raw = candidate.raw;
-      if (!raw || typeof raw === 'string') continue;
-      const content = raw.content ?? raw.message?.content;
-      if (!Array.isArray(content)) continue;
-      const resultBlock = content.find(
-        (block): block is ToolResultBlock =>
-          Boolean(block) && block.type === 'tool_result' && block.tool_use_id === toolUseId,
-      );
-      if (resultBlock) {
-        toolResultRawMapRef.current.set(toolUseId, raw);
-        return resultBlock;
-      }
-    }
-    return null;
-  }, []);
+      return null;
+    },
+    [],
+  );
 
   const getToolResultRaw = useCallback<GetToolResultRawFn>(
     (toolUseId: string) => toolResultRawMapRef.current.get(toolUseId) ?? null,
@@ -96,38 +104,68 @@ export function useChatComputations({
 
   // File changes (depend on findToolResult which is now stable above).
   const fileChangeMgmt = useFileChangesManagement({
-    currentSessionId, currentSessionIdRef, messages,
-    getContentBlocks, findToolResult,
+    currentSessionId,
+    currentSessionIdRef,
+    messages,
+    getContentBlocks,
+    findToolResult,
   });
   const fileChanges = useFileChanges({
-    messages, getContentBlocks, findToolResult,
+    messages,
+    getContentBlocks,
+    findToolResult,
     startFromIndex: fileChangeMgmt.baseMessageIndex,
   });
 
-  const filteredFileChanges = useMemo(() => {
-    if (fileChangeMgmt.processedFiles.length === 0) return fileChanges;
-    return fileChanges.filter((fc) => !fileChangeMgmt.processedFiles.includes(fc.filePath));
-  }, [fileChanges, fileChangeMgmt.processedFiles]);
+  const filteredFileChanges = useMemo(
+    () =>
+      filterProcessedFileChanges(
+        fileChanges,
+        fileChangeMgmt.processedOperationKeys,
+      ),
+    [fileChanges, fileChangeMgmt.processedOperationKeys],
+  );
 
-  const latestTurnMessages = useMemo(() => sliceLatestConversationTurn(messages), [messages]);
+  const latestTurnMessages = useMemo(
+    () => sliceLatestConversationTurn(messages),
+    [messages],
+  );
 
-  const latestTurnSubagents = useSubagents({
-    messages: latestTurnMessages,
+  const latestTurnStartIndex = useMemo(
+    () => Math.max(0, messages.length - latestTurnMessages.length),
+    [messages.length, latestTurnMessages.length],
+  );
+  const allSubagents = useSubagents({
+    messages,
     getContentBlocks,
     findToolResult,
     getToolResultRaw,
   });
+  const latestTurnSubagents = useMemo(
+    () =>
+      allSubagents.filter(
+        (subagent) => (subagent.messageIndex ?? 0) >= latestTurnStartIndex,
+      ),
+    [allSubagents, latestTurnStartIndex],
+  );
 
   const subagents = useMemo(
     () => finalizeSubagentsForSettledTurn(latestTurnSubagents, streamingActive),
     [latestTurnSubagents, streamingActive],
+  );
+  const hasPendingSubagent = useMemo(
+    () =>
+      finalizeSubagentsForSettledTurn(allSubagents, streamingActive).some(
+        (subagent) => subagent.status === "running",
+      ),
+    [allSubagents, streamingActive],
   );
 
   const globalTodos = useMemo(() => {
     let latestTodos: ReturnType<typeof extractTodosFromToolUse> = null;
     for (let i = latestTurnMessages.length - 1; i >= 0; i--) {
       const msg = latestTurnMessages[i];
-      if (msg.type !== 'assistant') continue;
+      if (msg.type !== "assistant") continue;
       const blocks = getContentBlocks(msg);
       for (let j = blocks.length - 1; j >= 0; j--) {
         const todos = extractTodosFromToolUse(blocks[j]);
@@ -143,23 +181,27 @@ export function useChatComputations({
 
   const canRewindFromMessageIndex = useCallback(
     (userMessageIndex: number) => {
-      if (userMessageIndex < 0 || userMessageIndex >= mergedMessages.length) return false;
+      if (userMessageIndex < 0 || userMessageIndex >= mergedMessages.length)
+        return false;
       const current = mergedMessages[userMessageIndex];
-      if (current.type !== 'user') return false;
-      if ((current.content || '').trim() === '[tool_result]') return false;
+      if (current.type !== "user") return false;
+      if ((current.content || "").trim() === "[tool_result]") return false;
       const raw = current.raw;
-      if (raw && typeof raw !== 'string') {
+      if (raw && typeof raw !== "string") {
         const content = raw.content ?? raw.message?.content;
-        if (Array.isArray(content) && content.some((block) => block && block.type === 'tool_result')) {
+        if (
+          Array.isArray(content) &&
+          content.some((block) => block && block.type === "tool_result")
+        ) {
           return false;
         }
       }
       for (let i = userMessageIndex + 1; i < mergedMessages.length; i += 1) {
         const msg = mergedMessages[i];
-        if (msg.type === 'user') break;
+        if (msg.type === "user") break;
         const blocks = getContentBlocks(msg);
         for (const block of blocks) {
-          if (block.type !== 'tool_use') continue;
+          if (block.type !== "tool_use") continue;
           if (isToolName(block.name, FILE_MODIFY_TOOL_NAMES)) return true;
         }
       }
@@ -169,24 +211,39 @@ export function useChatComputations({
   );
 
   const rewindableMessages = useMemo((): RewindableMessage[] => {
-    if (currentProvider !== 'claude') return [];
+    if (currentProvider !== "claude") return [];
     const result: RewindableMessage[] = [];
     for (let i = 0; i < mergedMessages.length - 1; i++) {
       if (!canRewindFromMessageIndex(i)) continue;
       const message = mergedMessages[i];
       const content = message.content || getMessageText(message);
-      const timestamp = message.timestamp ? formatTime(message.timestamp) : undefined;
+      const timestamp = message.timestamp
+        ? formatTime(message.timestamp)
+        : undefined;
       const messagesAfterCount = mergedMessages.length - i - 1;
-      result.push({ messageIndex: i, message, displayContent: content, timestamp, messagesAfterCount });
+      result.push({
+        messageIndex: i,
+        message,
+        displayContent: content,
+        timestamp,
+        messagesAfterCount,
+      });
     }
     return result;
-  }, [mergedMessages, currentProvider, canRewindFromMessageIndex, getMessageText]);
+  }, [
+    mergedMessages,
+    currentProvider,
+    canRewindFromMessageIndex,
+    getMessageText,
+  ]);
 
   const sessionTitle = useMemo(() => {
     if (customSessionTitle) return customSessionTitle;
-    if (messages.length === 0) return t('common.newSession');
-    const firstUserMessage = messages.find((message) => message.type === 'user');
-    if (!firstUserMessage) return t('common.newSession');
+    if (messages.length === 0) return t("common.newSession");
+    const firstUserMessage = messages.find(
+      (message) => message.type === "user",
+    );
+    if (!firstUserMessage) return t("common.newSession");
     const text = getMessageText(firstUserMessage);
     return text.length > 15 ? `${text.substring(0, 15)}...` : text;
   }, [customSessionTitle, messages, t, getMessageText]);
@@ -197,6 +254,7 @@ export function useChatComputations({
     fileChangeMgmt,
     filteredFileChanges,
     subagents,
+    hasPendingSubagent,
     globalTodos,
     rewindableMessages,
     sessionTitle,

--- a/webview/src/hooks/useFileChanges.test.ts
+++ b/webview/src/hooks/useFileChanges.test.ts
@@ -1,0 +1,165 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useFileChanges } from './useFileChanges';
+import type { ClaudeMessage, ClaudeContentBlock, ToolResultBlock } from '../types';
+
+const successResult: ToolResultBlock = { type: 'tool_result', tool_use_id: 'unused', content: 'ok', is_error: false } as any;
+
+const messageWithEdit = (id: string, source: 'subagent' | 'codex_session_patch', editSequence = 1): ClaudeMessage => ({
+  type: 'assistant',
+  content: '',
+  timestamp: new Date().toISOString(),
+  raw: {},
+  blocks: [{
+    type: 'tool_use',
+    id,
+    name: 'edit',
+    input: {
+      file_path: '/repo/a.ts',
+      old_string: 'before',
+      new_string: 'after',
+      source,
+      scope_id: 'scope-1',
+      operation_id: `${source}-op`,
+      safe_to_rollback: true,
+      edit_sequence: editSequence,
+    },
+  } as any],
+} as ClaudeMessage);
+
+describe('useFileChanges', () => {
+  it('dedupes duplicate operations regardless of source metadata', () => {
+    const messages = [
+      messageWithEdit('tool-1', 'codex_session_patch', 4),
+      messageWithEdit('tool-2', 'subagent', 4),
+    ];
+    const { result } = renderHook(() => useFileChanges({
+      messages,
+      getContentBlocks: (message) => (message as any).blocks as ClaudeContentBlock[],
+      findToolResult: () => successResult,
+    }));
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].operations).toHaveLength(1);
+    expect(result.current[0].operations[0].source).toBe('codex_session_patch');
+    expect(result.current[0].operations[0].editSequence).toBe(4);
+  });
+
+  it('keeps later synthetic operations even when edit sequence values repeat', () => {
+    const messages = [messageWithEdit('tool-1', 'subagent', 1), messageWithEdit('tool-2', 'codex_session_patch', 1)];
+    (messages[1] as any).blocks[0].input.operation_id = 'codex-session-next-turn-op';
+
+    const { result } = renderHook(() => useFileChanges({
+      messages,
+      getContentBlocks: (message) => (message as any).blocks as ClaudeContentBlock[],
+      findToolResult: () => successResult,
+      startFromIndex: 1,
+    }));
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].operations[0].source).toBe('codex_session_patch');
+    expect(result.current[0].operations[0].editSequence).toBe(1);
+  });
+
+
+  it('treats empty oldString edit on an existing file as modified, not added', () => {
+    const messages: ClaudeMessage[] = [{
+      type: 'assistant',
+      content: '',
+      timestamp: new Date().toISOString(),
+      raw: {},
+      blocks: [{
+        type: 'tool_use',
+        id: 'insert-1',
+        name: 'edit',
+        input: { file_path: '/repo/empty.txt', old_string: '', new_string: 'content' },
+      } as any],
+    } as ClaudeMessage];
+
+    const { result } = renderHook(() => useFileChanges({
+      messages,
+      getContentBlocks: (message) => (message as any).blocks as ClaudeContentBlock[],
+      findToolResult: () => successResult,
+    }));
+
+    expect(result.current[0].status).toBe('M');
+  });
+
+  it('keeps repeated same hunk operations distinct when tool ids differ', () => {
+    const messages = [
+      messageWithEdit('tool-1', 'subagent', 1),
+      messageWithEdit('tool-2', 'subagent', 2),
+    ];
+    (messages[1] as any).blocks[0].input.operation_id = 'subagent-op-2';
+
+    const { result } = renderHook(() => useFileChanges({
+      messages,
+      getContentBlocks: (message) => (message as any).blocks as ClaudeContentBlock[],
+      findToolResult: () => successResult,
+    }));
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].operations).toHaveLength(2);
+  });
+
+
+  it('treats write operation with existedBefore true as modified', () => {
+    const messages: ClaudeMessage[] = [{
+      type: 'assistant',
+      content: '',
+      timestamp: new Date().toISOString(),
+      raw: {},
+      blocks: [{
+        type: 'tool_use',
+        id: 'write-existing',
+        name: 'write',
+        input: { file_path: '/repo/existing.txt', content: 'replacement', existed_before: true },
+      } as any],
+    } as ClaudeMessage];
+
+    const { result } = renderHook(() => useFileChanges({
+      messages,
+      getContentBlocks: (message) => (message as any).blocks as ClaudeContentBlock[],
+      findToolResult: () => successResult,
+    }));
+
+    expect(result.current[0].status).toBe('M');
+  });
+
+
+  it('shows Codex filesystem snapshot writes as added files', () => {
+    const messages: ClaudeMessage[] = [{
+      type: 'assistant',
+      content: '',
+      timestamp: new Date().toISOString(),
+      raw: {},
+      blocks: [{
+        type: 'tool_use',
+        id: 'codex-fs-1',
+        name: 'write',
+        input: {
+          file_path: '/repo/src/generated.js',
+          old_string: '',
+          new_string: 'export const generated = true;\n',
+          source: 'codex_session_patch',
+          operation_id: 'codex-fs-1',
+          safe_to_rollback: true,
+          existed_before: false,
+        },
+      } as any],
+    } as ClaudeMessage];
+
+    const { result } = renderHook(() => useFileChanges({
+      messages,
+      getContentBlocks: (message) => (message as any).blocks as ClaudeContentBlock[],
+      findToolResult: () => successResult,
+    }));
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].filePath).toBe('/repo/src/generated.js');
+    expect(result.current[0].status).toBe('A');
+    expect(result.current[0].operations[0].source).toBe('codex_session_patch');
+    expect(result.current[0].operations[0].safeToRollback).toBe(true);
+  });
+
+});

--- a/webview/src/hooks/useFileChanges.ts
+++ b/webview/src/hooks/useFileChanges.ts
@@ -5,9 +5,71 @@ import { getFileName } from '../utils/helpers';
 import { FILE_MODIFY_TOOL_NAMES, isToolName, normalizeToolName } from '../utils/toolConstants';
 import { normalizeToolInput } from '../utils/toolInputNormalization';
 import { getToolLineInfo } from '../utils/toolPresentation';
+import { getFileChangeStatusFromOperations } from '../utils/fileChangeProcessing';
 
-/** Write tool names that indicate a new file */
-const WRITE_TOOL_NAMES = new Set(['write', 'write_file', 'create_file']);
+
+const SOURCE_PRIORITY: Record<string, number> = {
+  codex_session_patch: 3,
+  main: 2,
+  subagent: 1,
+};
+
+function getOperationIdentityKey(operation: EditOperation): string | undefined {
+  if (operation.operationId) {
+    return `op:${operation.operationId}`;
+  }
+  if (operation.toolUseId) {
+    return `tool:${operation.toolUseId}`;
+  }
+  return undefined;
+}
+
+function getOperationDedupeKey(filePath: string, operation: EditOperation): string {
+  return [
+    filePath,
+    operation.toolName,
+    operation.oldString,
+    operation.newString,
+    operation.lineStart ?? '',
+    operation.lineEnd ?? '',
+    operation.existedBefore ?? '',
+  ].join('\u0000');
+}
+
+function normalizedSource(operation: EditOperation): string {
+  return operation.source ?? 'main';
+}
+
+function shouldDedupeOperation(existing: EditOperation, next: EditOperation, filePath: string): boolean {
+  const existingIdentity = getOperationIdentityKey(existing);
+  const nextIdentity = getOperationIdentityKey(next);
+  if (existingIdentity && nextIdentity && existingIdentity === nextIdentity) {
+    return true;
+  }
+  if (normalizedSource(existing) === normalizedSource(next)) {
+    return false;
+  }
+  return getOperationDedupeKey(filePath, existing) === getOperationDedupeKey(filePath, next);
+}
+
+function shouldReplaceOperation(existing: EditOperation, next: EditOperation): boolean {
+  const existingPriority = existing.source ? SOURCE_PRIORITY[existing.source] ?? 0 : 0;
+  const nextPriority = next.source ? SOURCE_PRIORITY[next.source] ?? 0 : 0;
+  return nextPriority > existingPriority;
+}
+
+function addDedupedOperation(operations: EditOperation[], filePath: string, operation: EditOperation): EditOperation[] {
+  const existingIndex = operations.findIndex((existing) => shouldDedupeOperation(existing, operation, filePath));
+  if (existingIndex < 0) {
+    return [...operations, operation];
+  }
+  if (!shouldReplaceOperation(operations[existingIndex], operation)) {
+    return operations;
+  }
+  const next = [...operations];
+  next[existingIndex] = operation;
+  return next;
+}
 
 /**
  * Maximum lines to use LCS algorithm.
@@ -168,18 +230,7 @@ function extractStrings(input: Record<string, unknown>): { oldString: string; ne
  * Determine file status (A = Added, M = Modified)
  */
 function determineFileStatus(operations: EditOperation[]): FileChangeStatus {
-  if (operations.length === 0) return 'M';
-
-  const firstOp = operations[0];
-  // Write/create_file tools indicate a new file
-  if (WRITE_TOOL_NAMES.has(normalizeToolName(firstOp.toolName))) {
-    return 'A';
-  }
-  // If first operation has empty oldString, it's likely a new file
-  if (firstOp.oldString === '' && firstOp.newString !== '') {
-    return 'A';
-  }
-  return 'M';
+  return getFileChangeStatusFromOperations(operations);
 }
 
 /**
@@ -193,7 +244,7 @@ interface UseFileChangesParams {
   messages: ClaudeMessage[];
   getContentBlocks: (message: ClaudeMessage) => ClaudeContentBlock[];
   findToolResult: (toolUseId?: string, messageIndex?: number) => ToolResultBlock | null;
-  /** Start processing messages from this index (for Keep All feature) */
+  /** Start processing messages from this index (legacy Keep All fallback) */
   startFromIndex?: number;
 }
 
@@ -219,7 +270,7 @@ export function useFileChanges({
 
       const blocks = getContentBlocks(message);
 
-      blocks.forEach((block) => {
+      blocks.forEach((block, blockIndex) => {
         if (block.type !== 'tool_use') return;
 
         const toolName = normalizeToolName(block.name ?? '');
@@ -251,12 +302,26 @@ export function useFileChanges({
           replaceAll,
           lineStart: lineInfo.start,
           lineEnd: lineInfo.end,
+          source: input.source === 'subagent' || input.source === 'codex_session_patch' || input.source === 'main'
+            ? input.source
+            : 'main',
+          scopeId: typeof input.scope_id === 'string' ? input.scope_id : (typeof input.scopeId === 'string' ? input.scopeId : undefined),
+          agentHandle: typeof input.agent_handle === 'string' ? input.agent_handle : (typeof input.agentHandle === 'string' ? input.agentHandle : undefined),
+          parentToolUseId: typeof input.parent_tool_use_id === 'string' ? input.parent_tool_use_id : (typeof input.parentToolUseId === 'string' ? input.parentToolUseId : undefined),
+          operationId: typeof input.operation_id === 'string' ? input.operation_id : (typeof input.operationId === 'string' ? input.operationId : undefined),
+          safeToRollback: typeof input.safe_to_rollback === 'boolean' ? input.safe_to_rollback : (typeof input.safeToRollback === 'boolean' ? input.safeToRollback : undefined),
+          expectedAfterContentHash: typeof input.expected_after_content_hash === 'string' ? input.expected_after_content_hash : (typeof input.expectedAfterContentHash === 'string' ? input.expectedAfterContentHash : undefined),
+          editSequence: typeof input.edit_sequence === 'number' ? input.edit_sequence : (typeof input.editSequence === 'number' ? input.editSequence : undefined),
+          existedBefore: typeof input.existed_before === 'boolean' ? input.existed_before : (typeof input.existedBefore === 'boolean' ? input.existedBefore : undefined),
+          toolUseId: typeof block.id === 'string' ? block.id : undefined,
+          messageIndex,
+          blockIndex,
+          occurrenceId: typeof block.id === 'string' ? `${messageIndex}:${block.id}` : `${messageIndex}:${blockIndex}`,
         };
 
-        // Group by file path
+        // Group by file path with defensive operation dedupe
         const existing = fileOperationsMap.get(filePath) ?? [];
-        existing.push(operation);
-        fileOperationsMap.set(filePath, existing);
+        fileOperationsMap.set(filePath, addDedupedOperation(existing, filePath, operation));
       });
     });
 

--- a/webview/src/hooks/useFileChangesManagement.test.ts
+++ b/webview/src/hooks/useFileChangesManagement.test.ts
@@ -1,0 +1,49 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { useRef } from 'react';
+import { useFileChangesManagement } from './useFileChangesManagement';
+import type { ClaudeMessage, FileChangeSummary } from '../types';
+
+const fileChange = (filePath: string, operationId: string): FileChangeSummary => ({
+  filePath,
+  fileName: filePath.split('/').pop() || filePath,
+  status: 'M',
+  additions: 1,
+  deletions: 1,
+  operations: [{ toolName: 'edit', oldString: 'before', newString: 'after', additions: 1, deletions: 1, operationId }],
+});
+
+const renderManagement = () => renderHook(() => {
+  const sessionRef = useRef<string | null>('session-1');
+  return useFileChangesManagement({
+    currentSessionId: 'session-1',
+    currentSessionIdRef: sessionRef,
+    messages: [] as ClaudeMessage[],
+    getContentBlocks: () => [],
+    findToolResult: () => null,
+  });
+});
+
+describe('useFileChangesManagement pending diff callbacks', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    delete window.handleDiffResult;
+  });
+
+  it('does not consume ambiguous pending diff actions when requestId is missing', () => {
+    const { result } = renderManagement();
+    const first = fileChange('/repo/a.ts', 'op-1');
+    const second = fileChange('/repo/a.ts', 'op-2');
+
+    act(() => {
+      result.current.registerPendingFileChangeAction(first);
+      result.current.registerPendingFileChangeAction(second);
+    });
+
+    act(() => {
+      window.handleDiffResult?.(JSON.stringify({ filePath: '/repo/a.ts', action: 'APPLY' }));
+    });
+
+    expect(result.current.processedOperationKeys).toEqual([]);
+  });
+});

--- a/webview/src/hooks/useFileChangesManagement.ts
+++ b/webview/src/hooks/useFileChangesManagement.ts
@@ -1,147 +1,240 @@
-import { useCallback, useEffect, useState, type RefObject } from 'react';
-import type { ClaudeMessage, ToolResultBlock } from '../types';
-import { debugLog } from '../utils/debug';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+import type {
+  ClaudeMessage,
+  EditOperation,
+  FileChangeSummary,
+  ToolResultBlock,
+} from "../types";
+import { getProcessedOperationKeys } from "../utils/fileChangeProcessing";
+import { debugLog } from "../utils/debug";
 
 export interface UseFileChangesManagementOptions {
   currentSessionId: string | null;
   currentSessionIdRef: RefObject<string | null>;
   messages: ClaudeMessage[];
   getContentBlocks: (message: ClaudeMessage) => any[];
-  findToolResult: (toolUseId?: string, messageIndex?: number) => ToolResultBlock | null;
+  findToolResult: (
+    toolUseId?: string,
+    messageIndex?: number,
+  ) => ToolResultBlock | null;
 }
 
-export interface FileChange {
-  filePath: string;
-  [key: string]: any;
-}
+export type FileChange = FileChangeSummary;
 
-/**
- * Manages file change tracking: processedFiles, baseMessageIndex,
- * undo/discard/keep handlers, diff result callbacks, and session state restore.
- */
+const createRequestId = (counter: number): string => {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return `file-change-${crypto.randomUUID()}`;
+  }
+  return `file-change-${Date.now()}-${counter}`;
+};
+
+const sameStringArray = (left: string[], right: string[]): boolean =>
+  left.length === right.length &&
+  left.every((value, index) => value === right[index]);
+
 export function useFileChangesManagement({
   currentSessionId,
   currentSessionIdRef,
   messages,
 }: UseFileChangesManagementOptions) {
-  // List of processed file paths (filtered from fileChanges after Apply/Reject, persisted to localStorage)
-  const [processedFiles, setProcessedFiles] = useState<string[]>([]);
-  // Base message index (for Keep All feature, only counts changes after this index)
+  const [processedOperationKeys, setProcessedOperationKeys] = useState<
+    string[]
+  >([]);
   const [baseMessageIndex, setBaseMessageIndex] = useState(0);
+  const pendingActionCounterRef = useRef(0);
+  const pendingFileChangeActionsRef = useRef(new Map<string, FileChange>());
+  const loadedSessionRef = useRef<string | null>(null);
 
-  // Callback after file undo success (triggered from StatusPanel)
-  const handleUndoFile = useCallback((filePath: string) => {
-    setProcessedFiles(prev => {
-      if (prev.includes(filePath)) return prev;
-      const newList = [...prev, filePath];
-
-      // Persist to localStorage
-      if (currentSessionId) {
-        try {
-          localStorage.setItem(
-            `processed-files-${currentSessionId}`,
-            JSON.stringify(newList)
-          );
-        } catch (e) {
-          console.error('Failed to persist processed files:', e);
-        }
-      }
-
-      return newList;
-    });
-  }, [currentSessionId]);
-
-  // Helper to add a file to the processed list with localStorage persistence
-  const addFileToProcessed = useCallback((filePath: string) => {
-    setProcessedFiles(prev => {
-      if (prev.includes(filePath)) return prev;
-      const newList = [...prev, filePath];
-
+  const persistProcessedOperationKeys = useCallback(
+    (keys: string[]) => {
       const sessionId = currentSessionIdRef.current;
-      if (sessionId) {
-        try {
-          localStorage.setItem(
-            `processed-files-${sessionId}`,
-            JSON.stringify(newList)
-          );
-        } catch (e) {
-          console.error('Failed to persist processed files:', e);
-        }
+      if (!sessionId) return;
+      try {
+        localStorage.setItem(
+          `processed-edit-keys-${sessionId}`,
+          JSON.stringify(keys),
+        );
+        localStorage.removeItem(`processed-files-${sessionId}`);
+      } catch (error) {
+        console.error("Failed to persist processed edit keys:", error);
       }
+    },
+    [currentSessionIdRef],
+  );
 
-      return newList;
-    });
-  }, [currentSessionIdRef]);
+  useEffect(() => {
+    if (loadedSessionRef.current !== currentSessionId) {
+      return;
+    }
+    persistProcessedOperationKeys(processedOperationKeys);
+  }, [currentSessionId, persistProcessedOperationKeys, processedOperationKeys]);
 
-  // Callback after batch undo success (Discard All)
-  const handleDiscardAll = useCallback((filteredFileChanges: FileChange[]) => {
-    setProcessedFiles(prev => {
-      const filesToAdd = filteredFileChanges.map(fc => fc.filePath);
-      const newList = [...prev, ...filesToAdd.filter(f => !prev.includes(f))];
+  const addOperationsToProcessed = useCallback(
+    (filePath: string, operations?: EditOperation[]) => {
+      if (!filePath || !Array.isArray(operations) || operations.length === 0) {
+        return;
+      }
+      const keysToAdd = getProcessedOperationKeys(filePath, operations);
+      if (keysToAdd.length === 0) {
+        return;
+      }
+      setProcessedOperationKeys((prev) => {
+        const next = [...prev];
+        keysToAdd.forEach((key) => {
+          if (!next.includes(key)) {
+            next.push(key);
+          }
+        });
+        return sameStringArray(prev, next) ? prev : next;
+      });
+    },
+    [],
+  );
+
+  const handleUndoFile = useCallback(
+    (filePath: string, operations?: EditOperation[]) => {
+      addOperationsToProcessed(filePath, operations);
+    },
+    [addOperationsToProcessed],
+  );
+
+  const registerPendingFileChangeAction = useCallback(
+    (fileChange: FileChangeSummary): string => {
+      pendingActionCounterRef.current += 1;
+      const requestId = createRequestId(pendingActionCounterRef.current);
+      pendingFileChangeActionsRef.current.set(requestId, fileChange);
+      return requestId;
+    },
+    [],
+  );
+
+  const clearPendingFileChangeAction = useCallback((requestId?: string) => {
+    if (requestId) {
+      pendingFileChangeActionsRef.current.delete(requestId);
+    }
+  }, []);
+
+  const consumePendingFileChangeAction = useCallback(
+    (filePath?: string, requestId?: string): FileChange | undefined => {
+      if (requestId) {
+        const fileChange = pendingFileChangeActionsRef.current.get(requestId);
+        pendingFileChangeActionsRef.current.delete(requestId);
+        if (!fileChange) {
+          console.warn(
+            "[InteractiveDiff] No pending file change action for request id:",
+            requestId,
+          );
+        }
+        return fileChange;
+      }
+      if (!filePath) {
+        return undefined;
+      }
+      const matches = Array.from(
+        pendingFileChangeActionsRef.current.entries(),
+      ).filter(([, value]) => value.filePath === filePath);
+      if (matches.length === 0) {
+        console.warn(
+          "[InteractiveDiff] No pending file change action for file:",
+          filePath,
+        );
+        return undefined;
+      }
+      if (matches.length > 1) {
+        matches.forEach(([key]) =>
+          pendingFileChangeActionsRef.current.delete(key),
+        );
+        console.warn(
+          "[InteractiveDiff] Ambiguous pending file change actions cleared for file:",
+          filePath,
+        );
+        return undefined;
+      }
+      const [key, value] = matches[0];
+      pendingFileChangeActionsRef.current.delete(key);
+      return value;
+    },
+    [],
+  );
+
+  const handleKeepAll = useCallback(
+    (_currentFileChanges: FileChange[] = []) => {
+      const newBaseIndex = messages.length;
+
+      setBaseMessageIndex(newBaseIndex);
+      setProcessedOperationKeys([]);
+      pendingFileChangeActionsRef.current.clear();
 
       if (currentSessionId) {
         try {
           localStorage.setItem(
-            `processed-files-${currentSessionId}`,
-            JSON.stringify(newList)
+            `keep-all-base-${currentSessionId}`,
+            String(newBaseIndex),
           );
-        } catch (e) {
-          console.error('Failed to persist processed files:', e);
+          localStorage.removeItem(`keep-all-edit-sequence-${currentSessionId}`);
+          localStorage.removeItem(`processed-edit-keys-${currentSessionId}`);
+          localStorage.removeItem(`processed-files-${currentSessionId}`);
+        } catch (error) {
+          console.error("Failed to persist Keep All state:", error);
         }
       }
+    },
+    [messages.length, currentSessionId],
+  );
 
-      return newList;
-    });
-  }, [currentSessionId]);
-
-  // Callback for Keep All - set current changes as the new baseline
-  const handleKeepAll = useCallback(() => {
-    const newBaseIndex = messages.length;
-    setBaseMessageIndex(newBaseIndex);
-    setProcessedFiles([]);
-
-    if (currentSessionId) {
-      try {
-        localStorage.setItem(`keep-all-base-${currentSessionId}`, String(newBaseIndex));
-        localStorage.removeItem(`processed-files-${currentSessionId}`);
-      } catch (e) {
-        console.error('Failed to persist Keep All state:', e);
-      }
-    }
-  }, [messages.length, currentSessionId]);
-
-  // Register window callbacks for editable diff operations from Java backend
   useEffect(() => {
-    // Handle remove file from edits list (legacy callback)
     window.handleRemoveFileFromEdits = (jsonStr: string) => {
       try {
         const data = JSON.parse(jsonStr);
-        const filePath = data.filePath;
-        if (filePath) {
-          addFileToProcessed(filePath);
+        const fileChange = consumePendingFileChangeAction(
+          data.filePath,
+          data.requestId,
+        );
+        if (fileChange) {
+          addOperationsToProcessed(fileChange.filePath, fileChange.operations);
         }
-      } catch {
-        // JSON parse failed, ignore
+      } catch (error) {
+        console.error("Failed to handle remove file from edits:", error);
       }
     };
 
-    // Handle interactive diff result (Apply/Reject from the new interactive diff view)
     window.handleDiffResult = (jsonStr: string) => {
       try {
         const data = JSON.parse(jsonStr);
-        const { filePath, action, error } = data;
+        const { filePath, action, error, requestId } = data;
 
         if (error) {
-          console.error('[InteractiveDiff] Error:', error);
+          console.error("[InteractiveDiff] Error:", error);
+          consumePendingFileChangeAction(filePath, requestId);
           return;
         }
 
-        if (action === 'APPLY' || action === 'REJECT') {
-          addFileToProcessed(filePath);
+        if (action === "APPLY" || action === "REJECT") {
+          const fileChange = consumePendingFileChangeAction(
+            filePath,
+            requestId,
+          );
+          if (fileChange) {
+            addOperationsToProcessed(
+              fileChange.filePath,
+              fileChange.operations,
+            );
+          }
           debugLog(`[InteractiveDiff] ${action} changes to:`, filePath);
+        } else if (action === "ERROR" || action === "DISMISS") {
+          consumePendingFileChangeAction(filePath, requestId);
         }
-      } catch {
-        // JSON parse failed, ignore
+      } catch (error) {
+        console.error("Failed to handle diff result:", error);
       }
     };
 
@@ -149,67 +242,80 @@ export function useFileChangesManagement({
       delete window.handleRemoveFileFromEdits;
       delete window.handleDiffResult;
     };
-  }, [addFileToProcessed]);
+  }, [addOperationsToProcessed, consumePendingFileChangeAction]);
 
-  // Restore/reset state on session switch
   useEffect(() => {
-    setProcessedFiles([]);
+    loadedSessionRef.current = null;
+    setProcessedOperationKeys([]);
+    pendingFileChangeActionsRef.current.clear();
 
     if (!currentSessionId) {
       setBaseMessageIndex(0);
+      loadedSessionRef.current = null;
       return;
     }
 
-    // Cleanup old localStorage entries to prevent infinite growth
+    setBaseMessageIndex(0);
+
     const MAX_STORED_SESSIONS = 50;
     try {
-      const keysToCheck = Object.keys(localStorage)
-        .filter(k => k.startsWith('processed-files-') || k.startsWith('keep-all-base-'));
+      const keysToCheck = Object.keys(localStorage).filter(
+        (k) =>
+          k.startsWith("processed-files-") ||
+          k.startsWith("processed-edit-keys-") ||
+          k.startsWith("keep-all-base-") ||
+          k.startsWith("keep-all-edit-sequence-"),
+      );
       if (keysToCheck.length > MAX_STORED_SESSIONS) {
-        const toRemove = keysToCheck.slice(0, keysToCheck.length - MAX_STORED_SESSIONS);
-        toRemove.forEach(k => localStorage.removeItem(k));
+        const toRemove = keysToCheck.slice(
+          0,
+          keysToCheck.length - MAX_STORED_SESSIONS,
+        );
+        toRemove.forEach((k) => localStorage.removeItem(k));
       }
-    } catch {
-      // Ignore cleanup errors
+    } catch (error) {
+      console.warn("Failed to clean persisted file change state:", error);
     }
 
-    // Restore processed files from localStorage
     try {
-      const savedProcessedFiles = localStorage.getItem(
-        `processed-files-${currentSessionId}`
+      const savedProcessedKeys = localStorage.getItem(
+        `processed-edit-keys-${currentSessionId}`,
       );
-      if (savedProcessedFiles) {
-        const files = JSON.parse(savedProcessedFiles);
-        if (Array.isArray(files)) {
-          setProcessedFiles(files);
+      if (savedProcessedKeys) {
+        const keys = JSON.parse(savedProcessedKeys);
+        if (Array.isArray(keys)) {
+          setProcessedOperationKeys(
+            keys.filter((key): key is string => typeof key === "string"),
+          );
         }
       }
-    } catch (e) {
-      console.error('Failed to load processed files:', e);
+    } catch (error) {
+      console.error("Failed to load processed edit keys:", error);
     }
 
-    // Restore Keep All base index
     try {
-      const savedBaseIndex = localStorage.getItem(`keep-all-base-${currentSessionId}`);
+      const savedBaseIndex = localStorage.getItem(
+        `keep-all-base-${currentSessionId}`,
+      );
       if (savedBaseIndex) {
         const index = parseInt(savedBaseIndex, 10);
         if (!isNaN(index) && index >= 0) {
           setBaseMessageIndex(index);
-          return;
         }
       }
-    } catch (e) {
-      console.error('Failed to load Keep All state:', e);
+    } catch (error) {
+      console.error("Failed to load Keep All state:", error);
     }
 
-    setBaseMessageIndex(0);
+    loadedSessionRef.current = currentSessionId;
   }, [currentSessionId]);
 
   return {
-    processedFiles,
+    processedOperationKeys,
     baseMessageIndex,
     handleUndoFile,
-    handleDiscardAll,
     handleKeepAll,
+    registerPendingFileChangeAction,
+    clearPendingFileChangeAction,
   };
 }

--- a/webview/src/hooks/useSubagents.test.ts
+++ b/webview/src/hooks/useSubagents.test.ts
@@ -185,7 +185,7 @@ describe('useSubagents lifecycle extraction', () => {
     expect(subagents.find((subagent) => subagent.agentHandle === 'agent-2')?.status).toBe('completed');
   });
 
-  it('does not guess a completed handle from multi-target wait_agent without result identity', () => {
+  it('marks all target handles completed when multi-target wait_agent succeeds without a single result identity', () => {
     const messages = [
       assistantWithTool('spawn-1', 'spawn_agent', { message: 'work 1' }),
       assistantWithTool('spawn-2', 'spawn_agent', { message: 'work 2' }),
@@ -205,7 +205,7 @@ describe('useSubagents lifecycle extraction', () => {
     );
 
     expect(subagents).toHaveLength(2);
-    expect(subagents.every((subagent) => subagent.status === 'running')).toBe(true);
+    expect(subagents.every((subagent) => subagent.status === 'completed')).toBe(true);
   });
 
   it('uses send_input target instead of generic result text as Codex handle', () => {

--- a/webview/src/hooks/useSubagents.test.ts
+++ b/webview/src/hooks/useSubagents.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from 'vitest';
-import type { ClaudeContentBlock, ClaudeMessage, ToolResultBlock } from '../types';
 import { extractSubagentsFromMessages } from './useSubagents';
+import { finalizeSubagentsForSettledTurn } from '../utils/turnScope';
+import type { ClaudeContentBlock, ClaudeMessage, ClaudeRawMessage, ToolResultBlock } from '../types';
+
+const noopGetToolResultRaw = () => null;
+
+const assistantWithTool = (id: string, name: string, input: Record<string, unknown>): ClaudeMessage => ({
+  type: 'assistant',
+  content: '',
+  timestamp: new Date().toISOString(),
+  raw: {},
+  blocks: [{ type: 'tool_use', id, name, input } as ClaudeContentBlock],
+} as ClaudeMessage);
 
 const assistantWithAgent = (toolUseId: string): ClaudeMessage => ({
   type: 'assistant',
@@ -21,6 +32,13 @@ const assistantWithAgent = (toolUseId: string): ClaudeMessage => ({
       ],
     },
   },
+});
+
+const successResult = (toolUseId: string, content = 'ok'): ToolResultBlock => ({
+  type: 'tool_result',
+  tool_use_id: toolUseId,
+  content,
+  is_error: false,
 });
 
 const toolResultMessage = (toolUseId: string): ClaudeMessage => ({
@@ -47,13 +65,15 @@ const toolResultMessage = (toolUseId: string): ClaudeMessage => ({
 });
 
 const getContentBlocks = (message: ClaudeMessage): ClaudeContentBlock[] => {
+  if ((message as any).blocks) return (message as any).blocks as ClaudeContentBlock[];
   const raw = message.raw;
   if (!raw || typeof raw === 'string') return [];
   const content = raw.message?.content ?? raw.content;
   return Array.isArray(content) ? content.filter((block): block is ClaudeContentBlock => block.type === 'tool_use') : [];
 };
 
-const findToolResult = (messages: ClaudeMessage[]) => (toolUseId?: string): ToolResultBlock | null => {
+const findToolResult = (messages: ClaudeMessage[], results?: Map<string, ToolResultBlock>) => (toolUseId?: string): ToolResultBlock | null => {
+  if (toolUseId && results?.has(toolUseId)) return results.get(toolUseId) ?? null;
   for (const message of messages) {
     const raw = message.raw;
     if (!raw || typeof raw === 'string') continue;
@@ -65,19 +85,19 @@ const findToolResult = (messages: ClaudeMessage[]) => (toolUseId?: string): Tool
   return null;
 };
 
-const getToolResultRaw = (messages: ClaudeMessage[]) => (toolUseId: string) => {
+const getToolResultRaw = (messages: ClaudeMessage[]) => (toolUseId: string): ClaudeRawMessage | null => {
   for (const message of messages) {
     const raw = message.raw;
     if (!raw || typeof raw === 'string') continue;
     const content = raw.content ?? raw.message?.content;
     if (Array.isArray(content) && content.some((block) => block.type === 'tool_result' && (block as ToolResultBlock).tool_use_id === toolUseId)) {
-      return raw as Record<string, unknown>;
+      return raw;
     }
   }
   return null;
 };
 
-describe('extractSubagentsFromMessages', () => {
+describe('useSubagents lifecycle extraction', () => {
   it('attaches completed Agent result metadata including stable agent id', () => {
     const messages = [assistantWithAgent('tooluse_backend'), toolResultMessage('tooluse_backend')];
 
@@ -92,10 +112,135 @@ describe('extractSubagentsFromMessages', () => {
       type: 'research',
       description: '分析后端历史索引服务的设计模式',
       status: 'completed',
+      provider: 'claude',
       totalDurationMs: 62629,
       totalTokens: 110586,
       totalToolUseCount: 4,
     });
     expect(subagents[0].toolStats).toMatchObject({ readCount: 4 });
+  });
+
+  it('keeps successful Codex spawn running until wait or close completes', () => {
+    const messages = [assistantWithTool('spawn-1', 'spawn_agent', { message: 'work' })];
+    const results = new Map<string, ToolResultBlock>([
+      ['spawn-1', successResult('spawn-1', JSON.stringify({ agent_id: 'agent-1' }))],
+    ]);
+
+    const subagents = extractSubagentsFromMessages(
+      messages,
+      getContentBlocks,
+      findToolResult(messages, results),
+      noopGetToolResultRaw,
+    );
+    const finalized = finalizeSubagentsForSettledTurn(subagents, false);
+
+    expect(finalized).toHaveLength(1);
+    expect(finalized[0].provider).toBe('codex');
+    expect(finalized[0].agentHandle).toBe('agent-1');
+    expect(finalized[0].status).toBe('running');
+  });
+
+  it('marks Codex spawn completed when wait_agent completes for the same handle', () => {
+    const messages = [
+      assistantWithTool('spawn-1', 'spawn_agent', { message: 'work' }),
+      assistantWithTool('wait-1', 'wait_agent', { targets: ['agent-1'] }),
+    ];
+    const results = new Map<string, ToolResultBlock>([
+      ['spawn-1', successResult('spawn-1', JSON.stringify({ agent_id: 'agent-1' }))],
+      ['wait-1', successResult('wait-1', JSON.stringify({ agent_id: 'agent-1', status: 'completed' }))],
+    ]);
+
+    const subagents = extractSubagentsFromMessages(
+      messages,
+      getContentBlocks,
+      findToolResult(messages, results),
+      noopGetToolResultRaw,
+    );
+
+    expect(subagents).toHaveLength(1);
+    expect(subagents[0].status).toBe('completed');
+  });
+
+  it('completes only the handle reported by wait_agent when multiple targets are provided', () => {
+    const messages = [
+      assistantWithTool('spawn-1', 'spawn_agent', { message: 'work 1' }),
+      assistantWithTool('spawn-2', 'spawn_agent', { message: 'work 2' }),
+      assistantWithTool('wait-1', 'wait_agent', { targets: ['agent-1', 'agent-2'] }),
+    ];
+    const results = new Map<string, ToolResultBlock>([
+      ['spawn-1', successResult('spawn-1', JSON.stringify({ agent_id: 'agent-1' }))],
+      ['spawn-2', successResult('spawn-2', JSON.stringify({ agent_id: 'agent-2' }))],
+      ['wait-1', successResult('wait-1', JSON.stringify({ agent_id: 'agent-2', status: 'completed' }))],
+    ]);
+
+    const subagents = extractSubagentsFromMessages(
+      messages,
+      getContentBlocks,
+      findToolResult(messages, results),
+      noopGetToolResultRaw,
+    );
+
+    expect(subagents).toHaveLength(2);
+    expect(subagents.find((subagent) => subagent.agentHandle === 'agent-1')?.status).toBe('running');
+    expect(subagents.find((subagent) => subagent.agentHandle === 'agent-2')?.status).toBe('completed');
+  });
+
+  it('does not guess a completed handle from multi-target wait_agent without result identity', () => {
+    const messages = [
+      assistantWithTool('spawn-1', 'spawn_agent', { message: 'work 1' }),
+      assistantWithTool('spawn-2', 'spawn_agent', { message: 'work 2' }),
+      assistantWithTool('wait-1', 'wait_agent', { targets: ['agent-1', 'agent-2'] }),
+    ];
+    const results = new Map<string, ToolResultBlock>([
+      ['spawn-1', successResult('spawn-1', JSON.stringify({ agent_id: 'agent-1' }))],
+      ['spawn-2', successResult('spawn-2', JSON.stringify({ agent_id: 'agent-2' }))],
+      ['wait-1', successResult('wait-1', JSON.stringify({ targets: ['agent-1', 'agent-2'] }))],
+    ]);
+
+    const subagents = extractSubagentsFromMessages(
+      messages,
+      getContentBlocks,
+      findToolResult(messages, results),
+      noopGetToolResultRaw,
+    );
+
+    expect(subagents).toHaveLength(2);
+    expect(subagents.every((subagent) => subagent.status === 'running')).toBe(true);
+  });
+
+  it('uses send_input target instead of generic result text as Codex handle', () => {
+    const messages = [assistantWithTool('send-1', 'send_input', { target: 'agent-1', message: 'continue' })];
+    const results = new Map<string, ToolResultBlock>([
+      ['send-1', successResult('send-1', 'ok')],
+    ]);
+
+    const subagents = extractSubagentsFromMessages(
+      messages,
+      getContentBlocks,
+      findToolResult(messages, results),
+      noopGetToolResultRaw,
+    );
+
+    expect(subagents).toHaveLength(1);
+    expect(subagents[0].agentHandle).toBe('agent-1');
+    expect(subagents[0].status).toBe('running');
+  });
+
+  it('marks Codex spawn result without a plausible handle as error instead of running', () => {
+    const messages = [assistantWithTool('spawn-invalid', 'spawn_agent', { message: 'work' })];
+    const results = new Map<string, ToolResultBlock>([
+      ['spawn-invalid', successResult('spawn-invalid', 'Full-history forked agents inherit the parent agent type, model, and reasoning effort; omit agent_type, model, and reasoning_effort.')],
+    ]);
+
+    const subagents = extractSubagentsFromMessages(
+      messages,
+      getContentBlocks,
+      findToolResult(messages, results),
+      noopGetToolResultRaw,
+    );
+
+    expect(subagents).toHaveLength(1);
+    expect(subagents[0].agentHandle).toBeUndefined();
+    expect(subagents[0].status).toBe('error');
   });
 });

--- a/webview/src/hooks/useSubagents.ts
+++ b/webview/src/hooks/useSubagents.ts
@@ -284,7 +284,7 @@ export function extractSubagentsFromMessages(
             resultHandles.forEach((handle) => handles.add(handle));
           } else if (directInputHandles.size > 0) {
             directInputHandles.forEach((handle) => handles.add(handle));
-          } else if (targetArrayHandles.size === 1) {
+          } else if (targetArrayHandles.size === 1 || (targetArrayHandles.size > 1 && !!result && !result.is_error)) {
             targetArrayHandles.forEach((handle) => handles.add(handle));
           }
         } else {

--- a/webview/src/hooks/useSubagents.ts
+++ b/webview/src/hooks/useSubagents.ts
@@ -12,8 +12,12 @@ interface UseSubagentsParams {
   getToolResultRaw: GetToolResultRawFn;
 }
 
+const UUID_PATTERN = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/g;
+const CODEX_START_TOOLS = new Set(['spawn_agent', 'send_input', 'resume_agent']);
+const CODEX_TERMINAL_TOOLS = new Set(['wait_agent', 'close_agent']);
+
 /**
- * Determine subagent status based on tool result
+ * Determine subagent status based on tool result.
  */
 function determineStatus(result: ToolResultBlock | null): SubagentStatus {
   if (!result) {
@@ -67,6 +71,138 @@ function extractResultMetadata(
   };
 }
 
+function addStringHandle(handles: Set<string>, value: unknown): void {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    handles.add(value.trim());
+  }
+}
+
+function extractTargetArrayHandles(value: unknown): Set<string> {
+  const handles = new Set<string>();
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return handles;
+  }
+  const targets = (value as Record<string, unknown>).targets;
+  if (Array.isArray(targets)) {
+    targets.forEach((target) => addStringHandle(handles, target));
+  }
+  return handles;
+}
+
+function extractHandlesFromObject(value: unknown, includeTargets = true): Set<string> {
+  const handles = new Set<string>();
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return handles;
+  }
+  const object = value as Record<string, unknown>;
+  [
+    'agentHandle', 'agent_handle', 'agentId', 'agent_id', 'agentPath', 'agent_path',
+    'target', 'id', 'path',
+  ].forEach((key) => addStringHandle(handles, object[key]));
+
+  if (includeTargets) {
+    extractTargetArrayHandles(object).forEach((handle) => handles.add(handle));
+  }
+
+  return handles;
+}
+
+function isPlausiblePlainTextHandle(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed || trimmed.length > 512 || trimmed.includes('\n')) {
+    return false;
+  }
+  if (/^(\/|~\/|[A-Za-z]:[\\/])/.test(trimmed)) {
+    return true;
+  }
+  if (/^[A-Za-z0-9._:-]+$/.test(trimmed) && /(agent|codex|[0-9a-fA-F]{6,})/i.test(trimmed)) {
+    return true;
+  }
+  return false;
+}
+
+function extractTextFromResult(result: ToolResultBlock | null): string {
+  if (!result || result.content === undefined || result.content === null) {
+    return '';
+  }
+  if (typeof result.content === 'string') {
+    return result.content;
+  }
+  if (Array.isArray(result.content)) {
+    return result.content
+      .map((item) => (item && typeof item.text === 'string' ? item.text : ''))
+      .filter(Boolean)
+      .join('\n');
+  }
+  return '';
+}
+
+function extractHandlesFromResult(
+  result: ToolResultBlock | null,
+  allowPlainTextHandle = false,
+  includeTargets = true,
+  allowMultipleUuidHandles = true,
+): Set<string> {
+  const handles = new Set<string>();
+  const text = extractTextFromResult(result).trim();
+  if (!text) {
+    return handles;
+  }
+
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    extractHandlesFromObject(parsed, includeTargets).forEach((handle) => handles.add(handle));
+  } catch {
+    // Fall through to text extraction.
+  }
+
+  const uuidMatches = Array.from(text.matchAll(UUID_PATTERN), (match) => match[0]);
+  if (allowMultipleUuidHandles || uuidMatches.length === 1) {
+    uuidMatches.forEach((handle) => handles.add(handle));
+  }
+
+  if (allowPlainTextHandle && handles.size === 0 && isPlausiblePlainTextHandle(text)) {
+    handles.add(text);
+  }
+
+  return handles;
+}
+
+function ensureCodexSubagent(
+  subagents: SubagentInfo[],
+  byHandle: Map<string, SubagentInfo>,
+  id: string,
+  handle: string | undefined,
+  type: string,
+  description: string,
+  prompt: string,
+  status: SubagentStatus,
+  messageIndex: number,
+): SubagentInfo {
+  const existing = handle ? byHandle.get(handle) : undefined;
+  if (existing) {
+    existing.status = status;
+    if (!existing.agentHandle) existing.agentHandle = handle;
+    return existing;
+  }
+
+  const subagent: SubagentInfo = {
+    id,
+    type,
+    description,
+    prompt,
+    status,
+    provider: 'codex',
+    agentHandle: handle,
+    messageIndex,
+  };
+  subagents.push(subagent);
+  if (handle) {
+    byHandle.set(handle, subagent);
+  }
+  return subagent;
+}
+
 export function extractSubagentsFromMessages(
   messages: ClaudeMessage[],
   getContentBlocks: (message: ClaudeMessage) => ClaudeContentBlock[],
@@ -74,45 +210,97 @@ export function extractSubagentsFromMessages(
   getToolResultRaw: GetToolResultRawFn,
 ): SubagentInfo[] {
   const subagents: SubagentInfo[] = [];
+  const codexSubagentByHandle = new Map<string, SubagentInfo>();
 
   messages.forEach((message, messageIndex) => {
     if (message.type !== 'assistant') return;
 
     const blocks = getContentBlocks(message);
 
-    blocks.forEach((block) => {
+    blocks.forEach((block, blockIndex) => {
       if (block.type !== 'tool_use') return;
 
       const toolName = normalizeToolName(block.name ?? '');
-
-      // Only process task/agent-style subagent tool calls.
-      if (toolName !== 'task' && toolName !== 'agent' && toolName !== 'spawn_agent') return;
-
       const rawInput = block.input as Record<string, unknown> | undefined;
       const input = rawInput ? normalizeToolInput(block.name, rawInput) as Record<string, unknown> : undefined;
       if (!input) return;
 
-      // Defensive: ensure all string values are actually strings
-      const id = String(block.id ?? `task-${messageIndex}-${subagents.length}`);
-      const subagentType = String((input.subagent_type as string) ?? (input.subagentType as string) ?? 'Unknown');
-      const description = String((input.description as string) ?? '');
-      const prompt = String((input.prompt as string) ?? '');
-
-      // Check tool result to determine status
+      const id = String(block.id ?? `${toolName}-${messageIndex}-${blockIndex}`);
       const toolUseId = block.id ?? '';
       const result = findToolResult(toolUseId, messageIndex);
-      const status = determineStatus(result);
-      const resultMetadata = extractResultMetadata(result, getToolResultRaw, toolUseId);
 
-      subagents.push({
-        id,
-        type: subagentType,
-        description,
-        prompt,
-        status,
-        messageIndex,
-        ...resultMetadata,
-      });
+      if (toolName === 'task' || toolName === 'agent') {
+        const resultMetadata = extractResultMetadata(result, getToolResultRaw, toolUseId);
+        subagents.push({
+          id,
+          type: String((input.subagent_type as string) ?? (input.subagentType as string) ?? 'Unknown'),
+          description: String((input.description as string) ?? ''),
+          prompt: String((input.prompt as string) ?? ''),
+          status: determineStatus(result),
+          provider: 'claude',
+          messageIndex,
+          ...resultMetadata,
+        });
+        return;
+      }
+
+      if (CODEX_START_TOOLS.has(toolName)) {
+        const resultHandles = result && !result.is_error
+          ? extractHandlesFromResult(result, toolName === 'spawn_agent')
+          : new Set<string>();
+        const inputHandles = extractHandlesFromObject(input);
+        const handles = toolName === 'spawn_agent'
+          ? (resultHandles.size > 0 ? resultHandles : inputHandles)
+          : (inputHandles.size > 0 ? inputHandles : resultHandles);
+        const fallbackHandle = handles.values().next().value as string | undefined;
+        const status: SubagentStatus = result?.is_error || (toolName === 'spawn_agent' && !!result && handles.size === 0)
+          ? 'error'
+          : 'running';
+        const type = String(input.agent_type ?? input.agentType ?? toolName);
+        const description = String(input.description ?? input.name ?? fallbackHandle ?? toolName);
+        const prompt = String(input.prompt ?? input.message ?? '');
+
+        if (handles.size === 0) {
+          ensureCodexSubagent(subagents, codexSubagentByHandle, id, undefined, type, description, prompt, status, messageIndex);
+          return;
+        }
+
+        handles.forEach((handle) => {
+          ensureCodexSubagent(subagents, codexSubagentByHandle, id, handle, type, description, prompt, status, messageIndex);
+        });
+        return;
+      }
+
+      if (CODEX_TERMINAL_TOOLS.has(toolName)) {
+        const resultHandles = toolName === 'wait_agent'
+          ? extractHandlesFromResult(result, false, false, false)
+          : extractHandlesFromResult(result);
+        const directInputHandles = extractHandlesFromObject(input, false);
+        const targetArrayHandles = extractTargetArrayHandles(input);
+        const handles = new Set<string>();
+
+        if (toolName === 'wait_agent') {
+          if (resultHandles.size > 0) {
+            resultHandles.forEach((handle) => handles.add(handle));
+          } else if (directInputHandles.size > 0) {
+            directInputHandles.forEach((handle) => handles.add(handle));
+          } else if (targetArrayHandles.size === 1) {
+            targetArrayHandles.forEach((handle) => handles.add(handle));
+          }
+        } else {
+          directInputHandles.forEach((handle) => handles.add(handle));
+          targetArrayHandles.forEach((handle) => handles.add(handle));
+          resultHandles.forEach((handle) => handles.add(handle));
+        }
+
+        const status: SubagentStatus = result?.is_error ? 'error' : (result ? 'completed' : 'running');
+        handles.forEach((handle) => {
+          const existing = codexSubagentByHandle.get(handle);
+          if (existing) {
+            existing.status = status;
+          }
+        });
+      }
     });
   });
 
@@ -120,7 +308,7 @@ export function extractSubagentsFromMessages(
 }
 
 /**
- * Hook to extract subagent information from Task tool calls
+ * Hook to extract subagent information from Task tool calls.
  */
 export function useSubagents({
   messages,

--- a/webview/src/hooks/windowCallbacks/settingsBootstrap.ts
+++ b/webview/src/hooks/windowCallbacks/settingsBootstrap.ts
@@ -10,6 +10,9 @@ import { sendBridgeEvent } from '../../utils/bridge';
 
 const MAX_RETRIES = 30;
 
+const isWindowAvailable = (): boolean => typeof window !== 'undefined';
+const getSendToJava = (): typeof window.sendToJava | undefined => isWindowAvailable() ? window.sendToJava : undefined;
+
 /**
  * Fire the three settings queries to the backend.  Retries up to MAX_RETRIES
  * times (at 100 ms intervals) if window.sendToJava is not yet available.
@@ -17,11 +20,13 @@ const MAX_RETRIES = 30;
 export const startInitialSettingsRequest = (): void => {
   let settingsRetryCount = 0;
   const requestInitialSettings = () => {
-    if (window.sendToJava) {
-      window.sendToJava('get_streaming_enabled:');
-      window.sendToJava('get_send_shortcut:');
-      window.sendToJava('get_auto_open_file_enabled:');
+    const sendToJava = getSendToJava();
+    if (sendToJava) {
+      sendToJava('get_streaming_enabled:');
+      sendToJava('get_send_shortcut:');
+      sendToJava('get_auto_open_file_enabled:');
     } else {
+      if (!isWindowAvailable()) return;
       settingsRetryCount++;
       if (settingsRetryCount < MAX_RETRIES) {
         setTimeout(requestInitialSettings, 100);
@@ -38,9 +43,10 @@ export const startInitialSettingsRequest = (): void => {
 export const startActiveProviderRequest = (): void => {
   let retryCount = 0;
   const requestActiveProvider = () => {
-    if (window.sendToJava) {
+    if (getSendToJava()) {
       sendBridgeEvent('get_active_provider');
     } else {
+      if (!isWindowAvailable()) return;
       retryCount++;
       if (retryCount < MAX_RETRIES) {
         setTimeout(requestActiveProvider, 100);
@@ -56,9 +62,10 @@ export const startActiveProviderRequest = (): void => {
 export const startModeRequest = (): void => {
   let modeRetryCount = 0;
   const requestMode = () => {
-    if (window.sendToJava) {
+    if (getSendToJava()) {
       sendBridgeEvent('get_mode');
     } else {
+      if (!isWindowAvailable()) return;
       modeRetryCount++;
       if (modeRetryCount < MAX_RETRIES) {
         setTimeout(requestMode, 100);
@@ -74,9 +81,10 @@ export const startModeRequest = (): void => {
 export const startThinkingEnabledRequest = (): void => {
   let thinkingRetryCount = 0;
   const requestThinkingEnabled = () => {
-    if (window.sendToJava) {
+    if (getSendToJava()) {
       sendBridgeEvent('get_thinking_enabled');
     } else {
+      if (!isWindowAvailable()) return;
       thinkingRetryCount++;
       if (thinkingRetryCount < MAX_RETRIES) {
         setTimeout(requestThinkingEnabled, 100);
@@ -132,7 +140,8 @@ export const drainAndRequestDependencyStatus = (): void => {
     window.updateDependencyStatus?.(pending);
   }
 
-  if (window.sendToJava) {
-    window.sendToJava('get_dependency_status:');
+  const sendToJava = getSendToJava();
+  if (sendToJava) {
+    sendToJava('get_dependency_status:');
   }
 };

--- a/webview/src/types/fileChanges.ts
+++ b/webview/src/types/fileChanges.ts
@@ -15,6 +15,19 @@ export interface EditOperation {
   replaceAll?: boolean;
   lineStart?: number;
   lineEnd?: number;
+  source?: 'main' | 'subagent' | 'codex_session_patch';
+  scopeId?: string;
+  agentHandle?: string;
+  parentToolUseId?: string;
+  operationId?: string;
+  safeToRollback?: boolean;
+  expectedAfterContentHash?: string;
+  editSequence?: number;
+  existedBefore?: boolean;
+  toolUseId?: string;
+  messageIndex?: number;
+  blockIndex?: number;
+  occurrenceId?: string;
 }
 
 /** Aggregated file change summary */

--- a/webview/src/types/subagent.ts
+++ b/webview/src/types/subagent.ts
@@ -26,6 +26,10 @@ export interface SubagentInfo {
   prompt?: string;
   /** Execution status */
   status: SubagentStatus;
+  /** Provider-specific lifecycle source */
+  provider?: 'claude' | 'codex';
+  /** Provider-specific background agent handle, when available */
+  agentHandle?: string;
   /** Message index where this subagent was invoked */
   messageIndex: number;
   /** Stable runtime agent id returned by Claude Code, used to locate sidechain logs */

--- a/webview/src/utils/bridge.ts
+++ b/webview/src/utils/bridge.ts
@@ -105,7 +105,7 @@ export const openBrowser = (url?: string) => {
 
 export const sendToJava = (message: string, payload: any = {}) => {
   const payloadStr = typeof payload === 'string' ? payload : JSON.stringify(payload);
-  sendBridgeEvent(message, payloadStr);
+  return sendBridgeEvent(message, payloadStr);
 };
 
 export const refreshFile = (filePath: string) => {
@@ -140,14 +140,30 @@ export const showMultiEditDiff = (
  */
 export const showEditableDiff = (
   filePath: string,
-  operations: Array<{ oldString: string; newString: string; replaceAll?: boolean }>,
-  status: 'A' | 'M'
+  operations: Array<{
+    oldString: string;
+    newString: string;
+    replaceAll?: boolean;
+    lineStart?: number;
+    lineEnd?: number;
+    operationId?: string;
+    source?: string;
+    scopeId?: string;
+    agentHandle?: string;
+    parentToolUseId?: string;
+    safeToRollback?: boolean;
+    editSequence?: number;
+    existedBefore?: boolean;
+    toolUseId?: string;
+  }>,
+  status: 'A' | 'M',
+  requestId?: string
 ) => {
   // Security: Validate file path (defense-in-depth, backend also validates)
   if (!isValidMutatingPath(filePath)) {
-    return;
+    return false;
   }
-  sendToJava('show_editable_diff', { filePath, operations, status });
+  return sendToJava('show_editable_diff', { filePath, operations, status, requestId });
 };
 
 /**
@@ -230,7 +246,22 @@ export const rewindFiles = (sessionId: string, userMessageId: string) => {
 export const undoFileChanges = (
   filePath: string,
   status: 'A' | 'M',
-  operations: Array<{ oldString: string; newString: string; replaceAll?: boolean }>
+  operations: Array<{
+    oldString: string;
+    newString: string;
+    replaceAll?: boolean;
+    lineStart?: number;
+    lineEnd?: number;
+    operationId?: string;
+    source?: string;
+    scopeId?: string;
+    agentHandle?: string;
+    parentToolUseId?: string;
+    safeToRollback?: boolean;
+    editSequence?: number;
+    existedBefore?: boolean;
+    toolUseId?: string;
+  }>
 ) => {
   // Security: Validate file path (defense-in-depth, backend also validates)
   if (!isValidMutatingPath(filePath)) {

--- a/webview/src/utils/fileChangeProcessing.ts
+++ b/webview/src/utils/fileChangeProcessing.ts
@@ -1,0 +1,77 @@
+import type { EditOperation, FileChangeSummary } from '../types';
+
+const WRITE_TOOL_NAMES = new Set(['write', 'write_file', 'create_file']);
+
+const normalizeToolName = (toolName?: string): string => (toolName || '').trim().toLowerCase();
+
+export const getFileChangeStatusFromOperations = (operations: EditOperation[] = []): 'A' | 'M' => {
+  if (operations.length === 0) {
+    return 'M';
+  }
+  const firstOperation = operations[0];
+  if (firstOperation.existedBefore === false) {
+    return 'A';
+  }
+  if (firstOperation.existedBefore === true) {
+    return 'M';
+  }
+  return WRITE_TOOL_NAMES.has(normalizeToolName(firstOperation.toolName)) ? 'A' : 'M';
+};
+
+export const getProcessedOperationKey = (filePath: string, operation: EditOperation): string => {
+  if (operation.operationId) {
+    return `op:${operation.operationId}`;
+  }
+  if (operation.toolUseId) {
+    return `tool:${operation.toolUseId}`;
+  }
+  if (operation.occurrenceId) {
+    return `occ:${operation.occurrenceId}`;
+  }
+  return [
+    `fp:${filePath}`,
+    operation.toolName,
+    operation.oldString,
+    operation.newString,
+    operation.lineStart ?? '',
+    operation.lineEnd ?? '',
+  ].join('\u0000');
+};
+
+export const getProcessedOperationKeys = (filePath: string, operations: EditOperation[] = []): string[] =>
+  operations.map((operation) => getProcessedOperationKey(filePath, operation));
+
+export const filterProcessedFileChanges = (
+  fileChanges: FileChangeSummary[],
+  processedOperationKeys: string[]
+): FileChangeSummary[] => {
+  if (processedOperationKeys.length === 0) {
+    return fileChanges;
+  }
+  const processed = new Set(processedOperationKeys);
+  return fileChanges
+    .map((fileChange) => {
+      const operations = fileChange.operations.filter(
+        (operation) => !processed.has(getProcessedOperationKey(fileChange.filePath, operation))
+      );
+      if (operations.length === fileChange.operations.length) {
+        return fileChange;
+      }
+      if (operations.length === 0) {
+        return null;
+      }
+      const additions = operations.reduce((sum, operation) => sum + (operation.additions || 0), 0);
+      const deletions = operations.reduce((sum, operation) => sum + (operation.deletions || 0), 0);
+      const firstLineOperation = operations.find((operation) => typeof operation.lineStart === 'number');
+      return {
+        ...fileChange,
+        status: getFileChangeStatusFromOperations(operations),
+        additions,
+        deletions,
+        lineStart: firstLineOperation?.lineStart,
+        lineEnd: firstLineOperation?.lineEnd,
+        operations,
+      };
+    })
+    .filter((fileChange): fileChange is FileChangeSummary => fileChange !== null);
+};

--- a/webview/src/utils/messageUtils.test.ts
+++ b/webview/src/utils/messageUtils.test.ts
@@ -283,6 +283,28 @@ describe('mergeConsecutiveAssistantMessages', () => {
     expect(mergedRaw.content?.filter((block) => block.type === 'tool_use').map((block) => block.id)).toEqual(['tool-1', 'tool-2']);
   });
 
+
+
+  it('does not merge hidden meta assistant messages into visible assistant groups', () => {
+    const messages: ClaudeMessage[] = [
+      makeMsg('assistant', '', {
+        raw: { content: [{ type: 'tool_use', id: 'tool-visible', name: 'shell_command', input: { command: 'git status' } }] } as any,
+      }),
+      makeMsg('user', '[tool_result]', {
+        raw: { content: [{ type: 'tool_result', tool_use_id: 'tool-visible', content: 'ok' }] } as any,
+      }),
+      makeMsg('assistant', '', {
+        raw: { isMeta: true, content: [{ type: 'tool_use', id: 'tool-synthetic', name: 'edit', input: { file_path: '/repo/a.ts' } }] } as any,
+      }),
+    ];
+
+    const result = mergeConsecutiveAssistantMessages(messages, normalizeBlocks);
+
+    expect(result).toHaveLength(2);
+    expect(((result[0].raw as any).content ?? []).map((block: any) => block.id)).toEqual(['tool-visible']);
+    expect((result[1].raw as any).isMeta).toBe(true);
+  });
+
   // ---------------------------------------------------------------------------
   // hasToolUse + __turnId absence — tool_use merging behavior
   // ---------------------------------------------------------------------------

--- a/webview/src/utils/messageUtils.ts
+++ b/webview/src/utils/messageUtils.ts
@@ -396,7 +396,15 @@ export function mergeConsecutiveAssistantMessages(
     };
   };
 
+  const isMetaMessage = (message: ClaudeMessage): boolean => {
+    const raw = typeof message.raw === 'object' ? message.raw as ClaudeRawMessage : null;
+    return raw?.isMeta === true;
+  };
+
   const shouldMergeAssistantMessage = (previous: ClaudeMessage, next: ClaudeMessage): boolean => {
+    if (isMetaMessage(previous) || isMetaMessage(next)) {
+      return false;
+    }
     // Distinct streaming turns must stay visually separated even when the
     // backend emits adjacent assistant fragments during synchronization.
     // Block merge when either side has a __turnId and they differ.

--- a/webview/src/utils/turnScope.ts
+++ b/webview/src/utils/turnScope.ts
@@ -42,7 +42,7 @@ export function finalizeTodosForSettledTurn(todos: TodoItem[], isStreaming: bool
 export function finalizeSubagentsForSettledTurn(subagents: SubagentInfo[], isStreaming: boolean): SubagentInfo[] {
   if (isStreaming) return subagents;
   return subagents.map((subagent) => (
-    subagent.status === 'running'
+    subagent.status === 'running' && subagent.provider !== 'codex'
       ? { ...subagent, status: 'completed' }
       : subagent
   ));


### PR DESCRIPTION
## Summary
- Track Claude and Codex subagent edit scopes and surface synthetic file changes in the status panel
- Support diff, keep all, discard all, and undo flows for subagent-generated edits
- Fix Codex spawn parsing so invalid/unresolved subagents do not stay running forever

## Verification
- cd webview && npm test
- ./gradlew test verifyPluginStructure verifyPluginProjectConfiguration buildPlugin verifyPlugin prepareSandbox
- Targeted Codex subagent status tests and plugin sandbox smoke checks were run locally