### PR TITLE
feat: allow overriding the Claude Code CLI executable + add Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+.git
+.github
+.idea
+.agents
+
+# Build outputs — must be regenerated inside the container.
+build/
+out/
+**/dist/
+**/node_modules/
+
+# Host-only / IDE files.
+local.properties
+*.iml
+.gradle/
+
+# Docs/media not needed for the build.
+docs/
+*.md
+
+# Misc
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# Builds the CC GUI IntelliJ plugin distribution (.zip) inside a container.
+#
+# Build the image:
+#   docker build -t cc-gui-build .
+#
+# Produce the plugin zip into ./dist on the host:
+#   mkdir -p dist && docker run --rm -v "$(pwd)/dist:/out" cc-gui-build
+#
+# Target a different IDE (IC = IntelliJ Community [default], PC, PY, RD):
+#   docker run --rm -v "$(pwd)/dist:/out" -e TARGET_IDE=PC cc-gui-build
+
+FROM eclipse-temurin:17-jdk-jammy AS build
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.welcome=never"
+
+# Node.js 20.x + zip/unzip (zip is invoked by the packageAiBridge Gradle task).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        curl ca-certificates gnupg git zip unzip \
+ && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/* \
+ && node --version && npm --version && java -version
+
+WORKDIR /workspace
+
+# Install npm deps first so they cache independently of source changes.
+COPY webview/package.json   webview/package-lock.json   webview/
+COPY ai-bridge/package.json ai-bridge/package-lock.json ai-bridge/
+
+# Use `npm install` (not `npm ci`) because the upstream lockfiles drift from
+# package.json — `npm ci` aborts on any missing transitive entry, which makes
+# the container build fail on a repo issue rather than a real problem.
+RUN cd webview   && npm install --no-audit --no-fund
+RUN cd ai-bridge && npm install --no-audit --no-fund
+
+# Now bring in the rest of the sources. .dockerignore keeps host build/ and
+# node_modules/ out so the container build is reproducible.
+COPY . .
+
+RUN chmod +x gradlew
+
+ARG TARGET_IDE=IC
+ENV TARGET_IDE=${TARGET_IDE}
+
+# buildPlugin transitively runs buildWebview + packageAiBridge.
+RUN ./gradlew --no-daemon -PtargetIde=${TARGET_IDE} clean buildPlugin
+
+# Default entrypoint: copy the produced artifact to a bind-mounted /out.
+CMD ["bash", "-lc", "mkdir -p /out && cp build/distributions/*.zip /out/ && ls -lh /out/"]

--- a/ai-bridge/services/claude/message-rewind.js
+++ b/ai-bridge/services/claude/message-rewind.js
@@ -10,6 +10,7 @@ import { setupApiKey, buildCliEnv } from '../../config/api-config.js';
 import { getClaudeDir, getRealHomeDir, selectWorkingDirectory } from '../../utils/path-utils.js';
 import { ensureClaudeSdk, hasClaudeProjectSessionFile, waitForClaudeProjectSessionFile, isNoConversationFoundError } from './message-utils.js';
 import { getActiveQueryResult, getActiveSessionIds } from './message-session-registry.js';
+import { getClaudeCliPathOverride } from '../../utils/claude-cli-path.js';
 
 export async function rewindFiles(sessionId, userMessageId, cwd = null) {
   let result = null;
@@ -47,6 +48,7 @@ export async function rewindFiles(sessionId, userMessageId, cwd = null) {
           await waitForClaudeProjectSessionFile(sessionId, workingDirectory, 2500, 100);
         }
 
+        const claudeCliOverride = getClaudeCliPathOverride();
         const options = {
           resume: sessionId,
           cwd: workingDirectory,
@@ -69,7 +71,8 @@ export async function rewindFiles(sessionId, userMessageId, cwd = null) {
             if (data && data.trim()) {
               console.log(`[SDK-STDERR] ${data.trim()}`);
             }
-          }
+          },
+          ...(claudeCliOverride && { pathToClaudeCodeExecutable: claudeCliOverride })
         };
 
         console.log('[REWIND] Resuming session with options:', JSON.stringify(options));

--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -32,6 +32,7 @@ import { loadMcpServersConfigAsRecord } from './mcp-status/config-loader.js';
 import { setActiveQueryResult } from './message-session-registry.js';
 import { normalizeStreamDelta, rememberStreamSnapshot } from './stream-delta-normalizer.js';
 import { generateSessionTitle } from '../session-title-service.js';
+import { getClaudeCliPathOverride } from '../../utils/claude-cli-path.js';
 
 // ========== Internal helpers for deduplication ==========
 
@@ -62,6 +63,7 @@ function resolveThinkingConfig(settings) {
  * Build query options object shared by both send functions.
  */
 function buildQueryOptions({ workingDirectory, permissionMode, sdkModelName, maxThinkingTokens, streamingEnabled, systemPromptAppend, preToolUseHook, sdkStderrLines, mcpServers }) {
+  const claudeCliOverride = getClaudeCliPathOverride();
   return {
     cwd: workingDirectory,
     permissionMode,
@@ -78,6 +80,7 @@ function buildQueryOptions({ workingDirectory, permissionMode, sdkModelName, max
     hooks: { PreToolUse: [{ hooks: [preToolUseHook] }] },
     settingSources: ['user', 'project', 'local'],
     ...(mcpServers && { mcpServers }),
+    ...(claudeCliOverride && { pathToClaudeCodeExecutable: claudeCliOverride }),
     systemPrompt: {
       type: 'preset',
       preset: 'claude_code',

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -52,6 +52,7 @@ import {
   shouldOutputMessage,
 } from './stream-event-processor.js';
 import { generateSessionTitle } from '../session-title-service.js';
+import { getClaudeCliPathOverride } from '../../utils/claude-cli-path.js';
 
 const SUPPORTED_EFFORT_LEVELS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
 
@@ -114,6 +115,7 @@ function resolveRequestModelState(modelId, settingsEnv) {
 }
 
 function buildQueryOptions(workingDirectory, sdkModelName, permissionMode, maxThinkingTokens, reasoningEffort, streamingEnabled, systemPromptAppend, requestedSessionId, mcpServers) {
+  const claudeCliOverride = getClaudeCliPathOverride();
   return {
     cwd: workingDirectory,
     permissionMode,
@@ -132,6 +134,7 @@ function buildQueryOptions(workingDirectory, sdkModelName, permissionMode, maxTh
     canUseTool,
     settingSources: ['user', 'project', 'local'],
     ...(mcpServers && { mcpServers }),
+    ...(claudeCliOverride && { pathToClaudeCodeExecutable: claudeCliOverride }),
     systemPrompt: {
       type: 'preset',
       preset: 'claude_code',

--- a/ai-bridge/services/prompt-enhancer.js
+++ b/ai-bridge/services/prompt-enhancer.js
@@ -20,6 +20,7 @@ import {
 import { setupApiKey, buildCliEnv } from '../config/api-config.js';
 import { mapModelIdToSdkName } from '../utils/model-utils.js';
 import { getRealHomeDir } from '../utils/path-utils.js';
+import { getClaudeCliPathOverride } from '../utils/claude-cli-path.js';
 import { buildCodexCliEnvironment } from './codex/codex-utils.js';
 
 let claudeSdk = null;
@@ -312,6 +313,7 @@ async function enhancePromptWithClaude(originalPrompt, systemPrompt, model, cont
   const fullPrompt = buildFullPrompt(originalPrompt, context);
   console.log(`[PromptEnhancer] Full prompt length: ${fullPrompt.length}`);
 
+  const claudeCliOverride = getClaudeCliPathOverride();
   const options = {
     cwd: workingDirectory,
     permissionMode: 'bypassPermissions',
@@ -320,6 +322,7 @@ async function enhancePromptWithClaude(originalPrompt, systemPrompt, model, cont
     env: buildCliEnv(),
     systemPrompt,
     settingSources: ['user', 'project', 'local'],
+    ...(claudeCliOverride && { pathToClaudeCodeExecutable: claudeCliOverride }),
   };
 
   console.log('[PromptEnhancer] Calling Claude Agent SDK...');

--- a/ai-bridge/utils/claude-cli-path.js
+++ b/ai-bridge/utils/claude-cli-path.js
@@ -1,0 +1,15 @@
+/**
+ * Resolves the user-configured Claude Code CLI executable, if any.
+ *
+ * The Java daemon sets CLAUDE_CODE_PATH when the user has provided a custom
+ * path in Settings > Basic. When set, the Claude Agent SDK is told to spawn
+ * that binary instead of its bundled CLI via `pathToClaudeCodeExecutable`.
+ *
+ * Returns null when unset/blank so callers can spread the field conditionally.
+ */
+export function getClaudeCliPathOverride() {
+  const raw = process.env.CLAUDE_CODE_PATH;
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/src/main/java/com/github/claudecodegui/handler/ClaudeCliPathHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/ClaudeCliPathHandler.java
@@ -1,0 +1,152 @@
+package com.github.claudecodegui.handler;
+
+import com.github.claudecodegui.handler.core.HandlerContext;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.util.concurrency.AppExecutorUtil;
+
+import java.io.File;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Handles persistence of a user-provided Claude Code CLI executable path.
+ *
+ * <p>When set, the daemon spawns its Claude Agent SDK with
+ * {@code pathToClaudeCodeExecutable} pointing at this binary, overriding the
+ * SDK's bundled CLI. Persisted in {@link PropertiesComponent} under
+ * {@link #CLAUDE_CLI_PATH_PROPERTY_KEY}; mirrors {@link NodePathHandler}.
+ */
+public class ClaudeCliPathHandler {
+
+    private static final Logger LOG = Logger.getInstance(ClaudeCliPathHandler.class);
+
+    public static final String CLAUDE_CLI_PATH_PROPERTY_KEY = "claude.code.cli.path";
+
+    private final HandlerContext context;
+    private final Gson gson = new Gson();
+
+    public ClaudeCliPathHandler(HandlerContext context) {
+        this.context = context;
+    }
+
+    /**
+     * Get the configured Claude CLI path (empty string when unset).
+     */
+    public void handleGetClaudeCliPath() {
+        CompletableFuture.runAsync(() -> {
+            try {
+                String saved = PropertiesComponent.getInstance().getValue(CLAUDE_CLI_PATH_PROPERTY_KEY);
+                String pathToSend = (saved != null) ? saved.trim() : "";
+
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    JsonObject response = new JsonObject();
+                    response.addProperty("path", pathToSend);
+                    context.callJavaScript("window.updateClaudeCliPath", context.escapeJs(gson.toJson(response)));
+                });
+            } catch (Exception e) {
+                LOG.error("[ClaudeCliPathHandler] Failed to get Claude CLI path: " + e.getMessage(), e);
+                ApplicationManager.getApplication().invokeLater(() ->
+                    context.callJavaScript("window.showError", context.escapeJs("Failed to load Claude CLI path: " + e.getMessage()))
+                );
+            }
+        }, AppExecutorUtil.getAppExecutorService()).exceptionally(ex -> {
+            LOG.error("[ClaudeCliPathHandler] Unexpected error in handleGetClaudeCliPath: " + ex.getMessage(), ex);
+            return null;
+        });
+    }
+
+    /**
+     * Persist a custom Claude CLI path. Validates that the path points at an
+     * existing file (when non-empty), then shuts down the daemon so the next
+     * request picks up the new {@code CLAUDE_CODE_PATH} env var.
+     */
+    public void handleSetClaudeCliPath(String content) {
+        String parsedPath = null;
+        try {
+            JsonObject json = gson.fromJson(content, JsonObject.class);
+            if (json != null && json.has("path") && !json.get("path").isJsonNull()) {
+                parsedPath = json.get("path").getAsString();
+            }
+        } catch (Exception e) {
+            LOG.error("[ClaudeCliPathHandler] Failed to parse set_claude_cli_path content: " + e.getMessage(), e);
+            ApplicationManager.getApplication().invokeLater(() ->
+                context.callJavaScript("window.showError", context.escapeJs("Failed to save Claude CLI path: " + e.getMessage()))
+            );
+            return;
+        }
+        final String pathArg = (parsedPath != null) ? parsedPath.trim() : null;
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                PropertiesComponent props = PropertiesComponent.getInstance();
+                String finalPath = "";
+                boolean success = false;
+                String failureMsg = null;
+
+                if (pathArg == null || pathArg.isEmpty()) {
+                    props.unsetValue(CLAUDE_CLI_PATH_PROPERTY_KEY);
+                    LOG.info("[ClaudeCliPathHandler] Cleared custom Claude CLI path");
+                    success = true;
+                } else {
+                    File f = new File(pathArg);
+                    if (!f.exists()) {
+                        failureMsg = "File does not exist: " + pathArg;
+                    } else if (f.isDirectory()) {
+                        failureMsg = "Path is a directory, expected an executable file: " + pathArg;
+                    } else if (!f.canExecute()) {
+                        failureMsg = "File is not executable (check permissions): " + pathArg;
+                    } else {
+                        props.setValue(CLAUDE_CLI_PATH_PROPERTY_KEY, pathArg);
+                        finalPath = pathArg;
+                        success = true;
+                        LOG.info("[ClaudeCliPathHandler] Saved custom Claude CLI path: " + pathArg);
+                    }
+                }
+
+                // Restart the daemon so CLAUDE_CODE_PATH is re-injected on next request.
+                // The env var is read at daemon spawn, so an in-flight daemon retains the
+                // old value until we tear it down. shutdownDaemon() is safe: the next
+                // request triggers a fresh start via ClaudeDaemonCoordinator.
+                if (success) {
+                    try {
+                        context.getClaudeSDKBridge().shutdownDaemon();
+                    } catch (Exception e) {
+                        LOG.warn("[ClaudeCliPathHandler] Failed to shutdown daemon after path change: " + e.getMessage());
+                    }
+                }
+
+                final boolean successFlag = success;
+                final String failureMsgFinal = failureMsg;
+                final String finalPathToSend = finalPath;
+
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    JsonObject response = new JsonObject();
+                    response.addProperty("path", finalPathToSend);
+                    context.callJavaScript("window.updateClaudeCliPath", context.escapeJs(gson.toJson(response)));
+
+                    if (successFlag) {
+                        String msg = finalPathToSend.isEmpty()
+                            ? "Claude CLI path cleared, using bundled SDK"
+                            : "Claude CLI path saved: " + finalPathToSend;
+                        context.callJavaScript("window.showSwitchSuccess", context.escapeJs(msg));
+                    } else {
+                        String msg = failureMsgFinal != null ? failureMsgFinal : "Invalid Claude CLI path";
+                        context.callJavaScript("window.showError", context.escapeJs(msg));
+                    }
+                });
+            } catch (Exception e) {
+                LOG.error("[ClaudeCliPathHandler] Failed to set Claude CLI path: " + e.getMessage(), e);
+                ApplicationManager.getApplication().invokeLater(() ->
+                    context.callJavaScript("window.showError", context.escapeJs("Failed to save Claude CLI path: " + e.getMessage()))
+                );
+            }
+        }, AppExecutorUtil.getAppExecutorService()).exceptionally(ex -> {
+            LOG.error("[ClaudeCliPathHandler] Unexpected error in handleSetClaudeCliPath: " + ex.getMessage(), ex);
+            return null;
+        });
+    }
+}

--- a/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
@@ -26,6 +26,7 @@ public class SettingsHandler extends BaseMessageHandler {
     private final PermissionModeHandler permissionModeHandler;
     private final ModelProviderHandler modelProviderHandler;
     private final NodePathHandler nodePathHandler;
+    private final ClaudeCliPathHandler claudeCliPathHandler;
     private final ProjectConfigHandler projectConfigHandler;
 
     private static final String[] SUPPORTED_TYPES = {
@@ -36,6 +37,8 @@ public class SettingsHandler extends BaseMessageHandler {
         "set_reasoning_effort",
         "get_node_path",
         "set_node_path",
+        "get_claude_cli_path",
+        "set_claude_cli_path",
         "get_usage_statistics",
         "get_working_directory",
         "set_working_directory",
@@ -94,6 +97,7 @@ public class SettingsHandler extends BaseMessageHandler {
         this.permissionModeHandler = new PermissionModeHandler(context);
         this.modelProviderHandler = new ModelProviderHandler(context, usagePushService);
         this.nodePathHandler = new NodePathHandler(context);
+        this.claudeCliPathHandler = new ClaudeCliPathHandler(context);
         this.projectConfigHandler = new ProjectConfigHandler(context);
         // Register theme change listener to automatically notify frontend when IDE theme changes
         registerThemeChangeListener();
@@ -141,6 +145,13 @@ public class SettingsHandler extends BaseMessageHandler {
                 return true;
             case "set_node_path":
                 nodePathHandler.handleSetNodePath(content);
+                return true;
+            // Claude CLI path
+            case "get_claude_cli_path":
+                claudeCliPathHandler.handleGetClaudeCliPath();
+                return true;
+            case "set_claude_cli_path":
+                claudeCliPathHandler.handleSetClaudeCliPath(content);
                 return true;
             // Project configuration
             case "get_usage_statistics":

--- a/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
@@ -3,9 +3,11 @@ package com.github.claudecodegui.provider.common;
 import com.github.claudecodegui.bridge.BridgeDirectoryResolver;
 import com.github.claudecodegui.bridge.EnvironmentConfigurator;
 import com.github.claudecodegui.bridge.NodeDetector;
+import com.github.claudecodegui.handler.ClaudeCliPathHandler;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.diagnostic.Logger;
 
 import java.io.*;
@@ -129,6 +131,15 @@ public class DaemonBridge {
                 // Configure environment
                 Map<String, String> env = pb.environment();
                 envConfigurator.updateProcessEnvironment(pb, nodePath);
+
+                // Pass through user-configured Claude Code CLI override (if any).
+                // Picked up by ai-bridge to set SDK option `pathToClaudeCodeExecutable`.
+                String claudeCliPath = PropertiesComponent.getInstance()
+                        .getValue(ClaudeCliPathHandler.CLAUDE_CLI_PATH_PROPERTY_KEY);
+                if (claudeCliPath != null && !claudeCliPath.trim().isEmpty()) {
+                    env.put("CLAUDE_CODE_PATH", claudeCliPath.trim());
+                    LOG.info("[DaemonBridge] Using custom Claude CLI: " + claudeCliPath.trim());
+                }
 
                 // Keep stderr separate for debugging
                 pb.redirectErrorStream(false);

--- a/webview/src/components/settings/BasicConfigSection/EnvironmentTab.tsx
+++ b/webview/src/components/settings/BasicConfigSection/EnvironmentTab.tsx
@@ -8,6 +8,10 @@ export interface EnvironmentTabProps {
   savingNodePath: boolean;
   nodeVersion?: string | null;
   minNodeVersion?: number;
+  claudeCliPath?: string;
+  onClaudeCliPathChange?: (path: string) => void;
+  onSaveClaudeCliPath?: () => void;
+  savingClaudeCliPath?: boolean;
   workingDirectory?: string;
   onWorkingDirectoryChange?: (dir: string) => void;
   onSaveWorkingDirectory?: () => void;
@@ -21,6 +25,10 @@ const EnvironmentTab = ({
   savingNodePath,
   nodeVersion,
   minNodeVersion = 18,
+  claudeCliPath = '',
+  onClaudeCliPathChange = () => {},
+  onSaveClaudeCliPath = () => {},
+  savingClaudeCliPath = false,
   workingDirectory = '',
   onWorkingDirectoryChange = () => {},
   onSaveWorkingDirectory = () => {},
@@ -87,6 +95,39 @@ const EnvironmentTab = ({
           <span>
             {t('settings.basic.nodePath.hint')} <code>{t('settings.basic.nodePath.hintCommand')}</code> {t('settings.basic.nodePath.hintText')}
           </span>
+        </small>
+      </div>
+
+      {/* Custom Claude CLI path */}
+      <div className={styles.nodePathSection}>
+        <div className={styles.fieldHeader}>
+          <span className="codicon codicon-rocket" />
+          <span className={styles.fieldLabel}>{t('settings.basic.claudeCliPath.label')}</span>
+        </div>
+        <div className={styles.nodePathInputWrapper}>
+          <input
+            type="text"
+            className={styles.nodePathInput}
+            placeholder={t('settings.basic.claudeCliPath.placeholder')}
+            value={claudeCliPath}
+            onChange={(e) => onClaudeCliPathChange(e.target.value)}
+          />
+          <button
+            className={styles.saveBtn}
+            onClick={onSaveClaudeCliPath}
+            disabled={savingClaudeCliPath}
+          >
+            {savingClaudeCliPath && (
+              <span
+                className="codicon codicon-loading codicon-modifier-spin"
+              />
+            )}
+            {t('common.save')}
+          </button>
+        </div>
+        <small className={styles.formHint}>
+          <span className="codicon codicon-info" />
+          <span>{t('settings.basic.claudeCliPath.hint')}</span>
         </small>
       </div>
 

--- a/webview/src/components/settings/BasicConfigSection/index.tsx
+++ b/webview/src/components/settings/BasicConfigSection/index.tsx
@@ -26,6 +26,10 @@ interface BasicConfigSectionProps {
   savingNodePath: boolean;
   nodeVersion?: string | null;
   minNodeVersion?: number;
+  claudeCliPath?: string;
+  onClaudeCliPathChange?: (path: string) => void;
+  onSaveClaudeCliPath?: () => void;
+  savingClaudeCliPath?: boolean;
   workingDirectory?: string;
   onWorkingDirectoryChange?: (dir: string) => void;
   onSaveWorkingDirectory?: () => void;
@@ -175,6 +179,10 @@ const BasicConfigSection = (props: BasicConfigSectionProps) => {
           savingNodePath={props.savingNodePath}
           nodeVersion={props.nodeVersion}
           minNodeVersion={props.minNodeVersion}
+          claudeCliPath={props.claudeCliPath}
+          onClaudeCliPathChange={props.onClaudeCliPathChange}
+          onSaveClaudeCliPath={props.onSaveClaudeCliPath}
+          savingClaudeCliPath={props.savingClaudeCliPath}
           workingDirectory={props.workingDirectory}
           onWorkingDirectoryChange={props.onWorkingDirectoryChange}
           onSaveWorkingDirectory={props.onSaveWorkingDirectory}

--- a/webview/src/components/settings/hooks/useSettingsBasicActions.ts
+++ b/webview/src/components/settings/hooks/useSettingsBasicActions.ts
@@ -36,6 +36,8 @@ export interface UseSettingsBasicActionsReturn {
   nodeVersion: string | null;
   minNodeVersion: number;
   savingNodePath: boolean;
+  claudeCliPath: string;
+  savingClaudeCliPath: boolean;
   workingDirectory: string;
   savingWorkingDirectory: boolean;
   editorFontConfig:
@@ -77,6 +79,7 @@ export interface UseSettingsBasicActionsReturn {
   // Handler functions (public API for components)
   // =========================================================================
   handleSaveNodePath: () => void;
+  handleSaveClaudeCliPath: () => void;
   handleSaveWorkingDirectory: () => void;
   handleUiFontSelectionChange: (selection: string) => void;
   handleSaveUiFontCustomPath: (path: string) => void;
@@ -115,6 +118,8 @@ export interface UseSettingsBasicActionsReturn {
   /** @internal */ setNodeVersion: (version: string | null) => void;
   /** @internal */ setMinNodeVersion: (version: number) => void;
   /** @internal */ setSavingNodePath: (saving: boolean) => void;
+  /** @internal */ setClaudeCliPath: (path: string) => void;
+  /** @internal */ setSavingClaudeCliPath: (saving: boolean) => void;
   /** @internal */ setWorkingDirectory: (dir: string) => void;
   /** @internal */ setSavingWorkingDirectory: (saving: boolean) => void;
   /** @internal */ setEditorFontConfig: (
@@ -164,6 +169,10 @@ export function useSettingsBasicActions({
   const [nodeVersion, setNodeVersion] = useState<string | null>(null);
   const [minNodeVersion, setMinNodeVersion] = useState(18);
   const [savingNodePath, setSavingNodePath] = useState(false);
+
+  // Custom Claude CLI path (overrides bundled SDK when set)
+  const [claudeCliPath, setClaudeCliPath] = useState('');
+  const [savingClaudeCliPath, setSavingClaudeCliPath] = useState(false);
 
   // Working directory configuration
   const [workingDirectory, setWorkingDirectory] = useState('');
@@ -267,6 +276,12 @@ export function useSettingsBasicActions({
     const payload = { path: (nodePath || '').trim() };
     sendToJava(`set_node_path:${JSON.stringify(payload)}`);
   }, [nodePath]);
+
+  const handleSaveClaudeCliPath = useCallback(() => {
+    setSavingClaudeCliPath(true);
+    const payload = { path: (claudeCliPath || '').trim() };
+    sendToJava(`set_claude_cli_path:${JSON.stringify(payload)}`);
+  }, [claudeCliPath]);
 
   const handleSaveWorkingDirectory = useCallback(() => {
     setSavingWorkingDirectory(true);
@@ -545,6 +560,10 @@ export function useSettingsBasicActions({
     setMinNodeVersion,
     savingNodePath,
     setSavingNodePath,
+    claudeCliPath,
+    setClaudeCliPath,
+    savingClaudeCliPath,
+    setSavingClaudeCliPath,
     workingDirectory,
     setWorkingDirectory,
     savingWorkingDirectory,
@@ -581,6 +600,7 @@ export function useSettingsBasicActions({
     historyCompletionEnabled,
     setHistoryCompletionEnabled,
     handleSaveNodePath,
+    handleSaveClaudeCliPath,
     handleSaveWorkingDirectory,
     handleUiFontSelectionChange,
     handleSaveUiFontCustomPath,

--- a/webview/src/components/settings/hooks/useSettingsWindowCallbacks.test.ts
+++ b/webview/src/components/settings/hooks/useSettingsWindowCallbacks.test.ts
@@ -16,6 +16,8 @@ describe('useSettingsWindowCallbacks', () => {
     setNodeVersion: vi.fn(),
     setMinNodeVersion: vi.fn(),
     setSavingNodePath: vi.fn(),
+    setClaudeCliPath: vi.fn(),
+    setSavingClaudeCliPath: vi.fn(),
     setWorkingDirectory: vi.fn(),
     setSavingWorkingDirectory: vi.fn(),
     setCommitPrompt: vi.fn(),

--- a/webview/src/components/settings/hooks/useSettingsWindowCallbacks.ts
+++ b/webview/src/components/settings/hooks/useSettingsWindowCallbacks.ts
@@ -28,6 +28,8 @@ export interface SettingsWindowCallbacksDeps {
   setNodeVersion: (version: string | null) => void;
   setMinNodeVersion: (version: number) => void;
   setSavingNodePath: (saving: boolean) => void;
+  setClaudeCliPath: (path: string) => void;
+  setSavingClaudeCliPath: (saving: boolean) => void;
   setWorkingDirectory: (dir: string) => void;
   setSavingWorkingDirectory: (saving: boolean) => void;
   setCommitPrompt: (prompt: string) => void;
@@ -130,6 +132,7 @@ export function useSettingsWindowCallbacks(deps: SettingsWindowCallbacksDeps) {
       d().showAlert('error', t('toast.operationFailed'), message);
       d().setLoading(false);
       d().setSavingNodePath(false);
+      d().setSavingClaudeCliPath(false);
       d().setSavingWorkingDirectory(false);
       d().setSavingCommitPrompt(false);
       d().setSavingProjectCommitPrompt(false);
@@ -155,6 +158,17 @@ export function useSettingsWindowCallbacks(deps: SettingsWindowCallbacksDeps) {
       window.dispatchEvent(new CustomEvent('nodePathReady'));
     };
 
+    window.updateClaudeCliPath = (jsonStr: string) => {
+      try {
+        const data = JSON.parse(jsonStr);
+        d().setClaudeCliPath(data.path || '');
+      } catch (e) {
+        console.warn('[SettingsView] Failed to parse updateClaudeCliPath JSON, fallback to legacy format:', e);
+        d().setClaudeCliPath(jsonStr || '');
+      }
+      d().setSavingClaudeCliPath(false);
+    };
+
     window.updateWorkingDirectory = (jsonStr: string) => {
       try {
         const data = JSON.parse(jsonStr);
@@ -169,6 +183,7 @@ export function useSettingsWindowCallbacks(deps: SettingsWindowCallbacksDeps) {
     window.showSuccess = (message: string) => {
       d().showAlert('success', t('toast.operationSuccess'), message);
       d().setSavingNodePath(false);
+      d().setSavingClaudeCliPath(false);
       d().setSavingWorkingDirectory(false);
     };
 
@@ -487,6 +502,7 @@ export function useSettingsWindowCallbacks(deps: SettingsWindowCallbacksDeps) {
     // Note: loadPrompts is now handled by PromptSection component
     d().loadPrompts?.();
     sendToJava('get_node_path:');
+    sendToJava('get_claude_cli_path:');
     sendToJava('get_working_directory:');
     sendToJava('get_editor_font_config:');
     sendToJava('get_ui_font_config:');
@@ -513,6 +529,7 @@ export function useSettingsWindowCallbacks(deps: SettingsWindowCallbacksDeps) {
       window.showError = undefined;
       window.showSwitchSuccess = undefined;
       window.updateNodePath = undefined;
+      window.updateClaudeCliPath = undefined;
       window.updateWorkingDirectory = undefined;
       window.showSuccess = undefined;
       window.showSuccessI18n = undefined;

--- a/webview/src/components/settings/index.tsx
+++ b/webview/src/components/settings/index.tsx
@@ -115,6 +115,10 @@ const SettingsView = ({
     setMinNodeVersion,
     savingNodePath,
     setSavingNodePath,
+    claudeCliPath,
+    setClaudeCliPath,
+    savingClaudeCliPath,
+    setSavingClaudeCliPath,
     workingDirectory,
     setWorkingDirectory,
     savingWorkingDirectory,
@@ -149,6 +153,7 @@ const SettingsView = ({
     historyCompletionEnabled,
     setHistoryCompletionEnabled,
     handleSaveNodePath,
+    handleSaveClaudeCliPath,
     handleSaveWorkingDirectory,
     handleUiFontSelectionChange,
     handleSaveUiFontCustomPath,
@@ -290,6 +295,8 @@ const SettingsView = ({
     setNodeVersion,
     setMinNodeVersion,
     setSavingNodePath,
+    setClaudeCliPath,
+    setSavingClaudeCliPath,
     setWorkingDirectory,
     setSavingWorkingDirectory,
     setCommitPrompt,
@@ -450,6 +457,10 @@ const SettingsView = ({
               savingNodePath={savingNodePath}
               nodeVersion={nodeVersion}
               minNodeVersion={minNodeVersion}
+              claudeCliPath={claudeCliPath}
+              onClaudeCliPathChange={setClaudeCliPath}
+              onSaveClaudeCliPath={handleSaveClaudeCliPath}
+              savingClaudeCliPath={savingClaudeCliPath}
               workingDirectory={workingDirectory}
               onWorkingDirectoryChange={setWorkingDirectory}
               onSaveWorkingDirectory={handleSaveWorkingDirectory}

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -325,6 +325,11 @@ interface Window {
   updateNodePath?: (path: string) => void;
 
   /**
+   * Update custom Claude CLI path
+   */
+  updateClaudeCliPath?: (path: string) => void;
+
+  /**
    * Update working directory configuration
    */
   updateWorkingDirectory?: (json: string) => void;

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -145,6 +145,11 @@
         "invalidFileName": "Path must end with node.exe on Windows, or node on macOS/Linux",
         "cannotExecute": "File exists but cannot be executed, please check file permissions"
       },
+      "claudeCliPath": {
+        "label": "Claude CLI Path (override)",
+        "placeholder": "e.g. /usr/local/bin/claude — leave empty to use the bundled SDK",
+        "hint": "Optional. When set, the plugin spawns this binary instead of the bundled @anthropic-ai/claude-agent-sdk. Daemon restarts on save."
+      },
       "workingDirectory": {
         "label": "Working Directory",
         "placeholder": "e.g. project1 or leave empty to use project root",


### PR DESCRIPTION
## Summary

Adds a **Claude CLI Path (override)** setting that lets users point the plugin at a specific `claude` binary instead of the Claude Agent SDK's bundled CLI. Also adds a Dockerfile to build the plugin distribution in a container.

### Custom Claude CLI path
- New **Settings → Basic → Environment** input + save button to set/clear the path.
- `ClaudeCliPathHandler` (Java) persists it in `PropertiesComponent` (`claude.code.cli.path`), validates it (exists / not a directory / executable), and restarts the daemon on save so the change takes effect. Mirrors the existing `NodePathHandler`.
- `DaemonBridge` exports the configured path as `CLAUDE_CODE_PATH` when spawning the daemon.
- ai-bridge reads it via a new `getClaudeCliPathOverride()` helper and passes `pathToClaudeCodeExecutable` to the SDK across all query paths: `message-sender`, `persistent-query-service`, `message-rewind`, and `prompt-enhancer`. The field is spread conditionally, so behavior is unchanged when the override is empty.
- Frontend wiring: `EnvironmentTab` / `BasicConfigSection`, `useSettingsBasicActions`, `useSettingsWindowCallbacks` (+ test), `global.d.ts`, and an `en.json` string block.

### Docker build
- `Dockerfile` (Temurin 17 JDK + Node 20) runs `buildPlugin` and copies the resulting `.zip` to a bind-mounted `/out`, so the plugin can be built reproducibly without a local toolchain. Supports `TARGET_IDE` (IC/PC/PY/RD).
- `.dockerignore` keeps host `build/`, `node_modules/`, and IDE files out of the build context.

## Notes
- The override is fully optional — when unset, the bundled SDK CLI is used exactly as before.
