### PR TITLE
fix(terminal): use getChildActionsOrStubs() for IntelliJ 2023.3+ comp…

### DIFF
--- a/src/main/java/com/github/claudecodegui/terminal/SendTerminalSelectionToInputAction.java
+++ b/src/main/java/com/github/claudecodegui/terminal/SendTerminalSelectionToInputAction.java
@@ -144,7 +144,9 @@ public class SendTerminalSelectionToInputAction extends AnAction implements Dumb
             }
 
             DefaultActionGroup group = (DefaultActionGroup) groupAction;
-            boolean alreadyRegistered = Arrays.stream(group.getChildren(actionManager))
+            // Use getChildActionsOrStubs() for compatibility with IntelliJ 2023.3+;
+            // getChildren(ActionManager) was only added in 2024.2 and triggers NoSuchMethodError on older builds.
+            boolean alreadyRegistered = Arrays.stream(group.getChildActionsOrStubs())
                     .map(actionManager::getId)
                     .anyMatch(ACTION_ID::equals);
             if (alreadyRegistered) {

--- a/src/test/java/com/github/claudecodegui/terminal/SendTerminalSelectionToInputActionTest.java
+++ b/src/test/java/com/github/claudecodegui/terminal/SendTerminalSelectionToInputActionTest.java
@@ -148,7 +148,7 @@ public class SendTerminalSelectionToInputActionTest {
     }
 
     private static List<String> childIds(TestActionManager actionManager, DefaultActionGroup group) {
-        return Arrays.stream(group.getChildren(actionManager))
+        return Arrays.stream(group.getChildActionsOrStubs())
                 .map(actionManager::getId)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
…atibility

Replace getChildren(ActionManager) with getChildActionsOrStubs() to avoid NoSuchMethodError on IntelliJ builds older than 2024.2.