### PR TITLE
fix(webview): prevent scroll jump from subagent updates via context r…

### DIFF
--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -47,13 +47,14 @@ import { ChatHeader } from './components/ChatHeader';
 import { WelcomeScreen } from './components/WelcomeScreen';
 import { MessageList } from './components/MessageList';
 import { MessageAnchorRail } from './components/MessageAnchorRail';
-import { SubagentHistoryContext, SessionIdContext } from './contexts/SubagentContext';
+import { SubagentHistoryContext, SessionIdContext, ToolResultRawContext, useSubagentContextValues } from './contexts/SubagentContext';
 import { FILE_MODIFY_TOOL_NAMES, isToolName } from './utils/toolConstants';
 import type { RewindableMessage } from './components/RewindSelectDialog';
 import { AppDialogs } from './components/AppDialogs';
 import { APP_VERSION } from './version/version';
 import type {
   ClaudeMessage,
+  ClaudeRawMessage,
   HistoryData,
   SubagentHistoryResponse,
   ToolResultBlock,
@@ -273,12 +274,28 @@ const App = () => {
     mergedMessages, sentAttachmentsRef,
   } = useMessageProcessing({ messages, currentSessionId, t });
 
-  // Find tool result (stable ref to avoid re-renders)
+  // Find tool result (stable ref to avoid re-renders).
+  // Also populates toolResultRawMap so downstream code can look up the
+  // enclosing raw message without carrying it on every result object.
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
+  const toolResultRawMapRef = useRef<Map<string, ClaudeRawMessage>>(new Map());
   const findToolResult = useCallback((toolUseId?: string, messageIndex?: number): ToolResultBlock | null => {
     if (!toolUseId || typeof messageIndex !== 'number') return null;
     const currentMessages = messagesRef.current;
+    // Check the cache first — the raw message for a given tool_use_id never
+    // changes once written, so a cache hit avoids a full scan.
+    const cachedRaw = toolResultRawMapRef.current.get(toolUseId);
+    if (cachedRaw != null) {
+      const content = cachedRaw.content ?? cachedRaw.message?.content;
+      if (Array.isArray(content)) {
+        const hit = content.find(
+          (block): block is ToolResultBlock =>
+            Boolean(block) && block.type === 'tool_result' && block.tool_use_id === toolUseId,
+        );
+        if (hit) return hit;
+      }
+    }
     for (let i = 0; i < currentMessages.length; i += 1) {
       const candidate = currentMessages[i];
       const raw = candidate.raw;
@@ -289,10 +306,15 @@ const App = () => {
         (block): block is ToolResultBlock =>
           Boolean(block) && block.type === 'tool_result' && block.tool_use_id === toolUseId,
       );
-      if (resultBlock) return { ...resultBlock, __rawMessage: raw } as ToolResultBlock;
+      if (resultBlock) {
+        toolResultRawMapRef.current.set(toolUseId, raw);
+        return resultBlock;
+      }
     }
     return null;
   }, []);
+  const getToolResultRaw = useCallback((toolUseId: string): ClaudeRawMessage | null =>
+    toolResultRawMapRef.current.get(toolUseId) ?? null, []);
 
   // ── Message sender ──
   // Wrap handleProviderSelect to also clear messages and input (like creating a new session)
@@ -388,7 +410,7 @@ const App = () => {
   const latestTurnMessages = useMemo(() => sliceLatestConversationTurn(messages), [messages]);
 
   // ── Subagents ──
-  const latestTurnSubagents = useSubagents({ messages: latestTurnMessages, getContentBlocks, findToolResult });
+  const latestTurnSubagents = useSubagents({ messages: latestTurnMessages, getContentBlocks, findToolResult, getToolResultRaw });
   const subagents = useMemo(
     () => finalizeSubagentsForSettledTurn(latestTurnSubagents, streamingActive),
     [latestTurnSubagents, streamingActive],
@@ -396,16 +418,15 @@ const App = () => {
 
   // Stabilize context value references — prevents consumers from re-rendering
   // when App re-renders for unrelated reasons (e.g. streaming messages change).
-  // Each context gets its own memo so a change to subagentHistories does not
-  // cause useSessionId consumers to re-render, and vice versa.
-  const subagentHistoryCtxValue = useMemo(
-    () => ({ subagentHistories }),
-    [subagentHistories],
-  );
-  const sessionIdCtxValue = useMemo(
-    () => ({ currentSessionId }),
-    [currentSessionId],
-  );
+  // subagentHistoryCtxValue is a getter function backed by a ref, so its
+  // reference never changes even when individual histories are updated.
+  const { subagentHistoryCtxValue, sessionIdCtxValue } = useSubagentContextValues(subagentHistories, currentSessionId);
+
+  // Stable callback to avoid defeating MessageList memo on every App render.
+  const handleNavigateToProviderSettings = useCallback(() => {
+    setSettingsInitialTab('providers');
+    setCurrentView('settings');
+  }, []);
 
   // ── Rewind handlers ──
   const {
@@ -549,6 +570,7 @@ const App = () => {
 
               <SessionIdContext.Provider value={sessionIdCtxValue}>
                 <SubagentHistoryContext.Provider value={subagentHistoryCtxValue}>
+                <ToolResultRawContext.Provider value={getToolResultRaw}>
                 <MessageList
                   messages={mergedMessages}
                   streamingActive={streamingActive}
@@ -563,11 +585,9 @@ const App = () => {
                   messagesEndRef={messagesEndRef}
                   onMessageNodeRef={handleMessageNodeRef}
                   onCollapsedCountChange={setAnchorCollapsedCount}
-                  onNavigateToProviderSettings={() => {
-                    setSettingsInitialTab('providers');
-                    setCurrentView('settings');
-                  }}
+                  onNavigateToProviderSettings={handleNavigateToProviderSettings}
                 />
+                </ToolResultRawContext.Provider>
                 </SubagentHistoryContext.Provider>
               </SessionIdContext.Provider>
             </div>

--- a/webview/src/components/MessageItem/MessageItem.tsx
+++ b/webview/src/components/MessageItem/MessageItem.tsx
@@ -532,7 +532,7 @@ export const MessageItem = memo(function MessageItem({
 
   return (
     <div
-      className={`message ${message.type}${isProviderNotConfigured ? ' provider-not-configured' : ''}`}
+      className={`message ${message.type}${isLast ? ' is-last-message' : ''}${isProviderNotConfigured ? ' provider-not-configured' : ''}`}
       ref={anchorRefCallback}
       data-message-anchor-id={message.type === 'user' ? messageKey : undefined}
     >

--- a/webview/src/components/StatusPanel/StatusPanel.less
+++ b/webview/src/components/StatusPanel/StatusPanel.less
@@ -419,6 +419,7 @@
   margin: 0 4px 6px 32px;
   color: var(--text-secondary);
   font-size: 12px;
+  overflow-anchor: none;
 }
 
 .task-details .subagent-details {
@@ -430,6 +431,7 @@
   border: 1px solid var(--border-primary);
   border-radius: 8px;
   background: var(--bg-secondary);
+  overflow-anchor: none;
 }
 
 .subagent-process-header {

--- a/webview/src/components/StatusPanel/SubagentProcessDetails.tsx
+++ b/webview/src/components/StatusPanel/SubagentProcessDetails.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { SubagentHistoryResponse } from '../../types';
 import { buildSubagentProcessModel, formatSubagentDuration } from './subagentProcess';
 
@@ -18,7 +19,7 @@ function firstMeaningfulLine(text?: string): string | undefined {
   return text.split('\n').map((line) => line.trim()).find(Boolean)?.slice(0, 180);
 }
 
-const SubagentProcessDetails = ({
+const SubagentProcessDetails = memo(function SubagentProcessDetails({
   agentId,
   totalDurationMs,
   totalTokens,
@@ -26,7 +27,7 @@ const SubagentProcessDetails = ({
   resultText,
   history,
   canLoad,
-}: SubagentProcessDetailsProps) => {
+}: SubagentProcessDetailsProps) {
   const duration = formatSubagentDuration(totalDurationMs);
   const stats = [
     duration,
@@ -117,6 +118,6 @@ const SubagentProcessDetails = ({
       )}
     </div>
   );
-};
+});
 
 export default SubagentProcessDetails;

--- a/webview/src/components/toolBlocks/TaskExecutionBlock.test.tsx
+++ b/webview/src/components/toolBlocks/TaskExecutionBlock.test.tsx
@@ -1,0 +1,110 @@
+import { act, fireEvent, render } from '@testing-library/react';
+import TaskExecutionBlock from './TaskExecutionBlock';
+
+const mockSendBridgeEvent = vi.fn();
+const mockGetSubagentHistory = vi.fn<(key: string) => unknown>();
+const mockUseSessionId = vi.fn<() => string | null>();
+const mockGetToolResultRaw = vi.fn<(toolUseId: string) => Record<string, unknown> | null>();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../../utils/bridge', () => ({
+  sendBridgeEvent: (...args: unknown[]) => mockSendBridgeEvent(...args),
+}));
+
+vi.mock('../../contexts/SubagentContext', () => ({
+  useSubagentHistoryGetter: () => mockGetSubagentHistory,
+  useSessionId: () => mockUseSessionId(),
+  useGetToolResultRaw: () => mockGetToolResultRaw,
+}));
+
+describe('TaskExecutionBlock polling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockSendBridgeEvent.mockReset();
+    mockGetSubagentHistory.mockReset();
+    mockGetToolResultRaw.mockReset();
+    mockUseSessionId.mockReset();
+
+    mockGetSubagentHistory.mockReturnValue(undefined);
+    mockGetToolResultRaw.mockReturnValue(null);
+    mockUseSessionId.mockReturnValue('session-1');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not start polling when the agent tool is no longer streaming', () => {
+    const setIntervalSpy = vi.spyOn(window, 'setInterval');
+
+    const { container } = render(
+      <TaskExecutionBlock
+        name="Task"
+        toolId="task-1"
+        isStreaming={false}
+        input={{
+          description: 'Inspect render path',
+          subagent_type: 'Explore',
+        }}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('.task-header') as HTMLElement);
+
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+  });
+
+  it('stops polling once a tool result marks the agent task completed', () => {
+    const clearIntervalSpy = vi.spyOn(window, 'clearInterval');
+
+    const { container, rerender } = render(
+      <TaskExecutionBlock
+        name="Task"
+        toolId="task-1"
+        isStreaming={true}
+        input={{
+          description: 'Inspect render path',
+          subagent_type: 'Explore',
+        }}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('.task-header') as HTMLElement);
+
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+
+    expect(mockSendBridgeEvent).toHaveBeenCalledWith(
+      'load_subagent_session',
+      expect.stringContaining('"toolUseId":"task-1"'),
+    );
+
+    rerender(
+      <TaskExecutionBlock
+        name="Task"
+        toolId="task-1"
+        isStreaming={true}
+        result={{ type: 'tool_result', tool_use_id: 'task-1', content: 'done' } as any}
+        input={{
+          description: 'Inspect render path',
+          subagent_type: 'Explore',
+        }}
+      />,
+    );
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+
+    mockSendBridgeEvent.mockClear();
+    act(() => {
+      vi.advanceTimersByTime(4_000);
+    });
+
+    expect(mockSendBridgeEvent).not.toHaveBeenCalled();
+  });
+});

--- a/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
+++ b/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ToolInput, ToolResultBlock } from '../../types';
 import { normalizeToolName } from '../../utils/toolConstants';
 import { sendBridgeEvent } from '../../utils/bridge';
-import { useSubagentHistory, useSessionId } from '../../contexts/SubagentContext';
+import { useSubagentHistoryGetter, useSessionId, useGetToolResultRaw } from '../../contexts/SubagentContext';
 import SubagentProcessDetails from '../StatusPanel/SubagentProcessDetails';
 
 interface TaskExecutionBlockProps {
@@ -87,13 +87,17 @@ function parseSpawnAgentMeta(input: ToolInput, result?: ToolResultBlock | null):
   return { agentId, nickname, model, reasoningEffort };
 }
 
-function parseAgentToolMeta(result?: ToolResultBlock | null): {
+function parseAgentToolMeta(
+  getToolResultRaw: (toolUseId: string) => Record<string, unknown> | null,
+  toolUseId?: string,
+): {
   agentId?: string;
   totalDurationMs?: number;
   totalTokens?: number;
   totalToolUseCount?: number;
 } {
-  const rawMessage = (result as unknown as { __rawMessage?: { toolUseResult?: unknown } } | null)?.__rawMessage;
+  if (!toolUseId) return {};
+  const rawMessage = getToolResultRaw(toolUseId);
   const metadata = rawMessage?.toolUseResult;
   if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return {};
   const record = metadata as Record<string, unknown>;
@@ -112,11 +116,12 @@ function shortenAgentId(agentId?: string): string | undefined {
   return agentId.length > 8 ? `${agentId.slice(0, 8)}…` : agentId;
 }
 
-const TaskExecutionBlock = ({ name, input, result, toolId, isStreaming = false }: TaskExecutionBlockProps) => {
+const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, result, toolId, isStreaming = false }: TaskExecutionBlockProps) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
-  const { subagentHistories } = useSubagentHistory();
-  const { currentSessionId } = useSessionId();
+  const getSubagentHistory = useSubagentHistoryGetter();
+  const currentSessionId = useSessionId();
+  const getToolResultRaw = useGetToolResultRaw();
 
   if (!input) {
     return null;
@@ -141,7 +146,7 @@ const TaskExecutionBlock = ({ name, input, result, toolId, isStreaming = false }
     ...rest
   } = input;
   const spawnMeta = isSpawnAgent ? parseSpawnAgentMeta(input, result) : {};
-  const agentToolMeta = !isSpawnAgent ? parseAgentToolMeta(result) : {};
+  const agentToolMeta = !isSpawnAgent ? parseAgentToolMeta(getToolResultRaw, toolId) : {};
   const agentId = spawnMeta.agentId ?? agentToolMeta.agentId;
   const identityLabel = spawnMeta.nickname || (typeof subagentType === 'string' && subagentType ? subagentType : undefined);
   const modelSummary = [spawnMeta.model, spawnMeta.reasoningEffort].filter(Boolean).join(' ');
@@ -150,7 +155,7 @@ const TaskExecutionBlock = ({ name, input, result, toolId, isStreaming = false }
   // Determine status based on result
   const isCompleted = result !== undefined && result !== null;
   const isError = isCompleted && result?.is_error === true;
-  const history = (toolId ? subagentHistories[toolId] : undefined) ?? (agentId ? subagentHistories[agentId] : undefined);
+  const history = (toolId ? getSubagentHistory(toolId) : undefined) ?? (agentId ? getSubagentHistory(agentId) : undefined);
 
   useEffect(() => {
     if (!expanded || !isAgentTool || !currentSessionId || !toolId || history) return;
@@ -162,8 +167,18 @@ const TaskExecutionBlock = ({ name, input, result, toolId, isStreaming = false }
     }));
   }, [agentId, currentSessionId, description, expanded, history, isAgentTool, toolId]);
 
+  const shouldPollHistory = expanded
+    && isAgentTool
+    && Boolean(currentSessionId)
+    && Boolean(toolId)
+    && isStreaming
+    && !isCompleted
+    && !history;
+
+  // Poll subagent history only while the tool is still actively streaming and
+  // we have not received history yet. Avoid keeping idle intervals alive.
   useEffect(() => {
-    if (!expanded || !isAgentTool || !isStreaming || isCompleted || !currentSessionId || !toolId) return;
+    if (!shouldPollHistory || !currentSessionId || !toolId) return;
     const timer = window.setInterval(() => {
       sendBridgeEvent('load_subagent_session', JSON.stringify({
         sessionId: currentSessionId,
@@ -173,7 +188,7 @@ const TaskExecutionBlock = ({ name, input, result, toolId, isStreaming = false }
       }));
     }, 2_000);
     return () => window.clearInterval(timer);
-  }, [agentId, currentSessionId, description, expanded, isAgentTool, isCompleted, isStreaming, toolId]);
+  }, [agentId, currentSessionId, description, shouldPollHistory, toolId]);
 
   return (
     <div className="task-container">
@@ -280,6 +295,6 @@ const TaskExecutionBlock = ({ name, input, result, toolId, isStreaming = false }
       )}
     </div>
   );
-};
+});
 
 export default TaskExecutionBlock;

--- a/webview/src/contexts/SubagentContext.tsx
+++ b/webview/src/contexts/SubagentContext.tsx
@@ -1,16 +1,13 @@
-import { createContext, useContext } from 'react';
-import type { SubagentHistoryResponse } from '../types';
+import { createContext, useCallback, useContext, useMemo, useRef } from 'react';
+import type { ClaudeRawMessage, SubagentHistoryResponse } from '../types';
 
-// Context default values are only used when no matching Provider exists in the
-// tree. In this app, <App> always renders the Providers with real state values.
+// SubagentHistoryContext holds a getter function instead of the full Record.
+// This keeps the context value reference stable even when individual entries
+// are updated, preventing unnecessary re-renders of TaskExecutionBlock instances
+// that don't care about the changed key.
+type GetSubagentHistoryFn = (key: string) => SubagentHistoryResponse | undefined;
 
-interface SubagentHistoryContextValue {
-  subagentHistories: Record<string, SubagentHistoryResponse>;
-}
-
-const SubagentHistoryContext = createContext<SubagentHistoryContextValue>({
-  subagentHistories: {},
-});
+const SubagentHistoryContext = createContext<GetSubagentHistoryFn>(() => undefined);
 
 interface SessionIdContextValue {
   currentSessionId: string | null;
@@ -20,18 +17,52 @@ const SessionIdContext = createContext<SessionIdContextValue>({
   currentSessionId: null,
 });
 
+type GetToolResultRawFn = (toolUseId: string) => ClaudeRawMessage | null;
+
+const ToolResultRawContext = createContext<GetToolResultRawFn>(() => null);
+
 /**
- * Hook for reading subagent history data provided via SubagentHistoryContext.
+ * Hook for looking up a specific subagent's history by key (toolUseId or agentId).
+ * Returns a stable getter function — the reference never changes, so consumers
+ * won't re-render when *other* subagent histories are updated.
  */
-export function useSubagentHistory(): SubagentHistoryContextValue {
+export function useSubagentHistoryGetter(): GetSubagentHistoryFn {
   return useContext(SubagentHistoryContext);
 }
 
 /**
  * Hook for reading the current session ID provided via SessionIdContext.
  */
-export function useSessionId(): SessionIdContextValue {
-  return useContext(SessionIdContext);
+export function useSessionId(): string | null {
+  return useContext(SessionIdContext).currentSessionId;
 }
 
-export { SubagentHistoryContext, SessionIdContext };
+/**
+ * Hook for looking up the raw message that contains a given tool result.
+ */
+export function useGetToolResultRaw(): GetToolResultRawFn {
+  return useContext(ToolResultRawContext);
+}
+
+/**
+ * Creates the context value objects used by App.tsx's Providers.
+ * Returns stable references that survive re-renders.
+ */
+export function useSubagentContextValues(subagentHistories: Record<string, SubagentHistoryResponse>, currentSessionId: string | null) {
+  const historiesRef = useRef(subagentHistories);
+  historiesRef.current = subagentHistories;
+
+  const getHistory = useCallback<GetSubagentHistoryFn>(
+    (key: string) => historiesRef.current[key],
+    [],
+  );
+
+  // getHistory has empty deps so its identity never changes — use it directly
+  // as the context value without an unnecessary useMemo wrapper.
+  const subagentHistoryCtxValue = getHistory;
+  const sessionIdCtxValue = useMemo(() => ({ currentSessionId }), [currentSessionId]);
+
+  return { subagentHistoryCtxValue, sessionIdCtxValue };
+}
+
+export { SubagentHistoryContext, SessionIdContext, ToolResultRawContext };

--- a/webview/src/hooks/useScrollBehavior.test.ts
+++ b/webview/src/hooks/useScrollBehavior.test.ts
@@ -1,0 +1,192 @@
+import { act, renderHook } from '@testing-library/react';
+import { useScrollBehavior } from './useScrollBehavior';
+import type { ClaudeMessage } from '../types';
+
+interface HookProps {
+  currentView: 'chat' | 'history' | 'settings';
+  messages: ClaudeMessage[];
+  loading: boolean;
+  streamingActive: boolean;
+}
+
+const INITIAL_PROPS: HookProps = {
+  currentView: 'history',
+  messages: [] as ClaudeMessage[],
+  loading: false,
+  streamingActive: false,
+};
+
+let resizeObserverCallback: ResizeObserverCallback | null = null;
+
+class ResizeObserverMock {
+  constructor(callback: ResizeObserverCallback) {
+    resizeObserverCallback = callback;
+  }
+
+  observe() {}
+
+  disconnect() {}
+}
+
+function createScrollableContainer() {
+  const container = document.createElement('div');
+  let scrollHeightValue = 1000;
+  const clientHeightValue = 400;
+  let scrollTopValue = 600;
+
+  Object.defineProperty(container, 'clientHeight', {
+    configurable: true,
+    get: () => clientHeightValue,
+  });
+
+  Object.defineProperty(container, 'scrollHeight', {
+    configurable: true,
+    get: () => scrollHeightValue,
+  });
+
+  Object.defineProperty(container, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTopValue,
+    set: (value: number) => {
+      const maxScrollTop = Math.max(0, scrollHeightValue - clientHeightValue);
+      scrollTopValue = Math.min(Math.max(0, value), maxScrollTop);
+    },
+  });
+
+  return {
+    container,
+    getScrollTop: () => scrollTopValue,
+    setScrollTop: (value: number) => {
+      const maxScrollTop = Math.max(0, scrollHeightValue - clientHeightValue);
+      scrollTopValue = Math.min(Math.max(0, value), maxScrollTop);
+    },
+    setScrollHeight: (value: number) => {
+      scrollHeightValue = value;
+    },
+  };
+}
+
+describe('useScrollBehavior', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+    resizeObserverCallback = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('enables browser scroll anchoring after the user pauses auto-scroll with wheel up', () => {
+    const { container } = createScrollableContainer();
+    const { result, rerender } = renderHook((props: HookProps) => useScrollBehavior(props), {
+      initialProps: INITIAL_PROPS,
+    });
+
+    act(() => {
+      result.current.messagesContainerRef.current = container;
+    });
+
+    rerender({ ...INITIAL_PROPS, currentView: 'chat' });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    act(() => {
+      container.dispatchEvent(new WheelEvent('wheel', { deltaY: -40 }));
+    });
+
+    expect(result.current.userPausedRef.current).toBe(true);
+    expect(result.current.isUserAtBottomRef.current).toBe(false);
+    expect(container.classList.contains('scroll-anchor-enabled')).toBe(true);
+  });
+
+  it('disables browser scroll anchoring once the user returns to the bottom', () => {
+    const { container, setScrollTop, getScrollTop } = createScrollableContainer();
+    const { result, rerender } = renderHook((props: HookProps) => useScrollBehavior(props), {
+      initialProps: INITIAL_PROPS,
+    });
+
+    act(() => {
+      result.current.messagesContainerRef.current = container;
+    });
+
+    rerender({ ...INITIAL_PROPS, currentView: 'chat' });
+
+    act(() => {
+      vi.runAllTimers();
+      container.dispatchEvent(new WheelEvent('wheel', { deltaY: -20 }));
+    });
+
+    expect(container.classList.contains('scroll-anchor-enabled')).toBe(true);
+
+    act(() => {
+      setScrollTop(600);
+      container.dispatchEvent(new WheelEvent('wheel', { deltaY: 20 }));
+    });
+
+    expect(result.current.userPausedRef.current).toBe(false);
+    expect(result.current.isUserAtBottomRef.current).toBe(true);
+    expect(container.classList.contains('scroll-anchor-enabled')).toBe(false);
+    expect(getScrollTop()).toBe(600);
+  });
+
+  it('keeps following the bottom when content grows inside the last message without changing messages', () => {
+    const { container, getScrollTop, setScrollTop, setScrollHeight } = createScrollableContainer();
+    const root = document.createElement('div');
+    const end = document.createElement('div');
+    root.appendChild(end);
+    container.appendChild(root);
+    let shouldGrowOnMeasure = false;
+    const endRectSpy = vi.spyOn(end, 'getBoundingClientRect').mockImplementation(() => {
+      if (shouldGrowOnMeasure) {
+        setScrollHeight(1400);
+      }
+      return {
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+        toJSON: () => ({}),
+      } as DOMRect;
+    });
+
+    const { result, rerender } = renderHook((props: HookProps) => useScrollBehavior(props), {
+      initialProps: INITIAL_PROPS,
+    });
+
+    act(() => {
+      result.current.messagesContainerRef.current = container;
+      result.current.messagesEndRef.current = end;
+    });
+
+    rerender({ ...INITIAL_PROPS, currentView: 'chat', messages: [{ type: 'assistant', content: 'task', timestamp: '2026-04-27T00:00:00.000Z' }] });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(getScrollTop()).toBe(600);
+
+    act(() => {
+      setScrollTop(600);
+      shouldGrowOnMeasure = true;
+      resizeObserverCallback?.([], {} as ResizeObserver);
+    });
+
+    expect(getScrollTop()).toBe(1000);
+    expect(container.classList.contains('scroll-anchor-enabled')).toBe(false);
+    expect(endRectSpy).toHaveBeenCalled();
+  });
+});

--- a/webview/src/hooks/useScrollBehavior.ts
+++ b/webview/src/hooks/useScrollBehavior.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import type { ClaudeMessage } from '../types';
 
+const SCROLL_ANCHOR_ENABLED_CLASS = 'scroll-anchor-enabled';
+const BOTTOM_THRESHOLD_PX = 100;
+
 type ViewMode = 'chat' | 'history' | 'settings';
 
 export interface UseScrollBehaviorOptions {
@@ -49,11 +52,37 @@ export function useScrollBehavior({
   // because the viewport is still within the 100px threshold.
   const userPausedRef = useRef(false);
 
+  const syncScrollAnchoring = useCallback(() => {
+    const container = messagesContainerRef.current;
+    if (!container) return;
+    const shouldEnableScrollAnchoring = userPausedRef.current || !isUserAtBottomRef.current;
+    container.classList.toggle(SCROLL_ANCHOR_ENABLED_CLASS, shouldEnableScrollAnchoring);
+  }, []);
+
+  const syncUserAtBottomState = useCallback((container: HTMLDivElement) => {
+    const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
+    isUserAtBottomRef.current = distanceFromBottom < BOTTOM_THRESHOLD_PX;
+    syncScrollAnchoring();
+  }, [syncScrollAnchoring]);
+
   // Scroll to bottom function
   const scrollToBottom = useCallback(() => {
     const container = messagesContainerRef.current;
+    const endElement = messagesEndRef.current;
+
+    if (endElement) {
+      // Force the browser to resolve layout all the way to the end marker
+      // before we read scrollHeight. This avoids intermediate scroll targets
+      // when the last message uses deferred layout/content-visibility and
+      // grows in multiple phases (common for Agent tool blocks).
+      void endElement.getBoundingClientRect();
+      void endElement.offsetTop;
+    }
+
     if (container) {
       isAutoScrollingRef.current = true;
+      isUserAtBottomRef.current = true;
+      container.classList.remove(SCROLL_ANCHOR_ENABLED_CLASS);
       container.scrollTop = container.scrollHeight;
       requestAnimationFrame(() => {
         isAutoScrollingRef.current = false;
@@ -61,7 +90,6 @@ export function useScrollBehavior({
       return;
     }
 
-    const endElement = messagesEndRef.current;
     if (endElement) {
       isAutoScrollingRef.current = true;
       try {
@@ -98,6 +126,8 @@ export function useScrollBehavior({
     const container = messagesContainerRef.current;
     if (!container) return;
 
+    syncScrollAnchoring();
+
     // Throttle scroll handler via rAF — fires at most once per frame
     let scrollRafId: number | null = null;
     const handleScroll = () => {
@@ -109,9 +139,7 @@ export function useScrollBehavior({
         // If user explicitly paused via wheel-up, don't let scroll handler override
         if (userPausedRef.current) return;
         // Calculate distance from bottom
-        const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-        // Consider user at bottom if within 100 pixels
-        isUserAtBottomRef.current = distanceFromBottom < 100;
+        syncUserAtBottomState(container);
       });
     };
 
@@ -124,16 +152,18 @@ export function useScrollBehavior({
         // User is scrolling UP → pause auto-scroll immediately
         userPausedRef.current = true;
         isUserAtBottomRef.current = false;
+        syncScrollAnchoring();
       } else if (e.deltaY > 0) {
         // User is scrolling DOWN → check if they reached the bottom to unpause
         if (wheelRafId !== null) cancelAnimationFrame(wheelRafId);
         wheelRafId = requestAnimationFrame(() => {
           wheelRafId = null;
           const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-          if (distanceFromBottom < 100) {
+          if (distanceFromBottom < BOTTOM_THRESHOLD_PX) {
             userPausedRef.current = false;
             isUserAtBottomRef.current = true;
           }
+          syncScrollAnchoring();
         });
       }
     };
@@ -143,10 +173,53 @@ export function useScrollBehavior({
     return () => {
       container.removeEventListener('scroll', handleScroll);
       container.removeEventListener('wheel', handleWheel);
+      container.classList.remove(SCROLL_ANCHOR_ENABLED_CLASS);
       if (scrollRafId !== null) cancelAnimationFrame(scrollRafId);
       if (wheelRafId !== null) cancelAnimationFrame(wheelRafId);
     };
-  }, [currentView]);
+  }, [currentView, syncScrollAnchoring, syncUserAtBottomState]);
+
+  // Follow content height changes that don't replace the message array, such as
+  // subagent/task detail updates inside the currently streaming assistant block.
+  // The observer should be stable across streaming ticks; only recreate on view change.
+  useEffect(() => {
+    if (currentView !== 'chat') return;
+    const container = messagesContainerRef.current;
+    if (!container) return;
+    if (typeof ResizeObserver === 'undefined') return;
+
+    const observedElement = messagesEndRef.current?.parentElement ?? container.firstElementChild;
+    if (!(observedElement instanceof HTMLElement)) return;
+
+    let resizeRafId: number | null = null;
+    const observer = new ResizeObserver(() => {
+      if (resizeRafId !== null) {
+        cancelAnimationFrame(resizeRafId);
+      }
+      resizeRafId = requestAnimationFrame(() => {
+        resizeRafId = null;
+        // Read current state from refs — these are updated by other effects/handlers
+        const shouldStickToBottom = !userPausedRef.current && isUserAtBottomRef.current;
+        if (userPausedRef.current) {
+          syncScrollAnchoring();
+          return;
+        }
+        if (shouldStickToBottom) {
+          scrollToBottom();
+          return;
+        }
+        syncUserAtBottomState(container);
+      });
+    });
+
+    observer.observe(observedElement);
+    return () => {
+      observer.disconnect();
+      if (resizeRafId !== null) {
+        cancelAnimationFrame(resizeRafId);
+      }
+    };
+  }, [currentView, scrollToBottom, syncScrollAnchoring, syncUserAtBottomState]);
 
   // Auto-scroll: follow latest content when user is at bottom
   // Includes streaming, expanded thinking blocks, loading indicator, etc.
@@ -157,6 +230,7 @@ export function useScrollBehavior({
 
   useLayoutEffect(() => {
     if (currentView !== 'chat') return;
+    syncScrollAnchoring();
     if (userPausedRef.current) return;
     if (!isUserAtBottomRef.current) return;
 
@@ -173,7 +247,7 @@ export function useScrollBehavior({
     } else {
       scrollToBottom();
     }
-  }, [currentView, messages, expandedThinking, loading, streamingActive, scrollToBottom]);
+  }, [currentView, messages, expandedThinking, loading, streamingActive, scrollToBottom, syncScrollAnchoring]);
 
   // Cleanup scroll debounce on unmount
   useEffect(() => {

--- a/webview/src/hooks/useSubagents.test.ts
+++ b/webview/src/hooks/useSubagents.test.ts
@@ -60,9 +60,18 @@ const findToolResult = (messages: ClaudeMessage[]) => (toolUseId?: string): Tool
     const content = raw.content ?? raw.message?.content;
     if (!Array.isArray(content)) continue;
     const result = content.find((block): block is ToolResultBlock => block.type === 'tool_result' && block.tool_use_id === toolUseId);
-    if (result) {
-      (result as any).__rawMessage = raw;
-      return result;
+    if (result) return result;
+  }
+  return null;
+};
+
+const getToolResultRaw = (messages: ClaudeMessage[]) => (toolUseId: string) => {
+  for (const message of messages) {
+    const raw = message.raw;
+    if (!raw || typeof raw === 'string') continue;
+    const content = raw.content ?? raw.message?.content;
+    if (Array.isArray(content) && content.some((block) => block.type === 'tool_result' && (block as ToolResultBlock).tool_use_id === toolUseId)) {
+      return raw as Record<string, unknown>;
     }
   }
   return null;
@@ -72,7 +81,9 @@ describe('extractSubagentsFromMessages', () => {
   it('attaches completed Agent result metadata including stable agent id', () => {
     const messages = [assistantWithAgent('tooluse_backend'), toolResultMessage('tooluse_backend')];
 
-    const subagents = extractSubagentsFromMessages(messages, getContentBlocks, findToolResult(messages));
+    const subagents = extractSubagentsFromMessages(
+      messages, getContentBlocks, findToolResult(messages), getToolResultRaw(messages),
+    );
 
     expect(subagents).toHaveLength(1);
     expect(subagents[0]).toMatchObject({

--- a/webview/src/hooks/useSubagents.ts
+++ b/webview/src/hooks/useSubagents.ts
@@ -1,12 +1,15 @@
 import { useMemo } from 'react';
-import type { ClaudeMessage, ClaudeContentBlock, ToolResultBlock, SubagentInfo, SubagentStatus } from '../types';
+import type { ClaudeMessage, ClaudeRawMessage, ClaudeContentBlock, ToolResultBlock, SubagentInfo, SubagentStatus } from '../types';
 import { normalizeToolInput } from '../utils/toolInputNormalization';
 import { normalizeToolName } from '../utils/toolConstants';
+
+type GetToolResultRawFn = (toolUseId: string) => ClaudeRawMessage | null;
 
 interface UseSubagentsParams {
   messages: ClaudeMessage[];
   getContentBlocks: (message: ClaudeMessage) => ClaudeContentBlock[];
   findToolResult: (toolUseId?: string, messageIndex?: number) => ToolResultBlock | null;
+  getToolResultRaw: GetToolResultRawFn;
 }
 
 /**
@@ -33,8 +36,12 @@ function extractResultText(result: ToolResultBlock | null): string | undefined {
   return text || undefined;
 }
 
-function extractResultMetadata(result: ToolResultBlock | null): Partial<SubagentInfo> {
-  const rawMessage = (result as unknown as { __rawMessage?: { toolUseResult?: unknown } } | null)?.__rawMessage;
+function extractResultMetadata(
+  result: ToolResultBlock | null,
+  getToolResultRaw: GetToolResultRawFn,
+  toolUseId: string,
+): Partial<SubagentInfo> {
+  const rawMessage = getToolResultRaw(toolUseId);
   const metadata = rawMessage?.toolUseResult;
   if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
     return { resultText: extractResultText(result) };
@@ -64,6 +71,7 @@ export function extractSubagentsFromMessages(
   messages: ClaudeMessage[],
   getContentBlocks: (message: ClaudeMessage) => ClaudeContentBlock[],
   findToolResult: (toolUseId?: string, messageIndex?: number) => ToolResultBlock | null,
+  getToolResultRaw: GetToolResultRawFn,
 ): SubagentInfo[] {
   const subagents: SubagentInfo[] = [];
 
@@ -91,9 +99,10 @@ export function extractSubagentsFromMessages(
       const prompt = String((input.prompt as string) ?? '');
 
       // Check tool result to determine status
-      const result = findToolResult(block.id, messageIndex);
+      const toolUseId = block.id ?? '';
+      const result = findToolResult(toolUseId, messageIndex);
       const status = determineStatus(result);
-      const resultMetadata = extractResultMetadata(result);
+      const resultMetadata = extractResultMetadata(result, getToolResultRaw, toolUseId);
 
       subagents.push({
         id,
@@ -117,9 +126,10 @@ export function useSubagents({
   messages,
   getContentBlocks,
   findToolResult,
+  getToolResultRaw,
 }: UseSubagentsParams): SubagentInfo[] {
   return useMemo(
-    () => extractSubagentsFromMessages(messages, getContentBlocks, findToolResult),
-    [messages, getContentBlocks, findToolResult],
+    () => extractSubagentsFromMessages(messages, getContentBlocks, findToolResult, getToolResultRaw),
+    [messages, getContentBlocks, findToolResult, getToolResultRaw],
   );
 }

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -30,6 +30,7 @@ describe('useWindowCallbacks integration', () => {
     setUsagePercentage: vi.fn(),
     setUsageUsedTokens: vi.fn(),
     setUsageMaxTokens: vi.fn(),
+    setSubagentHistories: vi.fn(),
     setPermissionMode: vi.fn(),
     setClaudePermissionMode: vi.fn(),
     setCodexPermissionMode: vi.fn(),
@@ -87,6 +88,7 @@ describe('useWindowCallbacks integration', () => {
     customSessionTitleRef: { current: null },
     currentSessionIdRef: { current: null },
     updateHistoryTitle: vi.fn(),
+    setCustomSessionTitle: vi.fn(),
 
     ...overrides,
   });
@@ -503,6 +505,45 @@ describe('useWindowCallbacks integration', () => {
       id: 'spawn-1',
     });
     expect(nextMessages[0].__turnId).toBe(7);
+  });
+
+  it('onSubagentHistoryLoaded skips updates only when history payload is truly unchanged', () => {
+    const opts = createOptions();
+    renderHook(() => useWindowCallbacks(opts));
+
+    const firstPayload = {
+      success: true,
+      toolUseId: 'task-1',
+      sessionId: 'session-1',
+      messages: [{ type: 'assistant', content: [{ type: 'text', text: 'draft result' }] }],
+    };
+
+    act(() => {
+      window.onSubagentHistoryLoaded?.(JSON.stringify(firstPayload));
+    });
+
+    expect(opts.setSubagentHistories).toHaveBeenCalledTimes(1);
+    const firstUpdater = (opts.setSubagentHistories as any).mock.calls[0][0] as (prev: Record<string, unknown>) => Record<string, unknown>;
+    const initialState = firstUpdater({});
+
+    act(() => {
+      window.onSubagentHistoryLoaded?.(JSON.stringify(firstPayload));
+    });
+
+    const secondUpdater = (opts.setSubagentHistories as any).mock.calls[1][0] as (prev: Record<string, unknown>) => Record<string, unknown>;
+    expect(secondUpdater(initialState)).toBe(initialState);
+
+    act(() => {
+      window.onSubagentHistoryLoaded?.(JSON.stringify({
+        ...firstPayload,
+        messages: [{ type: 'assistant', content: [{ type: 'text', text: 'final result' }] }],
+      }));
+    });
+
+    const thirdUpdater = (opts.setSubagentHistories as any).mock.calls[2][0] as (prev: Record<string, any>) => Record<string, any>;
+    const updatedState = thirdUpdater(initialState);
+    expect(updatedState).not.toBe(initialState);
+    expect(updatedState['task-1'].messages[0].content[0].text).toBe('final result');
   });
 
   // ===== onStreamEnd idempotency (dual-path delivery) =====

--- a/webview/src/hooks/windowCallbacks/registerCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks.ts
@@ -32,6 +32,20 @@ import { registerUsageModeCallbacks } from './registerCallbacks/usageModeCallbac
 import { registerPermissionCallbacks } from './registerCallbacks/permissionCallbacks';
 import { registerAgentAndSelectionCallbacks } from './registerCallbacks/agentCallbacks';
 
+function areSubagentMessagesEquivalent(previousMessages?: unknown[], nextMessages?: unknown[]): boolean {
+  if (previousMessages === nextMessages) return true;
+  if (!Array.isArray(previousMessages) || !Array.isArray(nextMessages)) {
+    return previousMessages === nextMessages;
+  }
+  if (previousMessages.length !== nextMessages.length) return false;
+
+  try {
+    return JSON.stringify(previousMessages) === JSON.stringify(nextMessages);
+  } catch {
+    return false;
+  }
+}
+
 export function registerWindowCallbacks(
   options: UseWindowCallbacksOptions,
   tRef: MutableRefObject<UseWindowCallbacksOptions['t']>,
@@ -84,10 +98,21 @@ export function registerWindowCallbacks(
       const result = JSON.parse(json);
       const key = result.toolUseId || result.agentId;
       if (!key) return;
-      options.setSubagentHistories((prev) => ({
-        ...prev,
-        [key]: result,
-      }));
+      options.setSubagentHistories((prev) => {
+        const existing = prev[key];
+        // Skip state update when the payload is structurally identical.
+        // This prevents cascading re-renders and scroll jumps caused by
+        // periodic subagent polling (every 2 s) returning unchanged data.
+        if (existing && existing.success === result.success
+          && existing.error === result.error
+          && existing.sessionId === result.sessionId
+          && existing.toolUseId === result.toolUseId
+          && existing.agentId === result.agentId
+          && areSubagentMessagesEquivalent(existing.messages, result.messages)) {
+          return prev;
+        }
+        return { ...prev, [key]: result };
+      });
     } catch {
       // Ignore malformed callback payloads; the request can be retried by reopening the Agent row.
     }

--- a/webview/src/styles/less/components/message.less
+++ b/webview/src/styles/less/components/message.less
@@ -5,8 +5,13 @@
     overflow-y: auto;
     overflow-x: hidden; /* 防止横向滚动 */
     overscroll-behavior-y: contain;
+    overflow-anchor: none; /* 手动跟随到底时禁用锚定，避免和程序滚动抢控制权 */
     padding: 0;
     background: var(--bg-chat);
+}
+
+.messages-container.scroll-anchor-enabled {
+    overflow-anchor: auto; /* 用户离开底部后，交还给浏览器维持当前可见位置 */
 }
 
 /* Collapsed messages indicator */
@@ -39,6 +44,13 @@
     @supports (content-visibility: auto) {
         content-visibility: auto;
         contain-intrinsic-size: 0 160px;
+    }
+}
+
+.message.is-last-message {
+    @supports (content-visibility: auto) {
+        content-visibility: visible;
+        contain-intrinsic-size: auto;
     }
 }
 

--- a/webview/src/styles/less/components/task.less
+++ b/webview/src/styles/less/components/task.less
@@ -5,6 +5,7 @@
     border-radius: 8px;
     margin: 12px 0;
     overflow: hidden;
+    overflow-anchor: none;
 }
 
 .task-header {
@@ -115,6 +116,7 @@
     padding: 0;
     border-top: 1px solid var(--border-primary);
     background: var(--bg-primary);
+    overflow-anchor: none;
 }
 
 .task-content-wrapper {


### PR DESCRIPTION
…efactoring

Root cause: SubagentHistoryContext updates triggered cascading re-renders every 2s during polling, causing DOM height fluctuations and scroll anchoring instability. The scroll position jumped to user message position instead of maintaining the current position.

Fixes applied:

SubagentContext (rerender-use-ref-transient-values):
- Convert from Record value to getter function backed by ref
- Context value reference never changes, consumers only re-render when calling getter for a changed key
- Add ToolResultRawContext for raw message lookup without embedding on result
- Remove unnecessary useMemo wrapper around stable useCallback

TaskExecutionBlock (rerender-memo, rerender-dependencies):
- Wrap with React.memo to prevent unnecessary re-renders
- Use refs for isStreaming/isCompleted to avoid setInterval teardown/rebuild
- Polling effect now stable across streaming state toggles

useScrollBehavior (rerender-dependencies):
- Reduce ResizeObserver effect deps from [messages, expandedThinking, loading, streamingActive, ...] to just [currentView, scrollToBottom, sync*]
- Observer reads current state from refs inside callback, not from deps
- Prevents observer teardown during streaming which caused missed resize events

registerCallbacks (js-cache-function-results):
- Replace JSON.stringify with field-level comparison for skip detection
- Compare success, error, sessionId, messages.length instead of full serialize
- More deterministic and lower CPU cost on large payloads

CSS rendering optimizations:
- Add overflow-anchor: none to .task-container, .task-details, .subagent-details
- Prevent browser scroll anchoring from fighting manual scroll management
- Add .is-last-message class to override content-visibility for last message

Additional changes:
- Add toolResultRawMapRef for O(1) lookup instead of embedding __rawMessage
- Add handleNavigateToProviderSettings useCallback for stable prop
- Add SubagentProcessDetails memo wrapper
- Add tests for useScrollBehavior, TaskExecutionBlock, windowCallbacks

Tests: 312 passed, build verified