### PR TITLE
fix(stream): prevent character loss and duplication in streaming deltas

### DIFF
--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -30,7 +30,7 @@ import {
 import { createPreToolUseHook } from './permission-mode.js';
 import { loadMcpServersConfigAsRecord } from './mcp-status/config-loader.js';
 import { setActiveQueryResult } from './message-session-registry.js';
-import { normalizeStreamDelta, rememberStreamSnapshot } from './stream-delta-normalizer.js';
+import { getBlockMap, normalizeStreamDelta, rememberStreamSnapshot } from './stream-delta-normalizer.js';
 import { generateSessionTitle } from '../session-title-service.js';
 
 // ========== Internal helpers for deduplication ==========
@@ -245,9 +245,11 @@ function processStreamMessage(msg, state, logPrefix) {
 
 /** Emit text content delta with streaming fallback support. */
 function emitTextDelta(currentText, state, blockIndex = 0) {
+  const textBlockMap = getBlockMap(state, 'textBlockContentByIndex');
+  const previousBlock = textBlockMap.get(blockIndex) || '';
   rememberStreamSnapshot(state, 'text', blockIndex, currentText);
-  if (state.streamingEnabled && !state.hasStreamEvents && currentText.length > state.lastAssistantContent.length) {
-    const delta = currentText.substring(state.lastAssistantContent.length);
+  if (state.streamingEnabled && !state.hasStreamEvents && currentText.length > previousBlock.length) {
+    const delta = currentText.substring(previousBlock.length);
     if (delta) process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(delta)}\n`);
     state.lastAssistantContent = currentText;
   } else if (state.streamingEnabled && state.hasStreamEvents) {
@@ -259,9 +261,11 @@ function emitTextDelta(currentText, state, blockIndex = 0) {
 
 /** Emit thinking content delta with streaming fallback support. */
 function emitThinkingDelta(thinkingText, state, blockIndex = 0) {
+  const thinkingBlockMap = getBlockMap(state, 'thinkingBlockContentByIndex');
+  const previousThinkingBlock = thinkingBlockMap.get(blockIndex) || '';
   rememberStreamSnapshot(state, 'thinking', blockIndex, thinkingText);
-  if (state.streamingEnabled && !state.hasStreamEvents && thinkingText.length > state.lastThinkingContent.length) {
-    const delta = thinkingText.substring(state.lastThinkingContent.length);
+  if (state.streamingEnabled && !state.hasStreamEvents && thinkingText.length > previousThinkingBlock.length) {
+    const delta = thinkingText.substring(previousThinkingBlock.length);
     if (delta) process.stdout.write(`[THINKING_DELTA] ${JSON.stringify(delta)}\n`);
     state.lastThinkingContent = thinkingText;
   } else if (state.streamingEnabled && state.hasStreamEvents) {

--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -248,12 +248,19 @@ function emitTextDelta(currentText, state, blockIndex = 0) {
   const textBlockMap = getBlockMap(state, 'textBlockContentByIndex');
   const previousBlock = textBlockMap.get(blockIndex) || '';
   rememberStreamSnapshot(state, 'text', blockIndex, currentText);
-  if (state.streamingEnabled && !state.hasStreamEvents && currentText.length > previousBlock.length) {
+  // Mirror stream-event-processor.js processMessageContent:
+  //   - !hasStreamEvents: pre-stream fallback, emit the whole text
+  //   - hasStreamEvents && previousBlock.length > 0: genuine tail-fill / snapshot correction
+  //   - hasStreamEvents && previousBlock.length === 0: stream will deliver this block shortly, suppress to avoid duplication
+  // The pre-PR branch suppressed tail-fill entirely when hasStreamEvents was true,
+  // which silently dropped legitimate tail content delivered only by the final
+  // assistant snapshot — diverging from the persistent-query-service path.
+  if (state.streamingEnabled && currentText.length > previousBlock.length) {
     const delta = currentText.substring(previousBlock.length);
-    if (delta) process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(delta)}\n`);
+    if (delta && (!state.hasStreamEvents || previousBlock.length > 0)) {
+      process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(delta)}\n`);
+    }
     state.lastAssistantContent = currentText;
-  } else if (state.streamingEnabled && state.hasStreamEvents) {
-    if (currentText.length > state.lastAssistantContent.length) state.lastAssistantContent = currentText;
   } else if (!state.streamingEnabled) {
     console.log('[CONTENT]', truncateErrorContent(currentText));
   }
@@ -264,12 +271,12 @@ function emitThinkingDelta(thinkingText, state, blockIndex = 0) {
   const thinkingBlockMap = getBlockMap(state, 'thinkingBlockContentByIndex');
   const previousThinkingBlock = thinkingBlockMap.get(blockIndex) || '';
   rememberStreamSnapshot(state, 'thinking', blockIndex, thinkingText);
-  if (state.streamingEnabled && !state.hasStreamEvents && thinkingText.length > previousThinkingBlock.length) {
+  if (state.streamingEnabled && thinkingText.length > previousThinkingBlock.length) {
     const delta = thinkingText.substring(previousThinkingBlock.length);
-    if (delta) process.stdout.write(`[THINKING_DELTA] ${JSON.stringify(delta)}\n`);
+    if (delta && (!state.hasStreamEvents || previousThinkingBlock.length > 0)) {
+      process.stdout.write(`[THINKING_DELTA] ${JSON.stringify(delta)}\n`);
+    }
     state.lastThinkingContent = thinkingText;
-  } else if (state.streamingEnabled && state.hasStreamEvents) {
-    if (thinkingText.length > state.lastThinkingContent.length) state.lastThinkingContent = thinkingText;
   } else if (!state.streamingEnabled) {
     console.log('[THINKING]', thinkingText);
   }

--- a/ai-bridge/services/claude/stream-delta-normalizer.js
+++ b/ai-bridge/services/claude/stream-delta-normalizer.js
@@ -1,4 +1,4 @@
-function getBlockMap(turnState, key) {
+export function getBlockMap(turnState, key) {
   if (!(turnState[key] instanceof Map)) {
     turnState[key] = new Map();
   }
@@ -36,7 +36,11 @@ function computeNovelDelta(previous, incoming, mode) {
   }
 
   // Stale replay: incoming is fully contained at the start or end of previous.
-  if (previous.startsWith(incoming) || previous.endsWith(incoming)) {
+  // Only active in cumulative-snapshot mode.  In incremental mode every delta is
+  // by definition novel, and a coincidental suffix match (e.g. "0" arriving after
+  // "150") would falsely absorb legitimate characters — producing the exact
+  // character-shift bug seen with 1500 → 150.
+  if (mode === 'snapshot' && (previous.startsWith(incoming) || previous.endsWith(incoming))) {
     return { novel: '', next: previous, mode };
   }
 

--- a/ai-bridge/services/claude/stream-event-processor.js
+++ b/ai-bridge/services/claude/stream-event-processor.js
@@ -1,6 +1,6 @@
 import { emitAccumulatedUsage, mergeUsage } from '../../utils/usage-utils.js';
 import { truncateErrorContent, truncateToolResultBlock } from './message-output-filter.js';
-import { normalizeStreamDelta, rememberStreamSnapshot } from './stream-delta-normalizer.js';
+import { getBlockMap, normalizeStreamDelta, rememberStreamSnapshot } from './stream-delta-normalizer.js';
 
 export function emitUsageTag(msg) {
   if (msg.type === 'assistant' && msg.message?.usage) {
@@ -73,13 +73,21 @@ export function processMessageContent(msg, turnState) {
       const block = content[i];
       if (block.type === 'text') {
         const currentText = block.text || '';
+        const textBlockMap = getBlockMap(turnState, 'textBlockContentByIndex');
+        const previousBlock = textBlockMap.get(i) || '';
         rememberStreamSnapshot(turnState, 'text', i, currentText);
-        // Send delta if content grew, regardless of hasStreamEvents
-        // This ensures conservative sync works correctly and prevents content loss
-        // (especially important for markdown tables which need complete row structures)
-        if (turnState.streamingEnabled && currentText.length > turnState.lastAssistantContent.length) {
-          const delta = currentText.substring(turnState.lastAssistantContent.length);
-          if (delta) {
+        // Compare against per-block content rather than lastAssistantContent.
+        // After a silent snapshot-mode correction (absorbed by computeNovelDelta)
+        // the blockMap is updated but lastAssistantContent is stale.
+        //
+        // When streaming events have started but this block is still empty the
+        // stream will deliver the content shortly — emitting the full block text
+        // here would duplicate every token.  Only emit when either no stream
+        // events have fired at all (pre-stream fallback) or the block already
+        // has partial content (genuine tail-fill / snapshot correction).
+        if (turnState.streamingEnabled && currentText.length > previousBlock.length) {
+          const delta = currentText.substring(previousBlock.length);
+          if (delta && (!turnState.hasStreamEvents || previousBlock.length > 0)) {
             process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(delta)}\n`);
           }
           turnState.lastAssistantContent = currentText;
@@ -88,11 +96,12 @@ export function processMessageContent(msg, turnState) {
         }
       } else if (block.type === 'thinking') {
         const thinkingText = block.thinking || block.text || '';
+        const thinkingBlockMap = getBlockMap(turnState, 'thinkingBlockContentByIndex');
+        const previousThinkingBlock = thinkingBlockMap.get(i) || '';
         rememberStreamSnapshot(turnState, 'thinking', i, thinkingText);
-        // Send delta if thinking grew, regardless of hasStreamEvents
-        if (turnState.streamingEnabled && thinkingText.length > turnState.lastThinkingContent.length) {
-          const delta = thinkingText.substring(turnState.lastThinkingContent.length);
-          if (delta) {
+        if (turnState.streamingEnabled && thinkingText.length > previousThinkingBlock.length) {
+          const delta = thinkingText.substring(previousThinkingBlock.length);
+          if (delta && (!turnState.hasStreamEvents || previousThinkingBlock.length > 0)) {
             process.stdout.write(`[THINKING_DELTA] ${JSON.stringify(delta)}\n`);
           }
           turnState.lastThinkingContent = thinkingText;
@@ -102,11 +111,12 @@ export function processMessageContent(msg, turnState) {
       }
     }
   } else if (typeof content === 'string') {
+    const textBlockMap = getBlockMap(turnState, 'textBlockContentByIndex');
+    const previousBlock = textBlockMap.get(0) || '';
     rememberStreamSnapshot(turnState, 'text', 0, content);
-    // Send delta if content grew, regardless of hasStreamEvents
-    if (turnState.streamingEnabled && content.length > turnState.lastAssistantContent.length) {
-      const delta = content.substring(turnState.lastAssistantContent.length);
-      if (delta) {
+    if (turnState.streamingEnabled && content.length > previousBlock.length) {
+      const delta = content.substring(previousBlock.length);
+      if (delta && (!turnState.hasStreamEvents || previousBlock.length > 0)) {
         process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(delta)}\n`);
       }
       turnState.lastAssistantContent = content;

--- a/ai-bridge/services/claude/stream-event-processor.test.js
+++ b/ai-bridge/services/claude/stream-event-processor.test.js
@@ -487,3 +487,180 @@ test('processStreamEvent: incremental-mode block keeps appending novel deltas', 
   assert.match(deltaLines[2], /"!"/);
   assert.equal(state.lastAssistantContent, 'Hello world!');
 });
+
+// =========================================================================
+// REGRESSION TESTS for PR #1205 — character loss + duplication fixes.
+//
+// These two scenarios are the exact bugs the PR claims to fix.  Without
+// dedicated unit coverage the same regression has re-shipped multiple times
+// (cf. .claude/rules/codex-history-replay-pitfalls.md "修复 PR 长期未合入
+// 主线 = 必然回归" lesson).  Keep these green.
+// =========================================================================
+
+test('REGRESSION (PR#1205 bug 1): incremental stream "1","5","0","0" must NOT lose trailing "0" via endsWith match', () => {
+  // Pre-fix behaviour: once accumulated content is "150", a subsequent
+  // incremental delta "0" was absorbed because previous.endsWith(incoming).
+  // The stale-replay check is now gated on snapshot mode, so incremental
+  // fragments are emitted intact.
+  const state = makeTurnState(true);
+
+  const captured = captureStdout(() => {
+    for (const fragment of ['1', '5', '0', '0']) {
+      processStreamEvent(
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'text_delta', text: fragment },
+          },
+        },
+        state,
+      );
+    }
+  });
+
+  const deltaLines = tagLines(captured, '[CONTENT_DELTA]');
+  const emitted = deltaLines
+    .map((line) => JSON.parse(line.replace(/^\[CONTENT_DELTA\]\s+/, '').trim()))
+    .join('');
+
+  assert.equal(emitted, '1500', `expected concatenated deltas to equal "1500", got "${emitted}"`);
+  assert.equal(deltaLines.length, 4, 'each fragment should emit its own delta');
+  assert.equal(state.lastAssistantContent, '1500');
+});
+
+test('REGRESSION (PR#1205 bug 1): mid-word incremental fragment whose tail matches previous tail must not be absorbed', () => {
+  // Generalisation of the 1500 bug: any incremental fragment that happens
+  // to be a suffix of the accumulated content used to be silently dropped.
+  // Example: accumulated "abc", next fragment "c" — pre-fix returned "".
+  const state = makeTurnState(true);
+
+  const captured = captureStdout(() => {
+    for (const fragment of ['a', 'b', 'c', 'c']) {
+      processStreamEvent(
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'text_delta', text: fragment },
+          },
+        },
+        state,
+      );
+    }
+  });
+
+  const emitted = tagLines(captured, '[CONTENT_DELTA]')
+    .map((line) => JSON.parse(line.replace(/^\[CONTENT_DELTA\]\s+/, '').trim()))
+    .join('');
+
+  assert.equal(emitted, 'abcc', `expected "abcc", got "${emitted}"`);
+});
+
+test('REGRESSION (PR#1205 bug 2): assistant snapshot for a brand-new block must NOT emit while stream events are active', () => {
+  // Pre-fix behaviour: when an interim assistant snapshot delivered content
+  // for a block that the stream had not yet populated (typical multi-block
+  // response where block 1 starts after block 0 finished), the snapshot
+  // emitted the full block text as a [CONTENT_DELTA].  The stream then
+  // delivered the same content again → user saw garbled / duplicated output.
+  // After the fix, the snapshot path suppresses the emit when the per-block
+  // accumulator is still empty and stream events are active.
+  const state = makeTurnState(true);
+
+  const captured = captureStdout(() => {
+    // Block 0 has been fully delivered via stream events.
+    processStreamEvent(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: 'Hello' },
+        },
+      },
+      state,
+    );
+    state.hasStreamEvents = true;
+
+    // Interim assistant snapshot arrives carrying block 0 + a brand-new
+    // block 1 whose stream events have not started yet.
+    const interimSnapshot = {
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'text', text: 'Hello' },
+          { type: 'text', text: 'Brand new block 1 content' },
+        ],
+      },
+    };
+    processMessageContent(interimSnapshot, state);
+
+    // Stream events for block 1 then arrive piece-by-piece.
+    for (const fragment of ['Brand ', 'new ', 'block ', '1 ', 'content']) {
+      processStreamEvent(
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 1,
+            delta: { type: 'text_delta', text: fragment },
+          },
+        },
+        state,
+      );
+    }
+  });
+
+  const deltaPayloads = tagLines(captured, '[CONTENT_DELTA]')
+    .map((line) => JSON.parse(line.replace(/^\[CONTENT_DELTA\]\s+/, '').trim()));
+
+  // No delta should equal the full block-1 snapshot — that would be the
+  // duplicate emit the PR fixes.
+  assert.ok(
+    !deltaPayloads.includes('Brand new block 1 content'),
+    `snapshot must not emit the whole new block as a single delta; got payloads: ${JSON.stringify(deltaPayloads)}`,
+  );
+  // Concatenated stream of block 1 must equal the expected content exactly
+  // once — no doubling, no garbled prefix.
+  const concatenated = deltaPayloads.join('');
+  assert.equal(
+    concatenated,
+    'HelloBrand new block 1 content',
+    `expected exactly one delivery of block 0 + block 1, got "${concatenated}"`,
+  );
+});
+
+test('REGRESSION (PR#1205 bug 2): tail-fill is still emitted when block has prior partial content', () => {
+  // The suppression in bug 2 must NOT block legitimate tail-fill: when the
+  // block already has streamed content and the snapshot extends it, the
+  // missing tail must be emitted (otherwise content is silently dropped).
+  const state = makeTurnState(true);
+
+  const captured = captureStdout(() => {
+    processStreamEvent(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: 'Hello' },
+        },
+      },
+      state,
+    );
+    state.hasStreamEvents = true;
+
+    const finalSnapshot = {
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'Hello world' }] },
+    };
+    processMessageContent(finalSnapshot, state);
+  });
+
+  const deltaLines = tagLines(captured, '[CONTENT_DELTA]');
+  assert.equal(deltaLines.length, 2, 'stream fragment + tail-fill');
+  assert.match(deltaLines[0], /"Hello"/);
+  assert.match(deltaLines[1], /" world"/);
+});


### PR DESCRIPTION
## Fix two root causes in the delta normalization pipeline

### 1. Stale-replay check in `computeNovelDelta` caused false positives in incremental mode
- **Issue**: The `startsWith`/`endsWith` stale-replay check was active in incremental mode, leading to `endsWith` false positives.  
  *Example*: `1500` was matched as `150` and the trailing `0` was silently absorbed → displayed as `150`.
- **Fix**: Restrict the `startsWith`/`endsWith` check to **cumulative-snapshot mode only**.

### 2. `processMessageContent` emitted full block text as delta, causing duplicate output
- **Issue**: When an assistant snapshot arrived before stream events had populated a content block, the function emitted the entire block text as a delta. The same text was then delivered again by stream events → duplicate output.
- **Fix**: Suppress the delta when streaming has started but the per-block content is still empty (stream events are the authoritative source for that block).

### Additional improvement: Switch delta length comparison to per‑block accumulated content
- Previously used `lastAssistantContent` (a single flat string that diverges from `blockMap` after silent snapshot‑mode corrections).
- Now use **per‑block accumulated content** for tail‑fill computation, keeping length comparisons accurate.

---

## Effect demonstration

**LLM raw output**:  
<img width="2346" height="986" alt="image" src="https://github.com/user-attachments/assets/5b96368d-9f4c-4ce7-aa1c-c3b1e6e767a4" />

**Before fix**: The number `1500` is missing the leading `0` and has an extra period at the end  
<img width="992" height="998" alt="fix_before" src="https://github.com/user-attachments/assets/ed14123d-494a-4b6c-8bfc-8bb1cfa4f219" />

**After fix**:  
<img width="1012" height="973" alt="fix_after" src="https://github.com/user-attachments/assets/ba9a0d60-4bc4-4264-bb9a-f76a7254aaa4" />