### PR TITLE
fix(webview): use setTimeout instead of requestAnimationFrame for streaming update batching

### DIFF
--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -534,6 +534,11 @@ describe('useWindowCallbacks integration', () => {
   });
 
   it('accepts streaming updateMessages when assistant raw blocks gain spawn_agent tool_use', () => {
+    vi.stubGlobal('setTimeout', (callback: () => void) => {
+      callback();
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    });
+    vi.stubGlobal('clearTimeout', vi.fn());
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
       callback(0);
       return 1;

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
@@ -121,7 +121,7 @@ export function registerMessageCallbacks(
   // (e.g., HMR, parent re-render), the previous pending rAF is cancelled
   // first — preventing stale closures from executing.
   if (window.__pendingUpdateRaf != null) {
-    cancelAnimationFrame(window.__pendingUpdateRaf);
+    clearTimeout(window.__pendingUpdateRaf);
     window.__pendingUpdateRaf = null;
     window.__pendingUpdateJson = null;
     window.__pendingUpdateSequence = null;
@@ -135,7 +135,7 @@ export function registerMessageCallbacks(
   // streaming refs are cleared.
   const cancelPendingUpdateMessages = () => {
     if (pendingUpdateRaf !== null) {
-      cancelAnimationFrame(pendingUpdateRaf);
+      clearTimeout(pendingUpdateRaf);
     }
     pendingUpdateRaf = null;
     pendingUpdateJson = null;
@@ -390,7 +390,7 @@ export function registerMessageCallbacks(
       window.__pendingUpdateJson = json;
       window.__pendingUpdateSequence = sequence;
       if (pendingUpdateRaf === null) {
-        const rafId = requestAnimationFrame(() => {
+        const timerId = setTimeout(() => {
           pendingUpdateRaf = null;
           window.__pendingUpdateRaf = null;
           const latestJson = pendingUpdateJson;
@@ -402,9 +402,9 @@ export function registerMessageCallbacks(
           if (latestJson) {
             processUpdateMessages(latestJson, latestSequence);
           }
-        });
-        pendingUpdateRaf = rafId;
-        window.__pendingUpdateRaf = rafId;
+        }, 16);
+        pendingUpdateRaf = timerId as unknown as number;
+        window.__pendingUpdateRaf = timerId as unknown as number;
       }
       return;
     }
@@ -551,7 +551,7 @@ export function registerMessageCallbacks(
     // Cancel any pending deferred updateMessages to prevent stale data from
     // being applied after messages are cleared.
     if (pendingUpdateRaf !== null) {
-      cancelAnimationFrame(pendingUpdateRaf);
+      clearTimeout(pendingUpdateRaf);
       pendingUpdateRaf = null;
       pendingUpdateJson = null;
       pendingUpdateSequence = null;


### PR DESCRIPTION
## Summary

- Replace `requestAnimationFrame` with `setTimeout(fn, 16)` for the streaming-update batching path in `messageCallbacks.ts` (4 call sites: line 124, 138, 393, 554) so the queued flush isn't gated by Chromium's paint cycle.
- Update the corresponding cancellation calls from `cancelAnimationFrame` to `clearTimeout`.
- Leave the unrelated `requestAnimationFrame` in `addUserMessage` (scroll-to-bottom on user submit, line 640) untouched — that one runs right after user interaction, so paint cycle is active and vsync sync is appropriate for scroll animation.
- Update the rAF-stubbing regression test (`useWindowCallbacks.test.ts:537`) to also stub `setTimeout` / `clearTimeout` so the synchronous-fire pattern still drives the streaming code path.

Net diff in `messageCallbacks.ts`: **7 swaps, no structural change**.

## Why

`updateMessages` batches streaming payloads via `requestAnimationFrame` to coalesce backend pushes into one parse-and-render per frame. The intent is correct (avoid main-thread blocking from JSON.parse on large payloads at 50ms cadence), but `requestAnimationFrame` is paint-cycle gated: when the JCEF webview sits in a deprioritized paint state — no DOM mutations, user not interacting with the chat panel — Chromium defers rAF callbacks indefinitely. Any streaming update arriving in that window accumulates in `pendingUpdateJson` and only flushes when something forces a paint (typing Enter, which adds a DOM node via `addUserMessage`; switching chat tabs, which remounts; etc.).

This bites hardest on **scheduled-wakeup workflows**: scheduler fires Claude, Claude produces tokens for several seconds while the user is reading other code in the editor, but the chat panel shows nothing. User eventually interacts → all accumulated tokens render at once.

Reproduced in a real session (`/tmp` stockbot, scheduler-triggered deploy verification): JSONL records 17 seconds of continuous backend activity (assistant text + Bash tool_use + tool_results) with zero corresponding visible UI updates until the user typed Enter. The full payload then rendered instantly. Tab-switch sometimes works as a workaround; not reliably (whether the chat panel actually remounts depends on the tab UI's internal lifecycle).

`setTimeout(fn, 16)` provides the same ~60fps debounce behavior the original code wanted (one flush per frame budget) but fires regardless of paint state. Channel batching is preserved — `pendingUpdateRaf` guard still prevents multiple timers from queuing up. The trade-off is losing vsync alignment, which doesn't matter for text rendering (no animation), and gaining a few CPU cycles on idle pages, which is negligible compared to running an interactive chat at all.

## Test plan

- [x] `npx vitest run src/hooks/useWindowCallbacks.test.ts` — 25/25 pass. The single test that needed an update (line 537, "accepts streaming updateMessages when assistant raw blocks gain spawn_agent tool_use") was stubbing `requestAnimationFrame` to fire synchronously; now also stubs `setTimeout`/`clearTimeout` for the same effect on the new code path.
- [x] `npx tsc --noEmit -p tsconfig.test.json` — same 2 pre-existing errors as `upstream/feature/v0.4.3` (missing auto-generated `version/version.ts`), zero introduced by this change.
- [ ] Manual smoke: trigger a scheduled wakeup (`ScheduleWakeup` tool with a short delay), do nothing in the IDE during the work window, confirm the chat panel updates streaming content without requiring an Enter press or tab switch.

## Out of scope

- The "AskUserQuestion modal that doesn't pop up" behavior reported in chatter is a different code path (`showAskUserQuestionDialog` → `openAskUserQuestionDialog` → React state, not rAF-batched) and not addressed here.
- Architectural rework of the message-streaming pipeline (e.g., switching to React's `useTransition` or a dedicated worker for parsing) is out of scope. This PR is the minimal change that unblocks the immediate symptom.
