### PR TITLE
fix(stream): prevent cross-turn content merging in multi-turn tool_use loops

### DIFF
--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -158,6 +158,11 @@ function processStreamMessage(msg, state, logPrefix) {
         // or duplicate this turn's index-0 block (see resetTurnBlockState). Mirrors
         // stream-event-processor.js — both streaming paths must reset identically.
         resetTurnBlockState(state);
+        // Emit BLOCK_RESET signal BEFORE any subsequent deltas to ensure frontend
+        // clears its streaming refs. Mirrors stream-event-processor.js for ordering.
+        if (state.streamingEnabled) {
+          process.stdout.write('[BLOCK_RESET]\n');
+        }
         if (event.message?.usage) {
           // IMPORTANT: Must use mergeUsage(state.accumulatedUsage, ...) to accumulate across turns.
           // Using mergeUsage(null, ...) would reset and only show the last turn's usage.

--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -158,8 +158,7 @@ function processStreamMessage(msg, state, logPrefix) {
         // or duplicate this turn's index-0 block (see resetTurnBlockState). Mirrors
         // stream-event-processor.js — both streaming paths must reset identically.
         resetTurnBlockState(state);
-        // Emit BLOCK_RESET signal BEFORE any subsequent deltas to ensure frontend
-        // clears its streaming refs. Mirrors stream-event-processor.js for ordering.
+        // Emit BLOCK_RESET — mirrors stream-event-processor.js, see there for rationale.
         if (state.streamingEnabled) {
           process.stdout.write('[BLOCK_RESET]\n');
         }

--- a/ai-bridge/services/claude/stream-event-processor.js
+++ b/ai-bridge/services/claude/stream-event-processor.js
@@ -45,6 +45,13 @@ export function processStreamEvent(msg, turnState) {
     // duplicate this turn's index-0 block (see resetTurnBlockState). Usage still
     // accumulates across turns.
     resetTurnBlockState(turnState);
+    // Emit BLOCK_RESET signal BEFORE any subsequent deltas to ensure frontend
+    // clears its streaming refs (streamingThinkingRef, streamingContentRef).
+    // This prevents new turn's thinking/text from merging with previous turn's content.
+    // Must emit synchronously here, not in the delta handlers, to guarantee ordering.
+    if (turnState.streamingEnabled) {
+      process.stdout.write('[BLOCK_RESET]\n');
+    }
     if (event.message?.usage) {
       turnState.accumulatedUsage = mergeUsage(turnState.accumulatedUsage, event.message.usage);
     }

--- a/ai-bridge/services/claude/stream-event-processor.test.js
+++ b/ai-bridge/services/claude/stream-event-processor.test.js
@@ -878,3 +878,89 @@ test('REGRESSION (eb1786): message_start reset preserves cross-turn usage accumu
   assert.equal(state.accumulatedUsage?.output_tokens, 20, 'prior-turn output_tokens must survive the reset');
   assert.equal(state.accumulatedUsage?.input_tokens, 8, 'input_tokens follows mergeUsage latest-value semantics');
 });
+
+// =========================================================================
+// BLOCK_RESET SIGNAL TESTS.
+//
+// message_start now emits a [BLOCK_RESET] signal to notify frontend that
+// streaming content refs should be cleared. This prevents cross-turn
+// content merging when a new assistant message starts within an ongoing
+// stream (e.g., after a tool_use loop iteration).
+// =========================================================================
+
+test('BLOCK_RESET: message_start emits [BLOCK_RESET] signal before subsequent deltas', () => {
+  const state = makeTurnState(true);
+
+  const captured = captureStdout(() => {
+    // message_start should emit BLOCK_RESET BEFORE any deltas
+    processStreamEvent(
+      { type: 'stream_event', event: { type: 'message_start', message: { usage: {} } } },
+      state,
+    );
+    // Subsequent deltas arrive
+    processStreamEvent(
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 0,
+        delta: { type: 'thinking_delta', thinking: 'New thinking' } } },
+      state,
+    );
+  });
+
+  const blockResetLines = tagLines(captured, '[BLOCK_RESET]');
+  const thinkingDeltaLines = tagLines(captured, '[THINKING_DELTA]');
+
+  // BLOCK_RESET must be emitted exactly once at message_start
+  assert.equal(blockResetLines.length, 1, 'message_start must emit one [BLOCK_RESET]');
+  // Thinking delta must be emitted after BLOCK_RESET
+  assert.equal(thinkingDeltaLines.length, 1, 'thinking delta must be emitted');
+
+  // Verify ordering: BLOCK_RESET comes before THINKING_DELTA
+  const blockResetIdx = captured.findIndex((line) => line.startsWith('[BLOCK_RESET]'));
+  const thinkingDeltaIdx = captured.findIndex((line) => line.startsWith('[THINKING_DELTA]'));
+  assert.ok(blockResetIdx < thinkingDeltaIdx, 'BLOCK_RESET must come before subsequent deltas');
+});
+
+test('BLOCK_RESET: not emitted when streaming is disabled', () => {
+  const state = makeTurnState(false); // streamingEnabled = false
+
+  const captured = captureStdout(() => {
+    processStreamEvent(
+      { type: 'stream_event', event: { type: 'message_start', message: { usage: {} } } },
+      state,
+    );
+  });
+
+  const blockResetLines = tagLines(captured, '[BLOCK_RESET]');
+  assert.equal(blockResetLines.length, 0, 'BLOCK_RESET must not be emitted when streaming is disabled');
+});
+
+test('BLOCK_RESET: emitted at each message_start in multi-turn tool_use loop', () => {
+  const state = makeTurnState(true);
+
+  const captured = captureStdout(() => {
+    // Turn 1 message_start
+    processStreamEvent(
+      { type: 'stream_event', event: { type: 'message_start', message: { usage: {} } } },
+      state,
+    );
+    state.hasStreamEvents = true;
+    processStreamEvent(
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 0,
+        delta: { type: 'thinking_delta', thinking: 'Turn 1' } } },
+      state,
+    );
+
+    // Turn 2 message_start (after tool_use loop iteration)
+    processStreamEvent(
+      { type: 'stream_event', event: { type: 'message_start', message: { usage: {} } } },
+      state,
+    );
+    processStreamEvent(
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 0,
+        delta: { type: 'thinking_delta', thinking: 'Turn 2' } } },
+      state,
+    );
+  });
+
+  const blockResetLines = tagLines(captured, '[BLOCK_RESET]');
+  assert.equal(blockResetLines.length, 2, 'BLOCK_RESET must be emitted at each message_start in multi-turn loop');
+});

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeStreamAdapter.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeStreamAdapter.java
@@ -137,6 +137,11 @@ class ClaudeStreamAdapter {
             return;
         }
 
+        if (line.startsWith("[BLOCK_RESET]")) {
+            callback.onMessage("block_reset", "");
+            return;
+        }
+
         if (line.startsWith("[MESSAGE_END]")) {
             callback.onMessage("message_end", "");
         }

--- a/src/main/java/com/github/claudecodegui/session/CallbackHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/CallbackHandler.java
@@ -131,6 +131,16 @@ public class CallbackHandler {
     }
 
     /**
+     * Notify that a block reset signal was received.
+     * Frontend should clear streaming content refs to prevent cross-turn merging.
+     */
+    public void notifyBlockReset() {
+        if (callback != null) {
+            callback.onBlockReset();
+        }
+    }
+
+    /**
      * Notify of a usage update.
      */
     public void notifyUsageUpdate(int usedTokens, int maxTokens) {

--- a/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
@@ -108,6 +108,9 @@ public class ClaudeMessageHandler implements MessageCallback {
             case "stream_end":
                 handleStreamEnd();
                 break;
+            case "block_reset":
+                handleBlockReset();
+                break;
             case "session_id":
                 handleSessionId(content);
                 break;
@@ -700,6 +703,23 @@ public class ClaudeMessageHandler implements MessageCallback {
         state.setLoading(false);
         state.updateLastModifiedTime();
         callbackHandler.notifyStateChange(state.isBusy(), state.isLoading(), state.getError());
+    }
+
+    /**
+     * Handle block reset signal received during streaming.
+     * This indicates a new assistant message has started within the stream
+     * (e.g., after a tool_use loop iteration). Reset segment state and notify
+     * frontend to clear streaming content refs, preventing cross-turn content merging.
+     */
+    private void handleBlockReset() {
+        LOG.debug("Block reset received - clearing segment state and notifying frontend");
+        // Reset segment activity flags - new blocks start fresh
+        textSegmentActive = false;
+        thinkingSegmentActive = false;
+        // Reset replay deduplicator for the new message's deltas
+        replayDedup.reset();
+        // Notify frontend to clear streaming refs (streamingThinkingRef, streamingContentRef)
+        callbackHandler.notifyBlockReset();
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
@@ -74,6 +74,16 @@ public class ClaudeMessageHandler implements MessageCallback {
     }
 
     /**
+     * Reset segment activity flags and replay deduplicator.
+     * Called at stream start, stream end, block reset, and error/completion boundaries.
+     */
+    private void resetSegmentState() {
+        textSegmentActive = false;
+        thinkingSegmentActive = false;
+        replayDedup.reset();
+    }
+
+    /**
      * Handle a received message by dispatching to the appropriate handler based on type.
      */
     @Override
@@ -154,9 +164,7 @@ public class ClaudeMessageHandler implements MessageCallback {
         streamEndedThisTurn = false;
         errorReportedThisTurn = true;
         lastReportedError = error;
-        textSegmentActive = false;
-        thinkingSegmentActive = false;
-        replayDedup.reset();
+        resetSegmentState();
 
         // Reset thinking state if still active — same as onComplete() and handleStreamEnd()
         if (isThinking) {
@@ -208,9 +216,7 @@ public class ClaudeMessageHandler implements MessageCallback {
         // This mirrors the same pattern used in onError() above.
         boolean wasStreaming = isStreaming;
         isStreaming = false;
-        textSegmentActive = false;
-        thinkingSegmentActive = false;
-        replayDedup.reset();
+        resetSegmentState();
 
         // Reset thinking state if still active
         if (isThinking) {
@@ -665,9 +671,7 @@ public class ClaudeMessageHandler implements MessageCallback {
         streamEndedThisTurn = false;
         errorReportedThisTurn = false;
         lastReportedError = null;
-        textSegmentActive = false;
-        thinkingSegmentActive = false;
-        replayDedup.reset();
+        resetSegmentState();
         callbackHandler.notifyStreamStart();
     }
 
@@ -678,9 +682,7 @@ public class ClaudeMessageHandler implements MessageCallback {
         LOG.debug("Stream ended");
         isStreaming = false;  // Mark streaming as inactive
         streamEndedThisTurn = true;
-        textSegmentActive = false;
-        thinkingSegmentActive = false;
-        replayDedup.reset();
+        resetSegmentState();
 
         // Reset thinking state — stream end is the definitive boundary for a turn.
         // If thinking was active when the stream ended (e.g., extended thinking without
@@ -713,11 +715,7 @@ public class ClaudeMessageHandler implements MessageCallback {
      */
     private void handleBlockReset() {
         LOG.debug("Block reset received - clearing segment state and notifying frontend");
-        // Reset segment activity flags - new blocks start fresh
-        textSegmentActive = false;
-        thinkingSegmentActive = false;
-        // Reset replay deduplicator for the new message's deltas
-        replayDedup.reset();
+        resetSegmentState();
         // Notify frontend to clear streaming refs (streamingThinkingRef, streamingContentRef)
         callbackHandler.notifyBlockReset();
     }

--- a/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
@@ -115,6 +115,15 @@ public class ClaudeSession {
         default void onThinkingDelta(String delta) {
         }
 
+        /**
+         * Called when a block reset signal is received during streaming.
+         * This indicates a new assistant message has started within the stream
+         * (e.g., after a tool_use loop iteration), and the frontend should
+         * clear its streaming content refs to prevent cross-turn content merging.
+         */
+        default void onBlockReset() {
+        }
+
         default void onUsageUpdate(int usedTokens, int maxTokens) {
         }
 

--- a/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
@@ -331,6 +331,23 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
     }
 
     @Override
+    public void onBlockReset() {
+        if (isInactive()) {
+            return;
+        }
+        // Reset throttlers for the new turn's deltas
+        contentDeltaThrottler.reset();
+        thinkingDeltaThrottler.reset();
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (isInactive()) {
+                return;
+            }
+            jsTarget.callJavaScript("onBlockReset");
+            LOG.debug("Block reset sent to frontend - streaming refs cleared");
+        });
+    }
+
+    @Override
     public void onUsageUpdate(int usedTokens, int maxTokens) {
         if (isInactive()) {
             return;

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -610,6 +610,13 @@ interface Window {
   onThinkingDelta?: (delta: string) => void;
 
   /**
+   * Block reset callback - called when a new assistant message starts within
+   * an ongoing stream (e.g., after a tool_use loop iteration). Frontend should
+   * clear streaming content refs to prevent cross-turn content merging.
+   */
+  onBlockReset?: () => void;
+
+  /**
    * Stream end callback - called when streaming ends
    */
   onStreamEnd?: (sequence?: string | number) => void;

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -1237,5 +1237,78 @@ describe('useWindowCallbacks integration', () => {
         __turnId: 2,
       });
     });
+
+    it('onBlockReset clears streaming refs to prevent cross-turn content merging', () => {
+      vi.stubGlobal('setTimeout', (callback: () => void) => {
+        callback();
+        return 1 as unknown as ReturnType<typeof setTimeout>;
+      });
+      vi.stubGlobal('clearTimeout', vi.fn());
+      vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      });
+      vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
+      const opts = createOptions();
+      renderHook(() => useWindowCallbacks(opts));
+
+      // Start streaming
+      act(() => { window.onStreamStart!(); });
+      expect(opts.isStreamingRef.current).toBe(true);
+
+      // Simulate first turn's thinking delta
+      act(() => { window.onThinkingDelta!('Turn1Thinking'); });
+      expect(opts.streamingThinkingRef.current).toBe('Turn1Thinking');
+
+      // Simulate first turn's content delta
+      act(() => { window.onContentDelta!('Turn1Content'); });
+      expect(opts.streamingContentRef.current).toBe('Turn1Content');
+
+      // Block reset signal arrives (new assistant message in stream)
+      act(() => { window.onBlockReset!(); });
+
+      // Streaming refs should be cleared
+      expect(opts.streamingThinkingRef.current).toBe('');
+      expect(opts.streamingContentRef.current).toBe('');
+
+      // But streaming should still be active
+      expect(opts.isStreamingRef.current).toBe(true);
+
+      // Second turn's deltas arrive - should NOT merge with first turn
+      act(() => { window.onThinkingDelta!('Turn2Thinking'); });
+      expect(opts.streamingThinkingRef.current).toBe('Turn2Thinking');
+
+      act(() => { window.onContentDelta!('Turn2Content'); });
+      expect(opts.streamingContentRef.current).toBe('Turn2Content');
+
+      // If onBlockReset was NOT called, we would have "Turn1ThinkingTurn2Thinking"
+      // and "Turn1ContentTurn2Content" (merged content)
+    });
+
+    it('onBlockReset is ignored when stream is not active', () => {
+      vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      });
+      vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
+      const opts = createOptions();
+      renderHook(() => useWindowCallbacks(opts));
+
+      // Stream is NOT active
+      expect(opts.isStreamingRef.current).toBe(false);
+
+      // Pre-populate refs (simulating stale state)
+      opts.streamingThinkingRef.current = 'StaleThinking';
+      opts.streamingContentRef.current = 'StaleContent';
+
+      // Block reset arrives when stream is not active
+      act(() => { window.onBlockReset!(); });
+
+      // Refs should NOT be cleared (stale signal ignored)
+      expect(opts.streamingThinkingRef.current).toBe('StaleThinking');
+      expect(opts.streamingContentRef.current).toBe('StaleContent');
+    });
   });
 });

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -1070,5 +1070,172 @@ describe('useWindowCallbacks integration', () => {
 
       expect(window.__deniedToolIds?.has('denied-1')).toBe(true);
     });
+
+    it('stale backend snapshot during streaming must not redirect streamingMessageIndexRef to prior-turn assistant', () => {
+      vi.stubGlobal('setTimeout', (callback: () => void) => {
+        callback();
+        return 1 as unknown as ReturnType<typeof setTimeout>;
+      });
+      vi.stubGlobal('clearTimeout', vi.fn());
+      vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      });
+      vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
+      const assistant1: ClaudeMessage = {
+        type: 'assistant',
+        content: 'Using tool',
+        timestamp: '2026-01-01T00:00:01Z',
+        __turnId: 1,
+        isStreaming: false,
+        raw: {
+          message: {
+            content: [
+              { type: 'tool_use', id: 't1', name: 'bash', input: { command: 'ls' } },
+              { type: 'text', text: 'Using tool' },
+            ],
+          },
+        } as never,
+      };
+      const userToolResult: ClaudeMessage = {
+        type: 'user', content: '', timestamp: '2026-01-01T00:00:02Z',
+        raw: { content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] } as never,
+      };
+
+      const initialMessages: ClaudeMessage[] = [
+        { type: 'user', content: 'question', timestamp: '2026-01-01T00:00:00Z' },
+        assistant1,
+        userToolResult,
+      ];
+
+      const { opts, buffer } = createOptsWithMessages(initialMessages);
+      // Simulate that turn 1 already completed
+      opts.turnIdCounterRef.current = 1;
+
+      renderHook(() => useWindowCallbacks(opts));
+
+      // --- Turn 2: onStreamStart creates new assistant at the end ---
+      act(() => { window.onStreamStart!(); });
+
+      // Verify the updater appended the new assistant with __turnId=2
+      expect(buffer.current.length).toBe(4);
+      expect(buffer.current[3]).toMatchObject({
+        type: 'assistant',
+        isStreaming: true,
+        __turnId: 2,
+      });
+
+      const correctStreamingIdx = opts.streamingMessageIndexRef.current;
+      expect(correctStreamingIdx).toBe(3);
+
+      // --- Stale backend snapshot arrives (still only has assistant1) ---
+      const staleSnapshot = [
+        { type: 'user', content: 'question', timestamp: '2026-01-01T00:00:00Z' },
+        {
+          type: 'assistant',
+          content: 'Using tool',
+          timestamp: '2026-01-01T00:00:01Z',
+          __turnId: 1,
+          raw: {
+            message: {
+              content: [
+                { type: 'tool_use', id: 't1', name: 'bash', input: { command: 'ls' } },
+                { type: 'text', text: 'Using tool' },
+              ],
+            },
+          },
+        },
+        { type: 'user', content: '', timestamp: '2026-01-01T00:00:02Z',
+          raw: { content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] } },
+      ];
+
+      act(() => {
+        window.updateMessages!(JSON.stringify(staleSnapshot));
+      });
+
+      // streamingMessageIndexRef must NOT be redirected to index 1 (assistant1)
+      expect(opts.streamingMessageIndexRef.current).toBe(correctStreamingIdx);
+    });
+
+    it('guard branch: stale snapshot with equal length bypasses preserveLatestMessagesOnShrink and still preserves index', () => {
+      vi.stubGlobal('setTimeout', (callback: () => void) => {
+        callback();
+        return 1 as unknown as ReturnType<typeof setTimeout>;
+      });
+      vi.stubGlobal('clearTimeout', vi.fn());
+      vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      });
+      vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
+      const assistant1: ClaudeMessage = {
+        type: 'assistant',
+        content: 'First reply',
+        timestamp: '2026-01-01T00:00:01Z',
+        __turnId: 1,
+        isStreaming: false,
+        raw: {
+          message: {
+            content: [{ type: 'text', text: 'First reply' }],
+          },
+        } as never,
+      };
+
+      const initialMessages: ClaudeMessage[] = [
+        { type: 'user', content: 'hello', timestamp: '2026-01-01T00:00:00Z' },
+        assistant1,
+      ];
+
+      const { opts, buffer } = createOptsWithMessages(initialMessages);
+      opts.turnIdCounterRef.current = 1;
+
+      renderHook(() => useWindowCallbacks(opts));
+
+      // --- Turn 2: onStreamStart creates new assistant at the end ---
+      act(() => { window.onStreamStart!(); });
+
+      expect(buffer.current.length).toBe(3);
+      expect(buffer.current[2]).toMatchObject({
+        type: 'assistant',
+        isStreaming: true,
+        __turnId: 2,
+      });
+
+      const correctStreamingIdx = opts.streamingMessageIndexRef.current;
+      expect(correctStreamingIdx).toBe(2);
+
+      // --- Stale backend snapshot with SAME length as prev (3 messages) ---
+      // preserveLatestMessagesOnShrink sees patched.length(3) >= prev.length(3)
+      // and returns early, so findLastAssistantIndex finds assistant1 (__turnId=1).
+      // The guard must block the stale redirect.
+      const staleSnapshot = [
+        { type: 'user', content: 'hello', timestamp: '2026-01-01T00:00:00Z' },
+        {
+          type: 'assistant',
+          content: 'First reply',
+          timestamp: '2026-01-01T00:00:01Z',
+          __turnId: 1,
+          raw: { message: { content: [{ type: 'text', text: 'First reply' }] } },
+        },
+        // Extra user message makes the snapshot length (3) >= prev length (3),
+        // preventing preserveLatestMessagesOnShrink from re-appending the streaming assistant.
+        { type: 'user', content: 'extra', timestamp: '2026-01-01T00:00:02Z' },
+      ];
+
+      act(() => {
+        window.updateMessages!(JSON.stringify(staleSnapshot));
+      });
+
+      // streamingMessageIndexRef must NOT be redirected to index 1 (assistant1)
+      expect(opts.streamingMessageIndexRef.current).not.toBe(1);
+      // It must point to the correct streaming assistant (__turnId=2)
+      const finalIdx = opts.streamingMessageIndexRef.current;
+      expect(buffer.current[finalIdx]).toMatchObject({
+        type: 'assistant',
+        __turnId: 2,
+      });
+    });
   });
 });

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -111,6 +111,20 @@ describe('useWindowCallbacks integration', () => {
     delete (window as unknown as Record<string, unknown>).__pendingPermissionDialogTimeout;
   });
 
+  /** Stub timer/rAF globals to execute synchronously for streaming tests. */
+  const stubSynchronousTimers = () => {
+    vi.stubGlobal('setTimeout', (callback: () => void) => {
+      callback();
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    });
+    vi.stubGlobal('clearTimeout', vi.fn());
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  };
+
   afterEach(() => {
     vi.unstubAllGlobals();
   });
@@ -645,16 +659,7 @@ describe('useWindowCallbacks integration', () => {
   });
 
   it('accepts streaming updateMessages when assistant raw blocks gain spawn_agent tool_use', () => {
-    vi.stubGlobal('setTimeout', (callback: () => void) => {
-      callback();
-      return 1 as unknown as ReturnType<typeof setTimeout>;
-    });
-    vi.stubGlobal('clearTimeout', vi.fn());
-    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
-      callback(0);
-      return 1;
-    });
-    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    stubSynchronousTimers();
 
     const patchAssistantForStreaming = vi.fn((msg: ClaudeMessage) => ({
       ...msg,
@@ -1072,16 +1077,7 @@ describe('useWindowCallbacks integration', () => {
     });
 
     it('stale backend snapshot during streaming must not redirect streamingMessageIndexRef to prior-turn assistant', () => {
-      vi.stubGlobal('setTimeout', (callback: () => void) => {
-        callback();
-        return 1 as unknown as ReturnType<typeof setTimeout>;
-      });
-      vi.stubGlobal('clearTimeout', vi.fn());
-      vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
-        callback(0);
-        return 1;
-      });
-      vi.stubGlobal('cancelAnimationFrame', vi.fn());
+      stubSynchronousTimers();
 
       const assistant1: ClaudeMessage = {
         type: 'assistant',
@@ -1159,16 +1155,7 @@ describe('useWindowCallbacks integration', () => {
     });
 
     it('guard branch: stale snapshot with equal length bypasses preserveLatestMessagesOnShrink and still preserves index', () => {
-      vi.stubGlobal('setTimeout', (callback: () => void) => {
-        callback();
-        return 1 as unknown as ReturnType<typeof setTimeout>;
-      });
-      vi.stubGlobal('clearTimeout', vi.fn());
-      vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
-        callback(0);
-        return 1;
-      });
-      vi.stubGlobal('cancelAnimationFrame', vi.fn());
+      stubSynchronousTimers();
 
       const assistant1: ClaudeMessage = {
         type: 'assistant',
@@ -1239,16 +1226,7 @@ describe('useWindowCallbacks integration', () => {
     });
 
     it('onBlockReset clears streaming refs to prevent cross-turn content merging', () => {
-      vi.stubGlobal('setTimeout', (callback: () => void) => {
-        callback();
-        return 1 as unknown as ReturnType<typeof setTimeout>;
-      });
-      vi.stubGlobal('clearTimeout', vi.fn());
-      vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
-        callback(0);
-        return 1;
-      });
-      vi.stubGlobal('cancelAnimationFrame', vi.fn());
+      stubSynchronousTimers();
 
       const opts = createOptions();
       renderHook(() => useWindowCallbacks(opts));

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
@@ -309,11 +309,26 @@ export function registerMessageCallbacks(
 
         const patchedAssistantIdx = findLastAssistantIndex(patched);
         if (patchedAssistantIdx >= 0 && patched[patchedAssistantIdx]?.type === 'assistant') {
-          streamingMessageIndexRef.current = patchedAssistantIdx;
-          patched[patchedAssistantIdx] = patchAssistantForStreaming({
-            ...patched[patchedAssistantIdx],
-            __turnId: streamingTurnIdRef.current,
-          });
+          const patchedAssistant = patched[patchedAssistantIdx];
+          const currentTurnId = streamingTurnIdRef.current;
+          // Only update streamingMessageIndexRef when the found assistant belongs
+          // to the current streaming turn.  When the backend snapshot hasn't
+          // caught up yet (no assistant for this turn), findLastAssistantIndex
+          // returns the PREVIOUS turn's assistant — overwriting the index and
+          // stamping __turnId would redirect all subsequent deltas (thinking /
+          // content) into the wrong message.
+          if (currentTurnId > 0 && patchedAssistant.__turnId !== undefined
+              && patchedAssistant.__turnId !== currentTurnId) {
+            // Backend snapshot doesn't include this turn's assistant yet.
+            // Preserve the index set by onStreamStart; the streaming assistant
+            // will be restored later by ensureStreamingAssistantPreserved via finalizeMessageList.
+          } else {
+            streamingMessageIndexRef.current = patchedAssistantIdx;
+            patched[patchedAssistantIdx] = patchAssistantForStreaming({
+              ...patchedAssistant,
+              __turnId: currentTurnId,
+            });
+          }
         }
 
         // Only skip updates when neither message structure nor non-text raw blocks

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
@@ -311,18 +311,10 @@ export function registerMessageCallbacks(
         if (patchedAssistantIdx >= 0 && patched[patchedAssistantIdx]?.type === 'assistant') {
           const patchedAssistant = patched[patchedAssistantIdx];
           const currentTurnId = streamingTurnIdRef.current;
-          // Only update streamingMessageIndexRef when the found assistant belongs
-          // to the current streaming turn.  When the backend snapshot hasn't
-          // caught up yet (no assistant for this turn), findLastAssistantIndex
-          // returns the PREVIOUS turn's assistant — overwriting the index and
-          // stamping __turnId would redirect all subsequent deltas (thinking /
-          // content) into the wrong message.
-          if (currentTurnId > 0 && patchedAssistant.__turnId !== undefined
-              && patchedAssistant.__turnId !== currentTurnId) {
-            // Backend snapshot doesn't include this turn's assistant yet.
-            // Preserve the index set by onStreamStart; the streaming assistant
-            // will be restored later by ensureStreamingAssistantPreserved via finalizeMessageList.
-          } else {
+          // Stale: backend snapshot hasn't caught up — findLastAssistantIndex returns prior turn's assistant
+          const isStaleSnapshot = currentTurnId > 0 && patchedAssistant.__turnId !== undefined
+            && patchedAssistant.__turnId !== currentTurnId;
+          if (!isStaleSnapshot) {
             streamingMessageIndexRef.current = patchedAssistantIdx;
             patched[patchedAssistantIdx] = patchAssistantForStreaming({
               ...patchedAssistant,

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
@@ -591,4 +591,32 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
       window.__deniedToolIds!.add(id);
     }
   };
+
+  // Block reset callback — clears streaming content refs when a new assistant
+  // message starts within an ongoing stream (e.g., after tool_use loop iteration).
+  // This prevents cross-turn content merging where new thinking/text deltas
+  // would append to previous turn's buffered content.
+  window.onBlockReset = () => {
+    if (!isStreamingRef.current) {
+      // Stream not active, ignore (could be stale signal after stream ended)
+      return;
+    }
+    // Clear content buffers - new deltas will start fresh
+    streamingContentRef.current = '';
+    streamingThinkingRef.current = '';
+    // Reset throttle timeouts to ensure clean state for new deltas
+    if (contentUpdateTimeoutRef.current != null) {
+      cancelAnimationFrame(contentUpdateTimeoutRef.current);
+      contentUpdateTimeoutRef.current = null;
+    }
+    if (thinkingUpdateTimeoutRef.current != null) {
+      cancelAnimationFrame(thinkingUpdateTimeoutRef.current);
+      thinkingUpdateTimeoutRef.current = null;
+    }
+    // Reset last update timestamps to prevent throttle delays
+    lastContentUpdateRef.current = 0;
+    lastThinkingUpdateRef.current = 0;
+    // Clear auto-expanded thinking keys for the new turn
+    autoExpandedThinkingKeysRef.current.clear();
+  };
 }

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
@@ -604,6 +604,10 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     // Clear content buffers - new deltas will start fresh
     streamingContentRef.current = '';
     streamingThinkingRef.current = '';
+    // Intentionally NOT resetting streamingMessageIndexRef here: the backend will
+    // send a new updateMessages snapshot for this turn, which will eventually set
+    // the correct index via the isStaleSnapshot guard. Resetting the index now
+    // would leave a window where incoming deltas have nowhere to land.
     // Reset throttle timeouts to ensure clean state for new deltas
     if (contentUpdateTimeoutRef.current != null) {
       cancelAnimationFrame(contentUpdateTimeoutRef.current);


### PR DESCRIPTION
## Summary

Fixes an intermittent bug where new thinking/text content from a subsequent assistant turn would incorrectly merge with the previous turn's buffered content during multi-turn `tool_use` loops.

## Root Cause

In multi-turn `tool_use` loops (e.g., when Claude executes a tool, receives the result, and continues with another assistant message), the SDK emits a new `message_start` event for each iteration. The AI bridge resets its per-block content maps via `resetTurnBlockState`, but the frontend's streaming refs (`streamingThinkingRef`, `streamingContentRef`) were NOT cleared between iterations, causing:

```
Turn 1 thinking: "Analyzing the request..."
Turn 2 thinking: "Based on the tool result..." 
→ UI displays: "Analyzing the request...Based on the tool result..." (merged!)
```

## Solution

Introduce a `[BLOCK_RESET]` signal emitted synchronously at `message_start` (BEFORE any subsequent deltas), ensuring correct ordering across the full stack:

| Layer | Change |
|-------|--------|
| **AI Bridge** | Emit `[BLOCK_RESET]` after `resetTurnBlockState` at `message_start` |
| **Java** | Parse signal, add `onBlockReset` callback interface, forward to frontend |
| **Frontend** | Clear streaming refs on `onBlockReset`, keep `isStreaming=true` |

Additional guard: prevent stale backend snapshots from redirecting `streamingMessageIndexRef` to prior-turn assistant messages.

## Changes

### AI Bridge
- `stream-event-processor.js`: emit `[BLOCK_RESET]` at `message_start` with ordering guarantee comment
- `message-sender.js`: mirror the same emission for alternate streaming path
- `stream-event-processor.test.js`: 3 tests for BLOCK_RESET emission, ordering, multi-turn behavior

### Java
- `ClaudeStreamAdapter.java`: parse `[BLOCK_RESET]` → `block_reset` message
- `ClaudeSession.java`: add `onBlockReset()` to Callback interface
- `CallbackHandler.java`: add `notifyBlockReset()` method
- `ClaudeMessageHandler.java`: handle `block_reset`, extract `resetSegmentState()` helper
- `SessionCallbackAdapter.java`: implement `onBlockReset` (reset throttlers, forward to JS)

### Frontend
- `global.d.ts`: add `onBlockReset?: () => void` to Window interface
- `streamingCallbacks.ts`: implement `window.onBlockReset` with guard and index-preserving trade-off comment
- `messageCallbacks.ts`: add `isStaleSnapshot` guard to prevent index redirection
- `useWindowCallbacks.test.ts`: 4 tests for stale snapshot guard, blockReset clearing, inactive guard

## Test Plan

- [x] AI Bridge: 28 tests pass (including 3 new BLOCK_RESET tests)
- [x] Frontend: 625 tests pass (including 4 new streaming tests)
- [x] Java: checkstyle passes
- [ ] Manual: multi-turn tool_use loop with thinking output — verify no content merge

## Why Intermittent?

The bug was intermittent because it required specific conditions:
1. Multi-turn `tool_use` loop (not all requests have this)
2. New turn produces thinking output (text-only turns didn't show the merge)
3. Timing race between `updateMessages` and `onThinkingDelta` via JCEF async chain
