### PR TITLE
fix(webview): prevent scroll position jump caused by context propagation

### DIFF
--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -47,6 +47,7 @@ import { ChatHeader } from './components/ChatHeader';
 import { WelcomeScreen } from './components/WelcomeScreen';
 import { MessageList } from './components/MessageList';
 import { MessageAnchorRail } from './components/MessageAnchorRail';
+import { SubagentHistoryContext, SessionIdContext } from './contexts/SubagentContext';
 import { FILE_MODIFY_TOOL_NAMES, isToolName } from './utils/toolConstants';
 import type { RewindableMessage } from './components/RewindSelectDialog';
 import { AppDialogs } from './components/AppDialogs';
@@ -393,6 +394,19 @@ const App = () => {
     [latestTurnSubagents, streamingActive],
   );
 
+  // Stabilize context value references — prevents consumers from re-rendering
+  // when App re-renders for unrelated reasons (e.g. streaming messages change).
+  // Each context gets its own memo so a change to subagentHistories does not
+  // cause useSessionId consumers to re-render, and vice versa.
+  const subagentHistoryCtxValue = useMemo(
+    () => ({ subagentHistories }),
+    [subagentHistories],
+  );
+  const sessionIdCtxValue = useMemo(
+    () => ({ currentSessionId }),
+    [currentSessionId],
+  );
+
   // ── Rewind handlers ──
   const {
     handleRewindConfirm, handleRewindCancel,
@@ -533,27 +547,29 @@ const App = () => {
                 />
               )}
 
-              <MessageList
-                messages={mergedMessages}
-                streamingActive={streamingActive}
-                isThinking={isThinking}
-                loading={loading}
-                loadingStartTime={loadingStartTime}
-                t={t}
-                getMessageText={getMessageText}
-                getContentBlocks={getContentBlocks}
-                findToolResult={findToolResult}
-                extractMarkdownContent={extractMarkdownContent}
-                messagesEndRef={messagesEndRef}
-                onMessageNodeRef={handleMessageNodeRef}
-                onCollapsedCountChange={setAnchorCollapsedCount}
-                onNavigateToProviderSettings={() => {
-                  setSettingsInitialTab('providers');
-                  setCurrentView('settings');
-                }}
-                currentSessionId={currentSessionId}
-                subagentHistories={subagentHistories}
-              />
+              <SessionIdContext.Provider value={sessionIdCtxValue}>
+                <SubagentHistoryContext.Provider value={subagentHistoryCtxValue}>
+                <MessageList
+                  messages={mergedMessages}
+                  streamingActive={streamingActive}
+                  isThinking={isThinking}
+                  loading={loading}
+                  loadingStartTime={loadingStartTime}
+                  t={t}
+                  getMessageText={getMessageText}
+                  getContentBlocks={getContentBlocks}
+                  findToolResult={findToolResult}
+                  extractMarkdownContent={extractMarkdownContent}
+                  messagesEndRef={messagesEndRef}
+                  onMessageNodeRef={handleMessageNodeRef}
+                  onCollapsedCountChange={setAnchorCollapsedCount}
+                  onNavigateToProviderSettings={() => {
+                    setSettingsInitialTab('providers');
+                    setCurrentView('settings');
+                  }}
+                />
+                </SubagentHistoryContext.Provider>
+              </SessionIdContext.Provider>
             </div>
           </div>
 

--- a/webview/src/components/MessageItem/ContentBlockRenderer.tsx
+++ b/webview/src/components/MessageItem/ContentBlockRenderer.tsx
@@ -1,5 +1,5 @@
 import type { TFunction } from 'i18next';
-import type { ClaudeContentBlock, SubagentHistoryResponse, ToolResultBlock } from '../../types';
+import type { ClaudeContentBlock, ToolResultBlock } from '../../types';
 
 import MarkdownBlock from '../MarkdownBlock';
 import CollapsibleTextBlock from '../CollapsibleTextBlock';
@@ -45,8 +45,6 @@ export interface ContentBlockRendererProps {
   t: TFunction;
   onToggleThinking: () => void;
   findToolResult: (toolId: string | undefined, messageIndex: number) => ToolResultBlock | null | undefined;
-  currentSessionId?: string | null;
-  subagentHistories?: Record<string, SubagentHistoryResponse>;
 }
 
 export function ContentBlockRenderer({
@@ -61,8 +59,6 @@ export function ContentBlockRenderer({
   t,
   onToggleThinking,
   findToolResult,
-  currentSessionId,
-  subagentHistories,
 }: ContentBlockRendererProps): React.ReactElement | null {
   if (block.type === 'text') {
     return messageType === 'user' ? (
@@ -189,8 +185,6 @@ export function ContentBlockRenderer({
           input={block.input}
           result={findToolResult(block.id, messageIndex)}
           toolId={block.id}
-          currentSessionId={currentSessionId}
-          subagentHistories={subagentHistories}
           isStreaming={isStreaming}
         />
       );

--- a/webview/src/components/MessageItem/MessageItem.tsx
+++ b/webview/src/components/MessageItem/MessageItem.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo, memo, useEffect, useRef } from 'react';
 import type { TFunction } from 'i18next';
-import type { ClaudeMessage, ClaudeContentBlock, SubagentHistoryResponse, ToolResultBlock } from '../../types';
+import type { ClaudeMessage, ClaudeContentBlock, ToolResultBlock } from '../../types';
 
 import MarkdownBlock from '../MarkdownBlock';
 import { ProviderNotConfiguredCard, isProviderNotConfiguredError } from './ProviderNotConfiguredCard';
@@ -33,8 +33,6 @@ export interface MessageItemProps {
   onNodeRef?: (id: string, node: HTMLDivElement | null) => void;
   onNavigateToProviderSettings?: () => void;
   toolResultSignature?: string;
-  currentSessionId?: string | null;
-  subagentHistories?: Record<string, SubagentHistoryResponse>;
 }
 
 type GroupedBlock =
@@ -222,8 +220,6 @@ export const MessageItem = memo(function MessageItem({
   onNodeRef,
   onNavigateToProviderSettings,
   toolResultSignature: _toolResultSignature,
-  currentSessionId,
-  subagentHistories,
 }: MessageItemProps): React.ReactElement {
   const [copiedMessageIndex, setCopiedMessageIndex] = useState<number | null>(null);
   const [showStreamingConnectHint, setShowStreamingConnectHint] = useState(false);
@@ -496,8 +492,6 @@ export const MessageItem = memo(function MessageItem({
                 t={t}
                 onToggleThinking={() => {}}
                 findToolResult={findToolResult}
-                currentSessionId={currentSessionId}
-                subagentHistories={subagentHistories}
               />
             </div>
           );
@@ -526,8 +520,6 @@ export const MessageItem = memo(function MessageItem({
             t={t}
             onToggleThinking={() => toggleThinking(blockIndex)}
             findToolResult={findToolResult}
-            currentSessionId={currentSessionId}
-            subagentHistories={subagentHistories}
           />
         </div>
       );

--- a/webview/src/components/MessageList.tsx
+++ b/webview/src/components/MessageList.tsx
@@ -1,6 +1,6 @@
 import { memo, useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import type { TFunction } from 'i18next';
-import type { ClaudeMessage, ClaudeContentBlock, SubagentHistoryResponse, ToolResultBlock } from '../types';
+import type { ClaudeMessage, ClaudeContentBlock, ToolResultBlock } from '../types';
 import { getMessageKey } from '../utils/messageUtils';
 import { MessageItem } from './MessageItem';
 import WaitingIndicator from './WaitingIndicator';
@@ -59,8 +59,6 @@ interface MessageListProps {
   /** Notify parent when the number of collapsed (hidden) messages changes. */
   onCollapsedCountChange?: (count: number) => void;
   onNavigateToProviderSettings?: () => void;
-  currentSessionId?: string | null;
-  subagentHistories?: Record<string, SubagentHistoryResponse>;
 }
 
 export const MessageList = memo(function MessageList({
@@ -78,8 +76,6 @@ export const MessageList = memo(function MessageList({
   onMessageNodeRef,
   onCollapsedCountChange,
   onNavigateToProviderSettings,
-  currentSessionId,
-  subagentHistories,
 }: MessageListProps) {
   const [showAll, setShowAll] = useState(false);
 
@@ -157,8 +153,6 @@ export const MessageList = memo(function MessageList({
             onNodeRef={onMessageNodeRef}
             onNavigateToProviderSettings={onNavigateToProviderSettings}
             toolResultSignature={toolResultSignature}
-            currentSessionId={currentSessionId}
-            subagentHistories={subagentHistories}
           />
         );
       })}

--- a/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
+++ b/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { SubagentHistoryResponse, ToolInput, ToolResultBlock } from '../../types';
+import type { ToolInput, ToolResultBlock } from '../../types';
 import { normalizeToolName } from '../../utils/toolConstants';
 import { sendBridgeEvent } from '../../utils/bridge';
+import { useSubagentHistory, useSessionId } from '../../contexts/SubagentContext';
 import SubagentProcessDetails from '../StatusPanel/SubagentProcessDetails';
 
 interface TaskExecutionBlockProps {
@@ -10,8 +11,6 @@ interface TaskExecutionBlockProps {
   input?: ToolInput;
   result?: ToolResultBlock | null;
   toolId?: string;
-  currentSessionId?: string | null;
-  subagentHistories?: Record<string, SubagentHistoryResponse>;
   isStreaming?: boolean;
 }
 
@@ -113,9 +112,11 @@ function shortenAgentId(agentId?: string): string | undefined {
   return agentId.length > 8 ? `${agentId.slice(0, 8)}…` : agentId;
 }
 
-const TaskExecutionBlock = ({ name, input, result, toolId, currentSessionId, subagentHistories = {}, isStreaming = false }: TaskExecutionBlockProps) => {
+const TaskExecutionBlock = ({ name, input, result, toolId, isStreaming = false }: TaskExecutionBlockProps) => {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
+  const { subagentHistories } = useSubagentHistory();
+  const { currentSessionId } = useSessionId();
 
   if (!input) {
     return null;

--- a/webview/src/contexts/SubagentContext.tsx
+++ b/webview/src/contexts/SubagentContext.tsx
@@ -1,0 +1,37 @@
+import { createContext, useContext } from 'react';
+import type { SubagentHistoryResponse } from '../types';
+
+// Context default values are only used when no matching Provider exists in the
+// tree. In this app, <App> always renders the Providers with real state values.
+
+interface SubagentHistoryContextValue {
+  subagentHistories: Record<string, SubagentHistoryResponse>;
+}
+
+const SubagentHistoryContext = createContext<SubagentHistoryContextValue>({
+  subagentHistories: {},
+});
+
+interface SessionIdContextValue {
+  currentSessionId: string | null;
+}
+
+const SessionIdContext = createContext<SessionIdContextValue>({
+  currentSessionId: null,
+});
+
+/**
+ * Hook for reading subagent history data provided via SubagentHistoryContext.
+ */
+export function useSubagentHistory(): SubagentHistoryContextValue {
+  return useContext(SubagentHistoryContext);
+}
+
+/**
+ * Hook for reading the current session ID provided via SessionIdContext.
+ */
+export function useSessionId(): SessionIdContextValue {
+  return useContext(SessionIdContext);
+}
+
+export { SubagentHistoryContext, SessionIdContext };


### PR DESCRIPTION
Extract subagentHistories and currentSessionId from the MessageList → MessageItem → ContentBlockRenderer prop chain into separate React contexts.  When subagentHistories loads asynchronously during streaming, the state update broke memo() on every intermediate component, causing a full re-render cascade that interfered with the scroll container's position tracking.

Changes:
- Add SubagentHistoryContext and SessionIdContext with memoized Provider values so each context only updates when its own data changes
- Remove subagentHistories / currentSessionId props from MessageList, MessageItem, and ContentBlockRenderer — none of them consume the data
- Have TaskExecutionBlock read both values via useSubagentHistory() and useSessionId() hooks instead of props