### PR TITLE
feat: add Shift+Esc to hide panel and improve panel activation UX

### DIFF
--- a/src/main/java/com/github/claudecodegui/action/HidePanelAction.java
+++ b/src/main/java/com/github/claudecodegui/action/HidePanelAction.java
@@ -1,0 +1,44 @@
+package com.github.claudecodegui.action;
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import org.jetbrains.annotations.NotNull;
+
+public class HidePanelAction extends AnAction implements DumbAware {
+
+    private static final String TOOL_WINDOW_ID = "CCG";
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.BGT;
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        Project project = e.getProject();
+        if (project == null) {
+            e.getPresentation().setEnabled(false);
+            return;
+        }
+        ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow(TOOL_WINDOW_ID);
+        e.getPresentation().setEnabled(toolWindow != null && toolWindow.isVisible());
+    }
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        Project project = e.getProject();
+        if (project == null) {
+            return;
+        }
+
+        ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow(TOOL_WINDOW_ID);
+        if (toolWindow != null && toolWindow.isVisible()) {
+            toolWindow.hide();
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/action/editor/SendSelectionToTerminalAction.java
+++ b/src/main/java/com/github/claudecodegui/action/editor/SendSelectionToTerminalAction.java
@@ -1,6 +1,7 @@
 package com.github.claudecodegui.action.editor;
 
 import com.github.claudecodegui.i18n.ClaudeCodeGuiBundle;
+import com.github.claudecodegui.ui.toolwindow.ClaudeChatWindow;
 import com.github.claudecodegui.ui.toolwindow.ClaudeSDKToolWindow;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
@@ -199,13 +200,19 @@ public class SendSelectionToTerminalAction extends AnAction implements DumbAware
     }
 
     /**
-     * Activate the CCG tool window without sending any content.
+     * Activate the CCG tool window and focus the input field.
      */
     private void activateToolWindow(@NotNull Project project) {
         ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(project);
         ToolWindow toolWindow = toolWindowManager.getToolWindow("CCG");
-        if (toolWindow != null) {
-            toolWindow.activate(null, true);
+        if (toolWindow == null) {
+            return;
         }
+        toolWindow.activate(() -> {
+            ClaudeChatWindow chatWindow = ClaudeSDKToolWindow.getChatWindow(project);
+            if (chatWindow != null && !chatWindow.isDisposed()) {
+                chatWindow.focusInputPane();
+            }
+        }, true);
     }
 }

--- a/src/main/java/com/github/claudecodegui/action/editor/SendSelectionToTerminalAction.java
+++ b/src/main/java/com/github/claudecodegui/action/editor/SendSelectionToTerminalAction.java
@@ -10,7 +10,6 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.editor.SelectionModel;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -54,11 +53,25 @@ public class SendSelectionToTerminalAction extends AnAction implements DumbAware
 
     /**
      * Main logic for executing the action.
+     * With selection: sends selected code and opens the panel.
+     * Without selection: just opens the CCG panel.
      */
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         Project project = e.getProject();
         if (project == null) {
+            return;
+        }
+
+        Editor editor = e.getData(CommonDataKeys.EDITOR);
+        if (editor == null) {
+            return;
+        }
+
+        String selectedText = editor.getSelectionModel().getSelectedText();
+        if (selectedText == null || selectedText.isEmpty()) {
+            // No selection — just open the panel
+            activateToolWindow(project);
             return;
         }
 
@@ -92,7 +105,9 @@ public class SendSelectionToTerminalAction extends AnAction implements DumbAware
 
     /**
      * Updates the action's availability state.
-     * Only enabled when an editor is active, a file is open, and text is selected.
+     * Always enabled when an editor is active.
+     * With selection: sends selected code and opens the panel.
+     * Without selection: just opens the CCG panel.
      */
     @Override
     public void update(@NotNull AnActionEvent e) {
@@ -103,16 +118,9 @@ public class SendSelectionToTerminalAction extends AnAction implements DumbAware
         }
 
         Editor editor = e.getData(CommonDataKeys.EDITOR);
-        if (editor == null) {
-            e.getPresentation().setEnabledAndVisible(false);
-            return;
-        }
 
-        SelectionModel selectionModel = editor.getSelectionModel();
-        String selectedText = selectionModel.getSelectedText();
-
-        // Only enable when there is selected text
-        e.getPresentation().setEnabledAndVisible(selectedText != null && !selectedText.isEmpty());
+        // Always enable when an editor is active, regardless of selection
+        e.getPresentation().setEnabledAndVisible(editor != null);
     }
 
     /**
@@ -187,6 +195,17 @@ public class SendSelectionToTerminalAction extends AnAction implements DumbAware
             ApplicationManager.getApplication().invokeLater(() -> {
                 com.intellij.openapi.ui.Messages.showInfoMessage(project, message, ClaudeCodeGuiBundle.message("dialog.info.title"));
             });
+        }
+    }
+
+    /**
+     * Activate the CCG tool window without sending any content.
+     */
+    private void activateToolWindow(@NotNull Project project) {
+        ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(project);
+        ToolWindow toolWindow = toolWindowManager.getToolWindow("CCG");
+        if (toolWindow != null) {
+            toolWindow.activate(null, true);
         }
     }
 }

--- a/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
@@ -19,6 +19,7 @@ import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.jcef.JBCefBrowser;
 import com.intellij.ui.jcef.JBCefBrowserBase;
@@ -218,6 +219,25 @@ public class WebviewInitializer {
                 }
             });
 
+            // Create a dedicated JSQuery for hiding the CCG panel via Shift+Esc
+            JBCefJSQuery hidePanelQuery = JBCefJSQuery.create(browserBase);
+            hidePanelQuery.addHandler((msg) -> {
+                try {
+                    Project project = host.getProject();
+                    if (project != null && !project.isDisposed()) {
+                        ApplicationManager.getApplication().invokeLater(() -> {
+                            ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("CCG");
+                            if (toolWindow != null && toolWindow.isVisible()) {
+                                toolWindow.hide();
+                            }
+                        });
+                    }
+                } catch (Exception ex) {
+                    LOG.warn("Failed to hide CCG panel via shortcut: " + ex.getMessage());
+                }
+                return new JBCefJSQuery.Response("ok");
+            });
+
             HtmlLoader htmlLoader = host.getHtmlLoader();
             String htmlContent = htmlLoader.loadChatHtml();
 
@@ -232,6 +252,21 @@ public class WebviewInitializer {
 
                     String injection = "window.sendToJava = function(msg) { " + jsQuery.inject("msg") + " };";
                     cefBrowser.executeJavaScript(injection, cefBrowser.getURL(), 0);
+
+                    // Register Shift+Esc shortcut handler.
+                    // Intercepted at the JavaScript level — JCEF forwards keydown events
+                    // to the renderer before Chromium processes them for Task Manager.
+                    String shiftEscInjection =
+                        "document.addEventListener('keydown', function(e) {" +
+                        "  if (e.key === 'Escape' && e.shiftKey) {" +
+                        "    e.preventDefault();" +
+                        "    e.stopPropagation();" +
+                        "    " + hidePanelQuery.inject("''",
+                            "function() {}",
+                            "function() {}") +
+                        "  }" +
+                        "}, true);";
+                    cefBrowser.executeJavaScript(shiftEscInjection, cefBrowser.getURL(), 0);
 
                     // Inject clipboard path retrieval function
                     String clipboardPathInjection =

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -679,6 +679,18 @@ public class ClaudeChatWindow {
         }
     }
 
+    /**
+     * Focus the chat input field in the frontend.
+     * Called when Ctrl+Alt+K activates the panel without a selection.
+     */
+    public void focusInputPane() {
+        if (disposed || browser == null) {
+            return;
+        }
+        browser.getComponent().requestFocus();
+        executeJavaScriptCode("window.focusChatInput?.()");
+    }
+
     // ==================== Dispose ====================
 
     public synchronized void dispose() {

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -671,6 +671,10 @@ public class ClaudeChatWindow {
 
     private void addCodeSnippet(String selectionInfo) {
         if (selectionInfo != null && !selectionInfo.isEmpty()) {
+            // Ensure the browser has focus so the frontend can focus the input field
+            if (browser != null) {
+                browser.getComponent().requestFocus();
+            }
             callJavaScript("addCodeSnippet", JsUtils.escapeJs(selectionInfo));
         }
     }

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -65,6 +65,7 @@ public class ClaudeChatWindow {
     private volatile boolean disposed = false;
     private volatile boolean initialized = false;
     private volatile boolean frontendReady = false;
+    private volatile String pendingCodeSnippet = null;
     private volatile boolean slashCommandsFetched = false;
     private final AtomicBoolean restoredHistoryLoadStarted = new AtomicBoolean(false);
 
@@ -414,7 +415,23 @@ public class ClaudeChatWindow {
     }
 
     public void addCodeSnippetFromExternal(String selectionInfo) {
-        addCodeSnippet(selectionInfo);
+        if (selectionInfo == null || selectionInfo.isEmpty()) {
+            return;
+        }
+        if (frontendReady) {
+            addCodeSnippet(selectionInfo);
+        } else {
+            // Defer until frontend signals readiness
+            pendingCodeSnippet = selectionInfo;
+        }
+    }
+
+    private void flushPendingCodeSnippet() {
+        if (pendingCodeSnippet != null) {
+            String snippet = pendingCodeSnippet;
+            pendingCodeSnippet = null;
+            addCodeSnippet(snippet);
+        }
     }
 
     public void updateTabStatus(ChatWindowDelegate.TabAnswerStatus status) {
@@ -845,6 +862,9 @@ public class ClaudeChatWindow {
             @Override
             public void setFrontendReady(boolean ready) {
                 frontendReady = ready;
+                if (ready) {
+                    flushPendingCodeSnippet();
+                }
             }
         };
     }
@@ -974,6 +994,9 @@ public class ClaudeChatWindow {
             @Override
             public void setFrontendReady(boolean ready) {
                 frontendReady = ready;
+                if (ready) {
+                    flushPendingCodeSnippet();
+                }
             }
 
             @Override

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -217,5 +217,11 @@
             <keyboard-shortcut keymap="Mac OS X" first-keystroke="shift ENTER"/>
             <keyboard-shortcut keymap="macOS" first-keystroke="shift ENTER"/>
         </action>
+
+        <!-- Hide CC GUI Panel (handled via CefKeyboardHandler at JCEF level to avoid conflict with built-in HideActiveWindow) -->
+        <action id="ClaudeCodeGUI.HidePanelAction"
+                class="com.github.claudecodegui.action.HidePanelAction"
+                text="Hide CC GUI Panel"
+                description="Hide the CC GUI tool window panel"/>
     </actions>
 </idea-plugin>

--- a/webview/src/components/ChatInputBox/hooks/useGlobalCallbacks.ts
+++ b/webview/src/components/ChatInputBox/hooks/useGlobalCallbacks.ts
@@ -246,8 +246,13 @@ export function useGlobalCallbacks({
       }
     };
 
+    window.focusChatInput = () => {
+      focusInput();
+    };
+
     return () => {
       delete window.insertCodeSnippetAtCursor;
+      delete window.focusChatInput;
     };
-  }, [editableRef, getTextContent, renderFileTags, adjustHeight, onInput, setHasContent]);
+  }, [editableRef, getTextContent, renderFileTags, adjustHeight, onInput, setHasContent, focusInput]);
 }

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -176,6 +176,11 @@ interface Window {
   insertCodeSnippetAtCursor?: (selectionInfo: string) => void;
 
   /**
+   * Focus the chat input box - registered by ChatInputBox
+   */
+  focusChatInput?: () => void;
+
+  /**
    * Clear selection info
    */
   clearSelectionInfo?: () => void;


### PR DESCRIPTION
## Summary

- **Shift+Esc**: Quickly closes the CC GUI tool window panel (intercepted via JavaScript to prevent JCEF/Chromium from consuming the shortcut)
- **Ctrl+Alt+K**: Opens the panel regardless of whether any code is selected (sends the code and opens the panel if text is selected; only opens the panel if no text is selected)
- **Automatic Focus**: The input field gets automatically focused after the code snippet is sent to the panel.
## Test plan

- [x] In the editor, press `Ctrl+Alt+K` (with no text selected) to verify that the panel opens and the input field gains focus.
- [x] After selecting the code, press `Ctrl+Alt+K` to verify that the code has been inserted into the input box and that the input box has gained focus.
- [x] When the panel is expanded, press `Shift+Esc` to verify that the panel closes.
