### PR TITLE
Add Claude Opus 4.8 model support

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/provider/ModelProviderHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/provider/ModelProviderHandler.java
@@ -26,10 +26,12 @@ public class ModelProviderHandler {
     static {
         // Claude models with 1M context (base IDs)
         MODEL_CONTEXT_LIMITS.put("claude-sonnet-4-6", 200_000);
+        MODEL_CONTEXT_LIMITS.put("claude-opus-4-8", 200_000);
         MODEL_CONTEXT_LIMITS.put("claude-opus-4-7", 200_000);
         MODEL_CONTEXT_LIMITS.put("claude-opus-4-6", 200_000);
         // Claude models with [1m] suffix - 1M context
         MODEL_CONTEXT_LIMITS.put("claude-sonnet-4-6[1m]", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("claude-opus-4-8[1m]", 1_000_000);
         MODEL_CONTEXT_LIMITS.put("claude-opus-4-7[1m]", 1_000_000);
         MODEL_CONTEXT_LIMITS.put("claude-opus-4-6[1m]", 1_000_000);
         // Haiku - no 1M context available

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeUsageAggregator.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeUsageAggregator.java
@@ -44,6 +44,7 @@ class ClaudeUsageAggregator {
             Map.entry("claude-opus-4-20250514", LEGACY_OPUS_PRICING),
             Map.entry("claude-opus-4-5", OPUS_4_5_PRICING),
             Map.entry("claude-opus-4-6", OPUS_4_5_PRICING),
+            Map.entry("claude-opus-4-8", OPUS_4_5_PRICING),
             Map.entry("claude-sonnet-4", TIERED_SONNET_PRICING),
             Map.entry("claude-sonnet-4-20250514", TIERED_SONNET_PRICING),
             Map.entry("claude-sonnet-4-5", TIERED_SONNET_PRICING),
@@ -53,6 +54,7 @@ class ClaudeUsageAggregator {
     );
     private static final List<String> MODEL_PREFIXES = List.of(
             "claude-opus-4-20250514",
+            "claude-opus-4-8",
             "claude-opus-4-6",
             "claude-opus-4-5",
             "claude-opus-4-1",

--- a/src/test/java/com/github/claudecodegui/handler/provider/ModelProviderHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/provider/ModelProviderHandlerTest.java
@@ -73,10 +73,12 @@ public class ModelProviderHandlerTest {
     public void shouldReturnCorrectContextLimitsForClaudeModels() {
         // Base IDs without [1m] suffix - 200k context by default
         assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-sonnet-4-6"));
+        assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-8"));
         assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-7"));
         assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-6"));
         // IDs with [1m] suffix - 1M context
         assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("claude-sonnet-4-6[1m]"));
+        assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-8[1m]"));
         assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-7[1m]"));
         assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-6[1m]"));
         // Haiku - no 1M context available

--- a/webview/src/components/ChatInputBox/ButtonArea.tsx
+++ b/webview/src/components/ChatInputBox/ButtonArea.tsx
@@ -131,6 +131,7 @@ export const ButtonArea = ({
   const applyModelMapping = useCallback((model: ModelInfo, mapping: { main?: string; haiku?: string; sonnet?: string; opus?: string }): ModelInfo => {
     const modelKeyMap: Record<string, keyof typeof mapping> = {
       'claude-sonnet-4-6': 'sonnet',
+      'claude-opus-4-8': 'opus',
       'claude-opus-4-7': 'opus',
       'claude-haiku-4-5': 'haiku',
     };

--- a/webview/src/components/ChatInputBox/selectors/ModelSelect.test.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ModelSelect.test.tsx
@@ -79,6 +79,10 @@ describe('ModelSelect', () => {
     expect(CLAUDE_MODELS.map((model) => model.id)).not.toContain('claude-opus-4-6[1m]');
   });
 
+  it('Claude 内置模型列表应包含 Opus 4.8', () => {
+    expect(CLAUDE_MODELS.map((model) => model.id)).toContain('claude-opus-4-8');
+  });
+
   it('Codex 内置模型列表应与目标设计一致', () => {
     expect(CODEX_MODELS.map((model) => model.id)).toEqual([
       'gpt-5.5',

--- a/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
@@ -39,6 +39,7 @@ const DEFAULT_MODEL_MAP: Record<string, ModelInfo> = AVAILABLE_MODELS.reduce(
 
 const MODEL_LABEL_KEYS: Record<string, string> = {
   'claude-sonnet-4-6': 'models.claude.sonnet46.label',
+  'claude-opus-4-8': 'models.claude.opus48.label',
   'claude-opus-4-7': 'models.claude.opus46.label',
   'claude-opus-4-6': 'models.claude.opus46_1m.label',
   'claude-opus-4-6[1m]': 'models.claude.opus46_1m.label',
@@ -56,6 +57,7 @@ const MODEL_LABEL_KEYS: Record<string, string> = {
 
 const MODEL_DESCRIPTION_KEYS: Record<string, string> = {
   'claude-sonnet-4-6': 'models.claude.sonnet46.description',
+  'claude-opus-4-8': 'models.claude.opus48.description',
   'claude-opus-4-7': 'models.claude.opus46.description',
   'claude-opus-4-6': 'models.claude.opus46_1m.description',
   'claude-opus-4-6[1m]': 'models.claude.opus46_1m.description',
@@ -78,6 +80,7 @@ const MODEL_DESCRIPTION_KEYS: Record<string, string> = {
  */
 const MODEL_ID_TO_MAPPING_KEY: Record<string, string> = {
   'claude-sonnet-4-6': 'sonnet',
+  'claude-opus-4-8': 'opus',
   'claude-opus-4-7': 'opus',
   'claude-opus-4-6': 'opus',
   'claude-opus-4-6[1m]': 'opus',

--- a/webview/src/components/ChatInputBox/selectors/ReasoningSelect.test.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ReasoningSelect.test.tsx
@@ -9,6 +9,22 @@ vi.mock('react-i18next', () => ({
 }));
 
 describe('ReasoningSelect', () => {
+  it('shows xhigh and max for Claude Opus 4.8', () => {
+    render(
+      <ReasoningSelect
+        value="high"
+        onChange={vi.fn()}
+        currentProvider="claude"
+        selectedModel="claude-opus-4-8"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('XHigh')).toBeTruthy();
+    expect(screen.getByText('Max')).toBeTruthy();
+  });
+
   it('shows xhigh and max for Claude Opus 4.7', () => {
     render(
       <ReasoningSelect

--- a/webview/src/components/ChatInputBox/types.ts
+++ b/webview/src/components/ChatInputBox/types.ts
@@ -319,9 +319,14 @@ export const CLAUDE_MODELS: ModelInfo[] = [
     description: 'Sonnet 4.6 · Use the default model',
   },
   {
+    id: 'claude-opus-4-8',
+    label: 'Opus 4.8',
+    description: 'Opus 4.8 · Latest and most capable',
+  },
+  {
     id: 'claude-opus-4-7',
     label: 'Opus 4.7',
-    description: 'Opus 4.7 · Latest and most capable',
+    description: 'Opus 4.7 · Previous generation flagship',
   },
   {
     id: 'claude-opus-4-6',
@@ -416,6 +421,7 @@ export const AVAILABLE_PROVIDERS: ProviderInfo[] = [
  * Based on: https://code.claude.com/docs/en/model-config#adjust-effort-level
  */
 export const EFFORT_SUPPORTED_CLAUDE_MODELS = new Set([
+  'claude-opus-4-8',
   'claude-opus-4-7',
   'claude-opus-4-6',
   'claude-opus-4-6[1m]',
@@ -427,6 +433,7 @@ export const EFFORT_SUPPORTED_CLAUDE_MODELS = new Set([
  * Opus 4.7 is currently the only Claude Code model with xhigh support.
  */
 export const XHIGH_EFFORT_CLAUDE_MODELS = new Set([
+  'claude-opus-4-8',
   'claude-opus-4-7',
 ]);
 
@@ -434,6 +441,7 @@ export const XHIGH_EFFORT_CLAUDE_MODELS = new Set([
  * Claude models that support the 'max' effort level.
  */
 export const MAX_EFFORT_CLAUDE_MODELS = new Set([
+  'claude-opus-4-8',
   'claude-opus-4-7',
   'claude-opus-4-6',
   'claude-opus-4-6[1m]',

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -1456,9 +1456,13 @@
         "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · Use the default model"
       },
+      "opus48": {
+        "label": "Opus 4.8",
+        "description": "Opus 4.8 · Latest and most capable"
+      },
       "opus46": {
         "label": "Opus 4.7",
-        "description": "Opus 4.7 · Latest and most capable"
+        "description": "Opus 4.7 · Previous generation flagship"
       },
       "opus46_1m": {
         "label": "Opus 4.6",

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -1228,9 +1228,13 @@
         "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · Modelo recomendado por defecto"
       },
+      "opus48": {
+        "label": "Opus 4.8",
+        "description": "Opus 4.8 · El más reciente y capaz"
+      },
       "opus46": {
         "label": "Opus 4.7",
-        "description": "Opus 4.7 · El más reciente y capaz"
+        "description": "Opus 4.7 · Modelo insignia de la generación anterior"
       },
       "opus46_1m": {
         "label": "Opus 4.6",

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -1228,9 +1228,13 @@
         "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · Modèle recommandé par défaut"
       },
+      "opus48": {
+        "label": "Opus 4.8",
+        "description": "Opus 4.8 · Le plus récent et le plus performant"
+      },
       "opus46": {
         "label": "Opus 4.7",
-        "description": "Opus 4.7 · Le plus récent et le plus performant"
+        "description": "Opus 4.7 · Modèle phare de la génération précédente"
       },
       "opus46_1m": {
         "label": "Opus 4.6",

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -1227,9 +1227,13 @@
         "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · डिफ़ॉल्ट अनुशंसित मॉडल"
       },
+      "opus48": {
+        "label": "Opus 4.8",
+        "description": "Opus 4.8 · नवीनतम और सबसे सक्षम"
+      },
       "opus46": {
         "label": "Opus 4.7",
-        "description": "Opus 4.7 · नवीनतम और सबसे सक्षम"
+        "description": "Opus 4.7 · पिछली पीढ़ी का प्रमुख मॉडल"
       },
       "opus46_1m": {
         "label": "Opus 4.6",

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -1239,9 +1239,13 @@
         "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · デフォルトモデルを使用"
       },
+      "opus48": {
+        "label": "Opus 4.8",
+        "description": "Opus 4.8 · 最新かつ最も優れたモデル"
+      },
       "opus46": {
         "label": "Opus 4.7",
-        "description": "Opus 4.7 · 最新かつ最も優れたモデル"
+        "description": "Opus 4.7 · 前世代のフラッグシップ"
       },
       "opus46_1m": {
         "label": "Opus 4.6",

--- a/webview/src/i18n/locales/ko.json
+++ b/webview/src/i18n/locales/ko.json
@@ -1345,9 +1345,13 @@
         "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · 기본 모델 사용"
       },
+      "opus48": {
+        "label": "Opus 4.8",
+        "description": "Opus 4.8 · 최신 및 가장 강력한 모델"
+      },
       "opus46": {
         "label": "Opus 4.7",
-        "description": "Opus 4.7 · 최신 및 가장 강력한 모델"
+        "description": "Opus 4.7 · 이전 세대 플래그십 모델"
       },
       "opus46_1m": {
         "label": "Opus 4.6",

--- a/webview/src/i18n/locales/pt-BR.json
+++ b/webview/src/i18n/locales/pt-BR.json
@@ -1400,9 +1400,13 @@
         "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · Usar o modelo padrão"
       },
+      "opus48": {
+        "label": "Opus 4.8",
+        "description": "Opus 4.8 · O mais recente e capaz"
+      },
       "opus46": {
         "label": "Opus 4.7",
-        "description": "Opus 4.7 · O mais recente e capaz"
+        "description": "Opus 4.7 · Carro-chefe da geração anterior"
       },
       "opus46_1m": {
         "label": "Opus 4.6",

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -1254,9 +1254,13 @@
         "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · Модель по умолчанию"
       },
+      "opus48": {
+        "label": "Opus 4.8",
+        "description": "Opus 4.8 · Новейшая и самая мощная"
+      },
       "opus46": {
         "label": "Opus 4.7",
-        "description": "Opus 4.7 · Новейшая и самая мощная"
+        "description": "Opus 4.7 · Флагман предыдущего поколения"
       },
       "opus46_1m": {
         "label": "Opus 4.6",

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -1233,9 +1233,13 @@
         "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · 預設推薦模型"
       },
+      "opus48": {
+        "label": "Opus 4.8",
+        "description": "Opus 4.8 · 最新最強大的模型"
+      },
       "opus46": {
         "label": "Opus 4.7",
-        "description": "Opus 4.7 · 最新最強大的模型"
+        "description": "Opus 4.7 · 上一代旗艦模型"
       },
       "opus46_1m": {
         "label": "Opus 4.6",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -1461,9 +1461,13 @@
         "label": "Sonnet 4.6",
         "description": "Sonnet 4.6 · 默认推荐模型"
       },
+      "opus48": {
+        "label": "Opus 4.8",
+        "description": "Opus 4.8 · 最新最强大的模型"
+      },
       "opus46": {
         "label": "Opus 4.7",
-        "description": "Opus 4.7 · 最新最强大的模型"
+        "description": "Opus 4.7 · 上一代旗舰模型"
       },
       "opus46_1m": {
         "label": "Opus 4.6",


### PR DESCRIPTION
## Summary
- Register `claude-opus-4-8` as a selectable Claude model, marked as the latest flagship (Opus 4.7 relabeled "previous generation").
- Wire it into reasoning-effort sets (effort/xhigh/max), 200K & `[1m]` 1M context limits, and usage pricing (same tier as Opus 4.6).
- Add localized `opus48` labels/descriptions across all 10 locales.

## Changes
- **Frontend**: `types.ts` (`CLAUDE_MODELS`, effort sets), `ModelSelect.tsx`, `ButtonArea.tsx`
- **Backend**: `ModelProviderHandler.java` (context limits), `ClaudeUsageAggregator.java` (pricing + prefixes)
- **i18n**: en, zh, zh-TW, ru, pt-BR, fr, ja, ko, es, hi
- **Tests**: `ModelProviderHandlerTest.java`, `ModelSelect.test.tsx`, `ReasoningSelect.test.tsx`

## Test plan
- [x] `./gradlew test` — `ModelProviderHandlerTest` passes (2 unrelated `NodeDetectorWslTest` failures, Windows-only)
- [x] `npm test` (webview) — 547/547 pass
- [x] `node --test utils/model-utils.test.mjs` — 14/14 pass
- [x] `./gradlew buildPlugin` — builds successfully