### PR TITLE
Fixes markdown file links with spaces/special characters.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ logs/*.log
 .omx/
 
 .codex
+.opencode

--- a/webview/src/components/MarkdownBlock.test.tsx
+++ b/webview/src/components/MarkdownBlock.test.tsx
@@ -100,22 +100,47 @@ describe('MarkdownBlock linkify integration', () => {
     expect(screen.getByRole('link', { name: 'good' }).getAttribute('href')).toBe('https://example.com/docs');
   });
 
-  it('strips file: protocol links and does not route them to openFile', () => {
+  it('allows file: markdown links and routes them to openFile', () => {
     render(
       <MarkdownBlock
         content={'[click](https://example.com/docs) and [local](file:///tmp/demo.txt)'}
       />,
     );
 
-    // file: link should be stripped entirely by DOMPurify sanitization
-    expect(screen.queryByRole('link', { name: 'local' })).toBeNull();
+    const fileLink = screen.getByRole('link', { name: 'local' });
+    expect(fileLink.getAttribute('href')).toBe('file:///tmp/demo.txt');
+    expect(fileLink.classList.contains('file-link')).toBe(true);
 
-    // https link should still work
     const httpsLink = screen.getByRole('link', { name: 'click' });
     expect(httpsLink.getAttribute('href')).toBe('https://example.com/docs');
 
+    fireEvent.click(fileLink);
+    expect(bridgeMocks.openFile).toHaveBeenCalledWith('file:///tmp/demo.txt');
+
     fireEvent.click(httpsLink);
     expect(bridgeMocks.openBrowser).toHaveBeenCalledWith('https://example.com/docs');
+  });
+
+  it('opens markdown posix links with spaces and umlauts', () => {
+    render(
+      <MarkdownBlock
+        content={[
+          '[spaced](/Users/demo/my%20file.ts)',
+          '',
+          '[umlaut](/Users/demo/%C3%BCber.txt)',
+          '',
+          '[angle bracket](</Users/demo/with spaces/über.txt>)',
+        ].join('\n')}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'spaced' }));
+    fireEvent.click(screen.getByRole('link', { name: 'umlaut' }));
+    fireEvent.click(screen.getByRole('link', { name: 'angle bracket' }));
+
+    expect(bridgeMocks.openFile).toHaveBeenNthCalledWith(1, '/Users/demo/my%20file.ts');
+    expect(bridgeMocks.openFile).toHaveBeenNthCalledWith(2, '/Users/demo/%C3%BCber.txt');
+    expect(bridgeMocks.openFile).toHaveBeenNthCalledWith(3, '/Users/demo/with%20spaces/%C3%BCber.txt');
   });
 
   it('renders windows, posix, and explicit relative paths as file links', () => {

--- a/webview/src/components/MarkdownBlock.tsx
+++ b/webview/src/components/MarkdownBlock.tsx
@@ -37,6 +37,7 @@ import 'highlight.js/styles/github-dark.css';
 import { markedHighlight } from 'marked-highlight';
 
 const SAFE_HREF_PROTOCOL_REGEX = /^(?:https?|mailto):/i;
+const FILE_URI_SCHEME_REGEX = /^file:/i;
 const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/;
 const URI_SCHEME_REGEX = /^[A-Za-z][A-Za-z0-9+.-]*:/;
 let hrefSanitizerHookInstalled = false;
@@ -48,6 +49,10 @@ function isAllowedHrefValue(value: string): boolean {
   }
 
   if (WINDOWS_DRIVE_PATH_REGEX.test(trimmed)) {
+    return true;
+  }
+
+  if (FILE_URI_SCHEME_REGEX.test(trimmed)) {
     return true;
   }
 
@@ -68,15 +73,22 @@ function ensureSafeHrefSanitizerHook(): void {
       return;
     }
 
-    if (!isAllowedHrefValue(data.attrValue)) {
-      data.keepAttr = false;
+    if (isAllowedHrefValue(data.attrValue)) {
+      data.forceKeepAttr = true;
+      return;
     }
+
+    data.keepAttr = false;
   });
 
   hrefSanitizerHookInstalled = true;
 }
 
 ensureSafeHrefSanitizerHook();
+
+const MARKDOWN_LINK_SANITIZE_OPTIONS = {
+  ALLOW_UNKNOWN_PROTOCOLS: true,
+} as const;
 
 const highlightLanguages: Array<[string, Parameters<typeof hljs.registerLanguage>[1]]> = [
   ['bash', bash],
@@ -456,6 +468,7 @@ function renderStreamingContent(
 
   // Sanitize the assembled HTML to prevent XSS even during streaming
   return DOMPurify.sanitize(raw, {
+    ...MARKDOWN_LINK_SANITIZE_OPTIONS,
     ALLOWED_TAGS: ['a', 'p', 'br', 'pre', 'code', 'strong', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
     ALLOWED_ATTR: ['class', 'href', 'data-linkify'],
   });
@@ -653,7 +666,10 @@ const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps
       const parsed = marked.parse(cleaned);
       const sanitized = DOMPurify.sanitize(
         typeof parsed === 'string' ? parsed : String(parsed),
-        { ADD_ATTR: ['class', 'data-lang', 'data-copy-success', 'data-copy-title'] }
+        {
+          ...MARKDOWN_LINK_SANITIZE_OPTIONS,
+          ADD_ATTR: ['class', 'data-lang', 'data-copy-success', 'data-copy-title'],
+        }
       );
       const rawHtml = sanitized.trim();
 

--- a/webview/src/utils/bridge.test.ts
+++ b/webview/src/utils/bridge.test.ts
@@ -13,6 +13,22 @@ describe('bridge navigation helpers', () => {
     window.sendToJava = vi.fn();
   });
 
+  it('decodes percent-encoded navigation paths for openFile', () => {
+    openFile('/Users/demo/my%20file.ts');
+    openFile('/Users/demo/%C3%BCber.txt');
+    openFile('file:///Users/demo/my%20file.ts');
+
+    expect(window.sendToJava).toHaveBeenNthCalledWith(1, 'open_file:/Users/demo/my file.ts');
+    expect(window.sendToJava).toHaveBeenNthCalledWith(2, 'open_file:/Users/demo/über.txt');
+    expect(window.sendToJava).toHaveBeenNthCalledWith(3, 'open_file:/Users/demo/my file.ts');
+  });
+
+  it('parses line numbers from normalized navigation paths', () => {
+    openFile('/Users/demo/my%20file.ts:42');
+
+    expect(window.sendToJava).toHaveBeenCalledWith('open_file:/Users/demo/my file.ts:42');
+  });
+
   it('allows relative navigation paths for openFile', () => {
     openFile('../shared/utils.ts');
     expect(window.sendToJava).toHaveBeenCalledWith('open_file:../shared/utils.ts');

--- a/webview/src/utils/bridge.ts
+++ b/webview/src/utils/bridge.ts
@@ -1,4 +1,4 @@
-import { isJavaFqcnCandidate } from './linkify';
+import { isJavaFqcnCandidate, normalizeFileNavigationTarget, parseFileLinkTarget } from './linkify';
 
 const BRIDGE_UNAVAILABLE_WARNED = new Set<string>();
 const SAFE_BROWSER_PROTOCOLS = /^(https?|mailto):/i;
@@ -83,16 +83,17 @@ export const resolveFilePathWithCallback = (
     callback(null);
     return;
   }
-  if (!isValidOpenFileTarget(filePath)) {
+  const normalizedPath = normalizeFileNavigationTarget(filePath);
+  if (!normalizedPath || !isValidOpenFileTarget(normalizedPath)) {
     callback(null);
     return;
   }
 
   installResolveFilePathHandler();
 
-  const existing = resolveFilePathCallbacks.get(filePath);
+  const existing = resolveFilePathCallbacks.get(normalizedPath);
   if (existing) {
-    resolveFilePathCallbacks.set(filePath, {
+    resolveFilePathCallbacks.set(normalizedPath, {
       callbacks: [...existing.callbacks, callback],
       timeoutId: existing.timeoutId,
     });
@@ -100,14 +101,14 @@ export const resolveFilePathWithCallback = (
   }
 
   const timeoutId = setTimeout(() => {
-    flushPendingCallbacks(filePath, null);
+    flushPendingCallbacks(normalizedPath, null);
   }, RESOLVE_FILE_PATH_TIMEOUT_MS);
 
-  resolveFilePathCallbacks.set(filePath, {
+  resolveFilePathCallbacks.set(normalizedPath, {
     callbacks: [callback],
     timeoutId,
   });
-  sendBridgeEvent('resolve_file_path', filePath);
+  sendBridgeEvent('resolve_file_path', normalizedPath);
 };
 
 /**
@@ -172,24 +173,32 @@ export const resolveFilePath = (filePath?: string) => {
   if (!filePath) {
     return;
   }
-  if (!isValidOpenFileTarget(filePath)) {
+  const normalizedPath = normalizeFileNavigationTarget(filePath);
+  if (!normalizedPath || !isValidOpenFileTarget(normalizedPath)) {
     return;
   }
-  sendBridgeEvent('resolve_file_path', filePath);
+  sendBridgeEvent('resolve_file_path', normalizedPath);
 };
 
 export const openFile = (filePath?: string, lineStart?: number, lineEnd?: number) => {
   if (!filePath) {
     return;
   }
-  if (!isValidOpenFileTarget(filePath)) {
+  const normalizedPath = normalizeFileNavigationTarget(filePath);
+  if (!normalizedPath || !isValidOpenFileTarget(normalizedPath)) {
     return;
   }
-  let path = filePath;
-  if (lineStart !== undefined && Number.isFinite(lineStart) && lineStart > 0) {
-    path = (lineEnd !== undefined && Number.isFinite(lineEnd) && lineEnd > 0)
-      ? `${filePath}:${lineStart}-${lineEnd}`
-      : `${filePath}:${lineStart}`;
+
+  const parsedTarget = parseFileLinkTarget(normalizedPath);
+  const pathOnly = parsedTarget?.path ?? normalizedPath;
+  const resolvedLineStart = lineStart ?? parsedTarget?.lineStart;
+  const resolvedLineEnd = lineEnd ?? parsedTarget?.lineEnd;
+
+  let path = pathOnly;
+  if (resolvedLineStart !== undefined && Number.isFinite(resolvedLineStart) && resolvedLineStart > 0) {
+    path = (resolvedLineEnd !== undefined && Number.isFinite(resolvedLineEnd) && resolvedLineEnd > 0)
+      ? `${pathOnly}:${resolvedLineStart}-${resolvedLineEnd}`
+      : `${pathOnly}:${resolvedLineStart}`;
   }
   sendBridgeEvent('open_file', path);
 };

--- a/webview/src/utils/linkify.test.ts
+++ b/webview/src/utils/linkify.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
   decorateExistingAnchors,
   isJavaFqcnCandidate,
+  isMarkdownFileNavigationHref,
   linkifyHtml,
   linkifyPlainTextSegment,
+  normalizeFileNavigationTarget,
   parseFileLinkTarget,
 } from './linkify';
 import { DEFAULT_LINKIFY_CAPABILITIES } from './linkifyCapabilities';
@@ -23,6 +25,31 @@ describe('linkify', () => {
     });
 
     expect(parseFileLinkTarget('E:\\project\\src\\Foo.java:42:15')).toBeNull();
+  });
+
+  it('normalizes encoded and file:// markdown hrefs for navigation', () => {
+    expect(normalizeFileNavigationTarget('/Users/demo/my%20file.ts')).toBe('/Users/demo/my file.ts');
+    expect(normalizeFileNavigationTarget('/Users/demo/%C3%BCber.txt')).toBe('/Users/demo/über.txt');
+    expect(normalizeFileNavigationTarget('file:///Users/demo/my%20file.ts')).toBe('/Users/demo/my file.ts');
+    expect(normalizeFileNavigationTarget('/Users/demo/my%2520file.ts')).toBe('/Users/demo/my file.ts');
+    expect(isMarkdownFileNavigationHref('/Users/demo/my%20file.ts')).toBe(true);
+    expect(isMarkdownFileNavigationHref('file:///tmp/demo.txt')).toBe(true);
+    expect(isMarkdownFileNavigationHref('https://example.com/docs')).toBe(false);
+  });
+
+  it('decorates markdown file links with file-link metadata', () => {
+    const root = document.createElement('div');
+    root.innerHTML = [
+      '<p><a href="/Users/demo/my%20file.ts">spaced path</a></p>',
+      '<p><a href="file:///Users/demo/%C3%BCber.txt">umlaut path</a></p>',
+      '<p><a href="https://example.com/docs">docs</a></p>',
+    ].join('');
+
+    decorateExistingAnchors(root);
+
+    expect(root.querySelector('a.file-link')?.getAttribute('href')).toBe('/Users/demo/my%20file.ts');
+    expect(root.querySelectorAll('a.file-link').length).toBe(2);
+    expect(root.querySelector('a.url-link')?.getAttribute('data-linkify')).toBe('url');
   });
 
   it('recognizes valid Java FQCN values and rejects false positives', () => {

--- a/webview/src/utils/linkify.ts
+++ b/webview/src/utils/linkify.ts
@@ -425,6 +425,81 @@ function shouldSkipTextNode(textNode: Text): boolean {
   return parentElement.closest('a, pre') !== null;
 }
 
+const FILE_URI_SCHEME_REGEX = /^file:/i;
+const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/;
+
+function decodeHrefRepeatedly(value: string, maxPasses = 3): string {
+  let current = value;
+  for (let pass = 0; pass < maxPasses; pass += 1) {
+    try {
+      const decoded = decodeURIComponent(current.replace(/\+/g, ' '));
+      if (decoded === current) {
+        break;
+      }
+      current = decoded;
+    } catch {
+      break;
+    }
+  }
+  return current;
+}
+
+function fileUriToPath(uri: string): string {
+  try {
+    const url = new URL(uri);
+    let pathname = decodeHrefRepeatedly(url.pathname);
+    if (/^\/[A-Za-z]:\//.test(pathname)) {
+      pathname = pathname.slice(1);
+    }
+    return pathname;
+  } catch {
+    const withoutScheme = uri.replace(/^file:\/\//i, '');
+    if (/^[A-Za-z]:\//.test(withoutScheme)) {
+      return decodeHrefRepeatedly(withoutScheme);
+    }
+    const posixish = withoutScheme.startsWith('/') ? withoutScheme : `/${withoutScheme}`;
+    return decodeHrefRepeatedly(posixish);
+  }
+}
+
+/**
+ * Normalize markdown/file hrefs into a filesystem path suitable for open_file.
+ * Handles percent-encoding, repeated encoding, and file:// URIs.
+ */
+export function normalizeFileNavigationTarget(href: string): string | null {
+  const trimmed = href.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (FILE_URI_SCHEME_REGEX.test(trimmed)) {
+    return fileUriToPath(trimmed);
+  }
+
+  return decodeHrefRepeatedly(trimmed);
+}
+
+export function isMarkdownFileNavigationHref(href: string): boolean {
+  const normalized = normalizeFileNavigationTarget(href);
+  if (!normalized) {
+    return false;
+  }
+
+  if (FILE_URI_SCHEME_REGEX.test(href.trim())) {
+    return true;
+  }
+
+  if (WINDOWS_DRIVE_PATH_REGEX.test(normalized)) {
+    return true;
+  }
+
+  if (normalized.startsWith('./') || normalized.startsWith('../') || normalized.startsWith('/')) {
+    return true;
+  }
+
+  return /\.[A-Za-z0-9._-]+$/.test(normalized);
+}
+
 export function parseFileLinkTarget(value: string): FileLinkTarget | null {
   const trimmedValue = value.trim();
   if (!trimmedValue) {
@@ -474,12 +549,20 @@ export function isJavaFqcnCandidate(value: string): boolean {
 export function decorateExistingAnchors(root: Element): void {
   root.querySelectorAll('a[href]').forEach((anchor) => {
     const href = anchor.getAttribute('href')?.trim();
-    if (!href || !HTTP_LINK_REGEX.test(href)) {
+    if (!href) {
       return;
     }
 
-    anchor.classList.add('url-link');
-    anchor.setAttribute('data-linkify', 'url');
+    if (HTTP_LINK_REGEX.test(href)) {
+      anchor.classList.add('url-link');
+      anchor.setAttribute('data-linkify', 'url');
+      return;
+    }
+
+    if (isMarkdownFileNavigationHref(href)) {
+      anchor.classList.add('file-link');
+      anchor.setAttribute('data-linkify', 'file');
+    }
   });
 }
 


### PR DESCRIPTION
Changes:
* Preserve and route file:// markdown links.
* Decode percent-encoded paths before opening files.
* Support line suffixes after normalized paths.
* Add regression coverage for spaced/umlaut paths.