### PR TITLE
fix(permissions): let SDK evaluate settings.json permission rules

### DIFF
--- a/ai-bridge/services/claude/permission-mode.js
+++ b/ai-bridge/services/claude/permission-mode.js
@@ -358,72 +358,11 @@ export function createPreToolUseHook(permissionModeState, cwd = null, onModeChan
       };
     }
 
-    // ======== NON-PLAN MODES (default, acceptEdits, bypassPermissions) ========
-
-    // Auto-approve tools that should be auto-approved for this mode
-    // (safe tools in all modes, read-only tools in acceptEdits, everything in bypassPermissions)
-    if (shouldAutoApproveTool(currentPermissionMode, toolName)) {
-      return {
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'allow'
-        }
-      };
-    }
-
-    // acceptEdits mode: edit tools need CWD path validation before auto-approve
-    // Matches CLI's checkWritePermissionForTool: only allow edits within working directory
-    if (currentPermissionMode === 'acceptEdits' &&
-        ACCEPT_EDITS_AUTO_APPROVE_TOOLS.has(toolName)) {
-      if (shouldAcceptEditsTool(toolName, input?.tool_input, workingDirectory)) {
-        return {
-          hookSpecificOutput: {
-            hookEventName: 'PreToolUse',
-            permissionDecision: 'allow'
-          }
-        };
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'continue'
       }
-      // Path outside CWD or dangerous file → fall through to canUseTool for permission
-    }
-
-    // Everything else goes through canUseTool for permission
-    try {
-      const result = await canUseTool(toolName, input?.tool_input);
-      if (result?.behavior === 'allow') {
-        if (result?.updatedInput !== undefined) {
-          return {
-            hookSpecificOutput: {
-              hookEventName: 'PreToolUse',
-              permissionDecision: 'allow',
-              updatedInput: result.updatedInput
-            }
-          };
-        }
-        return {
-          hookSpecificOutput: {
-            hookEventName: 'PreToolUse',
-            permissionDecision: 'allow'
-          }
-        };
-      }
-      if (result?.behavior === 'deny') {
-        return {
-          hookSpecificOutput: {
-            hookEventName: 'PreToolUse',
-            permissionDecision: 'deny'
-          },
-          reason: result?.message || 'Permission denied'
-        };
-      }
-      return {};
-    } catch (error) {
-      return {
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'deny'
-        },
-        reason: 'Permission check failed: ' + (error?.message || String(error))
-      };
-    }
+    };
   };
 }

--- a/ai-bridge/services/claude/permission-mode.test.js
+++ b/ai-bridge/services/claude/permission-mode.test.js
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createPreToolUseHook } from './permission-mode.js';
+
+function makeHook(mode = 'default', cwd = '/tmp/test-cwd') {
+  return createPreToolUseHook({ value: mode }, cwd);
+}
+
+test('default mode: Bash yields "continue" so SDK can evaluate settings.json rules', async () => {
+  const hook = makeHook('default');
+  const result = await hook({
+    tool_name: 'Bash',
+    tool_input: { command: 'rm something.txt' },
+  });
+  assert.equal(result?.hookSpecificOutput?.permissionDecision, 'continue');
+});
+
+test('default mode: Read yields "continue" so deny rules like Read(./.env) can fire', async () => {
+  const hook = makeHook('default');
+  const result = await hook({
+    tool_name: 'Read',
+    tool_input: { file_path: '/tmp/test-cwd/.env' },
+  });
+  assert.equal(result?.hookSpecificOutput?.permissionDecision, 'continue');
+});
+
+test('default mode: Grep yields "continue"', async () => {
+  const hook = makeHook('default');
+  const result = await hook({
+    tool_name: 'Grep',
+    tool_input: { pattern: 'foo' },
+  });
+  assert.equal(result?.hookSpecificOutput?.permissionDecision, 'continue');
+});
+
+test('bypassPermissions mode: Bash yields "continue" (SDK mode-check auto-allows)', async () => {
+  const hook = makeHook('bypassPermissions');
+  const result = await hook({
+    tool_name: 'Bash',
+    tool_input: { command: 'date' },
+  });
+  assert.equal(result?.hookSpecificOutput?.permissionDecision, 'continue');
+});
+
+test('acceptEdits mode: Edit inside CWD yields "continue" (SDK mode-check auto-accepts)', async () => {
+  const cwd = '/tmp/test-cwd';
+  const hook = makeHook('acceptEdits', cwd);
+  const result = await hook({
+    tool_name: 'Edit',
+    tool_input: { file_path: `${cwd}/src/file.js`, old_string: 'a', new_string: 'b' },
+  });
+  assert.equal(result?.hookSpecificOutput?.permissionDecision, 'continue');
+});
+
+test('acceptEdits mode: Edit outside CWD yields "continue"', async () => {
+  const hook = makeHook('acceptEdits', '/tmp/test-cwd');
+  const result = await hook({
+    tool_name: 'Edit',
+    tool_input: { file_path: '/etc/passwd', old_string: 'a', new_string: 'b' },
+  });
+  assert.equal(result?.hookSpecificOutput?.permissionDecision, 'continue');
+});
+
+test('default mode: MCP tool yields "continue"', async () => {
+  const hook = makeHook('default');
+  const result = await hook({
+    tool_name: 'mcp__some-server__some-tool',
+    tool_input: { foo: 'bar' },
+  });
+  assert.equal(result?.hookSpecificOutput?.permissionDecision, 'continue');
+});
+
+test('EnterPlanMode is still auto-allowed (mode transition signal)', async () => {
+  const hook = makeHook('default');
+  const result = await hook({
+    tool_name: 'EnterPlanMode',
+    tool_input: {},
+  });
+  assert.equal(result?.hookSpecificOutput?.permissionDecision, 'allow');
+});
+
+test('plan mode: SAFE tools still short-circuit to allow (plan UX unchanged)', async () => {
+  const hook = makeHook('plan');
+  const result = await hook({
+    tool_name: 'Read',
+    tool_input: { file_path: '/tmp/test-cwd/x' },
+  });
+  assert.equal(result?.hookSpecificOutput?.permissionDecision, 'allow');
+});


### PR DESCRIPTION
## Summary

- Replace every non-plan-mode `allow`/`deny`/inline-`canUseTool` branch at the end of `createPreToolUseHook` (in `ai-bridge/services/claude/permission-mode.js`) with a single `permissionDecision: 'continue'` return.
- `permission-mode.js`: 71 deletions, 5 insertions (net −66 lines).
- Add `permission-mode.test.js`: 9 `node:test` cases covering all non-plan paths plus EnterPlanMode and plan-mode-Read regression pins.

Fixes #1120.

## Why

The hook was short-circuiting the Claude Agent SDK permission flow. `settingSources: ['user', 'project', 'local']` was wired up in `buildQueryOptions`, but for every non-plan tool the hook returned `permissionDecision: 'allow'` (safe tools, `bypassPermissions`, `acceptEdits` inside CWD) or called `canUseTool` inline (everything else). Both paths cut off the SDK's `Deny → Allow → Ask → Mode Check → canUseTool` flow before `~/.claude/settings.json` rules could be evaluated.

Concretely, a user with `{ "permissions": { "deny": ["Bash(rm:*)", "Read(./.env)"] } }` saw their rules silently ignored — every tool call jumped straight to the Java approval dialog, regardless of declared rules.

Returning `'continue'` instead yields to the SDK so it evaluates the rules natively and only calls the registered `canUseTool` callback as the final fallback. Verified empirically with `@anthropic-ai/claude-agent-sdk@0.2.139`: a `Bash(date:*)` deny rule blocks `date` without `canUseTool` ever firing.

## Behavior preservation

- **Plan mode is unchanged.** `EnterPlanMode`, `ExitPlanMode`, plan-mode `SAFE_ALWAYS_ALLOW`, `PLAN_MODE_ALLOWED_TOOLS`, plan-mode Edit/Write/Bash branches all keep their existing logic. Plan-specific UX (Edit only `PLAN.md`, plan approval dialog) is preserved.
- **Java approval dialog still fires for risky tools.** The `canUseTool` callback remains registered on `query()` options. SDK classifier escalates dangerous commands (`rm *`, `curl http://...`, `Read('/etc/passwd')`, `Edit('/tmp/<outside-cwd>')`) through `canUseTool`, where the existing `requestPermissionFromJava` and `isDangerousPath` checks run as before.
- **`bypassPermissions` semantics intentional.** Users who opt into this mode keep the "auto-allow everything" behavior; SDK Mode Check handles it after rules are evaluated.
- **Exported helpers untouched.** `shouldAutoApproveTool`, `shouldAcceptEditsTool`, `ACCEPT_EDITS_AUTO_APPROVE_TOOLS` are no longer called by the hook but remain exported for any external consumers.

One intentional behavior change worth flagging: previously every non-safe Bash call went through `canUseTool` inline → Java dialog (even for `echo hello`). After this PR, the SDK's safety classifier auto-allows benign commands and only escalates dangerous ones to the dialog. This matches CLI behavior and removes dialog-spam for trusted operations, but users who had built mental models around "every command needs my approval" will see fewer dialogs.

Path rewriting via `rewriteToolInputPaths` (inside `canUseTool`) no longer fires when an `allow` rule matches a tool; the SDK auto-allows without calling the callback. For rules the user explicitly wrote, honoring the path as-is is the right semantics, but it is a behavior change vs. the previous "always rewrite" path.

## Verification

Empirical end-to-end matrix with `@anthropic-ai/claude-agent-sdk@0.2.139`:

| Scenario | SDK routes to canUseTool? | Outcome |
| --- | --- | --- |
| `default` + `permissions.deny: ["Bash(date:*)"]`, run `date` | no (rule match) | denied by SDK ✓ |
| `default` + `Read('/etc/passwd')`, no rules | yes | `isDangerousPath` gate fires ✓ |
| `default` + `Bash('rm /tmp/x_*')`, no rules | yes | Java dialog ✓ |
| `default` + `Bash('curl http://...')`, no rules | yes | Java dialog ✓ |
| `default` + `Bash('echo hello')`, no rules | no (classifier safe) | auto-allowed ✓ |
| `acceptEdits` + `Edit('/tmp/<outside-cwd>')` | yes | gate available ✓ |
| `acceptEdits` + Edit inside CWD | no (mode auto-accepts) | as designed ✓ |
| `bypassPermissions` + Bash | no (mode auto-allows) | as designed ✓ |

## Test plan

- [x] `node --test ai-bridge/services/claude/permission-mode.test.js` — 9/9 pass
- [x] `node --test ai-bridge/services/claude/` — all permission-mode tests pass; the unrelated `api-config.test.js` failure (ERR_MODULE_NOT_FOUND on a child-process spawn) reproduces on `main` and is not caused by this change
- [x] Empirical SDK verification across all scenarios in the table above
- [ ] Manual smoke: run plugin with `~/.claude/settings.json` containing `permissions.deny: ["Bash(rm:*)"]`, ask Claude to run `rm something`, confirm denial fires without showing the approval dialog
- [ ] Manual smoke: confirm plan mode still blocks non-`PLAN.md` edits as before

## Out of scope

- Apply the same `'continue'` treatment to plan-mode auto-allow branches so `settings.json` deny rules also govern plan mode. Left out to keep scope tight.
- Wire the Java "Always allow" dialog to optionally persist granted patterns into `~/.claude/settings.json`'s `permissions.allow`, so the per-session cache in `PermissionDecisionStore` survives plugin reinstalls.

