### PR TITLE
feat: add /context command for context usage visualization

### DIFF
--- a/ai-bridge/channels/claude-channel.js
+++ b/ai-bridge/channels/claude-channel.js
@@ -105,11 +105,21 @@ export async function handleClaudeCommand(command, args, stdinData) {
       break;
     }
 
+    case 'getContextUsage': {
+      // getContextUsage requires a persistent runtime (daemon mode).
+      // In per-process mode, there is no persistent runtime, so return an error.
+      console.log(JSON.stringify({
+        success: false,
+        error: 'getContextUsage requires daemon mode. No persistent runtime available in per-process mode.'
+      }));
+      break;
+    }
+
     default:
       throw new Error(`Unknown Claude command: ${command}`);
   }
 }
 
 export function getClaudeCommandList() {
-  return ['send', 'sendWithAttachments', 'getSession', 'getLatestUserMessage', 'rewindFiles', 'getMcpServerStatus', 'getMcpServerTools', 'resetRuntime'];
+  return ['send', 'sendWithAttachments', 'getSession', 'getLatestUserMessage', 'rewindFiles', 'getMcpServerStatus', 'getMcpServerTools', 'resetRuntime', 'getContextUsage'];
 }

--- a/ai-bridge/daemon.js
+++ b/ai-bridge/daemon.js
@@ -33,7 +33,8 @@ import {
   preconnectPersistent,
   shutdownPersistentRuntimes,
   abortCurrentTurn,
-  resetRuntimePersistent
+  resetRuntimePersistent,
+  getContextUsagePersistent
 } from './services/claude/persistent-query-service.js';
 import { injectNetworkEnvVars } from './config/api-config.js';
 import { cleanupStaleTempImages } from './services/claude/attachment-service.js';
@@ -330,6 +331,8 @@ async function processRequest(request) {
       await preconnectPersistent(stdinData);
     } else if (provider === 'claude' && command === 'resetRuntime') {
       await resetRuntimePersistent(stdinData);
+    } else if (provider === 'claude' && command === 'getContextUsage') {
+      await getContextUsagePersistent(stdinData);
     } else {
       // Dispatch to the existing handlers for non-send commands.
       switch (provider) {

--- a/ai-bridge/services/claude/persistent-query-service.context.test.mjs
+++ b/ai-bridge/services/claude/persistent-query-service.context.test.mjs
@@ -1,0 +1,423 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __testing, getContextUsagePersistent } from './persistent-query-service.js';
+
+/**
+ * Create a query factory whose runtimes have getContextUsage() and setModel().
+ * The runtime's currentModel is set from options.model at creation time.
+ * Also stores modelId to track [1m] suffix state for context window changes.
+ * @param {object} contextUsageResult - The object returned by getContextUsage()
+ */
+function createContextAwareQueryFactory(contextUsageResult = { totalTokens: 1000 }) {
+  const runtimes = [];
+  return {
+    runtimes,
+    queryFn({ prompt, options }) {
+      // Set currentModel from options.model (matches SDK behavior)
+      // Also store the original modelId for [1m] suffix tracking
+      const runtime = {
+        prompt,
+        options,
+        closed: false,
+        currentModel: options.model || null,
+        modelId: options.modelId || options.model || null, // Track original modelId
+        setPermissionMode: async () => {},
+        setModel: async (model) => {
+          runtime.currentModel = model || null;
+        },
+        setMaxThinkingTokens: async () => {},
+        getContextUsage: async () => contextUsageResult,
+        close() {
+          this.closed = true;
+        },
+        async next() {
+          return { done: true, value: undefined };
+        }
+      };
+      runtimes.push(runtime);
+      return runtime;
+    }
+  };
+}
+
+test.beforeEach(async () => {
+  await __testing.resetState();
+});
+
+test('buildRequestContext preserves resolved model mapping for context usage runtimes', async () => {
+  const previousAnthropicModel = process.env.ANTHROPIC_MODEL;
+  const previousSonnetModel = process.env.ANTHROPIC_DEFAULT_SONNET_MODEL;
+
+  try {
+    const requestContext = await __testing.buildRequestContext(
+      {
+        model: 'claude-sonnet-4-6',
+        cwd: process.cwd(),
+      },
+      false,
+      {
+        settings: {
+          env: {
+            ANTHROPIC_DEFAULT_SONNET_MODEL: 'custom-sonnet-model',
+          },
+        },
+      },
+    );
+
+    const exactContext = __testing.applyExactModelForContextUsage(requestContext);
+
+    assert.deepEqual(
+      __testing.resolveRequestModelState('claude-sonnet-4-6', {
+        ANTHROPIC_DEFAULT_SONNET_MODEL: 'custom-sonnet-model',
+      }),
+      {
+        sdkModelName: 'sonnet',
+        resolvedModelId: 'custom-sonnet-model',
+      },
+      'resolved model state should honor mapped sonnet model settings',
+    );
+    assert.equal(requestContext.resolvedModelId, 'custom-sonnet-model');
+    assert.equal(process.env.ANTHROPIC_MODEL, 'custom-sonnet-model');
+    assert.equal(process.env.ANTHROPIC_DEFAULT_SONNET_MODEL, 'custom-sonnet-model');
+    assert.equal(exactContext.options.model, 'custom-sonnet-model');
+    assert.equal(exactContext.sdkModelName, 'custom-sonnet-model');
+    assert.equal(exactContext.modelId, 'claude-sonnet-4-6');
+  } finally {
+    if (previousAnthropicModel === undefined) {
+      delete process.env.ANTHROPIC_MODEL;
+    } else {
+      process.env.ANTHROPIC_MODEL = previousAnthropicModel;
+    }
+
+    if (previousSonnetModel === undefined) {
+      delete process.env.ANTHROPIC_DEFAULT_SONNET_MODEL;
+    } else {
+      process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = previousSonnetModel;
+    }
+  }
+});
+
+test('getContextUsagePersistent reuses existing runtime for same session', async () => {
+  const factory = createContextAwareQueryFactory({ totalTokens: 5000 });
+  __testing.setQueryFn(factory.queryFn);
+
+  // Pre-acquire a runtime for session 'sess-1'
+  const requestContext = await __testing.buildRequestContext({
+    sessionId: 'sess-1',
+    model: 'claude-sonnet-4-6',
+    cwd: process.cwd(),
+  });
+  await __testing.acquireRuntime(requestContext);
+
+  assert.equal(factory.runtimes.length, 1, 'should have created 1 runtime');
+
+  // Call getContextUsagePersistent for the same session
+  // It should reuse the existing runtime, not create a new one
+  const origConsoleLog = console.log;
+  console.log = (...args) => {
+    origConsoleLog(...args);
+  };
+
+  try {
+    await getContextUsagePersistent({
+      sessionId: 'sess-1',
+      model: 'claude-sonnet-4-6',
+      cwd: process.cwd(),
+    });
+
+    // Should still be only 1 runtime (reused, not recreated)
+    assert.equal(factory.runtimes.length, 1, 'should reuse existing runtime');
+  } finally {
+    console.log = origConsoleLog;
+  }
+});
+
+test('getContextUsagePersistent reuses runtime and calls setModel when model changes', async () => {
+  const factory = createContextAwareQueryFactory({ totalTokens: 5000 });
+  __testing.setQueryFn(factory.queryFn);
+
+  // Pre-acquire a runtime for session 'sess-2' with model 'opus'
+  const requestContext = await __testing.buildRequestContext({
+    sessionId: 'sess-2',
+    model: 'claude-opus-4-7',
+    cwd: process.cwd(),
+  });
+  await __testing.acquireRuntime(requestContext);
+
+  assert.equal(factory.runtimes.length, 1, 'should have 1 runtime initially');
+  assert.equal(factory.runtimes[0].currentModel, 'opus', 'runtime should have opus model');
+
+  // Request context usage with a DIFFERENT model (sonnet instead of opus)
+  // The runtime should be reused and setModel called to update the model
+  const origConsoleLog = console.log;
+  console.log = (...args) => { /* suppress */ };
+
+  try {
+    await getContextUsagePersistent({
+      sessionId: 'sess-2',
+      model: 'claude-sonnet-4-6',
+      cwd: process.cwd(),
+    });
+
+    // Should still be 1 runtime (reused), not recreated
+    assert.equal(factory.runtimes.length, 1,
+      `expected 1 runtime (reused), got ${factory.runtimes.length}`);
+
+    // The runtime's model should be updated with the exact model ID.
+    assert.equal(factory.runtimes[0].currentModel, 'claude-sonnet-4-6',
+      'runtime model should have been updated via setModel');
+  } finally {
+    console.log = origConsoleLog;
+  }
+});
+
+test('getContextUsagePersistent acquires new runtime when none exists', async () => {
+  const factory = createContextAwareQueryFactory({ totalTokens: 9999 });
+  __testing.setQueryFn(factory.queryFn);
+
+  assert.equal(factory.runtimes.length, 0, 'should start with 0 runtimes');
+
+  const origConsoleLog = console.log;
+  console.log = (...args) => { /* suppress */ };
+
+  try {
+    await getContextUsagePersistent({
+      model: 'claude-sonnet-4-6',
+      cwd: process.cwd(),
+    });
+
+    // Should have created a runtime via acquireRuntime
+    assert.equal(factory.runtimes.length, 1, 'should create 1 runtime via acquireRuntime');
+    assert.equal(
+      factory.runtimes[0].options.model,
+      'claude-sonnet-4-6',
+      'context runtime should be created with exact model ID',
+    );
+  } finally {
+    console.log = origConsoleLog;
+  }
+});
+
+test('getContextUsagePersistent throws when getContextUsage is not available', async () => {
+  // Create a factory WITHOUT getContextUsage on the runtime
+  const factory = {
+    queryFn({ prompt, options }) {
+      return {
+        prompt,
+        options,
+        closed: false,
+        setPermissionMode: async () => {},
+        setModel: async () => {},
+        setMaxThinkingTokens: async () => {},
+        close() { this.closed = true; },
+        async next() { return { done: true }; }
+      };
+    }
+  };
+  __testing.setQueryFn(factory.queryFn);
+
+  const origConsoleLog = console.log;
+  console.log = (...args) => { /* suppress */ };
+
+  try {
+    await assert.rejects(
+      () => getContextUsagePersistent({
+        model: 'claude-sonnet-4-6',
+        cwd: process.cwd(),
+      }),
+      /getContextUsage is not available/,
+    );
+  } finally {
+    console.log = origConsoleLog;
+  }
+});
+
+test('getContextUsagePersistent recreates runtime when [1m] suffix state changes', async () => {
+  const factory = createContextAwareQueryFactory({ totalTokens: 10000 });
+  __testing.setQueryFn(factory.queryFn);
+
+  // Pre-acquire a runtime with model that has [1m] suffix
+  const requestContext = await __testing.buildRequestContext({
+    sessionId: 'sess-1m',
+    model: 'claude-sonnet-4-6[1m]',
+    cwd: process.cwd(),
+  });
+  const runtime1 = await __testing.acquireRuntime(requestContext);
+
+  // Check the actual runtime object (not the mock query) stored the original modelId
+  assert.ok(runtime1.modelId?.includes('[1m]'),
+    `runtime.modelId should contain [1m], got: ${runtime1.modelId}`);
+
+  const origConsoleLog = console.log;
+  console.log = (...args) => { /* suppress */ };
+
+  try {
+    // Request context usage WITHOUT [1m] suffix - should recreate runtime
+    await getContextUsagePersistent({
+      sessionId: 'sess-1m',
+      model: 'claude-sonnet-4-6', // No [1m] suffix
+      cwd: process.cwd(),
+    });
+
+    // Get the runtime after the call
+    const runtime2 = __testing.getRuntimeForSession('sess-1m');
+
+    // The runtime should be different (old one disposed, new one created)
+    assert.ok(runtime2.modelId !== runtime1.modelId,
+      `new runtime should have different modelId`);
+
+    // New runtime should NOT have [1m] suffix in modelId
+    assert.ok(!runtime2.modelId?.includes('[1m]'),
+      `new runtime.modelId should NOT contain [1m], got: ${runtime2.modelId}`);
+  } finally {
+    console.log = origConsoleLog;
+  }
+});
+
+test('getContextUsagePersistent recreates runtime when existing runtime model is unknown', async () => {
+  const factory = createContextAwareQueryFactory({ totalTokens: 7777 });
+  __testing.setQueryFn(factory.queryFn);
+
+  const requestContext = await __testing.buildRequestContext({
+    sessionId: 'sess-unknown-model',
+    cwd: process.cwd(),
+  });
+  const runtime1 = await __testing.acquireRuntime(requestContext);
+
+  assert.equal(runtime1.modelId, null, 'preconnected runtime should have unknown modelId');
+  assert.equal(factory.runtimes.length, 1, 'should have 1 runtime initially');
+
+  const origConsoleLog = console.log;
+  console.log = (...args) => { /* suppress */ };
+
+  try {
+    await getContextUsagePersistent({
+      sessionId: 'sess-unknown-model',
+      model: 'claude-opus-4-7',
+      cwd: process.cwd(),
+    });
+
+    assert.equal(factory.runtimes.length, 2, 'should recreate runtime when modelId is unknown');
+
+    const runtime2 = __testing.getRuntimeForSession('sess-unknown-model');
+    assert.notEqual(runtime2, runtime1, 'should replace the old runtime');
+    assert.equal(runtime2.modelId, 'claude-opus-4-7', 'new runtime should track exact requested modelId');
+    assert.equal(
+      factory.runtimes[1].options.model,
+      'claude-opus-4-7',
+      'recreated runtime should be created with exact model ID',
+    );
+  } finally {
+    console.log = origConsoleLog;
+  }
+});
+
+test('getContextUsagePersistent temporarily disables 1M context when model has no [1m] suffix', async () => {
+  const observedValues = [];
+  const factory = {
+    queryFn({ prompt, options }) {
+      return {
+        prompt,
+        options,
+        closed: false,
+        currentModel: options.model || null,
+        modelId: options.model || null,
+        setPermissionMode: async () => {},
+        setModel: async () => {},
+        setMaxThinkingTokens: async () => {},
+        getContextUsage: async () => {
+          observedValues.push(process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT || null);
+          return { totalTokens: 1234, rawMaxTokens: 200000, maxTokens: 200000 };
+        },
+        close() {
+          this.closed = true;
+        },
+        async next() {
+          return { done: true, value: undefined };
+        }
+      };
+    }
+  };
+  __testing.setQueryFn(factory.queryFn);
+
+  const previousValue = process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT;
+  delete process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT;
+
+  const origConsoleLog = console.log;
+  console.log = (...args) => { /* suppress */ };
+
+  try {
+    await getContextUsagePersistent({
+      sessionId: 'sess-disable-1m',
+      model: 'claude-opus-4-7',
+      cwd: process.cwd(),
+    });
+
+    assert.deepEqual(observedValues, ['1'], 'should disable 1M context during /context query');
+    assert.equal(process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT, undefined,
+      'should restore CLAUDE_CODE_DISABLE_1M_CONTEXT after /context query');
+  } finally {
+    console.log = origConsoleLog;
+    if (previousValue === undefined) {
+      delete process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT;
+    } else {
+      process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT = previousValue;
+    }
+  }
+});
+
+test('getContextUsagePersistent temporarily clears 1M disable override for explicit [1m] model requests', async () => {
+  const observedValues = [];
+  const factory = {
+    queryFn({ prompt, options }) {
+      return {
+        prompt,
+        options,
+        closed: false,
+        currentModel: options.model || null,
+        modelId: options.model || null,
+        setPermissionMode: async () => {},
+        setModel: async () => {},
+        setMaxThinkingTokens: async () => {},
+        getContextUsage: async () => {
+          observedValues.push(process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT || null);
+          return { totalTokens: 1234, rawMaxTokens: 1000000, maxTokens: 1000000 };
+        },
+        close() {
+          this.closed = true;
+        },
+        async next() {
+          return { done: true, value: undefined };
+        }
+      };
+    }
+  };
+  __testing.setQueryFn(factory.queryFn);
+
+  const previousValue = process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT;
+  process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT = '1';
+
+  const origConsoleLog = console.log;
+  console.log = (...args) => { /* suppress */ };
+
+  try {
+    await getContextUsagePersistent({
+      sessionId: 'sess-keep-1m',
+      model: 'claude-opus-4-7[1m]',
+      cwd: process.cwd(),
+    });
+
+    assert.deepEqual(observedValues, [null],
+      'explicit [1m] requests should temporarily clear the disable-1M override');
+    assert.equal(process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT, '1',
+      'should restore original CLAUDE_CODE_DISABLE_1M_CONTEXT after explicit [1m] query');
+  } finally {
+    console.log = origConsoleLog;
+    if (previousValue === undefined) {
+      delete process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT;
+    } else {
+      process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT = previousValue;
+    }
+  }
+});

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -377,9 +377,17 @@ function emitSendError(runtime, error, requestContext) {
 
   payload.error = truncateString(payload.error, 2500);
 
-  console.error('[SEND_ERROR]', JSON.stringify(payload));
-  console.log('[SEND_ERROR]', JSON.stringify(payload));
-  console.log(JSON.stringify(payload));
+  // The error payload is emitted on three channels intentionally:
+  //   1. stderr ([SEND_ERROR] tag) — captured by Java's stderrLines for diagnostics
+  //   2. stdout ([SEND_ERROR] tag) — picked up by ClaudeStreamAdapter to surface
+  //      the error in the chat UI without waiting for the [MESSAGE_END] envelope
+  //   3. stdout (raw JSON) — the canonical request-result line consumed by the
+  //      daemon's request demuxer to complete the active CompletableFuture
+  // Removing any one of these breaks either logging, UX, or request completion.
+  const serialized = JSON.stringify(payload);
+  console.error('[SEND_ERROR]', serialized);
+  console.log('[SEND_ERROR]', serialized);
+  console.log(serialized);
 }
 
 function applyExactModelForContextUsage(requestContext) {
@@ -399,6 +407,33 @@ function applyExactModelForContextUsage(requestContext) {
       model: exactModelId,
     },
   };
+}
+
+/**
+ * Decide whether the existing runtime must be recreated to honor the requested model.
+ *
+ * The Claude SDK's `setModel()` can swap model names on an existing runtime, but it
+ * CANNOT change the context-window limit. The `[1m]` suffix on a modelId selects the
+ * 1M-token context window — toggling it requires building a new runtime from scratch.
+ *
+ * Two recreate conditions:
+ *   - contextWindowChanged: the request's [1m] state differs from the runtime's
+ *   - runtimeModelUnknown: caller specified a model but the runtime has no
+ *     tracked modelId (e.g. a prewarmed runtime created without a model), so
+ *     we cannot prove the existing window limit is correct.
+ *
+ * @param {object|null} runtime - The existing runtime (or null if none).
+ * @param {string|null} modelId - The requested model ID, may carry the `[1m]` suffix.
+ * @returns {boolean} True if the runtime must be disposed and recreated.
+ */
+function shouldRecreateRuntimeForModel(runtime, modelId) {
+  if (!runtime) return false;
+  const requestedHas1M = modelId?.includes('[1m]') ?? false;
+  const runtimeModelId = runtime.modelId || null;
+  const runtimeHas1M = runtimeModelId?.includes('[1m]') ?? false;
+  const contextWindowChanged = requestedHas1M !== runtimeHas1M;
+  const runtimeModelUnknown = !!modelId && !runtimeModelId;
+  return contextWindowChanged || runtimeModelUnknown;
 }
 
 async function withScopedContextWindowPreference(modelId, operation) {
@@ -533,20 +568,10 @@ export async function getContextUsagePersistent(params = {}) {
       }
     }
 
-    // Check if [1m] suffix state changed - this affects context window limits
-    // and requires creating a new runtime (setModel cannot change window limits)
-    // We need to compare the full modelId (which includes [1m]) stored in runtime
-    const requestedHas1M = modelId?.includes('[1m]') ?? false;
-    const runtimeModelId = runtime?.modelId || null; // Original modelId used to create runtime
-    const runtimeHas1M = runtimeModelId?.includes('[1m]') ?? false;
-    const contextWindowChanged = runtime && (requestedHas1M !== runtimeHas1M);
-    const runtimeModelUnknown = !!runtime && !!modelId && !runtimeModelId;
+    const mustRecreate = shouldRecreateRuntimeForModel(runtime, modelId);
 
-    // If no suitable runtime exists, OR context window limit changed, acquire one.
-    // The [1m] suffix affects runtime creation's context window limit, not just model name,
-    // so we must create a new runtime when the suffix state changes.
-    if (!runtime || runtime.closed || contextWindowChanged || runtimeModelUnknown) {
-      if ((contextWindowChanged || runtimeModelUnknown) && runtime && !runtime.closed) {
+    if (!runtime || runtime.closed || mustRecreate) {
+      if (mustRecreate && runtime && !runtime.closed) {
         await disposeRuntime(runtime, { removeSession });
         runtime = null;
       }

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -24,6 +24,7 @@ import {
   disposeRuntime,
   registerRuntimeSession,
   acquireRuntime,
+  applyDynamicControls,
   buildRuntimeSignature,
   endRuntimeTurn,
   resetCachedQueryFn,
@@ -105,6 +106,13 @@ function buildSystemPromptAppend(params) {
   return buildIDEContextPrompt(openedFiles, agentPrompt);
 }
 
+function resolveRequestModelState(modelId, settingsEnv) {
+  return {
+    sdkModelName: mapModelIdToSdkName(modelId),
+    resolvedModelId: resolveModelFromSettings(modelId, settingsEnv),
+  };
+}
+
 function buildQueryOptions(workingDirectory, sdkModelName, permissionMode, maxThinkingTokens, reasoningEffort, streamingEnabled, systemPromptAppend, requestedSessionId, mcpServers) {
   return {
     cwd: workingDirectory,
@@ -154,7 +162,7 @@ async function buildUserMessage(params, withAttachments, requestedSessionId, res
   };
 }
 
-async function buildRequestContext(params, withAttachments) {
+async function buildRequestContext(params, withAttachments, overrides = {}) {
   setupApiKey();
 
   const baseUrl = process.env.ANTHROPIC_BASE_URL || process.env.ANTHROPIC_API_URL || '';
@@ -176,11 +184,10 @@ async function buildRequestContext(params, withAttachments) {
     console.error('[WARNING] Failed to change process.cwd():', error.message);
   }
 
-  const settings = loadClaudeSettings();
+  const settings = overrides.settings ?? loadClaudeSettings();
   const modelId = params.model || null;
-  const sdkModelName = mapModelIdToSdkName(modelId);
-  const resolvedModel = resolveModelFromSettings(modelId, settings?.env);
-  setModelEnvironmentVariables(resolvedModel, modelId);
+  const { sdkModelName, resolvedModelId } = resolveRequestModelState(modelId, settings?.env);
+  setModelEnvironmentVariables(resolvedModelId, modelId);
 
   const permissionMode = normalizePermissionMode(params.permissionMode);
   const streamingEnabled = resolveStreamingEnabled(params, settings);
@@ -196,7 +203,7 @@ async function buildRequestContext(params, withAttachments) {
     mcpServers
   );
 
-  const userMessage = await buildUserMessage(params, withAttachments, requestedSessionId, resolvedModel);
+  const userMessage = await buildUserMessage(params, withAttachments, requestedSessionId, resolvedModelId);
 
   const runtimeSignature = buildRuntimeSignature(options, systemPromptAppend, streamingEnabled, runtimeSessionEpoch);
   console.log('[LIFECYCLE] buildRequestContext sessionId=' + (requestedSessionId || '(new)')
@@ -210,6 +217,8 @@ async function buildRequestContext(params, withAttachments) {
     options,
     userMessage,
     sdkModelName,
+    modelId, // Original model ID from params, may contain [1m] suffix
+    resolvedModelId,
     permissionMode,
     maxThinkingTokens,
     reasoningEffort,
@@ -373,6 +382,50 @@ function emitSendError(runtime, error, requestContext) {
   console.log(JSON.stringify(payload));
 }
 
+function applyExactModelForContextUsage(requestContext) {
+  const exactModelId = typeof requestContext?.resolvedModelId === 'string'
+    ? requestContext.resolvedModelId.trim()
+    : '';
+
+  if (!exactModelId) {
+    return requestContext;
+  }
+
+  return {
+    ...requestContext,
+    sdkModelName: exactModelId,
+    options: {
+      ...requestContext.options,
+      model: exactModelId,
+    },
+  };
+}
+
+async function withScopedContextWindowPreference(modelId, operation) {
+  const envKey = 'CLAUDE_CODE_DISABLE_1M_CONTEXT';
+  const hadOriginalValue = Object.prototype.hasOwnProperty.call(process.env, envKey);
+  const originalValue = process.env[envKey];
+  const disable1MContext = typeof modelId === 'string'
+    && modelId.trim() !== ''
+    && !modelId.includes('[1m]');
+
+  if (disable1MContext) {
+    process.env[envKey] = '1';
+  } else {
+    delete process.env[envKey];
+  }
+
+  try {
+    return await operation();
+  } finally {
+    if (hadOriginalValue) {
+      process.env[envKey] = originalValue;
+    } else {
+      delete process.env[envKey];
+    }
+  }
+}
+
 async function sendInternal(params, withAttachments) {
   const safeParams = params || {};
   const turnMeta = { state: null };
@@ -450,6 +503,92 @@ export async function abortCurrentTurn() {
   }
 }
 
+/**
+ * Get context usage breakdown from the active runtime.
+ * Calls the SDK's getContextUsage() control request on the persistent runtime's query object.
+ * If no runtime exists for the requested session, one is created via preconnect
+ * so that /context works on historical sessions without sending a message first.
+ * Outputs the result as JSON to stdout for the Java daemon bridge to collect.
+ * @param {object} params - { sessionId?: string, cwd?: string, model?: string }
+ */
+export async function getContextUsagePersistent(params = {}) {
+  const safeParams = params || {};
+  const sessionId = safeParams.sessionId || null;
+  const modelId = safeParams.model || null; // Original model ID, may contain [1m] suffix
+  return withScopedContextWindowPreference(modelId, async () => {
+    const settings = loadClaudeSettings();
+    const { resolvedModelId } = resolveRequestModelState(modelId, settings?.env);
+    const targetModel = resolvedModelId || modelId || null;
+    let runtime = null;
+
+    // Try to find the runtime for the specific session first
+    if (sessionId) {
+      runtime = getRuntimeForSession(sessionId);
+    }
+    // Only fall back to active turn runtime if it belongs to the same session
+    if (!runtime || runtime.closed) {
+      const active = getActiveTurnRuntime();
+      if (active && !active.closed && (!sessionId || active.sessionId === sessionId)) {
+        runtime = active;
+      }
+    }
+
+    // Check if [1m] suffix state changed - this affects context window limits
+    // and requires creating a new runtime (setModel cannot change window limits)
+    // We need to compare the full modelId (which includes [1m]) stored in runtime
+    const requestedHas1M = modelId?.includes('[1m]') ?? false;
+    const runtimeModelId = runtime?.modelId || null; // Original modelId used to create runtime
+    const runtimeHas1M = runtimeModelId?.includes('[1m]') ?? false;
+    const contextWindowChanged = runtime && (requestedHas1M !== runtimeHas1M);
+    const runtimeModelUnknown = !!runtime && !!modelId && !runtimeModelId;
+
+    // If no suitable runtime exists, OR context window limit changed, acquire one.
+    // The [1m] suffix affects runtime creation's context window limit, not just model name,
+    // so we must create a new runtime when the suffix state changes.
+    if (!runtime || runtime.closed || contextWindowChanged || runtimeModelUnknown) {
+      if ((contextWindowChanged || runtimeModelUnknown) && runtime && !runtime.closed) {
+        await disposeRuntime(runtime, { removeSession });
+        runtime = null;
+      }
+      const requestContext = applyExactModelForContextUsage(
+        await buildRequestContext(safeParams, false)
+      );
+      runtime = await acquireRuntime(requestContext, { registerActiveQueryResult, removeSession });
+    } else {
+      // Fast path: reuse existing runtime with minimal model sync.
+      // Only map the model ID and call setModel if needed - skip full buildRequestContext
+      // which would unnecessarily load MCP config, settings, etc.
+      setModelEnvironmentVariables(targetModel, modelId);
+    }
+
+    if (typeof runtime.query?.setModel === 'function') {
+      try {
+        await runtime.query.setModel(targetModel || undefined);
+        runtime.currentModel = targetModel;
+        runtime.modelId = modelId || null;
+      } catch (error) {
+        console.error('[LIFECYCLE] setModel failed:', error.message);
+      }
+    }
+
+    if (!runtime || runtime.closed) {
+      throw new Error('Failed to establish a runtime for context usage query');
+    }
+    if (typeof runtime.query?.getContextUsage !== 'function') {
+      throw new Error('getContextUsage is not available on the current runtime');
+    }
+
+    try {
+      const data = await runtime.query.getContextUsage();
+      console.log(JSON.stringify({ success: true, data }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err || 'getContextUsage call failed');
+      console.error('[LIFECYCLE] getContextUsage SDK error:', message);
+      throw new Error(message);
+    }
+  });
+}
+
 export async function shutdownPersistentRuntimes() {
   const all = getAllRuntimes();
   for (const runtime of all) {
@@ -467,8 +606,14 @@ export const __testing = {
   setQueryFn(queryFn) {
     setCachedQueryFn(queryFn);
   },
-  async buildRequestContext(params = {}, withAttachments = false) {
-    return buildRequestContext(params, withAttachments);
+  async buildRequestContext(params = {}, withAttachments = false, overrides = {}) {
+    return buildRequestContext(params, withAttachments, overrides);
+  },
+  resolveRequestModelState(modelId, settingsEnv) {
+    return resolveRequestModelState(modelId, settingsEnv);
+  },
+  applyExactModelForContextUsage(requestContext) {
+    return applyExactModelForContextUsage(requestContext);
   },
   async acquireRuntime(requestContext) {
     return acquireRuntime(requestContext, { registerActiveQueryResult, removeSession });

--- a/ai-bridge/services/claude/runtime-lifecycle.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.js
@@ -86,6 +86,7 @@ async function createRuntime(requestContext, callbacks) {
     runtimeSessionEpoch: requestContext.runtimeSessionEpoch || null,
     runtimeSignature: requestContext.runtimeSignature,
     currentModel: requestContext.sdkModelName || null,
+    modelId: requestContext.modelId || null, // Original model ID, may contain [1m] suffix
     currentPermissionMode: initialPermissionMode,
     permissionModeState: { value: initialPermissionMode },
     currentMaxThinkingTokens: requestContext.maxThinkingTokens ?? null,
@@ -252,4 +253,4 @@ export async function cleanupStaleSessionRuntimes(callbacks) {
   return cleanupSessionsFromRegistry((runtime) => disposeRuntime(runtime, callbacks));
 }
 
-export { beginRuntimeTurn, endRuntimeTurn, touchRuntime };
+export { beginRuntimeTurn, endRuntimeTurn, touchRuntime, applyDynamicControls };

--- a/ai-bridge/utils/model-utils.js
+++ b/ai-bridge/utils/model-utils.js
@@ -101,6 +101,8 @@ export function setModelEnvironmentVariables(modelId, baseModelId) {
   // that doesn't contain 'opus'/'haiku'/'sonnet'.
   const lowerBase = (baseModelId || modelId).toLowerCase();
 
+  process.env.ANTHROPIC_MODEL = modelId;
+
   // Set the corresponding environment variable based on model type
   // so the SDK knows which specific version to use
   if (lowerBase.includes('opus')) {

--- a/src/main/java/com/github/claudecodegui/handler/ContextHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/ContextHandler.java
@@ -1,0 +1,151 @@
+package com.github.claudecodegui.handler;
+
+import com.github.claudecodegui.handler.core.BaseMessageHandler;
+import com.github.claudecodegui.handler.core.HandlerContext;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+
+/**
+ * Context usage handler.
+ * Handles the get_context_usage event from the frontend to display context window usage breakdown.
+ */
+public class ContextHandler extends BaseMessageHandler {
+
+    private static final Logger LOG = Logger.getInstance(ContextHandler.class);
+    private final Gson gson = new Gson();
+
+    private static final String[] SUPPORTED_TYPES = {"get_context_usage"};
+
+    public ContextHandler(HandlerContext context) {
+        super(context);
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return SUPPORTED_TYPES.clone();
+    }
+
+    @Override
+    public boolean handle(String type, String content) {
+        if ("get_context_usage".equals(type)) {
+            LOG.info("[ContextHandler] Handling: get_context_usage");
+            handleGetContextUsage(content);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Parse context usage request JSON into its component fields.
+     * Returns a 4-element String array: [sessionId, cwd, model, requestId].
+     * Any field not present in the JSON will be null.
+     */
+    static String[] parseContextUsageRequest(Gson gson, String content) {
+        String sessionId = null;
+        String cwd = null;
+        String model = null;
+        String requestId = null;
+
+        try {
+            if (content != null && !content.isEmpty()) {
+                JsonObject request = gson.fromJson(content, JsonObject.class);
+                if (request != null) {
+                    sessionId = request.has("sessionId") && !request.get("sessionId").isJsonNull()
+                            ? request.get("sessionId").getAsString() : null;
+                    cwd = request.has("cwd") && !request.get("cwd").isJsonNull()
+                            ? request.get("cwd").getAsString() : null;
+                    model = request.has("model") && !request.get("model").isJsonNull()
+                            ? request.get("model").getAsString() : null;
+                    requestId = request.has("requestId") && !request.get("requestId").isJsonNull()
+                            ? request.get("requestId").getAsString() : null;
+                }
+            }
+        } catch (Exception e) {
+            // Return partial results on parse failure
+        }
+
+        return new String[]{sessionId, cwd, model, requestId};
+    }
+
+    /**
+     * Handle the get_context_usage request.
+     * Calls the SDK's getContextUsage API via the daemon and returns the result to the frontend.
+     */
+    private void handleGetContextUsage(String content) {
+        String[] parsed = parseContextUsageRequest(this.gson, content);
+        String sessionId = parsed[0];
+        String cwd = parsed[1];
+        String model = parsed[2];
+        String requestId = parsed[3];
+
+        // Fall back to session state if not provided
+        if (sessionId == null || sessionId.isEmpty()) {
+            sessionId = this.context.getSession().getSessionId();
+        }
+        if (cwd == null || cwd.isEmpty()) {
+            cwd = this.context.getSession().getCwd();
+        }
+
+        final String finalSessionId = sessionId;
+        final String finalCwd = cwd;
+        final String finalModel = model;
+        final String finalRequestId = requestId;
+
+        try {
+            this.context.getClaudeSDKBridge()
+                    .getContextUsage(finalSessionId, finalCwd, finalModel)
+                    .thenAccept(result -> {
+                        ApplicationManager.getApplication().invokeLater(() -> {
+                            try {
+                                // If the result indicates failure, route through the error callback
+                                // to ensure the dialog is closed properly on the frontend.
+                                if (result.has("success") && !result.get("success").getAsBoolean()) {
+                                    String errorMsg = "Failed to get context usage";
+                                    if (result.has("error") && !result.get("error").isJsonNull()) {
+                                        String sdkError = result.get("error").getAsString();
+                                        if (!sdkError.isEmpty()) {
+                                            errorMsg = sdkError;
+                                        }
+                                    }
+                                    LOG.warn("[ContextHandler] Context usage query failed: " + errorMsg);
+                                    callContextUsageError(errorMsg, finalRequestId);
+                                    return;
+                                }
+                                JsonObject response = result.deepCopy();
+                                if (finalRequestId != null && !finalRequestId.isEmpty()) {
+                                    response.addProperty("requestId", finalRequestId);
+                                }
+                                String json = this.gson.toJson(response);
+                                callJavaScript("showContextUsageDialog", escapeJs(json));
+                            } catch (Exception e) {
+                                LOG.error("[ContextHandler] Failed to send result to frontend", e);
+                                callContextUsageError("Failed to process context usage data", finalRequestId);
+                            }
+                        });
+                    })
+                    .exceptionally(ex -> {
+                        LOG.error("[ContextHandler] getContextUsage failed", ex);
+                        ApplicationManager.getApplication().invokeLater(() -> {
+                            callContextUsageError("Failed to get context usage: " + ex.getMessage(), finalRequestId);
+                        });
+                        return null;
+                    });
+        } catch (Exception e) {
+            LOG.error("[ContextHandler] Unexpected error", e);
+            ApplicationManager.getApplication().invokeLater(() -> {
+                callContextUsageError("Unexpected error: " + e.getMessage(), finalRequestId);
+            });
+        }
+    }
+
+    private void callContextUsageError(String message, String requestId) {
+        if (requestId != null && !requestId.isEmpty()) {
+            callJavaScript("onContextUsageError", escapeJs(message), escapeJs(requestId));
+            return;
+        }
+        callJavaScript("onContextUsageError", escapeJs(message));
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeDaemonCoordinator.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeDaemonCoordinator.java
@@ -133,6 +133,10 @@ class ClaudeDaemonCoordinator {
     }
 
     void prewarmDaemonAsync(String cwd, String runtimeSessionEpoch) {
+        prewarmDaemonAsync(cwd, runtimeSessionEpoch, null);
+    }
+
+    void prewarmDaemonAsync(String cwd, String runtimeSessionEpoch, String sessionId) {
         CompletableFuture<?> previous = prewarmFuture;
         if (previous != null && !previous.isDone()) {
             previous.cancel(true);
@@ -148,7 +152,7 @@ class ClaudeDaemonCoordinator {
 
                 JsonObject params = new JsonObject();
                 params.addProperty("cwd", cwd != null ? cwd : "");
-                params.addProperty("sessionId", "");
+                params.addProperty("sessionId", sessionId != null ? sessionId : "");
                 params.addProperty("runtimeSessionEpoch", runtimeSessionEpoch != null ? runtimeSessionEpoch : "");
                 params.addProperty("permissionMode", "");
                 params.addProperty("model", "");

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridge.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -103,7 +104,19 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
      * Prewarm daemon asynchronously to reduce first-message latency.
      */
     public void prewarmDaemonAsync(String cwd, String runtimeSessionEpoch) {
-        daemonCoordinator.prewarmDaemonAsync(cwd, runtimeSessionEpoch);
+        daemonCoordinator.prewarmDaemonAsync(cwd, runtimeSessionEpoch, null);
+    }
+
+    /**
+     * Prewarm daemon asynchronously for a specific session.
+     * Creates a runtime that loads the session's context via --resume.
+     *
+     * @param cwd Working directory
+     * @param runtimeSessionEpoch Session epoch for cache invalidation
+     * @param sessionId The historical session ID to resume
+     */
+    public void prewarmDaemonAsync(String cwd, String runtimeSessionEpoch, String sessionId) {
+        daemonCoordinator.prewarmDaemonAsync(cwd, runtimeSessionEpoch, sessionId);
     }
 
     public void resetPersistentRuntime(String runtimeSessionEpoch) {
@@ -452,6 +465,112 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
 
     public CompletableFuture<JsonObject> rewindFiles(String sessionId, String userMessageId) {
         return rewindFiles(sessionId, userMessageId, null);
+    }
+
+    // ============================================================================
+    // Context usage query
+    // ============================================================================
+
+    /**
+     * Get context window usage breakdown from the active Claude runtime.
+     * Calls the SDK's getContextUsage() API via the daemon process.
+     *
+     * @param sessionId The session ID to query context for
+     * @param cwd Working directory
+     * @param model The model ID to use for the runtime (e.g., "claude-opus-4-7")
+     * @return CompletableFuture with context usage data as JsonObject
+     */
+    public CompletableFuture<JsonObject> getContextUsage(String sessionId, String cwd, String model) {
+        DaemonBridge db = this.daemonCoordinator.getDaemonBridge();
+        if (db == null) {
+            JsonObject error = new JsonObject();
+            error.addProperty("success", false);
+            error.addProperty("error", "Daemon not available. Context usage requires daemon mode.");
+            return CompletableFuture.completedFuture(error);
+        }
+
+        JsonObject params = new JsonObject();
+        if (sessionId != null && !sessionId.isEmpty()) {
+            params.addProperty("sessionId", sessionId);
+        }
+        if (cwd != null && !cwd.isEmpty()) {
+            params.addProperty("cwd", cwd);
+        }
+        if (model != null && !model.isEmpty()) {
+            params.addProperty("model", model);
+        }
+
+        AtomicReference<JsonObject> resultRef = new AtomicReference<>();
+        CompletableFuture<JsonObject> resultFuture = new CompletableFuture<>();
+
+        DaemonBridge.DaemonOutputCallback callback = new DaemonBridge.DaemonOutputCallback() {
+            @Override
+            public void onLine(String line) {
+                try {
+                    JsonObject parsed = ClaudeSDKBridge.this.gson.fromJson(line, JsonObject.class);
+                    resultRef.set(parsed);
+                } catch (Exception ignored) {
+                }
+            }
+            @Override
+            public void onStderr(String text) { }
+            @Override
+            public void onError(String error) {
+                if (!resultFuture.isDone()) {
+                    JsonObject err = new JsonObject();
+                    err.addProperty("success", false);
+                    err.addProperty("error", error);
+                    resultFuture.complete(err);
+                }
+            }
+            @Override
+            public void onComplete(boolean success) {
+                if (!resultFuture.isDone()) {
+                    if (success) {
+                        JsonObject result = resultRef.get();
+                        if (result != null) {
+                            resultFuture.complete(result);
+                        } else {
+                            JsonObject err = new JsonObject();
+                            err.addProperty("success", false);
+                            err.addProperty("error", "No response received");
+                            resultFuture.complete(err);
+                        }
+                    } else {
+                        JsonObject err = new JsonObject();
+                        err.addProperty("success", false);
+                        err.addProperty("error", "getContextUsage command failed");
+                        resultFuture.complete(err);
+                    }
+                }
+            }
+        };
+
+        try {
+            CompletableFuture<Boolean> commandFuture = db.sendCommand("claude.getContextUsage", params, callback);
+            commandFuture.exceptionally(ex -> {
+                if (!resultFuture.isDone()) {
+                    JsonObject err = new JsonObject();
+                    err.addProperty("success", false);
+                    err.addProperty("error", ex.getMessage());
+                    resultFuture.complete(err);
+                }
+                return false;
+            });
+        } catch (Exception e) {
+            LOG.error("[ClaudeSDKBridge] getContextUsage failed: " + e.getMessage(), e);
+            JsonObject err = new JsonObject();
+            err.addProperty("success", false);
+            err.addProperty("error", e.getMessage());
+            return CompletableFuture.completedFuture(err);
+        }
+
+        return resultFuture.orTimeout(180, TimeUnit.SECONDS).exceptionally(ex -> {
+            JsonObject err = new JsonObject();
+            err.addProperty("success", false);
+            err.addProperty("error", "getContextUsage timed out after 180 seconds (SDK may be loading)");
+            return err;
+        });
     }
 
     // ============================================================================

--- a/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
@@ -209,6 +209,9 @@ public class SessionLifecycleManager {
                                     ? projectPath : determineWorkingDirectory();
             newSession.setSessionInfo(sessionId, workingDir);
 
+            // Prewarm daemon runtime for the historical session so /context and first message are fast
+            host.getClaudeSDKBridge().prewarmDaemonAsync(workingDir, newSession.getRuntimeSessionEpoch(), sessionId);
+
             newSession.loadFromServer().thenRun(() -> ApplicationManager.getApplication().invokeLater(() -> {
                 host.callJavaScript("historyLoadComplete");
             })).exceptionally(ex -> {

--- a/src/main/java/com/github/claudecodegui/skill/SlashCommandRegistry.java
+++ b/src/main/java/com/github/claudecodegui/skill/SlashCommandRegistry.java
@@ -50,6 +50,7 @@ public final class SlashCommandRegistry {
     // Bundled skills from CLI that are userInvocable and work in GUI environment
     public static final List<SlashCommand> CLAUDE_BUILTIN = List.of(
             new SlashCommand("/compact", "Summarize conversation to free context", "builtin"),
+            new SlashCommand("/context", "Visualize current context usage as a colored grid", "builtin"),
             new SlashCommand("/init", "Initialize a new CLAUDE.md file with codebase documentation", "builtin"),
             new SlashCommand("/plan", "Switch to plan mode", "builtin"),
             new SlashCommand("/resume", "Resume a previous conversation", "builtin"),

--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -5,6 +5,7 @@ import com.github.claudecodegui.session.ClaudeSession;
 import com.github.claudecodegui.settings.CodemossSettingsService;
 import com.github.claudecodegui.handler.AgentHandler;
 import com.github.claudecodegui.handler.ClipboardHandler;
+import com.github.claudecodegui.handler.ContextHandler;
 import com.github.claudecodegui.handler.CodexMcpServerHandler;
 import com.github.claudecodegui.handler.DependencyHandler;
 import com.github.claudecodegui.handler.DiffHandler;
@@ -251,6 +252,7 @@ public class ChatWindowDelegate {
         messageDispatcher.registerHandler(new FileHandler(handlerContext));
         messageDispatcher.registerHandler(new SettingsHandler(handlerContext));
         messageDispatcher.registerHandler(new SessionHandler(handlerContext));
+        messageDispatcher.registerHandler(new ContextHandler(handlerContext));
         messageDispatcher.registerHandler(new FileExportHandler(handlerContext));
         messageDispatcher.registerHandler(new DiffHandler(handlerContext));
         messageDispatcher.registerHandler(new PromptEnhancerHandler(handlerContext));

--- a/src/test/java/com/github/claudecodegui/handler/ContextHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/ContextHandlerTest.java
@@ -1,0 +1,126 @@
+package com.github.claudecodegui.handler;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.github.claudecodegui.handler.core.HandlerContext;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests for {@link ContextHandler} request parsing logic.
+ */
+public class ContextHandlerTest {
+
+    private static final Gson GSON = new Gson();
+
+    @Test
+    public void parseAllFieldsFromValidRequest() {
+        JsonObject body = new JsonObject();
+        body.addProperty("sessionId", "sess-123");
+        body.addProperty("cwd", "/home/user/project");
+        body.addProperty("model", "claude-opus-4-7[1m]");
+        body.addProperty("requestId", "req-abc");
+
+        String[] result = ContextHandler.parseContextUsageRequest(GSON, body.toString());
+
+        assertEquals("sess-123", result[0]);
+        assertEquals("/home/user/project", result[1]);
+        assertEquals("claude-opus-4-7[1m]", result[2]);
+        assertEquals("req-abc", result[3]);
+    }
+
+    @Test
+    public void parsePartialRequestWithOnlyModelAndRequestId() {
+        JsonObject body = new JsonObject();
+        body.addProperty("model", "claude-sonnet-4-6");
+        body.addProperty("requestId", "req-xyz");
+
+        String[] result = ContextHandler.parseContextUsageRequest(GSON, body.toString());
+
+        assertNull(result[0]); // sessionId
+        assertNull(result[1]); // cwd
+        assertEquals("claude-sonnet-4-6", result[2]);
+        assertEquals("req-xyz", result[3]);
+    }
+
+    @Test
+    public void parseNullContentReturnsAllNulls() {
+        String[] result = ContextHandler.parseContextUsageRequest(GSON, null);
+
+        assertNull(result[0]);
+        assertNull(result[1]);
+        assertNull(result[2]);
+        assertNull(result[3]);
+    }
+
+    @Test
+    public void parseEmptyContentReturnsAllNulls() {
+        String[] result = ContextHandler.parseContextUsageRequest(GSON, "");
+
+        assertNull(result[0]);
+        assertNull(result[1]);
+        assertNull(result[2]);
+        assertNull(result[3]);
+    }
+
+    @Test
+    public void parseNullJsonFieldsReturnNull() {
+        JsonObject body = new JsonObject();
+        body.add("sessionId", null);
+        body.addProperty("model", "claude-opus-4-7");
+        body.add("requestId", null);
+
+        String[] result = ContextHandler.parseContextUsageRequest(GSON, body.toString());
+
+        assertNull(result[0]); // sessionId is null
+        assertNull(result[1]); // cwd not present
+        assertEquals("claude-opus-4-7", result[2]);
+        assertNull(result[3]); // requestId is null
+    }
+
+    @Test
+    public void parseInvalidJsonReturnsAllNulls() {
+        String[] result = ContextHandler.parseContextUsageRequest(GSON, "not valid json {{{");
+
+        assertNull(result[0]);
+        assertNull(result[1]);
+        assertNull(result[2]);
+        assertNull(result[3]);
+    }
+
+    @Test
+    public void parseModelWith1MContextSuffix() {
+        JsonObject body = new JsonObject();
+        body.addProperty("model", "claude-opus-4-7[1m]");
+
+        String[] result = ContextHandler.parseContextUsageRequest(GSON, body.toString());
+
+        assertEquals("claude-opus-4-7[1m]", result[2]);
+    }
+
+    @Test
+    public void handlerDeclaresGetContextUsageSupport() {
+        HandlerContext context = new HandlerContext(
+                null,
+                null,
+                null,
+                null,
+                new HandlerContext.JsCallback() {
+                    @Override
+                    public void callJavaScript(String functionName, String... args) {
+                    }
+
+                    @Override
+                    public String escapeJs(String str) {
+                        return str;
+                    }
+                }
+        );
+
+        ContextHandler handler = new ContextHandler(context);
+        assertArrayEquals(new String[]{"get_context_usage"}, handler.getSupportedTypes());
+    }
+}

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -23,6 +23,7 @@ import {
   NEW_SESSION_COMMANDS,
   RESUME_COMMANDS,
   PLAN_COMMANDS,
+  CONTEXT_COMMANDS,
 } from './hooks/useMessageSender';
 import { applyDiffTheme, getStoredDiffTheme } from './utils/diffTheme';
 import type { Attachment, ChatInputBoxHandle } from './components/ChatInputBox/types';
@@ -47,6 +48,9 @@ const App = () => {
     openPermissionDialog,
     openAskUserQuestionDialog,
     openPlanApprovalDialog,
+    openContextUsageDialog,
+    updateContextUsageData,
+    closeContextUsageDialog,
     setRewindDialogOpen, setCurrentRewindRequest,
     isRewinding, setIsRewinding, setRewindSelectDialogOpen,
   } = useDialogs();
@@ -226,6 +230,8 @@ const App = () => {
     getOrCreateStreamingAssistantIndex, patchAssistantForStreaming,
     syncActiveProviderModelMapping,
     openPermissionDialog, openAskUserQuestionDialog, openPlanApprovalDialog,
+    openContextUsageDialog, updateContextUsageData,
+    closeContextUsageDialog,
     customSessionTitleRef, currentSessionIdRef, updateHistoryTitle,
     setCustomSessionTitle,
   });
@@ -250,7 +256,7 @@ const App = () => {
     interruptSession,
   } = useMessageSender({
     t, addToast,
-    currentProvider, permissionMode, selectedAgent,
+    currentProvider, selectedModel, permissionMode, selectedAgent,
     sdkStatusLoaded, currentSdkInstalled,
     sentAttachmentsRef, chatInputRef, messagesContainerRef,
     isUserAtBottomRef, userPausedRef, isStreamingRef,
@@ -258,6 +264,9 @@ const App = () => {
     setSettingsInitialTab, setCurrentView,
     forceCreateNewSession,
     handleModeSelect,
+    longContextEnabled,
+    openContextUsageDialog,
+    closeContextUsageDialog,
   });
 
   // ── Message queue ──
@@ -289,6 +298,11 @@ const App = () => {
       if (PLAN_COMMANDS.has(command) && currentProvider === 'claude') {
         handleModeSelect('plan');
         addToast(t('chat.planModeEnabled', { defaultValue: 'Plan mode enabled' }), 'info');
+        return;
+      }
+      // /context - handled locally even while loading
+      if (CONTEXT_COMMANDS.has(command)) {
+        hookHandleSubmit(content, attachments);
         return;
       }
     }

--- a/webview/src/components/AppDialogs.tsx
+++ b/webview/src/components/AppDialogs.tsx
@@ -13,6 +13,7 @@ import { STORAGE_KEYS } from '../types/provider';
 import { CHANGELOG_DATA } from '../version/changelog';
 import { useDialogs } from '../contexts/DialogContext';
 import { useUIState } from '../contexts/UIStateContext';
+import ContextUsageDialog from './ContextUsageDialog';
 
 /**
  * Wrapper that manages plugin-level custom models for the add-model dialog.
@@ -89,6 +90,7 @@ export const AppDialogs = ({
     planApprovalDialogOpen, currentPlanApprovalRequest,
     handlePlanApprovalApprove, handlePlanApprovalReject,
     rewindSelectDialogOpen, rewindDialogOpen, currentRewindRequest, isRewinding,
+    contextUsageDialogOpen, contextUsageIsLoading, contextUsageData, closeContextUsageDialog,
   } = useDialogs();
   const {
     showChangelogDialog, closeChangelogDialog,
@@ -157,6 +159,14 @@ export const AppDialogs = ({
         onClose={() => setAddModelDialogOpen(false)}
         currentProvider={currentProvider}
       />
+      {contextUsageDialogOpen ? (
+        <ContextUsageDialog
+          isOpen={contextUsageDialogOpen}
+          isLoading={contextUsageIsLoading}
+          data={contextUsageData}
+          onClose={closeContextUsageDialog}
+        />
+      ) : null}
     </>
   );
 };

--- a/webview/src/components/ChatInputBox/providers/slashCommandProvider.ts
+++ b/webview/src/components/ChatInputBox/providers/slashCommandProvider.ts
@@ -7,7 +7,6 @@ import { debugError, debugLog, debugWarn } from '../../../utils/debug.js';
  * Local command list (commands to be filtered out)
  */
 const HIDDEN_COMMANDS = new Set([
-  '/context',
   '/cost',
   '/pr-comments',
   '/release-notes',

--- a/webview/src/components/ContextUsageDialog.css
+++ b/webview/src/components/ContextUsageDialog.css
@@ -1,0 +1,276 @@
+/* ContextUsageDialog Styles */
+
+.context-usage-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1200;
+  animation: fadeIn 0.2s ease-out;
+}
+
+.context-usage-dialog {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-secondary);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  width: 90%;
+  max-width: 560px;
+  max-height: 80vh;
+  overflow-y: auto;
+  animation: slideIn 0.2s ease-out;
+}
+
+.context-usage-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--color-dialog-border);
+}
+
+.context-usage-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.context-usage-close {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  line-height: 1;
+}
+
+.context-usage-close:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.context-usage-close:focus-visible {
+  outline: 2px solid var(--color-link);
+  outline-offset: 2px;
+}
+
+/* Summary */
+.context-usage-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--color-dialog-border);
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.context-usage-model {
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.context-usage-tokens {
+  font-variant-numeric: tabular-nums;
+}
+
+.context-usage-autocompact {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+/* Grid */
+.context-usage-grid {
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  border-bottom: 1px solid var(--color-dialog-border);
+}
+
+.context-usage-grid-row {
+  display: flex;
+  gap: 3px;
+}
+
+.context-usage-grid-cell {
+  width: 20px;
+  height: 20px;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: transform 0.1s;
+}
+
+.context-usage-grid-cell:hover {
+  transform: scale(1.3);
+  z-index: 1;
+}
+
+.context-usage-grid-cell.filled {
+  border-radius: 3px;
+}
+
+.context-usage-grid-cell.partial {
+  border-radius: 3px;
+}
+
+.context-usage-grid-cell.free-space {
+  background-color: var(--bg-hover);
+  border: 1px dashed var(--border-secondary);
+}
+
+/* Loading state */
+.context-usage-loading {
+  min-height: 200px;
+}
+
+.context-usage-loading-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 40px 20px;
+}
+
+.context-usage-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--border-secondary);
+  border-top-color: var(--color-link);
+  border-radius: 50%;
+  animation: context-usage-spin 1s linear infinite;
+}
+
+@keyframes context-usage-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.context-usage-loading-text {
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+/* Legend */
+.context-usage-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--color-dialog-border);
+}
+
+.context-usage-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.context-usage-legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.context-usage-legend-name {
+  color: var(--text-secondary);
+}
+
+.context-usage-legend-tokens {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.free-space-dot {
+  background-color: transparent;
+  border: 1px dashed var(--border-secondary);
+}
+
+.free-space-legend {
+  opacity: 0.7;
+}
+
+/* Details tables */
+.context-usage-details {
+  padding: 12px 20px;
+}
+
+.context-usage-detail-section {
+  margin-bottom: 8px;
+}
+
+.context-usage-detail-section summary {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 6px 0;
+  user-select: none;
+}
+
+.context-usage-detail-section summary:hover {
+  color: var(--text-primary);
+}
+
+.context-usage-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+.context-usage-table th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--text-secondary);
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border-secondary);
+}
+
+.context-usage-table td {
+  padding: 4px 8px;
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--color-dialog-border);
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.context-usage-table td:last-child {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Animation keyframes - defined locally to avoid implicit dependency
+   on global stylesheets (dialogs.less) that may change independently. */
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateY(-20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}

--- a/webview/src/components/ContextUsageDialog.test.tsx
+++ b/webview/src/components/ContextUsageDialog.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ContextUsageDialog, { type ContextUsageData } from './ContextUsageDialog';
+
+const translationMap: Record<string, string> = {
+  'contextUsage.title': '上下文使用',
+  'contextUsage.loading': '正在加载上下文使用情况...',
+  'contextUsage.autoCompactEnabledWithThreshold': '自动压缩已启用 (80%)',
+  'contextUsage.categories.systemPrompt': '系统提示词',
+  'contextUsage.categories.autoCompactBuffer': '自动压缩缓冲区',
+  'contextUsage.categories.freeSpace': '空闲空间',
+  'contextUsage.sections.mcpTools': 'MCP 工具 (1)',
+  'contextUsage.table.tool': '工具',
+  'contextUsage.table.server': '服务器',
+  'contextUsage.table.tokens': '令牌',
+  'common.close': '关闭',
+};
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => translationMap[key] ?? options?.defaultValue ?? key,
+    i18n: { language: 'zh' },
+  }),
+}));
+
+const sampleData: ContextUsageData = {
+  categories: [
+    { name: 'System prompt', tokens: 1200, color: 'promptBorder' },
+    { name: 'Free space', tokens: 800, color: 'inactive' },
+    { name: 'Autocompact buffer', tokens: 200, color: 'warning' },
+  ],
+  gridRows: [[
+    {
+      color: 'promptBorder',
+      isFilled: true,
+      categoryName: 'System prompt',
+      tokens: 1200,
+      percentage: 60,
+      squareFullness: 1,
+    },
+    {
+      color: 'inactive',
+      isFilled: false,
+      categoryName: 'Free space',
+      tokens: 800,
+      percentage: 40,
+      squareFullness: 0.4,
+    },
+  ]],
+  totalTokens: 1200,
+  maxTokens: 2000,
+  rawMaxTokens: 2000,
+  percentage: 60,
+  model: 'claude-sonnet-4-6',
+  memoryFiles: [],
+  mcpTools: [{ name: 'read_file', serverName: 'workspace', tokens: 50 }],
+  agents: [],
+  skills: undefined,
+  isAutoCompactEnabled: true,
+  autoCompactThreshold: 80,
+};
+
+describe('ContextUsageDialog', () => {
+  it('renders accessible dialog semantics and focuses the close button', async () => {
+    render(
+      <ContextUsageDialog
+        isOpen
+        isLoading={false}
+        data={sampleData}
+        onClose={() => {}}
+      />,
+    );
+
+    const dialog = screen.getByRole('dialog', { name: '上下文使用' });
+    expect(dialog).toBeTruthy();
+
+    const closeButton = screen.getByRole('button', { name: '关闭' });
+    expect(closeButton).toBeTruthy();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(document.activeElement).toBe(closeButton);
+  });
+
+  it('uses translated labels for summary, legend and table content', () => {
+    render(
+      <ContextUsageDialog
+        isOpen
+        isLoading={false}
+        data={sampleData}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('自动压缩已启用 (80%)')).toBeTruthy();
+    expect(screen.getByText('系统提示词')).toBeTruthy();
+    expect(screen.getByText('自动压缩缓冲区')).toBeTruthy();
+    expect(screen.getByText('空闲空间')).toBeTruthy();
+    expect(screen.getByText('MCP 工具 (1)')).toBeTruthy();
+    expect(screen.getByText('工具')).toBeTruthy();
+    expect(screen.getByText('服务器')).toBeTruthy();
+    expect(screen.getAllByText('令牌').length).toBeGreaterThan(0);
+  });
+});

--- a/webview/src/components/ContextUsageDialog.tsx
+++ b/webview/src/components/ContextUsageDialog.tsx
@@ -1,0 +1,489 @@
+import { useEffect, useRef, useMemo, useCallback, useId, memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import './ContextUsageDialog.css';
+
+export interface ContextUsageData {
+  categories: Array<{
+    name: string;
+    tokens: number;
+    color: string;
+    isDeferred?: boolean;
+  }>;
+  gridRows: Array<Array<{
+    color: string;
+    isFilled: boolean;
+    categoryName: string;
+    tokens: number;
+    percentage: number;
+    squareFullness: number;
+  }>>;
+  totalTokens: number;
+  maxTokens: number;
+  rawMaxTokens: number;
+  percentage: number;
+  model: string;
+  memoryFiles: Array<{ path: string; type: string; tokens: number }>;
+  mcpTools: Array<{ name: string; serverName: string; tokens: number }>;
+  agents: Array<{ agentType: string; source: string; tokens: number }>;
+  skills?: {
+    totalSkills: number;
+    includedSkills: number;
+    tokens: number;
+    skillFrontmatter: Array<{ name: string; source: string; tokens: number }>;
+  };
+  isAutoCompactEnabled: boolean;
+  autoCompactThreshold?: number;
+}
+
+interface ContextUsageDialogProps {
+  isOpen: boolean;
+  isLoading: boolean;
+  data: ContextUsageData | null;
+  onClose: () => void;
+}
+
+const COLOR_MAP: Record<string, string> = {
+  promptBorder: '#7c6ff7',
+  inactive: '#6b7280',
+  cyanForSubagents: '#22d3ee',
+  permission: '#10b981',
+  claude: '#d97706',
+  warning: '#f59e0b',
+  purpleForSubagents: '#a78bfa',
+  text: '#e5e7eb',
+  success: '#22c55e',
+  error: '#ef4444',
+};
+
+function resolveColor(key: string): string {
+  if (COLOR_MAP[key]) return COLOR_MAP[key];
+  if (key.startsWith('#')) return key;
+  return '#6b7280';
+}
+
+function formatTokens(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}k`;
+  return String(tokens);
+}
+
+const ContextUsageDialog = memo(function ContextUsageDialog({
+  isOpen,
+  isLoading,
+  data,
+  onClose,
+}: ContextUsageDialogProps) {
+  const { t } = useTranslation();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
+  const titleId = useId();
+  const descriptionId = useId();
+
+  const translateCategoryName = useCallback((name: string) => {
+    const keyMap: Record<string, string> = {
+      'System prompt': 'contextUsage.categories.systemPrompt',
+      'System tools': 'contextUsage.categories.systemTools',
+      'MCP tools': 'contextUsage.categories.mcpTools',
+      'Custom agents': 'contextUsage.categories.customAgents',
+      'Memory files': 'contextUsage.categories.memoryFiles',
+      'Skills': 'contextUsage.categories.skills',
+      'Messages': 'contextUsage.categories.messages',
+      'Autocompact buffer': 'contextUsage.categories.autoCompactBuffer',
+      'Free space': 'contextUsage.categories.freeSpace',
+    };
+
+    const translationKey = keyMap[name];
+    if (!translationKey) {
+      return name;
+    }
+
+    return t(translationKey, { defaultValue: name });
+  }, [t]);
+
+  const closeDialog = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  // Use mousedown instead of click for close buttons to ensure reliable
+  // event handling in JCEF environments where React synthetic onClick
+  // may not fire consistently.
+  // Unified mousedown handler for closing - used by both the overlay
+  // (click outside) and close button. Uses mousedown for reliability in JCEF.
+  const handleCloseMouseDown = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    closeDialog();
+  }, [closeDialog]);
+
+  const handleCloseClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    closeDialog();
+  }, [closeDialog]);
+
+  // Prevent overlay mousedown from reaching the dialog content
+  const handleDialogMouseDown = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+  }, []);
+
+  // Compute derived values before any early returns to satisfy hooks rules
+  const { visibleCategories, freeSpace, autoCompactBuffer } = useMemo(() => {
+    if (!data?.categories) {
+      return { visibleCategories: [], freeSpace: undefined, autoCompactBuffer: undefined };
+    }
+    const visible: typeof data.categories = [];
+    let free: typeof data.categories[0] | undefined;
+    let buffer: typeof data.categories[0] | undefined;
+
+    for (const cat of data.categories) {
+      if (cat.name === 'Free space') {
+        free = cat;
+      } else if (cat.name === 'Autocompact buffer') {
+        buffer = cat;
+      } else if (cat.tokens > 0) {
+        visible.push(cat);
+      }
+    }
+
+    return { visibleCategories: visible, freeSpace: free, autoCompactBuffer: buffer };
+  }, [data?.categories]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeDialog();
+    };
+    window.addEventListener('keydown', handleEscape);
+    return () => window.removeEventListener('keydown', handleEscape);
+  }, [isOpen, closeDialog]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    lastFocusedElementRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+
+    const rafId = window.requestAnimationFrame(() => {
+      closeButtonRef.current?.focus();
+    });
+
+    return () => {
+      window.cancelAnimationFrame(rafId);
+      lastFocusedElementRef.current?.focus();
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  // Loading state
+  if (isLoading || !data) {
+    return (
+      <div className="context-usage-overlay" onMouseDown={handleCloseMouseDown}>
+        <div
+          className="context-usage-dialog context-usage-loading"
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          aria-describedby={descriptionId}
+          tabIndex={-1}
+          onMouseDown={handleDialogMouseDown}
+        >
+          <div className="context-usage-header">
+            <h3 id={titleId} className="context-usage-title">
+              {t('contextUsage.title', { defaultValue: 'Context Usage' })}
+            </h3>
+            <button
+              ref={closeButtonRef}
+              type="button"
+              className="context-usage-close"
+              onMouseDown={handleCloseMouseDown}
+              onClick={handleCloseClick}
+              title={t('common.close', { defaultValue: 'Close' })}
+              aria-label={t('common.close', { defaultValue: 'Close' })}
+            >
+              ×
+            </button>
+          </div>
+          <div className="context-usage-loading-body">
+            <div className="context-usage-spinner" />
+            <span id={descriptionId} className="context-usage-loading-text">
+              {t('contextUsage.loading', { defaultValue: 'Loading context usage...' })}
+            </span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const {
+    gridRows = [],
+    totalTokens = 0,
+    rawMaxTokens = data.maxTokens ?? 0,
+    percentage = 0,
+    model = '',
+    memoryFiles = [],
+    mcpTools = [],
+    agents = [],
+    skills,
+    isAutoCompactEnabled = false,
+    autoCompactThreshold,
+  } = data;
+
+  return (
+    <div className="context-usage-overlay" onMouseDown={handleCloseMouseDown}>
+      <div
+        className="context-usage-dialog"
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
+        onMouseDown={handleDialogMouseDown}
+      >
+        {/* Header */}
+        <div className="context-usage-header">
+          <h3 id={titleId} className="context-usage-title">
+            {t('contextUsage.title', { defaultValue: 'Context Usage' })}
+          </h3>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="context-usage-close"
+            onMouseDown={handleCloseMouseDown}
+            onClick={handleCloseClick}
+            title={t('common.close', { defaultValue: 'Close' })}
+            aria-label={t('common.close', { defaultValue: 'Close' })}
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Summary */}
+        <div id={descriptionId} className="context-usage-summary">
+          <span className="context-usage-model">{model}</span>
+          <span className="context-usage-tokens">
+            {formatTokens(totalTokens)} / {formatTokens(rawMaxTokens)} ({percentage}%)
+          </span>
+          {isAutoCompactEnabled && (
+            <span className="context-usage-autocompact">
+              {autoCompactThreshold
+                ? t('contextUsage.autoCompactEnabledWithThreshold', {
+                    threshold: autoCompactThreshold,
+                    defaultValue: 'Auto-compact: enabled ({{threshold}}%)',
+                  })
+                : t('contextUsage.autoCompactEnabled', {
+                    defaultValue: 'Auto-compact: enabled',
+                  })}
+            </span>
+          )}
+        </div>
+
+        {/* Colored grid */}
+        {gridRows && gridRows.length > 0 && (
+          <div className="context-usage-grid">
+            {gridRows.map((row, ri) => (
+              <div key={`row-${ri}`} className="context-usage-grid-row">
+                {row.map((sq, ci) => {
+                  const squareKey = `${sq.categoryName}-${ri}-${ci}`;
+                  if (sq.categoryName === 'Free space') {
+                    return (
+                      <div
+                        key={squareKey}
+                        className="context-usage-grid-cell free-space"
+                        title={`${translateCategoryName(sq.categoryName)}: ${formatTokens(sq.tokens)}`}
+                      />
+                    );
+                  }
+                  if (sq.categoryName === 'Autocompact buffer') {
+                    return (
+                      <div
+                        key={squareKey}
+                        className="context-usage-grid-cell"
+                        style={{ backgroundColor: resolveColor(sq.color), opacity: 0.5 }}
+                        title={`${translateCategoryName(sq.categoryName)}: ${formatTokens(sq.tokens)}`}
+                      />
+                    );
+                  }
+                  const filled = sq.squareFullness >= 0.7;
+                  return (
+                    <div
+                      key={squareKey}
+                      className={`context-usage-grid-cell ${filled ? 'filled' : 'partial'}`}
+                      style={{
+                        backgroundColor: resolveColor(sq.color),
+                        ...(filled ? {} : { opacity: 0.5 + sq.squareFullness * 0.5 }),
+                      }}
+                      title={`${translateCategoryName(sq.categoryName)}: ${formatTokens(sq.tokens)} (${sq.percentage.toFixed(1)}%)`}
+                    />
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Legend */}
+        <div className="context-usage-legend">
+          {visibleCategories.map((cat) => {
+            const translatedName = translateCategoryName(cat.name);
+            return (
+            <div key={`${cat.name}-${cat.color}`} className="context-usage-legend-item" title={`${translatedName}: ${formatTokens(cat.tokens)}`}>
+              <span
+                className="context-usage-legend-dot"
+                style={{ backgroundColor: resolveColor(cat.color) }}
+              />
+              <span className="context-usage-legend-name">{translatedName}</span>
+              <span className="context-usage-legend-tokens">
+                {cat.isDeferred
+                  ? t('contextUsage.notAvailable', { defaultValue: 'N/A' })
+                  : formatTokens(cat.tokens)}
+              </span>
+            </div>
+            );
+          })}
+          {autoCompactBuffer && autoCompactBuffer.tokens > 0 && (
+            <div
+              className="context-usage-legend-item"
+              title={`${t('contextUsage.categories.autoCompactBuffer', { defaultValue: 'Autocompact buffer' })}: ${formatTokens(autoCompactBuffer.tokens)}`}
+            >
+              <span
+                className="context-usage-legend-dot"
+                style={{ backgroundColor: resolveColor(autoCompactBuffer.color), opacity: 0.5 }}
+              />
+              <span className="context-usage-legend-name">
+                {t('contextUsage.categories.autoCompactBuffer', { defaultValue: 'Autocompact buffer' })}
+              </span>
+              <span className="context-usage-legend-tokens">{formatTokens(autoCompactBuffer.tokens)}</span>
+            </div>
+          )}
+          {freeSpace && freeSpace.tokens > 0 && (
+            <div
+              className="context-usage-legend-item free-space-legend"
+              title={`${t('contextUsage.categories.freeSpace', { defaultValue: 'Free space' })}: ${formatTokens(freeSpace.tokens)}`}
+            >
+              <span className="context-usage-legend-dot free-space-dot" />
+              <span className="context-usage-legend-name">
+                {t('contextUsage.categories.freeSpace', { defaultValue: 'Free space' })}
+              </span>
+              <span className="context-usage-legend-tokens">{formatTokens(freeSpace.tokens)}</span>
+            </div>
+          )}
+        </div>
+
+        {/* Details tables */}
+        <div className="context-usage-details">
+          {mcpTools.length > 0 && (
+            <details className="context-usage-detail-section">
+              <summary>{t('contextUsage.sections.mcpTools', { count: mcpTools.length, defaultValue: 'MCP Tools ({{count}})' })}</summary>
+              <table className="context-usage-table">
+                <thead>
+                  <tr>
+                    <th>{t('contextUsage.table.tool', { defaultValue: 'Tool' })}</th>
+                    <th>{t('contextUsage.table.server', { defaultValue: 'Server' })}</th>
+                    <th>{t('contextUsage.table.tokens', { defaultValue: 'Tokens' })}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {mcpTools.map((tool) => (
+                    <tr key={`${tool.serverName}-${tool.name}`}>
+                      <td>{tool.name}</td>
+                      <td>{tool.serverName}</td>
+                      <td>{formatTokens(tool.tokens)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </details>
+          )}
+
+          {agents.length > 0 && (
+            <details className="context-usage-detail-section">
+              <summary>{t('contextUsage.sections.agents', { count: agents.length, defaultValue: 'Agents ({{count}})' })}</summary>
+              <table className="context-usage-table">
+                <thead>
+                  <tr>
+                    <th>{t('contextUsage.table.agent', { defaultValue: 'Agent' })}</th>
+                    <th>{t('contextUsage.table.source', { defaultValue: 'Source' })}</th>
+                    <th>{t('contextUsage.table.tokens', { defaultValue: 'Tokens' })}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {agents.map((agent) => (
+                    <tr key={`${agent.source}-${agent.agentType}`}>
+                      <td>{agent.agentType}</td>
+                      <td>{agent.source}</td>
+                      <td>{formatTokens(agent.tokens)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </details>
+          )}
+
+          {memoryFiles.length > 0 && (
+            <details className="context-usage-detail-section">
+              <summary>{t('contextUsage.sections.memoryFiles', { count: memoryFiles.length, defaultValue: 'Memory Files ({{count}})' })}</summary>
+              <table className="context-usage-table">
+                <thead>
+                  <tr>
+                    <th>{t('contextUsage.table.type', { defaultValue: 'Type' })}</th>
+                    <th>{t('contextUsage.table.path', { defaultValue: 'Path' })}</th>
+                    <th>{t('contextUsage.table.tokens', { defaultValue: 'Tokens' })}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {memoryFiles.map((file) => {
+                    const shortPath = file.path.length > 60 ? '...' + file.path.slice(-57) : file.path;
+                    return (
+                      <tr key={`${file.type}-${file.path}`}>
+                        <td>{file.type}</td>
+                        <td title={file.path}>{shortPath}</td>
+                        <td>{formatTokens(file.tokens)}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </details>
+          )}
+
+          {skills && skills.skillFrontmatter?.length > 0 && (
+            <details className="context-usage-detail-section">
+              <summary>
+                {t('contextUsage.sections.skills', {
+                  included: skills.includedSkills ?? 0,
+                  total: skills.totalSkills ?? 0,
+                  defaultValue: 'Skills ({{included}}/{{total}})',
+                })}
+              </summary>
+              <table className="context-usage-table">
+                <thead>
+                  <tr>
+                    <th>{t('contextUsage.table.skill', { defaultValue: 'Skill' })}</th>
+                    <th>{t('contextUsage.table.source', { defaultValue: 'Source' })}</th>
+                    <th>{t('contextUsage.table.tokens', { defaultValue: 'Tokens' })}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {skills.skillFrontmatter.map((skill) => (
+                    <tr key={`${skill.source}-${skill.name}`}>
+                      <td>{skill.name}</td>
+                      <td>{skill.source}</td>
+                      <td>{formatTokens(skill.tokens)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </details>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+});
+
+export default ContextUsageDialog;

--- a/webview/src/components/ContextUsageDialog.tsx
+++ b/webview/src/components/ContextUsageDialog.tsx
@@ -67,6 +67,43 @@ function formatTokens(tokens: number): string {
   return String(tokens);
 }
 
+interface DetailsTableProps<T> {
+  summary: string;
+  headers: readonly [string, string, string];
+  rows: readonly T[];
+  rowKey: (row: T) => string;
+  renderRow: (row: T) => readonly [React.ReactNode, React.ReactNode, React.ReactNode];
+}
+
+function DetailsTable<T>({ summary, headers, rows, rowKey, renderRow }: DetailsTableProps<T>) {
+  return (
+    <details className="context-usage-detail-section">
+      <summary>{summary}</summary>
+      <table className="context-usage-table">
+        <thead>
+          <tr>
+            <th>{headers[0]}</th>
+            <th>{headers[1]}</th>
+            <th>{headers[2]}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const cells = renderRow(row);
+            return (
+              <tr key={rowKey(row)}>
+                <td>{cells[0]}</td>
+                <td>{cells[1]}</td>
+                <td>{cells[2]}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </details>
+  );
+}
+
 const ContextUsageDialog = memo(function ContextUsageDialog({
   isOpen,
   isLoading,
@@ -377,108 +414,66 @@ const ContextUsageDialog = memo(function ContextUsageDialog({
         {/* Details tables */}
         <div className="context-usage-details">
           {mcpTools.length > 0 && (
-            <details className="context-usage-detail-section">
-              <summary>{t('contextUsage.sections.mcpTools', { count: mcpTools.length, defaultValue: 'MCP Tools ({{count}})' })}</summary>
-              <table className="context-usage-table">
-                <thead>
-                  <tr>
-                    <th>{t('contextUsage.table.tool', { defaultValue: 'Tool' })}</th>
-                    <th>{t('contextUsage.table.server', { defaultValue: 'Server' })}</th>
-                    <th>{t('contextUsage.table.tokens', { defaultValue: 'Tokens' })}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {mcpTools.map((tool) => (
-                    <tr key={`${tool.serverName}-${tool.name}`}>
-                      <td>{tool.name}</td>
-                      <td>{tool.serverName}</td>
-                      <td>{formatTokens(tool.tokens)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </details>
+            <DetailsTable
+              summary={t('contextUsage.sections.mcpTools', { count: mcpTools.length, defaultValue: 'MCP Tools ({{count}})' })}
+              headers={[
+                t('contextUsage.table.tool', { defaultValue: 'Tool' }),
+                t('contextUsage.table.server', { defaultValue: 'Server' }),
+                t('contextUsage.table.tokens', { defaultValue: 'Tokens' }),
+              ]}
+              rows={mcpTools}
+              rowKey={(tool) => `${tool.serverName}-${tool.name}`}
+              renderRow={(tool) => [tool.name, tool.serverName, formatTokens(tool.tokens)]}
+            />
           )}
 
           {agents.length > 0 && (
-            <details className="context-usage-detail-section">
-              <summary>{t('contextUsage.sections.agents', { count: agents.length, defaultValue: 'Agents ({{count}})' })}</summary>
-              <table className="context-usage-table">
-                <thead>
-                  <tr>
-                    <th>{t('contextUsage.table.agent', { defaultValue: 'Agent' })}</th>
-                    <th>{t('contextUsage.table.source', { defaultValue: 'Source' })}</th>
-                    <th>{t('contextUsage.table.tokens', { defaultValue: 'Tokens' })}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {agents.map((agent) => (
-                    <tr key={`${agent.source}-${agent.agentType}`}>
-                      <td>{agent.agentType}</td>
-                      <td>{agent.source}</td>
-                      <td>{formatTokens(agent.tokens)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </details>
+            <DetailsTable
+              summary={t('contextUsage.sections.agents', { count: agents.length, defaultValue: 'Agents ({{count}})' })}
+              headers={[
+                t('contextUsage.table.agent', { defaultValue: 'Agent' }),
+                t('contextUsage.table.source', { defaultValue: 'Source' }),
+                t('contextUsage.table.tokens', { defaultValue: 'Tokens' }),
+              ]}
+              rows={agents}
+              rowKey={(agent) => `${agent.source}-${agent.agentType}`}
+              renderRow={(agent) => [agent.agentType, agent.source, formatTokens(agent.tokens)]}
+            />
           )}
 
           {memoryFiles.length > 0 && (
-            <details className="context-usage-detail-section">
-              <summary>{t('contextUsage.sections.memoryFiles', { count: memoryFiles.length, defaultValue: 'Memory Files ({{count}})' })}</summary>
-              <table className="context-usage-table">
-                <thead>
-                  <tr>
-                    <th>{t('contextUsage.table.type', { defaultValue: 'Type' })}</th>
-                    <th>{t('contextUsage.table.path', { defaultValue: 'Path' })}</th>
-                    <th>{t('contextUsage.table.tokens', { defaultValue: 'Tokens' })}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {memoryFiles.map((file) => {
-                    const shortPath = file.path.length > 60 ? '...' + file.path.slice(-57) : file.path;
-                    return (
-                      <tr key={`${file.type}-${file.path}`}>
-                        <td>{file.type}</td>
-                        <td title={file.path}>{shortPath}</td>
-                        <td>{formatTokens(file.tokens)}</td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </details>
+            <DetailsTable
+              summary={t('contextUsage.sections.memoryFiles', { count: memoryFiles.length, defaultValue: 'Memory Files ({{count}})' })}
+              headers={[
+                t('contextUsage.table.type', { defaultValue: 'Type' }),
+                t('contextUsage.table.path', { defaultValue: 'Path' }),
+                t('contextUsage.table.tokens', { defaultValue: 'Tokens' }),
+              ]}
+              rows={memoryFiles}
+              rowKey={(file) => `${file.type}-${file.path}`}
+              renderRow={(file) => {
+                const shortPath = file.path.length > 60 ? '...' + file.path.slice(-57) : file.path;
+                return [file.type, <span title={file.path}>{shortPath}</span>, formatTokens(file.tokens)];
+              }}
+            />
           )}
 
           {skills && skills.skillFrontmatter?.length > 0 && (
-            <details className="context-usage-detail-section">
-              <summary>
-                {t('contextUsage.sections.skills', {
-                  included: skills.includedSkills ?? 0,
-                  total: skills.totalSkills ?? 0,
-                  defaultValue: 'Skills ({{included}}/{{total}})',
-                })}
-              </summary>
-              <table className="context-usage-table">
-                <thead>
-                  <tr>
-                    <th>{t('contextUsage.table.skill', { defaultValue: 'Skill' })}</th>
-                    <th>{t('contextUsage.table.source', { defaultValue: 'Source' })}</th>
-                    <th>{t('contextUsage.table.tokens', { defaultValue: 'Tokens' })}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {skills.skillFrontmatter.map((skill) => (
-                    <tr key={`${skill.source}-${skill.name}`}>
-                      <td>{skill.name}</td>
-                      <td>{skill.source}</td>
-                      <td>{formatTokens(skill.tokens)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </details>
+            <DetailsTable
+              summary={t('contextUsage.sections.skills', {
+                included: skills.includedSkills ?? 0,
+                total: skills.totalSkills ?? 0,
+                defaultValue: 'Skills ({{included}}/{{total}})',
+              })}
+              headers={[
+                t('contextUsage.table.skill', { defaultValue: 'Skill' }),
+                t('contextUsage.table.source', { defaultValue: 'Source' }),
+                t('contextUsage.table.tokens', { defaultValue: 'Tokens' }),
+              ]}
+              rows={skills.skillFrontmatter}
+              rowKey={(skill) => `${skill.source}-${skill.name}`}
+              renderRow={(skill) => [skill.name, skill.source, formatTokens(skill.tokens)]}
+            />
           )}
         </div>
       </div>

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -68,6 +68,16 @@ interface Window {
   addErrorMessage?: (message: string) => void;
 
   /**
+   * Context usage dialog callback - receives JSON string with context usage data to show in a dialog.
+   */
+  showContextUsageDialog?: (json: string) => void;
+
+  /**
+   * Context usage error callback - shows error toast.
+   */
+  onContextUsageError?: (message: string, requestId?: string) => void;
+
+  /**
    * Add single history message (used for Codex session loading)
    */
   addHistoryMessage?: (message: any) => void;

--- a/webview/src/hooks/useDialogManagement.context.test.ts
+++ b/webview/src/hooks/useDialogManagement.context.test.ts
@@ -1,0 +1,132 @@
+import { act, renderHook } from '@testing-library/react';
+import { useDialogManagement } from './useDialogManagement';
+
+const t = ((key: string) => key) as any;
+
+describe('useDialogManagement - context usage requestId isolation', () => {
+  it('openContextUsageDialog sets requestId and opens dialog', () => {
+    const { result } = renderHook(() => useDialogManagement({ t }));
+
+    act(() => {
+      result.current.openContextUsageDialog('req-1', true);
+    });
+
+    expect(result.current.contextUsageDialogOpen).toBe(true);
+    expect(result.current.contextUsageIsLoading).toBe(true);
+    expect(result.current.contextUsageData).toBeNull();
+  });
+
+  it('updateContextUsageData accepts matching requestId', () => {
+    const { result } = renderHook(() => useDialogManagement({ t }));
+    const data = { totalTokens: 1000, maxTokens: 200000 } as any;
+
+    act(() => {
+      result.current.openContextUsageDialog('req-1', true);
+    });
+
+    let accepted: boolean;
+    act(() => {
+      accepted = result.current.updateContextUsageData('req-1', data);
+    });
+
+    expect(accepted!).toBe(true);
+    expect(result.current.contextUsageIsLoading).toBe(false);
+    expect(result.current.contextUsageData).toBe(data);
+  });
+
+  it('updateContextUsageData rejects stale requestId', () => {
+    const { result } = renderHook(() => useDialogManagement({ t }));
+    const data1 = { totalTokens: 1000 } as any;
+    const data2 = { totalTokens: 2000 } as any;
+
+    // Open with req-1
+    act(() => {
+      result.current.openContextUsageDialog('req-1', true);
+    });
+
+    // Open with req-2 (simulates a new request before the first completes)
+    act(() => {
+      result.current.openContextUsageDialog('req-2', true);
+    });
+
+    // Late response for req-1 should be rejected
+    let accepted: boolean;
+    act(() => {
+      accepted = result.current.updateContextUsageData('req-1', data1);
+    });
+    expect(accepted!).toBe(false);
+    expect(result.current.contextUsageData).toBeNull();
+
+    // Response for req-2 should be accepted
+    act(() => {
+      accepted = result.current.updateContextUsageData('req-2', data2);
+    });
+    expect(accepted!).toBe(true);
+    expect(result.current.contextUsageData).toBe(data2);
+  });
+
+  it('closeContextUsageDialog with no requestId closes current dialog', () => {
+    const { result } = renderHook(() => useDialogManagement({ t }));
+
+    act(() => {
+      result.current.openContextUsageDialog('req-1', true);
+    });
+    expect(result.current.contextUsageDialogOpen).toBe(true);
+
+    // Close without requestId (user clicks X button)
+    let closed: boolean;
+    act(() => {
+      closed = result.current.closeContextUsageDialog();
+    });
+
+    expect(closed!).toBe(true);
+    expect(result.current.contextUsageDialogOpen).toBe(false);
+    expect(result.current.contextUsageData).toBeNull();
+  });
+
+  it('closeContextUsageDialog rejects stale requestId', () => {
+    const { result } = renderHook(() => useDialogManagement({ t }));
+
+    act(() => {
+      result.current.openContextUsageDialog('req-1', true);
+    });
+
+    // Switch to req-2
+    act(() => {
+      result.current.openContextUsageDialog('req-2', true);
+    });
+
+    // Try to close with stale req-1
+    let closed: boolean;
+    act(() => {
+      closed = result.current.closeContextUsageDialog('req-1');
+    });
+
+    expect(closed!).toBe(false);
+    expect(result.current.contextUsageDialogOpen).toBe(true);
+
+    // Close with correct req-2
+    act(() => {
+      closed = result.current.closeContextUsageDialog('req-2');
+    });
+    expect(closed!).toBe(true);
+    expect(result.current.contextUsageDialogOpen).toBe(false);
+  });
+
+  it('closeContextUsageDialog with null requestId closes (force close)', () => {
+    const { result } = renderHook(() => useDialogManagement({ t }));
+
+    act(() => {
+      result.current.openContextUsageDialog('req-1', true);
+    });
+
+    // null requestId means "close whatever is open"
+    let closed: boolean;
+    act(() => {
+      closed = result.current.closeContextUsageDialog(null);
+    });
+
+    expect(closed!).toBe(true);
+    expect(result.current.contextUsageDialogOpen).toBe(false);
+  });
+});

--- a/webview/src/hooks/useDialogManagement.ts
+++ b/webview/src/hooks/useDialogManagement.ts
@@ -4,6 +4,7 @@ import type { PermissionRequest } from '../components/PermissionDialog';
 import type { AskUserQuestionRequest } from '../components/AskUserQuestionDialog';
 import type { PlanApprovalRequest } from '../components/PlanApprovalDialog';
 import type { RewindRequest } from '../components/RewindDialog';
+import type { ContextUsageData } from '../components/ContextUsageDialog';
 import { sendBridgeEvent } from '../utils/bridge';
 
 interface UseDialogManagementOptions {
@@ -44,6 +45,14 @@ interface UseDialogManagementReturn {
   // Rewind select dialog
   rewindSelectDialogOpen: boolean;
   setRewindSelectDialogOpen: (open: boolean) => void;
+
+  // Context usage dialog
+  contextUsageDialogOpen: boolean;
+  contextUsageIsLoading: boolean;
+  contextUsageData: ContextUsageData | null;
+  openContextUsageDialog: (requestId?: string | null, loading?: boolean) => void;
+  updateContextUsageData: (requestId: string | null | undefined, data: ContextUsageData) => boolean;
+  closeContextUsageDialog: (requestId?: string | null) => boolean;
 }
 
 /**
@@ -78,6 +87,12 @@ export function useDialogManagement({ t }: UseDialogManagementOptions): UseDialo
 
   // Rewind select dialog state
   const [rewindSelectDialogOpen, setRewindSelectDialogOpen] = useState(false);
+
+  // Context usage dialog state
+  const [contextUsageDialogOpen, setContextUsageDialogOpen] = useState(false);
+  const [contextUsageIsLoading, setContextUsageIsLoading] = useState(false);
+  const [contextUsageData, setContextUsageData] = useState<ContextUsageData | null>(null);
+  const contextUsageRequestIdRef = useRef<string | null>(null);
 
   // Sync refs with state
   useEffect(() => {
@@ -292,6 +307,41 @@ export function useDialogManagement({ t }: UseDialogManagementOptions): UseDialo
     setCurrentPlanApprovalRequest(null);
   }, []);
 
+  // Context usage dialog handlers
+  const isCurrentContextUsageRequest = useCallback((requestId?: string | null) => {
+    if (requestId == null || requestId === '') {
+      return true;
+    }
+    return contextUsageRequestIdRef.current === requestId;
+  }, []);
+
+  const openContextUsageDialog = useCallback((requestId?: string | null, loading = true) => {
+    contextUsageRequestIdRef.current = requestId ?? null;
+    setContextUsageData(null);
+    setContextUsageIsLoading(loading);
+    setContextUsageDialogOpen(true);
+  }, []);
+
+  const updateContextUsageData = useCallback((requestId: string | null | undefined, data: ContextUsageData) => {
+    if (!isCurrentContextUsageRequest(requestId)) {
+      return false;
+    }
+    setContextUsageIsLoading(false);
+    setContextUsageData(data);
+    return true;
+  }, [isCurrentContextUsageRequest]);
+
+  const closeContextUsageDialog = useCallback((requestId?: string | null) => {
+    if (!isCurrentContextUsageRequest(requestId)) {
+      return false;
+    }
+    contextUsageRequestIdRef.current = null;
+    setContextUsageDialogOpen(false);
+    setContextUsageIsLoading(false);
+    setContextUsageData(null);
+    return true;
+  }, [isCurrentContextUsageRequest]);
+
   return {
     // Permission dialog
     permissionDialogOpen,
@@ -326,5 +376,13 @@ export function useDialogManagement({ t }: UseDialogManagementOptions): UseDialo
     // Rewind select dialog
     rewindSelectDialogOpen,
     setRewindSelectDialogOpen,
+
+    // Context usage dialog
+    contextUsageDialogOpen,
+    contextUsageIsLoading,
+    contextUsageData,
+    openContextUsageDialog,
+    updateContextUsageData,
+    closeContextUsageDialog,
   };
 }

--- a/webview/src/hooks/useMessageSender.context.test.ts
+++ b/webview/src/hooks/useMessageSender.context.test.ts
@@ -1,0 +1,142 @@
+import { act, renderHook } from '@testing-library/react';
+import { useMessageSender } from './useMessageSender';
+import type { UseMessageSenderOptions } from './useMessageSender';
+
+describe('useMessageSender - /context command', () => {
+  const t = ((key: string, opts?: any) => opts?.defaultValue ?? key) as any;
+
+  const createOptions = (overrides: Partial<UseMessageSenderOptions> = {}): UseMessageSenderOptions => ({
+    t,
+    addToast: vi.fn(),
+    currentProvider: 'claude',
+    selectedModel: 'claude-opus-4-7',
+    permissionMode: 'default',
+    selectedAgent: null,
+    sdkStatusLoaded: true,
+    currentSdkInstalled: true,
+    sentAttachmentsRef: { current: new Map() },
+    chatInputRef: { current: null },
+    messagesContainerRef: { current: null },
+    isUserAtBottomRef: { current: true },
+    userPausedRef: { current: false },
+    isStreamingRef: { current: false },
+    setMessages: vi.fn(),
+    setLoading: vi.fn(),
+    setLoadingStartTime: vi.fn(),
+    setStreamingActive: vi.fn(),
+    setSettingsInitialTab: vi.fn(),
+    setCurrentView: vi.fn(),
+    forceCreateNewSession: vi.fn(),
+    handleModeSelect: vi.fn(),
+    longContextEnabled: false,
+    openContextUsageDialog: vi.fn(),
+    closeContextUsageDialog: vi.fn().mockReturnValue(true),
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    window.sendToJava = vi.fn();
+  });
+
+  it('sends get_context_usage with base model when longContext is disabled', () => {
+    const opts = createOptions({
+      selectedModel: 'claude-opus-4-7',
+      longContextEnabled: false,
+    });
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('/context');
+    });
+
+    expect(window.sendToJava).toHaveBeenCalledTimes(1);
+    const call = (window.sendToJava as any).mock.calls[0][0] as string;
+    expect(call).toMatch(/^get_context_usage:/);
+
+    const payload = JSON.parse(call.substring('get_context_usage:'.length));
+    expect(payload.model).toBe('claude-opus-4-7');
+    expect(payload.requestId).toBeTruthy();
+  });
+
+  it('sends get_context_usage with [1m] suffix when longContext is enabled', () => {
+    const opts = createOptions({
+      selectedModel: 'claude-opus-4-7',
+      longContextEnabled: true,
+    });
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('/context');
+    });
+
+    expect(window.sendToJava).toHaveBeenCalledTimes(1);
+    const call = (window.sendToJava as any).mock.calls[0][0] as string;
+    const payload = JSON.parse(call.substring('get_context_usage:'.length));
+    expect(payload.model).toBe('claude-opus-4-7[1m]');
+  });
+
+  it('opens dialog with loading state before sending bridge event', () => {
+    const openContextUsageDialog = vi.fn();
+    const opts = createOptions({ openContextUsageDialog });
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('/context');
+    });
+
+    expect(openContextUsageDialog).toHaveBeenCalledTimes(1);
+    expect(openContextUsageDialog).toHaveBeenCalledWith(
+      expect.any(String),
+      true, // loading = true
+    );
+    // Dialog opened BEFORE bridge event sent
+    expect(openContextUsageDialog.mock.invocationCallOrder[0]).toBeLessThan(
+      (window.sendToJava as any).mock.invocationCallOrder[0],
+    );
+  });
+
+  it('shows warning toast and does not send bridge event for Codex provider', () => {
+    const addToast = vi.fn();
+    const opts = createOptions({
+      currentProvider: 'codex',
+      addToast,
+    });
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('/context');
+    });
+
+    expect(window.sendToJava).not.toHaveBeenCalled();
+    expect(addToast).toHaveBeenCalledTimes(1);
+    expect(addToast).toHaveBeenCalledWith(
+      expect.stringContaining('Claude'),
+      'warning',
+    );
+  });
+
+  it('closes dialog with error toast when bridge is unavailable', () => {
+    // Don't set window.sendToJava → bridge unavailable
+    delete (window as any).sendToJava;
+
+    const addToast = vi.fn();
+    const closeContextUsageDialog = vi.fn().mockReturnValue(true);
+    const opts = createOptions({ addToast, closeContextUsageDialog });
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('/context');
+    });
+
+    expect(closeContextUsageDialog).toHaveBeenCalledTimes(1);
+    expect(addToast).toHaveBeenCalledWith(
+      expect.any(String),
+      'error',
+    );
+  });
+});

--- a/webview/src/hooks/useMessageSender.ts
+++ b/webview/src/hooks/useMessageSender.ts
@@ -2,6 +2,7 @@ import { useCallback, type RefObject } from 'react';
 import type { TFunction } from 'i18next';
 import { sendBridgeEvent } from '../utils/bridge';
 import type { ClaudeContentBlock, ClaudeMessage } from '../types';
+import { apply1MContextSuffix } from '../components/ChatInputBox/types';
 import type { Attachment, ChatInputBoxHandle, PermissionMode, SelectedAgent } from '../components/ChatInputBox/types';
 import type { ViewMode } from './useModelProviderState';
 
@@ -11,11 +12,23 @@ import type { ViewMode } from './useModelProviderState';
 export const NEW_SESSION_COMMANDS = new Set(['/new', '/clear', '/reset']);
 export const RESUME_COMMANDS = new Set(['/resume', '/continue']);
 export const PLAN_COMMANDS = new Set(['/plan']);
+export const CONTEXT_COMMANDS = new Set(['/context']);
+
+// Hoisted regex to avoid creating new RegExp on every call
+const WHITESPACE_REGEX = /\s+/;
+
+function createContextUsageRequestId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `context-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
 
 export interface UseMessageSenderOptions {
   t: TFunction;
   addToast: (message: string, type?: 'info' | 'success' | 'warning' | 'error') => void;
   currentProvider: string;
+  selectedModel: string;
   permissionMode: PermissionMode;
   selectedAgent: SelectedAgent | null;
   sdkStatusLoaded: boolean;
@@ -34,6 +47,9 @@ export interface UseMessageSenderOptions {
   setCurrentView: React.Dispatch<React.SetStateAction<ViewMode>>;
   forceCreateNewSession: () => void;
   handleModeSelect?: (mode: PermissionMode) => void;
+  longContextEnabled?: boolean;
+  openContextUsageDialog: (requestId?: string | null, loading?: boolean) => void;
+  closeContextUsageDialog: (requestId?: string | null) => boolean;
 }
 
 /**
@@ -43,6 +59,7 @@ export function useMessageSender({
   t,
   addToast,
   currentProvider,
+  selectedModel,
   permissionMode,
   selectedAgent,
   sdkStatusLoaded,
@@ -61,6 +78,9 @@ export function useMessageSender({
   setCurrentView,
   forceCreateNewSession,
   handleModeSelect,
+  longContextEnabled,
+  openContextUsageDialog,
+  closeContextUsageDialog,
 }: UseMessageSenderOptions) {
   /**
    * Check if the input is a new session command
@@ -101,6 +121,47 @@ export function useMessageSender({
 
     return false;
   }, [setCurrentView, handleModeSelect, currentProvider, addToast, t]);
+
+  /**
+   * Check for context usage command (/context)
+   * Only available for Claude provider. Opens a dialog to display context window usage.
+   */
+  const checkContextCommand = useCallback((text: string): boolean => {
+    if (!text.startsWith('/')) return false;
+    const command = text.split(WHITESPACE_REGEX)[0].toLowerCase();
+    if (CONTEXT_COMMANDS.has(command)) {
+      if (currentProvider !== 'claude') {
+        addToast(t('chat.commandProviderOnly', {
+          command,
+          provider: 'Claude',
+          defaultValue: `${command} is only available for Claude provider`,
+        }), 'warning');
+        return true;
+      }
+
+      const requestId = createContextUsageRequestId();
+
+      // Open dialog with loading state immediately
+      openContextUsageDialog(requestId, true);
+
+      // Send bridge event to fetch context usage with current model
+      // Apply [1m] suffix if long context is enabled so the SDK creates
+      // a runtime with the correct context window limit.
+      const sent = sendBridgeEvent('get_context_usage', JSON.stringify({
+        model: apply1MContextSuffix(selectedModel, longContextEnabled ?? false),
+        requestId,
+      }));
+
+      if (!sent) {
+        closeContextUsageDialog(requestId);
+        addToast(t('chat.bridgeUnavailable', {
+          defaultValue: 'Bridge is not available right now',
+        }), 'error');
+      }
+      return true;
+    }
+    return false;
+  }, [currentProvider, selectedModel, longContextEnabled, addToast, t, openContextUsageDialog, closeContextUsageDialog]);
 
   /**
    * Check for unimplemented slash commands
@@ -338,12 +399,15 @@ export function useMessageSender({
     // Check local-handled commands (/resume, /plan)
     if (checkLocalCommand(text)) return;
 
+    // Check context usage command (/context)
+    if (checkContextCommand(text)) return;
+
     // Check for unimplemented commands
     if (checkUnimplementedCommand(text)) return;
 
     // Execute message
     executeMessage(content, attachments);
-  }, [checkNewSessionCommand, checkLocalCommand, checkUnimplementedCommand, executeMessage]);
+  }, [checkNewSessionCommand, checkLocalCommand, checkContextCommand, checkUnimplementedCommand, executeMessage]);
 
   /**
    * Interrupt the current session

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -80,6 +80,9 @@ describe('useWindowCallbacks integration', () => {
     openPermissionDialog: vi.fn(),
     openAskUserQuestionDialog: vi.fn(),
     openPlanApprovalDialog: vi.fn(),
+    openContextUsageDialog: vi.fn(),
+    updateContextUsageData: vi.fn(),
+    closeContextUsageDialog: vi.fn(),
 
     // B-011
     customSessionTitleRef: { current: null },

--- a/webview/src/hooks/useWindowCallbacks.ts
+++ b/webview/src/hooks/useWindowCallbacks.ts
@@ -92,6 +92,12 @@ export interface UseWindowCallbacksOptions {
   openPermissionDialog: (request: PermissionRequest) => void;
   openAskUserQuestionDialog: (request: AskUserQuestionRequest) => void;
   openPlanApprovalDialog: (request: PlanApprovalRequest) => void;
+  openContextUsageDialog: (requestId?: string | null, loading?: boolean) => void;
+  updateContextUsageData: (
+    requestId: string | null | undefined,
+    data: import('../components/ContextUsageDialog').ContextUsageData,
+  ) => boolean;
+  closeContextUsageDialog: (requestId?: string | null) => boolean;
 
   // B-011: Title migration on session ID change
   customSessionTitleRef: MutableRefObject<string | null>;

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
@@ -9,7 +9,9 @@
 
 import type { UseWindowCallbacksOptions } from '../../useWindowCallbacks';
 import type { ClaudeMessage } from '../../../types';
+import type { ContextUsageData } from '../../../components/ContextUsageDialog';
 import { sendBridgeEvent } from '../../../utils/bridge';
+import { debugError } from '../../../utils/debug';
 import {
   appendOptimisticMessageIfMissing,
   ensureStreamingAssistantInList,
@@ -85,6 +87,8 @@ export function registerMessageCallbacks(
     findLastAssistantIndex,
     extractRawBlocks,
     patchAssistantForStreaming,
+    updateContextUsageData,
+    closeContextUsageDialog,
   } = options;
 
   const ensureStreamingAssistantPreserved = (prevList: ClaudeMessage[], resultList: ClaudeMessage[]): ClaudeMessage[] => {
@@ -557,11 +561,37 @@ export function registerMessageCallbacks(
     }
     window.__deniedToolIds?.clear();
     resetTransientUiState();
+    closeContextUsageDialog();
     setMessages([]);
   };
 
   window.addErrorMessage = (message) => {
     addToast(message, 'error');
+  };
+
+  window.showContextUsageDialog = (json: string) => {
+    try {
+      const result = JSON.parse(json);
+      const requestId = typeof result.requestId === 'string' ? result.requestId : null;
+      const data: ContextUsageData = result.data || result;
+      if (result.success === false) {
+        if (closeContextUsageDialog(requestId)) {
+          addToast(result.error || 'Failed to get context usage', 'error');
+        }
+        return;
+      }
+      updateContextUsageData(requestId, data);
+    } catch (e) {
+      debugError('[ContextUsage] Failed to parse context usage result:', e);
+      closeContextUsageDialog();
+      addToast('Failed to parse context usage data', 'error');
+    }
+  };
+
+  window.onContextUsageError = (message: string, requestId?: string) => {
+    if (closeContextUsageDialog(requestId)) {
+      addToast(message, 'error');
+    }
   };
 
   window.addHistoryMessage = (message: ClaudeMessage) => {

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -1571,6 +1571,40 @@
     "enable": "Enable",
     "cancel": "Cancel"
   },
+  "contextUsage": {
+    "title": "Context Usage",
+    "loading": "Loading context usage...",
+    "autoCompactEnabled": "Auto-compact: enabled",
+    "autoCompactEnabledWithThreshold": "Auto-compact: enabled ({{threshold}}%)",
+    "notAvailable": "N/A",
+    "categories": {
+      "systemPrompt": "System prompt",
+      "systemTools": "System tools",
+      "mcpTools": "MCP tools",
+      "customAgents": "Custom agents",
+      "memoryFiles": "Memory files",
+      "skills": "Skills",
+      "messages": "Messages",
+      "autoCompactBuffer": "Autocompact buffer",
+      "freeSpace": "Free space"
+    },
+    "sections": {
+      "mcpTools": "MCP Tools ({{count}})",
+      "agents": "Agents ({{count}})",
+      "memoryFiles": "Memory Files ({{count}})",
+      "skills": "Skills ({{included}}/{{total}})"
+    },
+    "table": {
+      "tool": "Tool",
+      "server": "Server",
+      "tokens": "Tokens",
+      "agent": "Agent",
+      "source": "Source",
+      "type": "Type",
+      "path": "Path",
+      "skill": "Skill"
+    }
+  },
   "rewind": {
     "title": "Rewind Files to Previous State",
     "tooltip": "Rewind",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -1576,6 +1576,40 @@
     "enable": "开启",
     "cancel": "取消"
   },
+  "contextUsage": {
+    "title": "上下文使用",
+    "loading": "正在加载上下文使用情况...",
+    "autoCompactEnabled": "自动压缩已启用",
+    "autoCompactEnabledWithThreshold": "自动压缩已启用 ({{threshold}}%)",
+    "notAvailable": "不可用",
+    "categories": {
+      "systemPrompt": "系统提示词",
+      "systemTools": "系统工具",
+      "mcpTools": "MCP 工具",
+      "customAgents": "自定义智能体",
+      "memoryFiles": "记忆文件",
+      "skills": "Skills",
+      "messages": "消息",
+      "autoCompactBuffer": "自动压缩缓冲区",
+      "freeSpace": "空闲空间"
+    },
+    "sections": {
+      "mcpTools": "MCP 工具 ({{count}})",
+      "agents": "智能体 ({{count}})",
+      "memoryFiles": "记忆文件 ({{count}})",
+      "skills": "Skills ({{included}}/{{total}})"
+    },
+    "table": {
+      "tool": "工具",
+      "server": "服务器",
+      "tokens": "令牌",
+      "agent": "智能体",
+      "source": "来源",
+      "type": "类型",
+      "path": "路径",
+      "skill": "Skill"
+    }
+  },
   "rewind": {
     "title": "回溯文件到之前的状态",
     "tooltip": "回溯",


### PR DESCRIPTION
Add a slash command that displays the Claude context window breakdown as a
colored token-grid dialog. The feature is driven by the SDK's
getContextUsage() control request and works with historical sessions without
requiring a message to be sent first.

Node.js bridge:
- Add getContextUsagePersistent() to persistent-query-service – reuses or
  acquires a persistent runtime, syncs the model via setModel, and calls
  getContextUsage on the SDK runtime
- Handle [1m] suffix properly: temporarily clear/reset
  CLAUDE_CODE_DISABLE_1M_CONTEXT so the SDK returns the correct limit for
  each model variant; recreate the runtime when the suffix state changes
  since setModel alone can't switch context-window limits
- Track both modelId (original, may carry [1m]) and resolvedModelId
  throughout the request lifecycle, stash them on the runtime object
- Route getContextUsage command through claude-channel → daemon →
  persistent function
- Set ANTHROPIC_MODEL env var during model resolution so the SDK sees it
- Export applyDynamicControls from runtime-lifecycle for future use

Java plugin:
- New ContextHandler: parses get_context_usage events, delegates to
  ClaudeSDKBridge.getContextUsage(), routes JSON results or errors to the
  frontend via showContextUsageDialog / onContextUsageError callbacks
- ClaudeSDKBridge.getContextUsage(): sends a daemon command with 180s
  timeout, collects the JSON response via DaemonOutputCallback
- Extend prewarmDaemonAsync to accept a sessionId so the bridge can
  pre-warm runtimes for historical sessions (avoids cold start on /context)
- Register /context as a builtin slash command, wire ContextHandler in the
  message dispatcher
- Unit tests for ContextHandler.parseContextUsageRequest edge cases

Frontend:
- ContextUsageDialog component: modal with accessible semantics, colored
  token-grid, category legend, expandable detail tables for MCP tools,
  agents, memory files, and skills
- Dialog state management with requestId-based isolation to reject stale
  async responses
- Window callbacks: showContextUsageDialog (JSON→UI) and onContextUsageError
- /context in ChatInputBox sends a get_context_usage event with the current
  model, [1m] suffix when long-context is enabled, and a unique requestId
- Remove /context from HIDDEN_COMMANDS so it's offered by the slash-command
  autocomplete
- i18n strings in en.json and zh.json for all dialog labels
- Tests: ContextUsageDialog rendering, useDialogManagement requestId
  isolation, useMessageSender /context message payload

<img width="636" height="349" alt="image" src="https://github.com/user-attachments/assets/793097a5-60db-4bf3-9a2e-fd361c7d3b70" />

<img width="579" height="591" alt="image" src="https://github.com/user-attachments/assets/ac1fcf61-6cae-4bd4-a274-09cbe258dc1b" />
