### PR TITLE
feat(webview): render compact summary as collapsible notification block

### DIFF
--- a/src/main/java/com/github/claudecodegui/util/MessageJsonConverter.java
+++ b/src/main/java/com/github/claudecodegui/util/MessageJsonConverter.java
@@ -193,6 +193,12 @@ public class MessageJsonConverter {
         copyFieldIfPresent(raw, transport, "type");
         copyFieldIfPresent(raw, transport, "isMeta");
         copyFieldIfPresent(raw, transport, "text");
+        // Compact-related fields for filtering compact summary messages
+        copyFieldIfPresent(raw, transport, "isCompactSummary");
+        copyFieldIfPresent(raw, transport, "isVisibleInTranscriptOnly");
+        copyFieldIfPresent(raw, transport, "summarizeMetadata");
+        // Origin field for distinguishing human input from synthetic messages
+        copyFieldIfPresent(raw, transport, "origin");
 
         if (raw.has("content")) {
             transport.add("content", raw.get("content").deepCopy());

--- a/webview/src/components/MessageItem/ContentBlockRenderer.tsx
+++ b/webview/src/components/MessageItem/ContentBlockRenderer.tsx
@@ -1,5 +1,6 @@
+import { useState, useCallback, memo } from 'react';
 import type { TFunction } from 'i18next';
-import type { ClaudeContentBlock, ToolResultBlock } from '../../types';
+import type { ClaudeContentBlock, ToolResultBlock, CompactSummaryMetadata } from '../../types';
 
 import MarkdownBlock from '../MarkdownBlock';
 import CollapsibleTextBlock from '../CollapsibleTextBlock';
@@ -45,6 +46,53 @@ function getExtension(fileName?: string): string {
   const parts = fileName.split('.');
   return parts.length > 1 ? parts[parts.length - 1].toUpperCase() : '';
 }
+
+interface CompactSummaryBlockProps {
+  block: {
+    type: 'compact_summary';
+    title: string;
+    content: string;
+    metadata?: CompactSummaryMetadata;
+  };
+}
+
+/**
+ * Compact summary block - collapsed by default, click to expand.
+ * Memoized to prevent state reset on parent re-renders during streaming.
+ */
+const CompactSummaryBlock = memo(function CompactSummaryBlock({ block }: CompactSummaryBlockProps) {
+  const [expanded, setExpanded] = useState(false);
+  const toggleExpanded = useCallback(() => setExpanded(e => !e), []);
+  const meta = block.metadata;
+  const hasMeta = meta && typeof meta.messagesSummarized === 'number';
+
+  return (
+    <div className="compact-summary-block">
+      <div className="compact-summary-title" onClick={toggleExpanded}>
+        <span className="compact-summary-icon">●</span>
+        <span className="compact-summary-title-text">{block.title}</span>
+        <span className="compact-summary-toggle">{expanded ? '▼' : '▶'}</span>
+      </div>
+      {hasMeta && (
+        <div className="compact-summary-metadata">
+          <span className="compact-summary-meta-count">
+            Summarized {meta.messagesSummarized} messages {meta.direction === 'up_to' ? 'up to this point' : 'from this point'}
+          </span>
+          {meta.userContext && (
+            <span className="compact-summary-meta-context">
+              Context: "{meta.userContext}"
+            </span>
+          )}
+        </div>
+      )}
+      {expanded && block.content && (
+        <div className="compact-summary-content">
+          <MarkdownBlock content={block.content} />
+        </div>
+      )}
+    </div>
+  );
+});
 
 export interface ContentBlockRendererProps {
   block: ClaudeContentBlock;
@@ -228,6 +276,32 @@ export function ContentBlockRenderer({
         toolId={block.id}
       />
     );
+  }
+
+  // Compact notification block - renders as header + indented sub-items
+  if (block.type === 'compact_notification') {
+    return (
+      <div className="compact-notification-block">
+        <div className="compact-notification-header">
+          {block.headerText}
+        </div>
+        {block.items.length > 0 && (
+          <div className="compact-notification-items">
+            {block.items.map((item, idx) => (
+              <div key={idx} className="compact-notification-item">
+                <span className="compact-notification-prefix">⎿</span>
+                <span className="compact-notification-text">{item.text}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Compact summary block - collapsed by default, click to expand
+  if (block.type === 'compact_summary') {
+    return <CompactSummaryBlock block={block} />;
   }
 
   // Task notification block - renders as "● summary" with status color

--- a/webview/src/components/MessageItem/ContentBlockRenderer.tsx
+++ b/webview/src/components/MessageItem/ContentBlockRenderer.tsx
@@ -54,33 +54,56 @@ interface CompactSummaryBlockProps {
     content: string;
     metadata?: CompactSummaryMetadata;
   };
+  t: TFunction;
 }
 
 /**
- * Compact summary block - collapsed by default, click to expand.
+ * Compact summary block - collapsed by default, click/Enter/Space to expand.
  * Memoized to prevent state reset on parent re-renders during streaming.
+ * `block.title` is an i18n key resolved via t() at render time.
  */
-const CompactSummaryBlock = memo(function CompactSummaryBlock({ block }: CompactSummaryBlockProps) {
+const CompactSummaryBlock = memo(function CompactSummaryBlock({ block, t }: CompactSummaryBlockProps) {
   const [expanded, setExpanded] = useState(false);
   const toggleExpanded = useCallback(() => setExpanded(e => !e), []);
+  const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      setExpanded(prev => !prev);
+    }
+  }, []);
   const meta = block.metadata;
   const hasMeta = meta && typeof meta.messagesSummarized === 'number';
+  const titleText = t(block.title);
+  const toggleLabel = expanded ? t('chat.compactSummary.collapse') : t('chat.compactSummary.expand');
 
   return (
     <div className="compact-summary-block">
-      <div className="compact-summary-title" onClick={toggleExpanded}>
-        <span className="compact-summary-icon">●</span>
-        <span className="compact-summary-title-text">{block.title}</span>
-        <span className="compact-summary-toggle">{expanded ? '▼' : '▶'}</span>
+      <div
+        className="compact-summary-title"
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        aria-label={`${titleText} — ${toggleLabel}`}
+        onClick={toggleExpanded}
+        onKeyDown={onKeyDown}
+      >
+        <span className="compact-summary-icon" aria-hidden="true">●</span>
+        <span className="compact-summary-title-text">{titleText}</span>
+        <span className="compact-summary-toggle" aria-hidden="true">{expanded ? '▼' : '▶'}</span>
       </div>
       {hasMeta && (
         <div className="compact-summary-metadata">
           <span className="compact-summary-meta-count">
-            Summarized {meta.messagesSummarized} messages {meta.direction === 'up_to' ? 'up to this point' : 'from this point'}
+            {t(
+              meta.direction === 'from'
+                ? 'chat.compactSummary.messagesFrom'
+                : 'chat.compactSummary.messagesUpTo',
+              { count: meta.messagesSummarized },
+            )}
           </span>
           {meta.userContext && (
             <span className="compact-summary-meta-context">
-              Context: "{meta.userContext}"
+              {t('chat.compactSummary.userContext', { context: meta.userContext })}
             </span>
           )}
         </div>
@@ -301,7 +324,7 @@ export function ContentBlockRenderer({
 
   // Compact summary block - collapsed by default, click to expand
   if (block.type === 'compact_summary') {
-    return <CompactSummaryBlock block={block} />;
+    return <CompactSummaryBlock block={block} t={t} />;
   }
 
   // Task notification block - renders as "● summary" with status color

--- a/webview/src/components/MessageItem/MessageItem.tsx
+++ b/webview/src/components/MessageItem/MessageItem.tsx
@@ -580,8 +580,9 @@ export const MessageItem = memo(function MessageItem({
         />
       )}
 
-      {/* Role label for non-user/assistant messages */}
-      {message.type !== 'assistant' && message.type !== 'user' && (
+      {/* Role label for non-user/assistant messages — hidden for notification types */}
+      {message.type !== 'assistant' && message.type !== 'user'
+        && message.type !== 'notification' && message.type !== 'task_notification' && (
         <div className="message-role-label">
           {message.type}
         </div>

--- a/webview/src/hooks/useMessageProcessing.test.ts
+++ b/webview/src/hooks/useMessageProcessing.test.ts
@@ -50,4 +50,191 @@ describe('useMessageProcessing', () => {
     ]);
     expect(result.current.mergedMessages.map((message) => message.__turnId)).toEqual([1, 2]);
   });
+
+  it('renders /compact as user message with summary notification', () => {
+    const messages: ClaudeMessage[] = [
+      // /compact command → stays as user message
+      makeMessage('user', '', {
+        raw: { message: { content: '<command-name>/compact</command-name><command-message>compact</command-message>' } },
+        timestamp: '2026-01-01T10:00:00.000Z',
+      }),
+      // stdout → hidden (HIDDEN_OUTPUT_TAGS)
+      makeMessage('user', '', {
+        raw: { message: { content: '<local-command-stdout>Compacted Tip: test</local-command-stdout>' } },
+        timestamp: '2026-01-01T10:00:01.000Z',
+      }),
+      // isCompactSummary → notification with collapsible compact_summary block
+      makeMessage('user', '', {
+        raw: { isCompactSummary: true, summarizeMetadata: { messagesSummarized: 10 }, message: { content: 'This session is being continued...' } },
+        timestamp: '2026-01-01T10:00:02.000Z',
+      }),
+    ];
+
+    const { result } = renderHook(() =>
+      useMessageProcessing({ messages, currentSessionId: 'session-1', t }),
+    );
+
+    // /compact user message + summary notification
+    expect(result.current.mergedMessages).toHaveLength(2);
+    expect(result.current.mergedMessages[0].type).toBe('user');
+    expect(result.current.mergedMessages[1].type).toBe('notification');
+  });
+
+  it('shows auto-compact summary as notification', () => {
+    const messages: ClaudeMessage[] = [
+      makeMessage('user', '', {
+        raw: { isCompactSummary: true, message: { content: 'This session is being continued from a previous conversation...' } },
+        timestamp: '2026-01-01T10:00:00.000Z',
+      }),
+      makeMessage('assistant', 'Hello', {
+        raw: { content: [{ type: 'text', text: 'Hello' }] } as any,
+        timestamp: '2026-01-01T10:00:01.000Z',
+      }),
+    ];
+
+    const { result } = renderHook(() =>
+      useMessageProcessing({ messages, currentSessionId: 'session-1', t }),
+    );
+
+    expect(result.current.mergedMessages).toHaveLength(2);
+    expect(result.current.mergedMessages[0].type).toBe('notification');
+    expect(result.current.mergedMessages[1].type).toBe('assistant');
+  });
+
+  it('keeps standalone stdout hidden', () => {
+    const messages: ClaudeMessage[] = [
+      makeMessage('user', 'hello', { timestamp: '2026-01-01T10:00:00.000Z' }),
+      makeMessage('user', '', {
+        raw: { message: { content: '<local-command-stdout>orphan output</local-command-stdout>' } },
+        timestamp: '2026-01-01T10:00:01.000Z',
+      }),
+    ];
+
+    const { result } = renderHook(() =>
+      useMessageProcessing({ messages, currentSessionId: 'session-1', t }),
+    );
+
+    // Standalone stdout should be hidden (only hello visible)
+    expect(result.current.mergedMessages).toHaveLength(1);
+    expect(result.current.mergedMessages[0].content).toBe('hello');
+  });
+
+  it('swaps order when isCompactSummary precedes /compact', () => {
+    // Real CLI output: isCompactSummary is written before /compact in JSONL
+    const messages: ClaudeMessage[] = [
+      // isCompactSummary comes first in file order
+      makeMessage('user', '', {
+        raw: { isCompactSummary: true, summarizeMetadata: { messagesSummarized: 10 }, message: { content: 'Summary...' } },
+        timestamp: '2026-01-01T10:00:02.000Z',
+      }),
+      // /compact command follows
+      makeMessage('user', '', {
+        raw: { message: { content: '<command-name>/compact</command-name><command-message>compact</command-message>' } },
+        timestamp: '2026-01-01T10:00:00.000Z',
+      }),
+    ];
+
+    const { result } = renderHook(() =>
+      useMessageProcessing({ messages, currentSessionId: 'session-1', t }),
+    );
+
+    // /compact user message should be swapped before the summary notification
+    expect(result.current.mergedMessages).toHaveLength(2);
+    expect(result.current.mergedMessages[0].type).toBe('user');
+    expect(result.current.mergedMessages[1].type).toBe('notification');
+  });
+
+  it('non-compact command with stdout remains hidden', () => {
+    const messages: ClaudeMessage[] = [
+      makeMessage('user', '', {
+        raw: { message: { content: '<command-name>/aimax:auto</command-name><command-message>aimax:auto</command-message>' } },
+        timestamp: '2026-01-01T10:00:00.000Z',
+      }),
+      makeMessage('user', '', {
+        raw: { message: { content: '<local-command-stdout>some output</local-command-stdout>' } },
+        timestamp: '2026-01-01T10:00:01.000Z',
+      }),
+    ];
+
+    const { result } = renderHook(() =>
+      useMessageProcessing({ messages, currentSessionId: 'session-1', t }),
+    );
+
+    // Non-compact command renders as user message, stdout hidden
+    expect(result.current.mergedMessages).toHaveLength(1);
+    expect(result.current.mergedMessages[0].type).toBe('user');
+  });
+
+  it('shows new user message once after compact command during streaming', () => {
+    // Simulates backend response after compaction: compact command with XML
+    // tags + stdout, followed by a new user message. Verifies no duplicate.
+    const messages: ClaudeMessage[] = [
+      makeMessage('user', '', {
+        raw: { message: { content: '<command-name>/compact</command-name><command-message>compact</command-message>' } },
+        timestamp: '2026-01-01T10:00:00.000Z',
+      }),
+      makeMessage('user', '', {
+        raw: { message: { content: '<local-command-stdout>Compacted Tip: ...</local-command-stdout>' } },
+        timestamp: '2026-01-01T10:00:01.000Z',
+      }),
+      makeMessage('user', 'hello', {
+        raw: { message: { content: [{ type: 'text', text: 'hello' }] } },
+        timestamp: '2026-01-01T10:00:02.000Z',
+      }),
+    ];
+
+    const { result } = renderHook(() =>
+      useMessageProcessing({ messages, currentSessionId: 'session-1', t }),
+    );
+
+    // /compact user message + user "hello" (no duplicate, stdout hidden)
+    expect(result.current.mergedMessages).toHaveLength(2);
+    expect(result.current.mergedMessages[0].type).toBe('user');
+    expect(result.current.mergedMessages[1].type).toBe('user');
+    expect(result.current.mergedMessages[1].content).toBe('hello');
+  });
+
+  it('renders optimistic /compact as user message during streaming (no XML tags yet)', () => {
+    // When user sends /compact during streaming, the optimistic message
+    // has no XML tags — it should render as a normal user message.
+    // Only backend messages with XML tags should trigger compact grouping.
+    const messages: ClaudeMessage[] = [
+      makeMessage('user', '/compact', {
+        raw: { message: { content: [{ type: 'text', text: '/compact' }] } },
+        isOptimistic: true,
+        timestamp: '2026-01-01T10:00:00.000Z',
+      }),
+    ];
+
+    const { result } = renderHook(() =>
+      useMessageProcessing({ messages, currentSessionId: 'session-1', t }),
+    );
+
+    expect(result.current.mergedMessages).toHaveLength(1);
+    expect(result.current.mergedMessages[0].type).toBe('user');
+    expect(result.current.mergedMessages[0].content).toBe('/compact');
+  });
+
+  it('does not group /compact followed by another slash command', () => {
+    const messages: ClaudeMessage[] = [
+      makeMessage('user', '', {
+        raw: { message: { content: '<command-name>/compact</command-name><command-message>compact</command-message>' } },
+        timestamp: '2026-01-01T10:00:00.000Z',
+      }),
+      makeMessage('user', '/help', {
+        raw: { message: { content: [{ type: 'text', text: '/help' }] } },
+        timestamp: '2026-01-01T10:00:01.000Z',
+      }),
+    ];
+
+    const { result } = renderHook(() =>
+      useMessageProcessing({ messages, currentSessionId: 'session-1', t }),
+    );
+
+    // /compact user message + /help user message
+    expect(result.current.mergedMessages).toHaveLength(2);
+    expect(result.current.mergedMessages[0].type).toBe('user');
+    expect(result.current.mergedMessages[1].type).toBe('user');
+    expect(result.current.mergedMessages[1].content).toBe('/help');
+  });
 });

--- a/webview/src/hooks/useMessageProcessing.ts
+++ b/webview/src/hooks/useMessageProcessing.ts
@@ -9,6 +9,8 @@ import {
   mergeConsecutiveAssistantMessages,
   isTaskNotificationOnlyMessage,
   hasNonHumanOrigin,
+  isCompactRelatedMessage,
+  isCompactCommandMessage,
   MESSAGE_TYPES,
 } from '../utils/messageUtils';
 import type { ClaudeContentBlock, ClaudeMessage, ClaudeRawMessage } from '../types';
@@ -117,14 +119,29 @@ export function useMessageProcessing({ messages, currentSessionId, t }: UseMessa
     );
 
     const visible: ClaudeMessage[] = [];
+
     for (const message of merged) {
+      // ── Compact summary → notification ─────────────────────────────────
+      // Must happen before shouldShowMessage because isCompactSummary
+      // messages are filtered out there. Show as left-aligned collapsible
+      // notification block with title, metadata, and expandable summary.
+      // /compact command messages pass through to shouldShowMessage where
+      // hasCommandMessageTag returns true → rendered as normal user message.
+      // stdout messages are hidden by HIDDEN_OUTPUT_TAGS filter.
+      if (message.type === MESSAGE_TYPES.USER && isCompactRelatedMessage(message) && !isTaskNotificationOnlyMessage(message)) {
+        const raw = message.raw;
+        const isCompactSummary = raw && typeof raw === 'object' && 'isCompactSummary' in raw && raw.isCompactSummary;
+        if (isCompactSummary) {
+          visible.push({ ...message, type: MESSAGE_TYPES.NOTIFICATION });
+          continue;
+        }
+      }
+
+      // ── Standard visibility + type transforms ──────────────────────────
       if (shouldShowMessageCached(message)) {
-        // Transform task_notification messages to have specific type
         if (message.type === MESSAGE_TYPES.USER && isTaskNotificationOnlyMessage(message)) {
           visible.push({ ...message, type: MESSAGE_TYPES.TASK_NOTIFICATION });
         }
-        // Transform other non-human origin messages
-        // to 'notification' type for left-aligned display
         else if (message.type === MESSAGE_TYPES.USER && hasNonHumanOrigin(message)) {
           visible.push({ ...message, type: MESSAGE_TYPES.NOTIFICATION });
         } else {
@@ -132,10 +149,28 @@ export function useMessageProcessing({ messages, currentSessionId, t }: UseMessa
         }
       }
     }
+
+    // Post-process: ensure /compact command appears before its compact
+    // summary notification. In CLI output the isCompactSummary message can
+    // precede the /compact command in the JSONL file, so after filtering
+    // intermediate messages they may end up adjacent in the wrong order:
+    // [notification, /compact user]. Swap them.
+    for (let i = 0; i < visible.length - 1; i++) {
+      const curr = visible[i];
+      const next = visible[i + 1];
+      const currRaw = curr.raw;
+      if (curr.type === MESSAGE_TYPES.NOTIFICATION
+        && currRaw && typeof currRaw === 'object' && currRaw.isCompactSummary
+        && next.type === MESSAGE_TYPES.USER && isCompactCommandMessage(next)) {
+        visible[i] = next;
+        visible[i + 1] = curr;
+      }
+    }
+
     return visible;
-    // Note: isTaskNotificationOnlyMessage and hasNonHumanOrigin are stable module-level
-    // pure functions imported from messageUtils — their references never change,
-    // so they don't need to be in the dependency array.
+    // Note: isTaskNotificationOnlyMessage, hasNonHumanOrigin, isCompactRelatedMessage
+    // are stable module-level pure functions imported from messageUtils — their references
+    // never change, so they don't need to be in the dependency array.
   }, [messages, shouldShowMessageCached, normalizeBlocks]);
 
   return {

--- a/webview/src/hooks/useMessageProcessing.ts
+++ b/webview/src/hooks/useMessageProcessing.ts
@@ -155,6 +155,12 @@ export function useMessageProcessing({ messages, currentSessionId, t }: UseMessa
     // precede the /compact command in the JSONL file, so after filtering
     // intermediate messages they may end up adjacent in the wrong order:
     // [notification, /compact user]. Swap them.
+    //
+    // Assumption: each /compact invocation produces exactly one summary, so
+    // we only ever need to swap a single adjacent pair per cluster. After a
+    // swap we advance by 2 (via `i += 2`) to avoid re-considering the just-
+    // swapped notification as the `curr` of the next iteration, which would
+    // otherwise undo the swap if a second compact pair follows immediately.
     for (let i = 0; i < visible.length - 1; i++) {
       const curr = visible[i];
       const next = visible[i + 1];
@@ -164,6 +170,7 @@ export function useMessageProcessing({ messages, currentSessionId, t }: UseMessa
         && next.type === MESSAGE_TYPES.USER && isCompactCommandMessage(next)) {
         visible[i] = next;
         visible[i + 1] = curr;
+        i++; // Skip the swapped pair to keep ordering stable for chained compacts
       }
     }
 

--- a/webview/src/hooks/windowCallbacks/__tests__/messageSync.test.ts
+++ b/webview/src/hooks/windowCallbacks/__tests__/messageSync.test.ts
@@ -7,7 +7,9 @@ import {
   ensureStreamingAssistantInList,
   getStreamEndHandlingMode,
   getRawUuid,
+  getMessageTimestampMs,
   preserveLastAssistantIdentity,
+  preserveLatestMessagesOnShrink,
   preserveMessageIdentity,
   preserveStreamingAssistantContent,
   stripDuplicateTrailingToolMessages,
@@ -64,6 +66,83 @@ describe('getStreamEndHandlingMode', () => {
 
   it('skips finalize for non-Codex providers when no stream is active', () => {
     expect(getStreamEndHandlingMode('claude', false, 0)).toBe('skip');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getMessageTimestampMs
+// ---------------------------------------------------------------------------
+
+describe('getMessageTimestampMs', () => {
+  it('extracts timestamp from ISO string in raw.timestamp', () => {
+    const isoTimestamp = '2024-01-01T10:00:00.000Z';
+    const expectedMs = new Date(isoTimestamp).getTime();
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'test',
+      raw: { timestamp: isoTimestamp },
+    };
+    expect(getMessageTimestampMs(msg)).toBe(expectedMs);
+  });
+
+  it('extracts timestamp from number in raw.timestamp', () => {
+    const msTimestamp = Date.now();
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'test',
+      raw: { timestamp: msTimestamp },
+    };
+    expect(getMessageTimestampMs(msg)).toBe(msTimestamp);
+  });
+
+  it('extracts timestamp from ISO string in message.timestamp', () => {
+    const isoTimestamp = '2024-01-01T10:00:00.000Z';
+    const expectedMs = new Date(isoTimestamp).getTime();
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'test',
+      timestamp: isoTimestamp,
+    };
+    expect(getMessageTimestampMs(msg)).toBe(expectedMs);
+  });
+
+  it('extracts timestamp from number in message.timestamp', () => {
+    const msTimestamp = Date.now();
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'test',
+      timestamp: msTimestamp as unknown as string, // TypeScript type hack
+    };
+    expect(getMessageTimestampMs(msg)).toBe(msTimestamp);
+  });
+
+  it('prefers raw.timestamp over message.timestamp', () => {
+    const rawTimestamp = Date.now();
+    const msgTimestamp = rawTimestamp - 10000;
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'test',
+      timestamp: msgTimestamp as unknown as string,
+      raw: { timestamp: rawTimestamp },
+    };
+    expect(getMessageTimestampMs(msg)).toBe(rawTimestamp);
+  });
+
+  it('returns undefined when no valid timestamp found', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'test',
+    };
+    expect(getMessageTimestampMs(msg)).toBeUndefined();
+  });
+
+  it('returns undefined for invalid ISO string', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'test',
+      timestamp: 'invalid-date',
+    };
+    expect(getMessageTimestampMs(msg)).toBeUndefined();
   });
 });
 
@@ -286,6 +365,233 @@ describe('appendOptimisticMessageIfMissing', () => {
     const hasAttachment = raw.message.content.some((b: any) => b.type === 'attachment');
     expect(hasAttachment).toBe(true);
   });
+
+  it('does not append optimistic message when it is newer than everything in nextList (stale update)', () => {
+    // Simulates race condition: a stale backend update (from compaction)
+    // arrives after the user has already sent a new optimistic message.
+    // The stale update's newest timestamp is before the optimistic message.
+    const optimisticTime = Date.now();
+    const staleTime = optimisticTime - 10000; // 10 seconds older
+
+    const optimistic = makeUserMsg('fresh message', {
+      isOptimistic: true,
+      timestamp: new Date(optimisticTime).toISOString(),
+    });
+    const staleAssistant = makeAssistantMsg('old response', {
+      timestamp: new Date(staleTime).toISOString(),
+    });
+
+    const prev = [staleAssistant, optimistic];
+    const next: ClaudeMessage[] = [staleAssistant];
+
+    const result = appendOptimisticMessageIfMissing(prev, next);
+    // Stale update should NOT append the optimistic message
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(staleAssistant);
+  });
+
+  it('matches backend user message when Java sends numeric timestamp (millis)', () => {
+    // Java's MessageJsonConverter sends timestamp as number (milliseconds),
+    // while frontend optimistic message uses ISO string format.
+    // Verify fallback matches correctly even with format difference.
+    const nowMs = Date.now();
+    const javaTimestamp = nowMs + 500; // Java creates message slightly later
+
+    const optimistic = makeUserMsg('hello', {
+      isOptimistic: true,
+      timestamp: new Date(nowMs).toISOString(),
+    });
+    // Simulate Java message with numeric timestamp (as number, not string)
+    const backendMsg: ClaudeMessage = {
+      type: 'user',
+      content: 'hello',
+      timestamp: javaTimestamp as unknown as string, // TypeScript type hack to simulate Java format
+    };
+
+    const prev = [optimistic];
+    const next = [backendMsg];
+
+    const result = appendOptimisticMessageIfMissing(prev, next);
+    expect(result).toHaveLength(1);
+    // Should match and use backend message (even with numeric timestamp)
+    expect(result[0]).toBe(backendMsg);
+  });
+
+  it('matches backend user message when Java timestamp is slightly older than optimistic', () => {
+    // In some async scenarios, Java's timestamp may be older than frontend's
+    // due to clock skew or processing delays. Verify fallback allows match
+    // within time window.
+    const nowMs = Date.now();
+    const javaTimestamp = nowMs - 3000; // Java message 3 seconds older (within window)
+
+    const optimistic = makeUserMsg('hello', {
+      isOptimistic: true,
+      timestamp: new Date(nowMs).toISOString(),
+    });
+    const backendMsg: ClaudeMessage = {
+      type: 'user',
+      content: 'hello',
+      timestamp: javaTimestamp as unknown as string,
+    };
+
+    const prev = [optimistic];
+    const next = [backendMsg];
+
+    const result = appendOptimisticMessageIfMissing(prev, next);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(backendMsg);
+  });
+
+  it('matches when backend has raw.timestamp (ISO) and optimistic has message.timestamp (ISO)', () => {
+    // Simulates compact scenario: SDK messages have raw.timestamp as ISO string
+    const nowMs = Date.now();
+    const sdkTimestamp = new Date(nowMs).toISOString();
+
+    const optimistic = makeUserMsg('compact test', {
+      isOptimistic: true,
+      timestamp: new Date(nowMs + 100).toISOString(),
+    });
+    // Backend message from SDK has raw.timestamp (ISO string)
+    const backendMsg: ClaudeMessage = {
+      type: 'user',
+      content: 'compact test',
+      timestamp: '', // message.timestamp may be empty or stale from Java
+      raw: { timestamp: sdkTimestamp },
+    };
+
+    const prev = [optimistic];
+    const next = [backendMsg];
+
+    const result = appendOptimisticMessageIfMissing(prev, next);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(backendMsg);
+  });
+
+  it('matches when both have raw.timestamp in different formats', () => {
+    // Backend: raw.timestamp is number (milliseconds)
+    // Optimistic: raw.timestamp is ISO string
+    const nowMs = Date.now();
+
+    const optimistic: ClaudeMessage = {
+      type: 'user',
+      content: 'mixed format',
+      isOptimistic: true,
+      timestamp: new Date(nowMs).toISOString(),
+      raw: { timestamp: new Date(nowMs).toISOString() },
+    };
+    const backendMsg: ClaudeMessage = {
+      type: 'user',
+      content: 'mixed format',
+      timestamp: nowMs - 500 as unknown as string,
+      raw: { timestamp: nowMs }, // number format
+    };
+
+    const prev = [optimistic];
+    const next = [backendMsg];
+
+    const result = appendOptimisticMessageIfMissing(prev, next);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(backendMsg);
+  });
+
+  it('does not append optimistic when it is newer than all messages in nextList (stale update)', () => {
+    // When optimistic message timestamp is newer than the newest message in nextList,
+    // this indicates a stale update - the backend hasn't yet received the user message.
+    // Should NOT append to avoid showing duplicates.
+    const nowMs = Date.now();
+    const oldBackendTimestamp = nowMs - 10000; // 10 seconds older
+
+    const optimistic = makeUserMsg('new message', {
+      isOptimistic: true,
+      timestamp: new Date(nowMs).toISOString(),
+    });
+    const backendMsg: ClaudeMessage = {
+      type: 'user',
+      content: 'new message',
+      timestamp: '',
+      raw: { timestamp: new Date(oldBackendTimestamp).toISOString() },
+    };
+    // newerMsg is older than optimistic but newer than backendMsg
+    const newerMsg: ClaudeMessage = {
+      type: 'assistant',
+      content: 'response',
+      timestamp: new Date(nowMs - 1000).toISOString(),
+    };
+    const prev = [newerMsg, optimistic];
+    const next = [newerMsg, backendMsg];
+
+    const result = appendOptimisticMessageIfMissing(prev, next);
+    // Should NOT append because optimistic is newer than maxNextTime (stale update guard)
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(newerMsg);
+    expect(result[1]).toBe(backendMsg);
+  });
+
+  it('matches backend user message even when other messages have older timestamps (compact scenario)', () => {
+    // Compact scenario: backend sends compact summary (old timestamp) + new user message.
+    // The new user message's timestamp should match the optimistic, even if compact summary
+    // has an older timestamp that would trigger stale update guard.
+    const nowMs = Date.now();
+    const sdkTimestamp = new Date(nowMs).toISOString(); // SDK sends ISO format
+    const compactSummaryTimestamp = nowMs - 30000; // Compact summary is 30 seconds older
+
+    const optimistic = makeUserMsg('after compact', {
+      isOptimistic: true,
+      timestamp: new Date(nowMs).toISOString(),
+    });
+    // Compact summary message (older timestamp)
+    const compactSummary: ClaudeMessage = {
+      type: 'assistant',
+      content: 'compact summary text',
+      timestamp: new Date(compactSummaryTimestamp).toISOString(),
+    };
+    // New user message from SDK (timestamp matches optimistic within window)
+    const backendUserMsg: ClaudeMessage = {
+      type: 'user',
+      content: 'after compact',
+      timestamp: '', // message.timestamp may be empty from Java
+      raw: { timestamp: sdkTimestamp }, // SDK provides ISO timestamp in raw
+    };
+
+    const prev = [optimistic];
+    const next = [compactSummary, backendUserMsg];
+
+    const result = appendOptimisticMessageIfMissing(prev, next);
+    // Should match backendUserMsg (not trigger stale update guard based on compactSummary)
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(compactSummary);
+    expect(result[1]).toBe(backendUserMsg);
+  });
+
+  it('matches backend user message when its timestamp is slightly older than optimistic', () => {
+    // Real-world timing: SDK receives message slightly after frontend creates optimistic.
+    // SDK timestamp (T2) < frontend optimistic timestamp (T1) by a few milliseconds.
+    // Should still match because time difference is within window.
+    const nowMs = Date.now();
+    const sdkTimestamp = new Date(nowMs - 500).toISOString(); // SDK timestamp 500ms older
+
+    const optimistic = makeUserMsg('timing test', {
+      isOptimistic: true,
+      timestamp: new Date(nowMs).toISOString(),
+    });
+    const backendUserMsg: ClaudeMessage = {
+      type: 'user',
+      content: 'timing test',
+      timestamp: '',
+      raw: { timestamp: sdkTimestamp },
+    };
+    const assistantMsg = makeAssistantMsg('previous response', {
+      timestamp: new Date(nowMs - 1000).toISOString(),
+    });
+
+    const prev = [assistantMsg, optimistic];
+    const next = [assistantMsg, backendUserMsg];
+
+    const result = appendOptimisticMessageIfMissing(prev, next);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(assistantMsg);
+    expect(result[1]).toBe(backendUserMsg);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -488,6 +794,58 @@ describe('preserveStreamingAssistantContent', () => {
     );
     expect(result).toBe(next);
     expect(result[0].content).toBe('new streaming');
+  });
+});
+
+describe('preserveLatestMessagesOnShrink', () => {
+  it('preserves shrink tail when list shrinks for codex', () => {
+    const oldAssistant = makeAssistantMsg('old response');
+    const optimistic = makeUserMsg('new question', { isOptimistic: true });
+    const prev = [oldAssistant, optimistic];
+
+    const compactSummary = makeAssistantMsg('compact summary');
+    const backendUser = makeUserMsg('new question');
+    const next = [compactSummary, backendUser];
+
+    // prev.length = 2, next.length = 2, no shrink
+    const result = preserveLatestMessagesOnShrink(prev, next, 'codex');
+    expect(result).toBe(next);
+  });
+
+  it('does NOT add optimistic duplicate when shrink tail contains optimistic already matched', () => {
+    // Compact scenario: backend sends shorter list, optimistic was matched but shrink
+    // logic must filter it out to prevent duplicate display.
+    const oldAssistant1 = makeAssistantMsg('old response 1');
+    const oldAssistant2 = makeAssistantMsg('old response 2');
+    const optimistic = makeUserMsg('after compact', { isOptimistic: true });
+    const prev = [oldAssistant1, oldAssistant2, optimistic]; // length 3
+
+    const compactSummary = makeAssistantMsg('compact summary');
+    const backendUser = makeUserMsg('after compact'); // matches optimistic content
+    const next = [compactSummary, backendUser]; // length 2 < 3, triggers shrink
+
+    const result = preserveLatestMessagesOnShrink(prev, next, 'claude');
+    // Should NOT add optimistic because nextList already has matching backendUser
+    // Current bug: returns [compactSummary, backendUser, optimistic] - duplicate!
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(compactSummary);
+    expect(result[1]).toBe(backendUser);
+  });
+
+  it('preserves non-optimistic user message in shrink tail when no match in nextList', () => {
+    // Shrink scenario where preserved user message is NOT optimistic (history message)
+    const oldAssistant = makeAssistantMsg('old response');
+    const historyUser = makeUserMsg('history question', { timestamp: '2024-01-01T00:00:00.000Z' });
+    const prev = [oldAssistant, historyUser]; // length 2
+
+    const compactSummary = makeAssistantMsg('compact summary');
+    const next = [compactSummary]; // length 1 < 2, triggers shrink
+
+    const result = preserveLatestMessagesOnShrink(prev, next, 'claude');
+    // Should preserve historyUser because nextList doesn't have matching message
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(compactSummary);
+    expect(result[1]).toBe(historyUser);
   });
 });
 

--- a/webview/src/hooks/windowCallbacks/messageSync.ts
+++ b/webview/src/hooks/windowCallbacks/messageSync.ts
@@ -93,18 +93,15 @@ export const appendOptimisticMessageIfMissing = (
 
   const optimisticMsg = lastPrev;
   const optimisticText = getUserMessageComparableContent(optimisticMsg);
-  const optimisticTime = optimisticMsg.timestamp
-    ? new Date(optimisticMsg.timestamp).getTime()
-    : Number.NaN;
+  const optimisticTime = getMessageTimestampMs(optimisticMsg) ?? Number.NaN;
 
-  const matchFn = (m: ClaudeMessage) =>
-    m.type === 'user' &&
-    getUserMessageComparableContent(m) === optimisticText &&
-    m.timestamp &&
-    optimisticMsg.timestamp &&
-    Math.abs(
-      new Date(m.timestamp).getTime() - new Date(optimisticMsg.timestamp).getTime(),
-    ) < OPTIMISTIC_MESSAGE_TIME_WINDOW;
+  const matchFn = (m: ClaudeMessage) => {
+    if (m.type !== 'user') return false;
+    if (getUserMessageComparableContent(m) !== optimisticText) return false;
+    const candidateTime = getMessageTimestampMs(m) ?? Number.NaN;
+    if (!Number.isFinite(candidateTime) || !Number.isFinite(optimisticTime)) return false;
+    return Math.abs(candidateTime - optimisticTime) < OPTIMISTIC_MESSAGE_TIME_WINDOW;
+  };
 
   let matchedIndex = nextList.findIndex(matchFn);
   if (matchedIndex < 0 && optimisticText) {
@@ -112,8 +109,14 @@ export const appendOptimisticMessageIfMissing = (
       const candidate = nextList[i];
       if (candidate?.type !== 'user') continue;
       if (getUserMessageComparableContent(candidate) !== optimisticText) continue;
-      const candidateTime = candidate.timestamp ? new Date(candidate.timestamp).getTime() : Number.NaN;
-      if (Number.isFinite(optimisticTime) && Number.isFinite(candidateTime) && candidateTime < optimisticTime) {
+      const candidateTime = getMessageTimestampMs(candidate) ?? Number.NaN;
+      // Allow match when candidate is within time window (even if older than optimistic).
+      // This handles cases where Java's timestamp (number format) may differ from
+      // frontend's ISO string format due to clock skew or async processing delays.
+      // Reject only if candidate is significantly older (> time window) to avoid
+      // matching historical duplicate messages.
+      if (Number.isFinite(optimisticTime) && Number.isFinite(candidateTime) &&
+          optimisticTime - candidateTime > OPTIMISTIC_MESSAGE_TIME_WINDOW) {
         continue;
       }
       matchedIndex = i;
@@ -121,6 +124,23 @@ export const appendOptimisticMessageIfMissing = (
     }
   }
   if (matchedIndex < 0) {
+    // Guard against stale backend updates: if the optimistic message was
+    // created after the newest message in nextList, this update was
+    // generated before the user sent the message — a future update will
+    // include it. Don't append, otherwise the UI shows a duplicate until
+    // the real update arrives.
+    if (nextList.length > 0 && Number.isFinite(optimisticTime)) {
+      let maxNextTime = 0;
+      for (const m of nextList) {
+        const ts = getMessageTimestampMs(m) ?? 0;
+        if (Number.isFinite(ts) && ts > maxNextTime) {
+          maxNextTime = ts;
+        }
+      }
+      if (maxNextTime > 0 && optimisticTime > maxNextTime) {
+        return nextList;
+      }
+    }
     return [...nextList, optimisticMsg];
   }
 
@@ -155,6 +175,10 @@ export const appendOptimisticMessageIfMissing = (
   return nextList;
 };
 
+/**
+ * Extract comparable text content from a user message for deduplication matching.
+ * Handles both direct content string and raw.message.content array format.
+ */
 const getUserMessageComparableContent = (message: ClaudeMessage): string => {
   if (message.type !== 'user') return message.content || '';
   const rawContent = (message.raw as any)?.message?.content ?? (message.raw as any)?.content;
@@ -166,6 +190,40 @@ const getUserMessageComparableContent = (message: ClaudeMessage): string => {
     .map((block: any) => block.text)
     .join('\n');
   return rawText || message.content || '';
+};
+
+/**
+ * Extract timestamp from a message, handling both formats:
+ * - Java Message.timestamp: number (milliseconds)
+ * - SDK message.raw.timestamp: string (ISO format)
+ *
+ * Returns milliseconds since epoch for consistent comparison.
+ */
+export const getMessageTimestampMs = (message: ClaudeMessage): number | undefined => {
+  // First check the raw.timestamp field (SDK source, ISO string format)
+  const rawTimestamp = (message.raw as any)?.timestamp;
+  if (rawTimestamp != null) {
+    if (typeof rawTimestamp === 'string') {
+      const parsed = new Date(rawTimestamp).getTime();
+      if (Number.isFinite(parsed)) return parsed;
+    } else if (typeof rawTimestamp === 'number' && Number.isFinite(rawTimestamp)) {
+      // Raw timestamp might already be milliseconds (numeric)
+      return rawTimestamp;
+    }
+  }
+
+  // Fall back to message.timestamp field (may be number from Java or string from frontend)
+  const timestamp = message.timestamp;
+  if (timestamp != null) {
+    if (typeof timestamp === 'number' && Number.isFinite(timestamp)) {
+      return timestamp;
+    } else if (typeof timestamp === 'string') {
+      const parsed = new Date(timestamp).getTime();
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+
+  return undefined;
 };
 
 /**
@@ -460,8 +518,10 @@ export const stripDuplicateTrailingToolMessages = (
  * When backend snapshots briefly shrink (e.g., Codex compaction or Claude
  * conversation summarization), preserve the newest in-memory turn locally
  * until the backend catches up, instead of wiping it from the UI.
- * FIX: Apply to all providers, not just Codex, to prevent message loss
- * during streaming end race conditions.
+ *
+ * KEY FIX: Applies to all providers (not just Codex), and filters out
+ * optimistic messages if nextList already contains a matching user message.
+ * This prevents duplicate display after compact operation.
  */
 export const preserveLatestMessagesOnShrink = (
   prevList: ClaudeMessage[],
@@ -477,15 +537,40 @@ export const preserveLatestMessagesOnShrink = (
 
   // Check if the preserved tail contains streaming/recent assistant messages
   const hasStreamingTail = preservedTail.some((msg) => msg.type === 'assistant' && (msg.isStreaming || !!msg.__turnId));
-  const hasRecentUserTail = preservedTail.some((msg) => msg.type === 'user');
+  const hasUserTail = preservedTail.some((msg) => msg.type === 'user');
 
   // Codex: always preserve shrink tail (handles compaction/summarization)
   // Other providers: only preserve if tail contains streaming/recent messages
-  if (provider !== 'codex' && !hasStreamingTail && !hasRecentUserTail) {
+  if (provider !== 'codex' && !hasStreamingTail && !hasUserTail) {
     return nextList;
   }
 
-  return [...nextList, ...preservedTail];
+  // FIX: Filter out optimistic messages from preservedTail if nextList already
+  // has a matching user message. This prevents duplicate display when compact
+  // sends a shorter list but includes the backend version of the optimistic.
+  const nextListUserTexts = new Set<string>();
+  for (const msg of nextList) {
+    if (msg.type === 'user') {
+      const text = getUserMessageComparableContent(msg);
+      if (text) nextListUserTexts.add(text);
+    }
+  }
+
+  const filteredTail = preservedTail.filter((msg) => {
+    // Always preserve assistant and other non-user messages
+    if (msg.type !== 'user') return true;
+    // Don't preserve optimistic if nextList has matching content
+    if (msg.isOptimistic) {
+      const optimisticText = getUserMessageComparableContent(msg);
+      if (optimisticText && nextListUserTexts.has(optimisticText)) {
+        return false; // Skip this optimistic to avoid duplicate
+      }
+    }
+    return true;
+  });
+
+  if (filteredTail.length === 0) return nextList;
+  return [...nextList, ...filteredTail];
 };
 
 // ---------------------------------------------------------------------------

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
@@ -624,7 +624,17 @@ export function registerMessageCallbacks(
       content: content || '',
       timestamp: new Date().toISOString(),
     };
-    setMessages((prev) => [...prev, userMessage]);
+    setMessages((prev) => {
+      // If the last message is an optimistic message with matching content,
+      // skip adding — the frontend already rendered the optimistic copy.
+      // Otherwise addUserMessage + optimistic create a brief duplicate until
+      // the next updateMessages deduplicates them.
+      const lastMsg = prev[prev.length - 1];
+      if (lastMsg?.isOptimistic && lastMsg.type === 'user' && lastMsg.content === content) {
+        return prev;
+      }
+      return [...prev, userMessage];
+    });
     userPausedRef.current = false;
     isUserAtBottomRef.current = true;
     requestAnimationFrame(() => {

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -89,7 +89,16 @@
     "attachmentsUploaded": "[Attachments Uploaded]",
     "streamingConnected": "{{provider}} connected, understanding your question",
     "showEarlierMessages": "Show {{count}} earlier messages",
-    "totalDuration": "This reply took"
+    "totalDuration": "This reply took",
+    "compactSummary": {
+      "summarizedConversation": "Summarized conversation",
+      "compactSummary": "Compact summary",
+      "messagesUpTo": "Summarized {{count}} messages up to this point",
+      "messagesFrom": "Summarized {{count}} messages from this point",
+      "userContext": "Context: \"{{context}}\"",
+      "expand": "Expand summary",
+      "collapse": "Collapse summary"
+    }
   },
   "settings": {
     "title": "Settings",

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -89,7 +89,16 @@
     "attachmentsUploaded": "[Archivos adjuntos cargados]",
     "streamingConnected": "{{provider}} conectado, entendiendo tu pregunta",
     "showEarlierMessages": "Mostrar {{count}} mensajes anteriores",
-    "totalDuration": "Esta respuesta tardó"
+    "totalDuration": "Esta respuesta tardó",
+    "compactSummary": {
+      "summarizedConversation": "Conversación resumida",
+      "compactSummary": "Resumen compacto",
+      "messagesUpTo": "Se resumieron {{count}} mensajes hasta este punto",
+      "messagesFrom": "Se resumieron {{count}} mensajes desde este punto",
+      "userContext": "Contexto: \"{{context}}\"",
+      "expand": "Expandir resumen",
+      "collapse": "Contraer resumen"
+    }
   },
   "settings": {
     "title": "Configuración",

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -89,7 +89,16 @@
     "attachmentsUploaded": "[Pièces jointes téléchargées]",
     "streamingConnected": "{{provider}} connecté, en train de comprendre votre question",
     "showEarlierMessages": "Afficher {{count}} messages précédents",
-    "totalDuration": "Cette réponse a pris"
+    "totalDuration": "Cette réponse a pris",
+    "compactSummary": {
+      "summarizedConversation": "Conversation résumée",
+      "compactSummary": "Résumé compact",
+      "messagesUpTo": "{{count}} messages résumés jusqu'à ce point",
+      "messagesFrom": "{{count}} messages résumés à partir de ce point",
+      "userContext": "Contexte : « {{context}} »",
+      "expand": "Développer le résumé",
+      "collapse": "Réduire le résumé"
+    }
   },
   "settings": {
     "title": "Paramètres",

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -89,7 +89,16 @@
     "attachmentsUploaded": "[अटैचमेंट अपलोड हो गए]",
     "streamingConnected": "{{provider}} कनेक्ट हो गया, आपके प्रश्न को समझ रहा है",
     "showEarlierMessages": "{{count}} पुराने संदेश दिखाएं",
-    "totalDuration": "इस जवाब में लगा समय"
+    "totalDuration": "इस जवाब में लगा समय",
+    "compactSummary": {
+      "summarizedConversation": "सारांशित वार्तालाप",
+      "compactSummary": "संक्षिप्त सारांश",
+      "messagesUpTo": "इस बिंदु तक के {{count}} संदेश सारांशित किए गए",
+      "messagesFrom": "इस बिंदु से आगे के {{count}} संदेश सारांशित किए गए",
+      "userContext": "संदर्भ: \"{{context}}\"",
+      "expand": "सारांश विस्तृत करें",
+      "collapse": "सारांश संक्षिप्त करें"
+    }
   },
   "settings": {
     "title": "सेटिंग्स",

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -89,7 +89,16 @@
     "attachmentsUploaded": "[添付ファイルがアップロードされました]",
     "streamingConnected": "{{provider}}に接続しました、質問を理解しています",
     "showEarlierMessages": "以前の{{count}}件のメッセージを表示",
-    "totalDuration": "今回の応答時間"
+    "totalDuration": "今回の応答時間",
+    "compactSummary": {
+      "summarizedConversation": "要約された会話",
+      "compactSummary": "会話の要約",
+      "messagesUpTo": "この時点までの{{count}}件のメッセージを要約しました",
+      "messagesFrom": "この時点以降の{{count}}件のメッセージを要約しました",
+      "userContext": "コンテキスト：「{{context}}」",
+      "expand": "要約を展開",
+      "collapse": "要約を折りたたむ"
+    }
   },
   "settings": {
     "title": "設定",

--- a/webview/src/i18n/locales/ko.json
+++ b/webview/src/i18n/locales/ko.json
@@ -89,7 +89,16 @@
     "attachmentsUploaded": "[첨부파일 업로드됨]",
     "streamingConnected": "{{provider}} 연결됨, 질문을 이해하는 중",
     "showEarlierMessages": "이전 메시지 {{count}}개 보기",
-    "totalDuration": "이번 응답 소요 시간"
+    "totalDuration": "이번 응답 소요 시간",
+    "compactSummary": {
+      "summarizedConversation": "요약된 대화",
+      "compactSummary": "대화 요약",
+      "messagesUpTo": "이 시점까지의 메시지 {{count}}개를 요약했습니다",
+      "messagesFrom": "이 시점 이후의 메시지 {{count}}개를 요약했습니다",
+      "userContext": "컨텍스트: \"{{context}}\"",
+      "expand": "요약 펼치기",
+      "collapse": "요약 접기"
+    }
   },
   "settings": {
     "title": "설정",

--- a/webview/src/i18n/locales/pt-BR.json
+++ b/webview/src/i18n/locales/pt-BR.json
@@ -89,7 +89,16 @@
     "attachmentsUploaded": "[Anexos Enviados]",
     "streamingConnected": "{{provider}} conectado, entendendo sua pergunta",
     "showEarlierMessages": "Mostrar {{count}} mensagens anteriores",
-    "totalDuration": "Esta resposta levou"
+    "totalDuration": "Esta resposta levou",
+    "compactSummary": {
+      "summarizedConversation": "Conversa resumida",
+      "compactSummary": "Resumo compacto",
+      "messagesUpTo": "{{count}} mensagens resumidas até este ponto",
+      "messagesFrom": "{{count}} mensagens resumidas a partir deste ponto",
+      "userContext": "Contexto: \"{{context}}\"",
+      "expand": "Expandir resumo",
+      "collapse": "Recolher resumo"
+    }
   },
   "settings": {
     "title": "Configurações",

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -89,7 +89,16 @@
     "attachmentsUploaded": "[Вложения загружены]",
     "streamingConnected": "{{provider}} обрабатывает запрос",
     "showEarlierMessages": "Показать предыдущие сообщения ({{count}})",
-    "totalDuration": "Этот ответ занял"
+    "totalDuration": "Этот ответ занял",
+    "compactSummary": {
+      "summarizedConversation": "Сводка беседы",
+      "compactSummary": "Краткое резюме",
+      "messagesUpTo": "Сведено {{count}} сообщений до этого момента",
+      "messagesFrom": "Сведено {{count}} сообщений начиная с этого момента",
+      "userContext": "Контекст: «{{context}}»",
+      "expand": "Развернуть сводку",
+      "collapse": "Свернуть сводку"
+    }
   },
   "settings": {
     "title": "Настройки",

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -89,7 +89,16 @@
     "attachmentsUploaded": "[已上傳附件]",
     "streamingConnected": "{{provider}} 已成功連接，正在理解問題",
     "showEarlierMessages": "顯示之前的 {{count}} 則訊息",
-    "totalDuration": "本次耗時"
+    "totalDuration": "本次耗時",
+    "compactSummary": {
+      "summarizedConversation": "已總結的對話",
+      "compactSummary": "對話摘要",
+      "messagesUpTo": "已總結此節點之前的 {{count}} 則訊息",
+      "messagesFrom": "已總結此節點之後的 {{count}} 則訊息",
+      "userContext": "補充說明：「{{context}}」",
+      "expand": "展開摘要",
+      "collapse": "摺疊摘要"
+    }
   },
   "settings": {
     "title": "設定",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -89,7 +89,16 @@
     "attachmentsUploaded": "[已上传附件]",
     "streamingConnected": "{{provider}} 已成功连接，正在理解问题",
     "showEarlierMessages": "显示之前的 {{count}} 条消息",
-    "totalDuration": "本次耗时"
+    "totalDuration": "本次耗时",
+    "compactSummary": {
+      "summarizedConversation": "已总结的对话",
+      "compactSummary": "对话摘要",
+      "messagesUpTo": "已总结此节点之前的 {{count}} 条消息",
+      "messagesFrom": "已总结此节点之后的 {{count}} 条消息",
+      "userContext": "补充说明：「{{context}}」",
+      "expand": "展开摘要",
+      "collapse": "折叠摘要"
+    }
   },
   "settings": {
     "title": "设置",

--- a/webview/src/styles/less/components/message.less
+++ b/webview/src/styles/less/components/message.less
@@ -84,9 +84,10 @@
     white-space: pre-wrap;
 }
 
-/* System notification messages: left-aligned, no bubble (task_notification + non-human origin) */
+/* System notification messages: left-aligned, no bubble (task_notification + compact_notification + non-human origin) */
 .message.task_notification,
-.message.notification {
+.message.notification,
+.message.compact_notification {
     background-color: transparent;
     border-left: none;
     align-items: flex-start;
@@ -94,7 +95,8 @@
 }
 
 .message.task_notification .message-content,
-.message.notification .message-content {
+.message.notification .message-content,
+.message.compact_notification .message-content {
     background-color: transparent;
     padding: 0;
     border-radius: 0;
@@ -1116,4 +1118,109 @@
     .task-notification-icon {
         color: var(--text-tertiary);
     }
+}
+
+/* Compact Notification Block - matching CLI's compact output display */
+.compact-notification-block {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 4px 0;
+}
+
+.compact-notification-header {
+    font-size: 13px;
+    color: var(--text-primary);
+    line-height: 1.5;
+}
+
+.compact-notification-items {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding-left: 8px;
+}
+
+.compact-notification-item {
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
+    font-size: 12.5px;
+    line-height: 1.5;
+}
+
+.compact-notification-prefix {
+    color: var(--text-tertiary);
+    font-family: var(--idea-editor-font-family, 'JetBrains Mono', 'Consolas', monospace);
+    flex-shrink: 0;
+}
+
+.compact-notification-text {
+    color: var(--text-secondary);
+}
+
+/* Compact Summary Block - collapsed by default, matching thinking-block pattern */
+.compact-summary-block {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 4px 0;
+}
+
+.compact-summary-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-tertiary);
+    cursor: pointer;
+    user-select: none;
+    transition: opacity 0.2s;
+}
+
+.compact-summary-title:hover {
+    opacity: 0.8;
+}
+
+.compact-summary-icon {
+    font-size: 12px;
+    opacity: 0.8;
+}
+
+.compact-summary-toggle {
+    font-size: 10px;
+    opacity: 0.8;
+}
+
+.compact-summary-metadata {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding-left: 16px;
+    font-size: 12px;
+    color: var(--text-tertiary);
+}
+
+.compact-summary-meta-count {
+    opacity: var(--opacity-subtle, 0.8);
+}
+
+.compact-summary-meta-context {
+    opacity: var(--opacity-muted, 0.7);
+}
+
+.compact-summary-content {
+    padding-left: 12px;
+    border-left: 2px solid var(--border-primary);
+    font-size: 12.5px;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    max-width: 100%;
+    overflow-wrap: break-word;
+}
+
+.compact-summary-content .markdown-block {
+    font-size: 12.5px;
+    color: var(--text-secondary);
 }

--- a/webview/src/types/index.ts
+++ b/webview/src/types/index.ts
@@ -1,6 +1,33 @@
-export type ClaudeRole = 'user' | 'assistant' | 'error' | 'task_notification' | 'notification' | string;
+export type ClaudeRole = 'user' | 'assistant' | 'error' | 'task_notification' | 'notification' | 'compact_notification' | string;
 
 export type ToolInput = Record<string, unknown>;
+
+export interface CompactNotificationItem {
+  type: 'stdout';
+  text: string;
+}
+
+/**
+ * Metadata for compact summary messages.
+ * Contains information about the compaction operation.
+ */
+export interface CompactSummaryMetadata {
+  messagesSummarized?: number;
+  direction?: 'up_to' | 'from';
+  userContext?: string;
+}
+
+/**
+ * Type guard for CompactSummaryMetadata.
+ */
+export function isCompactSummaryMetadata(obj: unknown): obj is CompactSummaryMetadata {
+  if (!obj || typeof obj !== 'object') return false;
+  const m = obj as Record<string, unknown>;
+  if (m.messagesSummarized !== undefined && typeof m.messagesSummarized !== 'number') return false;
+  if (m.direction !== undefined && m.direction !== 'up_to' && m.direction !== 'from') return false;
+  if (m.userContext !== undefined && typeof m.userContext !== 'string') return false;
+  return true;
+}
 
 export type ClaudeContentBlock =
   | { type: 'text'; text?: string }
@@ -8,7 +35,9 @@ export type ClaudeContentBlock =
   | { type: 'tool_use'; id?: string; name?: string; input?: ToolInput }
   | { type: 'image'; src?: string; mediaType?: string; alt?: string }
   | { type: 'attachment'; fileName?: string; mediaType?: string }
-  | { type: 'task_notification'; icon: string; summary: string; status: string };
+  | { type: 'task_notification'; icon: string; summary: string; status: string }
+  | { type: 'compact_notification'; headerText: string; items: CompactNotificationItem[] }
+  | { type: 'compact_summary'; title: string; content: string; metadata?: CompactSummaryMetadata };
 
 export interface ToolResultBlock {
   type: 'tool_result';

--- a/webview/src/utils/contentBlockNormalize.ts
+++ b/webview/src/utils/contentBlockNormalize.ts
@@ -10,6 +10,7 @@ export const MESSAGE_TYPES = {
   ASSISTANT: 'assistant',
   TASK_NOTIFICATION: 'task_notification',
   NOTIFICATION: 'notification',
+  COMPACT_NOTIFICATION: 'compact_notification',
   ERROR: 'error',
 } as const;
 

--- a/webview/src/utils/messageUtils.test.ts
+++ b/webview/src/utils/messageUtils.test.ts
@@ -13,6 +13,11 @@ import {
   isSyntheticToolMessageContent,
   hasNonHumanOrigin,
   shouldShowMessage,
+  isCompactCommandMessage,
+  isCompactStdoutMessage,
+  isCompactRelatedMessage,
+  extractCompactItems,
+  buildCompactNotification,
   TASK_STATUS_COLORS,
 } from './messageUtils';
 
@@ -741,6 +746,311 @@ describe('shouldShowMessage', () => {
       raw: { isMeta: true },
     };
     expect(shouldShowMessage(msg, mockGetMessageText, mockNormalizeBlocks, mockT)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compact notification detection
+// ---------------------------------------------------------------------------
+
+describe('isCompactCommandMessage', () => {
+  it('returns true for message with <command-name>/compact in raw.content string', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: '',
+      timestamp: '1',
+      raw: {
+        message: {
+          content: '<command-name>/compact</command-name><command-message>compact</command-message>',
+        },
+      },
+    };
+    expect(isCompactCommandMessage(msg)).toBe(true);
+  });
+
+  it('returns true for message with <command-name>/compact with args', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: '',
+      timestamp: '1',
+      raw: {
+        content: '<command-name>/compact</command-name><command-args>注意保留cli源码地址</command-args>',
+      },
+    };
+    expect(isCompactCommandMessage(msg)).toBe(true);
+  });
+
+  it('returns false for message with other command', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: '',
+      timestamp: '1',
+      raw: {
+        message: {
+          content: '<command-name>/aimax:auto</command-name><command-message>aimax:auto</command-message>',
+        },
+      },
+    };
+    expect(isCompactCommandMessage(msg)).toBe(false);
+  });
+
+  it('returns false for non-user messages', () => {
+    const msg: ClaudeMessage = {
+      type: 'assistant',
+      content: '<command-name>/compact</command-name>',
+      timestamp: '1',
+    };
+    expect(isCompactCommandMessage(msg)).toBe(false);
+  });
+
+  it('returns false when raw is undefined and content is not /compact', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'hello',
+      timestamp: '1',
+    };
+    expect(isCompactCommandMessage(msg)).toBe(false);
+  });
+
+  it('does not detect optimistic /compact command by content (no XML tags)', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: '/compact',
+      timestamp: '1',
+    };
+    expect(isCompactCommandMessage(msg)).toBe(false);
+  });
+
+  it('detects /compact in raw.content array of text blocks', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: '',
+      timestamp: '1',
+      raw: {
+        content: [
+          { type: 'text', text: '<command-name>/compact</command-name><command-message>compact</command-message>' },
+        ],
+      },
+    };
+    expect(isCompactCommandMessage(msg)).toBe(true);
+  });
+
+  it('does not detect optimistic /compact with arguments by content (no XML tags)', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: '/compact --verbose',
+      timestamp: '1',
+    };
+    expect(isCompactCommandMessage(msg)).toBe(false);
+  });
+
+  it('does not match non-compact content without XML tags', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: '/compactextra',
+      timestamp: '1',
+    };
+    expect(isCompactCommandMessage(msg)).toBe(false);
+  });
+});
+
+describe('isCompactStdoutMessage', () => {
+  it('returns true for message with <local-command-stdout> in raw', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: '',
+      timestamp: '1',
+      raw: {
+        message: {
+          content: '<local-command-stdout>Compacted Tip: You have access to Opus 1M</local-command-stdout>',
+        },
+      },
+    };
+    expect(isCompactStdoutMessage(msg)).toBe(true);
+  });
+
+  it('returns false for message without stdout tag', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'regular message',
+      timestamp: '1',
+      raw: { content: 'regular message' },
+    };
+    expect(isCompactStdoutMessage(msg)).toBe(false);
+  });
+
+  it('returns false for non-user messages', () => {
+    const msg: ClaudeMessage = {
+      type: 'assistant',
+      content: '<local-command-stdout>output</local-command-stdout>',
+      timestamp: '1',
+    };
+    expect(isCompactStdoutMessage(msg)).toBe(false);
+  });
+});
+
+describe('isCompactRelatedMessage', () => {
+  it('returns true for compact command message', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: '',
+      timestamp: '1',
+      raw: { message: { content: '<command-name>/compact</command-name>' } },
+    };
+    expect(isCompactRelatedMessage(msg)).toBe(true);
+  });
+
+  it('returns true for compact stdout message', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: '',
+      timestamp: '1',
+      raw: { message: { content: '<local-command-stdout>Compacted</local-command-stdout>' } },
+    };
+    expect(isCompactRelatedMessage(msg)).toBe(true);
+  });
+
+  it('returns true for isCompactSummary message', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'summary',
+      timestamp: '1',
+      raw: { isCompactSummary: true },
+    };
+    expect(isCompactRelatedMessage(msg)).toBe(true);
+  });
+
+  it('returns false for regular message', () => {
+    const msg: ClaudeMessage = {
+      type: 'user',
+      content: 'hello',
+      timestamp: '1',
+    };
+    expect(isCompactRelatedMessage(msg)).toBe(false);
+  });
+});
+
+describe('extractCompactItems', () => {
+  it('extracts stdout text from messages', () => {
+    const messages: ClaudeMessage[] = [
+      {
+        type: 'user',
+        content: '',
+        timestamp: '1',
+        raw: { message: { content: '<local-command-stdout>Compacted Tip: test</local-command-stdout>' } },
+      },
+    ];
+    const items = extractCompactItems(messages);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toEqual({ type: 'stdout', text: 'Compacted Tip: test' });
+  });
+
+  it('returns empty for messages without stdout', () => {
+    const messages: ClaudeMessage[] = [
+      {
+        type: 'user',
+        content: '',
+        timestamp: '1',
+        raw: { message: { content: '<command-name>/compact</command-name>' } },
+      },
+    ];
+    expect(extractCompactItems(messages)).toHaveLength(0);
+  });
+
+  it('extracts multiple stdout items from group', () => {
+    const messages: ClaudeMessage[] = [
+      {
+        type: 'user',
+        content: '',
+        timestamp: '1',
+        raw: { message: { content: '<local-command-stdout>line one</local-command-stdout>' } },
+      },
+      {
+        type: 'user',
+        content: '',
+        timestamp: '2',
+        raw: { message: { content: '<local-command-stdout>line two</local-command-stdout>' } },
+      },
+    ];
+    const items = extractCompactItems(messages);
+    expect(items).toHaveLength(2);
+    expect(items[0].text).toBe('line one');
+    expect(items[1].text).toBe('line two');
+  });
+});
+
+describe('buildCompactNotification', () => {
+  it('returns null for empty group', () => {
+    expect(buildCompactNotification([])).toBeNull();
+  });
+
+  it('returns null when group has no command message', () => {
+    const messages: ClaudeMessage[] = [
+      {
+        type: 'user',
+        content: '',
+        timestamp: '1',
+        raw: { message: { content: '<local-command-stdout>output</local-command-stdout>' } },
+      },
+    ];
+    expect(buildCompactNotification(messages)).toBeNull();
+  });
+
+  it('builds notification with command and stdout', () => {
+    const messages: ClaudeMessage[] = [
+      {
+        type: 'user',
+        content: '',
+        timestamp: '2026-01-01T00:00:00Z',
+        raw: { message: { content: '<command-name>/compact</command-name><command-message>compact</command-message>' } },
+      },
+      {
+        type: 'user',
+        content: '',
+        timestamp: '2026-01-01T00:00:01Z',
+        raw: { message: { content: '<local-command-stdout>Compacted Tip: test</local-command-stdout>' } },
+      },
+    ];
+    const result = buildCompactNotification(messages);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('compact_notification');
+    expect(result!.content).toBe('/compact');
+    expect(result!.timestamp).toBe('2026-01-01T00:00:00Z');
+    const compactItems = (result!.raw as any)?.compactItems;
+    expect(compactItems).toHaveLength(1);
+    expect(compactItems[0]).toEqual({ type: 'stdout', text: 'Compacted Tip: test' });
+  });
+
+  it('uses formatCommandForDisplay for header text with args', () => {
+    const messages: ClaudeMessage[] = [
+      {
+        type: 'user',
+        content: '',
+        timestamp: '1',
+        raw: {
+          message: {
+            content: '<command-name>/compact</command-name><command-message>compact</command-message><command-args>注意保留cli源码地址</command-args>',
+          },
+        },
+      },
+    ];
+    const result = buildCompactNotification(messages);
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe('/compact 注意保留cli源码地址');
+  });
+
+  it('falls back to /compact when formatCommandForDisplay returns null', () => {
+    const messages: ClaudeMessage[] = [
+      {
+        type: 'user',
+        content: '',
+        timestamp: '1',
+        raw: { message: { content: '<command-name>/compact</command-name>' } },
+      },
+    ];
+    const result = buildCompactNotification(messages);
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe('/compact');
   });
 });
 

--- a/webview/src/utils/messageUtils.ts
+++ b/webview/src/utils/messageUtils.ts
@@ -451,9 +451,11 @@ export function getContentBlocks(
         summaryText = message.content;
       }
 
+      // Pass i18n key as `title`; the renderer resolves it via t().
+      // Keeps localization concerns out of this pure data helper.
       const title = meta && typeof meta.messagesSummarized === 'number'
-        ? 'Summarized conversation'
-        : 'Compact summary';
+        ? 'chat.compactSummary.summarizedConversation'
+        : 'chat.compactSummary.compactSummary';
       return [{ type: 'compact_summary', title, content: summaryText, metadata: meta }];
     }
   }

--- a/webview/src/utils/messageUtils.ts
+++ b/webview/src/utils/messageUtils.ts
@@ -1,5 +1,6 @@
 import type { TFunction } from 'i18next';
-import type { ClaudeContentBlock, ClaudeMessage, ClaudeRawMessage } from '../types';
+import type { ClaudeContentBlock, ClaudeMessage, ClaudeRawMessage, CompactSummaryMetadata } from '../types';
+import { isCompactSummaryMetadata } from '../types';
 import {
   containsAnyTag,
   createTaskNotificationBlock,
@@ -15,6 +16,7 @@ import {
   ORIGIN_KINDS,
   type LocalizeMessageFn,
 } from './contentBlockNormalize';
+import type { CompactNotificationItem } from '../types';
 import { MESSAGE_MERGE_CACHE_LIMIT } from './messageMergeCache';
 import { clearStaleStreamEndedMarker, hasRecentlyEndedTurnId } from './streamMarkers';
 
@@ -125,6 +127,96 @@ export function isTaskNotificationOnlyMessage(message: ClaudeMessage): boolean {
 
   // Fallback: check message.content (may differ from raw when set independently)
   return typeof message.content === 'string' && hasTaskNotificationTag(message.content);
+}
+
+// ---------------------------------------------------------------------------
+// Compact notification detection and grouping
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a message is a compact command message.
+ * Only detects backend/history messages containing <command-name>/compact</command-name>
+ * XML tags. Optimistic streaming messages (plain "/compact" text without tags) are
+ * NOT detected — they render as normal user messages until the backend responds.
+ */
+export function isCompactCommandMessage(message: ClaudeMessage): boolean {
+  if (message.type !== MESSAGE_TYPES.USER) return false;
+  const texts = extractTextsFromRaw(message.raw);
+  return texts.some(t => t.includes('<command-name>/compact</command-name>'));
+}
+
+/**
+ * Check if a message is a compact stdout message (contains <local-command-stdout>).
+ */
+export function isCompactStdoutMessage(message: ClaudeMessage): boolean {
+  if (message.type !== MESSAGE_TYPES.USER) return false;
+  const texts = extractTextsFromRaw(message.raw);
+  return texts.some(t => t.includes('<local-command-stdout>'));
+}
+
+/**
+ * Check if a message is compact-related (command, stdout, or summary).
+ */
+export function isCompactRelatedMessage(message: ClaudeMessage): boolean {
+  if (message.type !== MESSAGE_TYPES.USER) return false;
+  if (isCompactCommandMessage(message) || isCompactStdoutMessage(message)) return true;
+  // Also check isCompactSummary flag on raw
+  if (message.raw && typeof message.raw === 'object' && 'isCompactSummary' in message.raw && message.raw.isCompactSummary) {
+    return true;
+  }
+  return false;
+}
+
+const COMPACT_STDOUT_REGEX = /<local-command-stdout>([\s\S]*?)<\/local-command-stdout>/;
+
+/**
+ * Extract compact notification items from a group of messages.
+ */
+export function extractCompactItems(group: ClaudeMessage[]): CompactNotificationItem[] {
+  return group.flatMap(msg => {
+    const texts = extractTextsFromRaw(msg.raw);
+    return texts.flatMap(text => {
+      const match = COMPACT_STDOUT_REGEX.exec(text);
+      return match?.[1] ? [{ type: 'stdout' as const, text: match[1].trim() }] : [];
+    });
+  });
+}
+
+/**
+ * Build a compact_notification message from a group of compact-related messages.
+ * Returns null if no command message is found in the group.
+ */
+export function buildCompactNotification(group: ClaudeMessage[]): ClaudeMessage | null {
+  if (group.length === 0) return null;
+
+  // Find the command message as primary
+  const commandMsg = group.find(m => isCompactCommandMessage(m));
+  if (!commandMsg) return null;
+
+  let headerText = '/compact';
+  const commandTexts = extractTextsFromRaw(commandMsg.raw);
+  for (const text of commandTexts) {
+    const display = formatCommandForDisplay(text);
+    if (display) {
+      headerText = display;
+      break;
+    }
+  }
+
+  // Collect stdout items from the group
+  const items = extractCompactItems(group);
+
+  // Preserve timestamp from first message for ordering
+  const timestamp = commandMsg.timestamp || group[0].timestamp;
+
+  return {
+    type: MESSAGE_TYPES.COMPACT_NOTIFICATION,
+    content: headerText,
+    timestamp,
+    raw: {
+      compactItems: items,
+    },
+  };
 }
 
 /**
@@ -320,6 +412,52 @@ export function getContentBlocks(
   normalizeBlocksFn: (raw?: ClaudeRawMessage | string) => ClaudeContentBlock[] | null,
   localizeMessage: LocalizeMessageFn
 ): ClaudeContentBlock[] {
+  // Compact notification messages carry items in raw.compactItems
+  if (message.type === MESSAGE_TYPES.COMPACT_NOTIFICATION) {
+    const rawObj = typeof message.raw === 'object' ? (message.raw as Record<string, unknown> | null) : null;
+    const items = rawObj?.compactItems as CompactNotificationItem[] | undefined;
+    const headerText = message.content || '';
+    return [{ type: 'compact_notification', headerText, items: items || [] }];
+  }
+
+  // Compact summary notifications — show title + metadata subtitle + full content (expanded)
+  if (message.type === MESSAGE_TYPES.NOTIFICATION) {
+    const rawObj = typeof message.raw === 'object' ? (message.raw as Record<string, unknown> | null) : null;
+    if (rawObj && 'isCompactSummary' in rawObj && rawObj.isCompactSummary) {
+      // Use type guard for safe metadata extraction
+      const meta: CompactSummaryMetadata | undefined = isCompactSummaryMetadata(rawObj.summarizeMetadata)
+        ? rawObj.summarizeMetadata
+        : undefined;
+      // Extract full summary text from raw.message.content
+      const messageObj = rawObj.message as { content?: string | unknown[] } | undefined;
+      let summaryText = '';
+      if (messageObj?.content) {
+        if (typeof messageObj.content === 'string') {
+          summaryText = messageObj.content;
+        } else if (Array.isArray(messageObj.content)) {
+          // Use flatMap to filter and map in single iteration (Vercel best practice)
+          summaryText = messageObj.content
+            .flatMap((b: unknown) => {
+              if (b && typeof b === 'object' && 'type' in (b as Record<string, unknown>) && (b as Record<string, unknown>).type === 'text') {
+                return [((b as Record<string, unknown>).text as string) || ''];
+              }
+              return [];
+            })
+            .join('\n');
+        }
+      }
+      // Fallback to message.content
+      if (!summaryText && message.content) {
+        summaryText = message.content;
+      }
+
+      const title = meta && typeof meta.messagesSummarized === 'number'
+        ? 'Summarized conversation'
+        : 'Compact summary';
+      return [{ type: 'compact_summary', title, content: summaryText, metadata: meta }];
+    }
+  }
+
   const rawBlocks = normalizeBlocksFn(message.raw);
   if (rawBlocks && rawBlocks.length > 0) {
     // Don't add message.content if we have task_notification blocks


### PR DESCRIPTION
Render CLI's compact summary (isCompactSummary) as a left-aligned, collapsible notification block matching CLI's CompactSummary component:
- Title: "● Summarized conversation" or "● Compact summary" (gray, dimmed)
- Metadata subtitle: "Summarized N messages up to/from this point"
- Optional context: user-provided context string
- Expandable full summary content via click toggle

Key changes:
- Java: transport isCompactSummary, summarizeMetadata, origin fields
- Frontend: convert isCompactSummary messages to notification type
- Post-process: swap order when summary precedes /compact in JSONL
- CompactSummaryBlock: memoized component with useCallback toggle
- Type guard: isCompactSummaryMetadata for safe metadata extraction
- CSS: matching thinking-block style with content-visibility pattern

Follows Vercel React best practices:
- memo() to prevent state reset during parent streaming
- useCallback for stable click handler
- flatMap for single-pass filter+map iteration
- CSS variables for semantic opacity values