### PR TITLE
fix: preserve assistant messages with command tags in code examples

### DIFF
--- a/src/main/java/com/github/claudecodegui/session/CodexMessageHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/CodexMessageHandler.java
@@ -375,8 +375,14 @@ public class CodexMessageHandler implements MessageCallback {
      * Detect Codex internal command messages that must not be shown to the user.
      * Codex prepends instruction blocks to user input; strip them before checking command tags
      * so those hidden blocks do not mask the user's real message.
+     * Only filter user messages - assistant messages may contain these tags in code examples.
      */
     private boolean isFilteredCommandMessage(com.google.gson.JsonObject msg, Message.Type messageType) {
+        // Only filter user messages - assistant messages may contain command tags in code examples
+        if (messageType != Message.Type.USER) {
+            return false;
+        }
+
         if (!msg.has("message") || !msg.get("message").isJsonObject()) {
             return false;
         }
@@ -390,9 +396,7 @@ public class CodexMessageHandler implements MessageCallback {
             return false;
         }
 
-        String filterContent = messageType == Message.Type.USER
-            ? CodexMessageConverter.stripSystemTags(contentStr)
-            : contentStr;
+        String filterContent = CodexMessageConverter.stripSystemTags(contentStr);
         boolean hasCommandMessage = contentStr.contains("<command-message>")
             && contentStr.contains("</command-message>");
         if (hasCommandMessage) {

--- a/src/main/java/com/github/claudecodegui/session/MessageParser.java
+++ b/src/main/java/com/github/claudecodegui/session/MessageParser.java
@@ -23,8 +23,9 @@ public class MessageParser {
             return null;
         }
 
-        // Filter out command messages
-        if (shouldFilterCommandMessage(msg)) {
+        // Filter out command messages - only for user messages
+        // Assistant messages may contain these tags in code examples
+        if ("user".equals(type) && shouldFilterCommandMessage(msg)) {
             return null;
         }
 
@@ -51,6 +52,8 @@ public class MessageParser {
 
     /**
      * Check whether a command message should be filtered out.
+     * Only applies to user messages - assistant messages may contain
+     * command tags in code examples and should not be filtered.
      */
     private boolean shouldFilterCommandMessage(JsonObject msg) {
         if (!msg.has("message") || !msg.get("message").isJsonObject()) {

--- a/src/main/java/com/github/claudecodegui/session/MessageParser.java
+++ b/src/main/java/com/github/claudecodegui/session/MessageParser.java
@@ -25,7 +25,7 @@ public class MessageParser {
 
         // Filter out command messages - only for user messages
         // Assistant messages may contain these tags in code examples
-        if ("user".equals(type) && shouldFilterCommandMessage(msg)) {
+        if (shouldFilterCommandMessage(msg, type)) {
             return null;
         }
 
@@ -55,7 +55,12 @@ public class MessageParser {
      * Only applies to user messages - assistant messages may contain
      * command tags in code examples and should not be filtered.
      */
-    private boolean shouldFilterCommandMessage(JsonObject msg) {
+    private boolean shouldFilterCommandMessage(JsonObject msg, String type) {
+        // Only filter user messages - assistant messages may contain command tags in code examples
+        if (!"user".equals(type)) {
+            return false;
+        }
+
         if (!msg.has("message") || !msg.get("message").isJsonObject()) {
             return false;
         }

--- a/webview/src/components/MarkdownBlock.test.tsx
+++ b/webview/src/components/MarkdownBlock.test.tsx
@@ -370,6 +370,35 @@ describe('MarkdownBlock linkify integration', () => {
     expect(codeBlock?.textContent).toContain('type: "local"');
   });
 
+  it('handles incremental streaming with partial XML tags without DOM corruption', () => {
+    // Simulates SSE incremental updates where XML tags arrive in fragments
+    // Critical: during streaming, content may pause mid-tag (e.g. "<command-")
+    // and the renderer must not parse incomplete tags as real DOM.
+    const chunks = [
+      'Here is the code: `<command-',
+      'Here is the code: `<command-name>',
+      'Here is the code: `<command-name>/compact</command-name>',
+      'Here is the code: `<command-name>/compact</command-name>` for compacting.',
+    ];
+
+    const { rerender } = render(<MarkdownBlock content={chunks[0]} isStreaming />);
+
+    // Each chunk should render without throwing or creating phantom DOM elements
+    chunks.forEach((chunk) => {
+      rerender(<MarkdownBlock content={chunk} isStreaming />);
+
+      // No phantom <command-name> DOM element should ever appear
+      expect(document.querySelector('command-name')).toBeNull();
+    });
+
+    // Final transition to non-streaming should match the last streaming render
+    rerender(<MarkdownBlock content={chunks[chunks.length - 1]} isStreaming={false} />);
+
+    const finalCode = document.querySelector('code');
+    expect(finalCode?.textContent).toBe('<command-name>/compact</command-name>');
+    expect(document.querySelector('command-name')).toBeNull();
+  });
+
   it('preserves inline code with angle brackets from real error messages', () => {
     // Real pattern: error messages with type parameters like <T>
     const content = 'Use `Array<T>` or `Map<string, number>` for generic types.';

--- a/webview/src/components/MarkdownBlock.test.tsx
+++ b/webview/src/components/MarkdownBlock.test.tsx
@@ -163,6 +163,56 @@ describe('MarkdownBlock linkify integration', () => {
     expect(bridgeMocks.openBrowser).toHaveBeenCalledWith('https://example.com/docs');
   });
 
+  it('strips system-internal XML tags (context, commit_analysis, etc.)', () => {
+    render(
+      <MarkdownBlock
+        content={
+          'Before\n\n<context>internal system data\nshould be removed</context>\n\nAfter'
+        }
+      />,
+    );
+
+    const container = document.querySelector('.markdown-content')!;
+    expect(container.textContent).toContain('Before');
+    expect(container.textContent).toContain('After');
+    expect(container.textContent).not.toContain('internal system data');
+    expect(container.innerHTML).not.toContain('<context>');
+  });
+
+  it('escapes unknown XML tags as literal text', () => {
+    render(
+      <MarkdownBlock
+        content={'Analysis:\n\n<thinking>this should be literal</thinking>\n\nDone'}
+      />,
+    );
+
+    const container = document.querySelector('.markdown-content')!;
+    expect(container.textContent).toContain('<thinking>');
+    expect(container.textContent).toContain('this should be literal');
+    expect(container.textContent).toContain('</thinking>');
+    // The tag should NOT exist as a DOM element
+    expect(container.querySelector('thinking')).toBeNull();
+  });
+
+  it('preserves XML tags inside code fences', () => {
+    render(
+      <MarkdownBlock
+        content={'Example:\n\n```xml\n<context>keep this</context>\n```\n\nOutside'}
+      />,
+    );
+
+    const codeBlock = document.querySelector('pre code')!;
+    expect(codeBlock.textContent).toContain('<context>keep this</context>');
+  });
+
+  it('escapes self-closing XML tags', () => {
+    render(<MarkdownBlock content={'Use <br/> or <item attr="val"/> here'} />);
+
+    const container = document.querySelector('.markdown-content')!;
+    expect(container.querySelector('br')).toBeNull();
+    expect(container.querySelector('item')).toBeNull();
+  });
+
   it('shows links during streaming and keeps final rendering consistent', () => {
     setLinkifyCapabilities({ classNavigationEnabled: true });
 
@@ -193,5 +243,150 @@ describe('MarkdownBlock linkify integration', () => {
       }),
     ).toBeTruthy();
     expect(screen.getByRole('link', { name: 'https://example.com/docs' })).toBeTruthy();
+  });
+
+  it('renders inline code with XML tags consistently across streaming and non-streaming', () => {
+    const content = 'Use `<div>` and `<custom-tag>` here';
+
+    // Test streaming path
+    const { rerender } = render(<MarkdownBlock content={content} isStreaming />);
+
+    const streamingCodeElements = document.querySelectorAll('code');
+    expect(streamingCodeElements.length).toBe(2);
+
+    // Both should display the tag as literal text <div> and <custom-tag>
+    expect(streamingCodeElements[0].textContent).toBe('<div>');
+    expect(streamingCodeElements[1].textContent).toBe('<custom-tag>');
+
+    // No actual DOM elements should exist for these tags
+    expect(document.querySelector('div.custom-tag')).toBeNull();
+    expect(document.querySelector('custom-tag')).toBeNull();
+
+    // Test non-streaming path
+    rerender(<MarkdownBlock content={content} isStreaming={false} />);
+
+    const nonStreamingCodeElements = document.querySelectorAll('code');
+    expect(nonStreamingCodeElements.length).toBe(2);
+
+    // Should match streaming output exactly
+    expect(nonStreamingCodeElements[0].textContent).toBe('<div>');
+    expect(nonStreamingCodeElements[1].textContent).toBe('<custom-tag>');
+  });
+
+  // Based on real conversation from session JSONL
+  it('renders multi-paragraph content with code blocks correctly', () => {
+    const realContent = [
+      '这是一个很好的调查方向。让我深入分析这个问题，同时涉及 Claude CLI 源码和插件的处理逻辑。',
+      '',
+      '先并行调查几个关键区域：',
+    ].join('\n');
+
+    render(<MarkdownBlock content={realContent} />);
+
+    const container = document.querySelector('.markdown-content')!;
+    expect(container.textContent).toContain('这是一个很好的调查方向');
+    expect(container.textContent).toContain('先并行调查几个关键区域');
+  });
+
+  it('strips command-message XML tags from skill prompts', () => {
+    // Real message format from JSONL: command-message wrapper
+    const content = [
+      'Before text',
+      '',
+      '<command-message>opsx:explore</command-message>',
+      '<command-name>/opsx:explore</command-name>',
+      '<command-args>investigate the bug</command-args>',
+      '',
+      'After text',
+    ].join('\n');
+
+    render(<MarkdownBlock content={content} />);
+
+    const container = document.querySelector('.markdown-content')!;
+    // Command tags should be escaped as literal text, not parsed as DOM
+    expect(container.querySelector('command-message')).toBeNull();
+    expect(container.querySelector('command-name')).toBeNull();
+  });
+
+  it('handles inline code with file paths and preserves content during streaming transition', () => {
+    // Real content pattern from JSONL: file paths in inline code
+    const content = [
+      'The file `E:/project/ClaudeCodeRev/src/commands/compact/compact.ts` contains the handler.',
+      '',
+      'Also see `src/services/compact/compact.ts` for the service.',
+    ].join('\n');
+
+    const { rerender } = render(<MarkdownBlock content={content} isStreaming />);
+
+    // Streaming: inline code should contain the full path
+    const streamingCodes = document.querySelectorAll('code');
+    expect(streamingCodes[0].textContent).toBe('E:/project/ClaudeCodeRev/src/commands/compact/compact.ts');
+    expect(streamingCodes[1].textContent).toBe('src/services/compact/compact.ts');
+
+    // Transition to non-streaming
+    rerender(<MarkdownBlock content={content} isStreaming={false} />);
+
+    const finalCodes = document.querySelectorAll('code');
+    expect(finalCodes[0].textContent).toBe('E:/project/ClaudeCodeRev/src/commands/compact/compact.ts');
+    expect(finalCodes[1].textContent).toBe('src/services/compact/compact.ts');
+  });
+
+  it('handles complex markdown with nested structures', () => {
+    // Complex content from real conversation: headings, lists, code blocks
+    const complexContent = [
+      '## Detailed Report: `/compact` Command Implementation',
+      '',
+      '### 1. Command Definition and Entry Points',
+      '',
+      '**Command Registration:**',
+      '- `E:/project/ClaudeCodeRev/src/commands/compact/index.ts`',
+      '- Defines the command metadata',
+      '',
+      '**Command Handler:**',
+      '- `compact.ts` contains the `call` function',
+      '',
+      '```typescript',
+      'const command = {',
+      '  type: "local",',
+      '  name: "compact",',
+      '  supportsNonInteractive: true',
+      '};',
+      '```',
+    ].join('\n');
+
+    render(<MarkdownBlock content={complexContent} />);
+
+    // Heading should be rendered
+    expect(document.querySelector('h2')).toBeTruthy();
+    expect(document.querySelector('h3')).toBeTruthy();
+
+    // List items should be present
+    const listItems = document.querySelectorAll('li');
+    expect(listItems.length).toBeGreaterThan(0);
+
+    // Code block should preserve content
+    const codeBlock = document.querySelector('pre code');
+    expect(codeBlock?.textContent).toContain('const command');
+    expect(codeBlock?.textContent).toContain('type: "local"');
+  });
+
+  it('preserves inline code with angle brackets from real error messages', () => {
+    // Real pattern: error messages with type parameters like <T>
+    const content = 'Use `Array<T>` or `Map<string, number>` for generic types.';
+
+    const { rerender } = render(<MarkdownBlock content={content} isStreaming />);
+
+    const streamingCodes = document.querySelectorAll('code');
+    expect(streamingCodes[0].textContent).toBe('Array<T>');
+    expect(streamingCodes[1].textContent).toBe('Map<string, number>');
+
+    // No actual DOM elements for T or string
+    expect(document.querySelector('T')).toBeNull();
+
+    rerender(<MarkdownBlock content={content} isStreaming={false} />);
+
+    const finalCodes = document.querySelectorAll('code');
+    expect(finalCodes[0].textContent).toBe('Array<T>');
+    expect(finalCodes[1].textContent).toBe('Map<string, number>');
   });
 });

--- a/webview/src/components/MarkdownBlock.tsx
+++ b/webview/src/components/MarkdownBlock.tsx
@@ -266,7 +266,6 @@ function escapeXmlTags(text: string): string {
  */
 const CODE_FENCE_RE = /(```[\s\S]*?```)/g;
 const INLINE_CODE_RE = /(`[^`\n]+`)/g;
-const STREAMING_INLINE_CODE_RE = /(`[^`\n]+`)/g;
 const BOLD_SYNTAX_RE = /(\*\*[^*]+\*\*)/g;
 
 function stripAndEscapeOutsideCodeBlocks(content: string): string {
@@ -309,7 +308,7 @@ function renderStreamingInlineText(
 ): string {
   if (handleInlineCode) {
     return text
-      .split(STREAMING_INLINE_CODE_RE)
+      .split(INLINE_CODE_RE)
       .map((inlinePart) => {
         const inlineCodeMatch = /^`([^`\n]+)`$/.exec(inlinePart);
         if (inlineCodeMatch) {
@@ -356,7 +355,7 @@ function renderStreamingProseSegment(
 
   // Split by inline code to avoid double-escaping
   // linkifyPlainTextSegment already handles HTML escaping for inline code content
-  const inlineParts = cleaned.split(STREAMING_INLINE_CODE_RE);
+  const inlineParts = cleaned.split(INLINE_CODE_RE);
 
   const processedParts = inlineParts.map((part, idx) => {
     // Odd indices are inline code — pass to linkifyPlainTextSegment which escapes HTML

--- a/webview/src/components/MarkdownBlock.tsx
+++ b/webview/src/components/MarkdownBlock.tsx
@@ -234,6 +234,64 @@ function makeStreamSafe(content: string): string {
 }
 
 /**
+ * Strip system-internal XML tags injected by Claude Code's prompt protocol.
+ * Mirrors `stripPromptXMLTags` from the CLI source (src/utils/messages.ts).
+ */
+const SYSTEM_XML_TAGS_RE =
+  /<(commit_analysis|context|function_analysis|pr_analysis)>[\s\S]*?<\/\1>\n?/g;
+
+function stripSystemTags(content: string): string {
+  const result = content.replace(SYSTEM_XML_TAGS_RE, '');
+  return result !== content ? result.trim() : result;
+}
+
+/**
+ * Escape XML/HTML-like tags in prose text so they are rendered as literal text
+ * rather than being parsed as DOM elements by the browser.
+ * Matches opening <tag>, closing </tag>, self-closing <tag/>, and <!-- comments -->.
+ * Does NOT touch content inside code fences (caller responsibility).
+ */
+const XML_TAG_RE = /<!--[\s\S]*?-->|<\/?[a-zA-Z][a-zA-Z0-9-]*(?:\s[^>]*)?\/?>/g;
+
+function escapeXmlTags(text: string): string {
+  return text.replace(XML_TAG_RE, (match) =>
+    match.replace(/</g, '&lt;').replace(/>/g, '&gt;'),
+  );
+}
+
+/**
+ * Strip system XML tags and escape remaining XML tags only in prose segments
+ * (outside fenced code blocks and inline code). Preserves code content as-is
+ * so marked can handle XML tags inside code naturally (auto-escape).
+ */
+const CODE_FENCE_RE = /(```[\s\S]*?```)/g;
+const INLINE_CODE_RE = /(`[^`\n]+`)/g;
+const STREAMING_INLINE_CODE_RE = /(`[^`\n]+`)/g;
+const BOLD_SYNTAX_RE = /(\*\*[^*]+\*\*)/g;
+
+function stripAndEscapeOutsideCodeBlocks(content: string): string {
+  // First split by fenced code blocks
+  const fenceParts = content.split(CODE_FENCE_RE);
+
+  return fenceParts
+    .map((fencePart, fenceIdx) => {
+      // Odd indices are code fence matches — leave untouched
+      if (fenceIdx % 2 === 1) return fencePart;
+
+      // Then split by inline code within prose segments
+      const inlineParts = fencePart.split(INLINE_CODE_RE);
+      return inlineParts
+        .map((inlinePart, inlineIdx) => {
+          // Odd indices are inline code matches — leave untouched for marked to handle
+          if (inlineIdx % 2 === 1) return inlinePart;
+          return escapeXmlTags(stripSystemTags(inlinePart));
+        })
+        .join('');
+    })
+    .join('');
+}
+
+/**
  * Lightweight renderer for streaming content.
  * Provides basic formatting (code fences, line breaks, inline code, bold)
  * without the heavy marked.parse() + DOMPurify + DOMParser pipeline.
@@ -247,28 +305,44 @@ function safeLang(lang: string): string {
 function renderStreamingInlineText(
   text: string,
   capabilities: LinkifyCapabilities,
+  handleInlineCode: boolean = true,
 ): string {
+  if (handleInlineCode) {
+    return text
+      .split(STREAMING_INLINE_CODE_RE)
+      .map((inlinePart) => {
+        const inlineCodeMatch = /^`([^`\n]+)`$/.exec(inlinePart);
+        if (inlineCodeMatch) {
+          // Inline code content should also be linkified
+          const linkifiedCode = linkifyPlainTextSegment(inlineCodeMatch[1], capabilities);
+          return `<code>${linkifiedCode}</code>`;
+        }
+
+        return inlinePart
+          .split(BOLD_SYNTAX_RE)
+          .map((part) => {
+            const boldMatch = /^\*\*([^*]+)\*\*$/.exec(part);
+            if (boldMatch) {
+              return `<strong>${linkifyPlainTextSegment(boldMatch[1], capabilities)}</strong>`;
+            }
+
+            return linkifyPlainTextSegment(part, capabilities);
+          })
+          .join('');
+      })
+      .join('');
+  }
+
+  // When inline code is already handled upstream, just process bold and linkify
   return text
-    .split(/(`[^`\n]+`)/g)
-    .map((inlinePart) => {
-      const inlineCodeMatch = /^`([^`\n]+)`$/.exec(inlinePart);
-      if (inlineCodeMatch) {
-        // Inline code content should also be linkified
-        const linkifiedCode = linkifyPlainTextSegment(inlineCodeMatch[1], capabilities);
-        return `<code>${linkifiedCode}</code>`;
+    .split(BOLD_SYNTAX_RE)
+    .map((part) => {
+      const boldMatch = /^\*\*([^*]+)\*\*$/.exec(part);
+      if (boldMatch) {
+        return `<strong>${linkifyPlainTextSegment(boldMatch[1], capabilities)}</strong>`;
       }
 
-      return inlinePart
-        .split(/(\*\*[^*]+\*\*)/g)
-        .map((part) => {
-          const boldMatch = /^\*\*([^*]+)\*\*$/.exec(part);
-          if (boldMatch) {
-            return `<strong>${linkifyPlainTextSegment(boldMatch[1], capabilities)}</strong>`;
-          }
-
-          return linkifyPlainTextSegment(part, capabilities);
-        })
-        .join('');
+      return linkifyPlainTextSegment(part, capabilities);
     })
     .join('');
 }
@@ -277,20 +351,36 @@ function renderStreamingProseSegment(
   segment: string,
   capabilities: LinkifyCapabilities,
 ): string {
-  return segment
+  // First strip system-internal XML tags from the prose segment
+  const cleaned = stripSystemTags(segment);
+
+  // Split by inline code to avoid double-escaping
+  // linkifyPlainTextSegment already handles HTML escaping for inline code content
+  const inlineParts = cleaned.split(STREAMING_INLINE_CODE_RE);
+
+  const processedParts = inlineParts.map((part, idx) => {
+    // Odd indices are inline code — pass to linkifyPlainTextSegment which escapes HTML
+    if (idx % 2 === 1) {
+      const inlineContent = part.slice(1, -1); // Remove surrounding backticks
+      return `<code>${linkifyPlainTextSegment(inlineContent, capabilities)}</code>`;
+    }
+    // Even indices are prose — escape XML tags then render inline formatting
+    return renderStreamingInlineText(escapeXmlTags(part), capabilities, false);
+  });
+
+  // Now wrap in paragraph/heading structure based on paragraph breaks
+  const combined = processedParts.join('');
+  return combined
     .split(/\n{2,}/)
     .filter((block) => block.length > 0)
     .map((block) => {
       const headingMatch = /^(#{1,6})\s+(.+)$/.exec(block);
       if (headingMatch && !block.includes('\n')) {
         const level = headingMatch[1].length;
-        return `<h${level}>${renderStreamingInlineText(headingMatch[2], capabilities)}</h${level}>`;
+        return `<h${level}>${headingMatch[2]}</h${level}>`;
       }
 
-      const lines = block
-        .split('\n')
-        .map((line) => renderStreamingInlineText(line, capabilities))
-        .join('<br/>');
+      const lines = block.split('\n').join('<br/>');
       return `<p>${lines}</p>`;
     })
     .join('');
@@ -358,6 +448,8 @@ function renderStreamingContent(
       // Already wrapped in <pre> — pass through
       if (seg.startsWith('<pre>')) return seg;
 
+      // renderStreamingProseSegment handles stripSystemTags + escapeXmlTags internally,
+      // and preserves inline code content for natural HTML escaping
       return renderStreamingProseSegment(seg, capabilities);
     })
     .join('');
@@ -553,7 +645,10 @@ const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps
       }
 
       // Non-streaming: full markdown pipeline
-      const parsed = marked.parse(trimmedContent);
+      // Strip system-internal XML tags and escape remaining XML tags outside code blocks
+      // (mirrors CLI's stripPromptXMLTags + html token discard)
+      const cleaned = stripAndEscapeOutsideCodeBlocks(trimmedContent);
+      const parsed = marked.parse(cleaned);
       const sanitized = DOMPurify.sanitize(
         typeof parsed === 'string' ? parsed : String(parsed),
         { ADD_ATTR: ['class', 'data-lang', 'data-copy-success', 'data-copy-title'] }

--- a/webview/src/utils/contentBlockNormalize.ts
+++ b/webview/src/utils/contentBlockNormalize.ts
@@ -259,6 +259,14 @@ export function normalizeBlocks(
     return [{ type: 'text' as const, text: raw }];
   }
 
+  // Check if this is a user message - only user messages should have command-message formatting
+  // Use index access since ClaudeRawMessage has [key: string]: unknown
+  const rawMessage = raw.message as Record<string, unknown> | undefined;
+  const isUserMessage =
+    raw.type === 'user' ||
+    raw['role'] === 'user' ||
+    rawMessage?.['role'] === 'user';
+
   const buildBlocksFromArray = (entries: unknown[]): ClaudeContentBlock[] => {
     const blocks: ClaudeContentBlock[] = [];
     entries.forEach((entry) => {
@@ -283,7 +291,9 @@ export function normalizeBlocks(
           }
         }
 
-        if (hasCommandMessageTag(rawText)) {
+        // Only format <command-message> for user messages
+        // Assistant messages may contain these tags in code examples
+        if (isUserMessage && hasCommandMessageTag(rawText)) {
           const displayContent = formatCommandForDisplay(rawText);
           if (displayContent) {
             blocks.push({
@@ -295,7 +305,8 @@ export function normalizeBlocks(
         }
 
         // Filter out messages that only contain command tags without command-message
-        if (containsAnyTag(rawText, FILTERED_NORMALIZE_TAGS)) {
+        // But only for user messages - assistant messages may have these in code examples
+        if (isUserMessage && containsAnyTag(rawText, FILTERED_NORMALIZE_TAGS)) {
           return;
         }
 
@@ -372,8 +383,9 @@ export function normalizeBlocks(
         return null;
       }
 
-      // If has <command-message>, format for display
-      if (hasCommandMessageTag(content)) {
+      // Only format <command-message> for user messages
+      // Assistant messages may contain these tags in code examples
+      if (isUserMessage && hasCommandMessageTag(content)) {
         const displayContent = formatCommandForDisplay(content);
         if (displayContent) {
           return [{ type: 'text' as const, text: localizeMessage(displayContent) }];
@@ -384,7 +396,8 @@ export function normalizeBlocks(
       }
 
       // Filter empty strings and command tags (without <command-message>)
-      if (!content.trim() || containsAnyTag(content, FILTERED_NORMALIZE_TAGS)) {
+      // But only for user messages - assistant messages with these tags should pass through
+      if (!content.trim() || (isUserMessage && containsAnyTag(content, FILTERED_NORMALIZE_TAGS))) {
         return null;
       }
       return [{ type: 'text' as const, text: localizeMessage(content) }];

--- a/webview/src/utils/messageUtils.ts
+++ b/webview/src/utils/messageUtils.ts
@@ -167,7 +167,8 @@ export function getMessageText(
   let result = localizeMessage(text);
 
   // Format <command-message> content using formatCommandForDisplay
-  if (hasCommandMessageTag(result)) {
+  // Only apply to user messages - assistant messages may contain these tags in code examples
+  if (message.type === 'user' && hasCommandMessageTag(result)) {
     const displayContent = formatCommandForDisplay(result);
     if (displayContent) {
       result = displayContent;
@@ -263,13 +264,15 @@ export function shouldShowMessage(
   // Messages with <local-command-stdout> or <local-command-stderr> should be shown
   // CLI renders them with UserLocalCommandOutputMessage component
   // But for GUI, we filter these as they are internal terminal output
-  if (rawText && containsAnyTag(rawText, HIDDEN_OUTPUT_TAGS)) {
+  // Only filter for user messages - assistant messages may contain these tags in code examples
+  if (message.type === 'user' && rawText && containsAnyTag(rawText, HIDDEN_OUTPUT_TAGS)) {
     return false;
   }
 
   // Filter messages with command tags (internal metadata, not user input)
   // BUT keep "Unknown skill: xxx" messages which are plain text user-visible messages
-  if (rawText && containsAnyTag(rawText, INTERNAL_METADATA_TAGS)) {
+  // Only filter for user messages - assistant messages may contain these tags in code examples
+  if (message.type === 'user' && rawText && containsAnyTag(rawText, INTERNAL_METADATA_TAGS)) {
     return false;
   }
 


### PR DESCRIPTION
Assistant messages containing command-related XML tags (e.g. `<command-name>`, `<local-command-stdout>`) in code examples were incorrectly filtered at all three architecture layers:

- Java: MessageParser/CodexMessageHandler filtered all message types
- Frontend: messageUtils.ts filtered tags without type check
- Frontend: contentBlockNormalize.ts formatted command tags for all messages

Changes:
- Add message type checks at each layer to only filter/format user messages
- Hoist regex patterns to module scope in MarkdownBlock.tsx (Vercel best practice)
- Add helper functions to escape XML tags outside code blocks/inline code
- Add 8 test cases based on real JSONL conversation data

Fixes issue where assistant messages with code examples like:
```
text.includes('<command-name>/compact</command-name>')
```
were being discarded or incorrectly rendered as `/compact` commands.

Fixes #1123