### PR TITLE
fix(permissions): respect settings.json rules in plan mode

### DIFF
--- a/ai-bridge/services/claude/permission-mode.js
+++ b/ai-bridge/services/claude/permission-mode.js
@@ -232,14 +232,12 @@ export function createPreToolUseHook(permissionModeState, cwd = null, onModeChan
         }
       }
 
-      // Step 2: Safe always-allow tools are auto-approved (includes AskUserQuestion,
-      // TodoWrite, Task*, EnterPlanMode, Glob, Grep, Read, LSP, etc.
-      // NOTE: WebFetch/WebSearch/Skill are NOT here — they go through plan mode allowed or canUseTool)
+      // Step 2: Safe always-allow tools yield to SDK so settings.json deny rules can fire.
       if (SAFE_ALWAYS_ALLOW_TOOLS.has(toolName)) {
         return {
           hookSpecificOutput: {
             hookEventName: 'PreToolUse',
-            permissionDecision: 'allow'
+            permissionDecision: 'continue'
           }
         };
       }
@@ -333,7 +331,7 @@ export function createPreToolUseHook(permissionModeState, cwd = null, onModeChan
         return {
           hookSpecificOutput: {
             hookEventName: 'PreToolUse',
-            permissionDecision: 'allow'
+            permissionDecision: 'continue'
           }
         };
       }
@@ -343,7 +341,7 @@ export function createPreToolUseHook(permissionModeState, cwd = null, onModeChan
         return {
           hookSpecificOutput: {
             hookEventName: 'PreToolUse',
-            permissionDecision: 'allow'
+            permissionDecision: 'continue'
           }
         };
       }

--- a/ai-bridge/services/claude/permission-mode.test.js
+++ b/ai-bridge/services/claude/permission-mode.test.js
@@ -80,11 +80,47 @@ test('EnterPlanMode is still auto-allowed (mode transition signal)', async () =>
   assert.equal(result?.hookSpecificOutput?.permissionDecision, 'allow');
 });
 
-test('plan mode: SAFE tools still short-circuit to allow (plan UX unchanged)', async () => {
+test('plan mode: SAFE tool (Read) yields "continue" so deny rules apply in plan mode', async () => {
   const hook = makeHook('plan');
   const result = await hook({
     tool_name: 'Read',
     tool_input: { file_path: '/tmp/test-cwd/x' },
   });
+  assert.equal(result?.hookSpecificOutput?.permissionDecision, 'continue');
+});
+
+test('plan mode: PLAN_MODE_ALLOWED_TOOLS (WebFetch) yields "continue"', async () => {
+  const hook = makeHook('plan');
+  const result = await hook({
+    tool_name: 'WebFetch',
+    tool_input: { url: 'https://example.com', prompt: 'title' },
+  });
+  assert.equal(result?.hookSpecificOutput?.permissionDecision, 'continue');
+});
+
+test('plan mode: read-only MCP tool yields "continue"', async () => {
+  const hook = makeHook('plan');
+  const result = await hook({
+    tool_name: 'mcp__some-server__lookup',
+    tool_input: { query: 'x' },
+  });
+  assert.equal(result?.hookSpecificOutput?.permissionDecision, 'continue');
+});
+
+test('plan mode: Agent is still auto-allowed (sub-agent permission flow unchanged)', async () => {
+  const hook = makeHook('plan');
+  const result = await hook({
+    tool_name: 'Agent',
+    tool_input: { description: 'x', prompt: 'y' },
+  });
   assert.equal(result?.hookSpecificOutput?.permissionDecision, 'allow');
+});
+
+test('plan mode: non-allowed tool falls through to plan-specific deny', async () => {
+  const hook = makeHook('plan');
+  const result = await hook({
+    tool_name: 'SomeUnknownTool',
+    tool_input: {},
+  });
+  assert.equal(result?.hookSpecificOutput?.permissionDecision, 'deny');
 });


### PR DESCRIPTION
## Summary

- Convert three plan-mode auto-allow short-circuits in `createPreToolUseHook` to `permissionDecision: 'continue'`, completing the second "Out of scope" item from #1121:
  - `SAFE_ALWAYS_ALLOW_TOOLS` (Step 2)
  - `PLAN_MODE_ALLOWED_TOOLS` (Step 5)
  - read-only `mcp__*` tools (Step 6)
- Update the Step 2 comment from "auto-approved" to accurately describe the yield-to-SDK behavior.
- Extend `permission-mode.test.js`: 4 new plan-mode cases (Read continue, WebFetch continue, MCP continue, Agent allow regression, unknown-tool deny regression). 13/13 tests pass.

Follow-up to #1121, second item in its "Out of scope" section.

## Why

#1121 made the SDK evaluate `~/.claude/settings.json` permission rules for default/acceptEdits/bypassPermissions modes. Plan mode was deferred because its hook has its own opinionated UX (Edit only `PLAN.md`, no execution, etc.) that isn't expressible as settings.json rules.

But the three branches converted here are pure auto-allow paths with no plan-specific semantics — they just shortcut tool execution. A user with `{ "permissions": { "deny": ["Read(./.env)"] } }` would see plan-mode Read of `.env` go through silently, while the same rule fires in default mode. That inconsistency is the bug.

Plan-mode-specific branches that *do* have unique semantics are preserved (see Behavior preservation).

## Behavior preservation

- **`EnterPlanMode` and `ExitPlanMode`** still go through their existing paths (mode-switch signal + plan approval dialog).
- **`Agent` / `Task` in plan mode** still auto-allow. Sub-agent spawn has its own permission flow downstream; routing through `canUseTool` here would prompt on every spawn.
- **`Edit`/`Write`/`MultiEdit`/`NotebookEdit` on `PLAN.md`** still auto-allow. This is plan mode's core UX — editing the plan file should be unconditional.
- **`Edit`/`Write` on non-`PLAN.md`** still call `canUseTool` inline, preserving the plan-specific deny message ("Cannot edit non-plan files in plan mode").
- **`Bash` in plan mode** still calls `canUseTool` inline, preserving the "every command needs explicit approval in plan mode" UX.
- **Fallback deny** for unrecognized tools still fires with the existing reason ("Tool X is not allowed in plan mode").

One UX change worth flagging: previously `WebFetch`, `WebSearch`, and read-only MCP tools in plan mode auto-allowed without any dialog. After this change, if no settings.json rule matches, the SDK classifier escalates them through `canUseTool` → Java approval dialog. This is the same trade-off #1121 made for non-plan modes: silent auto-allow → rule-driven gating, with dialog fallback. The benefit is that explicit deny rules now apply uniformly across all modes.

## Verification

Empirical end-to-end with `@anthropic-ai/claude-agent-sdk@0.2.139`, `permissionMode: 'plan'`, hook returning `'continue'`:

| Scenario | SDK routes to canUseTool? | Outcome |
| --- | --- | --- |
| `plan` + `Read('/tmp/sdk-perm-test/package.json')` | no (classifier safe) | auto-allowed, file read ✓ |
| `plan` + `Bash('echo PLANMODETEST')` | n/a | model refused upstream ("plan mode is active, which restricts me to read-only actions") |
| `plan` + `WebFetch('https://example.com')` | yes | dialog (Java) → approval → fetched ✓ |

The Bash result is particularly important: Claude itself enforces plan mode at the model level, so changing the hook doesn't enable bash execution in plan mode. The "discourage execution" UX is preserved both upstream (model refusal) and downstream (inline `canUseTool` if the model ever does try).

## Test plan

- [x] `node --test ai-bridge/services/claude/permission-mode.test.js` — 13/13 pass (9 from #1121 + 4 new plan-mode cases)
- [x] Empirical SDK verification across the three plan-mode scenarios above
- [ ] Manual smoke: enter plan mode in the plugin with `~/.claude/settings.json` containing `permissions.deny: ["Read(./.env)"]`, ask Claude to read `.env`, confirm denial fires
- [ ] Manual smoke: enter plan mode and confirm `Edit('./PLAN.md')` still auto-allows; `Edit('./other.js')` still surfaces the plan-mode deny message

## Out of scope

- The remaining item from #1121's Out of scope: wiring the Java "Always allow" dialog to optionally persist granted patterns into `~/.claude/settings.json`'s `permissions.allow`. Larger change touching Java + settings.json + (currently empty) UI section.
