### PR TITLE
feat: add /fork slash command for isolated branch exploration

### DIFF
--- a/ai-bridge/channels/claude-channel.js
+++ b/ai-bridge/channels/claude-channel.js
@@ -28,7 +28,7 @@ export async function handleClaudeCommand(command, args, stdinData) {
     case 'send': {
       if (stdinData && stdinData.message !== undefined) {
         // Include streaming and disableThinking when destructuring
-        const { message, sessionId, cwd, permissionMode, model, openedFiles, agentPrompt, streaming, disableThinking, reasoningEffort } = stdinData;
+        const { message, sessionId, cwd, permissionMode, model, openedFiles, agentPrompt, streaming, disableThinking, reasoningEffort, forkSession } = stdinData;
         await claudeSendMessage(
           message,
           sessionId || '',
@@ -39,7 +39,8 @@ export async function handleClaudeCommand(command, args, stdinData) {
           agentPrompt || null,
           streaming,  // Pass streaming parameter
           disableThinking || false,  // Pass disableThinking parameter
-          reasoningEffort || null  // Pass reasoning effort level
+          reasoningEffort || null,  // Pass reasoning effort level
+          forkSession === true
         );
       } else {
         await claudeSendMessage(args[0], args[1], args[2], args[3], args[4]);
@@ -50,14 +51,14 @@ export async function handleClaudeCommand(command, args, stdinData) {
     case 'sendWithAttachments': {
       if (stdinData && stdinData.message !== undefined) {
         // Include streaming when destructuring
-        const { message, sessionId, cwd, permissionMode, model, attachments, openedFiles, agentPrompt, streaming, reasoningEffort } = stdinData;
+        const { message, sessionId, cwd, permissionMode, model, attachments, openedFiles, agentPrompt, streaming, reasoningEffort, forkSession } = stdinData;
         await claudeSendMessageWithAttachments(
           message,
           sessionId || '',
           cwd || '',
           permissionMode || '',
           model || '',
-          attachments ? { attachments, openedFiles, agentPrompt, streaming, reasoningEffort } : { openedFiles, agentPrompt, streaming, reasoningEffort }
+          attachments ? { attachments, openedFiles, agentPrompt, streaming, reasoningEffort, forkSession } : { openedFiles, agentPrompt, streaming, reasoningEffort, forkSession }
         );
       } else {
         await claudeSendMessageWithAttachments(args[0], args[1], args[2], args[3], args[4], stdinData);

--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -99,10 +99,13 @@ function buildQueryOptions({ workingDirectory, permissionMode, sdkModelName, max
 /**
  * Prepare session resume on the options object if a resumeSessionId is provided.
  */
-async function prepareSessionResume(options, resumeSessionId, workingDirectory) {
+async function prepareSessionResume(options, resumeSessionId, workingDirectory, forkSession = false) {
   if (resumeSessionId && resumeSessionId !== '') {
     options.resume = resumeSessionId;
-    console.log('[RESUMING]', resumeSessionId);
+    if (forkSession) {
+      options.forkSession = true;
+    }
+    process.stderr.write(`${forkSession ? '[FORKING]' : '[RESUMING]'} ${resumeSessionId}\n`);
     if (!hasClaudeProjectSessionFile(resumeSessionId, workingDirectory)) {
       console.log('[RESUME_WAIT] Waiting for session file to appear before resuming...');
       await waitForClaudeProjectSessionFile(resumeSessionId, workingDirectory, 2500, 100);
@@ -231,6 +234,10 @@ function processStreamMessage(msg, state, logPrefix) {
 
   // Capture session_id
   if (msg.type === 'system' && msg.session_id) {
+    if (state.forkSession && msg.session_id === state.sourceSessionId) {
+      console.warn('[LIFECYCLE] Ignoring fork session_id that matches source session');
+      return;
+    }
     state.currentSessionId = msg.session_id;
     console.log('[SESSION_ID]', msg.session_id);
     setActiveQueryResult(msg.session_id, state.queryResult);
@@ -274,17 +281,19 @@ function emitThinkingDelta(thinkingText, state, blockIndex = 0) {
 /**
  * Execute a query call with auto-retry logic for transient API errors.
  */
-async function executeWithRetry({ createQueryResult, streamingEnabled, resumeSessionId, workingDirectory, logPrefix, outerStreamState, userMessage }) {
+async function executeWithRetry({ createQueryResult, streamingEnabled, resumeSessionId, forkSession = false, workingDirectory, logPrefix, outerStreamState, userMessage }) {
   let retryAttempt = 0;
   let lastRetryError = null;
   const lp = logPrefix ? ` ${logPrefix}` : '';
 
   while (retryAttempt <= AUTO_RETRY_CONFIG.maxRetries) {
     const state = {
-      currentSessionId: resumeSessionId, messageCount: 0, hasStreamEvents: false,
+      currentSessionId: forkSession ? null : resumeSessionId, messageCount: 0, hasStreamEvents: false,
       lastAssistantContent: '', lastThinkingContent: '', accumulatedUsage: null,
       streamingEnabled, streamStarted: outerStreamState.streamStarted,
-      streamEnded: outerStreamState.streamEnded, queryResult: null
+      streamEnded: outerStreamState.streamEnded, queryResult: null,
+      forkSession,
+      sourceSessionId: resumeSessionId
     };
 
     if (retryAttempt > 0) {
@@ -320,6 +329,9 @@ async function executeWithRetry({ createQueryResult, streamingEnabled, resumeSes
       }
 
       // Success
+      if (forkSession && (!state.currentSessionId || state.currentSessionId === resumeSessionId)) {
+        throw new Error('Fork request completed without a new session ID');
+      }
       if (retryAttempt > 0) console.log(`[RETRY]${lp} Success after ${retryAttempt} retry attempt(s)`);
       if (streamingEnabled && state.streamStarted) {
         // NOTE: Do NOT emit accumulatedUsage at stream end.
@@ -414,7 +426,7 @@ function handleSendError(error, streamState, sdkStderrLines) {
  * @param {string} agentPrompt - Agent prompt (optional)
  * @param {boolean} streaming - Whether to enable streaming (optional, defaults to config value)
  */
-export async function sendMessage(message, resumeSessionId = null, cwd = null, permissionMode = null, model = null, openedFiles = null, agentPrompt = null, streaming = null, disableThinking = false, reasoningEffort = null) {
+export async function sendMessage(message, resumeSessionId = null, cwd = null, permissionMode = null, model = null, openedFiles = null, agentPrompt = null, streaming = null, disableThinking = false, reasoningEffort = null, forkSession = false) {
   console.log('[DIAG] ========== sendMessage() START ==========');
   console.log('[DIAG] params:', { msgLen: message ? message.length : 0, resumeSessionId: resumeSessionId || '(new)', cwd, permissionMode, model });
 
@@ -458,7 +470,7 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
       console.log('[DEBUG] Set SDK effort:', normalizedReasoningEffort);
     }
 
-    await prepareSessionResume(options, resumeSessionId, workingDirectory);
+    await prepareSessionResume(options, resumeSessionId, workingDirectory, forkSession);
 
     const queryFn = await loadSdkQueryFunction('');
 
@@ -466,6 +478,7 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
       createQueryResult: () => queryFn({ prompt: message, options }),
       streamingEnabled,
       resumeSessionId,
+      forkSession,
       workingDirectory,
       logPrefix: '',
       outerStreamState,
@@ -534,7 +547,8 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
       console.log('[DEBUG] (withAttachments) Set SDK effort:', reasoningEffort);
     }
 
-    await prepareSessionResume(options, resumeSessionId, workingDirectory);
+    const forkSession = stdinData?.forkSession === true;
+    await prepareSessionResume(options, resumeSessionId, workingDirectory, forkSession);
 
     const queryFn = await loadSdkQueryFunction(' (withAttachments)');
 
@@ -548,6 +562,7 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
       },
       streamingEnabled,
       resumeSessionId,
+      forkSession,
       workingDirectory,
       logPrefix: '(withAttachments)',
       outerStreamState,
@@ -558,3 +573,7 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
     handleSendError(error, { streamingEnabled, ...outerStreamState }, sdkStderrLines);
   }
 }
+
+export const __testing = {
+  executeWithRetry
+};

--- a/ai-bridge/services/claude/message-sender.test.mjs
+++ b/ai-bridge/services/claude/message-sender.test.mjs
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __testing } from './message-sender.js';
+
+async function* messages(items) {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+test('forked retry path rejects when SDK returns the source session ID', async () => {
+  await assert.rejects(
+    __testing.executeWithRetry({
+      createQueryResult: () => messages([
+        { type: 'system', session_id: 'source-session' },
+        { type: 'result', is_error: false }
+      ]),
+      streamingEnabled: false,
+      resumeSessionId: 'source-session',
+      forkSession: true,
+      workingDirectory: process.cwd(),
+      logPrefix: '',
+      outerStreamState: { streamStarted: false, streamEnded: false, accumulatedUsage: null },
+      userMessage: 'branch continuation'
+    }),
+    /Fork request completed without a new session ID/
+  );
+});
+
+test('forked retry path resolves when SDK returns a new session ID', async () => {
+  const outerStreamState = { streamStarted: false, streamEnded: false, accumulatedUsage: null };
+
+  await __testing.executeWithRetry({
+    createQueryResult: () => messages([
+      { type: 'system', session_id: 'fork-session' },
+      { type: 'result', is_error: false }
+    ]),
+    streamingEnabled: false,
+    resumeSessionId: 'source-session',
+    forkSession: true,
+    workingDirectory: process.cwd(),
+    logPrefix: '',
+    outerStreamState,
+    userMessage: 'branch continuation'
+  });
+
+  assert.equal(outerStreamState.streamEnded, false);
+});

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -26,6 +26,7 @@ import {
   acquireRuntime,
   applyDynamicControls,
   buildRuntimeSignature,
+  describeRuntimeSignature,
   endRuntimeTurn,
   resetCachedQueryFn,
   setCachedQueryFn,
@@ -113,7 +114,7 @@ function resolveRequestModelState(modelId, settingsEnv) {
   };
 }
 
-function buildQueryOptions(workingDirectory, sdkModelName, permissionMode, maxThinkingTokens, reasoningEffort, streamingEnabled, systemPromptAppend, requestedSessionId, mcpServers) {
+function buildQueryOptions(workingDirectory, sdkModelName, permissionMode, maxThinkingTokens, reasoningEffort, streamingEnabled, systemPromptAppend, requestedSessionId, forkSession, mcpServers) {
   return {
     cwd: workingDirectory,
     permissionMode,
@@ -137,7 +138,8 @@ function buildQueryOptions(workingDirectory, sdkModelName, permissionMode, maxTh
       preset: 'claude_code',
       ...(systemPromptAppend && { append: systemPromptAppend })
     },
-    ...(requestedSessionId && { resume: requestedSessionId })
+    ...(requestedSessionId && { resume: requestedSessionId }),
+    ...(requestedSessionId && forkSession && { forkSession: true })
   };
 }
 
@@ -176,6 +178,7 @@ async function buildRequestContext(params, withAttachments, overrides = {}) {
   const runtimeSessionEpoch = (typeof params.runtimeSessionEpoch === 'string' && params.runtimeSessionEpoch.trim() !== '')
     ? params.runtimeSessionEpoch.trim()
     : null;
+  const forkSession = requestedSessionId !== null && params.forkSession === true;
 
   const workingDirectory = selectWorkingDirectory(params.cwd || null);
   try {
@@ -199,7 +202,7 @@ async function buildRequestContext(params, withAttachments, overrides = {}) {
 
   const options = buildQueryOptions(
     workingDirectory, sdkModelName, permissionMode,
-    maxThinkingTokens, reasoningEffort, streamingEnabled, systemPromptAppend, requestedSessionId,
+    maxThinkingTokens, reasoningEffort, streamingEnabled, systemPromptAppend, requestedSessionId, forkSession,
     mcpServers
   );
 
@@ -208,11 +211,13 @@ async function buildRequestContext(params, withAttachments, overrides = {}) {
   const runtimeSignature = buildRuntimeSignature(options, systemPromptAppend, streamingEnabled, runtimeSessionEpoch);
   console.log('[LIFECYCLE] buildRequestContext sessionId=' + (requestedSessionId || '(new)')
     + ' epoch=' + (runtimeSessionEpoch || '(none)')
-    + ' signature=' + runtimeSignature);
+    + ' fork=' + forkSession
+    + ' ' + describeRuntimeSignature(runtimeSignature));
 
   return {
     requestedSessionId,
     runtimeSessionEpoch,
+    forkSession,
     streamingEnabled,
     options,
     userMessage,
@@ -299,6 +304,10 @@ async function executeTurn(runtime, requestContext, turnMeta) {
       processToolResultMessages(msg);
 
       if (msg?.type === 'system' && msg.session_id) {
+        if (requestContext.forkSession && msg.session_id === requestContext.requestedSessionId) {
+          console.warn('[LIFECYCLE] Ignoring fork session_id that matches source session');
+          continue;
+        }
         turnState.finalSessionId = msg.session_id;
         console.log('[SESSION_ID]', msg.session_id);
         registerRuntimeSession(runtime, msg.session_id, { registerActiveQueryResult, removeSession });
@@ -320,7 +329,13 @@ async function executeTurn(runtime, requestContext, turnMeta) {
       turnState.streamEnded = true;
     }
 
-    const finalSessionId = turnState.finalSessionId || runtime.sessionId || requestContext.requestedSessionId || '';
+    const finalSessionId = turnState.finalSessionId
+      || runtime.sessionId
+      || (requestContext.forkSession ? '' : requestContext.requestedSessionId)
+      || '';
+    if (requestContext.forkSession && (!finalSessionId || finalSessionId === requestContext.requestedSessionId)) {
+      throw new Error('Fork request completed without a new session ID');
+    }
     if (finalSessionId) {
       registerRuntimeSession(runtime, finalSessionId, { registerActiveQueryResult, removeSession });
     }
@@ -331,9 +346,9 @@ async function executeTurn(runtime, requestContext, turnMeta) {
       sessionId: finalSessionId
     }));
 
-    // Fire-and-forget: generate AI title for new sessions (not resumes).
-    // titleGenerationAttempted prevents duplicate calls when a second message
-    // arrives before the first Haiku API response completes.
+    // Fire-and-forget: generate AI title for brand-new sessions only.
+    // Fork titles are seeded by the IDE from the source session title, so generating
+    // another title here would overwrite the [fork] marker after the first fork turn.
     // The flag is reset if generateSessionTitle reports a transient failure
     // so a future turn may retry; permanent skips (e.g. CLI login mode) keep
     // the flag set to avoid endless retries.
@@ -673,6 +688,9 @@ export const __testing = {
   },
   async executeTurn(runtime, requestContext, turnMeta = null) {
     return executeTurn(runtime, requestContext, turnMeta);
+  },
+  registerRuntimeSession(runtime, sessionId) {
+    return registerRuntimeSession(runtime, sessionId, { registerActiveQueryResult, removeSession });
   },
   async cleanupAnonymousRuntimes() {
     return cleanupStaleAnonymousRuntimes({ registerActiveQueryResult, removeSession });

--- a/ai-bridge/services/claude/persistent-query-service.test.mjs
+++ b/ai-bridge/services/claude/persistent-query-service.test.mjs
@@ -112,6 +112,42 @@ test('fixed thinking tokens remain configured when no reasoningEffort is provide
   assert.equal(context.maxThinkingTokens, 10000);
 });
 
+test('forkSession is passed with resume options for forked requests', async () => {
+  const context = await __testing.buildRequestContext({
+    sessionId: 'source-session',
+    runtimeSessionEpoch: 'epoch-fork',
+    cwd: process.cwd(),
+    message: 'continue from branch',
+    forkSession: true
+  }, false);
+
+  assert.equal(context.forkSession, true);
+  assert.equal(context.options.resume, 'source-session');
+  assert.equal(context.options.forkSession, true);
+  assert.doesNotMatch(context.runtimeSignature, /"forkSession":true/);
+});
+
+test('forked persistent turn does not generate an AI title that overwrites the seeded fork title', async () => {
+  const factory = createSequencedQueryFactory([
+    { done: false, value: { type: 'system', session_id: 'forked-session' } },
+    { done: false, value: { type: 'result', is_error: false } }
+  ]);
+  __testing.setQueryFn(factory.queryFn);
+
+  const context = await __testing.buildRequestContext({
+    sessionId: 'source-session',
+    runtimeSessionEpoch: 'epoch-fork-title',
+    cwd: process.cwd(),
+    message: 'first fork turn',
+    forkSession: true
+  }, false);
+
+  const runtime = await __testing.acquireRuntime(context);
+  await __testing.executeTurn(runtime, context);
+
+  assert.equal(runtime.titleGenerationAttempted, false);
+});
+
 test('anonymous runtime is isolated by runtimeSessionEpoch', async () => {
   const factory = createQueryFactory();
   __testing.setQueryFn(factory.queryFn);
@@ -219,6 +255,107 @@ test('restore-history continuation keeps runtime bound to restored session after
 
   assert.equal(restoredRuntime, restoredRuntimeAgain);
   assert.equal(__testing.getRuntimeForSession('hist-restore'), restoredRuntime);
+});
+
+test('forked requests create a new runtime without rebinding the source session', async () => {
+  const factory = createQueryFactory();
+  __testing.setQueryFn(factory.queryFn);
+
+  const sourceContext = await __testing.buildRequestContext({
+    sessionId: 'source-session',
+    runtimeSessionEpoch: 'epoch-source',
+    cwd: process.cwd(),
+    message: 'normal continuation'
+  }, false);
+  const sourceRuntime = await __testing.acquireRuntime(sourceContext);
+
+  const forkContext = await __testing.buildRequestContext({
+    sessionId: 'source-session',
+    runtimeSessionEpoch: 'epoch-source',
+    cwd: process.cwd(),
+    message: 'branch continuation',
+    forkSession: true
+  }, false);
+  const forkRuntime = await __testing.acquireRuntime(forkContext);
+
+  assert.notEqual(forkRuntime, sourceRuntime);
+  assert.equal(forkRuntime.sessionId, null);
+  assert.equal(__testing.getRuntimeForSession('source-session'), sourceRuntime);
+
+  __testing.registerRuntimeSession(forkRuntime, 'forked-session');
+  const forkFollowUpContext = await __testing.buildRequestContext({
+    sessionId: 'forked-session',
+    runtimeSessionEpoch: 'epoch-source',
+    cwd: process.cwd(),
+    message: 'continue forked branch'
+  }, false);
+  const forkFollowUpRuntime = await __testing.acquireRuntime(forkFollowUpContext);
+
+  assert.equal(forkFollowUpRuntime, forkRuntime);
+  assert.equal(factory.runtimes.length, 2);
+});
+
+test('forked turn without a new SDK session ID does not rebind the source session', async () => {
+  const factory = createSequencedQueryFactory([
+    { done: false, value: { type: 'result', is_error: false } }
+  ]);
+  __testing.setQueryFn(factory.queryFn);
+
+  const sourceContext = await __testing.buildRequestContext({
+    sessionId: 'source-session',
+    runtimeSessionEpoch: 'epoch-source-missing-id',
+    cwd: process.cwd(),
+    message: 'normal continuation'
+  }, false);
+  const sourceRuntime = await __testing.acquireRuntime(sourceContext);
+
+  const forkContext = await __testing.buildRequestContext({
+    sessionId: 'source-session',
+    runtimeSessionEpoch: 'epoch-source-missing-id',
+    cwd: process.cwd(),
+    message: 'branch continuation',
+    forkSession: true
+  }, false);
+  const forkRuntime = await __testing.acquireRuntime(forkContext);
+
+  await assert.rejects(
+    __testing.executeTurn(forkRuntime, forkContext),
+    /Fork request completed without a new session ID/
+  );
+  assert.equal(forkRuntime.sessionId, null);
+  assert.equal(__testing.getRuntimeForSession('source-session'), sourceRuntime);
+});
+
+test('forked turn that receives the source session ID does not rebind the source session', async () => {
+  const factory = createSequencedQueryFactory([
+    { done: false, value: { type: 'system', session_id: 'source-session' } },
+    { done: false, value: { type: 'result', is_error: false } }
+  ]);
+  __testing.setQueryFn(factory.queryFn);
+
+  const sourceContext = await __testing.buildRequestContext({
+    sessionId: 'source-session',
+    runtimeSessionEpoch: 'epoch-source-same-id',
+    cwd: process.cwd(),
+    message: 'normal continuation'
+  }, false);
+  const sourceRuntime = await __testing.acquireRuntime(sourceContext);
+
+  const forkContext = await __testing.buildRequestContext({
+    sessionId: 'source-session',
+    runtimeSessionEpoch: 'epoch-source-same-id',
+    cwd: process.cwd(),
+    message: 'branch continuation',
+    forkSession: true
+  }, false);
+  const forkRuntime = await __testing.acquireRuntime(forkContext);
+
+  await assert.rejects(
+    __testing.executeTurn(forkRuntime, forkContext),
+    /Fork request completed without a new session ID/
+  );
+  assert.equal(forkRuntime.sessionId, null);
+  assert.equal(__testing.getRuntimeForSession('source-session'), sourceRuntime);
 });
 
 test('active session runtime is not disposed by idle cleanup while a turn is executing', async () => {

--- a/ai-bridge/services/claude/runtime-lifecycle.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.js
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import { AsyncStream } from '../../utils/async-stream.js';
 import { loadClaudeSdk } from '../../utils/sdk-loader.js';
 import { createPreToolUseHook, normalizePermissionMode } from './permission-mode.js';
@@ -29,6 +31,12 @@ export function buildRuntimeSignature(options, systemPromptAppend, streamingEnab
   return JSON.stringify(material);
 }
 
+export function describeRuntimeSignature(runtimeSignature) {
+  const value = runtimeSignature || '';
+  const hash = createHash('sha256').update(value).digest('hex').slice(0, 12);
+  return 'signatureHash=' + hash + ' signatureLength=' + value.length;
+}
+
 async function ensureQueryFn() {
   if (cachedQueryFn) return cachedQueryFn;
   const sdk = await loadClaudeSdk();
@@ -56,7 +64,7 @@ export async function disposeRuntime(runtime, callbacks) {
   if (!runtime || runtime.closed) return;
   console.log('[LIFECYCLE] disposeRuntime sessionId=' + (runtime.sessionId || '(new)')
     + ' epoch=' + (runtime.runtimeSessionEpoch || '(none)')
-    + ' signature=' + (runtime.runtimeSignature || '(none)'));
+    + ' ' + describeRuntimeSignature(runtime.runtimeSignature));
   runtime.closed = true;
   runtime.activeTurnCount = 0;
 
@@ -82,7 +90,7 @@ async function createRuntime(requestContext, callbacks) {
 
   const runtime = {
     closed: false,
-    sessionId: requestContext.requestedSessionId || null,
+    sessionId: requestContext.forkSession ? null : (requestContext.requestedSessionId || null),
     runtimeSessionEpoch: requestContext.runtimeSessionEpoch || null,
     runtimeSignature: requestContext.runtimeSignature,
     currentModel: requestContext.sdkModelName || null,
@@ -146,7 +154,7 @@ async function createRuntime(requestContext, callbacks) {
 
   console.log('[LIFECYCLE] createRuntime sessionId=' + (runtime.sessionId || '(new)')
     + ' epoch=' + (runtime.runtimeSessionEpoch || '(none)')
-    + ' signature=' + runtime.runtimeSignature);
+    + ' ' + describeRuntimeSignature(runtime.runtimeSignature));
 
   return runtime;
 }
@@ -205,7 +213,7 @@ function assertRuntimeOwnership(runtime, requestContext) {
     throw err;
   }
 
-  if (requestContext.requestedSessionId && runtime.sessionId && runtime.sessionId !== requestContext.requestedSessionId) {
+  if (!requestContext.forkSession && requestContext.requestedSessionId && runtime.sessionId && runtime.sessionId !== requestContext.requestedSessionId) {
     const err = new Error(
       `Runtime ownership mismatch: expected session ${requestContext.requestedSessionId}, got ${runtime.sessionId}`
     );
@@ -236,7 +244,7 @@ export async function acquireRuntime(requestContext, callbacks) {
   } else {
     console.log('[LIFECYCLE] reuseRuntime sessionId=' + (runtime.sessionId || '(new)')
       + ' epoch=' + (runtime.runtimeSessionEpoch || '(none)')
-      + ' signature=' + runtime.runtimeSignature);
+      + ' ' + describeRuntimeSignature(runtime.runtimeSignature));
   }
 
   assertRuntimeOwnership(runtime, requestContext);

--- a/ai-bridge/services/claude/runtime-registry.js
+++ b/ai-bridge/services/claude/runtime-registry.js
@@ -17,7 +17,7 @@ export {
 };
 
 export function rememberRuntime(runtime, requestContext, registerActiveQueryResult) {
-  if (requestContext.requestedSessionId) {
+  if (requestContext.requestedSessionId && !requestContext.forkSession) {
     runtimesBySessionId.set(requestContext.requestedSessionId, runtime);
     registerActiveQueryResult?.(requestContext.requestedSessionId, runtime.query);
     return;
@@ -71,6 +71,7 @@ export function removeRuntime(runtime, removeSession) {
 }
 
 export function findRuntimeForRequest(requestContext) {
+  if (requestContext.forkSession) return null;
   if (requestContext.requestedSessionId) {
     return runtimesBySessionId.get(requestContext.requestedSessionId) || null;
   }

--- a/ai-bridge/services/claude/stream-event-processor.js
+++ b/ai-bridge/services/claude/stream-event-processor.js
@@ -29,7 +29,7 @@ export function createTurnState(requestContext, runtime) {
     lastThinkingContent: '',
     textBlockContentByIndex: new Map(),
     thinkingBlockContentByIndex: new Map(),
-    finalSessionId: requestContext.requestedSessionId || runtime?.sessionId || '',
+    finalSessionId: requestContext.forkSession ? '' : (requestContext.requestedSessionId || runtime?.sessionId || ''),
     accumulatedUsage: null
   };
 }

--- a/src/main/java/com/github/claudecodegui/handler/SessionHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SessionHandler.java
@@ -191,7 +191,7 @@ public class SessionHandler extends BaseMessageHandler {
             }
 
             // [FIX] Pass agent prompt and file tags directly to session
-            context.getSession().send(finalPrompt, finalAgentPrompt, finalFileTagPaths, finalRequestedPermissionMode)
+            context.getSession().send(finalPrompt, finalAgentPrompt, finalFileTagPaths, finalRequestedPermissionMode, false)
                 .thenRun(() -> {
                     // Claude now triggers success on actual stream_end callback.
                     // Codex has no stream_end event, keep success trigger at completion.
@@ -282,7 +282,6 @@ public class SessionHandler extends BaseMessageHandler {
                     LOG.warn("[SessionHandler] Ignoring invalid permissionMode from attachment payload: " + mode);
                 }
             }
-
             sendMessageWithAttachments(text, atts, agentPrompt, fileTagPaths, requestedPermissionMode);
         } catch (Exception e) {
             LOG.error("[SessionHandler] 解析附件负载失败: " + e.getMessage(), e);
@@ -337,7 +336,7 @@ public class SessionHandler extends BaseMessageHandler {
             }
 
             // [FIX] Pass agent prompt and file tags directly to session
-            context.getSession().send(prompt, attachments, finalAgentPrompt, finalFileTagPaths, finalRequestedPermissionMode)
+            context.getSession().send(prompt, attachments, finalAgentPrompt, finalFileTagPaths, finalRequestedPermissionMode, false)
                 .thenRun(() -> {
                     // Claude now triggers success on actual stream_end callback.
                     // Codex has no stream_end event, keep success trigger at completion.
@@ -388,7 +387,7 @@ public class SessionHandler extends BaseMessageHandler {
     /**
      * Determine the appropriate working directory.
      */
-    private String determineWorkingDirectory() {
+    protected String determineWorkingDirectory() {
         String projectPath = context.getProject().getBasePath();
 
         // Prefer the user-configured working directory first

--- a/src/main/java/com/github/claudecodegui/handler/TabHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/TabHandler.java
@@ -3,9 +3,14 @@ package com.github.claudecodegui.handler;
 import com.github.claudecodegui.handler.core.BaseMessageHandler;
 import com.github.claudecodegui.handler.core.HandlerContext;
 
+import com.github.claudecodegui.session.SessionState;
 import com.github.claudecodegui.ui.toolwindow.ClaudeChatWindow;
 import com.github.claudecodegui.ui.toolwindow.ClaudeSDKToolWindow;
+import com.github.claudecodegui.ui.toolwindow.ForkTitleFormatter;
 import com.github.claudecodegui.settings.TabStateService;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
@@ -14,6 +19,14 @@ import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
 import com.intellij.ui.content.ContentManager;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Tab management handler
@@ -22,9 +35,11 @@ import com.intellij.ui.content.ContentManager;
 public class TabHandler extends BaseMessageHandler {
 
     private static final Logger LOG = Logger.getInstance(TabHandler.class);
+    private static final Map<Project, Set<String>> RESERVED_FORK_TITLES = Collections.synchronizedMap(new WeakHashMap<>());
 
     private static final String[] SUPPORTED_TYPES = {
-        "create_new_tab"
+        "create_new_tab",
+        "fork_session"
     };
 
     public TabHandler(HandlerContext context) {
@@ -38,66 +53,213 @@ public class TabHandler extends BaseMessageHandler {
 
     @Override
     public boolean handle(String type, String content) {
-        if ("create_new_tab".equals(type)) {
-            LOG.debug("[TabHandler] Processing create_new_tab");
-            handleCreateNewTab();
-            return true;
+        switch (type) {
+            case "create_new_tab":
+                LOG.debug("[TabHandler] Processing create_new_tab");
+                createNewTabInternal(null);
+                return true;
+            case "fork_session":
+                LOG.debug("[TabHandler] Processing fork_session");
+                handleForkSession(content);
+                return true;
+            default:
+                return false;
         }
-        return false;
     }
 
     /**
-     * Create a new chat tab in the tool window
+     * Parses a fork_session payload and opens a branch tab from the source session ID.
+     *
+     * The webview emits this event for /fork so the source JSONL stays untouched while
+     * the user immediately sees a dedicated tab for the branched conversation.
      */
-    private void handleCreateNewTab() {
+    private void handleForkSession(String content) {
+        String sourceSessionId = null;
+        String sourceTitle = null;
+        try {
+            Gson gson = new Gson();
+            JsonObject payload = gson.fromJson(content, JsonObject.class);
+            if (payload != null && payload.has("sourceSessionId") && !payload.get("sourceSessionId").isJsonNull()) {
+                sourceSessionId = payload.get("sourceSessionId").getAsString();
+            }
+            if (payload != null && payload.has("sourceTitle") && !payload.get("sourceTitle").isJsonNull()) {
+                sourceTitle = payload.get("sourceTitle").getAsString();
+            }
+        } catch (Exception e) {
+            // Fork events should not crash the entire tool window on malformed payloads.
+            LOG.warn("[TabHandler] Failed to parse fork_session payload: " + e.getMessage());
+        }
+
+        if (!isValidSourceSessionId(sourceSessionId)) {
+            LOG.warn("[TabHandler] fork_session payload has invalid sourceSessionId, ignoring");
+            callJavaScript("addErrorMessage", escapeJs("无法从源会话 fork：缺少 sourceSessionId"));
+            return;
+        }
+        String currentSessionId = context.getSession() != null ? context.getSession().getSessionId() : null;
+        if (!isAuthorizedForkSourceSessionId(sourceSessionId, currentSessionId)) {
+            LOG.warn("[TabHandler] fork_session sourceSessionId does not match the active session, ignoring");
+            callJavaScript("addErrorMessage", escapeJs("无法从非当前会话 fork"));
+            return;
+        }
+
+        LOG.info("[TabHandler] Forking new tab from source session: " + sourceSessionId);
         Project project = context.getProject();
+        final String forkSourceId = sourceSessionId.trim();
+        final String forkSourceTitle = sourceTitle;
+        CompletableFuture
+                .supplyAsync(() -> reserveForkTitle(project, forkSourceTitle))
+                .thenAccept(forkTitle -> createNewTabInternal(forkSourceId, forkTitle))
+                .exceptionally(ex -> {
+                    LOG.warn("[TabHandler] Failed to resolve fork title numbering: " + ex.getMessage(), ex);
+                    createNewTabInternal(forkSourceId, ForkTitleFormatter.buildForkTitle(forkSourceTitle, Collections.emptyList()));
+                    return null;
+                });
+    }
+
+    static boolean isValidSourceSessionId(String sessionId) {
+        return SessionState.isValidSessionId(sessionId);
+    }
+
+    static boolean isAuthorizedForkSourceSessionId(String sourceSessionId, String currentSessionId) {
+        return isValidSourceSessionId(sourceSessionId)
+                && isValidSourceSessionId(currentSessionId)
+                && sourceSessionId.equals(currentSessionId);
+    }
+
+    static void addReservedForkTitle(Project project, String forkTitle) {
+        if (project == null || forkTitle == null || forkTitle.trim().isEmpty()) {
+            return;
+        }
+        RESERVED_FORK_TITLES.computeIfAbsent(project, ignored -> ConcurrentHashMap.newKeySet()).add(forkTitle);
+    }
+
+    static void releaseReservedForkTitle(Project project, String forkTitle) {
+        if (project == null || forkTitle == null || forkTitle.trim().isEmpty()) {
+            return;
+        }
+        Set<String> reservedTitles = RESERVED_FORK_TITLES.get(project);
+        if (reservedTitles == null) {
+            return;
+        }
+        reservedTitles.remove(forkTitle);
+        if (reservedTitles.isEmpty()) {
+            RESERVED_FORK_TITLES.remove(project);
+        }
+    }
+
+    static Set<String> getReservedForkTitlesSnapshot(Project project) {
+        Set<String> reservedTitles = RESERVED_FORK_TITLES.get(project);
+        return reservedTitles == null ? Collections.emptySet() : Set.copyOf(reservedTitles);
+    }
+
+    private String reserveForkTitle(Project project, String sourceTitle) {
+        String normalizedSourceTitle = sourceTitle != null ? sourceTitle.trim() : "";
+        if (normalizedSourceTitle.isEmpty()) {
+            return null;
+        }
+
+        List<String> existingTitles = new ArrayList<>(loadPersistedSessionTitles());
+        existingTitles.addAll(getReservedForkTitlesSnapshot(project));
+
+        String forkTitle = ForkTitleFormatter.buildForkTitle(normalizedSourceTitle, existingTitles);
+        addReservedForkTitle(project, forkTitle);
+        return forkTitle;
+    }
+
+    private List<String> loadPersistedSessionTitles() {
+        try {
+            String titlesJson = new NodeJsServiceCaller(context).callNodeJsTitlesService("loadTitles");
+            JsonObject titles = new Gson().fromJson(titlesJson, JsonObject.class);
+            if (titles == null) {
+                return Collections.emptyList();
+            }
+
+            List<String> result = new ArrayList<>();
+            for (Map.Entry<String, JsonElement> entry : titles.entrySet()) {
+                JsonElement value = entry.getValue();
+                if (value == null || !value.isJsonObject()) {
+                    continue;
+                }
+                JsonObject titleInfo = value.getAsJsonObject();
+                if (titleInfo.has("customTitle") && !titleInfo.get("customTitle").isJsonNull()) {
+                    result.add(titleInfo.get("customTitle").getAsString());
+                }
+            }
+            return result;
+        } catch (Exception e) {
+            LOG.warn("[TabHandler] Failed to load session titles for fork numbering: " + e.getMessage(), e);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Shared entry point for creating a new chat tab.
+     *
+     * @param sourceSessionIdForFork non-empty when the new tab should branch from that source session
+     */
+    private void createNewTabInternal(String sourceSessionIdForFork) {
+        createNewTabInternal(sourceSessionIdForFork, null);
+    }
+
+    private void createNewTabInternal(String sourceSessionIdForFork, String sourceTitleForFork) {
+        Project project = context.getProject();
+        // Immutable snapshots for lambdas so later local changes cannot leak into tab creation.
+        final String forkSourceId = sourceSessionIdForFork;
+        final String forkSourceTitle = sourceTitleForFork;
 
         ToolWindowManager.getInstance(project).invokeLater(() -> {
             try {
-                // Get the tool window
                 ToolWindow toolWindow = ToolWindowManager.getInstance(project)
                         .getToolWindow(ClaudeSDKToolWindow.TOOL_WINDOW_ID);
                 if (toolWindow == null) {
                     LOG.error("[TabHandler] Tool window not found");
+                    releaseReservedForkTitle(project, forkSourceTitle);
                     callJavaScript("addErrorMessage", escapeJs("无法找到 CCG 工具窗口"));
                     return;
                 }
 
-                // Create a new chat window instance with skipRegister=true (don't replace the main instance)
+                // Branch/new tabs must not replace the global main instance; otherwise top-level events
+                // can be routed to a branch tab instead of the original tool window.
                 ClaudeChatWindow newChatWindow = new ClaudeChatWindow(project, true);
 
-                // Get tab index before adding content
                 ContentManager contentManager = toolWindow.getContentManager();
                 int tabIndex = contentManager.getContentCount();
 
-                // Check if there's a saved name for this tab index
                 TabStateService tabStateService = TabStateService.getInstance(project);
                 String savedName = tabStateService.getTabName(tabIndex);
 
-                // Create a tab name: use saved name or generate new one
                 String tabName;
                 if (savedName != null && !savedName.isEmpty()) {
                     tabName = savedName;
                     LOG.info("[TabHandler] Restored tab name from storage: " + tabName);
                 } else {
+                    // IDE tab names keep the regular AI sequence; fork identity is shown in the chat title.
                     tabName = ClaudeSDKToolWindow.getNextTabName(toolWindow);
                 }
 
-                // Create and add the new tab content
                 ContentFactory contentFactory = ContentFactory.getInstance();
                 Content content = contentFactory.createContent(newChatWindow.getContent(), tabName, false);
                 content.setCloseable(true);
                 newChatWindow.setParentContent(content);
-                content.setDisposer(newChatWindow::dispose);
+                content.setDisposer(() -> {
+                    releaseReservedForkTitle(project, forkSourceTitle);
+                    newChatWindow.dispose();
+                });
 
                 contentManager.addContent(content);
                 contentManager.setSelectedContent(content);
 
-                // Ensure the tool window is visible
                 toolWindow.show(null);
 
-                LOG.info("[TabHandler] Created new tab: " + tabName);
+                // setForkContext must run after the tab is attached so restore callbacks target an initialized browser.
+                if (forkSourceId != null && !forkSourceId.trim().isEmpty()) {
+                    newChatWindow.setForkContext(forkSourceId, forkSourceTitle);
+                    LOG.info("[TabHandler] Created forked tab: " + tabName + " (source=" + forkSourceId + ")");
+                } else {
+                    LOG.info("[TabHandler] Created new tab: " + tabName);
+                }
             } catch (Exception e) {
+                releaseReservedForkTitle(project, forkSourceTitle);
                 LOG.error("[TabHandler] Error creating new tab: " + e.getMessage(), e);
                 callJavaScript("addErrorMessage", escapeJs("创建新标签页失败: " + e.getMessage()));
             }

--- a/src/main/java/com/github/claudecodegui/handler/TabHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/TabHandler.java
@@ -20,13 +20,14 @@ import com.intellij.ui.content.ContentFactory;
 import com.intellij.ui.content.ContentManager;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Tab management handler
@@ -92,7 +93,7 @@ public class TabHandler extends BaseMessageHandler {
 
         if (!isValidSourceSessionId(sourceSessionId)) {
             LOG.warn("[TabHandler] fork_session payload has invalid sourceSessionId, ignoring");
-            callJavaScript("addErrorMessage", escapeJs("无法从源会话 fork：缺少 sourceSessionId"));
+            callJavaScript("addErrorMessage", escapeJs(getInvalidSourceSessionIdMessage(sourceSessionId)));
             return;
         }
         String currentSessionId = context.getSession() != null ? context.getSession().getSessionId() : null;
@@ -105,7 +106,10 @@ public class TabHandler extends BaseMessageHandler {
         LOG.info("[TabHandler] Forking new tab from source session: " + sourceSessionId);
         Project project = context.getProject();
         final String forkSourceId = sourceSessionId.trim();
-        final String forkSourceTitle = sourceTitle;
+        String suppliedTitle = sourceTitle != null ? sourceTitle.trim() : "";
+        final String forkSourceTitle = suppliedTitle.isEmpty()
+                ? ClaudeChatWindow.buildForkTitleFromSource(project, forkSourceId)
+                : suppliedTitle;
         CompletableFuture
                 .supplyAsync(() -> reserveForkTitle(project, forkSourceTitle))
                 .thenAccept(forkTitle -> createNewTabInternal(forkSourceId, forkTitle))
@@ -126,44 +130,80 @@ public class TabHandler extends BaseMessageHandler {
                 && sourceSessionId.equals(currentSessionId);
     }
 
+    static String getInvalidSourceSessionIdMessage(String sourceSessionId) {
+        String normalized = sourceSessionId != null ? sourceSessionId.trim() : "";
+        if (normalized.isEmpty()) {
+            return "无法从源会话 fork：缺少 sourceSessionId";
+        }
+        return "无法从源会话 fork：sourceSessionId 无效";
+    }
+
     static void addReservedForkTitle(Project project, String forkTitle) {
         if (project == null || forkTitle == null || forkTitle.trim().isEmpty()) {
             return;
         }
-        RESERVED_FORK_TITLES.computeIfAbsent(project, ignored -> ConcurrentHashMap.newKeySet()).add(forkTitle);
+        synchronized (RESERVED_FORK_TITLES) {
+            getOrCreateReservedForkTitles(project).add(forkTitle);
+        }
     }
 
     static void releaseReservedForkTitle(Project project, String forkTitle) {
         if (project == null || forkTitle == null || forkTitle.trim().isEmpty()) {
             return;
         }
-        Set<String> reservedTitles = RESERVED_FORK_TITLES.get(project);
-        if (reservedTitles == null) {
-            return;
-        }
-        reservedTitles.remove(forkTitle);
-        if (reservedTitles.isEmpty()) {
-            RESERVED_FORK_TITLES.remove(project);
+        synchronized (RESERVED_FORK_TITLES) {
+            Set<String> reservedTitles = RESERVED_FORK_TITLES.get(project);
+            if (reservedTitles == null) {
+                return;
+            }
+            reservedTitles.remove(forkTitle);
+            if (reservedTitles.isEmpty()) {
+                RESERVED_FORK_TITLES.remove(project);
+            }
         }
     }
 
     static Set<String> getReservedForkTitlesSnapshot(Project project) {
+        if (project == null) {
+            return Collections.emptySet();
+        }
+        synchronized (RESERVED_FORK_TITLES) {
+            Set<String> reservedTitles = RESERVED_FORK_TITLES.get(project);
+            return reservedTitles == null ? Collections.emptySet() : Set.copyOf(reservedTitles);
+        }
+    }
+
+    static String reserveForkTitle(Project project, String sourceTitle, Collection<String> persistedTitles) {
+        String normalizedSourceTitle = sourceTitle != null ? sourceTitle.trim() : "";
+
+        synchronized (RESERVED_FORK_TITLES) {
+            List<String> existingTitles = new ArrayList<>();
+            if (persistedTitles != null) {
+                existingTitles.addAll(persistedTitles);
+            }
+            if (project != null) {
+                existingTitles.addAll(getOrCreateReservedForkTitles(project));
+            }
+
+            String forkTitle = ForkTitleFormatter.buildForkTitle(normalizedSourceTitle, existingTitles);
+            if (project != null) {
+                getOrCreateReservedForkTitles(project).add(forkTitle);
+            }
+            return forkTitle;
+        }
+    }
+
+    private static Set<String> getOrCreateReservedForkTitles(Project project) {
         Set<String> reservedTitles = RESERVED_FORK_TITLES.get(project);
-        return reservedTitles == null ? Collections.emptySet() : Set.copyOf(reservedTitles);
+        if (reservedTitles == null) {
+            reservedTitles = new HashSet<>();
+            RESERVED_FORK_TITLES.put(project, reservedTitles);
+        }
+        return reservedTitles;
     }
 
     private String reserveForkTitle(Project project, String sourceTitle) {
-        String normalizedSourceTitle = sourceTitle != null ? sourceTitle.trim() : "";
-        if (normalizedSourceTitle.isEmpty()) {
-            return null;
-        }
-
-        List<String> existingTitles = new ArrayList<>(loadPersistedSessionTitles());
-        existingTitles.addAll(getReservedForkTitlesSnapshot(project));
-
-        String forkTitle = ForkTitleFormatter.buildForkTitle(normalizedSourceTitle, existingTitles);
-        addReservedForkTitle(project, forkTitle);
-        return forkTitle;
+        return reserveForkTitle(project, sourceTitle, loadPersistedSessionTitles());
     }
 
     private List<String> loadPersistedSessionTitles() {

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeDaemonRequestExecutor.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeDaemonRequestExecutor.java
@@ -51,6 +51,7 @@ class ClaudeDaemonRequestExecutor {
             Boolean streaming,
             Boolean disableThinking,
             String reasoningEffort,
+            Boolean forkSession,
             MessageCallback callback
     ) {
         return CompletableFuture.supplyAsync(() -> {
@@ -74,7 +75,8 @@ class ClaudeDaemonRequestExecutor {
                         agentPrompt,
                         streaming,
                         disableThinking,
-                        reasoningEffort
+                        reasoningEffort,
+                        forkSession
                 );
 
                 boolean hasAttachments = attachments != null && !attachments.isEmpty() && params.has("attachments");

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeProcessInvoker.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeProcessInvoker.java
@@ -75,6 +75,7 @@ class ClaudeProcessInvoker {
             Boolean streaming,
             Boolean disableThinking,
             String reasoningEffort,
+            Boolean forkSession,
             MessageCallback callback
     ) {
         AtomicBoolean errorAlreadyReported = new AtomicBoolean(false);
@@ -113,7 +114,8 @@ class ClaudeProcessInvoker {
                         agentPrompt,
                         streaming,
                         disableThinking,
-                        reasoningEffort
+                        reasoningEffort,
+                        forkSession
                 );
                 String stdinJson = gson.toJson(stdinInput);
                 String preview = logSanitizer.buildPreview(stdinJson, 500);

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeRequestParamsBuilder.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeRequestParamsBuilder.java
@@ -33,7 +33,8 @@ class ClaudeRequestParamsBuilder {
             String agentPrompt,
             Boolean streaming,
             Boolean disableThinking,
-            String reasoningEffort
+            String reasoningEffort,
+            Boolean forkSession
     ) {
         JsonObject params = new JsonObject();
         params.addProperty("message", message);
@@ -62,6 +63,9 @@ class ClaudeRequestParamsBuilder {
         }
         if (reasoningEffort != null && !reasoningEffort.trim().isEmpty()) {
             params.addProperty("reasoningEffort", reasoningEffort);
+        }
+        if (Boolean.TRUE.equals(forkSession)) {
+            params.addProperty("forkSession", true);
         }
 
         return params;

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridge.java
@@ -291,7 +291,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
             List<ClaudeSession.Attachment> attachments,
             MessageCallback callback
     ) {
-        return sendMessage(channelId, message, sessionId, null, cwd, attachments, null, null, null, null, null, false, callback);
+        return sendMessage(channelId, message, sessionId, null, cwd, attachments, null, null, null, null, null, false, null, false, callback);
     }
 
     /**
@@ -309,7 +309,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
             String agentPrompt,
             MessageCallback callback
     ) {
-        return sendMessage(channelId, message, sessionId, null, cwd, attachments, permissionMode, model, openedFiles, agentPrompt, null, false, callback);
+        return sendMessage(channelId, message, sessionId, null, cwd, attachments, permissionMode, model, openedFiles, agentPrompt, null, false, null, false, callback);
     }
 
     /**
@@ -328,7 +328,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
             Boolean streaming,
             MessageCallback callback
     ) {
-        return sendMessage(channelId, message, sessionId, null, cwd, attachments, permissionMode, model, openedFiles, agentPrompt, streaming, false, callback);
+        return sendMessage(channelId, message, sessionId, null, cwd, attachments, permissionMode, model, openedFiles, agentPrompt, streaming, false, null, false, callback);
     }
 
     /**
@@ -349,7 +349,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
             MessageCallback callback
     ) {
         return sendMessage(channelId, message, sessionId, null, cwd, attachments, permissionMode,
-                model, openedFiles, agentPrompt, streaming, disableThinking, callback);
+                model, openedFiles, agentPrompt, streaming, disableThinking, null, false, callback);
     }
 
     /**
@@ -371,7 +371,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
             MessageCallback callback
     ) {
         return sendMessage(channelId, message, sessionId, runtimeSessionEpoch, cwd, attachments, permissionMode,
-                model, openedFiles, agentPrompt, streaming, disableThinking, null, callback);
+                model, openedFiles, agentPrompt, streaming, disableThinking, null, false, callback);
     }
 
     /**
@@ -391,6 +391,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
             Boolean streaming,
             Boolean disableThinking,
             String reasoningEffort,
+            Boolean forkSession,
             MessageCallback callback
     ) {
         // Try daemon mode first (avoids per-request Node.js process spawning)
@@ -398,7 +399,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
         if (db != null) {
             return sendMessageViaDaemon(db, channelId, message, sessionId, runtimeSessionEpoch, cwd,
                     attachments, permissionMode, model, openedFiles, agentPrompt,
-                    streaming, disableThinking, reasoningEffort, callback);
+                    streaming, disableThinking, reasoningEffort, forkSession, callback);
         }
 
         // Fallback: per-process mode (spawns a new Node.js process per request)
@@ -417,6 +418,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
                 streaming,
                 disableThinking,
                 reasoningEffort,
+                forkSession,
                 callback
         );
     }
@@ -596,6 +598,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
             Boolean streaming,
             Boolean disableThinking,
             String reasoningEffort,
+            Boolean forkSession,
             MessageCallback callback
     ) {
         return daemonRequestExecutor.sendMessageViaDaemon(
@@ -613,6 +616,7 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
                 streaming,
                 disableThinking,
                 reasoningEffort,
+                forkSession,
                 callback
         );
     }

--- a/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
@@ -204,7 +204,7 @@ public class ClaudeSession {
     }
 
     /**
-     * 提供底层会话状态访问，用于历史恢复等需要直接重建会话内存态的场景。
+     * Exposes mutable session state for restore flows that must rebuild in-memory session data.
      */
     public SessionState getState() {
         return state;
@@ -350,6 +350,16 @@ public class ClaudeSession {
         return send(input, null, agentPrompt, fileTagPaths, requestedPermissionMode);
     }
 
+    public CompletableFuture<Void> send(
+            String input,
+            String agentPrompt,
+            List<String> fileTagPaths,
+            String requestedPermissionMode,
+            boolean forkSession
+    ) {
+        return send(input, null, agentPrompt, fileTagPaths, requestedPermissionMode, forkSession);
+    }
+
     /**
      * Send a message with attachments using global agent settings.
      *
@@ -397,6 +407,17 @@ public class ClaudeSession {
             List<String> fileTagPaths,
             String requestedPermissionMode
     ) {
+        return send(input, attachments, agentPrompt, fileTagPaths, requestedPermissionMode, false);
+    }
+
+    public CompletableFuture<Void> send(
+            String input,
+            List<Attachment> attachments,
+            String agentPrompt,
+            List<String> fileTagPaths,
+            String requestedPermissionMode,
+            boolean forkSession
+    ) {
         String normalizedInput = (input != null) ? input.trim() : "";
         Message userMessage = contextService.buildUserMessage(normalizedInput, attachments);
         sendService.updateSessionStateForSend(userMessage, normalizedInput);
@@ -404,6 +425,13 @@ public class ClaudeSession {
         final String finalAgentPrompt = agentPrompt;
         final List<String> finalFileTagPaths = fileTagPaths;
         final String finalRequestedPermissionMode = requestedPermissionMode;
+        // Consume the pending fork marker before the provider call so only the first
+        // message in a branch tab uses SDK forkSession; follow-up messages must resume normally.
+        final boolean finalForkSession = forkSession || state.popPendingForkOnNextSend();
+        if (finalForkSession && LOG.isDebugEnabled()) {
+            LOG.debug("[Fork] send() will be issued as a forked branch (frontendForkFlag=" + forkSession
+                    + ", sessionId=" + state.getSessionId() + ")");
+        }
 
         return launchClaude().thenCompose(chId -> {
             sendService.prepareContextCollector(contextCollector);
@@ -416,7 +444,8 @@ public class ClaudeSession {
                             openedFilesJson,
                             finalAgentPrompt,
                             finalFileTagPaths,
-                            finalRequestedPermissionMode
+                            finalRequestedPermissionMode,
+                            finalForkSession
                     )
             ).thenCompose(v -> syncUserMessageUuidsAfterSend());
         }).exceptionally(ex -> {
@@ -609,6 +638,22 @@ public class ClaudeSession {
         return state.getSlashCommands();
     }
 
+
+    /**
+     * Marks the next send() as a branch fork.
+     * Called when a branch tab is created so its first user message triggers SDK resume+forkSession.
+     */
+    public void setPendingForkOnNextSend(boolean pending) {
+        state.setPendingForkOnNextSend(pending);
+    }
+
+    /**
+     * Reads and resets the pending fork marker for tests and fallback flows.
+     * Normal sends already consume this marker internally.
+     */
+    public boolean popPendingForkOnNextSend() {
+        return state.popPendingForkOnNextSend();
+    }
 
     /**
      * Create a permission request (called by the SDK).

--- a/src/main/java/com/github/claudecodegui/session/SessionSendService.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionSendService.java
@@ -85,7 +85,8 @@ public class SessionSendService {
             JsonObject openedFilesJson,
             String externalAgentPrompt,
             List<String> fileTagPaths,
-            String requestedPermissionMode
+            String requestedPermissionMode,
+            boolean forkSession
     ) {
         String agentPrompt = externalAgentPrompt;
         if (agentPrompt == null) {
@@ -123,7 +124,7 @@ public class SessionSendService {
             );
         }
 
-        return sendToClaude(channelId, input, attachments, openedFilesJson, agentPrompt, effectivePermissionMode);
+        return sendToClaude(channelId, input, attachments, openedFilesJson, agentPrompt, effectivePermissionMode, forkSession);
     }
 
     public static String normalizeRequestedPermissionMode(String mode) {
@@ -210,7 +211,8 @@ public class SessionSendService {
             List<ClaudeSession.Attachment> attachments,
             JsonObject openedFilesJson,
             String agentPrompt,
-            String effectivePermissionMode
+            String effectivePermissionMode,
+            boolean forkSession
     ) {
         ClaudeMessageHandler handler = new ClaudeMessageHandler(
                 project,
@@ -243,6 +245,7 @@ public class SessionSendService {
                         streaming,
                         false,
                         state.getReasoningEffort(),
+                        forkSession,
                         handler
                 ).thenApply(result -> null);
     }

--- a/src/main/java/com/github/claudecodegui/session/SessionState.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionState.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 /**
  * Session state management.
@@ -18,6 +19,9 @@ public class SessionState {
      * Canonical whitelist of valid permission modes.
      * Shared across SessionHandler (payload validation) and ClaudeSession (mode resolution).
      */
+    private static final int MAX_SESSION_ID_LENGTH = 128;
+    private static final Pattern SESSION_ID_PATTERN = Pattern.compile("^[A-Za-z0-9._-]+$");
+
     public static final Set<String> VALID_PERMISSION_MODES;
     static {
         Set<String> modes = new HashSet<>();
@@ -34,6 +38,17 @@ public class SessionState {
      */
     public static boolean isValidPermissionMode(String mode) {
         return mode != null && VALID_PERMISSION_MODES.contains(mode.trim());
+    }
+
+    public static boolean isValidSessionId(String sessionId) {
+        if (sessionId == null) {
+            return false;
+        }
+        String trimmed = sessionId.trim();
+        if (trimmed.isEmpty() || !trimmed.equals(sessionId) || trimmed.length() > MAX_SESSION_ID_LENGTH) {
+            return false;
+        }
+        return SESSION_ID_PATTERN.matcher(trimmed).matches();
     }
 
     // Session identifiers
@@ -69,6 +84,11 @@ public class SessionState {
 
     // PSI context collection toggle
     private boolean psiContextEnabled = true;
+
+    // One-shot fork marker: the next send should use forkSession=true, then reset immediately.
+    // The IDE sets this while creating a branch tab because the user's later message payload
+    // does not know that the tab was created from /fork.
+    private volatile boolean pendingForkOnNextSend = false;
 
     // Getters
     public String getSessionId() {
@@ -216,6 +236,24 @@ public class SessionState {
 
     public void setPsiContextEnabled(boolean psiContextEnabled) {
         this.psiContextEnabled = psiContextEnabled;
+    }
+
+    /**
+     * Marks the next send() as a branch fork.
+     * Only the immediately following send is affected, then popPendingForkOnNextSend() resets it.
+     */
+    public void setPendingForkOnNextSend(boolean pending) {
+        this.pendingForkOnNextSend = pending;
+    }
+
+    /**
+     * Reads and resets the pending fork marker.
+     * synchronized prevents concurrent sends from consuming the marker twice and creating two branch sessions.
+     */
+    public synchronized boolean popPendingForkOnNextSend() {
+        boolean current = this.pendingForkOnNextSend;
+        this.pendingForkOnNextSend = false;
+        return current;
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/skill/SlashCommandRegistry.java
+++ b/src/main/java/com/github/claudecodegui/skill/SlashCommandRegistry.java
@@ -54,6 +54,7 @@ public final class SlashCommandRegistry {
             new SlashCommand("/init", "Initialize a new CLAUDE.md file with codebase documentation", "builtin"),
             new SlashCommand("/plan", "Switch to plan mode", "builtin"),
             new SlashCommand("/resume", "Resume a previous conversation", "builtin"),
+            new SlashCommand("/fork", "Create a new branch from the current conversation", "builtin"),
             new SlashCommand("/review", "Review a pull request", "builtin"),
             // Bundled skills (userInvocable, no ANT-only restriction)
             new SlashCommand("/batch", "Execute large-scale changes in parallel across isolated worktrees", "bundled"),

--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -96,6 +96,15 @@ public class ChatWindowDelegate {
         void setSlashCommandsFetched(boolean fetched);
         void setFetchedSlashCommandsCount(int count);
         void persistTabSessionState();
+
+        /**
+         * Consumes the fork title seeded by {@code ClaudeChatWindow#setForkContext}.
+         * This must run after frontend_ready so the frontend can show the source title first,
+         * then persist the fork title under the new SDK session ID when it arrives.
+         */
+        default String popPendingForkTitle() {
+            return null;
+        }
     }
 
     private final DelegateHost host;
@@ -478,6 +487,22 @@ public class ChatWindowDelegate {
         host.getStreamCoalescer().flush(null);
     }
 
+    public void replayPendingForkTitleIfReady() {
+        if (!host.isFrontendReady()) {
+            return;
+        }
+        ClaudeSession session = host.getSession();
+        if (session == null || host.isDisposed()) {
+            return;
+        }
+        String sessionId = session.getSessionId();
+        if (sessionId == null || sessionId.trim().isEmpty()) {
+            return;
+        }
+        host.callJavaScript("setSessionId", JsUtils.escapeJs(sessionId));
+        seedPendingForkTitle();
+    }
+
     private void replayCurrentSessionStateToFrontend() {
         ClaudeSession session = host.getSession();
         if (session == null || host.isDisposed()) {
@@ -488,6 +513,7 @@ public class ChatWindowDelegate {
             String sessionId = session.getSessionId();
             if (sessionId != null && !sessionId.trim().isEmpty()) {
                 host.callJavaScript("setSessionId", JsUtils.escapeJs(sessionId));
+                seedPendingForkTitle();
             }
 
             List<ClaudeSession.Message> messages = session.getMessages();
@@ -522,6 +548,14 @@ public class ChatWindowDelegate {
                     + ", streaming=" + streamActive);
         } catch (Exception e) {
             LOG.warn("Failed to replay current session state to frontend: " + e.getMessage(), e);
+        }
+    }
+
+    private void seedPendingForkTitle() {
+        String forkTitle = host.popPendingForkTitle();
+        if (forkTitle != null && !forkTitle.isEmpty()) {
+            host.callJavaScript("seedForkSessionTitle", JsUtils.escapeJs(forkTitle));
+            LOG.info("[Fork] Seeded fork title to webview (length=" + forkTitle.length() + ")");
         }
     }
 

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -14,6 +14,7 @@ import com.github.claudecodegui.session.ClaudeSession;
 import com.github.claudecodegui.session.SessionCallbackAdapter;
 import com.github.claudecodegui.session.SessionLifecycleManager;
 import com.github.claudecodegui.session.SessionLoadService;
+import com.github.claudecodegui.session.SessionState;
 import com.github.claudecodegui.session.StreamMessageCoalescer;
 import com.github.claudecodegui.settings.CodemossSettingsService;
 import com.github.claudecodegui.settings.TabStateService;
@@ -36,6 +37,7 @@ import com.intellij.ui.jcef.JBCefBrowser;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -45,6 +47,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class ClaudeChatWindow {
 
     private static final Logger LOG = Logger.getInstance(ClaudeChatWindow.class);
+    private static final String FORK_TITLE_SUFFIX = "[fork]";
 
     private final JPanel mainPanel;
     private final ClaudeSDKBridge claudeSDKBridge;
@@ -56,6 +59,11 @@ public class ClaudeChatWindow {
     private Content parentContent;
     private String originalTabName;
     private volatile String sessionId = null;
+
+    // Seeded by setForkContext and consumed once during frontend state replay.
+    // The title must be sent after setSessionId(sourceSessionId), otherwise the frontend
+    // drops title updates whose session ID does not match the current session.
+    private volatile String pendingForkTitle = null;
 
     private JBCefBrowser browser;
     private ClaudeSession session;
@@ -378,6 +386,103 @@ public class ClaudeChatWindow {
         }
     }
 
+    /**
+     * Configures this tab as a branch of the given source session.
+     * It loads the source JSONL into the tab, marks the next send as a pending fork,
+     * and lets the SDK return the real branch session ID on the first user message.
+     * <p>
+     * The SDK is not called with an empty prompt here because empty queries are rejected
+     * and would create a confusing blank conversation entry even if accepted.
+     */
+    public void setForkContext(String sourceSessionId) {
+        setForkContext(sourceSessionId, null);
+    }
+
+    public void setForkContext(String sourceSessionId, String forkTitle) {
+        if (!SessionState.isValidSessionId(sourceSessionId)) {
+            LOG.warn("[Fork] setForkContext called with invalid sourceSessionId, ignoring");
+            return;
+        }
+        String normalizedSourceSessionId = sourceSessionId.trim();
+        if (session == null) {
+            LOG.warn("[Fork] setForkContext called before session was initialized; cannot fork");
+            return;
+        }
+
+        String suppliedForkTitle = forkTitle != null ? forkTitle.trim() : "";
+        this.pendingForkTitle = suppliedForkTitle.isEmpty()
+                ? buildForkTitleFromSource(normalizedSourceSessionId)
+                : suppliedForkTitle;
+
+        // Load the source history so the branch tab visibly starts from the fork point.
+        TabStateService.TabSessionState forkState = new TabStateService.TabSessionState();
+        forkState.sessionId = normalizedSourceSessionId;
+        forkState.provider = "claude";
+        forkState.cwd = session.getCwd();
+        forkState.model = session.getModel();
+        forkState.permissionMode = session.getPermissionMode();
+        forkState.reasoningEffort = session.getReasoningEffort();
+        restorePersistedTabSessionState(forkState, true);
+
+        // The next send must use resume+forkSession so the SDK creates a new branch session ID.
+        session.setPendingForkOnNextSend(true);
+        chatWindowDelegate.replayPendingForkTitleIfReady();
+
+        LOG.info("[Fork] Configured tab to fork from session: " + normalizedSourceSessionId
+                + " (cwd=" + forkState.cwd + ", hasPendingTitle=" + (this.pendingForkTitle != null) + ")");
+    }
+
+    /**
+     * Derives a branch title from the source tab's first user message.
+     *
+     * The webview title fallback uses customSessionTitle ?? firstUserMessage[0..15],
+     * so this mirrors that truncation before appending the fork suffix.
+     *
+     * When the source tab or message is unavailable, the bare [fork] marker is enough
+     * to distinguish the branch tab from a normal restored session.
+     */
+    private String buildForkTitleFromSource(String sourceSessionId) {
+        try {
+            Content sourceContent = ClaudeSDKToolWindow.findContentForSession(project, sourceSessionId);
+            if (sourceContent == null) {
+                LOG.debug("[Fork] No source content found for sessionId=" + sourceSessionId
+                        + ", falling back to bare [fork]");
+                return FORK_TITLE_SUFFIX;
+            }
+            ClaudeChatWindow sourceWindow = ClaudeSDKToolWindow.getChatWindowForContent(sourceContent);
+            if (sourceWindow == null || sourceWindow.getSession() == null) {
+                LOG.debug("[Fork] No source window/session for sessionId=" + sourceSessionId);
+                return FORK_TITLE_SUFFIX;
+            }
+            for (ClaudeSession.Message msg : sourceWindow.getSession().getMessages()) {
+                if (msg.type != ClaudeSession.Message.Type.USER || msg.content == null) {
+                    continue;
+                }
+                String text = msg.content.trim();
+                if (text.isEmpty()) {
+                    continue;
+                }
+                String base = text.length() > 15 ? text.substring(0, 15) + "..." : text;
+                return ForkTitleFormatter.buildForkTitle(base, Collections.emptyList());
+            }
+            LOG.debug("[Fork] Source session has no user message yet, falling back to bare [fork]");
+        } catch (Exception e) {
+            LOG.warn("[Fork] Failed to derive fork title from source session " + sourceSessionId
+                    + ": " + e.getMessage());
+        }
+        return FORK_TITLE_SUFFIX;
+    }
+
+    /**
+     * Consumes the branch title seeded by {@link #setForkContext(String)}.
+     * Called after frontend_ready so the frontend has already received setSessionId(sourceSessionId).
+     */
+    public String popPendingForkTitle() {
+        String value = this.pendingForkTitle;
+        this.pendingForkTitle = null;
+        return value;
+    }
+
     public void loadRestoredHistoryIfNeeded() {
         if (session == null) {
             return;
@@ -446,6 +551,12 @@ public class ClaudeChatWindow {
     private static final java.util.regex.Pattern SAFE_JS_FUNCTION_NAME =
             java.util.regex.Pattern.compile("^[a-zA-Z_$][a-zA-Z0-9_$.]*$");
 
+    /**
+     * Calls a JavaScript function in the JCEF browser.
+     * <p><strong>SECURITY:</strong> All args must be pre-escaped with {@link JsUtils#escapeJs(String)}
+     * before passing. This method wraps args in single quotes without additional escaping;
+     * unescaped user-controlled data creates a JS-injection vulnerability.
+     */
     void callJavaScript(String functionName, String... args) {
         if (disposed || browser == null) {
             LOG.warn("Cannot call JS function " + functionName + ": disposed=" + disposed + ", browser=" + (browser == null ? "null" : "exists"));
@@ -455,6 +566,15 @@ public class ClaudeChatWindow {
         if (functionName == null || !SAFE_JS_FUNCTION_NAME.matcher(functionName).matches()) {
             LOG.error("Invalid JavaScript function name rejected: " + functionName);
             return;
+        }
+
+        if (args != null) {
+            for (String arg : args) {
+                if (looksUnescaped(arg)) {
+                    LOG.warn(buildUnescapedJavaScriptArgumentWarning(functionName, arg));
+                    break;
+                }
+            }
         }
 
         ApplicationManager.getApplication().invokeLater(() -> {
@@ -494,6 +614,34 @@ public class ClaudeChatWindow {
         });
     }
 
+    static String buildUnescapedJavaScriptArgumentWarning(String functionName, String arg) {
+        int length = arg != null ? arg.length() : 0;
+        return "callJavaScript arg looks unescaped for '" + functionName
+                + "'. Callers must use JsUtils.escapeJs(). length=" + length;
+    }
+
+    static String buildWebviewConsoleLogMessage(String logType, String... args) {
+        return buildWebviewConsoleLogMessage(logType, args != null ? args.length : 0);
+    }
+
+    static String buildWebviewConsoleLogMessage(String logType, int argCount) {
+        return "[Webview] " + logType + " args=" + argCount;
+    }
+
+    /**
+     * Heuristic to detect strings that likely have not been JS-escaped.
+     * Returns true when the arg contains dangerous chars (single quotes, newlines)
+     * without common escape sequences that would indicate prior escaping.
+     */
+    private static boolean looksUnescaped(String arg) {
+        if (arg == null || arg.isEmpty()) {
+            return false;
+        }
+        boolean hasDangerous = arg.indexOf('\'') >= 0 || arg.indexOf('\n') >= 0 || arg.indexOf('\r') >= 0;
+        boolean hasEscapeSeq = arg.contains("\\'") || arg.contains("\\\\") || arg.contains("\\n");
+        return hasDangerous && !hasEscapeSeq;
+    }
+
     void handleJavaScriptMessage(String message) {
         if (message.startsWith("{\"type\":\"console.")) {
             try {
@@ -501,18 +649,14 @@ public class ClaudeChatWindow {
                 String logType = json.get("type").getAsString();
                 JsonArray args = json.getAsJsonArray("args");
 
-                StringBuilder logMessage = new StringBuilder("[Webview] ");
-                for (int i = 0; i < args.size(); i++) {
-                    if (i > 0) { logMessage.append(" "); }
-                    logMessage.append(args.get(i).toString());
-                }
+                String logMessage = buildWebviewConsoleLogMessage(logType, args.size());
 
                 if ("console.error".equals(logType)) {
-                    LOG.warn(logMessage.toString());
+                    LOG.warn(logMessage);
                 } else if ("console.warn".equals(logType)) {
-                    LOG.info(logMessage.toString());
+                    LOG.info(logMessage);
                 } else {
-                    LOG.debug(logMessage.toString());
+                    LOG.debug(logMessage);
                 }
             } catch (Exception e) {
                 LOG.warn("Failed to parse console log: " + e.getMessage());
@@ -973,6 +1117,11 @@ public class ClaudeChatWindow {
             @Override
             public void persistTabSessionState() {
                 ClaudeChatWindow.this.persistTabSessionState();
+            }
+
+            @Override
+            public String popPendingForkTitle() {
+                return ClaudeChatWindow.this.popPendingForkTitle();
             }
         };
     }

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -411,7 +411,7 @@ public class ClaudeChatWindow {
 
         String suppliedForkTitle = forkTitle != null ? forkTitle.trim() : "";
         this.pendingForkTitle = suppliedForkTitle.isEmpty()
-                ? buildForkTitleFromSource(normalizedSourceSessionId)
+                ? buildForkTitleFromSource(project, normalizedSourceSessionId)
                 : suppliedForkTitle;
 
         // Load the source history so the branch tab visibly starts from the fork point.
@@ -441,7 +441,7 @@ public class ClaudeChatWindow {
      * When the source tab or message is unavailable, the bare [fork] marker is enough
      * to distinguish the branch tab from a normal restored session.
      */
-    private String buildForkTitleFromSource(String sourceSessionId) {
+    public static String buildForkTitleFromSource(Project project, String sourceSessionId) {
         try {
             Content sourceContent = ClaudeSDKToolWindow.findContentForSession(project, sourceSessionId);
             if (sourceContent == null) {

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeSDKToolWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeSDKToolWindow.java
@@ -19,6 +19,7 @@ import com.intellij.ui.content.ContentManager;
 import com.intellij.ui.content.ContentManagerEvent;
 import com.intellij.ui.content.ContentManagerListener;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
@@ -103,6 +104,27 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
 
     static void unregisterContentMapping(Content content) {
         contentToWindowMap.remove(content);
+    }
+
+    /**
+     * Finds the content associated with a session ID in the current project.
+     *
+     * /fork uses this lookup to derive source-tab display context before naming the branch title.
+     * The static mapping includes both tool-window and detached windows, so detached source
+     * sessions are not missed.
+     *
+     * @return the matching content, or null when no session is found.
+     */
+    public static @Nullable Content findContentForSession(@NotNull Project project, @NotNull String sessionId) {
+        for (Map.Entry<Content, ClaudeChatWindow> entry : contentToWindowMap.entrySet()) {
+            ClaudeChatWindow window = entry.getValue();
+            if (window != null
+                    && project.equals(window.getProject())
+                    && sessionId.equals(window.getSessionId())) {
+                return entry.getKey();
+            }
+        }
+        return null;
     }
 
     private static Set<ClaudeChatWindow> collectProjectChatWindows(@NotNull Project project) {

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ForkTitleFormatter.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ForkTitleFormatter.java
@@ -26,10 +26,6 @@ public final class ForkTitleFormatter {
      */
     public static String buildForkTitle(String sourceTitle, Collection<String> existingTitles) {
         String rootTitle = normalizeRootTitle(sourceTitle);
-        if (rootTitle.isEmpty()) {
-            return "[" + FORK_LABEL + "]";
-        }
-
         int nextIndex = findNextForkIndex(rootTitle, existingTitles);
         String suffix = nextIndex <= 1 ? "[" + FORK_LABEL + "]" : "[" + FORK_LABEL + " " + nextIndex + "]";
         return truncateRootForSuffix(rootTitle, suffix) + suffix;

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ForkTitleFormatter.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ForkTitleFormatter.java
@@ -1,0 +1,83 @@
+package com.github.claudecodegui.ui.toolwindow;
+
+import java.util.Collection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Formats forked session titles while preserving the 50-character custom-title limit.
+ */
+public final class ForkTitleFormatter {
+    private static final String FORK_LABEL = "fork";
+    private static final int CUSTOM_TITLE_MAX_LENGTH = 50;
+    private static final Pattern TRAILING_FORK_SUFFIX = Pattern.compile("(?:\\[fork(?:\\s+\\d+)?\\])+$");
+    private static final Pattern LAST_FORK_SUFFIX = Pattern.compile("\\[fork(?:\\s+(\\d+))?\\]$");
+
+    private ForkTitleFormatter() {
+    }
+
+    /**
+     * Builds a fork title by stripping existing fork suffixes, selecting the next sibling index,
+     * and truncating the root so the final title fits the persisted custom-title limit.
+     *
+     * @param sourceTitle the source session title or an existing fork title
+     * @param existingTitles titles already used for the same source root
+     * @return a title ending in [fork] or [fork n]
+     */
+    public static String buildForkTitle(String sourceTitle, Collection<String> existingTitles) {
+        String rootTitle = normalizeRootTitle(sourceTitle);
+        if (rootTitle.isEmpty()) {
+            return "[" + FORK_LABEL + "]";
+        }
+
+        int nextIndex = findNextForkIndex(rootTitle, existingTitles);
+        String suffix = nextIndex <= 1 ? "[" + FORK_LABEL + "]" : "[" + FORK_LABEL + " " + nextIndex + "]";
+        return truncateRootForSuffix(rootTitle, suffix) + suffix;
+    }
+
+    private static String normalizeRootTitle(String title) {
+        String value = title != null ? title.trim() : "";
+        return TRAILING_FORK_SUFFIX.matcher(value).replaceAll("").trim();
+    }
+
+    private static int findNextForkIndex(String rootTitle, Collection<String> existingTitles) {
+        int maxIndex = 0;
+        if (existingTitles == null) {
+            return 1;
+        }
+
+        for (String existingTitle : existingTitles) {
+            String normalizedExistingTitle = existingTitle != null ? existingTitle.trim() : "";
+            Matcher matcher = LAST_FORK_SUFFIX.matcher(normalizedExistingTitle);
+            if (!matcher.find()) {
+                continue;
+            }
+
+            String indexGroup = matcher.group(1);
+            int index = indexGroup == null ? 1 : parseIndex(indexGroup);
+            String suffix = index <= 1 ? "[" + FORK_LABEL + "]" : "[" + FORK_LABEL + " " + index + "]";
+            if (!truncateRootForSuffix(rootTitle, suffix).equals(normalizeRootTitle(normalizedExistingTitle))) {
+                continue;
+            }
+
+            maxIndex = Math.max(maxIndex, index);
+        }
+        return maxIndex + 1;
+    }
+
+    private static int parseIndex(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException ignored) {
+            return 1;
+        }
+    }
+
+    private static String truncateRootForSuffix(String rootTitle, String suffix) {
+        int maxRootLength = CUSTOM_TITLE_MAX_LENGTH - suffix.length();
+        if (rootTitle.length() <= maxRootLength) {
+            return rootTitle;
+        }
+        return rootTitle.substring(0, Math.max(0, maxRootLength));
+    }
+}

--- a/src/test/java/com/github/claudecodegui/handler/SessionHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/SessionHandlerTest.java
@@ -1,0 +1,122 @@
+package com.github.claudecodegui.handler;
+
+import com.github.claudecodegui.handler.core.HandlerContext;
+import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
+import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.session.ClaudeSession;
+import com.github.claudecodegui.settings.CodemossSettingsService;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SessionHandlerTest {
+
+    @Test
+    public void sendMessageIgnoresClientControlledForkSession() throws Exception {
+        RecordingSession session = new RecordingSession();
+        SessionHandler handler = createHandler(session);
+
+        handler.handle("send_message", "{\"text\":\"hello\",\"forkSession\":true}");
+
+        assertTrue(session.awaitSend());
+        assertFalse(session.lastForkSession);
+    }
+
+    @Test
+    public void sendMessageWithAttachmentsIgnoresClientControlledForkSession() throws Exception {
+        RecordingSession session = new RecordingSession();
+        SessionHandler handler = createHandler(session);
+
+        handler.handle("send_message_with_attachments", "{\"text\":\"hello\",\"attachments\":[],\"forkSession\":true}");
+
+        assertTrue(session.awaitSend());
+        assertFalse(session.lastForkSession);
+    }
+
+    private static SessionHandler createHandler(RecordingSession session) {
+        HandlerContext context = new HandlerContext(
+                null,
+                new ReadyClaudeSDKBridge(),
+                new CodexSDKBridge(),
+                new CodemossSettingsService(),
+                new NoopJsCallback()
+        );
+        context.setSession(session);
+        return new TestableSessionHandler(context);
+    }
+
+    private static class TestableSessionHandler extends SessionHandler {
+        TestableSessionHandler(HandlerContext context) {
+            super(context);
+        }
+
+        @Override
+        protected String determineWorkingDirectory() {
+            return System.getProperty("user.dir");
+        }
+    }
+
+    private static class ReadyClaudeSDKBridge extends ClaudeSDKBridge {
+        @Override
+        public String getCachedNodeVersion() {
+            return "v22.0.0";
+        }
+    }
+
+    private static class NoopJsCallback implements HandlerContext.JsCallback {
+        @Override
+        public void callJavaScript(String functionName, String... args) {
+        }
+
+        @Override
+        public String escapeJs(String str) {
+            return str;
+        }
+    }
+
+    private static class RecordingSession extends ClaudeSession {
+        private final CountDownLatch sendLatch = new CountDownLatch(1);
+        private volatile boolean lastForkSession = true;
+
+        RecordingSession() {
+            super(null, null, null);
+        }
+
+        @Override
+        public CompletableFuture<Void> send(
+                String input,
+                String agentPrompt,
+                List<String> fileTagPaths,
+                String requestedPermissionMode,
+                boolean forkSession
+        ) {
+            this.lastForkSession = forkSession;
+            sendLatch.countDown();
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletableFuture<Void> send(
+                String input,
+                List<Attachment> attachments,
+                String agentPrompt,
+                List<String> fileTagPaths,
+                String requestedPermissionMode,
+                boolean forkSession
+        ) {
+            this.lastForkSession = forkSession;
+            sendLatch.countDown();
+            return CompletableFuture.completedFuture(null);
+        }
+
+        boolean awaitSend() throws InterruptedException {
+            return sendLatch.await(5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/src/test/java/com/github/claudecodegui/handler/TabHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/TabHandlerTest.java
@@ -1,0 +1,72 @@
+package com.github.claudecodegui.handler;
+
+import com.intellij.openapi.project.Project;
+import org.junit.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TabHandlerTest {
+
+    @Test
+    public void isAuthorizedForkSourceSessionIdRequiresCurrentSessionMatch() {
+        assertTrue(TabHandler.isAuthorizedForkSourceSessionId("session-123", "session-123"));
+        assertFalse(TabHandler.isAuthorizedForkSourceSessionId("session-123", "session-456"));
+        assertFalse(TabHandler.isAuthorizedForkSourceSessionId("session-123", null));
+    }
+
+    @Test
+    public void releaseReservedForkTitleRemovesEmptyProjectReservations() {
+        Project project = createProject("project-a");
+
+        TabHandler.addReservedForkTitle(project, "Title[fork]");
+        TabHandler.releaseReservedForkTitle(project, "Title[fork]");
+
+        assertEquals(Set.of(), TabHandler.getReservedForkTitlesSnapshot(project));
+    }
+
+    @Test
+    public void isValidSourceSessionIdAcceptsUuidLikeSessionIds() {
+        assertTrue(TabHandler.isValidSourceSessionId("550e8400-e29b-41d4-a716-446655440000"));
+        assertTrue(TabHandler.isValidSourceSessionId("session_123-abc.def"));
+    }
+
+    @Test
+    public void isValidSourceSessionIdRejectsPathTraversalAndControlCharacters() {
+        assertFalse(TabHandler.isValidSourceSessionId("../550e8400-e29b-41d4-a716-446655440000"));
+        assertFalse(TabHandler.isValidSourceSessionId("folder\\550e8400-e29b-41d4-a716-446655440000"));
+        assertFalse(TabHandler.isValidSourceSessionId("550e8400-e29b-41d4-a716-446655440000\n"));
+        assertFalse(TabHandler.isValidSourceSessionId("session id"));
+        assertFalse(TabHandler.isValidSourceSessionId("session$123"));
+        assertFalse(TabHandler.isValidSourceSessionId("a".repeat(129)));
+        assertFalse(TabHandler.isValidSourceSessionId(""));
+        assertFalse(TabHandler.isValidSourceSessionId(null));
+    }
+
+    private static Project createProject(String name) {
+        return (Project) Proxy.newProxyInstance(
+                Project.class.getClassLoader(),
+                new Class<?>[] { Project.class },
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "getName":
+                            return name;
+                        case "isDisposed":
+                            return false;
+                        case "hashCode":
+                            return System.identityHashCode(proxy);
+                        case "equals":
+                            return proxy == args[0];
+                        case "toString":
+                            return name;
+                        default:
+                            return null;
+                    }
+                }
+        );
+    }
+}

--- a/src/test/java/com/github/claudecodegui/handler/TabHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/TabHandlerTest.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.project.Project;
 import org.junit.Test;
 
 import java.lang.reflect.Proxy;
+import java.util.Collections;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -45,6 +46,44 @@ public class TabHandlerTest {
         assertFalse(TabHandler.isValidSourceSessionId("a".repeat(129)));
         assertFalse(TabHandler.isValidSourceSessionId(""));
         assertFalse(TabHandler.isValidSourceSessionId(null));
+    }
+
+    @Test
+    public void getInvalidSourceSessionIdMessageDistinguishesMissingFromInvalid() {
+        assertEquals("无法从源会话 fork：缺少 sourceSessionId", TabHandler.getInvalidSourceSessionIdMessage(null));
+        assertEquals("无法从源会话 fork：缺少 sourceSessionId", TabHandler.getInvalidSourceSessionIdMessage(""));
+        assertEquals("无法从源会话 fork：sourceSessionId 无效", TabHandler.getInvalidSourceSessionIdMessage("../session"));
+    }
+
+    @Test
+    public void reserveForkTitleUsesExistingReservationsBeforeAddingNewTitle() {
+        Project project = createProject("project-reservation");
+
+        String first = TabHandler.reserveForkTitle(project, "测试消息", Collections.emptyList());
+        String second = TabHandler.reserveForkTitle(project, "测试消息", Collections.emptyList());
+
+        assertEquals("测试消息[fork]", first);
+        assertEquals("测试消息[fork 2]", second);
+        assertEquals(Set.of(first, second), TabHandler.getReservedForkTitlesSnapshot(project));
+
+        TabHandler.releaseReservedForkTitle(project, first);
+        TabHandler.releaseReservedForkTitle(project, second);
+        assertEquals(Set.of(), TabHandler.getReservedForkTitlesSnapshot(project));
+    }
+
+    @Test
+    public void reserveForkTitleUsesReservationsForMissingSourceTitleFallback() {
+        Project project = createProject("project-empty-title-reservation");
+
+        String first = TabHandler.reserveForkTitle(project, "", Collections.emptyList());
+        String second = TabHandler.reserveForkTitle(project, null, Collections.emptyList());
+
+        assertEquals("[fork]", first);
+        assertEquals("[fork 2]", second);
+        assertEquals(Set.of(first, second), TabHandler.getReservedForkTitlesSnapshot(project));
+
+        TabHandler.releaseReservedForkTitle(project, first);
+        TabHandler.releaseReservedForkTitle(project, second);
     }
 
     private static Project createProject(String name) {

--- a/src/test/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridgeRefactorTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridgeRefactorTest.java
@@ -56,7 +56,8 @@ public class ClaudeSDKBridgeRefactorTest {
                 "system prompt",
                 Boolean.TRUE,
                 Boolean.TRUE,
-                "xhigh"
+                "xhigh",
+                Boolean.TRUE
         );
 
         assertEquals("hello", params.get("message").getAsString());
@@ -69,6 +70,7 @@ public class ClaudeSDKBridgeRefactorTest {
         assertTrue(params.get("streaming").getAsBoolean());
         assertTrue(params.get("disableThinking").getAsBoolean());
         assertEquals("xhigh", params.get("reasoningEffort").getAsString());
+        assertTrue(params.get("forkSession").getAsBoolean());
         assertTrue(params.has("attachments"));
         assertEquals(1, params.getAsJsonArray("attachments").size());
         assertEquals("image.png", params.getAsJsonArray("attachments").get(0).getAsJsonObject().get("fileName").getAsString());
@@ -93,10 +95,12 @@ public class ClaudeSDKBridgeRefactorTest {
                 null,
                 null,
                 null,
+                null,
                 null
         );
 
         assertFalse(params.has("attachments"));
+        assertFalse(params.has("forkSession"));
         assertEquals("", params.get("sessionId").getAsString());
         assertEquals("", params.get("cwd").getAsString());
     }
@@ -188,6 +192,7 @@ public class ClaudeSDKBridgeRefactorTest {
                 null,
                 null,
                 Boolean.TRUE,
+                null,
                 null,
                 null,
                 callback

--- a/src/test/java/com/github/claudecodegui/session/SessionStateTest.java
+++ b/src/test/java/com/github/claudecodegui/session/SessionStateTest.java
@@ -1,0 +1,35 @@
+package com.github.claudecodegui.session;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SessionStateTest {
+
+    @Test
+    public void isValidSessionIdAcceptsExpectedClaudeSessionCharacters() {
+        assertTrue(SessionState.isValidSessionId("550e8400-e29b-41d4-a716-446655440000"));
+        assertTrue(SessionState.isValidSessionId("session_123-abc.def"));
+    }
+
+    @Test
+    public void isValidSessionIdRejectsTooLongValues() {
+        assertTrue(SessionState.isValidSessionId("a".repeat(128)));
+        assertFalse(SessionState.isValidSessionId("a".repeat(129)));
+    }
+
+    @Test
+    public void isValidSessionIdRejectsNonAllowlistedCharacters() {
+        assertFalse(SessionState.isValidSessionId("session id"));
+        assertFalse(SessionState.isValidSessionId("session:123"));
+        assertFalse(SessionState.isValidSessionId("session$123"));
+        assertFalse(SessionState.isValidSessionId("session@123"));
+        assertFalse(SessionState.isValidSessionId("会话-123"));
+        assertFalse(SessionState.isValidSessionId("../session"));
+        assertFalse(SessionState.isValidSessionId("folder\\session"));
+        assertFalse(SessionState.isValidSessionId("session\n123"));
+        assertFalse(SessionState.isValidSessionId(" session"));
+        assertFalse(SessionState.isValidSessionId("session "));
+    }
+}

--- a/src/test/java/com/github/claudecodegui/skill/SlashCommandSourceScannersTest.java
+++ b/src/test/java/com/github/claudecodegui/skill/SlashCommandSourceScannersTest.java
@@ -8,8 +8,17 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SlashCommandSourceScannersTest {
+
+    @Test
+    public void claudeBuiltinsIncludeForkCommand() {
+        List<SlashCommandRegistry.SlashCommand> commands = SlashCommandRegistry.CLAUDE_BUILTIN;
+
+        assertTrue(commands.stream().anyMatch(command ->
+                "/fork".equals(command.name()) && "builtin".equals(command.source())));
+    }
 
     @Test
     public void managedSkillScannerReadsConditionalSkillsFromManagedDirectory() throws IOException {

--- a/src/test/java/com/github/claudecodegui/ui/ChatWindowDelegateTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/ChatWindowDelegateTest.java
@@ -1,0 +1,96 @@
+package com.github.claudecodegui.ui;
+
+import com.github.claudecodegui.handler.PermissionHandler;
+import com.github.claudecodegui.handler.core.HandlerContext;
+import com.github.claudecodegui.handler.core.MessageDispatcher;
+import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
+import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.session.ClaudeSession;
+import com.github.claudecodegui.session.SessionLifecycleManager;
+import com.github.claudecodegui.session.StreamMessageCoalescer;
+import com.github.claudecodegui.settings.CodemossSettingsService;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.jcef.JBCefBrowser;
+import org.junit.Test;
+
+import javax.swing.JPanel;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ChatWindowDelegateTest {
+
+    @Test
+    public void replayPendingForkTitleIfReadySeedsTitleAfterSessionId() {
+        RecordingHost host = new RecordingHost();
+        host.frontendReady = true;
+        host.session.setSessionInfo("source-session", System.getProperty("user.dir"));
+        host.pendingForkTitle = "Source title[fork]";
+        ChatWindowDelegate delegate = new ChatWindowDelegate(host);
+
+        delegate.replayPendingForkTitleIfReady();
+
+        assertEquals("setSessionId:source-session", host.calls.get(0));
+        assertEquals("seedForkSessionTitle:Source title[fork]", host.calls.get(1));
+        assertEquals(2, host.calls.size());
+        assertEquals(null, host.pendingForkTitle);
+    }
+
+    @Test
+    public void replayPendingForkTitleIfReadySkipsWhenFrontendIsNotReady() {
+        RecordingHost host = new RecordingHost();
+        host.frontendReady = false;
+        host.session.setSessionInfo("source-session", System.getProperty("user.dir"));
+        host.pendingForkTitle = "Source title[fork]";
+        ChatWindowDelegate delegate = new ChatWindowDelegate(host);
+
+        delegate.replayPendingForkTitleIfReady();
+
+        assertEquals(0, host.calls.size());
+        assertEquals("Source title[fork]", host.pendingForkTitle);
+    }
+
+    private static class RecordingHost implements ChatWindowDelegate.DelegateHost {
+        private final ClaudeSession session = new ClaudeSession(null, null, null);
+        private final JPanel mainPanel = new JPanel();
+        private final List<String> calls = new ArrayList<>();
+        private boolean frontendReady;
+        private String pendingForkTitle;
+
+        @Override public Project getProject() { return null; }
+        @Override public ClaudeSDKBridge getClaudeSDKBridge() { return null; }
+        @Override public CodexSDKBridge getCodexSDKBridge() { return null; }
+        @Override public ClaudeSession getSession() { return session; }
+        @Override public CodemossSettingsService getSettingsService() { return null; }
+        @Override public JPanel getMainPanel() { return mainPanel; }
+        @Override public JBCefBrowser getBrowser() { return null; }
+        @Override public boolean isDisposed() { return false; }
+        @Override public void callJavaScript(String fn, String... args) { calls.add(fn + ":" + (args.length > 0 ? args[0] : "")); }
+        @Override public Content getParentContent() { return null; }
+        @Override public String getOriginalTabName() { return null; }
+        @Override public void setOriginalTabName(String name) { }
+        @Override public String getSessionId() { return session.getSessionId(); }
+        @Override public HandlerContext getHandlerContext() { return null; }
+        @Override public void setHandlerContext(HandlerContext ctx) { }
+        @Override public void setMessageDispatcher(MessageDispatcher d) { }
+        @Override public void setPermissionHandler(PermissionHandler h) { }
+        @Override public void setHistoryHandler(com.github.claudecodegui.handler.history.HistoryHandler h) { }
+        @Override public SessionLifecycleManager getSessionLifecycleManager() { return null; }
+        @Override public StreamMessageCoalescer getStreamCoalescer() { return null; }
+        @Override public WebviewWatchdog getWebviewWatchdog() { return null; }
+        @Override public PermissionHandler getPermissionHandler() { return null; }
+        @Override public void interruptDueToPermissionDenial() { }
+        @Override public boolean isFrontendReady() { return frontendReady; }
+        @Override public void setFrontendReady(boolean ready) { frontendReady = ready; }
+        @Override public void setSlashCommandsFetched(boolean fetched) { }
+        @Override public void setFetchedSlashCommandsCount(int count) { }
+        @Override public void persistTabSessionState() { }
+        @Override public String popPendingForkTitle() {
+            String value = pendingForkTitle;
+            pendingForkTitle = null;
+            return value;
+        }
+    }
+}

--- a/src/test/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindowJavaScriptWarningTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindowJavaScriptWarningTest.java
@@ -1,0 +1,37 @@
+package com.github.claudecodegui.ui.toolwindow;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ClaudeChatWindowJavaScriptWarningTest {
+
+    @Test
+    public void buildUnescapedJavaScriptArgumentWarningDoesNotIncludeRawArgumentPreview() {
+        String warning = ClaudeChatWindow.buildUnescapedJavaScriptArgumentWarning(
+                "addErrorMessage",
+                "password=secret-token\n'raw user prompt'"
+        );
+
+        assertTrue(warning.contains("addErrorMessage"));
+        assertTrue(warning.contains("length="));
+        assertFalse(warning.contains("Preview:"));
+        assertFalse(warning.contains("password=secret-token"));
+        assertFalse(warning.contains("raw user prompt"));
+    }
+
+    @Test
+    public void buildWebviewConsoleLogMessageDoesNotIncludeRawArguments() {
+        String message = ClaudeChatWindow.buildWebviewConsoleLogMessage(
+                "console.error",
+                "password=secret-token",
+                "raw user prompt"
+        );
+
+        assertTrue(message.contains("console.error"));
+        assertTrue(message.contains("args=2"));
+        assertFalse(message.contains("password=secret-token"));
+        assertFalse(message.contains("raw user prompt"));
+    }
+}

--- a/src/test/java/com/github/claudecodegui/ui/toolwindow/ForkTitleFormatterTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/toolwindow/ForkTitleFormatterTest.java
@@ -1,0 +1,53 @@
+package com.github.claudecodegui.ui.toolwindow;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ForkTitleFormatterTest {
+
+    @Test
+    public void buildForkTitle_usesBareSuffixForFirstFork() {
+        assertEquals("测试消息[fork]",
+                ForkTitleFormatter.buildForkTitle("测试消息", Collections.emptyList()));
+    }
+
+    @Test
+    public void buildForkTitle_incrementsAcrossSiblingForks() {
+        assertEquals("测试消息[fork 2]",
+                ForkTitleFormatter.buildForkTitle(
+                        "测试消息",
+                        Arrays.asList("测试消息[fork]")));
+        assertEquals("测试消息[fork 3]",
+                ForkTitleFormatter.buildForkTitle(
+                        "测试消息[fork 2]",
+                        Arrays.asList("测试消息[fork]", "测试消息[fork 2]")));
+    }
+
+    @Test
+    public void buildForkTitle_ignoresUnrelatedTitles() {
+        assertEquals("测试消息[fork 4]",
+                ForkTitleFormatter.buildForkTitle(
+                        "测试消息",
+                        Arrays.asList("别的[fork]", "测试消息[fork]", "测试消息[fork 2]", "测试消息[fork 3]")));
+    }
+
+    @Test
+    public void buildForkTitle_incrementsRepeatedForksOfLongTitles() {
+        String sourceTitle = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+        String firstFork = ForkTitleFormatter.buildForkTitle(sourceTitle, Collections.emptyList());
+        String secondFork = ForkTitleFormatter.buildForkTitle(sourceTitle, Arrays.asList(firstFork));
+
+        assertTrue(firstFork.endsWith("[fork]"));
+        assertTrue(secondFork.endsWith("[fork 2]"));
+        assertNotEquals(firstFork, secondFork);
+        assertTrue(firstFork.length() <= 50);
+        assertTrue(secondFork.length() <= 50);
+    }
+}

--- a/src/test/java/com/github/claudecodegui/ui/toolwindow/ForkTitleFormatterTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/toolwindow/ForkTitleFormatterTest.java
@@ -50,4 +50,11 @@ public class ForkTitleFormatterTest {
         assertTrue(firstFork.length() <= 50);
         assertTrue(secondFork.length() <= 50);
     }
+
+    @Test
+    public void buildForkTitle_incrementsBareForkTitlesWhenSourceTitleIsEmpty() {
+        assertEquals("[fork]", ForkTitleFormatter.buildForkTitle("", Collections.emptyList()));
+        assertEquals("[fork 2]", ForkTitleFormatter.buildForkTitle("", Arrays.asList("[fork]")));
+        assertEquals("[fork 3]", ForkTitleFormatter.buildForkTitle(null, Arrays.asList("[fork]", "[fork 2]")));
+    }
 }

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -24,6 +24,7 @@ import {
   RESUME_COMMANDS,
   PLAN_COMMANDS,
   CONTEXT_COMMANDS,
+  FORK_COMMANDS,
 } from './hooks/useMessageSender';
 import { applyDiffTheme, getStoredDiffTheme } from './utils/diffTheme';
 import type { Attachment, ChatInputBoxHandle } from './components/ChatInputBox/types';
@@ -41,7 +42,7 @@ import { DEFAULT_PERMISSION_DIALOG_TIMEOUT_SECONDS } from './utils/permissionDia
 const App = () => {
   const { t } = useTranslation();
 
-  // ── Dialog management (extracted to DialogContext, stage 4 of TASK-P1-01) ──
+  // ── Dialog management ──
   // Open* / set* are still needed by hooks (useWindowCallbacks, useRewindHandlers).
   // Display state (permissionDialogOpen / askUserQuestionDialogOpen / etc.) is
   // consumed directly inside <AppDialogs> via useDialogs().
@@ -56,7 +57,7 @@ const App = () => {
     isRewinding, setIsRewinding, setRewindSelectDialogOpen,
   } = useDialogs();
 
-  // ── Messages flow state (extracted to MessagesContext, stage 1 of TASK-P1-01) ──
+  // ── Messages flow state ──
   // Display state (loadingStartTime / isThinking) is consumed inside <ChatScreen>.
   const {
     messages, setMessages,
@@ -67,7 +68,7 @@ const App = () => {
     streamingActive, setStreamingActive,
   } = useMessages();
 
-  // ── Session state (extracted to SessionContext, stage 2 of TASK-P1-01) ──
+  // ── Session state ──
   const {
     currentSessionId, setCurrentSessionId,
     customSessionTitle, setCustomSessionTitle,
@@ -75,7 +76,7 @@ const App = () => {
     currentSessionIdRef, customSessionTitleRef,
   } = useSession();
 
-  // ── UI state (extracted to UIStateContext, stage 3 of TASK-P1-01) ──
+  // ── UI state ──
   // Dialog visibility (addModelDialog / changelog) is consumed inside AppDialogs.
   const {
     currentView, setCurrentView,
@@ -248,6 +249,17 @@ const App = () => {
     mergedMessages, sentAttachmentsRef,
   } = useMessageProcessing({ messages, currentSessionId, t });
 
+  // ── Chat-view computations ──
+  const {
+    findToolResult, getToolResultRaw,
+    fileChangeMgmt,
+    filteredFileChanges, subagents, globalTodos, rewindableMessages, sessionTitle,
+  } = useChatComputations({
+    t, messages, mergedMessages, customSessionTitle, streamingActive, currentProvider,
+    currentSessionId, currentSessionIdRef,
+    getMessageText, getContentBlocks,
+  });
+
   // ── Message sender ──
   // Wrap handleProviderSelect to also clear messages and input (like creating a new session)
   const wrappedHandleProviderSelect = useCallback((providerId: string) => {
@@ -268,6 +280,8 @@ const App = () => {
     isUserAtBottomRef, userPausedRef, isStreamingRef,
     setMessages, setLoading, setLoadingStartTime, setStreamingActive,
     setSettingsInitialTab, setCurrentView,
+    currentSessionId,
+    currentSessionTitle: sessionTitle,
     forceCreateNewSession,
     handleModeSelect,
     longContextEnabled,
@@ -306,8 +320,8 @@ const App = () => {
         addToast(t('chat.planModeEnabled', { defaultValue: 'Plan mode enabled' }), 'info');
         return;
       }
-      // /context - handled locally even while loading
-      if (CONTEXT_COMMANDS.has(command)) {
+      // /context and /fork are handled locally even while loading (/fork is Claude only)
+      if (CONTEXT_COMMANDS.has(command) || FORK_COMMANDS.has(command)) {
         hookHandleSubmit(content, attachments);
         return;
       }
@@ -319,17 +333,6 @@ const App = () => {
     }
     hookHandleSubmit(content, attachments);
   }, [loading, enqueueMessage, hookHandleSubmit, forceCreateNewSession, currentProvider, handleModeSelect, setCurrentView, addToast, t]);
-
-  // ── Chat-view computations (stage 5 of TASK-P1-01) ──
-  const {
-    findToolResult, getToolResultRaw,
-    fileChangeMgmt,
-    filteredFileChanges, subagents, globalTodos, rewindableMessages, sessionTitle,
-  } = useChatComputations({
-    t, messages, mergedMessages, customSessionTitle, streamingActive, currentProvider,
-    currentSessionId, currentSessionIdRef,
-    getMessageText, getContentBlocks,
-  });
 
   const { handleUndoFile, handleDiscardAll: handleDiscardAllRaw, handleKeepAll } = fileChangeMgmt;
   const onDiscardAll = useCallback(

--- a/webview/src/components/AppDialogs.tsx
+++ b/webview/src/components/AppDialogs.tsx
@@ -68,7 +68,7 @@ export interface AppDialogsProps {
  * Renders all top-level dialogs.
  * Permission / ask-user / plan / rewind / changelog / add-model state is read
  * from DialogContext and UIStateContext directly to avoid prop drilling 25+
- * fields from App.tsx (stage 4-5 of TASK-P1-01).
+ * fields from App.tsx.
  */
 export const AppDialogs = ({
   showNewSessionConfirm,

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -470,6 +470,12 @@ interface Window {
   updateCommitAiConfig?: (json: string) => void;
 
   /**
+   * Seed the current fork tab title without writing it to source session history.
+   * @param title - The fork title text to carry into the next SDK session ID
+   */
+  seedForkSessionTitle?: (title: string) => void;
+
+  /**
    * Update session title (called when AI generates a title).
    * @param sessionId - The session ID the title belongs to
    * @param title - The generated title text

--- a/webview/src/hooks/useMessageSender.context.test.ts
+++ b/webview/src/hooks/useMessageSender.context.test.ts
@@ -244,7 +244,7 @@ describe('useMessageSender - /context command', () => {
     expect(call).toMatch(/^fork_session:/);
   });
 
-  it('executeMessage still treats /fork as a local action when replayed from the queue', () => {
+  it('executeMessage does not open a fork tab directly', () => {
     const opts = createOptions();
 
     const { result } = renderHook(() => useMessageSender(opts));
@@ -254,8 +254,8 @@ describe('useMessageSender - /context command', () => {
     });
 
     const calls = (window.sendToJava as any).mock.calls.map((call: string[]) => call[0]);
-    expect(calls.some((call: string) => call.startsWith('fork_session:'))).toBe(true);
-    expect(calls.some((call: string) => call.startsWith('send_message:'))).toBe(false);
+    expect(calls.some((call: string) => call.startsWith('fork_session:'))).toBe(false);
+    expect(calls.some((call: string) => call.startsWith('send_message:'))).toBe(true);
   });
 
   it('warns and does not fire fork_session without an existing Claude session', () => {

--- a/webview/src/hooks/useMessageSender.context.test.ts
+++ b/webview/src/hooks/useMessageSender.context.test.ts
@@ -14,6 +14,8 @@ describe('useMessageSender - /context command', () => {
     selectedAgent: null,
     sdkStatusLoaded: true,
     currentSdkInstalled: true,
+    currentSessionId: 'source-session',
+    currentSessionTitle: '测试消息',
     sentAttachmentsRef: { current: new Map() },
     chatInputRef: { current: null },
     messagesContainerRef: { current: null },
@@ -138,5 +140,167 @@ describe('useMessageSender - /context command', () => {
       expect.any(String),
       'error',
     );
+  });
+
+  it('fires fork_session event with the current session id when /fork is typed alone', () => {
+    const opts = createOptions();
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('/fork');
+    });
+
+    expect(window.sendToJava).toHaveBeenCalledTimes(1);
+    const call = (window.sendToJava as any).mock.calls[0][0] as string;
+    expect(call).toMatch(/^fork_session:/);
+
+    const payload = JSON.parse(call.substring('fork_session:'.length));
+    expect(payload.sourceSessionId).toBe('source-session');
+    expect(payload.sourceTitle).toBe('测试消息');
+  });
+
+  it('omits the placeholder new-session title from fork_session payload', () => {
+    const opts = createOptions({ currentSessionTitle: 'common.newSession' });
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('/fork');
+    });
+
+    const call = (window.sendToJava as any).mock.calls[0][0] as string;
+    const payload = JSON.parse(call.substring('fork_session:'.length));
+    expect(payload.sourceSessionId).toBe('source-session');
+    expect(payload.sourceTitle).toBeUndefined();
+  });
+
+  it('does not fire send_message for /fork because fork is a tab-opening action', () => {
+    // Regression guard: in the old design /fork piggy-backed on send_message
+    // with forkSession=true, which made the source tab spit out a fake user
+    // message. The new design must never enqueue a normal chat message.
+    const opts = createOptions();
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('/fork');
+    });
+
+    const calls = (window.sendToJava as any).mock.calls.map((call: string[]) => call[0]);
+    const sendMessageCall = calls.find((c: string) => c.startsWith('send_message:'));
+    expect(sendMessageCall).toBeUndefined();
+  });
+
+  it('still fires fork_session when /fork has trailing text and surfaces an info toast', () => {
+    const addToast = vi.fn();
+    const opts = createOptions({ addToast });
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      // Legacy users may type "/fork explore alt" expecting the old prompt-required
+      // flow. The trailing text must be ignored (not sent to Claude) but the user
+      // should be told once so they know to retype it in the new tab.
+      result.current.handleSubmit('/fork explore alternative');
+    });
+
+    expect(window.sendToJava).toHaveBeenCalledTimes(1);
+    const call = (window.sendToJava as any).mock.calls[0][0] as string;
+    expect(call).toMatch(/^fork_session:/);
+
+    expect(addToast).toHaveBeenCalledTimes(1);
+    expect(addToast).toHaveBeenCalledWith(expect.any(String), 'info');
+  });
+
+  it('treats /fork followed only by whitespace as the no-trailing-text case', () => {
+    const addToast = vi.fn();
+    const opts = createOptions({ addToast });
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      // handleSubmit already trims the input before dispatching, so trailing
+      // whitespace must not pop the "trailing text ignored" info toast.
+      result.current.handleSubmit('/fork   ');
+    });
+
+    expect(window.sendToJava).toHaveBeenCalledTimes(1);
+    const call = (window.sendToJava as any).mock.calls[0][0] as string;
+    expect(call).toMatch(/^fork_session:/);
+    expect(addToast).not.toHaveBeenCalled();
+  });
+
+  it('accepts uppercase /FORK case-insensitively', () => {
+    const opts = createOptions();
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('/FORK');
+    });
+
+    expect(window.sendToJava).toHaveBeenCalledTimes(1);
+    const call = (window.sendToJava as any).mock.calls[0][0] as string;
+    expect(call).toMatch(/^fork_session:/);
+  });
+
+  it('executeMessage still treats /fork as a local action when replayed from the queue', () => {
+    const opts = createOptions();
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.executeMessage('/fork');
+    });
+
+    const calls = (window.sendToJava as any).mock.calls.map((call: string[]) => call[0]);
+    expect(calls.some((call: string) => call.startsWith('fork_session:'))).toBe(true);
+    expect(calls.some((call: string) => call.startsWith('send_message:'))).toBe(false);
+  });
+
+  it('warns and does not fire fork_session without an existing Claude session', () => {
+    const addToast = vi.fn();
+    const opts = createOptions({ currentSessionId: null, addToast });
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('/fork');
+    });
+
+    expect(window.sendToJava).not.toHaveBeenCalled();
+    expect(addToast).toHaveBeenCalledTimes(1);
+    expect(addToast).toHaveBeenCalledWith(expect.any(String), 'warning');
+  });
+
+  it('warns and does not fire fork_session when Codex provider is active', () => {
+    const addToast = vi.fn();
+    const opts = createOptions({ currentProvider: 'codex', addToast });
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('/fork');
+    });
+
+    expect(window.sendToJava).not.toHaveBeenCalled();
+    expect(addToast).toHaveBeenCalledWith(expect.stringContaining('Claude'), 'warning');
+  });
+
+  it('shows an error toast when the bridge is unavailable during /fork', () => {
+    // Drop the bridge so sendBridgeEvent returns false. The user must be told
+    // something went wrong instead of being left with a silent no-op tab.
+    delete (window as any).sendToJava;
+
+    const addToast = vi.fn();
+    const opts = createOptions({ addToast });
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('/fork');
+    });
+
+    expect(addToast).toHaveBeenCalledWith(expect.any(String), 'error');
   });
 });

--- a/webview/src/hooks/useMessageSender.ts
+++ b/webview/src/hooks/useMessageSender.ts
@@ -13,6 +13,7 @@ export const NEW_SESSION_COMMANDS = new Set(['/new', '/clear', '/reset']);
 export const RESUME_COMMANDS = new Set(['/resume', '/continue']);
 export const PLAN_COMMANDS = new Set(['/plan']);
 export const CONTEXT_COMMANDS = new Set(['/context']);
+export const FORK_COMMANDS = new Set(['/fork']);
 
 // Hoisted regex to avoid creating new RegExp on every call
 const WHITESPACE_REGEX = /\s+/;
@@ -22,6 +23,11 @@ function createContextUsageRequestId(): string {
     return crypto.randomUUID();
   }
   return `context-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function getCommandToken(text: string): string | null {
+  if (!text.startsWith('/')) return null;
+  return text.split(WHITESPACE_REGEX)[0].toLowerCase();
 }
 
 export interface UseMessageSenderOptions {
@@ -45,6 +51,8 @@ export interface UseMessageSenderOptions {
   setStreamingActive: React.Dispatch<React.SetStateAction<boolean>>;
   setSettingsInitialTab: React.Dispatch<React.SetStateAction<any>>;
   setCurrentView: React.Dispatch<React.SetStateAction<ViewMode>>;
+  currentSessionId: string | null;
+  currentSessionTitle?: string | null;
   forceCreateNewSession: () => void;
   handleModeSelect?: (mode: PermissionMode) => void;
   longContextEnabled?: boolean;
@@ -76,6 +84,8 @@ export function useMessageSender({
   setStreamingActive,
   setSettingsInitialTab,
   setCurrentView,
+  currentSessionId,
+  currentSessionTitle,
   forceCreateNewSession,
   handleModeSelect,
   longContextEnabled,
@@ -164,6 +174,60 @@ export function useMessageSender({
   }, [currentProvider, selectedModel, longContextEnabled, addToast, t, openContextUsageDialog, closeContextUsageDialog]);
 
   /**
+   * Check for the /fork slash command.
+   *
+   * /fork opens a new branch tab via the fork_session bridge event. The source
+   * session stays unchanged, and the first message in the new tab triggers the
+   * SDK resume+forkSession path that creates the real branch session ID.
+   *
+   * Trailing text after /fork is ignored instead of being sent to Claude. A toast
+   * makes that visible for users who still type the old "/fork prompt" shape.
+   */
+  const checkForkCommand = useCallback((text: string): boolean => {
+    if (!text.startsWith('/')) return false;
+    const command = getCommandToken(text);
+    if (command === null || !FORK_COMMANDS.has(command)) return false;
+
+    if (currentProvider !== 'claude') {
+      addToast(t('chat.commandProviderOnly', {
+        command: '/fork',
+        provider: 'Claude',
+        defaultValue: '/fork is only available for Claude provider',
+      }), 'warning');
+      return true;
+    }
+    if (!currentSessionId) {
+      addToast(t('chat.forkRequiresSession', {
+        defaultValue: 'Cannot fork before a Claude session has been created.',
+      }), 'warning');
+      return true;
+    }
+
+    // Warn without blocking: trailing text is discarded and must not be sent as a chat message.
+    const rawToken = text.split(WHITESPACE_REGEX)[0];
+    const trailing = text.slice(rawToken.length).trim();
+    if (trailing.length > 0) {
+      addToast(t('chat.forkIgnoresPrompt', {
+        defaultValue: '/fork opens a new branch tab. The text after /fork was ignored — type your message in the new tab.',
+      }), 'info');
+    }
+
+    const trimmedTitle = currentSessionTitle?.trim();
+    const newSessionTitle = t('common.newSession').trim();
+    const sourceTitle = trimmedTitle && trimmedTitle !== newSessionTitle ? trimmedTitle : undefined;
+    const sent = sendBridgeEvent('fork_session', JSON.stringify({
+      sourceSessionId: currentSessionId,
+      ...(sourceTitle ? { sourceTitle } : {}),
+    }));
+    if (!sent) {
+      addToast(t('chat.bridgeUnavailable', {
+        defaultValue: 'Bridge is not available right now',
+      }), 'error');
+    }
+    return true;
+  }, [currentProvider, currentSessionId, currentSessionTitle, addToast, t]);
+
+  /**
    * Check for unimplemented slash commands
    */
   const checkUnimplementedCommand = useCallback((text: string): boolean => {
@@ -231,6 +295,12 @@ export function useMessageSender({
 
   /**
    * Send message to backend
+   *
+   * Fork branching is handled at the IDE level (see checkForkCommand → fork_session event),
+   * which opens a new tab with a pendingFork flag on the Java session. Subsequent send_message
+   * payloads from that tab do NOT carry forkSession=true; the Java side picks up the flag from
+   * SessionState. Keeping forkSession out of this payload prevents accidental double-forking
+   * in tabs that already have pendingFork set.
    */
   const sendMessageToBackend = useCallback((
     text: string,
@@ -292,6 +362,8 @@ export function useMessageSender({
     const hasAttachments = Array.isArray(attachments) && attachments.length > 0;
 
     if (!text && !hasAttachments) return;
+
+    if (checkForkCommand(text)) return;
 
     // Check SDK status
     if (!sdkStatusLoaded) {
@@ -370,7 +442,10 @@ export function useMessageSender({
       absolutePath: tag.absolutePath,
     })) : null;
 
-    // Send message to backend
+    // Send message to backend. Fork branching is handled separately by
+    // checkForkCommand (via fork_session event), so the regular send path
+    // never carries forkSession=true any more \u2014 the Java side picks up the
+    // pendingFork flag from SessionState when present.
     sendMessageToBackend(text, attachments, agentInfo, fileTagsInfo, permissionMode);
   }, [
     sdkStatusLoaded,
@@ -378,6 +453,7 @@ export function useMessageSender({
     currentProvider,
     permissionMode,
     selectedAgent,
+    checkForkCommand,
     buildUserContentBlocks,
     sendMessageToBackend,
     addToast,
@@ -402,12 +478,15 @@ export function useMessageSender({
     // Check context usage command (/context)
     if (checkContextCommand(text)) return;
 
+    // Check fork command (/fork) \u2014 opens a new branch tab; never enqueues a normal message.
+    if (checkForkCommand(text)) return;
+
     // Check for unimplemented commands
     if (checkUnimplementedCommand(text)) return;
 
     // Execute message
     executeMessage(content, attachments);
-  }, [checkNewSessionCommand, checkLocalCommand, checkContextCommand, checkUnimplementedCommand, executeMessage]);
+  }, [checkNewSessionCommand, checkLocalCommand, checkContextCommand, checkForkCommand, checkUnimplementedCommand, executeMessage]);
 
   /**
    * Interrupt the current session

--- a/webview/src/hooks/useMessageSender.ts
+++ b/webview/src/hooks/useMessageSender.ts
@@ -363,8 +363,6 @@ export function useMessageSender({
 
     if (!text && !hasAttachments) return;
 
-    if (checkForkCommand(text)) return;
-
     // Check SDK status
     if (!sdkStatusLoaded) {
       addToast(t('chat.sdkStatusLoading'), 'info');
@@ -453,7 +451,6 @@ export function useMessageSender({
     currentProvider,
     permissionMode,
     selectedAgent,
-    checkForkCommand,
     buildUserContentBlocks,
     sendMessageToBackend,
     addToast,

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -213,6 +213,27 @@ describe('useWindowCallbacks integration', () => {
 
   // ===== AI title path uses applyHistoryTitleLocal (no backend round-trip) =====
 
+  it('preserves a fork title seed for the next SDK session id without updating source history', () => {
+    const forkTitle = '测试消息[fork]';
+    const currentSessionIdRef = { current: null as string | null };
+    const customSessionTitleRef = { current: null as string | null };
+    const opts = createOptions({
+      currentSessionIdRef,
+      customSessionTitleRef,
+    });
+    renderHook(() => useWindowCallbacks(opts));
+
+    act(() => {
+      window.setSessionId!('source-session');
+      (window as any).seedForkSessionTitle(forkTitle);
+      window.setSessionId!('fork-session');
+    });
+
+    expect(opts.setCustomSessionTitle).toHaveBeenCalledWith(forkTitle);
+    expect(opts.applyHistoryTitleLocal).not.toHaveBeenCalledWith('source-session', forkTitle);
+    expect(opts.updateHistoryTitle).toHaveBeenCalledWith('fork-session', forkTitle);
+  });
+
   it('updateSessionTitle routes AI titles through applyHistoryTitleLocal, not updateHistoryTitle', () => {
     const opts = createOptions({
       currentSessionIdRef: { current: 'sess-123' },

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/sessionCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/sessionCallbacks.ts
@@ -37,6 +37,7 @@ export function registerSessionAndSdkCallbacks(
   window.setSessionId = (sessionId: string) => {
     const oldId = currentSessionIdRef.current;
     releaseSessionTransition();
+    currentSessionIdRef.current = sessionId;
     setCurrentSessionId(sessionId);
 
     // B-011 + B-014: Persist custom title under the real SDK session ID.
@@ -135,12 +136,21 @@ export function registerSessionAndSdkCallbacks(
   // AI Title Callback
   // =========================================================================
 
+  window.seedForkSessionTitle = (title: string) => {
+    if (!title || !title.trim()) return;
+    const trimmedTitle = title.trim();
+    customSessionTitleRef.current = trimmedTitle;
+    setCustomSessionTitle(trimmedTitle);
+  };
+
   window.updateSessionTitle = (sessionId: string, title: string) => {
     if (!title || !title.trim() || !sessionId) return;
     // Only apply the title if it matches the current session to prevent
     // stale events from overwriting the wrong session's title.
     if (currentSessionIdRef.current !== sessionId) return;
-    setCustomSessionTitle(title.trim());
-    applyHistoryTitleLocal(sessionId, title.trim());
+    const trimmedTitle = title.trim();
+    customSessionTitleRef.current = trimmedTitle;
+    setCustomSessionTitle(trimmedTitle);
+    applyHistoryTitleLocal(sessionId, trimmedTitle);
   };
 }


### PR DESCRIPTION
## Summary

Addresses #1176 (requirement 2: add `/fork` command adaptation — isolated exploration)
When a user types `/fork` in a Claude session, a new branched tab is created from the current conversation. The new tab loads the source session's historical context, but subsequent messages run on a brand-new SDK session ID, achieving "isolated exploration" — the original session remains completely untouched.

## Demo


https://github.com/user-attachments/assets/a6b6bea3-1805-407b-af52-6d8e74e7e2af



## Implementation Highlights

### Interaction Flow
1. User types `/fork` in the current Claude session
2. Webview sends a `fork_session` bridge event to the IDE
3. `TabHandler` receives the event, creates a new tab, and loads source history
4. On the new tab's first send, `ClaudeSession` consumes the `pendingForkOnNextSend` flag
5. AI Bridge calls the SDK with `resume + forkSession=true`, obtaining a new branch session ID
6. The original tab continues running independently

### Cross-Layer Changes

| Layer | Files | Changes |
|-------|-------|---------|
| **Webview** | `useMessageSender.ts` | Added `checkForkCommand`; intercepts `/fork` and emits `fork_session` event |
| | `sessionCallbacks.ts` | Added `seedForkSessionTitle` to pre-seed the fork tab's title |
| **Java** | `TabHandler.java` | Handles `fork_session`; creates tab, loads history, generates `[fork]` title |
| | `ClaudeChatWindow.java` | Added `setForkContext`; sets `pendingForkOnNextSend` flag |
| | `ClaudeSession.java` | Added `pendingForkOnNextSend` one-shot flag |
| | `SessionState.java` | Added session ID validation and `pendingForkOnNextSend` state |
| | `ChatWindowDelegate.java` | Added `seedPendingForkTitle`; injects title after `frontend_ready` |
| **AI Bridge** | `message-sender.js` | Supports `forkSession` param; ignores source session ID; validates new ID |
| | `persistent-query-service.js` | Supports `forkSession`; skips AI title generation for forks |
| | `runtime-lifecycle.js` | Fork initializes `sessionId` as `null` to avoid binding to source |
| | `runtime-registry.js` | Fork requests do not look up or bind to existing runtimes |

### Security & Edge Cases

- **Provider restriction**: `/fork` is Claude-only; typing it in Codex mode shows a warning toast
- **Session ID validation**: `SessionState.isValidSessionId()` uses regex to prevent malicious payloads
- **Source authorization**: `TabHandler` verifies `sourceSessionId` matches the currently active session
- **Title isolation**: `RESERVED_FORK_TITLES` pre-reservation prevents numbering collisions during concurrent creation
- **JS injection guard**: `ClaudeChatWindow.callJavaScript()` adds `looksUnescaped()` heuristic check

## Test Plan

- [x] `/fork` creates a branched tab from the current Claude session
- [x] Branched tab loads the source session's full history
- [x] Branched tab receives a new session ID after the first message
- [x] Original tab remains unaffected and can continue normally
- [x] `/fork` is blocked with a warning in Codex mode
- [x] Concurrent `/fork` commands produce non-conflicting numbered titles
- [x] `./gradlew test` passes
- [x] `(cd webview && npm test)` passes
- [x] `node --test ai-bridge/services/claude/persistent-query-service.test.mjs` passes


