### PR TITLE
fix(codex): suppress Windows taskkill parse noise after completion

### DIFF
--- a/ai-bridge/services/codex/codex-event-handler.js
+++ b/ai-bridge/services/codex/codex-event-handler.js
@@ -36,6 +36,23 @@ import {
 
 const COMMAND_DENIED_ABORT_ERROR = '__CODEX_COMMAND_DENIED_ABORT__';
 
+function isWindowsTaskkillParseNoise(message) {
+  if (typeof message !== 'string') return false;
+  if (!message.startsWith('Failed to parse item:')) return false;
+
+  const item = message.substring('Failed to parse item:'.length).trim();
+  if (!item) return false;
+
+  const hasPidPair = /\bPID\s+\d+\b[\s\S]*\bPID\s+\d+\b/i.test(item);
+  if (!hasPidPair) return false;
+
+  return /SUCCESS/i.test(item) ||
+    /terminated/i.test(item) ||
+    /process/i.test(item) ||
+    /[\u6210\u529f\u7ec8\u6b62\u8fdb\u7a0b\u5b50]/.test(item) ||
+    /[\uFFFD]{2,}/.test(item);
+}
+
 function toolUseMsg(id, name, input) {
   return { type: 'assistant', message: { role: 'assistant', content: [{ type: 'tool_use', id, name, input }] } };
 }
@@ -112,6 +129,7 @@ export function createInitialEventState(emitMessage) {
     commandApprovalAbortRequested: false,
     runtimePolicyLogged: false,
     suppressNoResponseFallback: false,
+    turnCompleted: false,
     currentThreadId: null,
     finalResponse: '',
     assistantText: '',
@@ -654,6 +672,7 @@ export async function processCodexEventStream(events, state, config) {
       }
 
       case 'turn.started': {
+        state.turnCompleted = false;
         const sessionPath = ensureSessionFilePath(state, config.threadId);
         if (sessionPath && existsSync(sessionPath)) {
           try {
@@ -723,6 +742,7 @@ export async function processCodexEventStream(events, state, config) {
       }
 
       case 'turn.completed': {
+        state.turnCompleted = true;
         console.log('[DEBUG] Turn completed');
         const replayed = await replayMissingFunctionCallsFromSession(state, config);
         if (replayed.toolUses > 0 || replayed.toolResults > 0) {
@@ -820,6 +840,8 @@ export async function processCodexEventStream(events, state, config) {
       /aborted|abort|cancel|interrupt/i.test(streamErrorMessage)
     )) {
       logInfo('PERM_DEBUG', `Suppress streamed turn abort after command denial: ${streamErrorMessage}`);
+    } else if (state.turnCompleted && isWindowsTaskkillParseNoise(streamErrorMessage)) {
+      console.warn('[DEBUG] Suppressed post-completion Codex taskkill parse noise:', streamErrorMessage);
     } else {
       throw streamError;
     }

--- a/src/main/java/com/github/claudecodegui/util/PlatformUtils.java
+++ b/src/main/java/com/github/claudecodegui/util/PlatformUtils.java
@@ -359,7 +359,8 @@ public class PlatformUtils {
                 ProcessBuilder pb = new ProcessBuilder(
                         "taskkill", "/F", "/T", "/PID", String.valueOf(pid)
                 );
-                pb.redirectErrorStream(true);
+                pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+                pb.redirectError(ProcessBuilder.Redirect.DISCARD);
                 Process killer = pb.start();
                 boolean finished = killer.waitFor(5, TimeUnit.SECONDS);
                 if (!finished) {
@@ -428,7 +429,8 @@ public class PlatformUtils {
                 ProcessBuilder pb = new ProcessBuilder(
                         "taskkill", "/F", "/T", "/PID", String.valueOf(pid)
                 );
-                pb.redirectErrorStream(true);
+                pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+                pb.redirectError(ProcessBuilder.Redirect.DISCARD);
                 Process killer = pb.start();
                 return killer.waitFor(5, TimeUnit.SECONDS);
             } else {


### PR DESCRIPTION
## Summary
- discard Windows taskkill output when terminating plugin-managed process trees
- suppress post-completion Codex SDK parse noise caused by Windows taskkill success messages
- keep real Codex errors visible by only filtering after turn.completed and only for PID termination noise

## Verification
- node --check ai-bridge/services/codex/codex-event-handler.js
- ./gradlew.bat compileJava packageAiBridge
- ./gradlew.bat clean runIde