### PR TITLE
feat: 支持任务管理工具（taskcreate/taskupdate）的识别与渲染

### DIFF
--- a/webview/src/components/MarkdownBlock.test.tsx
+++ b/webview/src/components/MarkdownBlock.test.tsx
@@ -43,7 +43,7 @@ describe('MarkdownBlock linkify integration', () => {
         content={[
           'Open src/components/App.tsx',
           '',
-          '`src/inline-code.ts` should be linkified',
+          '`src/inline-code.ts` should NOT be linkified',
           '',
           '```ts',
           'src/ignored-block.ts',
@@ -55,10 +55,10 @@ describe('MarkdownBlock linkify integration', () => {
     const fileLink = screen.getByRole('link', { name: 'src/components/App.tsx' });
     expect(fileLink.getAttribute('data-linkify')).toBe('file');
 
-    // Inline code content should be linkified
-    const inlineCodeLink = screen.getByRole('link', { name: 'src/inline-code.ts' });
-    expect(inlineCodeLink.getAttribute('data-linkify')).toBe('file');
-    expect(inlineCodeLink.closest('code')).toBeTruthy();
+    // Inline code content should NOT be linkified
+    const inlineCode = document.querySelector('code');
+    expect(inlineCode?.textContent).toContain('src/inline-code.ts');
+    expect(inlineCode?.querySelector('a')).toBeNull();
 
     // Code fence content should NOT be linkified
     const fencedCode = document.querySelector('pre code');

--- a/webview/src/components/MarkdownBlock.tsx
+++ b/webview/src/components/MarkdownBlock.tsx
@@ -6,6 +6,7 @@ import { openBrowser, openClass, openFile } from '../utils/bridge';
 import { useMarkdownFileLinkTooltip } from '../hooks/useMarkdownFileLinkTooltip';
 import {
   decorateExistingAnchors,
+  escapeHtml,
   linkifyHtml,
   linkifyPlainTextSegment,
 } from '../utils/linkify';
@@ -313,9 +314,7 @@ function renderStreamingInlineText(
       .map((inlinePart) => {
         const inlineCodeMatch = /^`([^`\n]+)`$/.exec(inlinePart);
         if (inlineCodeMatch) {
-          // Inline code content should also be linkified
-          const linkifiedCode = linkifyPlainTextSegment(inlineCodeMatch[1], capabilities);
-          return `<code>${linkifiedCode}</code>`;
+          return `<code>${escapeHtml(inlineCodeMatch[1])}</code>`;
         }
 
         return inlinePart
@@ -359,10 +358,10 @@ function renderStreamingProseSegment(
   const inlineParts = cleaned.split(INLINE_CODE_RE);
 
   const processedParts = inlineParts.map((part, idx) => {
-    // Odd indices are inline code — pass to linkifyPlainTextSegment which escapes HTML
+    // Odd indices are inline code — escape HTML only, no linkify
     if (idx % 2 === 1) {
       const inlineContent = part.slice(1, -1); // Remove surrounding backticks
-      return `<code>${linkifyPlainTextSegment(inlineContent, capabilities)}</code>`;
+      return `<code>${escapeHtml(inlineContent)}</code>`;
     }
     // Even indices are prose — escape XML tags then render inline formatting
     return renderStreamingInlineText(escapeXmlTags(part), capabilities, false);

--- a/webview/src/components/MessageItem/ContentBlockRenderer.tsx
+++ b/webview/src/components/MessageItem/ContentBlockRenderer.tsx
@@ -10,7 +10,7 @@ import {
   GenericToolBlock,
   TaskExecutionBlock,
 } from '../toolBlocks';
-import { EDIT_TOOL_NAMES, BASH_TOOL_NAMES, isToolName, isTransientInternalToolName, normalizeToolName } from '../../utils/toolConstants';
+import { EDIT_TOOL_NAMES, BASH_TOOL_NAMES, TASK_MANAGE_TOOL_NAMES, isToolName, isTransientInternalToolName, normalizeToolName } from '../../utils/toolConstants';
 import { TASK_STATUS_COLORS } from '../../utils/messageUtils';
 
 const IMAGE_BLOCK_STYLE: React.CSSProperties = { cursor: 'pointer' };
@@ -249,7 +249,7 @@ export function ContentBlockRenderer({
   if (block.type === 'tool_use') {
     const toolName = normalizeToolName(block.name ?? '');
 
-    if (toolName === 'todowrite' || toolName === 'update_plan') {
+    if (toolName === 'todowrite' || toolName === 'update_plan' || TASK_MANAGE_TOOL_NAMES.has(toolName)) {
       return null;
     }
 

--- a/webview/src/components/MessageItem/MessageItem.tsx
+++ b/webview/src/components/MessageItem/MessageItem.tsx
@@ -53,7 +53,7 @@ type GroupedBlock =
   | { type: 'edit_group'; blocks: ClaudeContentBlock[]; startIndex: number }
   | { type: 'bash_group'; blocks: ClaudeContentBlock[]; startIndex: number }
   | { type: 'search_group'; blocks: ClaudeContentBlock[]; startIndex: number }
-  | { type: 'agent_group'; agentBlock: ClaudeContentBlock; followingTextBlocks: ClaudeContentBlock[]; startIndex: number };
+  | { type: 'agent_group'; agentBlock: ClaudeContentBlock; followingBlocks: ClaudeContentBlock[]; startIndex: number };
 
 /** Shared copy icon SVG used by both user and assistant message copy buttons */
 const CopyIcon = () => (
@@ -109,7 +109,11 @@ function isToolBlockOfType(block: ClaudeContentBlock, toolNames: Set<string>): b
   return block.type === 'tool_use' && isToolName(block.name, toolNames);
 }
 
-function groupBlocks(blocks: ClaudeContentBlock[]): GroupedBlock[] {
+function groupBlocks(
+  blocks: ClaudeContentBlock[],
+  findToolResult: (toolId: string | undefined, messageIndex: number) => ToolResultBlock | null | undefined,
+  messageIndex: number,
+): GroupedBlock[] {
   const groupedBlocks: GroupedBlock[] = [];
   let currentReadGroup: ClaudeContentBlock[] = [];
   let readGroupStartIndex = -1;
@@ -176,7 +180,7 @@ function groupBlocks(blocks: ClaudeContentBlock[]): GroupedBlock[] {
       groupedBlocks.push({
         type: 'agent_group',
         agentBlock: currentAgentBlock,
-        followingTextBlocks: [...agentFollowingText],
+        followingBlocks: [...agentFollowingText],
         startIndex: agentGroupStartIndex,
       });
       currentAgentBlock = null;
@@ -186,13 +190,33 @@ function groupBlocks(blocks: ClaudeContentBlock[]): GroupedBlock[] {
   };
 
   blocks.forEach((block, idx) => {
-    // If we're collecting text for an agent group, check if this block continues it
+    // If we're collecting blocks for an agent group, determine boundary
     if (currentAgentBlock) {
-      if (block.type === 'text') {
+      const agentToolId = currentAgentBlock.type === 'tool_use' ? currentAgentBlock.id : undefined;
+      const agentResult = findToolResult(agentToolId, messageIndex);
+      const agentCompleted = agentResult !== undefined && agentResult !== null;
+
+      if (isToolBlockOfType(block, AGENT_TOOL_NAMES)) {
+        // New agent tool — flush current group, start new one
+        flushAgentGroup();
+        currentAgentBlock = block;
+        agentGroupStartIndex = idx;
+        return;
+      }
+
+      if (!agentCompleted) {
+        // Agent still running — absorb all subsequent blocks
         agentFollowingText.push(block);
         return;
       }
-      // Non-text block: flush the agent group
+
+      // Agent completed — only absorb the first text block (result summary)
+      if (block.type === 'text' && agentFollowingText.length === 0) {
+        agentFollowingText.push(block);
+        return;
+      }
+
+      // Any other block after completion belongs to main agent
       flushAgentGroup();
     }
 
@@ -398,7 +422,7 @@ export const MessageItem = memo(function MessageItem({
     }
   }, [blocks, isMessageStreaming, manuallyExpandedThinking]);
 
-  const groupedBlocks = useMemo(() => groupBlocks(blocks), [blocks]);
+  const groupedBlocks = useMemo(() => groupBlocks(blocks, findToolResult, messageIndex), [blocks, findToolResult, messageIndex]);
 
   // Register user message DOM node for anchor navigation
   // Must be called before any early returns to satisfy React hooks rules
@@ -579,13 +603,16 @@ export const MessageItem = memo(function MessageItem({
       }
 
       if (grouped.type === 'agent_group') {
+        const agentToolId = grouped.agentBlock.type === 'tool_use' ? grouped.agentBlock.id : undefined;
         return (
-          <div key={`${messageIndex}-agentgroup-${grouped.startIndex}`} className="content-block">
+          <div key={`agentgroup-${agentToolId ?? grouped.startIndex}`} className="content-block">
             <AgentGroupBlock
               agentBlock={grouped.agentBlock}
-              followingTextBlocks={grouped.followingTextBlocks}
+              followingBlocks={grouped.followingBlocks}
               messageIndex={messageIndex}
               isStreaming={isMessageStreaming}
+              isLastMessage={isLast}
+              isThinking={isThinking}
               findToolResult={findToolResult}
             />
           </div>

--- a/webview/src/components/MessageItem/MessageItem.tsx
+++ b/webview/src/components/MessageItem/MessageItem.tsx
@@ -109,6 +109,10 @@ function isToolBlockOfType(block: ClaudeContentBlock, toolNames: Set<string>): b
   return block.type === 'tool_use' && isToolName(block.name, toolNames);
 }
 
+// Tracks how many blocks each agent group absorbed while running.
+// Once the agent completes, this frozen count prevents blocks from being released.
+const agentGroupBlockCount = new Map<string, number>();
+
 function groupBlocks(
   blocks: ClaudeContentBlock[],
   findToolResult: (toolId: string | undefined, messageIndex: number) => ToolResultBlock | null | undefined,
@@ -177,6 +181,10 @@ function groupBlocks(
 
   const flushAgentGroup = () => {
     if (currentAgentBlock) {
+      const agentToolId = currentAgentBlock.type === 'tool_use' ? currentAgentBlock.id : undefined;
+      const key = agentToolId ?? `agent-${agentGroupStartIndex}`;
+      // Persist the count so it's stable after completion
+      agentGroupBlockCount.set(key, agentFollowingText.length);
       groupedBlocks.push({
         type: 'agent_group',
         agentBlock: currentAgentBlock,
@@ -190,33 +198,34 @@ function groupBlocks(
   };
 
   blocks.forEach((block, idx) => {
-    // If we're collecting blocks for an agent group, determine boundary
     if (currentAgentBlock) {
-      const agentToolId = currentAgentBlock.type === 'tool_use' ? currentAgentBlock.id : undefined;
-      const agentResult = findToolResult(agentToolId, messageIndex);
-      const agentCompleted = agentResult !== undefined && agentResult !== null;
-
       if (isToolBlockOfType(block, AGENT_TOOL_NAMES)) {
-        // New agent tool — flush current group, start new one
         flushAgentGroup();
         currentAgentBlock = block;
         agentGroupStartIndex = idx;
         return;
       }
 
+      const agentToolId = currentAgentBlock.type === 'tool_use' ? currentAgentBlock.id : undefined;
+      const agentResult = findToolResult(agentToolId, messageIndex);
+      const agentCompleted = agentResult !== undefined && agentResult !== null;
+
       if (!agentCompleted) {
-        // Agent still running — absorb all subsequent blocks
+        // Still running — absorb all subsequent blocks
         agentFollowingText.push(block);
         return;
       }
 
-      // Agent completed — only absorb the first text block (result summary)
-      if (block.type === 'text' && agentFollowingText.length === 0) {
+      // Completed — use the frozen count to decide boundary
+      const key = agentToolId ?? `agent-${agentGroupStartIndex}`;
+      const frozenCount = agentGroupBlockCount.get(key) ?? 0;
+      if (agentFollowingText.length < frozenCount) {
+        // Still within the previously established boundary
         agentFollowingText.push(block);
         return;
       }
 
-      // Any other block after completion belongs to main agent
+      // Beyond boundary — flush and let block be processed normally
       flushAgentGroup();
     }
 

--- a/webview/src/components/MessageItem/MessageItem.tsx
+++ b/webview/src/components/MessageItem/MessageItem.tsx
@@ -15,10 +15,11 @@ import {
   BashToolGroupBlock,
   SearchToolGroupBlock,
 } from '../toolBlocks';
+import AgentGroupBlock from '../toolBlocks/AgentGroupBlock';
 import { ContentBlockRenderer } from './ContentBlockRenderer';
 import { formatTime } from '../../utils/helpers';
 import { copyToClipboard } from '../../utils/copyUtils';
-import { READ_TOOL_NAMES, EDIT_TOOL_NAMES, BASH_TOOL_NAMES, SEARCH_TOOL_NAMES, isToolName } from '../../utils/toolConstants';
+import { READ_TOOL_NAMES, EDIT_TOOL_NAMES, BASH_TOOL_NAMES, SEARCH_TOOL_NAMES, AGENT_TOOL_NAMES, isToolName } from '../../utils/toolConstants';
 
 export interface MessageItemProps {
   message: ClaudeMessage;
@@ -51,7 +52,8 @@ type GroupedBlock =
   | { type: 'read_group'; blocks: ClaudeContentBlock[]; startIndex: number }
   | { type: 'edit_group'; blocks: ClaudeContentBlock[]; startIndex: number }
   | { type: 'bash_group'; blocks: ClaudeContentBlock[]; startIndex: number }
-  | { type: 'search_group'; blocks: ClaudeContentBlock[]; startIndex: number };
+  | { type: 'search_group'; blocks: ClaudeContentBlock[]; startIndex: number }
+  | { type: 'agent_group'; agentBlock: ClaudeContentBlock; followingTextBlocks: ClaudeContentBlock[]; startIndex: number };
 
 /** Shared copy icon SVG used by both user and assistant message copy buttons */
 const CopyIcon = () => (
@@ -117,6 +119,9 @@ function groupBlocks(blocks: ClaudeContentBlock[]): GroupedBlock[] {
   let bashGroupStartIndex = -1;
   let currentSearchGroup: ClaudeContentBlock[] = [];
   let searchGroupStartIndex = -1;
+  let currentAgentBlock: ClaudeContentBlock | null = null;
+  let agentFollowingText: ClaudeContentBlock[] = [];
+  let agentGroupStartIndex = -1;
 
   const flushReadGroup = () => {
     if (currentReadGroup.length > 0) {
@@ -166,8 +171,39 @@ function groupBlocks(blocks: ClaudeContentBlock[]): GroupedBlock[] {
     }
   };
 
+  const flushAgentGroup = () => {
+    if (currentAgentBlock) {
+      groupedBlocks.push({
+        type: 'agent_group',
+        agentBlock: currentAgentBlock,
+        followingTextBlocks: [...agentFollowingText],
+        startIndex: agentGroupStartIndex,
+      });
+      currentAgentBlock = null;
+      agentFollowingText = [];
+      agentGroupStartIndex = -1;
+    }
+  };
+
   blocks.forEach((block, idx) => {
-    if (isToolBlockOfType(block, READ_TOOL_NAMES)) {
+    // If we're collecting text for an agent group, check if this block continues it
+    if (currentAgentBlock) {
+      if (block.type === 'text') {
+        agentFollowingText.push(block);
+        return;
+      }
+      // Non-text block: flush the agent group
+      flushAgentGroup();
+    }
+
+    if (isToolBlockOfType(block, AGENT_TOOL_NAMES)) {
+      flushReadGroup();
+      flushEditGroup();
+      flushBashGroup();
+      flushSearchGroup();
+      currentAgentBlock = block;
+      agentGroupStartIndex = idx;
+    } else if (isToolBlockOfType(block, READ_TOOL_NAMES)) {
       flushEditGroup();
       flushBashGroup();
       flushSearchGroup();
@@ -208,6 +244,7 @@ function groupBlocks(blocks: ClaudeContentBlock[]): GroupedBlock[] {
     }
   });
 
+  flushAgentGroup();
   flushReadGroup();
   flushEditGroup();
   flushBashGroup();
@@ -537,6 +574,20 @@ export const MessageItem = memo(function MessageItem({
         return (
           <div key={`${messageIndex}-searchgroup-${grouped.startIndex}`} className="content-block">
             <SearchToolGroupBlock items={searchItems} />
+          </div>
+        );
+      }
+
+      if (grouped.type === 'agent_group') {
+        return (
+          <div key={`${messageIndex}-agentgroup-${grouped.startIndex}`} className="content-block">
+            <AgentGroupBlock
+              agentBlock={grouped.agentBlock}
+              followingTextBlocks={grouped.followingTextBlocks}
+              messageIndex={messageIndex}
+              isStreaming={isMessageStreaming}
+              findToolResult={findToolResult}
+            />
           </div>
         );
       }

--- a/webview/src/components/toolBlocks/AgentGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/AgentGroupBlock.tsx
@@ -5,13 +5,15 @@ import { normalizeToolName } from '../../utils/toolConstants';
 import { sendBridgeEvent } from '../../utils/bridge';
 import { useSubagentHistoryGetter, useSessionId, useGetToolResultRaw, type GetToolResultRawFn } from '../../contexts/SubagentContext';
 import SubagentProcessDetails from '../StatusPanel/SubagentProcessDetails';
-import MarkdownBlock from '../MarkdownBlock';
+import { ContentBlockRenderer } from '../MessageItem/ContentBlockRenderer';
 
 interface AgentGroupBlockProps {
   agentBlock: ClaudeContentBlock;
-  followingTextBlocks: ClaudeContentBlock[];
+  followingBlocks: ClaudeContentBlock[];
   messageIndex: number;
   isStreaming: boolean;
+  isLastMessage: boolean;
+  isThinking: boolean;
   findToolResult: (toolId: string | undefined, messageIndex: number) => ToolResultBlock | null | undefined;
 }
 
@@ -62,20 +64,34 @@ function parseAgentToolMeta(
   };
 }
 
+// Persist expanded state across re-mounts (streaming causes component remount)
+const expandedState = new Map<string, boolean>();
+
 const AgentGroupBlock = memo(function AgentGroupBlock({
   agentBlock,
-  followingTextBlocks,
+  followingBlocks,
   messageIndex,
   isStreaming,
+  isLastMessage,
+  isThinking,
   findToolResult,
 }: AgentGroupBlockProps) {
   const { t } = useTranslation();
-  const [expanded, setExpanded] = useState(false);
   const getSubagentHistory = useSubagentHistoryGetter();
   const currentSessionId = useSessionId();
   const getToolResultRaw = useGetToolResultRaw();
 
   const toolId = agentBlock.type === 'tool_use' ? agentBlock.id : undefined;
+  const stateKey = toolId ?? `agent-${messageIndex}`;
+  const [expanded, setExpandedRaw] = useState(() => expandedState.get(stateKey) ?? false);
+  const setExpanded = (updater: (prev: boolean) => boolean) => {
+    setExpandedRaw((prev) => {
+      const next = updater(prev);
+      expandedState.set(stateKey, next);
+      return next;
+    });
+  };
+
   const input = agentBlock.type === 'tool_use' ? (agentBlock.input as Record<string, unknown> | undefined) : undefined;
   const result = findToolResult(toolId, messageIndex);
   const isCompleted = result !== undefined && result !== null;
@@ -150,9 +166,21 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
             history={history}
             canLoad={Boolean(currentSessionId)}
           />
-          {followingTextBlocks.map((block, idx) => (
-            <div key={idx} className="agent-group-text-block">
-              <MarkdownBlock content={block.type === 'text' ? block.text : ''} />
+          {followingBlocks.map((block, idx) => (
+            <div key={idx} className="content-block">
+              <ContentBlockRenderer
+                block={block}
+                messageIndex={messageIndex}
+                messageType="assistant"
+                isStreaming={isStreaming}
+                isThinkingExpanded={false}
+                isThinking={isThinking}
+                isLastMessage={isLastMessage}
+                isLastBlock={idx === followingBlocks.length - 1}
+                t={t}
+                onToggleThinking={() => {}}
+                findToolResult={findToolResult}
+              />
             </div>
           ))}
         </div>

--- a/webview/src/components/toolBlocks/AgentGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/AgentGroupBlock.tsx
@@ -1,0 +1,164 @@
+import { memo, useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { ClaudeContentBlock, ToolResultBlock } from '../../types';
+import { normalizeToolName } from '../../utils/toolConstants';
+import { sendBridgeEvent } from '../../utils/bridge';
+import { useSubagentHistoryGetter, useSessionId, useGetToolResultRaw, type GetToolResultRawFn } from '../../contexts/SubagentContext';
+import SubagentProcessDetails from '../StatusPanel/SubagentProcessDetails';
+import MarkdownBlock from '../MarkdownBlock';
+
+interface AgentGroupBlockProps {
+  agentBlock: ClaudeContentBlock;
+  followingTextBlocks: ClaudeContentBlock[];
+  messageIndex: number;
+  isStreaming: boolean;
+  findToolResult: (toolId: string | undefined, messageIndex: number) => ToolResultBlock | null | undefined;
+}
+
+function getAgentSummary(block: ClaudeContentBlock): string {
+  if (block.type !== 'tool_use') return '';
+  const input = block.input as Record<string, unknown> | undefined;
+  if (!input) return '';
+  const desc = input.description ?? input.prompt;
+  return typeof desc === 'string' ? desc.slice(0, 120) : '';
+}
+
+function getAgentType(block: ClaudeContentBlock): string {
+  if (block.type !== 'tool_use') return '';
+  const input = block.input as Record<string, unknown> | undefined;
+  if (!input) return '';
+  const t = input.subagent_type ?? input.subagentType;
+  return typeof t === 'string' ? t : '';
+}
+
+function extractResultText(result?: ToolResultBlock | null): string | undefined {
+  if (!result) return undefined;
+  if (typeof result.content === 'string') return result.content;
+  if (Array.isArray(result.content)) {
+    return result.content
+      .filter((item): item is { type: string; text: string } => item?.type === 'text' && typeof item.text === 'string')
+      .map((item) => item.text)
+      .join('\n') || undefined;
+  }
+  return undefined;
+}
+
+function parseAgentToolMeta(
+  getToolResultRaw: GetToolResultRawFn,
+  toolUseId?: string,
+): { agentId?: string; totalDurationMs?: number; totalTokens?: number; totalToolUseCount?: number } {
+  if (!toolUseId) return {};
+  const rawMessage = getToolResultRaw(toolUseId);
+  const metadata = rawMessage?.toolUseResult;
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return {};
+  const record = metadata as Record<string, unknown>;
+  const getString = (value: unknown) => (typeof value === 'string' && value.trim() ? value.trim() : undefined);
+  const getNumber = (value: unknown) => (typeof value === 'number' && Number.isFinite(value) ? value : undefined);
+  return {
+    agentId: getString(record.agentId),
+    totalDurationMs: getNumber(record.totalDurationMs),
+    totalTokens: getNumber(record.totalTokens),
+    totalToolUseCount: getNumber(record.totalToolUseCount),
+  };
+}
+
+const AgentGroupBlock = memo(function AgentGroupBlock({
+  agentBlock,
+  followingTextBlocks,
+  messageIndex,
+  isStreaming,
+  findToolResult,
+}: AgentGroupBlockProps) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const getSubagentHistory = useSubagentHistoryGetter();
+  const currentSessionId = useSessionId();
+  const getToolResultRaw = useGetToolResultRaw();
+
+  const toolId = agentBlock.type === 'tool_use' ? agentBlock.id : undefined;
+  const input = agentBlock.type === 'tool_use' ? (agentBlock.input as Record<string, unknown> | undefined) : undefined;
+  const result = findToolResult(toolId, messageIndex);
+  const isCompleted = result !== undefined && result !== null;
+  const isError = isCompleted && result?.is_error === true;
+
+  const agentType = getAgentType(agentBlock);
+  const summary = getAgentSummary(agentBlock);
+  const toolName = agentBlock.type === 'tool_use' ? normalizeToolName(agentBlock.name ?? '') : '';
+
+  const agentToolMeta = parseAgentToolMeta(getToolResultRaw, toolId);
+  const agentId = agentToolMeta.agentId ?? (input?.agent_id as string | undefined) ?? (input?.agentId as string | undefined);
+  const history = (toolId ? getSubagentHistory(toolId) : undefined) ?? (agentId ? getSubagentHistory(agentId) : undefined);
+
+  useEffect(() => {
+    if (!expanded || !currentSessionId || !toolId || history) return;
+    sendBridgeEvent('load_subagent_session', JSON.stringify({
+      sessionId: currentSessionId,
+      agentId,
+      description: typeof summary === 'string' ? summary : undefined,
+      toolUseId: toolId,
+    }));
+  }, [agentId, currentSessionId, summary, expanded, history, toolId]);
+
+  useEffect(() => {
+    if (!expanded || !currentSessionId || !toolId || !isStreaming || isCompleted || history) return;
+    const timer = window.setInterval(() => {
+      sendBridgeEvent('load_subagent_session', JSON.stringify({
+        sessionId: currentSessionId,
+        agentId,
+        description: typeof summary === 'string' ? summary : undefined,
+        toolUseId: toolId,
+      }));
+    }, 2_000);
+    return () => window.clearInterval(timer);
+  }, [agentId, currentSessionId, summary, expanded, history, isStreaming, isCompleted, toolId]);
+
+  return (
+    <div className="task-container agent-group-container">
+      <div
+        className={`task-header ${expanded ? 'task-header-expanded' : ''}`}
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        <div className="task-title-section">
+          <span className="codicon codicon-type-hierarchy tool-title-icon" />
+          <span className="tool-title-text">
+            {toolName === 'spawn_agent' ? 'spawn_agent' : t('tools.agent', 'Agent')}
+          </span>
+          {agentType && (
+            <span className="tool-title-summary">{agentType}</span>
+          )}
+          {summary && (
+            <span className="task-summary-text tool-title-summary" title={summary} style={{ fontWeight: 'normal' }}>
+              {summary}
+            </span>
+          )}
+        </div>
+
+        <div className="task-header-right">
+          <div className={`tool-status-indicator ${isError ? 'error' : isCompleted ? 'completed' : 'pending'}`} />
+          <span className={`codicon ${expanded ? 'codicon-chevron-up' : 'codicon-chevron-down'}`} style={{ fontSize: '12px', color: 'var(--text-tertiary)' }} />
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="task-details agent-group-content">
+          <SubagentProcessDetails
+            agentId={agentId}
+            totalDurationMs={agentToolMeta.totalDurationMs}
+            totalTokens={agentToolMeta.totalTokens}
+            totalToolUseCount={agentToolMeta.totalToolUseCount}
+            resultText={extractResultText(result)}
+            history={history}
+            canLoad={Boolean(currentSessionId)}
+          />
+          {followingTextBlocks.map((block, idx) => (
+            <div key={idx} className="agent-group-text-block">
+              <MarkdownBlock content={block.type === 'text' ? block.text : ''} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+});
+
+export default AgentGroupBlock;

--- a/webview/src/components/toolBlocks/AgentGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/AgentGroupBlock.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { ClaudeContentBlock, ToolResultBlock } from '../../types';
 import { normalizeToolName } from '../../utils/toolConstants';
 import { sendBridgeEvent } from '../../utils/bridge';
+import { getPersistedExpanded, setPersistedExpanded } from '../../utils/expandedState';
 import { useSubagentHistoryGetter, useSessionId, useGetToolResultRaw, type GetToolResultRawFn } from '../../contexts/SubagentContext';
 import SubagentProcessDetails from '../StatusPanel/SubagentProcessDetails';
 import { ContentBlockRenderer } from '../MessageItem/ContentBlockRenderer';
@@ -65,7 +66,6 @@ function parseAgentToolMeta(
 }
 
 // Persist expanded state across re-mounts (streaming causes component remount)
-const expandedState = new Map<string, boolean>();
 
 const AgentGroupBlock = memo(function AgentGroupBlock({
   agentBlock,
@@ -82,12 +82,12 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
   const getToolResultRaw = useGetToolResultRaw();
 
   const toolId = agentBlock.type === 'tool_use' ? agentBlock.id : undefined;
-  const stateKey = toolId ?? `agent-${messageIndex}`;
-  const [expanded, setExpandedRaw] = useState(() => expandedState.get(stateKey) ?? false);
+  const stateKey = `agent-group-${toolId ?? messageIndex}`;
+  const [expanded, setExpandedRaw] = useState(() => getPersistedExpanded(stateKey));
   const setExpanded = (updater: (prev: boolean) => boolean) => {
     setExpandedRaw((prev) => {
       const next = updater(prev);
-      expandedState.set(stateKey, next);
+      setPersistedExpanded(stateKey, next);
       return next;
     });
   };

--- a/webview/src/components/toolBlocks/BashToolBlock.tsx
+++ b/webview/src/components/toolBlocks/BashToolBlock.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ToolInput, ToolResultBlock } from '../../types';
 import { useIsToolDenied } from '../../hooks/useIsToolDenied';
+import { getPersistedExpanded, setPersistedExpanded } from '../../utils/expandedState';
 
 const TASK_DETAILS_STYLE: React.CSSProperties = { padding: 0, border: 'none' };
 const TASK_CONTENT_WRAPPER_STYLE: React.CSSProperties = { paddingLeft: '40px', position: 'relative', zIndex: 1 };
@@ -17,7 +18,15 @@ interface BashToolBlockProps {
 
 const BashToolBlock = ({ input, result, toolId }: BashToolBlockProps) => {
   const { t } = useTranslation();
-  const [expanded, setExpanded] = useState(false);
+  const stateKey = `bash-${toolId ?? 'unknown'}`;
+  const [expanded, setExpandedRaw] = useState(() => getPersistedExpanded(stateKey));
+  const setExpanded = (v: boolean | ((prev: boolean) => boolean)) => {
+    setExpandedRaw((prev) => {
+      const next = typeof v === 'function' ? v(prev) : v;
+      setPersistedExpanded(stateKey, next);
+      return next;
+    });
+  };
 
   if (!input) {
     return null;

--- a/webview/src/components/toolBlocks/GenericToolBlock.tsx
+++ b/webview/src/components/toolBlocks/GenericToolBlock.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { ToolInput, ToolResultBlock } from '../../types';
 import { useIsToolDenied } from '../../hooks/useIsToolDenied';
 import { useResolvedFileLinkTooltip } from '../../hooks/useResolvedFileLinkTooltip';
+import { getPersistedExpanded, setPersistedExpanded } from '../../utils/expandedState';
 import { openFile } from '../../utils/bridge';
 import { formatParamValue, truncate } from '../../utils/helpers';
 import { getFileIcon, getFolderIcon } from '../../utils/fileIcons';
@@ -211,7 +212,15 @@ const PatchFileLink = ({ path }: PatchFileLinkProps) => {
 const GenericToolBlock = ({ name, input, result, toolId }: GenericToolBlockProps) => {
   const { t } = useTranslation();
   const lowerName = (name ?? '').toLowerCase();
-  const [expanded, setExpanded] = useState(false);
+  const stateKey = `generic-${toolId ?? lowerName}`;
+  const [expanded, setExpandedRaw] = useState(() => getPersistedExpanded(stateKey));
+  const setExpanded = (v: boolean | ((prev: boolean) => boolean)) => {
+    setExpandedRaw((prev) => {
+      const next = typeof v === 'function' ? v(prev) : v;
+      setPersistedExpanded(stateKey, next);
+      return next;
+    });
+  };
   const isDenied = useIsToolDenied(toolId);
 
   // Ignore write_stdin tool - it's waiting for previous command result

--- a/webview/src/components/toolBlocks/ReadToolBlock.tsx
+++ b/webview/src/components/toolBlocks/ReadToolBlock.tsx
@@ -6,6 +6,7 @@ import { openFile } from '../../utils/bridge';
 import { useResolvedFileLinkTooltip } from '../../hooks/useResolvedFileLinkTooltip';
 import { getFileIcon, getFolderIcon } from '../../utils/fileIcons';
 import { getToolLineInfo, resolveToolTarget } from '../../utils/toolPresentation';
+import { getPersistedExpanded, setPersistedExpanded } from '../../utils/expandedState';
 
 interface ReadToolBlockProps {
   input?: ToolInput;
@@ -65,7 +66,15 @@ const PARAM_VALUE_STYLE: React.CSSProperties = {
 };
 
 const ReadToolBlock = ({ input, result, toolId }: ReadToolBlockProps) => {
-  const [expanded, setExpanded] = useState(false);
+  const stateKey = `read-${toolId ?? 'unknown'}`;
+  const [expanded, setExpandedRaw] = useState(() => getPersistedExpanded(stateKey));
+  const setExpanded = (v: boolean | ((prev: boolean) => boolean)) => {
+    setExpandedRaw((prev) => {
+      const next = typeof v === 'function' ? v(prev) : v;
+      setPersistedExpanded(stateKey, next);
+      return next;
+    });
+  };
   const { t } = useTranslation();
   const isDenied = useIsToolDenied(toolId);
 

--- a/webview/src/components/toolBlocks/TaskExecutionBlock.test.tsx
+++ b/webview/src/components/toolBlocks/TaskExecutionBlock.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render } from '@testing-library/react';
 import TaskExecutionBlock from './TaskExecutionBlock';
+import { clearAllPersistedExpanded } from '../../utils/expandedState';
 
 const mockSendBridgeEvent = vi.fn();
 const mockGetSubagentHistory = vi.fn<(key: string) => unknown>();
@@ -24,6 +25,7 @@ vi.mock('../../contexts/SubagentContext', () => ({
 
 describe('TaskExecutionBlock polling', () => {
   beforeEach(() => {
+    clearAllPersistedExpanded();
     vi.useFakeTimers();
     mockSendBridgeEvent.mockReset();
     mockGetSubagentHistory.mockReset();

--- a/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
+++ b/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
@@ -6,9 +6,6 @@ import { sendBridgeEvent } from '../../utils/bridge';
 import { useSubagentHistoryGetter, useSessionId, useGetToolResultRaw, type GetToolResultRawFn } from '../../contexts/SubagentContext';
 import SubagentProcessDetails from '../StatusPanel/SubagentProcessDetails';
 
-const MONO_FONT_STYLE: React.CSSProperties = {
-  fontFamily: "var(--idea-editor-font-family, 'JetBrains Mono', 'Consolas', monospace)",
-};
 const NORMAL_WEIGHT_STYLE: React.CSSProperties = { fontWeight: 'normal' };
 
 interface TaskExecutionBlockProps {
@@ -214,7 +211,7 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
             <span className="tool-title-summary">· {modelSummary}</span>
           )}
           {shortAgentId && (
-            <span className="tool-title-summary" style={MONO_FONT_STYLE}>
+            <span className="tool-title-summary">
               · {shortAgentId}
             </span>
           )}

--- a/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
+++ b/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { ToolInput, ToolResultBlock } from '../../types';
 import { normalizeToolName } from '../../utils/toolConstants';
 import { sendBridgeEvent } from '../../utils/bridge';
+import { getPersistedExpanded, setPersistedExpanded } from '../../utils/expandedState';
 import { useSubagentHistoryGetter, useSessionId, useGetToolResultRaw, type GetToolResultRawFn } from '../../contexts/SubagentContext';
 import SubagentProcessDetails from '../StatusPanel/SubagentProcessDetails';
 
@@ -120,7 +121,15 @@ function shortenAgentId(agentId?: string): string | undefined {
 
 const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, result, toolId, isStreaming = false }: TaskExecutionBlockProps) {
   const { t } = useTranslation();
-  const [expanded, setExpanded] = useState(false);
+  const stateKey = `task-${toolId ?? 'unknown'}`;
+  const [expanded, setExpandedRaw] = useState(() => getPersistedExpanded(stateKey));
+  const setExpanded = (updater: (prev: boolean) => boolean) => {
+    setExpandedRaw((prev) => {
+      const next = updater(prev);
+      setPersistedExpanded(stateKey, next);
+      return next;
+    });
+  };
   const getSubagentHistory = useSubagentHistoryGetter();
   const currentSessionId = useSessionId();
   const getToolResultRaw = useGetToolResultRaw();

--- a/webview/src/hooks/useChatComputations.ts
+++ b/webview/src/hooks/useChatComputations.ts
@@ -8,7 +8,7 @@ import type {
 import type { GetToolResultRawFn } from '../contexts/SubagentContext';
 import type { RewindableMessage } from '../components/RewindSelectDialog';
 import { formatTime } from '../utils/helpers';
-import { extractTodosFromToolUse } from '../utils/todoToolNormalization';
+import { extractTodosFromToolUse, extractAccumulatedTasks } from '../utils/todoToolNormalization';
 import {
   finalizeSubagentsForSettledTurn,
   finalizeTodosForSettledTurn,
@@ -138,8 +138,15 @@ export function useChatComputations({
       }
       if (latestTodos) break;
     }
-    return finalizeTodosForSettledTurn(latestTodos ?? [], streamingActive);
-  }, [latestTurnMessages, getContentBlocks, streamingActive]);
+    if (latestTodos) {
+      return finalizeTodosForSettledTurn(latestTodos, streamingActive);
+    }
+    const accumulated = extractAccumulatedTasks(messages, getContentBlocks);
+    if (accumulated.length > 0) {
+      return accumulated;
+    }
+    return [];
+  }, [latestTurnMessages, messages, getContentBlocks, streamingActive]);
 
   const canRewindFromMessageIndex = useCallback(
     (userMessageIndex: number) => {

--- a/webview/src/styles/less/components/message.less
+++ b/webview/src/styles/less/components/message.less
@@ -902,7 +902,7 @@
     transition: opacity 0.2s;
     background: transparent;
     font-weight: 500;
-    font-size: 13px;
+    font-size: 14px;
 }
 
 .thinking-header:hover {
@@ -910,7 +910,7 @@
 }
 
 .thinking-icon {
-    font-size: 10px;
+    font-size: 12px;
     opacity: 0.8;
 }
 
@@ -920,7 +920,7 @@
     border-left: 2px solid var(--color-thinking-border);
     color: var(--text-tertiary);
     font-family: inherit;
-    font-size: 12px;
+    font-size: 13px;
     line-height: 1.5;
     word-wrap: break-word;
     overflow-wrap: break-word;

--- a/webview/src/styles/less/components/message.less
+++ b/webview/src/styles/less/components/message.less
@@ -828,34 +828,27 @@
 
 .markdown-content a {
     color: var(--accent-primary, #4ea1ff);
-    text-decoration-line: underline;
-    text-decoration-thickness: 1px;
-    text-underline-offset: 2px;
-    text-decoration-color: currentColor;
+    text-decoration: none;
     word-wrap: break-word;
     overflow-wrap: break-word;
     pointer-events: auto;
     cursor: pointer;
-    transition: color 0.15s ease, text-decoration-thickness 0.15s ease, opacity 0.15s ease;
+    transition: color 0.15s ease, opacity 0.15s ease;
 }
 
 .markdown-content a:hover {
-    text-decoration-thickness: 2px;
     opacity: 0.95;
 }
 
 .markdown-content a.file-link {
-    text-decoration-style: dotted;
     color: var(--color-tool-file-link, var(--accent-primary, #4ea1ff));
 }
 
 .markdown-content a.class-link {
-    text-decoration-style: dashed;
     color: var(--color-tool-class-link, var(--accent-primary, #4ea1ff));
 }
 
 .markdown-content a.url-link {
-    text-decoration-style: solid;
 }
 
 .message.user .markdown-content a {

--- a/webview/src/styles/less/components/message.less
+++ b/webview/src/styles/less/components/message.less
@@ -750,7 +750,7 @@
     background-color: var(--color-code-inline-bg);
     padding: 2px 4px;
     border-radius: 3px;
-    font-size: 12.5px;
+    font-size: 0.9em;
     word-wrap: break-word;
     overflow-wrap: break-word;
 }
@@ -811,9 +811,20 @@
     overflow-wrap: break-word;
 }
 
-.markdown-content h1 { font-size: 1.5em; }
-.markdown-content h2 { font-size: 1.3em; }
+.markdown-content h1 { font-size: 1.6em; }
+.markdown-content h2 { font-size: 1.4em; }
 .markdown-content h3 { font-size: 1.2em; }
+.markdown-content h4 { font-size: 1.1em; }
+.markdown-content h5 { font-size: 1.05em; }
+.markdown-content h6 { font-size: 1em; }
+
+.markdown-content strong {
+    font-weight: 700;
+    color: var(--text-secondary);
+    background-color: var(--color-code-inline-bg);
+    padding: 2px 4px;
+    border-radius: 3px;
+}
 
 .markdown-content a {
     color: var(--accent-primary, #4ea1ff);
@@ -1017,7 +1028,7 @@
     align-items: center;
     gap: 8px;
     padding: 6px 12px;
-    font-size: 13px;
+    font-size: 12px;
     min-width: 0; /* 允许内容缩小 */
 }
 

--- a/webview/src/styles/less/components/task.less
+++ b/webview/src/styles/less/components/task.less
@@ -12,8 +12,8 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 8px 12px;
-    background: var(--bg-primary);
+    padding: 6px 12px;
+    background: var(--bg-secondary);
     cursor: pointer;
     user-select: none;
     transition: background-color 0.2s;

--- a/webview/src/styles/less/components/task.less
+++ b/webview/src/styles/less/components/task.less
@@ -217,13 +217,15 @@
 
 .agent-group-content {
     padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
 
     .task-container {
         margin: 0;
     }
-}
 
-.agent-group-text-block {
-    margin-top: 10px;
-    padding: 0 4px;
+    > .content-block {
+        padding: 0 4px;
+    }
 }

--- a/webview/src/styles/less/components/task.less
+++ b/webview/src/styles/less/components/task.less
@@ -209,3 +209,21 @@
 .edit-group-action-btn:active {
     background: var(--bg-active, var(--bg-secondary));
 }
+
+/* Agent Group Block */
+.agent-group-container {
+    .task-container;
+}
+
+.agent-group-content {
+    padding: 10px;
+
+    .task-container {
+        margin: 0;
+    }
+}
+
+.agent-group-text-block {
+    margin-top: 10px;
+    padding: 0 4px;
+}

--- a/webview/src/styles/less/components/tools.less
+++ b/webview/src/styles/less/components/tools.less
@@ -35,7 +35,7 @@
 /* Bash命令块样式 */
 .bash-tool-header {
     border-bottom: none;
-    background: var(--bg-primary);
+    background: var(--bg-secondary);
 }
 
 .bash-tool-header.expanded {

--- a/webview/src/styles/less/components/tools.less
+++ b/webview/src/styles/less/components/tools.less
@@ -7,7 +7,7 @@
 
 .tool-title-text {
     font-weight: 500;
-    font-size: 13px;
+    font-size: 12px;
     color: var(--text-secondary);
     white-space: nowrap;
 }
@@ -50,7 +50,7 @@
 
 .bash-tool-title {
     font-weight: 500;
-    font-size: 13px;
+    font-size: 12px;
     color: var(--text-secondary);
     white-space: nowrap;
 }

--- a/webview/src/styles/less/variables.less
+++ b/webview/src/styles/less/variables.less
@@ -2,17 +2,17 @@
 /* 暗色主题（默认） */
 :root, [data-theme="dark"] {
     /* 背景色 */
-    --bg-primary: #1e1e1e;
+    --bg-primary: #2C2C2CFF;
     --bg-chat: var(--bg-primary);
-    --bg-secondary: #252526;
-    --bg-tertiary: #2b2d31;
-    --bg-elevated: #2d2d2d;
+    --bg-secondary: #3D3F41FF;
+    --bg-tertiary: #3D3F41FF;
+    --bg-elevated: #3D3F41FF;
     --bg-hover: #35373c;
     --bg-active: #37373d;
 
     /* 文字颜色 */
-    --text-primary: #cccccc;
-    --text-secondary: #e0e0e0;
+    --text-primary: #b4b4b4;
+    --text-secondary: #c9c8c8;
     --text-tertiary: #858585;
     --text-muted: #666;
     --text-placeholder: #6e6e6e;
@@ -51,12 +51,12 @@
     --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
 
     /* 滚动条 */
-    --scrollbar-track: #1e1e1e;
-    --scrollbar-thumb: #424242;
-    --scrollbar-thumb-hover: #4f4f4f;
+    --scrollbar-track: var(--bg-primary);
+    --scrollbar-thumb: var(--bg-secondary);
+    --scrollbar-thumb-hover: #484949;
 
     /* 代码块颜色 */
-    --color-code-block-bg: #1e1e1e;
+    --color-code-block-bg: var(--bg-primary);
     --color-code-block-border: #333;
     --color-code-inline-bg: rgba(255, 255, 255, 0.1);
 
@@ -146,7 +146,7 @@
     --color-scroll-control-icon: #b0b0b0;
 
     /* Toast 颜色 */
-    --color-toast-info-border: #4a90e2;
+    --color-toast-info-border: #333333;
     --color-toast-success-border: #4caf50;
     --color-toast-warning-border: #ff9800;
     --color-toast-error-border: #f44336;
@@ -190,9 +190,9 @@
 /* 亮色主题 */
 [data-theme="light"] {
     /* 背景色 */
-    --bg-primary: #ffffff;
+    --bg-primary: #b4b4b4;
     --bg-chat: var(--bg-primary);
-    --bg-secondary: #f3f3f3;
+    --bg-secondary: #c9c8c8;
     --bg-tertiary: #e8e8e8;
     --bg-elevated: #f5f5f5;
     --bg-hover: #e0e0e0;

--- a/webview/src/styles/less/variables.less
+++ b/webview/src/styles/less/variables.less
@@ -99,8 +99,8 @@
     --color-warning-button-hover: #e65100;
 
     /* 消息颜色 */
-    --color-message-user-bg: #005fb8;
-    --color-message-user-text: #ffffff;
+    --color-message-user-bg: #3b4754;
+    --color-message-user-text: #bbbbbb;
     --color-message-user-code-bg: rgba(0, 0, 0, 0.2);
     --color-message-user-code-border: rgba(255, 255, 255, 0.1);
     --color-message-error-border: #d32f2f;

--- a/webview/src/utils/expandedState.ts
+++ b/webview/src/utils/expandedState.ts
@@ -1,0 +1,13 @@
+const expandedState = new Map<string, boolean>();
+
+export function getPersistedExpanded(key: string): boolean {
+  return expandedState.get(key) ?? false;
+}
+
+export function setPersistedExpanded(key: string, value: boolean): void {
+  expandedState.set(key, value);
+}
+
+export function clearAllPersistedExpanded(): void {
+  expandedState.clear();
+}

--- a/webview/src/utils/linkify.test.ts
+++ b/webview/src/utils/linkify.test.ts
@@ -119,7 +119,7 @@ describe('linkify', () => {
     root.innerHTML = [
       '<p>Open src/components/App.tsx and com.github.foo.BarService</p>',
       '<p><a href="https://example.com/docs">docs</a></p>',
-      '<p><code>src/inline-code.ts</code> should be linkified</p>',
+      '<p><code>src/inline-code.ts</code> should NOT be linkified</p>',
       '<pre>com.github.foo.IgnoredService</pre>',
     ].join('');
 
@@ -129,8 +129,8 @@ describe('linkify', () => {
     expect(root.querySelector('a.file-link')?.textContent).toBe('src/components/App.tsx');
     expect(root.querySelector('a.class-link')?.textContent).toBe('com.github.foo.BarService');
     expect(root.querySelector('a.url-link')?.getAttribute('data-linkify')).toBe('url');
-    // Inline code content should be linkified
-    expect(root.querySelector('code a.file-link')?.textContent).toBe('src/inline-code.ts');
+    // Inline code content should NOT be linkified
+    expect(root.querySelector('code a.file-link')).toBeNull();
     // Code fence (pre) content should NOT be linkified
     expect(root.querySelector('pre a')).toBeNull();
   });

--- a/webview/src/utils/linkify.ts
+++ b/webview/src/utils/linkify.ts
@@ -177,7 +177,7 @@ function createGlobalRegex(regex: RegExp): RegExp {
   return new RegExp(regex.source, flags);
 }
 
-function escapeHtml(value: string): string {
+export function escapeHtml(value: string): string {
   return value.replace(/[&<>"']/g, (char) => HTML_ESCAPE_LOOKUP[char] ?? char);
 }
 
@@ -420,9 +420,8 @@ function shouldSkipTextNode(textNode: Text): boolean {
     return true;
   }
 
-  // Skip anchors (already linked) and code fences (pre blocks)
-  // Note: <code> is NOT skipped - inline code content should be linkified
-  return parentElement.closest('a, pre') !== null;
+  // Skip anchors (already linked), code fences (pre blocks), and inline code
+  return parentElement.closest('a, pre, code') !== null;
 }
 
 export function parseFileLinkTarget(value: string): FileLinkTarget | null {

--- a/webview/src/utils/todoToolNormalization.ts
+++ b/webview/src/utils/todoToolNormalization.ts
@@ -1,5 +1,5 @@
-import type { ClaudeContentBlock, TodoItem, ToolInput } from '../types';
-import { normalizeToolName } from './toolConstants';
+import type { ClaudeContentBlock, ClaudeMessage, TodoItem, ToolInput } from '../types';
+import { normalizeToolName, TASK_MANAGE_TOOL_NAMES } from './toolConstants';
 import { normalizeTodoStatus } from './todoShared';
 import type { RawTodoItem } from './todoShared';
 
@@ -58,4 +58,50 @@ export function extractTodosFromToolUse(block: ClaudeContentBlock): TodoItem[] |
   }
 
   return null;
+}
+
+export function isTaskManageTool(block: ClaudeContentBlock): boolean {
+  if (block.type !== 'tool_use') return false;
+  return TASK_MANAGE_TOOL_NAMES.has(normalizeToolName(block.name ?? ''));
+}
+
+export function extractAccumulatedTasks(
+  messages: ClaudeMessage[],
+  getContentBlocks: (msg: ClaudeMessage) => ClaudeContentBlock[],
+): TodoItem[] {
+  const tasks = new Map<string, TodoItem>();
+  let nextId = 1;
+
+  for (const msg of messages) {
+    if (msg.type !== 'assistant') continue;
+    const blocks = getContentBlocks(msg);
+    for (const block of blocks) {
+      if (block.type !== 'tool_use') continue;
+      const toolName = normalizeToolName(block.name ?? '');
+      const input = (block.input ?? {}) as ToolInput;
+
+      if (toolName === 'taskcreate') {
+        const subject = typeof input.subject === 'string' ? input.subject.trim() : '';
+        if (!subject) continue;
+        const id = String(nextId++);
+        tasks.set(id, { id, content: subject, status: 'pending' });
+      } else if (toolName === 'taskupdate') {
+        const taskId = typeof input.taskId === 'string' ? input.taskId : '';
+        if (!taskId || !tasks.has(taskId)) continue;
+        const task = tasks.get(taskId)!;
+        if (input.status === 'deleted') {
+          tasks.delete(taskId);
+        } else {
+          if (typeof input.status === 'string') {
+            task.status = normalizeTodoStatus(input.status);
+          }
+          if (typeof input.subject === 'string' && input.subject.trim()) {
+            task.content = input.subject.trim();
+          }
+        }
+      }
+    }
+  }
+
+  return Array.from(tasks.values());
 }

--- a/webview/src/utils/toolConstants.ts
+++ b/webview/src/utils/toolConstants.ts
@@ -25,6 +25,9 @@ export const TRANSIENT_INTERNAL_TOOL_NAMES = new Set([
   'multi_tool_use.parallel',
 ]);
 
+// Task management tools (incremental create/update, shown in StatusPanel)
+export const TASK_MANAGE_TOOL_NAMES = new Set(['taskcreate', 'taskupdate']);
+
 // File modification tools (for rewind feature - includes write for new file creation)
 export const FILE_MODIFY_TOOL_NAMES = new Set([
   'write',

--- a/webview/src/utils/toolConstants.ts
+++ b/webview/src/utils/toolConstants.ts
@@ -28,6 +28,9 @@ export const TRANSIENT_INTERNAL_TOOL_NAMES = new Set([
 // Task management tools (incremental create/update, shown in StatusPanel)
 export const TASK_MANAGE_TOOL_NAMES = new Set(['taskcreate', 'taskupdate']);
 
+// Agent/subagent tools
+export const AGENT_TOOL_NAMES = new Set(['task', 'agent', 'spawn_agent']);
+
 // File modification tools (for rewind feature - includes write for new file creation)
 export const FILE_MODIFY_TOOL_NAMES = new Set([
   'write',


### PR DESCRIPTION
背景: https://code.claude.com/docs/zh-CN/agent-sdk/todo-tracking 
截至 TypeScript Agent SDK 0.3.142 和 Claude Code v2.1.142，会话使用结构化的 Task 工具 TaskCreate、TaskUpdate、TaskGet 和 TaskList，而不是 TodoWrite。请参阅迁移到 Task 工具了解监控代码如何变化。本页面上的示例设置 CLAUDE_CODE_ENABLE_TASKS=0 以继续为尚未迁移的会话显示 TodoWrite。

1. 新增 `TASK_MANAGE_TOOL_NAMES` 常量集合，用于定义 `taskcreate` 和 `taskupdate` 两类任务管理工具
2. 在 `ContentBlockRenderer` 中隐藏任务管理工具对应的 `tool_use` 块，不进行渲染
3. 新增 `isTaskManageTool` 函数和 `extractAccumulatedTasks` 工具函数，用于从消息中提取并合并任务管理工具产生的待办事项（支持任务创建、状态更新和删除）
4. 在 `useChatComputations` 中，当常规待办事项为空时，回退使用 `extractAccumulatedTasks` 获取累计任务列表，确保任务状态能正确显示