### PR TITLE
fix(渲染): 修复外接屏幕切TAB时短暂缩放闪烁和部分渲染不显示的问题

### DIFF
--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -388,6 +388,13 @@ public class ClaudeChatWindow {
         loadRestoredHistoryIfNeeded(currentState);
     }
 
+    public void triggerScaleRefresh() {
+        if (disposed || browser == null) {
+            return;
+        }
+        callJavaScript("forceScaleRecovery", "tab-selected");
+    }
+
     private void loadRestoredHistoryIfNeeded(TabStateService.TabSessionState savedState) {
         if (!TabSessionRestorePolicy.shouldLoadHistory(savedState) || session == null) {
             return;

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeSDKToolWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeSDKToolWindow.java
@@ -300,6 +300,7 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
                 ClaudeChatWindow window = contentToWindowMap.get(event.getContent());
                 if (window != null) {
                     window.loadRestoredHistoryIfNeeded();
+                    window.triggerScaleRefresh();
                 }
             }
 

--- a/webview/src/components/MarkdownBlock.tsx
+++ b/webview/src/components/MarkdownBlock.tsx
@@ -1,6 +1,6 @@
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
-import { memo, useMemo, useState, useRef, useEffect, useCallback } from 'react';
+import { memo, useMemo, useState, useRef, useEffect, useLayoutEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { openBrowser, openClass, openFile } from '../utils/bridge';
 import { useMarkdownFileLinkTooltip } from '../hooks/useMarkdownFileLinkTooltip';
@@ -757,6 +757,14 @@ const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps
     prevIsStreamingRef.current = isStreaming;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isStreaming, html, renderMermaidDiagrams]);
+
+  // 非流式内容更新后强制合成器重绘
+  // JCEF 在 dangerouslySetInnerHTML 后可能不触发 paint invalidation
+  useLayoutEffect(() => {
+    if (!isStreaming && containerRef.current) {
+      void containerRef.current.offsetHeight;
+    }
+  }, [html, isStreaming]);
 
   const handleClick = async (event: React.MouseEvent<HTMLDivElement>) => {
     // React synthetic events may have a Text node as target when the user

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -436,6 +436,12 @@ interface Window {
   __pendingUiFontConfig?: import('./types/uiFontConfig').UiFontConfig;
 
   /**
+   * Force scale/DPI recovery — called from Java backend when a tab becomes selected,
+   * to handle DPI changes on external monitors.
+   */
+  forceScaleRecovery?: (reason: string) => void;
+
+  /**
    * Apply IDEA language configuration (called from Java backend)
    * @param config Language configuration object containing language code and IDEA locale
    */

--- a/webview/src/main.tsx
+++ b/webview/src/main.tsx
@@ -204,6 +204,12 @@ function setupScaleRecovery() {
     });
   };
 
+  // Java 端 TAB 切换时调用的强制缩放恢复（跳过所有冷却门槛）
+  window.forceScaleRecovery = (reason: string) => {
+    debugLog('[ScaleRecovery] forceScaleRecovery called, reason:', reason);
+    forceReapply(reason);
+  };
+
   const onVisibilityChange = () => {
     if (document.hidden) {
       hiddenAt = Date.now();
@@ -613,6 +619,15 @@ if (typeof window !== 'undefined') {
   window.updateLinkifyCapabilities = (json: string) => {
     applyLinkifyCapabilitiesPayload(json);
   };
+}
+
+// 禁用浏览器原生 Ctrl/⌘+滚轮缩放，仅保留设置中的字号缩放
+if (typeof document !== 'undefined') {
+  document.addEventListener('wheel', (e: WheelEvent) => {
+    if (e.ctrlKey || e.metaKey) {
+      e.preventDefault();
+    }
+  }, { passive: false });
 }
 
 // Render the React application


### PR DESCRIPTION
- TAB切换时Java端主动通知前端做DPI缩放恢复，跳过1500ms冷却门槛
- 非流式markdown内容更新后强制合成器重绘，修复JCEF部分渲染内容不可见
- 禁用浏览器原生Ctrl/滚轮缩放，仅保留设置中的字号缩放

Refs #1229