### PR TITLE
fix: provider-specific UI controls for plan mode and 1M context label

### DIFF
--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -285,14 +285,10 @@ const App = () => {
         setCurrentView('history');
         return;
       }
-      // /plan - switch to plan mode
-      if (PLAN_COMMANDS.has(command)) {
-        if (currentProvider === 'codex') {
-          addToast(t('chat.planModeNotAvailableForCodex', { defaultValue: 'Plan mode is not available for Codex provider' }), 'warning');
-        } else {
-          handleModeSelect('plan');
-          addToast(t('chat.planModeEnabled', { defaultValue: 'Plan mode enabled' }), 'info');
-        }
+      // /plan - switch to plan mode (Claude only; Codex sends as normal text)
+      if (PLAN_COMMANDS.has(command) && currentProvider === 'claude') {
+        handleModeSelect('plan');
+        addToast(t('chat.planModeEnabled', { defaultValue: 'Plan mode enabled' }), 'info');
         return;
       }
     }

--- a/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
@@ -167,7 +167,8 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
   };
 
   const append1MContextSuffix = (label: string, modelId: string, show1MContext: boolean): string => {
-    if (show1MContext && modelSupports1MContext(modelId) && longContextEnabled) {
+    // Only show 1M context suffix for Claude provider
+    if (currentProvider === 'claude' && show1MContext && modelSupports1MContext(modelId) && longContextEnabled) {
       return `${label} (${t('models.longContext.shortLabel')})`;
     }
     return label;

--- a/webview/src/hooks/useMessageSender.ts
+++ b/webview/src/hooks/useMessageSender.ts
@@ -90,11 +90,9 @@ export function useMessageSender({
       return true;
     }
 
-    // /plan - switch to plan mode (Claude only)
-    if (PLAN_COMMANDS.has(command)) {
-      if (currentProvider === 'codex') {
-        addToast(t('chat.planModeNotAvailableForCodex', { defaultValue: 'Plan mode is not available for Codex provider' }), 'warning');
-      } else if (handleModeSelect) {
+    // /plan - switch to plan mode (Claude only; Codex sends as normal text)
+    if (PLAN_COMMANDS.has(command) && currentProvider === 'claude') {
+      if (handleModeSelect) {
         handleModeSelect('plan');
         addToast(t('chat.planModeEnabled', { defaultValue: 'Plan mode enabled' }), 'info');
       }


### PR DESCRIPTION
- Allow /plan command to send as normal text in Codex mode instead of showing warning toast
- Only show "(1M context)" suffix on model names for Claude provider, not Codex