### PR TITLE
fix(webview): distinguish stream replay from new turn in onStreamStart

### DIFF
--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -514,7 +514,7 @@ public class ChatWindowDelegate {
             boolean streamActive = host.getStreamCoalescer().isStreamActive();
             if (streamActive) {
                 LOG.debug("Replaying streaming state to frontend (session was actively streaming during reload)");
-                host.callJavaScript("onStreamStart");
+                host.callJavaScript("onStreamStart", "replay");
             }
 
             LOG.info("Replayed current session state to frontend: sessionId="

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -595,7 +595,7 @@ interface Window {
   /**
    * Stream start callback - called when streaming begins
    */
-  onStreamStart?: () => void;
+  onStreamStart?: (mode?: string | boolean) => void;
 
   /**
    * Content delta callback - called when a content delta is received

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -728,7 +728,7 @@ describe('useWindowCallbacks integration', () => {
     renderHook(() => useWindowCallbacks(opts));
 
     act(() => {
-      window.onStreamStart?.();
+      window.onStreamStart?.('replay');
     });
 
     expect(opts.setMessages).toHaveBeenCalledTimes(1);
@@ -744,6 +744,42 @@ describe('useWindowCallbacks integration', () => {
     expect(nextMessages[1]).toMatchObject({
       type: 'assistant',
       content: 'partial answer',
+      isStreaming: true,
+      __turnId: 1,
+    });
+  });
+
+  it('starts a fresh assistant message for a new turn instead of reusing the previous completed assistant', () => {
+    const opts = createOptions();
+    renderHook(() => useWindowCallbacks(opts));
+
+    act(() => {
+      window.onStreamStart?.();
+    });
+
+    expect(opts.setMessages).toHaveBeenCalledTimes(1);
+    const updater = (opts.setMessages as any).mock.calls[0][0] as (messages: ClaudeMessage[]) => ClaudeMessage[];
+    const previousMessages: ClaudeMessage[] = [
+      { type: 'user', content: 'previous question', timestamp: '2026-04-27T00:00:00.000Z' },
+      {
+        type: 'assistant',
+        content: 'previous answer',
+        timestamp: '2026-04-27T00:00:01.000Z',
+        durationMs: 1200,
+      },
+    ];
+
+    const nextMessages = updater(previousMessages);
+
+    expect(nextMessages).toHaveLength(3);
+    expect(nextMessages[1]).toMatchObject({
+      type: 'assistant',
+      content: 'previous answer',
+    });
+    expect(nextMessages[1]?.isStreaming).not.toBe(true);
+    expect(nextMessages[2]).toMatchObject({
+      type: 'assistant',
+      content: '',
       isStreaming: true,
       __turnId: 1,
     });

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
@@ -194,8 +194,9 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     }, STREAM_STALL_CHECK_INTERVAL_MS);
   };
 
-  window.onStreamStart = () => {
+  window.onStreamStart = (mode?: string | boolean) => {
     if (window.__sessionTransitioning) return;
+    const isReplayStart = mode === 'replay' || mode === true;
     // Clear any stale pending updateMessages from previous turn.
     // This prevents onStreamEnd from using outdated snapshot data.
     if (typeof window.__cancelPendingUpdateMessages === 'function') {
@@ -225,7 +226,7 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     streamingTurnIdRef.current = turnIdCounterRef.current;
     setMessages((prev) => {
       const last = prev[prev.length - 1];
-      if (last?.type === 'assistant') {
+      if (isReplayStart && last?.type === 'assistant') {
         streamingMessageIndexRef.current = prev.length - 1;
         const updated = [...prev];
         updated[prev.length - 1] = {


### PR DESCRIPTION
When the frontend reloads mid-stream, Java sends onStreamStart("replay") to reuse the existing assistant message. For new turns without this flag, a fresh empty assistant message is now appended instead of overwriting the previous completed response.