### PR TITLE
fix(ai-bridge): pass MCP server config from ~/.claude.json to Claude Agent SDK

### DIFF
--- a/ai-bridge/services/claude/mcp-status/config-loader.js
+++ b/ai-bridge/services/claude/mcp-status/config-loader.js
@@ -183,6 +183,23 @@ export async function loadMcpServersConfig(cwd = null) {
 }
 
 /**
+ * Load enabled MCP server config and return as a Record<name, config> for the
+ * Claude Agent SDK's `mcpServers` option.
+ *
+ * Returns null (rather than an empty object) when no servers are enabled, so
+ * callers can naturally write `...(mcpServers && { mcpServers })` to omit the
+ * field from SDK options entirely.
+ *
+ * @param {string} cwd - Current working directory (used for project detection)
+ * @returns {Promise<Record<string, Object> | null>}
+ */
+export async function loadMcpServersConfigAsRecord(cwd = null) {
+  const list = await loadMcpServersConfig(cwd);
+  if (list.length === 0) return null;
+  return Object.fromEntries(list.map(({ name, config }) => [name, config]));
+}
+
+/**
  * Load all MCP server info (including disabled and invalid ones)
  * Merges global and project-level mcpServers to stay consistent with the server list seen by the Java side
  * @param {string} cwd - Current working directory

--- a/ai-bridge/services/claude/mcp-status/config-loader.test.mjs
+++ b/ai-bridge/services/claude/mcp-status/config-loader.test.mjs
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Redirect HOME to a temp dir BEFORE the first call to getRealHomeDir().
+// path-utils caches the resolved home on first invocation, so we lock in the
+// override here and share the same temp HOME across all tests in this file.
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const tempHomeRaw = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-mcp-config-'));
+const tempHome = fs.realpathSync(tempHomeRaw);
+process.env.HOME = tempHome;
+process.env.USERPROFILE = tempHome;
+
+const { loadMcpServersConfigAsRecord, loadMcpServersConfig } = await import('./config-loader.js');
+
+const claudeJsonPath = path.join(tempHome, '.claude.json');
+
+function writeConfig(obj) {
+  fs.writeFileSync(claudeJsonPath, JSON.stringify(obj));
+}
+
+function clearConfig() {
+  try { fs.unlinkSync(claudeJsonPath); } catch { /* not present */ }
+}
+
+test.after(() => {
+  if (originalHome === undefined) delete process.env.HOME; else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = originalUserProfile;
+  fs.rmSync(tempHome, { recursive: true, force: true });
+});
+
+test('loadMcpServersConfigAsRecord returns null when ~/.claude.json is missing', async () => {
+  clearConfig();
+  assert.equal(await loadMcpServersConfigAsRecord(), null);
+});
+
+test('loadMcpServersConfigAsRecord returns null when mcpServers is absent or empty', async () => {
+  writeConfig({});
+  assert.equal(await loadMcpServersConfigAsRecord(), null);
+
+  writeConfig({ mcpServers: {} });
+  assert.equal(await loadMcpServersConfigAsRecord(), null);
+});
+
+test('loadMcpServersConfigAsRecord returns null when every server is disabled', async () => {
+  writeConfig({
+    mcpServers: { foo: { command: 'node', args: ['s.js'] } },
+    disabledMcpServers: ['foo']
+  });
+  assert.equal(await loadMcpServersConfigAsRecord(), null);
+});
+
+test('loadMcpServersConfigAsRecord returns null on invalid JSON', async () => {
+  fs.writeFileSync(claudeJsonPath, '{ this is not valid json');
+  assert.equal(await loadMcpServersConfigAsRecord(), null);
+});
+
+test('loadMcpServersConfigAsRecord returns Record<name, config> for enabled servers', async () => {
+  writeConfig({
+    mcpServers: {
+      stdio: { command: 'node', args: ['server.js'] },
+      http: { url: 'http://localhost:3000' }
+    }
+  });
+  const result = await loadMcpServersConfigAsRecord();
+  assert.ok(result, 'expected a non-null record');
+  assert.deepEqual(Object.keys(result).sort(), ['http', 'stdio']);
+  assert.deepEqual(result.stdio, { command: 'node', args: ['server.js'] });
+  assert.deepEqual(result.http, { url: 'http://localhost:3000' });
+});
+
+test('loadMcpServersConfigAsRecord skips invalid server configs but keeps valid ones', async () => {
+  writeConfig({
+    mcpServers: {
+      good: { command: 'node' },
+      noCommandOrUrl: { foo: 'bar' },
+      badArgs: { command: 'node', args: 'not-an-array' }
+    }
+  });
+  const result = await loadMcpServersConfigAsRecord();
+  assert.ok(result, 'expected a non-null record');
+  assert.deepEqual(Object.keys(result), ['good']);
+});
+
+test('loadMcpServersConfig still returns an array (empty on missing config)', async () => {
+  clearConfig();
+  const list = await loadMcpServersConfig();
+  assert.ok(Array.isArray(list));
+  assert.equal(list.length, 0);
+});

--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -28,7 +28,7 @@ import {
   buildConfigErrorPayload
 } from './message-utils.js';
 import { createPreToolUseHook } from './permission-mode.js';
-import { loadMcpServersConfig } from './mcp-status/config-loader.js';
+import { loadMcpServersConfigAsRecord } from './mcp-status/config-loader.js';
 import { setActiveQueryResult } from './message-session-registry.js';
 import { normalizeStreamDelta, rememberStreamSnapshot } from './stream-delta-normalizer.js';
 
@@ -443,9 +443,8 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
     console.log('[DEBUG] Config:', { effectivePermissionMode, alwaysThinkingEnabled, maxThinkingTokens, streamingEnabled, reasoningEffort: normalizedReasoningEffort });
 
     const preToolUseHook = createPreToolUseHook(effectivePermissionMode, workingDirectory);
-    const mcpServers = await loadMcpServersConfig(workingDirectory);
-    const mcpServersForSdk = Object.fromEntries(mcpServers.map(({ name, config }) => [name, config]));
-    const options = buildQueryOptions({ workingDirectory, permissionMode: effectivePermissionMode, sdkModelName, maxThinkingTokens, streamingEnabled, systemPromptAppend, preToolUseHook, sdkStderrLines, mcpServers: mcpServersForSdk });
+    const mcpServers = await loadMcpServersConfigAsRecord(workingDirectory);
+    const options = buildQueryOptions({ workingDirectory, permissionMode: effectivePermissionMode, sdkModelName, maxThinkingTokens, streamingEnabled, systemPromptAppend, preToolUseHook, sdkStderrLines, mcpServers });
 
     if (normalizedReasoningEffort) {
       options.effort = normalizedReasoningEffort;
@@ -519,9 +518,8 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
     streamingEnabled = streamingParam != null ? streamingParam : (settings?.streamingEnabled ?? false);
     console.log('[DEBUG] (withAttachments) Config:', { normalizedPermissionMode, alwaysThinkingEnabled, maxThinkingTokens, streamingEnabled, reasoningEffort });
 
-    const mcpServers = await loadMcpServersConfig(workingDirectory);
-    const mcpServersForSdk = Object.fromEntries(mcpServers.map(({ name, config }) => [name, config]));
-    const options = buildQueryOptions({ workingDirectory, permissionMode: normalizedPermissionMode, sdkModelName, maxThinkingTokens, streamingEnabled, systemPromptAppend, preToolUseHook, sdkStderrLines, mcpServers: mcpServersForSdk });
+    const mcpServers = await loadMcpServersConfigAsRecord(workingDirectory);
+    const options = buildQueryOptions({ workingDirectory, permissionMode: normalizedPermissionMode, sdkModelName, maxThinkingTokens, streamingEnabled, systemPromptAppend, preToolUseHook, sdkStderrLines, mcpServers });
 
     if (reasoningEffort) {
       options.effort = reasoningEffort;

--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -28,6 +28,7 @@ import {
   buildConfigErrorPayload
 } from './message-utils.js';
 import { createPreToolUseHook } from './permission-mode.js';
+import { loadMcpServersConfig } from './mcp-status/config-loader.js';
 import { setActiveQueryResult } from './message-session-registry.js';
 import { normalizeStreamDelta, rememberStreamSnapshot } from './stream-delta-normalizer.js';
 
@@ -59,7 +60,7 @@ function resolveThinkingConfig(settings) {
 /**
  * Build query options object shared by both send functions.
  */
-function buildQueryOptions({ workingDirectory, permissionMode, sdkModelName, maxThinkingTokens, streamingEnabled, systemPromptAppend, preToolUseHook, sdkStderrLines }) {
+function buildQueryOptions({ workingDirectory, permissionMode, sdkModelName, maxThinkingTokens, streamingEnabled, systemPromptAppend, preToolUseHook, sdkStderrLines, mcpServers }) {
   return {
     cwd: workingDirectory,
     permissionMode,
@@ -75,6 +76,7 @@ function buildQueryOptions({ workingDirectory, permissionMode, sdkModelName, max
     canUseTool,
     hooks: { PreToolUse: [{ hooks: [preToolUseHook] }] },
     settingSources: ['user', 'project', 'local'],
+    ...(mcpServers && { mcpServers }),
     systemPrompt: {
       type: 'preset',
       preset: 'claude_code',
@@ -441,7 +443,9 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
     console.log('[DEBUG] Config:', { effectivePermissionMode, alwaysThinkingEnabled, maxThinkingTokens, streamingEnabled, reasoningEffort: normalizedReasoningEffort });
 
     const preToolUseHook = createPreToolUseHook(effectivePermissionMode, workingDirectory);
-    const options = buildQueryOptions({ workingDirectory, permissionMode: effectivePermissionMode, sdkModelName, maxThinkingTokens, streamingEnabled, systemPromptAppend, preToolUseHook, sdkStderrLines });
+    const mcpServers = await loadMcpServersConfig(workingDirectory);
+    const mcpServersForSdk = Object.fromEntries(mcpServers.map(({ name, config }) => [name, config]));
+    const options = buildQueryOptions({ workingDirectory, permissionMode: effectivePermissionMode, sdkModelName, maxThinkingTokens, streamingEnabled, systemPromptAppend, preToolUseHook, sdkStderrLines, mcpServers: mcpServersForSdk });
 
     if (normalizedReasoningEffort) {
       options.effort = normalizedReasoningEffort;
@@ -515,7 +519,9 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
     streamingEnabled = streamingParam != null ? streamingParam : (settings?.streamingEnabled ?? false);
     console.log('[DEBUG] (withAttachments) Config:', { normalizedPermissionMode, alwaysThinkingEnabled, maxThinkingTokens, streamingEnabled, reasoningEffort });
 
-    const options = buildQueryOptions({ workingDirectory, permissionMode: normalizedPermissionMode, sdkModelName, maxThinkingTokens, streamingEnabled, systemPromptAppend, preToolUseHook, sdkStderrLines });
+    const mcpServers = await loadMcpServersConfig(workingDirectory);
+    const mcpServersForSdk = Object.fromEntries(mcpServers.map(({ name, config }) => [name, config]));
+    const options = buildQueryOptions({ workingDirectory, permissionMode: normalizedPermissionMode, sdkModelName, maxThinkingTokens, streamingEnabled, systemPromptAppend, preToolUseHook, sdkStderrLines, mcpServers: mcpServersForSdk });
 
     if (reasoningEffort) {
       options.effort = reasoningEffort;

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -41,7 +41,7 @@ import {
   resetRegistryState,
   setActiveTurnRuntime,
 } from './runtime-registry.js';
-import { loadMcpServersConfig } from './mcp-status/config-loader.js';
+import { loadMcpServersConfigAsRecord } from './mcp-status/config-loader.js';
 import {
   createTurnState,
   emitUsageTag,
@@ -171,13 +171,12 @@ async function buildRequestContext(params, withAttachments) {
   const maxThinkingTokens = resolveThinkingTokens(params, settings);
   const systemPromptAppend = buildSystemPromptAppend(params);
 
-  const mcpServers = await loadMcpServersConfig(workingDirectory);
-  const mcpServersForSdk = Object.fromEntries(mcpServers.map(({ name, config }) => [name, config]));
+  const mcpServers = await loadMcpServersConfigAsRecord(workingDirectory);
 
   const options = buildQueryOptions(
     workingDirectory, sdkModelName, permissionMode,
     maxThinkingTokens, reasoningEffort, streamingEnabled, systemPromptAppend, requestedSessionId,
-    mcpServersForSdk
+    mcpServers
   );
 
   const userMessage = await buildUserMessage(params, withAttachments, requestedSessionId);

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -41,6 +41,7 @@ import {
   resetRegistryState,
   setActiveTurnRuntime,
 } from './runtime-registry.js';
+import { loadMcpServersConfig } from './mcp-status/config-loader.js';
 import {
   createTurnState,
   emitUsageTag,
@@ -87,7 +88,7 @@ function buildSystemPromptAppend(params) {
   return buildIDEContextPrompt(openedFiles, agentPrompt);
 }
 
-function buildQueryOptions(workingDirectory, sdkModelName, permissionMode, maxThinkingTokens, reasoningEffort, streamingEnabled, systemPromptAppend, requestedSessionId) {
+function buildQueryOptions(workingDirectory, sdkModelName, permissionMode, maxThinkingTokens, reasoningEffort, streamingEnabled, systemPromptAppend, requestedSessionId, mcpServers) {
   return {
     cwd: workingDirectory,
     permissionMode,
@@ -105,6 +106,7 @@ function buildQueryOptions(workingDirectory, sdkModelName, permissionMode, maxTh
     ),
     canUseTool,
     settingSources: ['user', 'project', 'local'],
+    ...(mcpServers && { mcpServers }),
     systemPrompt: {
       type: 'preset',
       preset: 'claude_code',
@@ -169,9 +171,13 @@ async function buildRequestContext(params, withAttachments) {
   const maxThinkingTokens = resolveThinkingTokens(params, settings);
   const systemPromptAppend = buildSystemPromptAppend(params);
 
+  const mcpServers = await loadMcpServersConfig(workingDirectory);
+  const mcpServersForSdk = Object.fromEntries(mcpServers.map(({ name, config }) => [name, config]));
+
   const options = buildQueryOptions(
     workingDirectory, sdkModelName, permissionMode,
-    maxThinkingTokens, reasoningEffort, streamingEnabled, systemPromptAppend, requestedSessionId
+    maxThinkingTokens, reasoningEffort, streamingEnabled, systemPromptAppend, requestedSessionId,
+    mcpServersForSdk
   );
 
   const userMessage = await buildUserMessage(params, withAttachments, requestedSessionId);


### PR DESCRIPTION
## Problem

When Claude Code sessions are created from the JetBrains IDE plugin (CC GUI),
MCP servers defined in `~/.claude.json` are not attached to the session. The
plugin's `config-loader.js` already reads `~/.claude.json` and parses the
`mcpServers` configuration correctly, but `buildQueryOptions()` in both
`message-sender.js` and `persistent-query-service.js` never passes this
configuration to the Claude Agent SDK's `query()` call.

This means MCP servers such as `claude-status` (status dashboard) are never
launched for IDE sessions, while CLI sessions work correctly.

## Changes

- `ai-bridge/services/claude/message-sender.js`
  - Import `loadMcpServersConfig` from the existing `mcp-status/config-loader`
  - `buildQueryOptions()`: accept optional `mcpServers` parameter, spread into
    SDK options as `Record<string, McpServerConfig>`
  - `sendMessage()` and `sendMessageWithAttachments()`: load MCP config from
    `~/.claude.json` and pass it through

- `ai-bridge/services/claude/persistent-query-service.js`
  - Same pattern for the daemon-mode code path
  - `buildQueryOptions()`: accept optional `mcpServers` parameter
  - `buildRequestContext()`: load MCP config and pass it through

## Safety

- All error paths in `loadMcpServersConfig()` are handled with try/catch,
  returning `[]` on failure (missing file, invalid JSON, malformed config)
- Invalid server configs are filtered by the existing `isValidServerConfig()`
- `Object.fromEntries([])` produces `{}` — an empty object is harmless
- MCP server loading is async but runs within already-async functions
- No changes to the config file or MCP server execution; only the wiring
  between the config loader and the SDK is added

## Test Plan

- [x] All 23 existing tests pass
- [x] Daemon runs stably with MCP servers attached (verified 30+ min uptime)
- [x] Dashboard widget receives status updates from IDE-launched sessions
- [x] No `SDK-STDERR` entries in IDE logs
- [x] Edge cases: missing file, missing key, invalid config, empty config