### PR TITLE
Historical record recovery

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto eol=lf
+
+*.bat text eol=crlf
+*.cmd text eol=crlf

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -378,6 +378,7 @@ async function sendInternal(params, withAttachments) {
   const turnMeta = { state: null };
   let runtime = null;
   let requestContext = null;
+  const sendStartTime = Date.now();
   try {
     requestContext = await buildRequestContext(safeParams, withAttachments);
     runtime = await acquireRuntime(requestContext, { registerActiveQueryResult, removeSession });
@@ -385,14 +386,28 @@ async function sendInternal(params, withAttachments) {
   } catch (error) {
     // Only clear if this runtime still owns the pointer (not cleared by abort)
     clearActiveTurnRuntimeIf(runtime);
+
+    const elapsedMs = Date.now() - sendStartTime;
+
+    const wasAborted = runtime?.abortRequested === true && error?.runtimeTerminated;
+
     if (turnMeta.state?.streamingEnabled && turnMeta.state?.streamStarted && !turnMeta.state?.streamEnded) {
-      // NOTE: Do NOT emit accumulatedUsage at stream end, even on error.
-      // If an assistant message was received, emitUsageTag already sent the correct usage.
-      // If no assistant message was received, the usage would be incomplete anyway.
       process.stdout.write('[STREAM_END]\n');
       turnMeta.state.streamEnded = true;
     }
-    emitSendError(runtime, error, requestContext);
+
+    if (wasAborted) {
+      // Graceful abort — output a clean result instead of SEND_ERROR so Java side
+      // does not show an error toast. Also emit elapsed time like Codex does.
+      console.log(JSON.stringify({
+        success: false,
+        error: 'User interrupted',
+        elapsedMs
+      }));
+    } else {
+      emitSendError(runtime, error, requestContext);
+    }
+
     // Only dispose if not already disposed by abort
     if (runtime && !runtime.closed && error?.runtimeTerminated) {
       await disposeRuntime(runtime, { removeSession });
@@ -438,6 +453,7 @@ export async function abortCurrentTurn() {
   const runtime = getActiveTurnRuntime();
   if (!runtime) return;
   console.log('[LIFECYCLE] abortCurrentTurn epoch=' + (runtime.runtimeSessionEpoch || '(none)'));
+  runtime.abortRequested = true;
   clearActiveTurnRuntime();
 
   try {

--- a/ai-bridge/services/claude/persistent-query-service.test.js
+++ b/ai-bridge/services/claude/persistent-query-service.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { __testing } from './persistent-query-service.js';
+
+test('abortCurrentTurn marks runtime as user-aborted before disposing it', async () => {
+  let disposed = false;
+  const runtime = {
+    closed: false,
+    sessionId: null,
+    runtimeSessionEpoch: 'epoch-test',
+    activeTurnCount: 1,
+    inputStream: {
+      done() {
+        disposed = true;
+      },
+    },
+    query: {
+      close() {},
+    },
+  };
+
+  __testing.setActiveTurnRuntime(runtime);
+
+  await __testing.abortCurrentTurn();
+
+  assert.equal(runtime.abortRequested, true);
+  assert.equal(runtime.closed, true);
+  assert.equal(disposed, true);
+});

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ checkstyle {
 }
 
 group = 'com.github.idea-claude-code-gui'
-version = '0.4.2'
+version = '0.4.3-Alpha4'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17
@@ -273,6 +273,7 @@ def aiBridgeHashFile = new File(aiBridgePackDir, 'ai-bridge.hash')
 def webviewDir = file('webview')
 def requestedTasks = gradle.startParameter.taskNames.collect { it.toLowerCase() }
 def enableVConsoleInWebview = requestedTasks.any { it.contains('runide') }
+def skipWebviewBuild = (project.findProperty('skipWebview') ?: 'false').toString().toBoolean()
 
 // Get custom Node.js path from local properties
 def localNodePath = getLocalProperty('node.path')
@@ -332,7 +333,10 @@ tasks.register('buildWebview', Exec) {
         commandLine npmCommand, 'run', 'build'
     }
 
-    onlyIf { webviewDir.exists() }
+    onlyIf { webviewDir.exists() && !skipWebviewBuild }
+    if (skipWebviewBuild) {
+        println "Skipping webview build because -PskipWebview=true"
+    }
     doFirst { println "Building webview..." }
     doLast { println "Webview build completed." }
 }
@@ -354,12 +358,19 @@ tasks.register('packageAiBridge', Exec) {
     // Switch to ai-bridge directory for packaging, avoiding inclusion of top-level directory
     workingDir aiBridgeDir
 
-    // Ensure output directory exists
+    // Ensure output directory exists and dependencies are installed
     doFirst {
         aiBridgePackDir.mkdirs()
         // Delete old zip file
         if (aiBridgeArchive.exists()) {
             aiBridgeArchive.delete()
+        }
+        // Install npm dependencies if node_modules doesn't exist
+        if (!new File(aiBridgeDir, 'node_modules').exists()) {
+            println 'Installing ai-bridge npm dependencies...'
+            String npmCmd = System.getProperty('os.name').toLowerCase().contains('windows') ? 'npm.cmd' : 'npm'
+            exec { commandLine npmCmd, 'install', '--silent', '--loglevel=error'; workingDir = aiBridgeDir }
+            println 'ai-bridge npm dependencies installed.'
         }
     }
 

--- a/src/main/java/com/github/claudecodegui/handler/CodexMessageConverter.java
+++ b/src/main/java/com/github/claudecodegui/handler/CodexMessageConverter.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.github.claudecodegui.util.UserMessageSanitizer;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -41,8 +42,6 @@ public class CodexMessageConverter {
     private static final Pattern WRITE_CMD_PATTERN = Pattern.compile(
         "cat\\s*>\\s*([^\\s;|&]+)|tee\\s+(?:-[a-zA-Z]+\\s+)*([^\\s;|&]+)|(?:echo|printf)\\s+[^>]*>\\s*([^\\s;|&]+)"
     );
-
-    private static final String[] SYSTEM_TAG_NAMES = {"agents-instructions", "system-reminder", "system-prompt"};
 
     private CodexMessageConverter() {
         // Utility class, no instantiation.
@@ -317,30 +316,7 @@ public class CodexMessageConverter {
      * These blocks are useful model context, but should not be rendered as user history.
      */
     public static String stripSystemTags(String text) {
-        if (text == null || text.isEmpty()) {
-            return text;
-        }
-        String result = text;
-        for (String tag : SYSTEM_TAG_NAMES) {
-            result = removeTagBlocks(result, tag);
-        }
-        return result.trim();
-    }
-
-    private static String removeTagBlocks(String text, String tagName) {
-        String result = text;
-        String openTag = "<" + tagName + ">";
-        String closeTag = "</" + tagName + ">";
-        int start = result.indexOf(openTag);
-        while (start >= 0) {
-            int end = result.indexOf(closeTag, start);
-            if (end < 0) {
-                break;
-            }
-            result = result.substring(0, start) + result.substring(end + closeTag.length());
-            start = result.indexOf(openTag);
-        }
-        return result;
+        return UserMessageSanitizer.sanitizeUserFacingText(text);
     }
 
     private static JsonArray textContentBlocks(String text) {

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryHandler.java
@@ -29,7 +29,7 @@ public class HistoryHandler extends BaseMessageHandler {
 
     // Session load callback interface
     public interface SessionLoadCallback {
-        void onLoadSession(String sessionId, String projectPath);
+        void onLoadSession(String sessionId, String projectPath, String provider);
     }
 
     private SessionLoadCallback sessionLoadCallback;

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
@@ -70,7 +70,7 @@ public class HistoryMessageInjector {
         } else {
             // Claude session: use existing callback mechanism
             if (sessionLoadCallback != null) {
-                sessionLoadCallback.onLoadSession(sessionId, projectPath);
+                sessionLoadCallback.onLoadSession(resolvedSessionId, projectPath, provider);
             } else {
                 LOG.warn("[HistoryHandler] WARNING: No session load callback set");
             }
@@ -159,11 +159,6 @@ public class HistoryMessageInjector {
         }
 
         return new String[]{actualThreadId, cwd};
-        if (sessionLoadCallback != null) {
-            sessionLoadCallback.onLoadSession(resolvedSessionId, projectPath, provider);
-        } else {
-            LOG.warn("[HistoryHandler] WARNING: No session load callback set");
-        }
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
@@ -6,13 +6,17 @@ import com.github.claudecodegui.provider.codex.CodexHistoryReader;
 import com.github.claudecodegui.session.ClaudeSession;
 import com.github.claudecodegui.session.SessionState;
 import com.github.claudecodegui.util.JsUtils;
-import com.google.gson.Gson;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -35,12 +39,30 @@ public class HistoryMessageInjector {
      * Load a history session.
      */
     void handleLoadSession(String sessionId, String currentProvider, HistoryHandler.SessionLoadCallback sessionLoadCallback) {
+        String provider = currentProvider;
+        String resolvedSessionId = sessionId;
+
+        try {
+            JsonObject payload = new Gson().fromJson(sessionId, JsonObject.class);
+            if (payload != null) {
+                if (payload.has("sessionId") && !payload.get("sessionId").isJsonNull()) {
+                    resolvedSessionId = payload.get("sessionId").getAsString();
+                }
+                if (payload.has("provider") && !payload.get("provider").isJsonNull()) {
+                    provider = payload.get("provider").getAsString();
+                }
+            }
+        } catch (Exception ignored) {
+            // Backward compatible: legacy payload is the raw sessionId string.
+        }
+
         String projectPath = context.getProject().getBasePath();
         if (projectPath == null) {
             LOG.warn("[HistoryHandler] Project base path is null");
             return;
         }
-        LOG.info("[HistoryHandler] Loading history session: " + sessionId + " from project: " + projectPath + ", provider: " + currentProvider);
+        LOG.info("[HistoryHandler] Loading history session: " + resolvedSessionId
+                + " from project: " + projectPath + ", provider: " + provider);
 
         if ("codex".equals(currentProvider)) {
             // Codex session: read session info and restore session state
@@ -137,6 +159,11 @@ public class HistoryMessageInjector {
         }
 
         return new String[]{actualThreadId, cwd};
+        if (sessionLoadCallback != null) {
+            sessionLoadCallback.onLoadSession(resolvedSessionId, projectPath, provider);
+        } else {
+            LOG.warn("[HistoryHandler] WARNING: No session load callback set");
+        }
     }
 
     /**
@@ -336,13 +363,22 @@ public class HistoryMessageInjector {
         if (!payload.has("type") || !"user_message".equals(payload.get("type").getAsString())) {
             return null;
         }
+        boolean hasLocalImages = hasLocalImages(payload);
         if (!payload.has("message") || payload.get("message").isJsonNull()) {
-            return null;
+            if (!hasLocalImages) {
+                return null;
+            }
         }
 
-        String content = CodexMessageConverter.stripSystemTags(payload.get("message").getAsString());
-        if (content == null || content.isBlank()) {
+        String content = "";
+        if (payload.has("message") && !payload.get("message").isJsonNull()) {
+            content = CodexMessageConverter.stripSystemTags(payload.get("message").getAsString());
+        }
+        if ((content == null || content.isBlank()) && !hasLocalImages) {
             return null;
+        }
+        if (content == null) {
+            content = "";
         }
 
         JsonObject frontendMsg = new JsonObject();
@@ -351,11 +387,7 @@ public class HistoryMessageInjector {
 
         // Build raw structure compatible with MessageParser
         JsonObject rawObj = new JsonObject();
-        JsonArray contentBlocks = new JsonArray();
-        JsonObject textBlock = new JsonObject();
-        textBlock.addProperty("type", "text");
-        textBlock.addProperty("text", content);
-        contentBlocks.add(textBlock);
+        JsonArray contentBlocks = buildUserMessageContentBlocks(payload, content);
         rawObj.add("content", contentBlocks);
         rawObj.addProperty("role", "user");
         frontendMsg.add("raw", rawObj);
@@ -365,6 +397,99 @@ public class HistoryMessageInjector {
         }
 
         return frontendMsg;
+    }
+
+    private static JsonArray buildUserMessageContentBlocks(JsonObject payload, String content) {
+        JsonArray contentBlocks = new JsonArray();
+        appendLocalImageBlocks(payload, contentBlocks);
+
+        if (content != null && !content.isBlank()) {
+            JsonObject textBlock = new JsonObject();
+            textBlock.addProperty("type", "text");
+            textBlock.addProperty("text", content);
+            contentBlocks.add(textBlock);
+        }
+        return contentBlocks;
+    }
+
+    private static boolean hasLocalImages(JsonObject payload) {
+        return payload.has("local_images")
+            && payload.get("local_images").isJsonArray()
+            && payload.getAsJsonArray("local_images").size() > 0;
+    }
+
+    private static void appendLocalImageBlocks(JsonObject payload, JsonArray contentBlocks) {
+        if (!payload.has("local_images") || !payload.get("local_images").isJsonArray()) {
+            return;
+        }
+
+        JsonArray localImages = payload.getAsJsonArray("local_images");
+        for (JsonElement imageElement : localImages) {
+            if (!imageElement.isJsonPrimitive()) {
+                continue;
+            }
+            String imagePath = imageElement.getAsString();
+            JsonObject imageBlock = createLocalImageBlock(imagePath);
+            if (imageBlock != null) {
+                contentBlocks.add(imageBlock);
+            }
+        }
+    }
+
+    private static JsonObject createLocalImageBlock(String imagePath) {
+        if (imagePath == null || imagePath.trim().isEmpty()) {
+            return null;
+        }
+
+        try {
+            Path path = Path.of(imagePath);
+            if (!Files.isRegularFile(path)) {
+                LOG.debug("[HistoryMessageInjector] Skip missing local image: " + imagePath);
+                return null;
+            }
+
+            String mediaType = Files.probeContentType(path);
+            if (mediaType == null || mediaType.isBlank()) {
+                mediaType = guessImageMediaType(path);
+            }
+            if (mediaType == null || mediaType.isBlank()) {
+                mediaType = "image/png";
+            }
+
+            String base64Data = Base64.getEncoder().encodeToString(Files.readAllBytes(path));
+            JsonObject imageBlock = new JsonObject();
+            imageBlock.addProperty("type", "image");
+            imageBlock.addProperty("src", "data:" + mediaType + ";base64," + base64Data);
+            imageBlock.addProperty("mediaType", mediaType);
+            imageBlock.addProperty("alt", path.getFileName() != null ? path.getFileName().toString() : "image");
+            return imageBlock;
+        } catch (Exception e) {
+            LOG.warn("[HistoryMessageInjector] Failed to restore local image from Codex history: " + imagePath, e);
+            return null;
+        }
+    }
+
+    private static String guessImageMediaType(Path path) {
+        String fileName = path.getFileName() != null ? path.getFileName().toString().toLowerCase() : "";
+        if (fileName.endsWith(".png")) {
+            return "image/png";
+        }
+        if (fileName.endsWith(".jpg") || fileName.endsWith(".jpeg")) {
+            return "image/jpeg";
+        }
+        if (fileName.endsWith(".gif")) {
+            return "image/gif";
+        }
+        if (fileName.endsWith(".webp")) {
+            return "image/webp";
+        }
+        if (fileName.endsWith(".bmp")) {
+            return "image/bmp";
+        }
+        if (fileName.endsWith(".svg")) {
+            return "image/svg+xml";
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeDaemonRequestExecutor.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeDaemonRequestExecutor.java
@@ -58,6 +58,8 @@ class ClaudeDaemonRequestExecutor {
             StringBuilder assistantContent = new StringBuilder();
             AtomicBoolean hadSendError = new AtomicBoolean(false);
             AtomicReference<String> lastNodeError = new AtomicReference<>(null);
+            AtomicBoolean wasAborted = new AtomicBoolean(false);
+            long startTime = System.currentTimeMillis();
 
             try {
                 JsonObject params = requestParamsBuilder.buildSendParams(
@@ -101,7 +103,8 @@ class ClaudeDaemonRequestExecutor {
                                         result,
                                         assistantContent,
                                         hadSendError,
-                                        lastNodeError
+                                        lastNodeError,
+                                        wasAborted
                                 );
                             }
 
@@ -114,7 +117,8 @@ class ClaudeDaemonRequestExecutor {
                                             result,
                                             assistantContent,
                                             hadSendError,
-                                            lastNodeError
+                                            lastNodeError,
+                                            wasAborted
                                     );
                                     return;
                                 }
@@ -127,6 +131,11 @@ class ClaudeDaemonRequestExecutor {
                                     result.success = false;
                                     result.error = error;
                                 }
+                            }
+
+                            @Override
+                            public void onAbort() {
+                                wasAborted.set(true);
                             }
 
                             @Override
@@ -162,6 +171,15 @@ class ClaudeDaemonRequestExecutor {
                     result.success = success != null && success;
                     if (result.success) {
                         callback.onComplete(result);
+                    } else if (wasAborted.get()) {
+                        // User manually aborted — treat as graceful completion, not an error.
+                        // This matches how Codex handles interruptions (callback.onComplete with
+                        // success=false instead of callback.onError), so the UI does not show
+                        // an error message or toast notification.
+                        long elapsed = System.currentTimeMillis() - startTime;
+                        log.info("[DaemonExecutor] Request was aborted by user (elapsed: " + elapsed + "ms)");
+                        result.error = "User interrupted";
+                        callback.onComplete(result);
                     } else {
                         String errorMsg = "Daemon command failed";
                         String nodeErr = lastNodeError.get();
@@ -177,7 +195,16 @@ class ClaudeDaemonRequestExecutor {
 
                 return result;
             } catch (Exception e) {
-                if (!hadSendError.get()) {
+                long elapsed = System.currentTimeMillis() - startTime;
+                if (wasAborted.get()) {
+                    // Abort arrived but future was already completed exceptionally by the
+                    // daemon's error output before sendAbort() could complete it normally.
+                    // Treat as graceful interruption, same as the wasAborted branch above.
+                    log.info("[DaemonExecutor] Request was aborted by user (caught exception, elapsed: " + elapsed + "ms)");
+                    result.success = false;
+                    result.error = "User interrupted";
+                    callback.onComplete(result);
+                } else if (!hadSendError.get()) {
                     result.success = false;
                     result.error = "Daemon request failed: " + outputExtractor.extractErrorMessage(e);
                     callback.onError(result.error);

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeProcessInvoker.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeProcessInvoker.java
@@ -84,6 +84,7 @@ class ClaudeProcessInvoker {
             StringBuilder assistantContent = new StringBuilder();
             AtomicBoolean hadSendError = new AtomicBoolean(false);
             AtomicReference<String> lastNodeError = new AtomicReference<>(null);
+            long startTime = System.currentTimeMillis();
 
             try {
                 String node = nodeDetector.findNodeExecutable();
@@ -169,6 +170,9 @@ class ClaudeProcessInvoker {
                     result.messageCount = result.messages.size();
 
                     if (wasInterrupted) {
+                        long elapsed = System.currentTimeMillis() - startTime;
+                        log.info("[ProcessInvoker] Request was interrupted by user (elapsed: " + elapsed + "ms)");
+                        result.error = "User interrupted";
                         callback.onComplete(result);
                     } else if (!hadSendError.get()) {
                         result.success = exitCode == 0;

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSessionQueryService.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSessionQueryService.java
@@ -2,18 +2,25 @@ package com.github.claudecodegui.provider.claude;
 
 import com.github.claudecodegui.bridge.EnvironmentConfigurator;
 import com.github.claudecodegui.bridge.NodeDetector;
+import com.github.claudecodegui.util.UserMessageSanitizer;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.function.Supplier;
 
 /**
@@ -23,7 +30,10 @@ class ClaudeSessionQueryService {
 
     private static final String CHANNEL_SCRIPT = "channel-manager.js";
     private static final int PROCESS_TIMEOUT_SECONDS = 30;
-    private static final java.util.regex.Pattern VALID_SESSION_ID = java.util.regex.Pattern.compile("[a-zA-Z0-9_\\-]+");
+    private static final Pattern VALID_SESSION_ID = Pattern.compile("[a-zA-Z0-9_\\-]+");
+    private static final Pattern IMAGE_REFERENCE_PATTERN = Pattern.compile("(?m)^\\[Image #\\d+:\\s*(.+?)\\]\\s*$");
+    private static final String IMAGE_ATTACHMENT_HINT =
+            "The user has attached the image(s) above. Please use the Read tool to view them.";
 
     private final Logger log;
     private final Gson gson;
@@ -57,7 +67,7 @@ class ClaudeSessionQueryService {
                 if (jsonResult.has("messages")) {
                     JsonArray messagesArray = jsonResult.getAsJsonArray("messages");
                     for (var msg : messagesArray) {
-                        messages.add(msg.getAsJsonObject());
+                        messages.add(normalizeClaudeHistoryMessage(msg.getAsJsonObject()));
                     }
                 }
                 return messages;
@@ -80,7 +90,7 @@ class ClaudeSessionQueryService {
 
             if (jsonResult.has("success") && jsonResult.get("success").getAsBoolean()) {
                 if (jsonResult.has("message") && jsonResult.get("message").isJsonObject()) {
-                    return jsonResult.getAsJsonObject("message");
+                    return normalizeClaudeHistoryMessage(jsonResult.getAsJsonObject("message"));
                 }
                 return null;
             }
@@ -159,5 +169,219 @@ class ClaudeSessionQueryService {
         log.debug("[" + logPrefix + "] JSON parsed successfully, success="
                 + (jsonResult.has("success") ? jsonResult.get("success").getAsBoolean() : "null"));
         return jsonResult;
+    }
+
+    static JsonObject normalizeClaudeHistoryMessage(JsonObject originalMessage) {
+        if (originalMessage == null
+                || !originalMessage.has("type")
+                || !"user".equals(originalMessage.get("type").getAsString())
+                || !originalMessage.has("message")
+                || !originalMessage.get("message").isJsonObject()) {
+            return originalMessage;
+        }
+
+        JsonObject message = originalMessage.getAsJsonObject("message");
+        if (!message.has("content") || message.get("content").isJsonNull()) {
+            return originalMessage;
+        }
+
+        JsonElement contentElement = message.get("content");
+        if (contentElement.isJsonPrimitive() && contentElement.getAsJsonPrimitive().isString()) {
+            ClaudeImageReferenceRewrite rewrite = rewriteClaudeImageReferenceText(contentElement.getAsString());
+            if (!rewrite.changed) {
+                return originalMessage;
+            }
+
+            JsonObject normalizedMessage = originalMessage.deepCopy();
+            normalizedMessage.getAsJsonObject("message").add("content", rewrite.contentBlocks);
+            return normalizedMessage;
+        }
+
+        if (!contentElement.isJsonArray()) {
+            return originalMessage;
+        }
+
+        JsonArray originalBlocks = contentElement.getAsJsonArray();
+        JsonArray rebuiltBlocks = new JsonArray();
+        boolean changed = false;
+
+        for (JsonElement blockElement : originalBlocks) {
+            if (!blockElement.isJsonObject()) {
+                rebuiltBlocks.add(blockElement.deepCopy());
+                continue;
+            }
+
+            JsonObject block = blockElement.getAsJsonObject();
+            if (!isTextBlock(block)) {
+                rebuiltBlocks.add(block.deepCopy());
+                continue;
+            }
+
+            ClaudeImageReferenceRewrite rewrite = rewriteClaudeImageReferenceText(block.get("text").getAsString());
+            if (!rewrite.changed) {
+                rebuiltBlocks.add(block.deepCopy());
+                continue;
+            }
+
+            changed = true;
+            for (JsonElement normalizedBlock : rewrite.contentBlocks) {
+                rebuiltBlocks.add(normalizedBlock);
+            }
+        }
+
+        if (!changed) {
+            return originalMessage;
+        }
+
+        JsonObject normalizedMessage = originalMessage.deepCopy();
+        normalizedMessage.getAsJsonObject("message").add("content", rebuiltBlocks);
+        return normalizedMessage;
+    }
+
+    private static boolean isTextBlock(JsonObject block) {
+        return block.has("type")
+                && "text".equals(block.get("type").getAsString())
+                && block.has("text")
+                && !block.get("text").isJsonNull();
+    }
+
+    private static ClaudeImageReferenceRewrite rewriteClaudeImageReferenceText(String text) {
+        if (text == null) {
+            return ClaudeImageReferenceRewrite.unchanged(null);
+        }
+
+        Matcher matcher = IMAGE_REFERENCE_PATTERN.matcher(text);
+        StringBuilder remainingText = new StringBuilder();
+        JsonArray contentBlocks = new JsonArray();
+        int lastEnd = 0;
+        boolean sawReference = false;
+        boolean restoredImage = false;
+
+        while (matcher.find()) {
+            remainingText.append(text, lastEnd, matcher.start());
+            lastEnd = matcher.end();
+            sawReference = true;
+
+            String imagePath = matcher.group(1) != null ? matcher.group(1).trim() : "";
+            JsonObject imageBlock = createLocalImageBlock(imagePath);
+            if (imageBlock != null) {
+                contentBlocks.add(imageBlock);
+                restoredImage = true;
+            } else {
+                remainingText.append(matcher.group());
+            }
+        }
+
+        if (!sawReference || !restoredImage) {
+            String sanitized = normalizeRemainingText(text);
+            if (sanitized.equals(text)) {
+                return ClaudeImageReferenceRewrite.unchanged(text);
+            }
+            appendTextBlock(contentBlocks, sanitized);
+            return new ClaudeImageReferenceRewrite(true, contentBlocks);
+        }
+
+        remainingText.append(text.substring(lastEnd));
+        String cleanedText = normalizeRemainingText(remainingText.toString());
+        appendTextBlock(contentBlocks, cleanedText);
+        return new ClaudeImageReferenceRewrite(true, contentBlocks);
+    }
+
+    private static String normalizeRemainingText(String text) {
+        if (text == null) {
+            return "";
+        }
+        String normalized = text.replace("\r\n", "\n");
+        normalized = normalized.replace("\r", "\n");
+        normalized = normalized.replace(IMAGE_ATTACHMENT_HINT, "");
+        normalized = UserMessageSanitizer.sanitizeUserFacingText(normalized);
+        normalized = normalized.replaceAll("(?m)^[ \\t]+$", "");
+        normalized = normalized.replaceAll("\n{3,}", "\n\n");
+        normalized = normalized.replaceAll("^(?:\\s*\\n)+", "");
+        normalized = normalized.replaceAll("(?:\\n\\s*)+$", "");
+        return normalized.trim();
+    }
+
+    private static void appendTextBlock(JsonArray contentBlocks, String text) {
+        if (text == null || text.isBlank()) {
+            return;
+        }
+        JsonObject textBlock = new JsonObject();
+        textBlock.addProperty("type", "text");
+        textBlock.addProperty("text", text);
+        contentBlocks.add(textBlock);
+    }
+
+    private static JsonObject createLocalImageBlock(String imagePath) {
+        if (imagePath == null || imagePath.isBlank()) {
+            return null;
+        }
+
+        try {
+            Path path = Path.of(imagePath);
+            if (!Files.isRegularFile(path)) {
+                return null;
+            }
+
+            String mediaType = Files.probeContentType(path);
+            if (mediaType == null || mediaType.isBlank()) {
+                mediaType = guessImageMediaType(path);
+            }
+            if (mediaType == null || mediaType.isBlank()) {
+                mediaType = "image/png";
+            }
+
+            String base64Data = Base64.getEncoder().encodeToString(Files.readAllBytes(path));
+            JsonObject imageBlock = new JsonObject();
+            imageBlock.addProperty("type", "image");
+            imageBlock.addProperty("src", "data:" + mediaType + ";base64," + base64Data);
+            imageBlock.addProperty("mediaType", mediaType);
+            imageBlock.addProperty("alt", path.getFileName() != null ? path.getFileName().toString() : "image");
+            return imageBlock;
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private static String guessImageMediaType(Path path) {
+        String fileName = path.getFileName() != null ? path.getFileName().toString().toLowerCase() : "";
+        if (fileName.endsWith(".png")) {
+            return "image/png";
+        }
+        if (fileName.endsWith(".jpg") || fileName.endsWith(".jpeg")) {
+            return "image/jpeg";
+        }
+        if (fileName.endsWith(".gif")) {
+            return "image/gif";
+        }
+        if (fileName.endsWith(".webp")) {
+            return "image/webp";
+        }
+        if (fileName.endsWith(".bmp")) {
+            return "image/bmp";
+        }
+        if (fileName.endsWith(".svg")) {
+            return "image/svg+xml";
+        }
+        return null;
+    }
+
+    private static final class ClaudeImageReferenceRewrite {
+        private final boolean changed;
+        private final JsonArray contentBlocks;
+
+        private ClaudeImageReferenceRewrite(boolean changed, JsonArray contentBlocks) {
+            this.changed = changed;
+            this.contentBlocks = contentBlocks;
+        }
+
+        private static ClaudeImageReferenceRewrite unchanged(String originalText) {
+            JsonArray contentBlocks = new JsonArray();
+            JsonObject textBlock = new JsonObject();
+            textBlock.addProperty("type", "text");
+            textBlock.addProperty("text", originalText != null ? originalText : "");
+            contentBlocks.add(textBlock);
+            return new ClaudeImageReferenceRewrite(false, contentBlocks);
+        }
     }
 }

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeStreamAdapter.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeStreamAdapter.java
@@ -27,6 +27,18 @@ class ClaudeStreamAdapter {
             AtomicBoolean hadSendError,
             AtomicReference<String> lastNodeError
     ) {
+        processOutputLine(line, callback, result, assistantContent, hadSendError, lastNodeError, new AtomicBoolean(false));
+    }
+
+    void processOutputLine(
+            String line,
+            MessageCallback callback,
+            SDKResult result,
+            StringBuilder assistantContent,
+            AtomicBoolean hadSendError,
+            AtomicReference<String> lastNodeError,
+            AtomicBoolean wasAborted
+    ) {
         if (line.startsWith("[STDIN_ERROR]")
                 || line.startsWith("[STDIN_PARSE_ERROR]")
                 || line.startsWith("[GET_SESSION_ERROR]")
@@ -47,6 +59,12 @@ class ClaudeStreamAdapter {
         }
 
         if (line.startsWith("[SEND_ERROR]")) {
+            // If the request was aborted by the user, suppress the SEND_ERROR
+            // so the UI does not show an error toast. The abort path in
+            // ClaudeDaemonRequestExecutor handles completion gracefully.
+            if (wasAborted.get()) {
+                return;
+            }
             String jsonStr = line.substring("[SEND_ERROR]".length()).trim();
             String errorMessage = jsonStr;
             try {

--- a/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
@@ -278,10 +278,12 @@ public class DaemonBridge {
             LOG.debug("[DaemonBridge] Error sending abort command: " + e.getMessage());
         }
 
-        // Complete all pending request futures so Java-side callers unblock
+        // Complete all pending request futures so Java-side callers unblock.
+        // Use onComplete(false) instead of onError() so that user-initiated aborts
+        // are treated as a normal (unsuccessful) completion rather than an error,
+        // matching the graceful handling that Codex uses.
         for (Map.Entry<String, RequestHandler> entry : pendingRequests.entrySet()) {
-            entry.getValue().onError("Request aborted by user");
-            entry.getValue().future.complete(false);
+            entry.getValue().onAbort();
         }
         pendingRequests.clear();
         activeRequestCount.set(0);
@@ -704,6 +706,16 @@ public class DaemonBridge {
         void onStderr(String text);
         void onError(String error);
         void onComplete(boolean success);
+
+        /**
+         * Called when the user manually aborts the request.
+         * Default implementation delegates to {@link #onComplete(boolean) onComplete(false)}
+         * so that aborts are treated as a graceful (unsuccessful) completion,
+         * not an error.
+         */
+        default void onAbort() {
+            onComplete(false);
+        }
     }
 
     /**
@@ -736,6 +748,17 @@ public class DaemonBridge {
         void onError(String error) {
             callback.onError(error);
             future.completeExceptionally(new RuntimeException(error));
+        }
+
+        /**
+         * Handle user-initiated abort gracefully.
+         * Unlike onError, this completes the future normally (with false) so callers
+         * do not see an exception. The DaemonOutputCallback.onAbort() method lets
+         * the downstream handler distinguish aborts from real errors.
+         */
+        void onAbort() {
+            callback.onAbort();
+            future.complete(false);
         }
 
         void onComplete(boolean success) {

--- a/src/main/java/com/github/claudecodegui/session/MessageParser.java
+++ b/src/main/java/com/github/claudecodegui/session/MessageParser.java
@@ -35,6 +35,9 @@ public class MessageParser {
                 if (hasToolResult(msg)) {
                     return new ClaudeSession.Message(ClaudeSession.Message.Type.USER, "[tool_result]", msg);
                 }
+                if (hasImageContent(msg)) {
+                    return new ClaudeSession.Message(ClaudeSession.Message.Type.USER, "", msg);
+                }
                 return null;
             }
             return new ClaudeSession.Message(ClaudeSession.Message.Type.USER, content, msg);
@@ -100,6 +103,14 @@ public class MessageParser {
      * Check whether the message contains a tool_result.
      */
     public boolean hasToolResult(JsonObject msg) {
+        return hasContentBlockType(msg, "tool_result");
+    }
+
+    public boolean hasImageContent(JsonObject msg) {
+        return hasContentBlockType(msg, "image");
+    }
+
+    private boolean hasContentBlockType(JsonObject msg, String blockType) {
         if (!msg.has("message") || !msg.get("message").isJsonObject()) {
             return false;
         }
@@ -114,7 +125,7 @@ public class MessageParser {
             JsonElement element = contentArray.get(i);
             if (element.isJsonObject()) {
                 JsonObject block = element.getAsJsonObject();
-                if (block.has("type") && "tool_result".equals(block.get("type").getAsString())) {
+                if (block.has("type") && blockType.equals(block.get("type").getAsString())) {
                     return true;
                 }
             }

--- a/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
@@ -154,6 +154,13 @@ public class SessionLifecycleManager {
      * Load a history session by ID.
      */
     public void loadHistorySession(String sessionId, String projectPath) {
+        loadHistorySession(sessionId, projectPath, null);
+    }
+
+    /**
+     * Load a history session by ID and provider.
+     */
+    public void loadHistorySession(String sessionId, String projectPath, String provider) {
         LOG.info("Loading history session: " + sessionId + " from project: " + projectPath);
 
         ClaudeSession oldSession = host.getSession();
@@ -196,10 +203,10 @@ public class SessionLifecycleManager {
             ClaudeSession newSession = new ClaudeSession(
                     host.getProject(), host.getClaudeSDKBridge(), host.getCodexSDKBridge());
             newSession.setPermissionMode(previousPermissionMode);
-            newSession.setProvider(previousProvider);
+            newSession.setProvider(provider != null && !provider.trim().isEmpty() ? provider : previousProvider);
             newSession.setModel(previousModel);
             LOG.info("Restored session state to loaded session: mode=" + previousPermissionMode
-                             + ", provider=" + previousProvider + ", model=" + previousModel);
+                             + ", provider=" + newSession.getProvider() + ", model=" + previousModel);
 
             host.setSession(newSession);
             host.getHandlerContext().setSession(newSession);

--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -295,8 +295,8 @@ public class ChatWindowDelegate {
         messageDispatcher.registerHandler(permissionHandler);
 
         HistoryHandler historyHandler = new HistoryHandler(handlerContext);
-        historyHandler.setSessionLoadCallback((sessionId, projectPath) ->
-            host.getSessionLifecycleManager().loadHistorySession(sessionId, projectPath));
+        historyHandler.setSessionLoadCallback((sessionId, projectPath, provider) ->
+            host.getSessionLifecycleManager().loadHistorySession(sessionId, projectPath, provider));
         host.setHistoryHandler(historyHandler);
         messageDispatcher.registerHandler(historyHandler);
 

--- a/src/main/java/com/github/claudecodegui/util/UserMessageSanitizer.java
+++ b/src/main/java/com/github/claudecodegui/util/UserMessageSanitizer.java
@@ -1,0 +1,86 @@
+package com.github.claudecodegui.util;
+
+/**
+ * Strips internal prompt/context additions from user-facing transcript text.
+ * These sections are useful when sending to providers, but should not be
+ * rendered back to users in history replay or tab restore flows.
+ */
+public final class UserMessageSanitizer {
+
+    private static final String[] SYSTEM_TAG_NAMES = {"agents-instructions", "system-reminder", "system-prompt"};
+
+    private static final String[] APPENDED_CONTEXT_MARKERS = {
+        "\n\n## Agent Role and Instructions\n\n",
+        "\n\n## Workspace Context\n\n",
+        "\n\n## Project Modules\n\nThis project contains multiple modules:\n",
+        "\n\n## Active Terminal Session\n\nThe user is working in the following terminal context:\n\n",
+        "\n\n## Referenced Files\n\nThe following files were referenced by the user:\n\n",
+        "\n\n## IDE Context\n\n",
+        "\n\n## User's Current IDE Context\n\nThe user is viewing this file in their IDE.",
+        "\n\n## User's Current IDE Context\n\nThe user is working in an IDE.",
+        "\n\n### Multi-Project Workspace Structure\n\n",
+        "\n\n### Project Module Structure\n\nThis project contains multiple modules:\n"
+    };
+
+    private UserMessageSanitizer() {
+    }
+
+    /**
+     * Removes system-only tags and appended prompt context from transcript text.
+     */
+    public static String sanitizeUserFacingText(String text) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+
+        String normalized = text.replace("\r\n", "\n").replace("\r", "\n");
+        String strippedTags = stripSystemTags(normalized);
+        String strippedContext = stripAppendedContext(strippedTags);
+        return strippedContext.trim();
+    }
+
+    private static String stripSystemTags(String text) {
+        String result = text;
+        for (String tag : SYSTEM_TAG_NAMES) {
+            result = removeTagBlocks(result, tag);
+        }
+        return result;
+    }
+
+    private static String removeTagBlocks(String text, String tagName) {
+        String result = text;
+        String openTag = "<" + tagName + ">";
+        String closeTag = "</" + tagName + ">";
+        int start = result.indexOf(openTag);
+        while (start >= 0) {
+            int end = result.indexOf(closeTag, start);
+            if (end < 0) {
+                break;
+            }
+            result = result.substring(0, start) + result.substring(end + closeTag.length());
+            start = result.indexOf(openTag);
+        }
+        return result;
+    }
+
+    private static String stripAppendedContext(String text) {
+        int cutIndex = -1;
+        for (String marker : APPENDED_CONTEXT_MARKERS) {
+            int idx = text.indexOf(marker);
+            if (idx <= 0) {
+                continue;
+            }
+            String prefix = text.substring(0, idx).trim();
+            if (prefix.isEmpty()) {
+                continue;
+            }
+            if (cutIndex == -1 || idx < cutIndex) {
+                cutIndex = idx;
+            }
+        }
+        if (cutIndex < 0) {
+            return text;
+        }
+        return text.substring(0, cutIndex);
+    }
+}

--- a/src/test/java/com/github/claudecodegui/handler/history/HistoryMessageInjectorTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/history/HistoryMessageInjectorTest.java
@@ -4,9 +4,13 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class HistoryMessageInjectorTest {
 
@@ -70,6 +74,69 @@ public class HistoryMessageInjectorTest {
                 .getAsString());
     }
 
+    @Test
+    public void convertCodexMessagesRestoresLocalImagesFromEventMessage() throws Exception {
+        Path imagePath = Files.createTempFile("codex-history-image", ".png");
+        try {
+            Files.write(imagePath, "png-bytes".getBytes(StandardCharsets.UTF_8));
+
+            JsonArray messages = new JsonArray();
+            messages.add(eventUserMessage("2026-05-11T09:02:20.861Z", "hello", imagePath.toString()));
+
+            List<JsonObject> result = HistoryMessageInjector.convertCodexMessagesToFrontendBatch(messages);
+
+            assertEquals(1, result.size());
+            JsonArray contentBlocks = result.get(0).getAsJsonObject("raw").getAsJsonArray("content");
+            assertEquals(2, contentBlocks.size());
+            assertEquals("image", contentBlocks.get(0).getAsJsonObject().get("type").getAsString());
+            assertEquals("image/png", contentBlocks.get(0).getAsJsonObject().get("mediaType").getAsString());
+            assertTrue(contentBlocks.get(0).getAsJsonObject().get("src").getAsString().startsWith("data:image/png;base64,"));
+            assertEquals("text", contentBlocks.get(1).getAsJsonObject().get("type").getAsString());
+            assertEquals("hello", contentBlocks.get(1).getAsJsonObject().get("text").getAsString());
+        } finally {
+            Files.deleteIfExists(imagePath);
+        }
+    }
+
+    @Test
+    public void convertCodexMessagesKeepsImageOnlyEventMessage() throws Exception {
+        Path imagePath = Files.createTempFile("codex-history-image-only", ".png");
+        try {
+            Files.write(imagePath, "png-bytes".getBytes(StandardCharsets.UTF_8));
+
+            JsonArray messages = new JsonArray();
+            messages.add(eventUserMessage("2026-05-11T09:03:20.861Z", "", imagePath.toString()));
+
+            List<JsonObject> result = HistoryMessageInjector.convertCodexMessagesToFrontendBatch(messages);
+
+            assertEquals(1, result.size());
+            assertEquals("", result.get(0).get("content").getAsString());
+            JsonArray contentBlocks = result.get(0).getAsJsonObject("raw").getAsJsonArray("content");
+            assertEquals(1, contentBlocks.size());
+            assertEquals("image", contentBlocks.get(0).getAsJsonObject().get("type").getAsString());
+            assertTrue(contentBlocks.get(0).getAsJsonObject().get("src").getAsString().startsWith("data:image/png;base64,"));
+        } finally {
+            Files.deleteIfExists(imagePath);
+        }
+    }
+
+    @Test
+    public void convertCodexMessagesStripsAppendedProjectModulesContext() {
+        JsonArray messages = new JsonArray();
+        messages.add(eventUserMessage(
+                "2026-05-11T09:03:20.861Z",
+                "只保留用户输入\n\n## Project Modules\n\nThis project contains multiple modules:\n- `idea-claude-code-gui`\n"
+        ));
+
+        List<JsonObject> result = HistoryMessageInjector.convertCodexMessagesToFrontendBatch(messages);
+
+        assertEquals(1, result.size());
+        assertEquals("只保留用户输入", result.get(0).get("content").getAsString());
+        JsonArray contentBlocks = result.get(0).getAsJsonObject("raw").getAsJsonArray("content");
+        assertEquals(1, contentBlocks.size());
+        assertEquals("只保留用户输入", contentBlocks.get(0).getAsJsonObject().get("text").getAsString());
+    }
+
     private static JsonObject responseItemUserMessage(String timestamp, String text) {
         JsonObject line = new JsonObject();
         line.addProperty("timestamp", timestamp);
@@ -99,6 +166,14 @@ public class HistoryMessageInjectorTest {
         payload.addProperty("type", "user_message");
         payload.addProperty("message", text);
         line.add("payload", payload);
+        return line;
+    }
+
+    private static JsonObject eventUserMessage(String timestamp, String text, String localImagePath) {
+        JsonObject line = eventUserMessage(timestamp, text);
+        JsonArray localImages = new JsonArray();
+        localImages.add(localImagePath);
+        line.getAsJsonObject("payload").add("local_images", localImages);
         return line;
     }
 }

--- a/src/test/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridgeRefactorTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridgeRefactorTest.java
@@ -1,6 +1,7 @@
 package com.github.claudecodegui.provider.claude;
 
 import com.github.claudecodegui.session.ClaudeSession;
+import com.github.claudecodegui.provider.common.DaemonBridge;
 import com.github.claudecodegui.provider.common.MessageCallback;
 import com.github.claudecodegui.provider.common.SDKResult;
 import com.google.gson.Gson;
@@ -9,6 +10,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -107,11 +109,12 @@ public class ClaudeSDKBridgeRefactorTest {
         StringBuilder assistantContent = new StringBuilder();
         AtomicBoolean hadSendError = new AtomicBoolean(false);
         AtomicReference<String> lastNodeError = new AtomicReference<>(null);
+        AtomicBoolean wasAborted = new AtomicBoolean(false);
 
-        adapter.processOutputLine("[MESSAGE] {\"type\":\"assistant\",\"content\":\"ignored\"}", callback, result, assistantContent, hadSendError, lastNodeError);
-        adapter.processOutputLine("[CONTENT_DELTA] \"Hello\\nWorld\"", callback, result, assistantContent, hadSendError, lastNodeError);
-        adapter.processOutputLine("[THINKING_DELTA] \"reasoning\"", callback, result, assistantContent, hadSendError, lastNodeError);
-        adapter.processOutputLine("[SESSION_ID] session-123", callback, result, assistantContent, hadSendError, lastNodeError);
+        adapter.processOutputLine("[MESSAGE] {\"type\":\"assistant\",\"content\":\"ignored\"}", callback, result, assistantContent, hadSendError, lastNodeError, wasAborted);
+        adapter.processOutputLine("[CONTENT_DELTA] \"Hello\\nWorld\"", callback, result, assistantContent, hadSendError, lastNodeError, wasAborted);
+        adapter.processOutputLine("[THINKING_DELTA] \"reasoning\"", callback, result, assistantContent, hadSendError, lastNodeError, wasAborted);
+        adapter.processOutputLine("[SESSION_ID] session-123", callback, result, assistantContent, hadSendError, lastNodeError, wasAborted);
 
         assertEquals(1, result.messages.size());
         assertEquals("assistant", callback.events.get(0).type);
@@ -133,14 +136,67 @@ public class ClaudeSDKBridgeRefactorTest {
         StringBuilder assistantContent = new StringBuilder();
         AtomicBoolean hadSendError = new AtomicBoolean(false);
         AtomicReference<String> lastNodeError = new AtomicReference<>(null);
+        AtomicBoolean wasAborted = new AtomicBoolean(false);
 
-        adapter.processOutputLine("[SEND_ERROR] {\"error\":\"boom\"}", callback, result, assistantContent, hadSendError, lastNodeError);
+        adapter.processOutputLine("[SEND_ERROR] {\"error\":\"boom\"}", callback, result, assistantContent, hadSendError, lastNodeError, wasAborted);
 
         assertTrue(hadSendError.get());
         assertFalse(result.success);
         assertEquals("boom", result.error);
         assertEquals(1, callback.errors.size());
         assertEquals("boom", callback.errors.get(0));
+    }
+
+    @Test
+    public void streamAdapterSuppressesSendErrorAfterUserAbort() {
+        ClaudeStreamAdapter adapter = new ClaudeStreamAdapter(new Gson());
+        RecordingCallback callback = new RecordingCallback();
+        SDKResult result = new SDKResult();
+        StringBuilder assistantContent = new StringBuilder();
+        AtomicBoolean hadSendError = new AtomicBoolean(false);
+        AtomicReference<String> lastNodeError = new AtomicReference<>(null);
+        AtomicBoolean wasAborted = new AtomicBoolean(true);
+
+        adapter.processOutputLine("[SEND_ERROR] {\"error\":\"Request aborted by user\"}", callback, result, assistantContent, hadSendError, lastNodeError, wasAborted);
+
+        assertFalse(hadSendError.get());
+        assertEquals(null, result.error);
+        assertTrue(callback.errors.isEmpty());
+    }
+
+    @Test
+    public void daemonExecutorCompletesGracefullyOnUserAbort() throws Exception {
+        Gson gson = new Gson();
+        ClaudeDaemonRequestExecutor executor = new ClaudeDaemonRequestExecutor(
+                com.intellij.openapi.diagnostic.Logger.getInstance(ClaudeDaemonRequestExecutor.class),
+                new ClaudeRequestParamsBuilder(gson),
+                new ClaudeStreamAdapter(gson),
+                new ClaudeJsonOutputExtractor()
+        );
+        RecordingCallback callback = new RecordingCallback();
+
+        SDKResult result = executor.sendMessageViaDaemon(
+                new AbortingDaemonBridge(),
+                "channel-1",
+                "hello",
+                null,
+                null,
+                "/workspace",
+                null,
+                "default",
+                "claude-sonnet-4-6",
+                null,
+                null,
+                Boolean.TRUE,
+                null,
+                null,
+                callback
+        ).get();
+
+        assertFalse(result.success);
+        assertEquals("User interrupted", result.error);
+        assertEquals(1, callback.completions.size());
+        assertTrue(callback.errors.isEmpty());
     }
 
     @Test
@@ -168,6 +224,7 @@ public class ClaudeSDKBridgeRefactorTest {
     private static class RecordingCallback implements MessageCallback {
         private final List<Event> events = new ArrayList<>();
         private final List<String> errors = new ArrayList<>();
+        private final List<SDKResult> completions = new ArrayList<>();
 
         @Override
         public void onMessage(String type, String content) {
@@ -181,6 +238,28 @@ public class ClaudeSDKBridgeRefactorTest {
 
         @Override
         public void onComplete(SDKResult result) {
+            completions.add(result);
+        }
+    }
+
+    private static class AbortingDaemonBridge extends DaemonBridge {
+        AbortingDaemonBridge() {
+            super(null, null, null);
+        }
+
+        @Override
+        public CompletableFuture<Boolean> sendCommand(
+                String method,
+                JsonObject params,
+                DaemonOutputCallback callback
+        ) {
+            callback.onAbort();
+            return CompletableFuture.completedFuture(false);
+        }
+
+        @Override
+        public boolean isAlive() {
+            return true;
         }
     }
 

--- a/src/test/java/com/github/claudecodegui/provider/claude/ClaudeSessionQueryServiceTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/ClaudeSessionQueryServiceTest.java
@@ -1,0 +1,102 @@
+package com.github.claudecodegui.provider.claude;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ClaudeSessionQueryServiceTest {
+
+    @Test
+    public void normalizeClaudeHistoryMessageRestoresImageBlocksAndKeepsUserText() throws IOException {
+        Path imagePath = Files.createTempFile("claude-history-image", ".png");
+        try {
+            Files.write(imagePath, "png-bytes".getBytes(StandardCharsets.UTF_8));
+
+            JsonObject normalized = ClaudeSessionQueryService.normalizeClaudeHistoryMessage(
+                    createUserMessage("[Image #1: " + imagePath + "]\n\n"
+                            + "The user has attached the image(s) above. Please use the Read tool to view them.\n\n"
+                            + "请分析这张图片")
+            );
+
+            JsonArray contentBlocks = normalized.getAsJsonObject("message").getAsJsonArray("content");
+            assertEquals(2, contentBlocks.size());
+            assertEquals("image", contentBlocks.get(0).getAsJsonObject().get("type").getAsString());
+            assertTrue(contentBlocks.get(0).getAsJsonObject().get("src").getAsString().startsWith("data:image/png;base64,"));
+            assertEquals("text", contentBlocks.get(1).getAsJsonObject().get("type").getAsString());
+            assertEquals("请分析这张图片", contentBlocks.get(1).getAsJsonObject().get("text").getAsString());
+        } finally {
+            Files.deleteIfExists(imagePath);
+        }
+    }
+
+    @Test
+    public void normalizeClaudeHistoryMessageKeepsImageOnlyPromptAsImageBlock() throws IOException {
+        Path imagePath = Files.createTempFile("claude-history-image-only", ".png");
+        try {
+            Files.write(imagePath, "png-bytes".getBytes(StandardCharsets.UTF_8));
+
+            JsonObject normalized = ClaudeSessionQueryService.normalizeClaudeHistoryMessage(
+                    createUserMessage("[Image #1: " + imagePath + "]\n\n"
+                            + "The user has attached the image(s) above. Please use the Read tool to view them.")
+            );
+
+            JsonArray contentBlocks = normalized.getAsJsonObject("message").getAsJsonArray("content");
+            assertEquals(1, contentBlocks.size());
+            assertEquals("image", contentBlocks.get(0).getAsJsonObject().get("type").getAsString());
+            assertTrue(contentBlocks.get(0).getAsJsonObject().get("src").getAsString().startsWith("data:image/png;base64,"));
+        } finally {
+            Files.deleteIfExists(imagePath);
+        }
+    }
+
+    @Test
+    public void normalizeClaudeHistoryMessageStripsAppendedProjectModulesContext() throws IOException {
+        Path imagePath = Files.createTempFile("claude-history-image-context", ".png");
+        try {
+            Files.write(imagePath, "png-bytes".getBytes(StandardCharsets.UTF_8));
+
+            JsonObject normalized = ClaudeSessionQueryService.normalizeClaudeHistoryMessage(
+                    createUserMessage("[Image #1: " + imagePath + "]\n\n"
+                            + "The user has attached the image(s) above. Please use the Read tool to view them.\n\n"
+                            + "用户原始描述\n\n"
+                            + "## Project Modules\n\n"
+                            + "This project contains multiple modules:\n"
+                            + "- `idea-claude-code-gui`\n")
+            );
+
+            JsonArray contentBlocks = normalized.getAsJsonObject("message").getAsJsonArray("content");
+            assertEquals(2, contentBlocks.size());
+            assertEquals("image", contentBlocks.get(0).getAsJsonObject().get("type").getAsString());
+            assertEquals("text", contentBlocks.get(1).getAsJsonObject().get("type").getAsString());
+            assertEquals("用户原始描述", contentBlocks.get(1).getAsJsonObject().get("text").getAsString());
+        } finally {
+            Files.deleteIfExists(imagePath);
+        }
+    }
+
+    private JsonObject createUserMessage(String text) {
+        JsonObject textBlock = new JsonObject();
+        textBlock.addProperty("type", "text");
+        textBlock.addProperty("text", text);
+
+        JsonArray content = new JsonArray();
+        content.add(textBlock);
+
+        JsonObject message = new JsonObject();
+        message.addProperty("role", "user");
+        message.add("content", content);
+
+        JsonObject raw = new JsonObject();
+        raw.addProperty("type", "user");
+        raw.add("message", message);
+        return raw;
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/codex/CodexSDKBridgeHistoryTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/codex/CodexSDKBridgeHistoryTest.java
@@ -2,16 +2,19 @@ package com.github.claudecodegui.provider.codex;
 
 import com.github.claudecodegui.session.ClaudeSession;
 import com.github.claudecodegui.session.MessageParser;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class CodexSDKBridgeHistoryTest {
 
@@ -119,6 +122,63 @@ public class CodexSDKBridgeHistoryTest {
         }
     }
 
+    @Test
+    public void getSessionMessagesRestoresLocalImagesForHistoryReplay() throws IOException {
+        Path sessionsDir = Files.createTempDirectory("codex-sdk-bridge-history-local-image");
+        Path imagePath = Files.createTempFile("codex-sdk-bridge-image", ".png");
+        try {
+            Files.write(imagePath, "png-bytes".getBytes(StandardCharsets.UTF_8));
+            writeSessionFile(
+                    sessionsDir,
+                    "session-local-image",
+                    line("2026-05-11T09:02:20Z", "event_msg",
+                            "{\"type\":\"user_message\",\"message\":\"Restore image\",\"local_images\":[\"" + escapeJson(imagePath.toString()) + "\"]}")
+            );
+
+            CodexSDKBridge bridge = new CodexSDKBridge(sessionsDir);
+            List<JsonObject> messages = bridge.getSessionMessages("session-local-image", sessionsDir.toString());
+
+            assertEquals(1, messages.size());
+            assertEquals("user", messages.get(0).get("type").getAsString());
+            assertEquals("Restore image", messages.get(0).get("content").getAsString());
+            JsonArray contentBlocks = messages.get(0).getAsJsonObject("raw").getAsJsonArray("content");
+            assertEquals("image", contentBlocks.get(0).getAsJsonObject().get("type").getAsString());
+            assertTrue(contentBlocks.get(0).getAsJsonObject().get("src").getAsString().startsWith("data:image/png;base64,"));
+        } finally {
+            Files.deleteIfExists(imagePath);
+            deleteDirectory(sessionsDir);
+        }
+    }
+
+    @Test
+    public void getSessionMessagesKeepsImageOnlyHistoryReplay() throws IOException {
+        Path sessionsDir = Files.createTempDirectory("codex-sdk-bridge-history-image-only");
+        Path imagePath = Files.createTempFile("codex-sdk-bridge-image-only", ".png");
+        try {
+            Files.write(imagePath, "png-bytes".getBytes(StandardCharsets.UTF_8));
+            writeSessionFile(
+                    sessionsDir,
+                    "session-image-only",
+                    line("2026-05-11T09:03:20Z", "event_msg",
+                            "{\"type\":\"user_message\",\"message\":\"\",\"local_images\":[\"" + escapeJson(imagePath.toString()) + "\"]}")
+            );
+
+            CodexSDKBridge bridge = new CodexSDKBridge(sessionsDir);
+            List<JsonObject> messages = bridge.getSessionMessages("session-image-only", sessionsDir.toString());
+
+            assertEquals(1, messages.size());
+            assertEquals("user", messages.get(0).get("type").getAsString());
+            assertEquals("", messages.get(0).get("content").getAsString());
+            JsonArray contentBlocks = messages.get(0).getAsJsonObject("raw").getAsJsonArray("content");
+            assertEquals(1, contentBlocks.size());
+            assertEquals("image", contentBlocks.get(0).getAsJsonObject().get("type").getAsString());
+            assertTrue(contentBlocks.get(0).getAsJsonObject().get("src").getAsString().startsWith("data:image/png;base64,"));
+        } finally {
+            Files.deleteIfExists(imagePath);
+            deleteDirectory(sessionsDir);
+        }
+    }
+
     private static Path writeSessionFile(Path dir, String sessionId, String... lines) throws IOException {
         Files.createDirectories(dir);
         Path file = dir.resolve(sessionId + ".jsonl");
@@ -128,6 +188,10 @@ public class CodexSDKBridgeHistoryTest {
 
     private static String line(String timestamp, String type, String payloadJson) {
         return "{\"timestamp\":\"" + timestamp + "\",\"type\":\"" + type + "\",\"payload\":" + payloadJson + "}";
+    }
+
+    private static String escapeJson(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
     private static void deleteDirectory(Path path) throws IOException {

--- a/src/test/java/com/github/claudecodegui/session/MessageParserTest.java
+++ b/src/test/java/com/github/claudecodegui/session/MessageParserTest.java
@@ -1,0 +1,37 @@
+package com.github.claudecodegui.session;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class MessageParserTest {
+
+    @Test
+    public void parseServerMessageKeepsUserMessageWithOnlyImageBlocks() {
+        MessageParser parser = new MessageParser();
+
+        JsonObject imageBlock = new JsonObject();
+        imageBlock.addProperty("type", "image");
+        imageBlock.addProperty("src", "data:image/png;base64,abc123");
+
+        JsonArray content = new JsonArray();
+        content.add(imageBlock);
+
+        JsonObject message = new JsonObject();
+        message.add("content", content);
+
+        JsonObject raw = new JsonObject();
+        raw.addProperty("type", "user");
+        raw.add("message", message);
+
+        ClaudeSession.Message parsed = parser.parseServerMessage(raw);
+
+        assertNotNull(parsed);
+        assertEquals(ClaudeSession.Message.Type.USER, parsed.type);
+        assertEquals("", parsed.content);
+        assertEquals(raw, parsed.raw);
+    }
+}

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -185,6 +185,7 @@ const App = () => {
     showNewSessionConfirm, showInterruptConfirm,
     suppressNextStatusToastRef,
     createNewSession, forceCreateNewSession,
+    forceCreateNewSessionWithProvider,
     handleConfirmNewSession, handleCancelNewSession,
     handleConfirmInterrupt, handleCancelInterrupt,
     loadHistorySession, deleteHistorySession, deleteHistorySessions, exportHistorySession,
@@ -239,10 +240,10 @@ const App = () => {
   // ── Message sender ──
   // Wrap handleProviderSelect to also clear messages and input (like creating a new session)
   const wrappedHandleProviderSelect = useCallback((providerId: string) => {
-    setMessages([]);
     chatInputRef.current?.clear();
     handleProviderSelect(providerId);
-  }, [handleProviderSelect]);
+    forceCreateNewSessionWithProvider(providerId);
+  }, [forceCreateNewSessionWithProvider, handleProviderSelect]);
 
   const {
     handleSubmit: hookHandleSubmit,

--- a/webview/src/components/history/HistoryView.tsx
+++ b/webview/src/components/history/HistoryView.tsx
@@ -61,7 +61,7 @@ const EMPTY_HINT_STYLE: React.CSSProperties = {
 interface HistoryViewProps {
   historyData: HistoryData | null;
   currentProvider?: string; // Current provider (claude or codex)
-  onLoadSession: (sessionId: string) => void;
+  onLoadSession: (sessionId: string, provider?: string) => void;
   onDeleteSession: (sessionId: string) => void; // Delete session callback
   onDeleteSessions: (sessionIds: string[]) => void; // Batch delete sessions callback
   onExportSession: (sessionId: string, title: string) => void; // Export session callback
@@ -331,7 +331,7 @@ const HistoryView = ({ historyData, currentProvider, onLoadSession, onDeleteSess
       return;
     }
     if (!isEditing) {
-      onLoadSession(session.sessionId);
+      onLoadSession(session.sessionId, session.provider);
     }
   }, [isSelectionMode, toggleSessionSelection, onLoadSession]);
 

--- a/webview/src/hooks/useSessionManagement.test.ts
+++ b/webview/src/hooks/useSessionManagement.test.ts
@@ -97,7 +97,10 @@ describe('useSessionManagement', () => {
     });
 
     expect(window.sendToJava).toHaveBeenNthCalledWith(1, 'interrupt_session:');
-    expect(window.sendToJava).toHaveBeenNthCalledWith(2, 'load_session:history-1');
+    expect(window.sendToJava).toHaveBeenNthCalledWith(
+      2,
+      'load_session:{"sessionId":"history-1","provider":"claude"}'
+    );
     expect(window.__sessionTransitioning).toBe(true);
     expect(window.__sessionTransitionToken).toBeTruthy();
     expect(mocks.clearToasts).toHaveBeenCalledTimes(1);
@@ -313,6 +316,31 @@ describe('useSessionManagement', () => {
     expect(mocks.setUsageUsedTokens).toHaveBeenCalledWith(undefined);
   });
 
+  it('forceCreateNewSessionWithProvider resets session and applies target provider before recreating', () => {
+    const mocks = createMocks();
+
+    const { result } = renderHook(() =>
+      useSessionManagement({
+        messages: [{ type: 'assistant', content: 'old', timestamp: new Date().toISOString() }],
+        loading: false,
+        historyData: null,
+        currentSessionId: 'active-session',
+        ...mocks,
+        t,
+      })
+    );
+
+    act(() => {
+      result.current.forceCreateNewSessionWithProvider('codex');
+    });
+
+    expect(window.sendToJava).toHaveBeenNthCalledWith(1, 'set_provider:codex');
+    expect(window.sendToJava).toHaveBeenNthCalledWith(2, 'create_new_session:');
+    expect(window.__sessionTransitioning).toBe(true);
+    expect(mocks.setMessages).toHaveBeenCalledWith([]);
+    expect(mocks.setCurrentSessionId).toHaveBeenCalledWith(null);
+  });
+
   it('shows confirm dialog when creating new session with existing messages', () => {
     const mocks = createMocks();
 
@@ -440,7 +468,7 @@ describe('useSessionManagement', () => {
     // Should NOT send interrupt when not loading
     const calls = (window.sendToJava as any).mock.calls.map((c: any) => c[0]);
     expect(calls).not.toContain('interrupt_session:');
-    expect(calls).toContain('load_session:hist-2');
+    expect(calls).toContain('load_session:{"sessionId":"hist-2","provider":"claude"}');
 
     // But should still set transition guard
     expect(window.__sessionTransitioning).toBe(true);
@@ -449,6 +477,44 @@ describe('useSessionManagement', () => {
     expect(mocks.setMessages).toHaveBeenCalledWith([]);
     expect(mocks.setCurrentSessionId).toHaveBeenCalledWith('hist-2');
     expect(mocks.setCustomSessionTitle).toHaveBeenCalledWith(null);
+  });
+
+  it('loadHistorySession sends explicit provider when provided by history item', () => {
+    const historyData = {
+      success: true,
+      sessions: [
+        {
+          sessionId: 'hist-codex',
+          title: 'Codex Session',
+          provider: 'codex',
+          model: 'gpt-5.4',
+          messageCount: 2,
+          lastTimestamp: Date.now(),
+        },
+      ],
+      total: 2,
+    } as unknown as HistoryData;
+
+    const mocks = createMocks();
+
+    const { result } = renderHook(() =>
+      useSessionManagement({
+        messages: [],
+        loading: false,
+        historyData,
+        currentSessionId: null,
+        ...mocks,
+        t,
+      })
+    );
+
+    act(() => {
+      result.current.loadHistorySession('hist-codex', 'codex');
+    });
+
+    expect(window.sendToJava).toHaveBeenCalledWith(
+      'load_session:{"sessionId":"hist-codex","provider":"codex"}'
+    );
   });
 
   it('all transition paths reset usage tokens', () => {

--- a/webview/src/hooks/useSessionManagement.ts
+++ b/webview/src/hooks/useSessionManagement.ts
@@ -38,11 +38,12 @@ interface UseSessionManagementReturn {
   suppressNextStatusToastRef: React.MutableRefObject<boolean>;
   createNewSession: () => void;
   forceCreateNewSession: () => void;
+  forceCreateNewSessionWithProvider: (providerId: string) => void;
   handleConfirmNewSession: () => void;
   handleCancelNewSession: () => void;
   handleConfirmInterrupt: () => void;
   handleCancelInterrupt: () => void;
-  loadHistorySession: (sessionId: string) => void;
+  loadHistorySession: (sessionId: string, provider?: string) => void;
   deleteHistorySession: (sessionId: string) => void;
   deleteHistorySessions: (sessionIds: string[]) => void;
   exportHistorySession: (sessionId: string, title: string) => void;
@@ -160,6 +161,15 @@ export function useSessionManagement({
     sendBridgeEvent('create_new_session');
   }, [beginSessionTransition, loading]);
 
+  const forceCreateNewSessionWithProvider = useCallback((providerId: string) => {
+    if (loading) {
+      sendBridgeEvent('interrupt_session');
+    }
+    beginSessionTransition(null, null);
+    sendBridgeEvent('set_provider', providerId);
+    sendBridgeEvent('create_new_session');
+  }, [beginSessionTransition, loading]);
+
   // Confirm new session
   const handleConfirmNewSession = useCallback(() => {
     setShowNewSessionConfirm(false);
@@ -195,7 +205,7 @@ export function useSessionManagement({
   }, []);
 
   // Load history session
-  const loadHistorySession = useCallback((sessionId: string) => {
+  const loadHistorySession = useCallback((sessionId: string, provider?: string) => {
     // [FIX] Send interrupt signal if AI is responding
     if (loading) {
       sendBridgeEvent('interrupt_session');
@@ -203,7 +213,10 @@ export function useSessionManagement({
 
     const session = historyDataRef.current?.sessions?.find(s => s.sessionId === sessionId);
     beginSessionTransition(sessionId, session?.title ?? null);
-    sendBridgeEvent('load_session', sessionId);
+    sendBridgeEvent('load_session', JSON.stringify({
+      sessionId,
+      provider: provider || session?.provider || 'claude',
+    }));
     setCurrentView('chat');
   }, [beginSessionTransition, loading, setCurrentView]);
 
@@ -361,6 +374,7 @@ export function useSessionManagement({
     suppressNextStatusToastRef,
     createNewSession,
     forceCreateNewSession,
+    forceCreateNewSessionWithProvider,
     handleConfirmNewSession,
     handleCancelNewSession,
     handleConfirmInterrupt,

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
@@ -317,10 +317,10 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     // Snapshot streaming state BEFORE clearing refs - used for post-stream merge guard
     const endedStreamingTurnId = streamingTurnIdRef.current;
     const endedStreamingMessageIndex = streamingMessageIndexRef.current;
-    // Use the more complete content between streaming ref and backend snapshot
-    const endedStreamingContent = (backendSnapshotContent && backendSnapshotContent.length > streamingContentRef.current.length)
-      ? backendSnapshotContent
-      : streamingContentRef.current;
+    // FIX: Prioritize streaming content over backend snapshot to prevent digit loss
+    // Streaming content has all the latest deltas (including the final one just flushed).
+    // Backend snapshot might be from an earlier coalescer push and may be incomplete.
+    const endedStreamingContent = streamingContentRef.current || backendSnapshotContent || '';
     const endedBackendRaw = backendSnapshotRaw;
 
     // Helper to measure total text length from raw blocks (for comparing completeness).


### PR DESCRIPTION
1. fix: treat user-initiated aborts as graceful completion instead of errors
2. refactor: extract UserMessageSanitizer utility for stripping system context from history
3. feat: restore local images in history replay for both Claude and Codex providers
4. fix: preserve provider when loading history sessions across providers
5. fix: prioritize streaming content over backend snapshot to prevent digit loss