### PR TITLE
fix: new session reuses previous session ID in TabStateService and getSessionId()

### DIFF
--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -535,6 +535,10 @@ public class ClaudeChatWindow {
     // ==================== Session Delegates ====================
 
     private void setupSessionCallbacks() {
+        // Reset sessionId when callbacks are re-bound (e.g., on new session creation),
+        // so stale session IDs are not exposed via getSessionId() between sessions.
+        this.sessionId = null;
+
         if (this.sessionCallbackAdapter != null) {
             this.sessionCallbackAdapter.deactivate();
         }
@@ -645,6 +649,13 @@ public class ClaudeChatWindow {
 
         int tabIndex = getTabIndex();
         if (tabIndex < 0) {
+            return;
+        }
+
+        // Skip persisting null/empty sessionId for new sessions
+        // so the TabStateService preserves the last valid session binding.
+        String currentSessionId = session.getSessionId();
+        if (currentSessionId == null || currentSessionId.trim().isEmpty()) {
             return;
         }
 

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -56,6 +56,12 @@ public class ClaudeChatWindow {
     private Content parentContent;
     private String originalTabName;
     private volatile String sessionId = null;
+    // Stable PermissionService routing key, assigned once at construction.
+    // Kept separate from sessionId, which is overwritten with AI session IDs
+    // (onSessionIdReceived) and would otherwise break dispose-time cleanup and
+    // clearPermissionDecisionMemory(), both of which must reach the instance
+    // the bridges actually route permission requests to.
+    private String permissionServiceKey = null;
 
     private JBCefBrowser browser;
     private ClaudeSession session;
@@ -136,7 +142,8 @@ public class ClaudeChatWindow {
         chatWindowDelegate.loadNodePathFromSettings();
         chatWindowDelegate.syncActiveProvider();
         chatWindowDelegate.initializeHandlers();
-        this.sessionId = chatWindowDelegate.setupPermissionService();
+        this.permissionServiceKey = chatWindowDelegate.setupPermissionService();
+        this.sessionId = this.permissionServiceKey;
 
         this.sessionLifecycleManager = new SessionLifecycleManager(new SessionLifecycleManager.SessionHost() {
             @Override
@@ -183,8 +190,8 @@ public class ClaudeChatWindow {
             @Override
             public void clearPermissionDecisionMemory() {
                 try {
-                    if (sessionId != null && !sessionId.isEmpty()) {
-                        PermissionService permissionService = PermissionService.getInstance(project, sessionId);
+                    if (permissionServiceKey != null && !permissionServiceKey.isEmpty()) {
+                        PermissionService permissionService = PermissionService.getInstance(project, permissionServiceKey);
                         permissionService.clearDecisionMemory();
                     }
                 } catch (Exception e) {
@@ -535,9 +542,12 @@ public class ClaudeChatWindow {
     // ==================== Session Delegates ====================
 
     private void setupSessionCallbacks() {
-        // Reset sessionId when callbacks are re-bound (e.g., on new session creation),
-        // so stale session IDs are not exposed via getSessionId() between sessions.
-        this.sessionId = null;
+        // Re-sync the exposed sessionId with the freshly bound session so a stale
+        // AI session ID from a previous session is not exposed via getSessionId().
+        // Falling back to permissionServiceKey (never null after construction)
+        // keeps the exposed ID stable for consumers like DetachTabAction, which
+        // skips DetachedWindowManager registration on a null ID.
+        this.sessionId = resolveExposedSessionId(session.getSessionId(), this.permissionServiceKey);
 
         if (this.sessionCallbackAdapter != null) {
             this.sessionCallbackAdapter.deactivate();
@@ -652,13 +662,6 @@ public class ClaudeChatWindow {
             return;
         }
 
-        // Skip persisting null/empty sessionId for new sessions
-        // so the TabStateService preserves the last valid session binding.
-        String currentSessionId = session.getSessionId();
-        if (currentSessionId == null || currentSessionId.trim().isEmpty()) {
-            return;
-        }
-
         TabStateService.TabSessionState snapshot = new TabStateService.TabSessionState();
         snapshot.provider = session.getProvider();
         snapshot.sessionId = session.getSessionId();
@@ -672,6 +675,18 @@ public class ClaudeChatWindow {
 
     private boolean isNonEmpty(String value) {
         return value != null && !value.trim().isEmpty();
+    }
+
+    /**
+     * Decide what {@link #getSessionId()} exposes after session callbacks are
+     * (re-)bound: the bound session's own ID when it has one (history load),
+     * otherwise the stable permission-service key (fresh session) — never a
+     * stale ID left over from a previously bound session.
+     */
+    static String resolveExposedSessionId(String boundSessionId, String permissionServiceKey) {
+        return boundSessionId != null && !boundSessionId.trim().isEmpty()
+                ? boundSessionId
+                : permissionServiceKey;
     }
 
     // ==================== Code Snippets ====================
@@ -705,13 +720,13 @@ public class ClaudeChatWindow {
         webviewWatchdog.stop();
 
         try {
-            if (this.sessionId != null && !this.sessionId.isEmpty()) {
-                PermissionService permissionService = PermissionService.getInstance(project, this.sessionId);
+            if (this.permissionServiceKey != null && !this.permissionServiceKey.isEmpty()) {
+                PermissionService permissionService = PermissionService.getInstance(project, this.permissionServiceKey);
                 permissionService.unregisterDialogShower(project);
                 permissionService.unregisterAskUserQuestionDialogShower(project);
                 permissionService.unregisterPlanApprovalDialogShower(project);
-                PermissionService.removeInstance(this.sessionId);
-                LOG.info("Removed PermissionService instance for sessionId: " + this.sessionId);
+                PermissionService.removeInstance(this.permissionServiceKey);
+                LOG.info("Removed PermissionService instance for key: " + this.permissionServiceKey);
             }
         } catch (Exception e) {
             LOG.warn("Failed to unregister dialog showers or remove session instance: " + e.getMessage());

--- a/src/test/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindowExposedSessionIdTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindowExposedSessionIdTest.java
@@ -1,0 +1,35 @@
+package com.github.claudecodegui.ui.toolwindow;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Regression tests for the stale-session-ID fix (PR #1192).
+ *
+ * After session callbacks are re-bound (new session, history load), the ID
+ * exposed via getSessionId() must never be the previous session's ID, and it
+ * must never become null either: DetachTabAction skips DetachedWindowManager
+ * registration on a null ID, and dispose-time PermissionService cleanup keys
+ * off a stable identifier.
+ */
+public class ClaudeChatWindowExposedSessionIdTest {
+
+    private static final String PERMISSION_KEY = "permission-key-uuid";
+
+    @Test
+    public void freshSessionFallsBackToPermissionServiceKey() {
+        assertEquals(PERMISSION_KEY,
+                ClaudeChatWindow.resolveExposedSessionId(null, PERMISSION_KEY));
+        assertEquals(PERMISSION_KEY,
+                ClaudeChatWindow.resolveExposedSessionId("", PERMISSION_KEY));
+        assertEquals(PERMISSION_KEY,
+                ClaudeChatWindow.resolveExposedSessionId("   ", PERMISSION_KEY));
+    }
+
+    @Test
+    public void historyLoadedSessionExposesItsOwnId() {
+        assertEquals("history-session-42",
+                ClaudeChatWindow.resolveExposedSessionId("history-session-42", PERMISSION_KEY));
+    }
+}


### PR DESCRIPTION
## Problem

When creating a new session while a session is already running, the new session reuses the previous session ID.

## Root Cause

Two interacting issues:

1. **`setupSessionCallbacks()` did not reset `this.sessionId`** — the `ClaudeChatWindow.sessionId` field retained the old session ID after `createNewSession()`, so any code calling `getSessionId()` before `onSessionIdReceived` fires gets the stale value.

2. **`persistTabSessionState()` overwrites TabStateService with null** — at the end of `setupSessionCallbacks()`, `persistTabSessionState()` is called. Since the new session has `session.getSessionId() == null`, the `TabStateService` entry is overwritten with null. If IDEA restarts before the new thread ID arrives, the tab loses its session binding.

## Fix

- Clear `this.sessionId` at the start of `setupSessionCallbacks()` so stale values are not exposed between sessions.
- Skip persisting when `session.getSessionId()` is null/empty, preserving the last valid session binding in `TabStateService`.

## Verification

1. Start a Codex session, send a message to obtain a thread ID.
2. Click "New Session" — verify the UI shows empty state not bound to the old session.
3. Send a message — verify the new session receives a new thread ID.
4. Before sending in the new session, restart IDEA — verify the tab restores correctly (or starts blank if no session ID was ever assigned).