### PR TITLE
fix(session-titles): route AI-generated titles around the 50-char rename endpoint

### DIFF
--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -193,7 +193,7 @@ const App = () => {
     handleConfirmNewSession, handleCancelNewSession,
     handleConfirmInterrupt, handleCancelInterrupt,
     loadHistorySession, deleteHistorySession, deleteHistorySessions, exportHistorySession,
-    toggleFavoriteSession, updateHistoryTitle,
+    toggleFavoriteSession, updateHistoryTitle, applyHistoryTitleLocal,
   } = useSessionManagement({
     messages, loading, historyData, currentSessionId,
     setHistoryData, setMessages, setCurrentView, setCurrentSessionId,
@@ -233,7 +233,7 @@ const App = () => {
     openPermissionDialog, openAskUserQuestionDialog, openPlanApprovalDialog,
     openContextUsageDialog, updateContextUsageData,
     closeContextUsageDialog,
-    customSessionTitleRef, currentSessionIdRef, updateHistoryTitle,
+    customSessionTitleRef, currentSessionIdRef, updateHistoryTitle, applyHistoryTitleLocal,
     setCustomSessionTitle,
   });
 

--- a/webview/src/hooks/useSessionManagement.ts
+++ b/webview/src/hooks/useSessionManagement.ts
@@ -49,6 +49,7 @@ interface UseSessionManagementReturn {
   exportHistorySession: (sessionId: string, title: string) => void;
   toggleFavoriteSession: (sessionId: string) => void;
   updateHistoryTitle: (sessionId: string, newTitle: string) => void;
+  applyHistoryTitleLocal: (sessionId: string, newTitle: string) => void;
 }
 
 /**
@@ -368,6 +369,21 @@ export function useSessionManagement({
     }
   }, [historyData, setHistoryData, addToast, t]);
 
+  // AI-generated titles are already persisted by saveAiTitle to the JSONL
+  // session file. This skips the round-trip through the customTitle endpoint,
+  // which would otherwise reject titles over its length limit.
+  const applyHistoryTitleLocal = useCallback((sessionId: string, newTitle: string) => {
+    if (historyData && historyData.sessions) {
+      const updatedSessions = historyData.sessions.map(session =>
+        session.sessionId === sessionId ? { ...session, title: newTitle } : session
+      );
+      setHistoryData({
+        ...historyData,
+        sessions: updatedSessions
+      });
+    }
+  }, [historyData, setHistoryData]);
+
   return {
     showNewSessionConfirm,
     showInterruptConfirm,
@@ -385,5 +401,6 @@ export function useSessionManagement({
     exportHistorySession,
     toggleFavoriteSession,
     updateHistoryTitle,
+    applyHistoryTitleLocal,
   };
 }

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -88,6 +88,7 @@ describe('useWindowCallbacks integration', () => {
     customSessionTitleRef: { current: null },
     currentSessionIdRef: { current: null },
     updateHistoryTitle: vi.fn(),
+    applyHistoryTitleLocal: vi.fn(),
 
     ...overrides,
   });
@@ -203,6 +204,88 @@ describe('useWindowCallbacks integration', () => {
     expect(window.__sessionTransitioning).toBe(false);
     expect(window.__sessionTransitionToken).toBeNull();
     expect(opts.setCurrentSessionId).toHaveBeenCalledWith('new-session-123');
+  });
+
+  // ===== AI title path uses applyHistoryTitleLocal (no backend round-trip) =====
+
+  it('updateSessionTitle routes AI titles through applyHistoryTitleLocal, not updateHistoryTitle', () => {
+    const opts = createOptions({
+      currentSessionIdRef: { current: 'sess-123' },
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    const longAiTitle = 'A very long AI-generated session title that exceeds fifty characters easily';
+
+    act(() => {
+      window.updateSessionTitle!('sess-123', longAiTitle);
+    });
+
+    expect(opts.applyHistoryTitleLocal).toHaveBeenCalledWith('sess-123', longAiTitle);
+    expect(opts.updateHistoryTitle).not.toHaveBeenCalled();
+    expect(opts.setCustomSessionTitle).toHaveBeenCalledWith(longAiTitle);
+  });
+
+  it('updateSessionTitle skips when sessionId does not match currentSessionIdRef (stale event)', () => {
+    const opts = createOptions({
+      currentSessionIdRef: { current: 'sess-current' },
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    act(() => {
+      window.updateSessionTitle!('sess-stale', 'Stale AI title');
+    });
+
+    expect(opts.applyHistoryTitleLocal).not.toHaveBeenCalled();
+    expect(opts.updateHistoryTitle).not.toHaveBeenCalled();
+    expect(opts.setCustomSessionTitle).not.toHaveBeenCalled();
+  });
+
+  it('updateSessionTitle skips empty / whitespace-only titles', () => {
+    const opts = createOptions({
+      currentSessionIdRef: { current: 'sess-123' },
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    act(() => {
+      window.updateSessionTitle!('sess-123', '   ');
+    });
+
+    expect(opts.applyHistoryTitleLocal).not.toHaveBeenCalled();
+    expect(opts.updateHistoryTitle).not.toHaveBeenCalled();
+  });
+
+  // ===== Codex thread transition: route long titles to local-only =====
+
+  it('setSessionId with title > 50 chars uses applyHistoryTitleLocal to avoid backend 50-char limit', () => {
+    const longTitle = 'A very long AI-generated session title that exceeds fifty characters easily';
+    const opts = createOptions({
+      customSessionTitleRef: { current: longTitle },
+      currentSessionIdRef: { current: 'sess-old' },
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    act(() => {
+      window.setSessionId!('sess-new');
+    });
+
+    expect(opts.applyHistoryTitleLocal).toHaveBeenCalledWith('sess-new', longTitle);
+    expect(opts.updateHistoryTitle).not.toHaveBeenCalled();
+  });
+
+  it('setSessionId with title <= 50 chars uses updateHistoryTitle for backend persistence', () => {
+    const shortTitle = 'Short user-set title';
+    const opts = createOptions({
+      customSessionTitleRef: { current: shortTitle },
+      currentSessionIdRef: { current: 'sess-old' },
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    act(() => {
+      window.setSessionId!('sess-new');
+    });
+
+    expect(opts.updateHistoryTitle).toHaveBeenCalledWith('sess-new', shortTitle);
+    expect(opts.applyHistoryTitleLocal).not.toHaveBeenCalled();
   });
 
   // ===== updateMessages is blocked during transition =====

--- a/webview/src/hooks/useWindowCallbacks.ts
+++ b/webview/src/hooks/useWindowCallbacks.ts
@@ -103,6 +103,7 @@ export interface UseWindowCallbacksOptions {
   customSessionTitleRef: MutableRefObject<string | null>;
   currentSessionIdRef: MutableRefObject<string | null>;
   updateHistoryTitle: (sessionId: string, newTitle: string) => void;
+  applyHistoryTitleLocal: (sessionId: string, newTitle: string) => void;
 
   // AI title generation: update the displayed session title when backend generates one
   setCustomSessionTitle: React.Dispatch<React.SetStateAction<string | null>>;

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/sessionCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/sessionCallbacks.ts
@@ -12,6 +12,9 @@ import { downloadJSON } from '../../../utils/exportMarkdown';
 import { releaseSessionTransition } from '../sessionTransition';
 import { drainAndRequestDependencyStatus } from '../settingsBootstrap';
 
+// Matches session-titles-service.cjs#updateTitle, which rejects longer titles.
+const CUSTOM_TITLE_MAX_LENGTH = 50;
+
 export function registerSessionAndSdkCallbacks(
   options: UseWindowCallbacksOptions,
   tRef: MutableRefObject<UseWindowCallbacksOptions['t']>,
@@ -27,6 +30,7 @@ export function registerSessionAndSdkCallbacks(
     customSessionTitleRef,
     currentSessionIdRef,
     updateHistoryTitle,
+    applyHistoryTitleLocal,
     setCustomSessionTitle,
   } = options;
 
@@ -41,7 +45,14 @@ export function registerSessionAndSdkCallbacks(
     // Orphaned title entries are harmless and cleaned up on session deletion.
     const title = customSessionTitleRef.current;
     if (title && oldId !== sessionId) {
-      updateHistoryTitle(sessionId, title);
+      // AI-generated titles can exceed the backend limit. Fall back to
+      // local-only update so the UI keeps the title visible without a
+      // silent backend write failure.
+      if (title.length <= CUSTOM_TITLE_MAX_LENGTH) {
+        updateHistoryTitle(sessionId, title);
+      } else {
+        applyHistoryTitleLocal(sessionId, title);
+      }
     }
   };
 
@@ -130,6 +141,6 @@ export function registerSessionAndSdkCallbacks(
     // stale events from overwriting the wrong session's title.
     if (currentSessionIdRef.current !== sessionId) return;
     setCustomSessionTitle(title.trim());
-    updateHistoryTitle(sessionId, title.trim());
+    applyHistoryTitleLocal(sessionId, title.trim());
   };
 }


### PR DESCRIPTION
## Summary

- Add `applyHistoryTitleLocal(sessionId, newTitle)` hook that updates the local sessions array without the backend round-trip or success toast (vs. the existing `updateHistoryTitle` which sends `update_title` and shows a "title updated" toast).
- Use it in `window.updateSessionTitle` (AI title webview callback) so AI-generated titles no longer flow through the user-rename endpoint and trip its 50-char check.
- Use it as a fallback in `window.setSessionId` (Codex thread transition) when `customSessionTitleRef.current` exceeds 50 chars, preserving backend persistence for the common short-title case.
- Wire the new hook through `App.tsx` → `useSessionManagement` → `useWindowCallbacks` → `sessionCallbacks`.

## Why

Reports of `Title too long (max 50 characters)` toasts appearing during normal use, without the user ever renaming a session. Tracing:

1. `session-title-service.js#saveAiTitle()` persists Haiku-generated titles to the JSONL session file (no length check) and emits `title_generated`.
2. Java's `ClaudeChatWindow` forwards the event to the webview via `window.updateSessionTitle`.
3. The webview callback called `updateHistoryTitle(sessionId, title.trim())` — which dispatches `update_title` to `session-titles-service.cjs#updateTitle()`.
4. That endpoint validates `customTitle.length <= 50` and rejects, surfacing the toast.

The backend round-trip in step 3 is redundant — `saveAiTitle` has already persisted the title. The `update_title` endpoint is meant for user-initiated `customTitle` renames, not for AI-generated `aiTitle` that lives in JSONL. Haiku-generated titles, especially in CJK languages, often exceed 50 chars even though the prompt requests "3-7 words".

The same pattern existed in the Codex thread transition path (`setSessionId`), where `customSessionTitleRef.current` could carry an AI-sourced long title and trip the same check silently.

## Behavior preservation

- **`updateHistoryTitle` is unchanged.** Manual rename from `App.tsx` (line 375), the prop `onUpdateTitle` (line 459), and short titles during Codex transition all still go through it — including the 50-char validation, success toast, and backend write.
- **`saveAiTitle` JSONL persistence** is untouched. AI titles are still saved to the session file by the backend before the webview is notified.
- **Codex transition still persists short titles to backend.** Only long (AI-sourced) titles fall back to local-only; short user-set titles keep the existing behavior.
- **AI title UI display** remains immediate — `applyHistoryTitleLocal` updates the sessions array the same way `updateHistoryTitle` does, just without the bridge call or toast.

The hardcoded `50` in the Codex transition branch matches the backend constant in `session-titles-service.cjs:70`. If the limit ever moves, both sides need updating — flagging here.

## Test plan

- [x] `npx vitest run src/hooks/useWindowCallbacks.test.ts` — 25/25 pass (20 pre-existing + 5 new wiring cases covering: AI title routes to local, stale-sessionId guard, empty-title guard, Codex transition routes long titles to local, Codex transition routes short titles to backend)
- [x] `npx tsc --noEmit -p tsconfig.test.json` — same 4 pre-existing errors as `upstream/feature/v0.4.3` (CommitSection prop expansion from commit `10b49af2`, missing auto-generated `version/version.ts`). Zero new errors.
- [ ] Manual smoke: send a message that produces a long Haiku title (e.g., a CJK prompt with non-trivial detail), verify the title appears in the chat header and history sidebar without the "Title too long" toast.
- [ ] Manual smoke (Codex): trigger a thread transition where `customSessionTitle` is >50 chars, verify no silent failure and the title still shows for the new session ID.

## Out of scope

- Architecturally separating `customSessionTitle` (user-set) from `aiSessionTitle` (AI-set) — currently both share the same `customSessionTitle` ref, which is what forces the length-branch on the Codex path. A cleaner split would require a larger refactor and is left for a follow-up.
- Suppressing the success toast on Codex transition (the `updateHistoryTitle` toast still fires when a short title transitions). Pre-existing UX issue, not in scope here.

