### PR TITLE
fix(wsl): add full WSL2 Node.js support and fix ProviderManager WSL path handling

### DIFF
--- a/src/main/java/com/github/claudecodegui/bridge/NodeDetector.java
+++ b/src/main/java/com/github/claudecodegui/bridge/NodeDetector.java
@@ -547,12 +547,73 @@ public class NodeDetector {
         if ("node".equals(path)) {
             return true;
         }
+        // For WSL paths (Unix-style), extract basename manually
+        if (isWslPath(path)) {
+            int lastSlash = path.lastIndexOf('/');
+            String name = (lastSlash >= 0) ? path.substring(lastSlash + 1) : path;
+            return "node".equalsIgnoreCase(name);
+        }
         String name = new File(path).getName().toLowerCase();
         return "node".equals(name) || "node.exe".equals(name);
     }
 
     /**
+     * Checks whether the given path is a WSL (Unix-style) path on a Windows host.
+     * A WSL path starts with '/' and the host OS is Windows.
+     *
+     * @param path the path to check
+     * @return true if it looks like a WSL path on Windows
+     */
+    public static boolean isWslPath(String path) {
+        return PlatformUtils.isWindows()
+                && path != null
+                && !path.isEmpty()
+                && path.charAt(0) == '/';
+    }
+
+    /**
+     * Converts a Windows file path to a WSL-accessible path.
+     * For example: "C:\Users\foo\bar" becomes "/mnt/c/Users/foo/bar".
+     * UNC paths like "\\wsl.localhost\Ubuntu\home\..." are converted to "/home/...".
+     * If the path is already a Unix-style path, it is returned as-is.
+     *
+     * @param windowsPath the Windows path to convert
+     * @return the WSL-accessible path
+     */
+    public static String convertToWslPath(String windowsPath) {
+        if (windowsPath == null || windowsPath.isEmpty()) {
+            return windowsPath;
+        }
+        // Already a Unix path
+        if (windowsPath.charAt(0) == '/') {
+            return windowsPath;
+        }
+        // UNC WSL path: \\wsl.localhost\<distro>\<path> or \\wsl$\<distro>\<path>
+        if (windowsPath.startsWith("\\\\wsl")) {
+            // Remove the \\wsl.localhost\Distro or \\wsl$\Distro prefix
+            String normalized = windowsPath.replace('\\', '/');
+            // normalized: //wsl.localhost/Ubuntu/home/... or //wsl$/Ubuntu/home/...
+            int thirdSlash = normalized.indexOf('/', 2); // after //wsl.localhost
+            if (thirdSlash > 0) {
+                int fourthSlash = normalized.indexOf('/', thirdSlash + 1); // after /Ubuntu
+                if (fourthSlash > 0) {
+                    return normalized.substring(fourthSlash); // /home/...
+                }
+            }
+        }
+        // Drive letter path: C:\Users\... -> /mnt/c/Users/...
+        if (windowsPath.length() >= 2 && windowsPath.charAt(1) == ':') {
+            char drive = Character.toLowerCase(windowsPath.charAt(0));
+            String rest = windowsPath.substring(2).replace('\\', '/');
+            return "/mnt/" + drive + rest;
+        }
+        // Fallback: just replace backslashes
+        return windowsPath.replace('\\', '/');
+    }
+
+    /**
      * Verifies whether a Node.js path is usable.
+     * For WSL paths on Windows, uses 'wsl' command to verify.
      *
      * @param path Node.js executable path
      * @return version string if usable, otherwise null
@@ -563,7 +624,12 @@ public class NodeDetector {
             return null;
         }
         try {
-            ProcessBuilder pb = new ProcessBuilder(path, "--version");
+            ProcessBuilder pb;
+            if (isWslPath(path)) {
+                pb = new ProcessBuilder("wsl", path, "--version");
+            } else {
+                pb = new ProcessBuilder(path, "--version");
+            }
             Process process = pb.start();
 
             String version = null;
@@ -737,6 +803,7 @@ public class NodeDetector {
     /**
      * Verify and cache a Node.js path.
      * Returns the detection result and updates the shared cache.
+     * Supports WSL paths on Windows (paths starting with '/').
      *
      * @param path Node.js executable path to verify
      * @return NodeDetectionResult with verification details
@@ -749,12 +816,14 @@ public class NodeDetector {
         // Check binary name before attempting execution
         if (!isValidNodeBinaryName(path)) {
             String hint = PlatformUtils.isWindows()
-                    ? "Windows 下路径必须以 node.exe 结尾，例如：C:\\Program Files\\nodejs\\node.exe"
+                    ? "Windows 下路径必须以 node 或 node.exe 结尾，例如：C:\\Program Files\\nodejs\\node.exe 或 /usr/bin/node (WSL)"
                     : "路径必须以 node 结尾，例如：/usr/local/bin/node";
             return NodeDetectionResult.failure("路径格式无效：" + hint);
         }
         // Check file existence before attempting execution
-        if (!"node".equals(path) && !new File(path).exists()) {
+        // Skip File.exists() check for WSL paths since Java's File class on Windows
+        // cannot resolve Unix-style paths; verification will be done via 'wsl' command.
+        if (!"node".equals(path) && !isWslPath(path) && !new File(path).exists()) {
             return NodeDetectionResult.failure("文件不存在，请检查路径是否正确：" + path);
         }
         String version = verifyNodePath(path);
@@ -762,7 +831,10 @@ public class NodeDetector {
         if (version != null) {
             result = NodeDetectionResult.success(path, version, NodeDetectionResult.DetectionMethod.KNOWN_PATH);
         } else {
-            result = NodeDetectionResult.failure("无法验证指定的 Node.js 路径: " + path);
+            String errorMsg = isWslPath(path)
+                    ? "无法通过 WSL 验证指定的 Node.js 路径: " + path + "（请确认 WSL 已安装且路径正确）"
+                    : "无法验证指定的 Node.js 路径: " + path;
+            result = NodeDetectionResult.failure(errorMsg);
         }
         cacheDetection(result);
         return result;

--- a/src/main/java/com/github/claudecodegui/bridge/NodeDetector.java
+++ b/src/main/java/com/github/claudecodegui/bridge/NodeDetector.java
@@ -572,6 +572,37 @@ public class NodeDetector {
     }
 
     /**
+     * Builds the base of a WSL-aware command list for running a Node.js script file.
+     * When {@code nodePath} is a WSL path, prepends {@code "wsl"} and converts
+     * {@code scriptPath} to a WSL-accessible format via {@link #convertToWslPath}.
+     * Callers may append additional arguments to the returned list.
+     *
+     * <p>Use this instead of repeating the {@code isWslPath} guard inline:
+     * <pre>
+     *     List&lt;String&gt; command = NodeDetector.buildNodeScriptCommand(node, scriptPath);
+     *     command.add("myProvider");
+     *     command.add("myAction");
+     *     ProcessBuilder pb = new ProcessBuilder(command);
+     * </pre>
+     *
+     * @param nodePath   Node.js executable path (may be a WSL Unix-style path on Windows)
+     * @param scriptPath path to the Node.js script file
+     * @return mutable command list
+     */
+    public static List<String> buildNodeScriptCommand(String nodePath, String scriptPath) {
+        List<String> command = new ArrayList<>();
+        if (isWslPath(nodePath)) {
+            command.add("wsl");
+            command.add(nodePath);
+            command.add(convertToWslPath(scriptPath));
+        } else {
+            command.add(nodePath);
+            command.add(scriptPath);
+        }
+        return command;
+    }
+
+    /**
      * Converts a Windows file path to a WSL-accessible path.
      * For example: "C:\Users\foo\bar" becomes "/mnt/c/Users/foo/bar".
      * UNC paths like "\\wsl.localhost\Ubuntu\home\..." are converted to "/home/...".

--- a/src/main/java/com/github/claudecodegui/dependency/DependencyManager.java
+++ b/src/main/java/com/github/claudecodegui/dependency/DependencyManager.java
@@ -616,7 +616,9 @@ public class DependencyManager {
      * Resolves the npm path based on the node path.
      */
     private String getNpmPath(String nodePath) {
-        // For WSL node paths, derive npm path from the same directory inside WSL
+        // For WSL node paths, derive npm path from the same directory inside WSL.
+        // NOTE: This assumes npm is co-located with node (true for official installs and nvm).
+        // Version managers like Volta use separate wrapper binaries and may not follow this layout.
         if (NodeDetector.isWslPath(nodePath)) {
             int lastSlash = nodePath.lastIndexOf('/');
             if (lastSlash > 0) {

--- a/src/main/java/com/github/claudecodegui/dependency/DependencyManager.java
+++ b/src/main/java/com/github/claudecodegui/dependency/DependencyManager.java
@@ -171,9 +171,16 @@ public class DependencyManager {
             String nodePath = nodeDetector.findNodeExecutable();
             String npmPath = getNpmPath(nodePath);
 
-            ProcessBuilder pb = new ProcessBuilder(
-                    npmPath, "view", sdk.getNpmPackage(), "version"
-            );
+            ProcessBuilder pb;
+            if (NodeDetector.isWslPath(nodePath)) {
+                pb = new ProcessBuilder(
+                        "wsl", npmPath, "view", sdk.getNpmPackage(), "version"
+                );
+            } else {
+                pb = new ProcessBuilder(
+                        npmPath, "view", sdk.getNpmPackage(), "version"
+                );
+            }
             configureProcessEnvironment(pb);
 
             Process process = pb.start();
@@ -218,9 +225,16 @@ public class DependencyManager {
             String nodePath = nodeDetector.findNodeExecutable();
             String npmPath = getNpmPath(nodePath);
 
-            ProcessBuilder pb = new ProcessBuilder(
-                    npmPath, "view", sdk.getNpmPackage(), "versions", "--json"
-            );
+            ProcessBuilder pb;
+            if (NodeDetector.isWslPath(nodePath)) {
+                pb = new ProcessBuilder(
+                        "wsl", npmPath, "view", sdk.getNpmPackage(), "versions", "--json"
+                );
+            } else {
+                pb = new ProcessBuilder(
+                        npmPath, "view", sdk.getNpmPackage(), "versions", "--json"
+                );
+            }
             configureProcessEnvironment(pb);
 
             Process process = pb.start();
@@ -384,9 +398,16 @@ public class DependencyManager {
                 }
 
                 log.accept("Running npm install...");
+                boolean isWsl = NodeDetector.isWslPath(nodePath);
+                Path prefixDir = isWsl
+                        ? Paths.get(NodeDetector.convertToWslPath(normalizedSdkDir.toString()))
+                        : normalizedSdkDir;
                 List<String> command = NpmPermissionHelper.buildInstallCommandWithFallback(
-                        npmPath, normalizedSdkDir, packages, attempt
+                        npmPath, prefixDir, packages, attempt
                 );
+                if (isWsl) {
+                    command.add(0, "wsl");
+                }
                 log.accept("Command: " + String.join(" ", command));
 
                 ProcessBuilder pb = new ProcessBuilder(command);
@@ -595,6 +616,15 @@ public class DependencyManager {
      * Resolves the npm path based on the node path.
      */
     private String getNpmPath(String nodePath) {
+        // For WSL node paths, derive npm path from the same directory inside WSL
+        if (NodeDetector.isWslPath(nodePath)) {
+            int lastSlash = nodePath.lastIndexOf('/');
+            if (lastSlash > 0) {
+                return nodePath.substring(0, lastSlash) + "/npm";
+            }
+            return "npm";
+        }
+
         String npmName = PlatformUtils.isWindows() ? "npm.cmd" : "npm";
 
         // 1. Try to find npm in the same directory as Node.js

--- a/src/main/java/com/github/claudecodegui/handler/NodeJsServiceCaller.java
+++ b/src/main/java/com/github/claudecodegui/handler/NodeJsServiceCaller.java
@@ -1,5 +1,6 @@
 package com.github.claudecodegui.handler;
 
+import com.github.claudecodegui.bridge.NodeDetector;
 import com.github.claudecodegui.handler.core.HandlerContext;
 
 import java.io.BufferedReader;
@@ -40,17 +41,20 @@ public class NodeJsServiceCaller {
 
         String bridgePath = context.getClaudeSDKBridge().getSdkTestDir().getAbsolutePath();
         String nodePath = context.getClaudeSDKBridge().getNodeExecutable();
+        String scriptBridgePath = NodeDetector.isWslPath(nodePath)
+                ? NodeDetector.convertToWslPath(bridgePath)
+                : bridgePath.replace("\\", "\\\\");
 
         String nodeScript = String.format(
             "const { %s } = require('%s/services/favorites-service.cjs'); " +
             "const result = %s(process.env.SESSION_ID); " +
             "console.log(JSON.stringify(result));",
             functionName,
-            bridgePath.replace("\\", "\\\\"),
+            scriptBridgePath,
             functionName
         );
 
-        ProcessBuilder pb = new ProcessBuilder(nodePath, "-e", nodeScript);
+        ProcessBuilder pb = buildNodeProcessBuilder(nodePath, nodeScript);
         pb.redirectErrorStream(true);
         pb.environment().put("SESSION_ID", sessionId);
 
@@ -65,17 +69,20 @@ public class NodeJsServiceCaller {
 
         String bridgePath = context.getClaudeSDKBridge().getSdkTestDir().getAbsolutePath();
         String nodePath = context.getClaudeSDKBridge().getNodeExecutable();
+        String scriptBridgePath = NodeDetector.isWslPath(nodePath)
+                ? NodeDetector.convertToWslPath(bridgePath)
+                : bridgePath.replace("\\", "\\\\");
 
         String nodeScript = String.format(
             "const { %s } = require('%s/services/session-titles-service.cjs'); " +
             "const result = %s(); " +
             "console.log(JSON.stringify(result));",
             functionName,
-            bridgePath.replace("\\", "\\\\"),
+            scriptBridgePath,
             functionName
         );
 
-        ProcessBuilder pb = new ProcessBuilder(nodePath, "-e", nodeScript);
+        ProcessBuilder pb = buildNodeProcessBuilder(nodePath, nodeScript);
         pb.redirectErrorStream(true);
 
         return executeNodeScript(pb);
@@ -89,17 +96,20 @@ public class NodeJsServiceCaller {
 
         String bridgePath = context.getClaudeSDKBridge().getSdkTestDir().getAbsolutePath();
         String nodePath = context.getClaudeSDKBridge().getNodeExecutable();
+        String scriptBridgePath = NodeDetector.isWslPath(nodePath)
+                ? NodeDetector.convertToWslPath(bridgePath)
+                : bridgePath.replace("\\", "\\\\");
 
         String nodeScript = String.format(
             "const { %s } = require('%s/services/session-titles-service.cjs'); " +
             "const result = %s(process.env.SESSION_ID, process.env.CUSTOM_TITLE); " +
             "console.log(JSON.stringify(result));",
             functionName,
-            bridgePath.replace("\\", "\\\\"),
+            scriptBridgePath,
             functionName
         );
 
-        ProcessBuilder pb = new ProcessBuilder(nodePath, "-e", nodeScript);
+        ProcessBuilder pb = buildNodeProcessBuilder(nodePath, nodeScript);
         pb.redirectErrorStream(true);
         pb.environment().put("SESSION_ID", sessionId);
         pb.environment().put("CUSTOM_TITLE", customTitle);
@@ -113,19 +123,33 @@ public class NodeJsServiceCaller {
     public String callNodeJsDeleteTitle(String sessionId) throws Exception {
         String bridgePath = context.getClaudeSDKBridge().getSdkTestDir().getAbsolutePath();
         String nodePath = context.getClaudeSDKBridge().getNodeExecutable();
+        String scriptBridgePath = NodeDetector.isWslPath(nodePath)
+                ? NodeDetector.convertToWslPath(bridgePath)
+                : bridgePath.replace("\\", "\\\\");
 
         String nodeScript = String.format(
             "const { deleteTitle } = require('%s/services/session-titles-service.cjs'); " +
             "const result = deleteTitle(process.env.SESSION_ID); " +
             "console.log(JSON.stringify({ success: result }));",
-            bridgePath.replace("\\", "\\\\")
+            scriptBridgePath
         );
 
-        ProcessBuilder pb = new ProcessBuilder(nodePath, "-e", nodeScript);
+        ProcessBuilder pb = buildNodeProcessBuilder(nodePath, nodeScript);
         pb.redirectErrorStream(true);
         pb.environment().put("SESSION_ID", sessionId);
 
         return executeNodeScript(pb);
+    }
+
+    /**
+     * Build a ProcessBuilder for running a Node.js inline script.
+     * When the node path is a WSL path, prepends 'wsl' to the command.
+     */
+    private ProcessBuilder buildNodeProcessBuilder(String nodePath, String nodeScript) {
+        if (NodeDetector.isWslPath(nodePath)) {
+            return new ProcessBuilder("wsl", nodePath, "-e", nodeScript);
+        }
+        return new ProcessBuilder(nodePath, "-e", nodeScript);
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeMcpQueryService.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeMcpQueryService.java
@@ -196,8 +196,15 @@ class ClaudeMcpQueryService {
             }
 
             List<String> command = new ArrayList<>();
-            command.add(node);
-            command.add(new File(bridgeDir, CHANNEL_SCRIPT).getAbsolutePath());
+            String scriptPath = new File(bridgeDir, CHANNEL_SCRIPT).getAbsolutePath();
+            if (NodeDetector.isWslPath(node)) {
+                command.add("wsl");
+                command.add(node);
+                command.add(NodeDetector.convertToWslPath(scriptPath));
+            } else {
+                command.add(node);
+                command.add(scriptPath);
+            }
             command.add("claude");
             command.add(commandName);
 

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeMcpQueryService.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeMcpQueryService.java
@@ -195,16 +195,8 @@ class ClaudeMcpQueryService {
                 return new MarkerResult(null, "", System.currentTimeMillis() - startTime);
             }
 
-            List<String> command = new ArrayList<>();
             String scriptPath = new File(bridgeDir, CHANNEL_SCRIPT).getAbsolutePath();
-            if (NodeDetector.isWslPath(node)) {
-                command.add("wsl");
-                command.add(node);
-                command.add(NodeDetector.convertToWslPath(scriptPath));
-            } else {
-                command.add(node);
-                command.add(scriptPath);
-            }
+            List<String> command = NodeDetector.buildNodeScriptCommand(node, scriptPath);
             command.add("claude");
             command.add(commandName);
 

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeProcessInvoker.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeProcessInvoker.java
@@ -121,8 +121,15 @@ class ClaudeProcessInvoker {
 
                 boolean hasAttachments = stdinInput.has("attachments");
                 List<String> command = new ArrayList<>();
-                command.add(node);
-                command.add(new File(workDir, CHANNEL_SCRIPT).getAbsolutePath());
+                String scriptPath = new File(workDir, CHANNEL_SCRIPT).getAbsolutePath();
+                if (NodeDetector.isWslPath(node)) {
+                    command.add("wsl");
+                    command.add(node);
+                    command.add(NodeDetector.convertToWslPath(scriptPath));
+                } else {
+                    command.add(node);
+                    command.add(scriptPath);
+                }
                 command.add(PROVIDER_NAME);
                 command.add(hasAttachments ? "sendWithAttachments" : "send");
 

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeProcessInvoker.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeProcessInvoker.java
@@ -120,16 +120,8 @@ class ClaudeProcessInvoker {
                 log.debug("[PROMPT] Sending to Node.js (" + stdinJson.length() + " chars):\n" + preview);
 
                 boolean hasAttachments = stdinInput.has("attachments");
-                List<String> command = new ArrayList<>();
                 String scriptPath = new File(workDir, CHANNEL_SCRIPT).getAbsolutePath();
-                if (NodeDetector.isWslPath(node)) {
-                    command.add("wsl");
-                    command.add(node);
-                    command.add(NodeDetector.convertToWslPath(scriptPath));
-                } else {
-                    command.add(node);
-                    command.add(scriptPath);
-                }
+                List<String> command = NodeDetector.buildNodeScriptCommand(node, scriptPath);
                 command.add(PROVIDER_NAME);
                 command.add(hasAttachments ? "sendWithAttachments" : "send");
 

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeQueryExecutor.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeQueryExecutor.java
@@ -70,8 +70,14 @@ class ClaudeQueryExecutor {
             }
 
             List<String> command = new ArrayList<>();
-            command.add(node);
-            command.add(NODE_SCRIPT);
+            if (NodeDetector.isWslPath(node)) {
+                command.add("wsl");
+                command.add(node);
+                command.add(NodeDetector.convertToWslPath(new File(workDir, NODE_SCRIPT).getAbsolutePath()));
+            } else {
+                command.add(node);
+                command.add(NODE_SCRIPT);
+            }
 
             ProcessBuilder pb = new ProcessBuilder(command);
             pb.directory(workDir);

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeQueryExecutor.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeQueryExecutor.java
@@ -69,15 +69,8 @@ class ClaudeQueryExecutor {
                 return result;
             }
 
-            List<String> command = new ArrayList<>();
-            if (NodeDetector.isWslPath(node)) {
-                command.add("wsl");
-                command.add(node);
-                command.add(NodeDetector.convertToWslPath(new File(workDir, NODE_SCRIPT).getAbsolutePath()));
-            } else {
-                command.add(node);
-                command.add(NODE_SCRIPT);
-            }
+            List<String> command = NodeDetector.buildNodeScriptCommand(
+                    node, new File(workDir, NODE_SCRIPT).getAbsolutePath());
 
             ProcessBuilder pb = new ProcessBuilder(command);
             pb.directory(workDir);

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeRewindService.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeRewindService.java
@@ -76,8 +76,15 @@ class ClaudeRewindService {
                 String stdinJson = gson.toJson(stdinInput);
 
                 List<String> command = new ArrayList<>();
-                command.add(node);
-                command.add(new File(workDir, CHANNEL_SCRIPT).getAbsolutePath());
+                String scriptPath = new File(workDir, CHANNEL_SCRIPT).getAbsolutePath();
+                if (NodeDetector.isWslPath(node)) {
+                    command.add("wsl");
+                    command.add(node);
+                    command.add(NodeDetector.convertToWslPath(scriptPath));
+                } else {
+                    command.add(node);
+                    command.add(scriptPath);
+                }
                 command.add("claude");
                 command.add("rewindFiles");
 

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeRewindService.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeRewindService.java
@@ -75,16 +75,8 @@ class ClaudeRewindService {
                 stdinInput.addProperty("cwd", cwd != null ? cwd : "");
                 String stdinJson = gson.toJson(stdinInput);
 
-                List<String> command = new ArrayList<>();
                 String scriptPath = new File(workDir, CHANNEL_SCRIPT).getAbsolutePath();
-                if (NodeDetector.isWslPath(node)) {
-                    command.add("wsl");
-                    command.add(node);
-                    command.add(NodeDetector.convertToWslPath(scriptPath));
-                } else {
-                    command.add(node);
-                    command.add(scriptPath);
-                }
+                List<String> command = NodeDetector.buildNodeScriptCommand(node, scriptPath);
                 command.add("claude");
                 command.add("rewindFiles");
 

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSessionQueryService.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSessionQueryService.java
@@ -109,8 +109,14 @@ class ClaudeSessionQueryService {
         }
 
         List<String> command = new ArrayList<>();
-        command.add(node);
-        command.add(CHANNEL_SCRIPT);
+        if (NodeDetector.isWslPath(node)) {
+            command.add("wsl");
+            command.add(node);
+            command.add(NodeDetector.convertToWslPath(new File(workDir, CHANNEL_SCRIPT).getAbsolutePath()));
+        } else {
+            command.add(node);
+            command.add(CHANNEL_SCRIPT);
+        }
         command.add("claude");
         command.add(commandName);
         command.add(sessionId);

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSessionQueryService.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSessionQueryService.java
@@ -108,15 +108,8 @@ class ClaudeSessionQueryService {
             throw new RuntimeException("Bridge directory not ready or invalid");
         }
 
-        List<String> command = new ArrayList<>();
-        if (NodeDetector.isWslPath(node)) {
-            command.add("wsl");
-            command.add(node);
-            command.add(NodeDetector.convertToWslPath(new File(workDir, CHANNEL_SCRIPT).getAbsolutePath()));
-        } else {
-            command.add(node);
-            command.add(CHANNEL_SCRIPT);
-        }
+        List<String> command = NodeDetector.buildNodeScriptCommand(
+                node, new File(workDir, CHANNEL_SCRIPT).getAbsolutePath());
         command.add("claude");
         command.add(commandName);
         command.add(sessionId);

--- a/src/main/java/com/github/claudecodegui/provider/codex/CodexSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/codex/CodexSDKBridge.java
@@ -9,6 +9,7 @@ import com.github.claudecodegui.session.ClaudeSession;
 import com.github.claudecodegui.settings.CodemossSettingsService;
 import com.github.claudecodegui.i18n.ClaudeCodeGuiBundle;
 import com.github.claudecodegui.dependency.DependencyManager;
+import com.github.claudecodegui.bridge.NodeDetector;
 import com.github.claudecodegui.provider.common.BaseSDKBridge;
 import com.github.claudecodegui.provider.common.MessageCallback;
 import com.github.claudecodegui.provider.common.SDKResult;
@@ -348,8 +349,15 @@ public class CodexSDKBridge extends BaseSDKBridge {
                 String stdinJson = gson.toJson(stdinInput);
 
                 List<String> command = new ArrayList<>();
-                command.add(node);
-                command.add(new File(bridgeDir, CHANNEL_SCRIPT).getAbsolutePath());
+                String scriptPath = new File(bridgeDir, CHANNEL_SCRIPT).getAbsolutePath();
+                if (NodeDetector.isWslPath(node)) {
+                    command.add("wsl");
+                    command.add(node);
+                    command.add(NodeDetector.convertToWslPath(scriptPath));
+                } else {
+                    command.add(node);
+                    command.add(scriptPath);
+                }
                 command.add("codex");
                 command.add("send");
 
@@ -548,8 +556,15 @@ public class CodexSDKBridge extends BaseSDKBridge {
                 String stdinJson = gson.toJson(stdinInput);
 
                 List<String> command = new ArrayList<>();
-                command.add(node);
-                command.add(new File(bridgeDir, CHANNEL_SCRIPT).getAbsolutePath());
+                String scriptPath = new File(bridgeDir, CHANNEL_SCRIPT).getAbsolutePath();
+                if (NodeDetector.isWslPath(node)) {
+                    command.add("wsl");
+                    command.add(node);
+                    command.add(NodeDetector.convertToWslPath(scriptPath));
+                } else {
+                    command.add(node);
+                    command.add(scriptPath);
+                }
                 command.add("codex");
                 command.add("getMcpServerTools");
 

--- a/src/main/java/com/github/claudecodegui/provider/codex/CodexSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/codex/CodexSDKBridge.java
@@ -348,16 +348,8 @@ public class CodexSDKBridge extends BaseSDKBridge {
 
                 String stdinJson = gson.toJson(stdinInput);
 
-                List<String> command = new ArrayList<>();
                 String scriptPath = new File(bridgeDir, CHANNEL_SCRIPT).getAbsolutePath();
-                if (NodeDetector.isWslPath(node)) {
-                    command.add("wsl");
-                    command.add(node);
-                    command.add(NodeDetector.convertToWslPath(scriptPath));
-                } else {
-                    command.add(node);
-                    command.add(scriptPath);
-                }
+                List<String> command = NodeDetector.buildNodeScriptCommand(node, scriptPath);
                 command.add("codex");
                 command.add("send");
 
@@ -555,16 +547,8 @@ public class CodexSDKBridge extends BaseSDKBridge {
                 }
                 String stdinJson = gson.toJson(stdinInput);
 
-                List<String> command = new ArrayList<>();
                 String scriptPath = new File(bridgeDir, CHANNEL_SCRIPT).getAbsolutePath();
-                if (NodeDetector.isWslPath(node)) {
-                    command.add("wsl");
-                    command.add(node);
-                    command.add(NodeDetector.convertToWslPath(scriptPath));
-                } else {
-                    command.add(node);
-                    command.add(scriptPath);
-                }
+                List<String> command = NodeDetector.buildNodeScriptCommand(node, scriptPath);
                 command.add("codex");
                 command.add("getMcpServerTools");
 

--- a/src/main/java/com/github/claudecodegui/provider/common/BaseSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/BaseSDKBridge.java
@@ -177,12 +177,8 @@ public abstract class BaseSDKBridge {
     public boolean checkEnvironment() {
         try {
             String node = nodeDetector.findNodeExecutable();
-            ProcessBuilder pb;
-            if (NodeDetector.isWslPath(node)) {
-                pb = new ProcessBuilder("wsl", node, "--version");
-            } else {
-                pb = new ProcessBuilder(node, "--version");
-            }
+            List<String> versionCmd = NodeDetector.buildNodeScriptCommand(node, "--version");
+            ProcessBuilder pb = new ProcessBuilder(versionCmd);
             envConfigurator.updateProcessEnvironment(pb, node);
             Process process = pb.start();
 
@@ -391,14 +387,7 @@ public abstract class BaseSDKBridge {
             }
 
             String scriptPath = new File(bridgeDir, CHANNEL_SCRIPT).getAbsolutePath();
-            if (NodeDetector.isWslPath(node)) {
-                command.add("wsl");
-                command.add(node);
-                command.add(NodeDetector.convertToWslPath(scriptPath));
-            } else {
-                command.add(node);
-                command.add(scriptPath);
-            }
+            command.addAll(NodeDetector.buildNodeScriptCommand(node, scriptPath));
             command.add(getProviderName());
             command.add(action);
         } catch (Exception e) {

--- a/src/main/java/com/github/claudecodegui/provider/common/BaseSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/BaseSDKBridge.java
@@ -177,7 +177,12 @@ public abstract class BaseSDKBridge {
     public boolean checkEnvironment() {
         try {
             String node = nodeDetector.findNodeExecutable();
-            ProcessBuilder pb = new ProcessBuilder(node, "--version");
+            ProcessBuilder pb;
+            if (NodeDetector.isWslPath(node)) {
+                pb = new ProcessBuilder("wsl", node, "--version");
+            } else {
+                pb = new ProcessBuilder(node, "--version");
+            }
             envConfigurator.updateProcessEnvironment(pb, node);
             Process process = pb.start();
 
@@ -369,6 +374,8 @@ public abstract class BaseSDKBridge {
 
     /**
      * Build the base command for invoking channel-manager.js.
+     * When the node executable is a WSL path, prepends 'wsl' and converts
+     * the script path to a WSL-accessible format.
      *
      * @param action The action to perform (e.g., "send", "sendWithAttachments")
      * @return Command list
@@ -383,8 +390,15 @@ public abstract class BaseSDKBridge {
                 return command;
             }
 
-            command.add(node);
-            command.add(new File(bridgeDir, CHANNEL_SCRIPT).getAbsolutePath());
+            String scriptPath = new File(bridgeDir, CHANNEL_SCRIPT).getAbsolutePath();
+            if (NodeDetector.isWslPath(node)) {
+                command.add("wsl");
+                command.add(node);
+                command.add(NodeDetector.convertToWslPath(scriptPath));
+            } else {
+                command.add(node);
+                command.add(scriptPath);
+            }
             command.add(getProviderName());
             command.add(action);
         } catch (Exception e) {

--- a/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
@@ -121,7 +121,13 @@ public class DaemonBridge {
                     return false;
                 }
 
-                ProcessBuilder pb = new ProcessBuilder(nodePath, daemonScript.getAbsolutePath());
+                ProcessBuilder pb;
+                if (NodeDetector.isWslPath(nodePath)) {
+                    String wslScriptPath = NodeDetector.convertToWslPath(daemonScript.getAbsolutePath());
+                    pb = new ProcessBuilder("wsl", nodePath, wslScriptPath);
+                } else {
+                    pb = new ProcessBuilder(nodePath, daemonScript.getAbsolutePath());
+                }
                 pb.directory(bridgeDir);
 
                 // Configure environment

--- a/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
@@ -121,13 +121,9 @@ public class DaemonBridge {
                     return false;
                 }
 
-                ProcessBuilder pb;
-                if (NodeDetector.isWslPath(nodePath)) {
-                    String wslScriptPath = NodeDetector.convertToWslPath(daemonScript.getAbsolutePath());
-                    pb = new ProcessBuilder("wsl", nodePath, wslScriptPath);
-                } else {
-                    pb = new ProcessBuilder(nodePath, daemonScript.getAbsolutePath());
-                }
+                List<String> daemonCmd = NodeDetector.buildNodeScriptCommand(
+                        nodePath, daemonScript.getAbsolutePath());
+                ProcessBuilder pb = new ProcessBuilder(daemonCmd);
                 pb.directory(bridgeDir);
 
                 // Configure environment

--- a/src/main/java/com/github/claudecodegui/settings/ProviderManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/ProviderManager.java
@@ -512,13 +512,20 @@ public class ProviderManager {
                 com.intellij.ide.util.PropertiesComponent props = com.intellij.ide.util.PropertiesComponent.getInstance();
                 String savedNodePath = props.getValue("claude.code.node.path");
                 if (savedNodePath != null && !savedNodePath.trim().isEmpty()) {
-                    // Validate whether the user-configured path is valid
-                    File nodeFile = new File(savedNodePath.trim());
-                    if (nodeFile.exists() && nodeFile.canExecute()) {
-                        nodePath = savedNodePath.trim();
-                        LOG.info("[ProviderManager] Using user-configured Node.js path: " + nodePath);
+                    String trimmed = savedNodePath.trim();
+                    // WSL paths (Unix-style) cannot be checked with File.exists() on the Windows JVM.
+                    // Validate via NodeDetector.isWslPath() first, then fall back to File checks.
+                    if (NodeDetector.isWslPath(trimmed)) {
+                        nodePath = trimmed;
+                        LOG.info("[ProviderManager] Using user-configured WSL Node.js path: " + nodePath);
                     } else {
-                        LOG.info("[ProviderManager] User-configured Node.js path is invalid, will auto-detect: " + savedNodePath);
+                        File nodeFile = new File(trimmed);
+                        if (nodeFile.exists() && nodeFile.canExecute()) {
+                            nodePath = trimmed;
+                            LOG.info("[ProviderManager] Using user-configured Node.js path: " + nodePath);
+                        } else {
+                            LOG.info("[ProviderManager] User-configured Node.js path is invalid, will auto-detect: " + savedNodePath);
+                        }
                     }
                 }
             } catch (Exception e) {
@@ -532,8 +539,10 @@ public class ProviderManager {
                 LOG.info("[ProviderManager] Auto-detected Node.js path: " + nodePath);
             }
 
-            // Build the Node.js command
-            ProcessBuilder pb = new ProcessBuilder(nodePath, scriptPath, dbPath);
+            // Build the Node.js command (WSL-aware: prepend 'wsl' and convert paths when needed)
+            List<String> command = NodeDetector.buildNodeScriptCommand(nodePath, scriptPath);
+            command.add(NodeDetector.isWslPath(nodePath) ? NodeDetector.convertToWslPath(dbPath) : dbPath);
+            ProcessBuilder pb = new ProcessBuilder(command);
             pb.directory(new File(aiBridgePath));
             pb.redirectErrorStream(true); // Merge stderr into stdout
 

--- a/src/test/java/com/github/claudecodegui/bridge/NodeDetectorWslTest.java
+++ b/src/test/java/com/github/claudecodegui/bridge/NodeDetectorWslTest.java
@@ -1,0 +1,109 @@
+package com.github.claudecodegui.bridge;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Unit tests for NodeDetector WSL path utilities.
+ * These are pure-function tests that do not require the IntelliJ Platform.
+ */
+public class NodeDetectorWslTest {
+
+    // =========================================================================
+    // convertToWslPath
+    // =========================================================================
+
+    @Test
+    public void convertToWslPath_alreadyUnix_returnsAsIs() {
+        assertEquals("/usr/bin/node", NodeDetector.convertToWslPath("/usr/bin/node"));
+        assertEquals("/home/user/.nvm/versions/node/v20/bin/node",
+                NodeDetector.convertToWslPath("/home/user/.nvm/versions/node/v20/bin/node"));
+    }
+
+    @Test
+    public void convertToWslPath_driveLetter_convertsToPosixMount() {
+        assertEquals("/mnt/c/Users/foo/bar", NodeDetector.convertToWslPath("C:\\Users\\foo\\bar"));
+        assertEquals("/mnt/c/Program Files/nodejs/node.exe",
+                NodeDetector.convertToWslPath("C:\\Program Files\\nodejs\\node.exe"));
+        assertEquals("/mnt/d/projects/app", NodeDetector.convertToWslPath("D:\\projects\\app"));
+    }
+
+    @Test
+    public void convertToWslPath_uncWslLocalhost_stripsPrefix() {
+        assertEquals("/home/user/project",
+                NodeDetector.convertToWslPath("\\\\wsl.localhost\\Ubuntu\\home\\user\\project"));
+        assertEquals("/home/user",
+                NodeDetector.convertToWslPath("\\\\wsl.localhost\\Ubuntu\\home\\user"));
+    }
+
+    @Test
+    public void convertToWslPath_uncWslDollar_stripsPrefix() {
+        assertEquals("/home/user/project",
+                NodeDetector.convertToWslPath("\\\\wsl$\\Ubuntu\\home\\user\\project"));
+    }
+
+    @Test
+    public void convertToWslPath_nullOrEmpty_returnsInput() {
+        assertEquals(null, NodeDetector.convertToWslPath(null));
+        assertEquals("", NodeDetector.convertToWslPath(""));
+    }
+
+    @Test
+    public void convertToWslPath_fallback_replacesBackslashes() {
+        assertEquals("relative/path", NodeDetector.convertToWslPath("relative\\path"));
+    }
+
+    // =========================================================================
+    // isWslPath  (always false on non-Windows; tested via static method contract)
+    // =========================================================================
+
+    @Test
+    public void isWslPath_nullOrEmpty_returnsFalse() {
+        assertFalse(NodeDetector.isWslPath(null));
+        assertFalse(NodeDetector.isWslPath(""));
+    }
+
+    @Test
+    public void isWslPath_windowsPath_returnsFalse() {
+        assertFalse(NodeDetector.isWslPath("C:\\Program Files\\nodejs\\node.exe"));
+        assertFalse(NodeDetector.isWslPath("node"));
+    }
+
+    // =========================================================================
+    // buildNodeScriptCommand
+    // =========================================================================
+
+    @Test
+    public void buildNodeScriptCommand_nonWslPath_returnsNodeAndScript() {
+        List<String> cmd = NodeDetector.buildNodeScriptCommand(
+                "/usr/local/bin/node", "/path/to/script.js");
+        assertNotNull(cmd);
+        assertEquals(2, cmd.size());
+        assertEquals("/usr/local/bin/node", cmd.get(0));
+        assertEquals("/path/to/script.js", cmd.get(1));
+    }
+
+    @Test
+    public void buildNodeScriptCommand_returnsModifiableList() {
+        List<String> cmd = NodeDetector.buildNodeScriptCommand("node", "script.js");
+        cmd.add("extra-arg");
+        assertEquals(3, cmd.size());
+        assertEquals("extra-arg", cmd.get(2));
+    }
+
+    @Test
+    public void buildNodeScriptCommand_windowsDrivePath_convertsScript() {
+        List<String> cmd = NodeDetector.buildNodeScriptCommand(
+                "C:\\Program Files\\nodejs\\node.exe",
+                "C:\\Users\\foo\\script.js");
+        assertNotNull(cmd);
+        assertEquals(2, cmd.size());
+        assertEquals("C:\\Program Files\\nodejs\\node.exe", cmd.get(0));
+        assertEquals("C:\\Users\\foo\\script.js", cmd.get(1));
+    }
+}


### PR DESCRIPTION
## Summary

Adds full WSL (Windows Subsystem for Linux) support for Node.js path detection and execution throughout the plugin. Users who have Node.js installed inside WSL2 can now configure a Unix-style path (e.g. `/usr/bin/node`) and have the plugin correctly detect, verify, and invoke it from Windows.

---

## Problem

When running JetBrains CC GUI on Windows with Node.js installed inside WSL2, the plugin would fail to:
- Detect the WSL node executable via `where node` (Windows-only lookup)
- Verify user-configured WSL paths (`File.exists()` always returns `false` for Unix-style paths on the Windows JVM)
- Execute node/npm commands — `ProcessBuilder` cannot directly run a Linux binary from Windows without the `wsl` prefix
- Convert Windows-style paths (e.g. [\\wsl.localhost\Ubuntu\home\...](cci:9://file://wsl.localhost/Ubuntu/home/...:0:0-0:0) or [C:\Users\...](cci:9://file:///Users/...:0:0-0:0)) into WSL-accessible paths (e.g. [/home/...](cci:9://file:///home/...:0:0-0:0) or `/mnt/c/...`)

---

## Changes

### Core WSL Utilities ([NodeDetector](cci:2://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/bridge/NodeDetector.java:26:0-935:1))
- [isWslPath(path)](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/bridge/NodeDetector.java:559:4-571:5) — detects Unix-style paths on a Windows host
- [convertToWslPath(windowsPath)](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/bridge/NodeDetector.java:604:4-642:5) — converts Windows paths to WSL-accessible format:
  - `C:\Users\foo` → `/mnt/c/Users/foo`
  - `\\wsl.localhost\Ubuntu\home\foo` → `/home/foo`
  - `\\wsl$\Ubuntu\home\foo` → `/home/foo`
- [buildNodeScriptCommand(nodePath, scriptPath)](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/bridge/NodeDetector.java:573:4-602:5) — builds a WSL-aware command list, prepending `wsl` and converting paths when needed. Single source of truth used by all bridge classes.
- [verifyNodePath(path)](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/bridge/NodeDetector.java:644:4-685:5) — uses `wsl node --version` for verification when path is a WSL path, skipping `File.exists()` check
- [resetInstance()](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/bridge/NodeDetector.java:77:4-91:5) — `@TestOnly` method for singleton reset between test cases

### Bug Fix: [ProviderManager](cci:2://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/settings/ProviderManager.java:26:0-810:1)
Fixed two issues in [parseProvidersFromCcSwitchDb](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/settings/ProviderManager.java:484:4-609:5) that caused provider loading (cc-switch) to silently fail on WSL setups:
1. WSL path validation used `File.exists()` which always returns `false` for Unix paths on Windows JVM — now validates via [isWslPath()](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/bridge/NodeDetector.java:559:4-571:5) first
2. `ProcessBuilder` was built without `wsl` prefix or path conversion — now uses [buildNodeScriptCommand](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/bridge/NodeDetector.java:573:4-602:5) with `dbPath` conversion

### Bridge & Service Classes
All command construction now uses [buildNodeScriptCommand()](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/bridge/NodeDetector.java:573:4-602:5) instead of the repeated inline [isWslPath](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/bridge/NodeDetector.java:559:4-571:5) guard block:
- [BaseSDKBridge](cci:2://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/provider/common/BaseSDKBridge.java:28:0-397:1) — [checkEnvironment()](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/provider/common/BaseSDKBridge.java:173:4-215:5) and [buildBaseCommand()](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/provider/common/BaseSDKBridge.java:370:4-396:5)
- [ClaudeProcessInvoker](cci:2://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/provider/claude/ClaudeProcessInvoker.java:27:0-318:1), [ClaudeQueryExecutor](cci:2://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/provider/claude/ClaudeQueryExecutor.java:24:0-282:1), [ClaudeRewindService](cci:2://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/provider/claude/ClaudeRewindService.java:24:0-154:1)
- [ClaudeSessionQueryService](cci:2://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSessionQueryService.java:21:0-161:1), [ClaudeMcpQueryService](cci:2://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/provider/claude/ClaudeMcpQueryService.java:26:0-273:1)
- [CodexSDKBridge](cci:2://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/provider/codex/CodexSDKBridge.java:34:0-866:1) (`send` and [getMcpServerTools](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/provider/codex/CodexSDKBridge.java:520:4-652:5))
- [DaemonBridge](cci:2://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java:33:0-747:1)
- [NodeJsServiceCaller](cci:2://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/handler/NodeJsServiceCaller.java:17:0-195:1) — inline `-e` script variant

### Dependency Management ([DependencyManager](cci:2://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/dependency/DependencyManager.java:35:0-882:1))
- [getLatestVersion](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/dependency/DependencyManager.java:160:4-215:5) / [getAvailableVersions](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/dependency/DependencyManager.java:217:4-265:5) — npm commands prefixed with `wsl` for WSL node paths
- [installSdk](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/dependency/DependencyManager.java:305:4-310:5) — npm install command prefixed with `wsl`, `--prefix` path converted via [convertToWslPath](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/bridge/NodeDetector.java:604:4-642:5)
- [getNpmPath](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/dependency/DependencyManager.java:614:4-659:5) — derives WSL npm path from node directory; documented co-location assumption (Volta caveat)

### Settings ([ProviderManager](cci:2://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/main/java/com/github/claudecodegui/settings/ProviderManager.java:26:0-810:1))
- User-configured node path lookup now skips `File.exists()` for WSL paths and accepts them directly

---

## Tests

Added [NodeDetectorWslTest](cci:2://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/test/java/com/github/claudecodegui/bridge/NodeDetectorWslTest.java:14:0-108:1) covering pure-function behaviour:

| Test | What it covers |
|---|---|
| [convertToWslPath_alreadyUnix_returnsAsIs](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/test/java/com/github/claudecodegui/bridge/NodeDetectorWslTest.java:20:4-25:5) | No-op for Unix paths |
| [convertToWslPath_driveLetter_convertsToPosixMount](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/test/java/com/github/claudecodegui/bridge/NodeDetectorWslTest.java:27:4-33:5) | [C:\...](cci:9://file:///...:0:0-0:0) → `/mnt/c/...` |
| [convertToWslPath_uncWslLocalhost_stripsPrefix](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/test/java/com/github/claudecodegui/bridge/NodeDetectorWslTest.java:35:4-41:5) | `\\wsl.localhost\Distro\...` → [/...](cci:9://file:///...:0:0-0:0) |
| [convertToWslPath_uncWslDollar_stripsPrefix](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/test/java/com/github/claudecodegui/bridge/NodeDetectorWslTest.java:43:4-47:5) | `\\wsl$\Distro\...` → [/...](cci:9://file:///...:0:0-0:0) |
| [convertToWslPath_nullOrEmpty_returnsInput](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/test/java/com/github/claudecodegui/bridge/NodeDetectorWslTest.java:49:4-53:5) | Null/empty safety |
| [convertToWslPath_fallback_replacesBackslashes](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/test/java/com/github/claudecodegui/bridge/NodeDetectorWslTest.java:55:4-58:5) | Relative path fallback |
| [isWslPath_nullOrEmpty_returnsFalse](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/test/java/com/github/claudecodegui/bridge/NodeDetectorWslTest.java:64:4-68:5) | Null/empty safety |
| [isWslPath_windowsPath_returnsFalse](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/test/java/com/github/claudecodegui/bridge/NodeDetectorWslTest.java:70:4-74:5) | Windows paths not misidentified |
| [buildNodeScriptCommand_nonWslPath_returnsNodeAndScript](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/test/java/com/github/claudecodegui/bridge/NodeDetectorWslTest.java:80:4-88:5) | Non-WSL command shape |
| [buildNodeScriptCommand_returnsModifiableList](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/test/java/com/github/claudecodegui/bridge/NodeDetectorWslTest.java:90:4-96:5) | Callers can append args |
| [buildNodeScriptCommand_windowsDrivePath_convertsScript](cci:1://file://wsl.localhost/Ubuntu/home/gazoon007/wfi/jetbrains-cc-gui/src/test/java/com/github/claudecodegui/bridge/NodeDetectorWslTest.java:98:4-107:5) | Windows path passthrough |

---

## How to Test Manually

1. Install Node.js inside WSL2 (e.g. via `nvm` or `apt`)
2. Open the plugin settings in the sandbox IDE and set the node path to `/usr/bin/node` (or your WSL node path)
3. Start a conversation — verify messages sent and the response stream
4. Check session history, favorites, and title management
5. If you have a `cc-switch.db`, verify that provider switching works

```bash
# Run unit tests
./gradlew test --tests "com.github.claudecodegui.bridge.NodeDetectorWslTest"
```

## Proof

<img width="579" height="480" alt="6e9bbf2587e9372d48cdf8bbc409047e5b3d541e1381e02a002ca0f270f4e053" src="https://github.com/user-attachments/assets/d0c7b52f-d408-4088-a682-e720970f011e" />

<img width="694" height="640" alt="f27ef81f08d0de3c1399e587bdfdefe3248e69ce8d9fdb1a93b738d2100b8dd0" src="https://github.com/user-attachments/assets/1e226898-a59a-4fc1-9583-e69d6c06f235" />

<img width="517" height="831" alt="777c1929dea09d5d758e952278963ab719bc38671e3d70b8d19df2f9d501e27d" src="https://github.com/user-attachments/assets/89dd8c46-b8cf-4f8c-ade7-3eefc1e2bf9b" />

<img width="572" height="378" alt="521b70133c2cd081f578c1a308eb643b22602a7a3d6a66afbc928fbf49636f59" src="https://github.com/user-attachments/assets/6bdd1b46-7efe-4322-b423-e862ce24f566" />

