### PR TITLE
Fix gui submenu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ bin/
 node_modules/
 **/node_modules/
 webview/dist/
+webview/test-results/
+webview/playwright-report/
 
 src/main/resources/html/*
 

--- a/webview/e2e/menu-viewports.spec.ts
+++ b/webview/e2e/menu-viewports.spec.ts
@@ -66,8 +66,24 @@ const LONG_MODEL = {
   description: 'A very long model description that should remain clipped inside the selector row instead of pushing the dropdown outside the visible webview viewport.',
 };
 
-async function installBridgeMocks(page: Page) {
-  await page.addInitScript(({ processSnapshot, claudeProviders, codexProviders, longModel }) => {
+const SEARCH_TARGET_MODEL = {
+  id: 'vendor/large-model-search-target-220',
+  label: 'Large Model Search Target 220',
+  description: 'Model outside the initial render cap that should still be selectable through search.',
+};
+
+const LARGE_MODEL_LIST = Array.from({ length: 240 }, (_, index) => {
+  if (index === 220) return SEARCH_TARGET_MODEL;
+  const padded = String(index).padStart(3, '0');
+  return {
+    id: `vendor/large-model-${padded}`,
+    label: `Large Model ${padded}`,
+    description: `Large model fixture ${padded}`,
+  };
+});
+
+async function installBridgeMocks(page: Page, customModels = [LONG_MODEL]) {
+  await page.addInitScript(({ processSnapshot, claudeProviders, codexProviders, models }) => {
     localStorage.setItem('model-selection-state', JSON.stringify({
       provider: 'claude',
       claudeModel: 'claude-sonnet-4-6',
@@ -77,7 +93,7 @@ async function installBridgeMocks(page: Page) {
       longContextEnabled: true,
       reasoningEffort: 'high',
     }));
-    localStorage.setItem('claude-custom-models', JSON.stringify([longModel]));
+    localStorage.setItem('claude-custom-models', JSON.stringify(models));
     localStorage.setItem('lastSeenChangelogVersion', '0.4.4');
 
     const hideVConsole = () => {
@@ -109,7 +125,7 @@ async function installBridgeMocks(page: Page) {
     processSnapshot: NODE_PROCESS_SNAPSHOT,
     claudeProviders: CLAUDE_PROVIDERS_PAYLOAD,
     codexProviders: CODEX_PROVIDERS_PAYLOAD,
-    longModel: LONG_MODEL,
+    models: customModels,
   });
 }
 
@@ -194,8 +210,11 @@ async function openSelectorMenu(page: Page, button: Locator, label: string) {
   await closeOpenMenus(page);
 }
 
-test.beforeEach(async ({ page }) => {
-  await installBridgeMocks(page);
+test.beforeEach(async ({ page }, testInfo) => {
+  const customModels = testInfo.title.includes('large model selector')
+    ? LARGE_MODEL_LIST
+    : [LONG_MODEL];
+  await installBridgeMocks(page, customModels);
 });
 
 test('footer selector menus render inside the viewport', async ({ page }) => {
@@ -282,6 +301,34 @@ test('long model and mode text stays contained in selector menus', async ({ page
   await expect(longModelDescription).toBeVisible();
   await expectContainedWithin(longModelOption, longModelLabel, 'long model label');
   await expectContainedWithin(longModelOption, longModelDescription, 'long model description');
+
+  expect(significantErrors(errors)).toEqual([]);
+});
+
+test('large model selector remains searchable and capped', async ({ page }) => {
+  const errors = collectPageErrors(page);
+  await page.goto('/');
+  await expect(page.locator('.button-area-left')).toBeVisible();
+
+  const modelButton = page.locator('.button-area-left .selector-button').nth(3);
+  await modelButton.click();
+  const modelDropdown = page.locator('.selector-dropdown').first();
+  await expect(modelDropdown).toBeVisible();
+  await expectInsideViewport(page, modelDropdown, 'large model dropdown');
+
+  const renderedLargeModels = modelDropdown.getByText(/^Large Model \d{3}$/);
+  await expect(renderedLargeModels).toHaveCount(100);
+  await expect(modelDropdown.getByText(/^\+ \d+ more models\. Type to search\.$/)).toBeVisible();
+  await expect(modelDropdown.getByText(SEARCH_TARGET_MODEL.label)).toHaveCount(0);
+
+  const searchInput = modelDropdown.getByPlaceholder('Search models');
+  await expect(searchInput).toBeVisible();
+  await searchInput.fill('Search Target 220');
+
+  const targetOption = modelDropdown.locator('.selector-option').filter({ hasText: SEARCH_TARGET_MODEL.label }).first();
+  await expect(targetOption).toBeVisible();
+  await targetOption.click();
+  await expect(modelButton).toHaveAttribute('title', new RegExp(SEARCH_TARGET_MODEL.label));
 
   expect(significantErrors(errors)).toEqual([]);
 });

--- a/webview/e2e/menu-viewports.spec.ts
+++ b/webview/e2e/menu-viewports.spec.ts
@@ -60,8 +60,14 @@ const CODEX_PROVIDERS_PAYLOAD = [
   { id: 'codex-proxy', name: 'Codex Proxy', remark: 'workspace config', isActive: false },
 ];
 
+const LONG_MODEL = {
+  id: 'vendor/super-long-model-name-that-should-not-force-horizontal-overflow-in-selector-menus',
+  label: 'Extremely Long Claude-Compatible Model Display Name With Multiple Provider And Capability Suffixes',
+  description: 'A very long model description that should remain clipped inside the selector row instead of pushing the dropdown outside the visible webview viewport.',
+};
+
 async function installBridgeMocks(page: Page) {
-  await page.addInitScript(({ processSnapshot, claudeProviders, codexProviders }) => {
+  await page.addInitScript(({ processSnapshot, claudeProviders, codexProviders, longModel }) => {
     localStorage.setItem('model-selection-state', JSON.stringify({
       provider: 'claude',
       claudeModel: 'claude-sonnet-4-6',
@@ -71,6 +77,7 @@ async function installBridgeMocks(page: Page) {
       longContextEnabled: true,
       reasoningEffort: 'high',
     }));
+    localStorage.setItem('claude-custom-models', JSON.stringify([longModel]));
     localStorage.setItem('lastSeenChangelogVersion', '0.4.4');
 
     const hideVConsole = () => {
@@ -102,6 +109,7 @@ async function installBridgeMocks(page: Page) {
     processSnapshot: NODE_PROCESS_SNAPSHOT,
     claudeProviders: CLAUDE_PROVIDERS_PAYLOAD,
     codexProviders: CODEX_PROVIDERS_PAYLOAD,
+    longModel: LONG_MODEL,
   });
 }
 
@@ -130,6 +138,18 @@ async function expectInsideViewport(page: Page, locator: Locator, label: string)
   expect(box.y, `${label} top edge`).toBeGreaterThanOrEqual(-tolerance);
   expect(box.x + box.width, `${label} right edge`).toBeLessThanOrEqual(viewport.width + tolerance);
   expect(box.y + box.height, `${label} bottom edge`).toBeLessThanOrEqual(viewport.height + tolerance);
+}
+
+async function expectContainedWithin(container: Locator, child: Locator, label: string) {
+  const containerBox = await container.boundingBox();
+  const childBox = await child.boundingBox();
+  expect(containerBox, `${label} container should have a visible bounding box`).not.toBeNull();
+  expect(childBox, `${label} child should have a visible bounding box`).not.toBeNull();
+  if (!containerBox || !childBox) return;
+
+  const tolerance = 2;
+  expect(childBox.x, `${label} left edge`).toBeGreaterThanOrEqual(containerBox.x - tolerance);
+  expect(childBox.x + childBox.width, `${label} right edge`).toBeLessThanOrEqual(containerBox.x + containerBox.width + tolerance);
 }
 
 async function expectSubmenuAnchoredToRow(page: Page, trigger: Locator, submenu: Locator, label: string) {
@@ -229,6 +249,39 @@ test('config submenus stay visible across constrained viewports', async ({ page 
   await expect(agentDropdown).toBeVisible();
   await expectInsideViewport(page, agentDropdown, 'agent submenu');
   await expectSubmenuAnchoredToRow(page, agentRow, agentDropdown, 'agent submenu');
+
+  expect(significantErrors(errors)).toEqual([]);
+});
+
+test('long model and mode text stays contained in selector menus', async ({ page }) => {
+  const errors = collectPageErrors(page);
+  await page.goto('/');
+  await expect(page.locator('.button-area-left')).toBeVisible();
+
+  const buttons = page.locator('.button-area-left .selector-button');
+  await expect(buttons).toHaveCount(5);
+
+  await buttons.nth(2).click();
+  const modeDropdown = page.locator('.selector-dropdown').first();
+  await expect(modeDropdown).toBeVisible();
+  await expectInsideViewport(page, modeDropdown, 'mode dropdown with long descriptions');
+  const longModeOption = modeDropdown.locator('.selector-option').filter({ hasText: 'Fully automated' }).first();
+  const longModeDescription = longModeOption.locator('span').filter({ hasText: 'Fully automated' }).first();
+  await expect(longModeDescription).toBeVisible();
+  await expectContainedWithin(longModeOption, longModeDescription, 'long mode description');
+  await closeOpenMenus(page);
+
+  await buttons.nth(3).click();
+  const modelDropdown = page.locator('.selector-dropdown').first();
+  await expect(modelDropdown).toBeVisible();
+  await expectInsideViewport(page, modelDropdown, 'model dropdown with long custom model');
+  const longModelOption = modelDropdown.locator('.selector-option').filter({ hasText: LONG_MODEL.label }).first();
+  const longModelLabel = longModelOption.locator('span').filter({ hasText: LONG_MODEL.label }).first();
+  const longModelDescription = longModelOption.locator('span').filter({ hasText: LONG_MODEL.description }).first();
+  await expect(longModelLabel).toBeVisible();
+  await expect(longModelDescription).toBeVisible();
+  await expectContainedWithin(longModelOption, longModelLabel, 'long model label');
+  await expectContainedWithin(longModelOption, longModelDescription, 'long model description');
 
   expect(significantErrors(errors)).toEqual([]);
 });

--- a/webview/e2e/menu-viewports.spec.ts
+++ b/webview/e2e/menu-viewports.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Locator, type Page } from '@playwright/test';
+import { APP_VERSION } from '../src/version/version';
 
 type BridgeWindow = Window & typeof globalThis & {
   sendToJava?: (message: string) => void;
@@ -83,7 +84,7 @@ const LARGE_MODEL_LIST = Array.from({ length: 240 }, (_, index) => {
 });
 
 async function installBridgeMocks(page: Page, customModels = [LONG_MODEL]) {
-  await page.addInitScript(({ processSnapshot, claudeProviders, codexProviders, models }) => {
+  await page.addInitScript(({ processSnapshot, claudeProviders, codexProviders, models, appVersion }) => {
     localStorage.setItem('model-selection-state', JSON.stringify({
       provider: 'claude',
       claudeModel: 'claude-sonnet-4-6',
@@ -94,7 +95,7 @@ async function installBridgeMocks(page: Page, customModels = [LONG_MODEL]) {
       reasoningEffort: 'high',
     }));
     localStorage.setItem('claude-custom-models', JSON.stringify(models));
-    localStorage.setItem('lastSeenChangelogVersion', '0.4.4');
+    localStorage.setItem('lastSeenChangelogVersion', appVersion);
 
     const hideVConsole = () => {
       const style = document.createElement('style');
@@ -126,6 +127,7 @@ async function installBridgeMocks(page: Page, customModels = [LONG_MODEL]) {
     claudeProviders: CLAUDE_PROVIDERS_PAYLOAD,
     codexProviders: CODEX_PROVIDERS_PAYLOAD,
     models: customModels,
+    appVersion: APP_VERSION,
   });
 }
 
@@ -246,8 +248,7 @@ test('config submenus stay visible across constrained viewports', async ({ page 
   await expect(mainDropdown).toBeVisible();
   await expectInsideViewport(page, mainDropdown, 'config dropdown');
 
-  const topLevelRows = mainDropdown.locator(':scope > .selector-option');
-  const nodeProcessRow = topLevelRows.filter({ hasText: /Node|进程|process/i }).first();
+  const nodeProcessRow = mainDropdown.getByTestId('config-option-node-processes');
   await nodeProcessRow.hover();
   const nodeDropdown = page.locator('.node-process-dropdown');
   await expect(nodeDropdown).toBeVisible();
@@ -255,14 +256,14 @@ test('config submenus stay visible across constrained viewports', async ({ page 
   await expectInsideViewport(page, nodeDropdown, 'node process submenu');
   await expectSubmenuAnchoredToRow(page, nodeProcessRow, nodeDropdown, 'node process submenu');
 
-  const runtimeProviderRow = topLevelRows.filter({ hasText: /provider|切换|提供/i }).first();
+  const runtimeProviderRow = mainDropdown.getByTestId('config-option-runtime-provider');
   await runtimeProviderRow.hover();
   const runtimeDropdown = page.locator('.runtime-provider-dropdown');
   await expect(runtimeDropdown).toBeVisible();
   await expectInsideViewport(page, runtimeDropdown, 'runtime provider submenu');
   await expectSubmenuAnchoredToRow(page, runtimeProviderRow, runtimeDropdown, 'runtime provider submenu');
 
-  const agentRow = topLevelRows.first();
+  const agentRow = mainDropdown.getByTestId('config-option-agent');
   await agentRow.hover();
   const agentDropdown = agentRow.locator('.selector-dropdown').first();
   await expect(agentDropdown).toBeVisible();
@@ -284,8 +285,8 @@ test('long model and mode text stays contained in selector menus', async ({ page
   const modeDropdown = page.locator('.selector-dropdown').first();
   await expect(modeDropdown).toBeVisible();
   await expectInsideViewport(page, modeDropdown, 'mode dropdown with long descriptions');
-  const longModeOption = modeDropdown.locator('.selector-option').filter({ hasText: 'Fully automated' }).first();
-  const longModeDescription = longModeOption.locator('span').filter({ hasText: 'Fully automated' }).first();
+  const longModeOption = modeDropdown.getByTestId('mode-option-bypassPermissions');
+  const longModeDescription = longModeOption.locator('.mode-description');
   await expect(longModeDescription).toBeVisible();
   await expectContainedWithin(longModeOption, longModeDescription, 'long mode description');
   await closeOpenMenus(page);
@@ -318,10 +319,10 @@ test('large model selector remains searchable and capped', async ({ page }) => {
 
   const renderedLargeModels = modelDropdown.getByText(/^Large Model \d{3}$/);
   await expect(renderedLargeModels).toHaveCount(100);
-  await expect(modelDropdown.getByText(/^\+ \d+ more models\. Type to search\.$/)).toBeVisible();
+  await expect(modelDropdown.getByTestId('model-hidden-count')).toBeVisible();
   await expect(modelDropdown.getByText(SEARCH_TARGET_MODEL.label)).toHaveCount(0);
 
-  const searchInput = modelDropdown.getByPlaceholder('Search models');
+  const searchInput = modelDropdown.getByTestId('model-search-input');
   await expect(searchInput).toBeVisible();
   await searchInput.fill('Search Target 220');
 

--- a/webview/e2e/menu-viewports.spec.ts
+++ b/webview/e2e/menu-viewports.spec.ts
@@ -1,0 +1,234 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+type BridgeWindow = Window & typeof globalThis & {
+  sendToJava?: (message: string) => void;
+};
+
+const NODE_PROCESS_SNAPSHOT = {
+  snapshotAt: Date.now(),
+  totals: { daemon: 1, channel: 1, orphan: 1, all: 3 },
+  processes: [
+    {
+      id: 'daemon-1',
+      kind: 'DAEMON',
+      provider: 'claude',
+      pid: 3010,
+      alive: true,
+      startedAt: Date.now() - 120_000,
+      uptimeMs: 120_000,
+      command: 'node daemon.js',
+      heapUsed: 42 * 1024 * 1024,
+      activeRequestCount: 0,
+      orphan: false,
+    },
+    {
+      id: 'channel-1',
+      kind: 'CHANNEL',
+      provider: 'codex',
+      pid: 3011,
+      alive: true,
+      startedAt: Date.now() - 60_000,
+      uptimeMs: 60_000,
+      command: 'node channel.js',
+      activeRequestCount: 1,
+      tabName: 'CC GUI',
+      orphan: false,
+    },
+    {
+      id: 'orphan-1',
+      kind: 'ORPHAN',
+      provider: 'claude',
+      pid: 3012,
+      alive: true,
+      startedAt: Date.now() - 30_000,
+      uptimeMs: 30_000,
+      command: 'node orphan.js',
+      activeRequestCount: 0,
+      orphan: true,
+    },
+  ],
+};
+
+const CLAUDE_PROVIDERS_PAYLOAD = [
+  { id: 'local-settings', name: 'Use local settings.json', isActive: true },
+  { id: 'cli-login', name: 'Use CLI login', isActive: false },
+  { id: 'proxy-a', name: 'Proxy A', remark: 'fast route', isActive: false },
+];
+
+const CODEX_PROVIDERS_PAYLOAD = [
+  { id: 'codex-cli-login', name: 'Use local Codex config', isActive: true },
+  { id: 'codex-proxy', name: 'Codex Proxy', remark: 'workspace config', isActive: false },
+];
+
+async function installBridgeMocks(page: Page) {
+  await page.addInitScript(({ processSnapshot, claudeProviders, codexProviders }) => {
+    localStorage.setItem('model-selection-state', JSON.stringify({
+      provider: 'claude',
+      claudeModel: 'claude-sonnet-4-6',
+      codexModel: 'gpt-5.5',
+      claudePermissionMode: 'bypassPermissions',
+      codexPermissionMode: 'default',
+      longContextEnabled: true,
+      reasoningEffort: 'high',
+    }));
+    localStorage.setItem('lastSeenChangelogVersion', '0.4.4');
+
+    const hideVConsole = () => {
+      const style = document.createElement('style');
+      style.textContent = '#__vconsole { display: none !important; pointer-events: none !important; }';
+      (document.head || document.documentElement)?.appendChild(style);
+    };
+    if (document.head || document.documentElement) {
+      hideVConsole();
+    } else {
+      window.addEventListener('DOMContentLoaded', hideVConsole, { once: true });
+    }
+
+    const respond = (callbackName: string, payload: unknown) => {
+      window.setTimeout(() => {
+        const callback = (window as unknown as Record<string, unknown>)[callbackName];
+        if (typeof callback === 'function') {
+          callback(JSON.stringify(payload));
+        }
+      }, 0);
+    };
+
+    (window as BridgeWindow).sendToJava = (message: string) => {
+      if (message.startsWith('get_node_processes:')) respond('updateNodeProcesses', processSnapshot);
+      if (message.startsWith('get_providers:')) respond('updateProviders', claudeProviders);
+      if (message.startsWith('get_codex_providers:')) respond('updateCodexProviders', codexProviders);
+    };
+  }, {
+    processSnapshot: NODE_PROCESS_SNAPSHOT,
+    claudeProviders: CLAUDE_PROVIDERS_PAYLOAD,
+    codexProviders: CODEX_PROVIDERS_PAYLOAD,
+  });
+}
+
+function collectPageErrors(page: Page) {
+  const errors: string[] = [];
+  page.on('pageerror', (error) => errors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(message.text());
+  });
+  return errors;
+}
+
+function significantErrors(errors: string[]) {
+  return errors.filter((error) => !error.includes('ResizeObserver loop'));
+}
+
+async function expectInsideViewport(page: Page, locator: Locator, label: string) {
+  const box = await locator.boundingBox();
+  expect(box, `${label} should have a visible bounding box`).not.toBeNull();
+  const viewport = page.viewportSize();
+  expect(viewport, 'viewport should be available').not.toBeNull();
+  if (!box || !viewport) return;
+
+  const tolerance = 2;
+  expect(box.x, `${label} left edge`).toBeGreaterThanOrEqual(-tolerance);
+  expect(box.y, `${label} top edge`).toBeGreaterThanOrEqual(-tolerance);
+  expect(box.x + box.width, `${label} right edge`).toBeLessThanOrEqual(viewport.width + tolerance);
+  expect(box.y + box.height, `${label} bottom edge`).toBeLessThanOrEqual(viewport.height + tolerance);
+}
+
+async function expectSubmenuAnchoredToRow(page: Page, trigger: Locator, submenu: Locator, label: string) {
+  const triggerBox = await trigger.boundingBox();
+  const submenuBox = await submenu.boundingBox();
+  expect(triggerBox, `${label} trigger should have a visible bounding box`).not.toBeNull();
+  expect(submenuBox, `${label} submenu should have a visible bounding box`).not.toBeNull();
+  const viewport = page.viewportSize();
+  expect(viewport, 'viewport should be available').not.toBeNull();
+  if (!triggerBox || !submenuBox || !viewport) return;
+
+  const verticalOverlap = Math.max(
+    0,
+    Math.min(triggerBox.y + triggerBox.height, submenuBox.y + submenuBox.height) - Math.max(triggerBox.y, submenuBox.y),
+  );
+  expect(verticalOverlap, `${label} should stay vertically attached to trigger row`).toBeGreaterThan(12);
+
+  const rightSideGap = Math.abs(submenuBox.x - (triggerBox.x + triggerBox.width));
+  const leftSideGap = Math.abs(triggerBox.x - (submenuBox.x + submenuBox.width));
+  const horizontalGap = Math.min(rightSideGap, leftSideGap);
+  const horizontalOverlap = Math.max(
+    0,
+    Math.min(triggerBox.x + triggerBox.width, submenuBox.x + submenuBox.width) - Math.max(triggerBox.x, submenuBox.x),
+  );
+
+  expect(
+    horizontalGap <= 40 || horizontalOverlap > 20,
+    `${label} should be adjacent to or intentionally overlap trigger row`,
+  ).toBe(true);
+}
+
+async function closeOpenMenus(page: Page) {
+  await page.mouse.click(8, 8);
+  await page.waitForTimeout(50);
+}
+
+async function openSelectorMenu(page: Page, button: Locator, label: string) {
+  await button.click();
+  const dropdown = page.locator('.selector-dropdown').first();
+  await expect(dropdown, `${label} dropdown`).toBeVisible();
+  await expectInsideViewport(page, dropdown, `${label} dropdown`);
+  await closeOpenMenus(page);
+}
+
+test.beforeEach(async ({ page }) => {
+  await installBridgeMocks(page);
+});
+
+test('footer selector menus render inside the viewport', async ({ page }) => {
+  const errors = collectPageErrors(page);
+  await page.goto('/');
+  await expect(page.locator('.button-area-left')).toBeVisible();
+  await expect(page.locator('.button-area').first()).toHaveAttribute('data-provider', 'claude');
+
+  const buttons = page.locator('.button-area-left .selector-button');
+  await expect(buttons).toHaveCount(5);
+
+  await openSelectorMenu(page, buttons.nth(0), 'config');
+  await openSelectorMenu(page, buttons.nth(1), 'provider');
+  await openSelectorMenu(page, buttons.nth(2), 'mode');
+  await openSelectorMenu(page, buttons.nth(3), 'model');
+  await openSelectorMenu(page, buttons.nth(4), 'reasoning');
+
+  expect(significantErrors(errors)).toEqual([]);
+});
+
+test('config submenus stay visible across constrained viewports', async ({ page }) => {
+  const errors = collectPageErrors(page);
+  await page.goto('/');
+  await expect(page.locator('.button-area-left')).toBeVisible();
+
+  const configButton = page.locator('.button-area-left .selector-button').first();
+  await configButton.click();
+  const mainDropdown = page.locator('.selector-dropdown').first();
+  await expect(mainDropdown).toBeVisible();
+  await expectInsideViewport(page, mainDropdown, 'config dropdown');
+
+  const topLevelRows = mainDropdown.locator(':scope > .selector-option');
+  const nodeProcessRow = topLevelRows.filter({ hasText: /Node|进程|process/i }).first();
+  await nodeProcessRow.hover();
+  const nodeDropdown = page.locator('.node-process-dropdown');
+  await expect(nodeDropdown).toBeVisible();
+  await expect(page.getByText('PID 3012')).toBeVisible();
+  await expectInsideViewport(page, nodeDropdown, 'node process submenu');
+  await expectSubmenuAnchoredToRow(page, nodeProcessRow, nodeDropdown, 'node process submenu');
+
+  const runtimeProviderRow = topLevelRows.filter({ hasText: /provider|切换|提供/i }).first();
+  await runtimeProviderRow.hover();
+  const runtimeDropdown = page.locator('.runtime-provider-dropdown');
+  await expect(runtimeDropdown).toBeVisible();
+  await expectInsideViewport(page, runtimeDropdown, 'runtime provider submenu');
+  await expectSubmenuAnchoredToRow(page, runtimeProviderRow, runtimeDropdown, 'runtime provider submenu');
+
+  const agentRow = topLevelRows.first();
+  await agentRow.hover();
+  const agentDropdown = agentRow.locator('.selector-dropdown').first();
+  await expect(agentDropdown).toBeVisible();
+  await expectInsideViewport(page, agentDropdown, 'agent submenu');
+  await expectSubmenuAnchoredToRow(page, agentRow, agentDropdown, 'agent submenu');
+
+  expect(significantErrors(errors)).toEqual([]);
+});

--- a/webview/package-lock.json
+++ b/webview/package-lock.json
@@ -22,6 +22,7 @@
         "vconsole": "^3.15.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/react": "^16.3.0",
         "@types/dompurify": "^3.0.5",
@@ -1230,6 +1231,22 @@
       "license": "MIT",
       "dependencies": {
         "langium": "^4.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rc-component/async-validator": {
@@ -5100,6 +5117,53 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/points-on-curve": {

--- a/webview/package.json
+++ b/webview/package.json
@@ -9,9 +9,11 @@
     "build": "tsc && vite build",
     "postbuild": "node scripts/copy-dist.mjs",
     "test": "vitest run && tsc -p tsconfig.test.json --noEmit",
+    "test:e2e": "playwright test",
     "preview": "vite preview"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.3.0",
     "@types/dompurify": "^3.0.5",

--- a/webview/playwright.config.ts
+++ b/webview/playwright.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = Number(process.env.PLAYWRIGHT_PORT ?? 4173);
+const baseURL = `http://127.0.0.1:${PORT}`;
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: false,
+  reporter: [['list']],
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  webServer: {
+    command: `npm run dev -- --host 127.0.0.1 --port ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+  projects: [
+    {
+      name: 'chromium-desktop',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 900 } },
+    },
+    {
+      name: 'chromium-narrow',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 496, height: 884 } },
+    },
+    {
+      name: 'chromium-short',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1018, height: 365 } },
+    },
+    {
+      name: 'chromium-mobile',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 393, height: 851 } },
+    },
+  ],
+});

--- a/webview/src/components/ChatInputBox/selectors/ConfigSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ConfigSelect.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import Switch from 'antd/es/switch';
@@ -11,6 +11,7 @@ import {
   subscribeNodeProcesses,
   type NodeProcessSnapshot,
 } from '../../../utils/nodeProcessCapabilities';
+import { useDropdownPosition } from '../../../hooks/useDropdownPosition';
 
 interface ConfigSelectProps {
   alwaysThinkingEnabled?: boolean;
@@ -33,11 +34,10 @@ const TOGGLE_BUTTON_STYLE: React.CSSProperties = {
   marginRight: '-2px',
 };
 
-const SUBMENU_STYLE: React.CSSProperties = {
+const SUBMENU_BASE_STYLE: React.CSSProperties = {
   position: 'absolute',
   left: '100%',
-  bottom: 0,
-  marginLeft: '-30px',
+  top: 0,
   zIndex: 10001,
   minWidth: '320px',
   maxWidth: '360px',
@@ -75,13 +75,14 @@ const AGENT_DESC_PLAIN_STYLE: React.CSSProperties = {
 const DROPDOWN_STYLE: React.CSSProperties = {
   position: 'absolute',
   bottom: '100%',
-  left: 0,
   marginBottom: '4px',
   zIndex: 10000,
   minWidth: '200px',
+  maxWidth: 'calc(100vw - 16px)',
+  overflow: 'visible',
 };
 
-const SELECTOR_OPTION_RELATIVE_STYLE: React.CSSProperties = { position: 'relative' };
+const SELECTOR_OPTION_RELATIVE_STYLE: React.CSSProperties = { position: 'relative', overflow: 'visible' };
 
 const ITEM_INFO_STYLE: React.CSSProperties = {
   display: 'flex',
@@ -152,16 +153,34 @@ export const ConfigSelect = ({
 
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const agentSubmenuRef = useRef<HTMLDivElement>(null);
+  const agentTriggerRef = useRef<HTMLDivElement>(null);
+  const runtimeProviderTriggerRef = useRef<HTMLDivElement>(null);
   const agentAbortControllerRef = useRef<AbortController | null>(null);
   const toastTimerRef = useRef<number | undefined>(undefined);
 
+  const { positionedStyle: mainPositionedStyle, recalculate: mainRecalculate } = useDropdownPosition({
+    buttonRef,
+    dropdownRef,
+  });
+  const { positionedStyle: agentSubmenuPositionedStyle, maxHeight: agentSubmenuMaxHeight, recalculate: agentSubmenuRecalculate } = useDropdownPosition({
+    buttonRef: agentTriggerRef,
+    dropdownRef: agentSubmenuRef,
+    submenu: true,
+    minWidth: 320,
+    submenuMaxHeight: 300,
+    submenuBottomClearance: 96,
+  });
+
   const handleToggle = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    setIsOpen(!isOpen);
-    if (!isOpen) {
+    const nextOpen = !isOpen;
+    setIsOpen(nextOpen);
+    if (nextOpen) {
       setActiveSubmenu('none');
+      mainRecalculate();
     }
-  }, [isOpen]);
+  }, [isOpen, mainRecalculate]);
 
   const loadAgents = useCallback(async () => {
     if (agentAbortControllerRef.current) {
@@ -264,6 +283,17 @@ export const ConfigSelect = ({
     loadAgents();
   }, [activeSubmenu, loadAgents]);
 
+  useLayoutEffect(() => {
+    if (isOpen) {
+      mainRecalculate();
+    }
+  }, [isOpen, mainRecalculate]);
+
+  useLayoutEffect(() => {
+    if (activeSubmenu !== 'agent') return;
+    agentSubmenuRecalculate();
+  }, [activeSubmenu, agentItems.length, agentsLoading, agentSubmenuRecalculate]);
+
   useEffect(() => {
     return () => {
       if (agentAbortControllerRef.current) {
@@ -275,10 +305,17 @@ export const ConfigSelect = ({
     };
   }, []);
 
-  const renderAgentSubmenu = () => (
+  const renderAgentSubmenu = () => {
+    const submenuMaxHeightPx = agentSubmenuMaxHeight ? `${Math.min(300, agentSubmenuMaxHeight)}px` : '300px';
+    return (
     <div
+      ref={agentSubmenuRef}
       className="selector-dropdown"
-      style={SUBMENU_STYLE}
+      style={{
+        ...SUBMENU_BASE_STYLE,
+        ...agentSubmenuPositionedStyle,
+        maxHeight: submenuMaxHeightPx,
+      }}
       onMouseEnter={(e) => {
         e.stopPropagation();
         setActiveSubmenu('agent');
@@ -333,7 +370,8 @@ export const ConfigSelect = ({
         })
       )}
     </div>
-  );
+    );
+  };
 
   return (
     <div style={WRAPPER_STYLE}>
@@ -351,12 +389,16 @@ export const ConfigSelect = ({
         <div
           ref={dropdownRef}
           className="selector-dropdown"
-          style={DROPDOWN_STYLE}
+          style={{ ...DROPDOWN_STYLE, ...mainPositionedStyle }}
         >
           {/* Agent Item */}
           <div
+            ref={agentTriggerRef}
             className="selector-option"
-            onMouseEnter={() => setActiveSubmenu('agent')}
+            onMouseEnter={() => {
+              setActiveSubmenu('agent');
+              agentSubmenuRecalculate();
+            }}
             onMouseLeave={() => setActiveSubmenu('none')}
             style={SELECTOR_OPTION_RELATIVE_STYLE}
           >
@@ -380,6 +422,7 @@ export const ConfigSelect = ({
 
           {/* Runtime Provider Item */}
           <div
+            ref={runtimeProviderTriggerRef}
             className="selector-option"
             onMouseEnter={() => setActiveSubmenu('runtimeProvider')}
             onMouseLeave={() => setActiveSubmenu('none')}
@@ -397,6 +440,7 @@ export const ConfigSelect = ({
               <RuntimeProviderSelect
                 currentProvider={currentProvider}
                 embedded
+                triggerRef={runtimeProviderTriggerRef}
                 onProviderSwitched={showProviderToast}
                 onClose={() => {
                   setIsOpen(false);

--- a/webview/src/components/ChatInputBox/selectors/ConfigSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ConfigSelect.tsx
@@ -395,6 +395,7 @@ export const ConfigSelect = ({
           <div
             ref={agentTriggerRef}
             className="selector-option"
+            data-testid="config-option-agent"
             onMouseEnter={() => {
               setActiveSubmenu('agent');
               agentSubmenuRecalculate();
@@ -424,6 +425,7 @@ export const ConfigSelect = ({
           <div
             ref={runtimeProviderTriggerRef}
             className="selector-option"
+            data-testid="config-option-runtime-provider"
             onMouseEnter={() => setActiveSubmenu('runtimeProvider')}
             onMouseLeave={() => setActiveSubmenu('none')}
             style={SELECTOR_OPTION_RELATIVE_STYLE}
@@ -455,6 +457,7 @@ export const ConfigSelect = ({
           {/* Node Process Management Item */}
           <div
             className="selector-option"
+            data-testid="config-option-node-processes"
             onMouseEnter={() => setActiveSubmenu('nodeProcesses')}
             onMouseLeave={() => setActiveSubmenu('none')}
             style={SELECTOR_OPTION_RELATIVE_STYLE}

--- a/webview/src/components/ChatInputBox/selectors/ModeSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ModeSelect.tsx
@@ -142,6 +142,7 @@ export const ModeSelect = ({ value, onChange, provider }: ModeSelectProps) => {
           {modeOptions.map((mode) => (
             <div
               key={mode.id}
+              data-testid={`mode-option-${mode.id}`}
               className={`selector-option ${mode.id === value ? 'selected' : ''} ${mode.disabled ? 'disabled' : ''}`}
               onClick={() => handleSelect(mode.id, mode.disabled)}
               title={getModeText(mode.id, 'tooltip')}

--- a/webview/src/components/ChatInputBox/selectors/ModeSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ModeSelect.tsx
@@ -1,17 +1,20 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AVAILABLE_MODES, type PermissionMode } from '../types';
+import { useDropdownPosition } from '../../../hooks/useDropdownPosition';
 
 const RELATIVE_INLINE_BLOCK_STYLE: React.CSSProperties = { position: 'relative', display: 'inline-block' };
 const CHEVRON_ICON_STYLE: React.CSSProperties = { fontSize: '10px', marginLeft: '2px' };
 const DROPDOWN_STYLE: React.CSSProperties = {
   position: 'absolute',
   bottom: '100%',
-  left: 0,
   marginBottom: '4px',
   zIndex: 10000,
+  maxWidth: 'calc(100vw - 16px)',
+  overflowX: 'hidden',
 };
-const MODE_INFO_STYLE: React.CSSProperties = { display: 'flex', flexDirection: 'column', flex: 1 };
+const MODE_INFO_STYLE: React.CSSProperties = { display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0, overflow: 'hidden' };
+const MODE_TEXT_STYLE: React.CSSProperties = { whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' };
 
 function getModeOptionStyle(disabled: boolean): React.CSSProperties {
   return {
@@ -35,6 +38,11 @@ export const ModeSelect = ({ value, onChange, provider }: ModeSelectProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const { positionedStyle, recalculate } = useDropdownPosition({
+    buttonRef,
+    dropdownRef,
+    preferredAlignment: 'right',
+  });
 
   const modeOptions = useMemo(() => {
     if (provider === 'codex') {
@@ -62,8 +70,12 @@ export const ModeSelect = ({ value, onChange, provider }: ModeSelectProps) => {
    */
   const handleToggle = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    setIsOpen(!isOpen);
-  }, [isOpen]);
+    const nextOpen = !isOpen;
+    setIsOpen(nextOpen);
+    if (nextOpen) {
+      recalculate();
+    }
+  }, [isOpen, recalculate]);
 
   /**
    * Select mode
@@ -102,6 +114,12 @@ export const ModeSelect = ({ value, onChange, provider }: ModeSelectProps) => {
     };
   }, [isOpen]);
 
+  useLayoutEffect(() => {
+    if (isOpen) {
+      recalculate();
+    }
+  }, [isOpen, recalculate]);
+
   return (
     <div style={RELATIVE_INLINE_BLOCK_STYLE}>
       <button
@@ -119,7 +137,7 @@ export const ModeSelect = ({ value, onChange, provider }: ModeSelectProps) => {
         <div
           ref={dropdownRef}
           className="selector-dropdown"
-          style={DROPDOWN_STYLE}
+          style={{ ...DROPDOWN_STYLE, ...positionedStyle }}
         >
           {modeOptions.map((mode) => (
             <div
@@ -131,8 +149,8 @@ export const ModeSelect = ({ value, onChange, provider }: ModeSelectProps) => {
             >
               <span className={`codicon ${mode.icon}`} />
               <div style={MODE_INFO_STYLE}>
-                <span>{getModeText(mode.id, 'label')}</span>
-                <span className="mode-description">{getModeText(mode.id, 'description')}</span>
+                <span style={MODE_TEXT_STYLE}>{getModeText(mode.id, 'label')}</span>
+                <span className="mode-description" style={MODE_TEXT_STYLE}>{getModeText(mode.id, 'description')}</span>
               </div>
               {mode.id === value && (
                 <span className="codicon codicon-check check-mark" />

--- a/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useDeferredValue, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AVAILABLE_MODELS, normalizeClaudeModelId, modelSupports1MContext, strip1MContextSuffix } from '../types';
 import type { ModelInfo } from '../types';
@@ -21,6 +21,7 @@ const MODEL_OPTION_INFO_STYLE: React.CSSProperties = { display: 'flex', flexDire
 const MODEL_TEXT_STYLE: React.CSSProperties = { whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' };
 const LONG_CONTEXT_OPTION_STYLE: React.CSSProperties = { justifyContent: 'space-between', cursor: 'default' };
 const LONG_CONTEXT_LABEL_STYLE: React.CSSProperties = { fontSize: '12px' };
+const MAX_VISIBLE_MODEL_OPTIONS = 100;
 
 interface ModelSelectProps {
   value: string;
@@ -132,9 +133,11 @@ const resolveModelIdForIcon = (
 export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, currentProvider = 'claude', onAddModel, longContextEnabled = true, onLongContextChange }: ModelSelectProps) => {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const deferredSearchQuery = useDeferredValue(searchQuery);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const { positionedStyle, recalculate } = useDropdownPosition({
+  const { positionedStyle, maxHeight, recalculate } = useDropdownPosition({
     buttonRef,
     dropdownRef,
     preferredAlignment: 'right',
@@ -193,6 +196,18 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
     return model.description;
   };
 
+  const normalizedSearchQuery = deferredSearchQuery.trim().toLowerCase();
+  const filteredModels = normalizedSearchQuery
+    ? models.filter((model) => {
+        const label = getModelLabel(model, false);
+        const description = getModelDescription(model) ?? '';
+        return [model.id, label, description].some((value) => value.toLowerCase().includes(normalizedSearchQuery));
+      })
+    : models;
+  const visibleModels = filteredModels.slice(0, MAX_VISIBLE_MODEL_OPTIONS);
+  const hiddenModelCount = Math.max(0, filteredModels.length - visibleModels.length);
+  const showSearch = models.length > MAX_VISIBLE_MODEL_OPTIONS || searchQuery.length > 0;
+
   /**
    * Toggle dropdown
    */
@@ -200,6 +215,9 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
     e.stopPropagation();
     const nextOpen = !isOpen;
     setIsOpen(nextOpen);
+    if (!nextOpen) {
+      setSearchQuery('');
+    }
     if (nextOpen) {
       recalculate();
     }
@@ -211,6 +229,7 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
   const handleSelect = useCallback((modelId: string) => {
     onChange(modelId);
     setIsOpen(false);
+    setSearchQuery('');
   }, [onChange]);
 
   /**
@@ -227,6 +246,7 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
         !buttonRef.current.contains(e.target as Node)
       ) {
         setIsOpen(false);
+        setSearchQuery('');
       }
     };
 
@@ -245,7 +265,7 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
     if (isOpen) {
       recalculate();
     }
-  }, [isOpen, recalculate]);
+  }, [isOpen, filteredModels.length, recalculate]);
 
   return (
     <div style={RELATIVE_INLINE_BLOCK_STYLE}>
@@ -269,9 +289,20 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
         <div
           ref={dropdownRef}
           className="selector-dropdown"
-          style={{ ...DROPDOWN_STYLE, ...positionedStyle }}
+          style={{ ...DROPDOWN_STYLE, ...positionedStyle, maxHeight, overflowY: 'auto' }}
         >
-          {models.map((model) => (
+          {showSearch && (
+            <div className="selector-search-row">
+              <input
+                className="selector-search-input"
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+                placeholder={t('models.searchPlaceholder', { defaultValue: 'Search models' })}
+                autoFocus
+              />
+            </div>
+          )}
+          {visibleModels.map((model) => (
             <div
               key={model.id}
               className={`selector-option ${isSelectedModel(model.id) ? 'selected' : ''}`}
@@ -294,6 +325,19 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
               )}
             </div>
           ))}
+          {visibleModels.length === 0 && (
+            <div className="selector-option selector-option-status">
+              {t('models.noModelsFound', { defaultValue: 'No models found' })}
+            </div>
+          )}
+          {hiddenModelCount > 0 && (
+            <div className="selector-option selector-option-status">
+              {t('models.hiddenModelCount', {
+                count: hiddenModelCount,
+                defaultValue: `+ ${hiddenModelCount} more models. Type to search.`,
+              })}
+            </div>
+          )}
           {currentProvider === 'claude' && onLongContextChange && (
             <>
               <div className="selector-divider" />
@@ -317,7 +361,7 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
               <div className="selector-divider" />
               <div
                 className="selector-option selector-option-add"
-                onClick={() => { onAddModel(); setIsOpen(false); }}
+                onClick={() => { onAddModel(); setIsOpen(false); setSearchQuery(''); }}
               >
                 <span className="codicon codicon-add selector-add-icon" />
                 <span>{t('models.addModel')}</span>

--- a/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
@@ -295,6 +295,7 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
             <div className="selector-search-row">
               <input
                 className="selector-search-input"
+                data-testid="model-search-input"
                 value={searchQuery}
                 onChange={(event) => setSearchQuery(event.target.value)}
                 placeholder={t('models.searchPlaceholder', { defaultValue: 'Search models' })}
@@ -331,7 +332,7 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
             </div>
           )}
           {hiddenModelCount > 0 && (
-            <div className="selector-option selector-option-status">
+            <div className="selector-option selector-option-status" data-testid="model-hidden-count">
               {t('models.hiddenModelCount', {
                 count: hiddenModelCount,
                 defaultValue: `+ ${hiddenModelCount} more models. Type to search.`,

--- a/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AVAILABLE_MODELS, normalizeClaudeModelId, modelSupports1MContext, strip1MContextSuffix } from '../types';
 import type { ModelInfo } from '../types';
 import { readClaudeModelMapping } from '../../../utils/claudeModelMapping';
 import { ProviderModelIcon } from '../../shared/ProviderModelIcon';
+import { useDropdownPosition } from '../../../hooks/useDropdownPosition';
 import Switch from 'antd/es/switch';
 
 const RELATIVE_INLINE_BLOCK_STYLE: React.CSSProperties = { position: 'relative', display: 'inline-block' };
@@ -11,11 +12,13 @@ const CHEVRON_ICON_STYLE: React.CSSProperties = { fontSize: '10px', marginLeft: 
 const DROPDOWN_STYLE: React.CSSProperties = {
   position: 'absolute',
   bottom: '100%',
-  left: 0,
   marginBottom: '4px',
   zIndex: 10000,
+  maxWidth: 'calc(100vw - 16px)',
+  overflowX: 'hidden',
 };
-const MODEL_OPTION_INFO_STYLE: React.CSSProperties = { display: 'flex', flexDirection: 'column', flex: 1 };
+const MODEL_OPTION_INFO_STYLE: React.CSSProperties = { display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0, overflow: 'hidden' };
+const MODEL_TEXT_STYLE: React.CSSProperties = { whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' };
 const LONG_CONTEXT_OPTION_STYLE: React.CSSProperties = { justifyContent: 'space-between', cursor: 'default' };
 const LONG_CONTEXT_LABEL_STYLE: React.CSSProperties = { fontSize: '12px' };
 
@@ -131,6 +134,11 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
   const [isOpen, setIsOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const { positionedStyle, recalculate } = useDropdownPosition({
+    buttonRef,
+    dropdownRef,
+    preferredAlignment: 'right',
+  });
 
   // Strip [1m] suffix for finding the model in the list
   const strippedValue = strip1MContextSuffix(value);
@@ -190,8 +198,12 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
    */
   const handleToggle = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    setIsOpen(!isOpen);
-  }, [isOpen]);
+    const nextOpen = !isOpen;
+    setIsOpen(nextOpen);
+    if (nextOpen) {
+      recalculate();
+    }
+  }, [isOpen, recalculate]);
 
   /**
    * Select model
@@ -229,6 +241,12 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
     };
   }, [isOpen]);
 
+  useLayoutEffect(() => {
+    if (isOpen) {
+      recalculate();
+    }
+  }, [isOpen, recalculate]);
+
   return (
     <div style={RELATIVE_INLINE_BLOCK_STYLE}>
       <button
@@ -251,7 +269,7 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
         <div
           ref={dropdownRef}
           className="selector-dropdown"
-          style={DROPDOWN_STYLE}
+          style={{ ...DROPDOWN_STYLE, ...positionedStyle }}
         >
           {models.map((model) => (
             <div
@@ -266,9 +284,9 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
                 colored
               />
               <div style={MODEL_OPTION_INFO_STYLE}>
-                <span>{getModelLabel(model, false)}</span>
+                <span style={MODEL_TEXT_STYLE}>{getModelLabel(model, false)}</span>
                 {getModelDescription(model) && (
-                  <span className="model-description">{getModelDescription(model)}</span>
+                  <span className="model-description" style={MODEL_TEXT_STYLE}>{getModelDescription(model)}</span>
                 )}
               </div>
               {isSelectedModel(model.id) && (

--- a/webview/src/components/ChatInputBox/selectors/NodeProcessSelect.positioning.test.ts
+++ b/webview/src/components/ChatInputBox/selectors/NodeProcessSelect.positioning.test.ts
@@ -1,28 +1,40 @@
 import { describe, expect, it } from 'vitest';
-import { shouldFlipNodeProcessDropdownLeft } from './NodeProcessSelect';
+import { getEmbeddedNodeProcessDropdownLayout } from './NodeProcessSelect';
 
 describe('NodeProcessSelect dropdown positioning', () => {
   it('keeps the submenu flipped left after right-side overflow is detected', () => {
-    const anchorRect = { left: 190, right: 390 };
-    const dropdownWidth = 350;
-    const viewportWidth = 410;
+    const layout = getEmbeddedNodeProcessDropdownLayout({
+      parentRect: { left: 190, right: 390, top: 0 },
+      viewportWidth: 410,
+      viewportHeight: 700,
+      dropdownHeight: 350,
+    });
 
-    expect(shouldFlipNodeProcessDropdownLeft({
-      anchorRect,
-      dropdownWidth,
-      viewportWidth,
-    })).toBe(true);
+    expect(layout.flipToLeft).toBe(true);
   });
 
   it('keeps the submenu on the right when there is enough room', () => {
-    const anchorRect = { left: 40, right: 240 };
-    const dropdownWidth = 260;
-    const viewportWidth = 700;
+    const layout = getEmbeddedNodeProcessDropdownLayout({
+      parentRect: { left: 40, right: 240, top: 0 },
+      viewportWidth: 700,
+      viewportHeight: 700,
+      dropdownHeight: 260,
+    });
 
-    expect(shouldFlipNodeProcessDropdownLeft({
-      anchorRect,
-      dropdownWidth,
-      viewportWidth,
-    })).toBe(false);
+    expect(layout.flipToLeft).toBe(false);
+  });
+
+  it('clamps width and height to the visible viewport', () => {
+    const layout = getEmbeddedNodeProcessDropdownLayout({
+      parentRect: { left: 20, right: 180, top: 120 },
+      viewportWidth: 260,
+      viewportHeight: 240,
+      dropdownHeight: 500,
+    });
+
+    expect(layout.maxWidth).toBeLessThanOrEqual(360);
+    expect(layout.maxWidth).toBeGreaterThan(0);
+    expect(layout.maxHeight).toBeLessThanOrEqual(240 - 8 - 120 - layout.topOffset);
+    expect(layout.maxHeight).toBeGreaterThan(0);
   });
 });

--- a/webview/src/components/ChatInputBox/selectors/NodeProcessSelect.render.test.tsx
+++ b/webview/src/components/ChatInputBox/selectors/NodeProcessSelect.render.test.tsx
@@ -22,43 +22,28 @@ vi.mock('../../../utils/nodeProcessCapabilities', () => ({
   subscribeNodeProcessKillResult: vi.fn(() => () => undefined),
 }));
 
-function rect(left: number, right: number, width = right - left): DOMRect {
+vi.mock('../../../utils/viewport', () => ({
+  getAppViewport: () => ({ left: 0, top: 0, width: 410, height: 700 }),
+}));
+
+function rect(left: number, right: number, width = right - left, top = 0, height = 200): DOMRect {
   return {
     x: left,
-    y: 0,
+    y: top,
     left,
     right,
-    top: 0,
-    bottom: 200,
+    top,
+    bottom: top + height,
     width,
-    height: 200,
+    height,
     toJSON: () => ({}),
   } as DOMRect;
 }
 
 describe('NodeProcessSelect render positioning', () => {
   let getBoundingClientRectSpy: ReturnType<typeof vi.spyOn>;
-  let originalInnerWidth: number;
 
   beforeEach(() => {
-    originalInnerWidth = window.innerWidth;
-    Object.defineProperty(window, 'innerWidth', {
-      configurable: true,
-      writable: true,
-      value: 410,
-    });
-  });
-
-  afterEach(() => {
-    getBoundingClientRectSpy?.mockRestore();
-    Object.defineProperty(window, 'innerWidth', {
-      configurable: true,
-      writable: true,
-      value: originalInnerWidth,
-    });
-  });
-
-  it('does not enter a layout update loop when the flipped dropdown has different measured bounds', async () => {
     getBoundingClientRectSpy = vi
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
       .mockImplementation(function getMockRect(this: HTMLElement) {
@@ -72,7 +57,13 @@ describe('NodeProcessSelect render positioning', () => {
         }
         return rect(0, 0, 0);
       });
+  });
 
+  afterEach(() => {
+    getBoundingClientRectSpy.mockRestore();
+  });
+
+  it('does not enter a layout update loop when the flipped dropdown has different measured bounds', async () => {
     const { container } = render(
       <div data-testid="node-process-anchor">
         <NodeProcessSelect embedded />

--- a/webview/src/components/ChatInputBox/selectors/NodeProcessSelect.test.tsx
+++ b/webview/src/components/ChatInputBox/selectors/NodeProcessSelect.test.tsx
@@ -1,0 +1,75 @@
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NodeProcessSelect } from './NodeProcessSelect';
+
+const nodeProcessMocks = vi.hoisted(() => ({
+  fetchNodeProcesses: vi.fn(),
+  killAllOrphanProcesses: vi.fn(),
+  killNodeProcess: vi.fn(),
+  restartNodeDaemon: vi.fn(),
+  subscribeNodeProcessKillResult: vi.fn(() => vi.fn()),
+  subscribeNodeProcesses: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('../../../utils/nodeProcessCapabilities', () => ({
+  ...nodeProcessMocks,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: string | { defaultValue?: string }) => {
+      if (typeof options === 'object' && options?.defaultValue) return options.defaultValue;
+      return typeof options === 'string' ? options : key;
+    },
+  }),
+}));
+
+function makeRect(left: number, right: number, width: number): DOMRect {
+  return {
+    x: left,
+    y: 0,
+    left,
+    right,
+    top: 0,
+    bottom: 100,
+    width,
+    height: 100,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+describe('NodeProcessSelect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 700 });
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function getBoundingClientRect(this: HTMLElement) {
+      if (this.classList.contains('node-process-dropdown')) {
+        const isFlipped = this.style.right === '100%';
+        return isFlipped ? makeRect(230, 530, 300) : makeRect(590, 890, 300);
+      }
+      if (this.dataset.testid === 'node-process-anchor') {
+        return makeRect(500, 620, 120);
+      }
+      return makeRect(0, 0, 0);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('keeps an embedded dropdown flipped without repeatedly toggling layout state', async () => {
+    const { container } = render(
+      <div data-testid="node-process-anchor">
+        <NodeProcessSelect embedded />
+      </div>,
+    );
+
+    const dropdown = container.querySelector('.node-process-dropdown') as HTMLElement;
+
+    await waitFor(() => {
+      expect(dropdown.style.right).toBe('100%');
+    });
+    expect(dropdown.style.left).toBe('auto');
+  });
+});

--- a/webview/src/components/ChatInputBox/selectors/NodeProcessSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/NodeProcessSelect.tsx
@@ -179,7 +179,7 @@ type PendingConfirm =
   | { kind: 'restart'; proc: NodeProcessInfo }
   | { kind: 'killAll'; orphans: NodeProcessInfo[] };
 
-interface EmbeddedDropdownLayout {
+export interface EmbeddedNodeProcessDropdownLayout {
   flipToLeft: boolean;
   maxWidth: number;
   maxHeight: number;
@@ -187,12 +187,19 @@ interface EmbeddedDropdownLayout {
   horizontalOverlap: number;
 }
 
-function getEmbeddedNodeProcessDropdownLayout(
-  parentRect: { left: number; right: number; top: number },
-  viewportWidth: number,
-  viewportHeight: number,
-  dropdownHeight: number,
-): EmbeddedDropdownLayout {
+export interface EmbeddedNodeProcessDropdownLayoutInput {
+  parentRect: { left: number; right: number; top: number };
+  viewportWidth: number;
+  viewportHeight: number;
+  dropdownHeight: number;
+}
+
+export function getEmbeddedNodeProcessDropdownLayout({
+  parentRect,
+  viewportWidth,
+  viewportHeight,
+  dropdownHeight,
+}: EmbeddedNodeProcessDropdownLayoutInput): EmbeddedNodeProcessDropdownLayout {
   const normalAvailableWidth = Math.max(
     0,
     viewportWidth - DROPDOWN_VIEWPORT_PADDING_PX - parentRect.right,
@@ -273,7 +280,7 @@ export const NodeProcessSelect = ({ embedded = false, onClose, onToast }: NodePr
   const [snapshot, setSnapshot] = useState<NodeProcessSnapshot | null>(null);
   const [loading, setLoading] = useState(true);
   const [pendingPids, setPendingPids] = useState<Set<number>>(() => new Set());
-  const [embeddedLayout, setEmbeddedLayout] = useState<EmbeddedDropdownLayout>(() => ({
+  const [embeddedLayout, setEmbeddedLayout] = useState<EmbeddedNodeProcessDropdownLayout>(() => ({
     flipToLeft: false,
     maxWidth: DROPDOWN_MAX_WIDTH_PX,
     maxHeight: DROPDOWN_MAX_HEIGHT_PX,
@@ -297,16 +304,16 @@ export const NodeProcessSelect = ({ embedded = false, onClose, onToast }: NodePr
     const viewport = getAppViewport();
     const parentRect = parent.getBoundingClientRect();
     const nodeRect = node.getBoundingClientRect();
-    const nextLayout = getEmbeddedNodeProcessDropdownLayout(
-      {
+    const nextLayout = getEmbeddedNodeProcessDropdownLayout({
+      parentRect: {
         left: parentRect.left - viewport.left,
         right: parentRect.right - viewport.left,
         top: parentRect.top - viewport.top,
       },
-      viewport.width,
-      viewport.height,
-      Math.max(nodeRect.height, node.scrollHeight),
-    );
+      viewportWidth: viewport.width,
+      viewportHeight: viewport.height,
+      dropdownHeight: Math.max(nodeRect.height, node.scrollHeight),
+    });
 
     setEmbeddedLayout((current) => (
       current.flipToLeft === nextLayout.flipToLeft

--- a/webview/src/components/ChatInputBox/selectors/NodeProcessSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/NodeProcessSelect.tsx
@@ -19,14 +19,11 @@ interface NodeProcessSelectProps {
   onToast?: (message: string) => void;
 }
 
-const DROPDOWN_SIDE_OVERLAP_PX = 30;
-const VIEWPORT_EDGE_MARGIN_PX = 8;
-
 const DROPDOWN_STYLE_EMBEDDED: React.CSSProperties = {
   position: 'absolute',
   bottom: 0,
   left: '100%',
-  marginLeft: -DROPDOWN_SIDE_OVERLAP_PX,
+  marginLeft: '-30px',
   zIndex: 10001,
   minWidth: '260px',
   width: 'max-content',
@@ -36,27 +33,6 @@ const DROPDOWN_STYLE_EMBEDDED: React.CSSProperties = {
   overflowX: 'hidden',
   padding: '6px 0',
 };
-
-export interface NodeProcessDropdownPositionInput {
-  anchorRect: { left: number; right: number };
-  dropdownWidth: number;
-  viewportWidth: number;
-  overlapPx?: number;
-  edgeMarginPx?: number;
-}
-
-export function shouldFlipNodeProcessDropdownLeft({
-  anchorRect,
-  dropdownWidth,
-  viewportWidth,
-  overlapPx = DROPDOWN_SIDE_OVERLAP_PX,
-  edgeMarginPx = VIEWPORT_EDGE_MARGIN_PX,
-}: NodeProcessDropdownPositionInput): boolean {
-  const rightStart = anchorRect.right - overlapPx;
-  const rightAvailable = viewportWidth - edgeMarginPx - rightStart;
-  const leftAvailable = anchorRect.left + overlapPx - edgeMarginPx;
-  return dropdownWidth > rightAvailable && leftAvailable > rightAvailable;
-}
 
 const GROUP_HEADER_STYLE: React.CSSProperties = {
   display: 'flex',
@@ -185,6 +161,9 @@ const REFRESH_BUTTON_STYLE: React.CSSProperties = {
   padding: '2px 6px',
 };
 
+const VIEWPORT_PADDING = 8;
+const SUBMENU_OVERLAP = 30;
+
 // Pending PIDs are per-component-instance state. Each ConfigSelect (one per tab)
 // owns its own pending set — sharing across instances would surface
 // "still working..." spinners in tabs that never issued the kill.
@@ -244,23 +223,24 @@ export const NodeProcessSelect = ({ embedded = false, onClose, onToast }: NodePr
   const refreshTimerRef = useRef<number | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // Decide the submenu side from the parent menu item, not from the current
-  // rendered dropdown position. Measuring the rendered position can oscillate
-  // right -> left -> right in narrow tool windows.
+  // Detect when the dropdown would overflow the viewport on the right side and
+  // flip it to render on the left of the parent menu item instead. Runs after
+  // every snapshot update because the dropdown height/width can change.
   useLayoutEffect(() => {
     if (!embedded) return;
     const node = dropdownRef.current;
     if (!node) return;
-    const anchor = node.parentElement;
-    if (!anchor) return;
-    const anchorRect = anchor.getBoundingClientRect();
-    const rect = node.getBoundingClientRect();
-    const nextFlipToLeft = shouldFlipNodeProcessDropdownLeft({
-      anchorRect,
-      dropdownWidth: rect.width,
-      viewportWidth: window.innerWidth,
-    });
-    setFlipToLeft((prev) => (prev === nextFlipToLeft ? prev : nextFlipToLeft));
+    const parent = node.parentElement;
+    if (!parent) return;
+
+    const parentRect = parent.getBoundingClientRect();
+    const dropdownWidth = node.getBoundingClientRect().width;
+    const unflippedRight = parentRect.right - SUBMENU_OVERLAP + dropdownWidth;
+    const flippedLeft = parentRect.left + SUBMENU_OVERLAP - dropdownWidth;
+    const shouldFlipLeft = unflippedRight > window.innerWidth - VIEWPORT_PADDING
+      && flippedLeft >= VIEWPORT_PADDING;
+
+    setFlipToLeft((current) => current === shouldFlipLeft ? current : shouldFlipLeft);
   }, [embedded, snapshot]);
 
   const requestRefresh = useCallback(() => {
@@ -525,7 +505,7 @@ export const NodeProcessSelect = ({ embedded = false, onClose, onToast }: NodePr
         left: 'auto',
         right: '100%',
         marginLeft: 0,
-        marginRight: -DROPDOWN_SIDE_OVERLAP_PX,
+        marginRight: '-30px',
       }
     : DROPDOWN_STYLE_EMBEDDED;
 

--- a/webview/src/components/ChatInputBox/selectors/NodeProcessSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/NodeProcessSelect.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import ConfirmDialog from '../../ConfirmDialog';
+import { getAppViewport } from '../../../utils/viewport';
 import {
   fetchNodeProcesses,
   killAllOrphanProcesses,
@@ -21,14 +22,14 @@ interface NodeProcessSelectProps {
 
 const DROPDOWN_STYLE_EMBEDDED: React.CSSProperties = {
   position: 'absolute',
-  bottom: 0,
+  top: 0,
   left: '100%',
-  marginLeft: '-30px',
+  marginLeft: 0,
   zIndex: 10001,
   minWidth: '260px',
   width: 'max-content',
-  maxWidth: 'min(360px, calc(100vw - 60px))',
-  maxHeight: 'min(380px, calc(100vh - 100px))',
+  maxWidth: '360px',
+  maxHeight: '380px',
   overflowY: 'auto',
   overflowX: 'hidden',
   padding: '6px 0',
@@ -161,8 +162,13 @@ const REFRESH_BUTTON_STYLE: React.CSSProperties = {
   padding: '2px 6px',
 };
 
-const VIEWPORT_PADDING = 8;
-const SUBMENU_OVERLAP = 30;
+const DROPDOWN_SIDE_OVERLAP_PX = 30;
+const DROPDOWN_VIEWPORT_PADDING_PX = 8;
+const DROPDOWN_MIN_WIDTH_PX = 260;
+const DROPDOWN_MIN_FLUSH_WIDTH_PX = 180;
+const DROPDOWN_MAX_WIDTH_PX = 360;
+const DROPDOWN_MAX_HEIGHT_PX = 380;
+const DROPDOWN_BOTTOM_CLEARANCE_PX = 72;
 
 // Pending PIDs are per-component-instance state. Each ConfigSelect (one per tab)
 // owns its own pending set — sharing across instances would surface
@@ -172,6 +178,55 @@ type PendingConfirm =
   | { kind: 'kill'; proc: NodeProcessInfo }
   | { kind: 'restart'; proc: NodeProcessInfo }
   | { kind: 'killAll'; orphans: NodeProcessInfo[] };
+
+interface EmbeddedDropdownLayout {
+  flipToLeft: boolean;
+  maxWidth: number;
+  maxHeight: number;
+  topOffset: number;
+  horizontalOverlap: number;
+}
+
+function getEmbeddedNodeProcessDropdownLayout(
+  parentRect: { left: number; right: number; top: number },
+  viewportWidth: number,
+  viewportHeight: number,
+  dropdownHeight: number,
+): EmbeddedDropdownLayout {
+  const normalAvailableWidth = Math.max(
+    0,
+    viewportWidth - DROPDOWN_VIEWPORT_PADDING_PX - parentRect.right,
+  );
+  const flippedAvailableWidth = Math.max(
+    0,
+    parentRect.left - DROPDOWN_VIEWPORT_PADDING_PX,
+  );
+  const normalShortfall = Math.max(0, DROPDOWN_MIN_FLUSH_WIDTH_PX - normalAvailableWidth);
+  const flippedShortfall = Math.max(0, DROPDOWN_MIN_FLUSH_WIDTH_PX - flippedAvailableWidth);
+  const flipToLeft = normalShortfall > 0 && flippedShortfall < normalShortfall;
+  const availableWidthWithoutOverlap = flipToLeft ? flippedAvailableWidth : normalAvailableWidth;
+  const horizontalOverlap = Math.min(
+    DROPDOWN_SIDE_OVERLAP_PX,
+    Math.max(0, DROPDOWN_MIN_FLUSH_WIDTH_PX - availableWidthWithoutOverlap),
+  );
+  const availableWidth = availableWidthWithoutOverlap + horizontalOverlap;
+  const desiredHeight = Math.min(DROPDOWN_MAX_HEIGHT_PX, Math.max(1, Math.ceil(dropdownHeight)));
+  const availableBelow = viewportHeight - DROPDOWN_VIEWPORT_PADDING_PX - parentRect.top;
+  const minTopOffset = DROPDOWN_VIEWPORT_PADDING_PX - parentRect.top;
+  const topOffset = Math.max(
+    minTopOffset,
+    Math.min(0, availableBelow - desiredHeight - DROPDOWN_BOTTOM_CLEARANCE_PX),
+  );
+  const availableHeight = viewportHeight - DROPDOWN_VIEWPORT_PADDING_PX - parentRect.top - topOffset;
+
+  return {
+    flipToLeft,
+    maxWidth: Math.max(1, Math.min(DROPDOWN_MAX_WIDTH_PX, Math.floor(availableWidth))),
+    maxHeight: Math.max(1, Math.min(DROPDOWN_MAX_HEIGHT_PX, Math.floor(availableHeight))),
+    topOffset,
+    horizontalOverlap,
+  };
+}
 
 function formatUptime(ms: number): string {
   if (ms <= 0) return '—';
@@ -218,7 +273,13 @@ export const NodeProcessSelect = ({ embedded = false, onClose, onToast }: NodePr
   const [snapshot, setSnapshot] = useState<NodeProcessSnapshot | null>(null);
   const [loading, setLoading] = useState(true);
   const [pendingPids, setPendingPids] = useState<Set<number>>(() => new Set());
-  const [flipToLeft, setFlipToLeft] = useState(false);
+  const [embeddedLayout, setEmbeddedLayout] = useState<EmbeddedDropdownLayout>(() => ({
+    flipToLeft: false,
+    maxWidth: DROPDOWN_MAX_WIDTH_PX,
+    maxHeight: DROPDOWN_MAX_HEIGHT_PX,
+    topOffset: 0,
+    horizontalOverlap: 0,
+  }));
   const [pendingConfirm, setPendingConfirm] = useState<PendingConfirm | null>(null);
   const refreshTimerRef = useRef<number | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -233,14 +294,29 @@ export const NodeProcessSelect = ({ embedded = false, onClose, onToast }: NodePr
     const parent = node.parentElement;
     if (!parent) return;
 
+    const viewport = getAppViewport();
     const parentRect = parent.getBoundingClientRect();
-    const dropdownWidth = node.getBoundingClientRect().width;
-    const unflippedRight = parentRect.right - SUBMENU_OVERLAP + dropdownWidth;
-    const flippedLeft = parentRect.left + SUBMENU_OVERLAP - dropdownWidth;
-    const shouldFlipLeft = unflippedRight > window.innerWidth - VIEWPORT_PADDING
-      && flippedLeft >= VIEWPORT_PADDING;
+    const nodeRect = node.getBoundingClientRect();
+    const nextLayout = getEmbeddedNodeProcessDropdownLayout(
+      {
+        left: parentRect.left - viewport.left,
+        right: parentRect.right - viewport.left,
+        top: parentRect.top - viewport.top,
+      },
+      viewport.width,
+      viewport.height,
+      Math.max(nodeRect.height, node.scrollHeight),
+    );
 
-    setFlipToLeft((current) => current === shouldFlipLeft ? current : shouldFlipLeft);
+    setEmbeddedLayout((current) => (
+      current.flipToLeft === nextLayout.flipToLeft
+      && current.maxWidth === nextLayout.maxWidth
+      && current.maxHeight === nextLayout.maxHeight
+      && current.topOffset === nextLayout.topOffset
+      && current.horizontalOverlap === nextLayout.horizontalOverlap
+        ? current
+        : nextLayout
+    ));
   }, [embedded, snapshot]);
 
   const requestRefresh = useCallback(() => {
@@ -496,18 +572,29 @@ export const NodeProcessSelect = ({ embedded = false, onClose, onToast }: NodePr
     );
   };
 
-  // When the right edge would overflow the viewport, anchor the dropdown to
-  // the parent menu item's LEFT side instead so it grows leftward and stays
-  // entirely visible on narrow IDE windows.
-  const dropdownStyle: React.CSSProperties = flipToLeft
+  const embeddedWidthStyle: React.CSSProperties = embedded
+    ? {
+        minWidth: `${Math.min(DROPDOWN_MIN_WIDTH_PX, embeddedLayout.maxWidth)}px`,
+        maxWidth: `${embeddedLayout.maxWidth}px`,
+        maxHeight: `${embeddedLayout.maxHeight}px`,
+        top: `${embeddedLayout.topOffset}px`,
+      }
+    : {};
+
+  const dropdownStyle: React.CSSProperties = embeddedLayout.flipToLeft
     ? {
         ...DROPDOWN_STYLE_EMBEDDED,
+        ...embeddedWidthStyle,
         left: 'auto',
         right: '100%',
         marginLeft: 0,
-        marginRight: '-30px',
+        marginRight: `-${embeddedLayout.horizontalOverlap}px`,
       }
-    : DROPDOWN_STYLE_EMBEDDED;
+    : {
+        ...DROPDOWN_STYLE_EMBEDDED,
+        ...embeddedWidthStyle,
+        marginLeft: `-${embeddedLayout.horizontalOverlap}px`,
+      };
 
   const renderDropdown = () => (
     <div

--- a/webview/src/components/ChatInputBox/selectors/ProviderSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ProviderSelect.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { AVAILABLE_PROVIDERS } from '../types';
@@ -8,15 +8,17 @@ import {
   subscribeCodexSubscriptionQuota,
   type CodexSubscriptionQuotaSnapshot,
 } from '../../../utils/codexSubscriptionQuotaCapabilities';
+import { useDropdownPosition } from '../../../hooks/useDropdownPosition';
 
 const RELATIVE_INLINE_BLOCK_STYLE: React.CSSProperties = { position: 'relative', display: 'inline-block' };
 const CHEVRON_ICON_STYLE: React.CSSProperties = { fontSize: '10px', marginLeft: '2px' };
 const DROPDOWN_STYLE: React.CSSProperties = {
   position: 'absolute',
   bottom: '100%',
-  left: 0,
   marginBottom: '4px',
   zIndex: 10000,
+  maxWidth: 'calc(100vw - 16px)',
+  overflowX: 'hidden',
 };
 const TOAST_STYLE: React.CSSProperties = { zIndex: 20000 };
 const SUBMENU_MAX_WIDTH_PX = 360;
@@ -81,6 +83,7 @@ export const ProviderSelect = ({ value, onChange, compact = false }: ProviderSel
   const [submenuShiftX, setSubmenuShiftX] = useState(0);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const { positionedStyle, recalculate } = useDropdownPosition({ buttonRef, dropdownRef });
 
   const currentProvider = AVAILABLE_PROVIDERS.find(p => p.id === value) || AVAILABLE_PROVIDERS[0];
 
@@ -94,9 +97,13 @@ export const ProviderSelect = ({ value, onChange, compact = false }: ProviderSel
    */
   const handleToggle = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    setIsOpen(!isOpen);
+    const nextOpen = !isOpen;
+    setIsOpen(nextOpen);
     setActiveSubmenu('none');
-  }, [isOpen]);
+    if (nextOpen) {
+      recalculate();
+    }
+  }, [isOpen, recalculate]);
 
   /**
    * Show toast message
@@ -174,6 +181,12 @@ export const ProviderSelect = ({ value, onChange, compact = false }: ProviderSel
     if (!isOpen || activeSubmenu !== 'codexQuota') return;
     requestCodexQuota();
   }, [activeSubmenu, isOpen, requestCodexQuota]);
+
+  useLayoutEffect(() => {
+    if (isOpen) {
+      recalculate();
+    }
+  }, [isOpen, recalculate]);
 
   const renderCodexQuotaSubmenu = () => {
     const fiveHour = codexQuota?.windows.fiveHour;
@@ -295,7 +308,7 @@ export const ProviderSelect = ({ value, onChange, compact = false }: ProviderSel
           <div
             ref={dropdownRef}
             className="selector-dropdown"
-            style={DROPDOWN_STYLE}
+            style={{ ...DROPDOWN_STYLE, ...positionedStyle }}
           >
             {AVAILABLE_PROVIDERS.map((provider) => (
               <div

--- a/webview/src/components/ChatInputBox/selectors/ReasoningSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ReasoningSelect.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   REASONING_LEVELS,
@@ -7,15 +7,17 @@ import {
   XHIGH_EFFORT_CLAUDE_MODELS,
   type ReasoningEffort,
 } from '../types';
+import { useDropdownPosition } from '../../../hooks/useDropdownPosition';
 
 const RELATIVE_INLINE_BLOCK_STYLE: React.CSSProperties = { position: 'relative', display: 'inline-block' };
 const CHEVRON_ICON_STYLE: React.CSSProperties = { fontSize: '10px', marginLeft: '2px' };
 const DROPDOWN_STYLE: React.CSSProperties = {
   position: 'absolute',
   bottom: '100%',
-  right: 0,
   marginBottom: '4px',
   zIndex: 10000,
+  maxWidth: 'calc(100vw - 16px)',
+  overflowX: 'hidden',
 };
 const LEVEL_INFO_STYLE: React.CSSProperties = { display: 'flex', flexDirection: 'column', flex: 1 };
 
@@ -41,6 +43,11 @@ export const ReasoningSelect = ({ value, onChange, disabled, selectedModel, curr
   const [isOpen, setIsOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const { positionedStyle, recalculate } = useDropdownPosition({
+    buttonRef,
+    dropdownRef,
+    preferredAlignment: 'right',
+  });
 
   // Determine visibility: for Claude, hide if model doesn't support adaptive thinking
   const isVisible = currentProvider !== 'claude' || !selectedModel || EFFORT_SUPPORTED_CLAUDE_MODELS.has(selectedModel);
@@ -88,8 +95,12 @@ export const ReasoningSelect = ({ value, onChange, disabled, selectedModel, curr
   const handleToggle = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
     if (disabled) return;
-    setIsOpen(!isOpen);
-  }, [isOpen, disabled]);
+    const nextOpen = !isOpen;
+    setIsOpen(nextOpen);
+    if (nextOpen) {
+      recalculate();
+    }
+  }, [isOpen, disabled, recalculate]);
 
   /**
    * Select reasoning level
@@ -126,6 +137,12 @@ export const ReasoningSelect = ({ value, onChange, disabled, selectedModel, curr
     };
   }, [isOpen]);
 
+  useLayoutEffect(() => {
+    if (isOpen) {
+      recalculate();
+    }
+  }, [isOpen, recalculate]);
+
   if (!isVisible) return null;
 
   return (
@@ -146,7 +163,7 @@ export const ReasoningSelect = ({ value, onChange, disabled, selectedModel, curr
         <div
           ref={dropdownRef}
           className="selector-dropdown"
-          style={DROPDOWN_STYLE}
+          style={{ ...DROPDOWN_STYLE, ...positionedStyle }}
         >
           {availableLevels.map((level) => (
             <div

--- a/webview/src/components/ChatInputBox/selectors/RuntimeProviderSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/RuntimeProviderSelect.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SPECIAL_PROVIDER_IDS, type CodexProviderConfig, type ProviderConfig } from '../../../types/provider';
 import { sendBridgeEvent } from '../../../utils/bridge';
@@ -8,6 +8,7 @@ import {
   subscribeCodexProviderList,
   subscribeProviderList,
 } from '../../../utils/runtimeProviderCapabilities';
+import { useDropdownPosition } from '../../../hooks/useDropdownPosition';
 
 const DISABLED_OPTION_STYLE: React.CSSProperties = { cursor: 'default' };
 const PROVIDER_INFO_STYLE: React.CSSProperties = { display: 'flex', flexDirection: 'column', minWidth: 0, flex: 1 };
@@ -17,6 +18,7 @@ const CHEVRON_ICON_STYLE: React.CSSProperties = { fontSize: '10px', marginLeft: 
 interface RuntimeProviderSelectProps {
   currentProvider: string;
   embedded?: boolean;
+  triggerRef?: React.RefObject<HTMLElement | null>;
   onClose?: () => void;
   onProviderSwitched?: (providerName: string) => void;
 }
@@ -36,7 +38,7 @@ const parseProviderList = (json: string): RuntimeProvider[] => {
  * RuntimeProviderSelect - lightweight active-provider switcher for current engine.
  * Claude mode switches Claude Code providers; Codex mode switches Codex providers.
  */
-export const RuntimeProviderSelect = ({ currentProvider, embedded = false, onClose, onProviderSwitched }: RuntimeProviderSelectProps) => {
+export const RuntimeProviderSelect = ({ currentProvider, embedded = false, triggerRef, onClose, onProviderSwitched }: RuntimeProviderSelectProps) => {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -46,6 +48,12 @@ export const RuntimeProviderSelect = ({ currentProvider, embedded = false, onClo
   });
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const { positionedStyle, maxHeight: viewportMaxHeight, recalculate } = useDropdownPosition({
+    buttonRef: (embedded ? triggerRef : buttonRef) as React.RefObject<HTMLElement | null>,
+    dropdownRef,
+    submenu: embedded,
+    minWidth: embedded ? 260 : 200,
+  });
 
   const providerKind: ProviderKind = currentProvider === 'codex' ? 'codex' : 'claude';
   const visibleProviders = providersByKind[providerKind];
@@ -87,9 +95,10 @@ export const RuntimeProviderSelect = ({ currentProvider, embedded = false, onClo
     const nextOpen = !isOpen;
     setIsOpen(nextOpen);
     if (nextOpen) {
+      recalculate();
       requestProviders(providerKind);
     }
-  }, [currentProvider, isOpen, providerKind, requestProviders]);
+  }, [currentProvider, isOpen, providerKind, recalculate, requestProviders]);
 
   const handleSelect = useCallback((provider: RuntimeProvider) => {
     const eventName = providerKind === 'codex' ? 'switch_codex_provider' : 'switch_provider';
@@ -198,23 +207,29 @@ export const RuntimeProviderSelect = ({ currentProvider, embedded = false, onClo
     requestProviders(providerKind);
   }, [embedded, providerKind, requestProviders]);
 
+  useLayoutEffect(() => {
+    if (!embedded) return;
+    recalculate();
+  }, [embedded, recalculate, visibleProviders.length, loading]);
+
+  useLayoutEffect(() => {
+    if (embedded || !isOpen) return;
+    recalculate();
+  }, [embedded, isOpen, recalculate, visibleProviders.length, loading]);
+
   if (!isProviderKind(currentProvider)) {
     return null;
   }
 
   const activeName = activeProvider ? getProviderDisplayName(activeProvider, providerKind) : t('config.runtimeProvider.title');
 
+  const dropdownMaxHeight = viewportMaxHeight ? `${Math.min(300, viewportMaxHeight)}px` : '300px';
   const dropdownStyle: React.CSSProperties = {
-    position: 'absolute',
-    bottom: embedded ? 0 : '100%',
-    left: embedded ? '100%' : 0,
-    marginLeft: embedded ? '-30px' : undefined,
-    marginBottom: embedded ? undefined : '4px',
-    zIndex: 10001,
     minWidth: '260px',
     maxWidth: '360px',
-    maxHeight: '300px',
+    maxHeight: dropdownMaxHeight,
     overflowY: 'auto',
+    ...positionedStyle,
   };
 
   const renderProviderDropdown = () => (

--- a/webview/src/components/ChatInputBox/styles/selectors.css
+++ b/webview/src/components/ChatInputBox/styles/selectors.css
@@ -227,6 +227,38 @@
   margin-top: 2px;
 }
 
+.selector-search-row {
+  padding: 4px 8px;
+}
+
+.selector-search-input {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 180px;
+  padding: 5px 8px;
+  border: 1px solid var(--dropdown-border);
+  border-radius: 4px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: inherit;
+  outline: none;
+}
+
+.selector-search-input:focus {
+  border-color: var(--accent-color);
+}
+
+.selector-option-status {
+  cursor: default;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.selector-option-status:hover {
+  background: transparent;
+}
+
 .selector-option .mode-description {
   font-size: 11px;
   color: var(--text-secondary);

--- a/webview/src/components/ChatInputBox/styles/selectors.css
+++ b/webview/src/components/ChatInputBox/styles/selectors.css
@@ -72,7 +72,27 @@
 }
 
 /* Container query for Claude: hide text when narrow (< 400px) */
-@container button-area (max-width: 350px) {
+@container button-area (max-width: 400px) {
+  .button-area[data-provider="claude"] .selector-button-text {
+    max-width: 0;
+    opacity: 0;
+    overflow: hidden;
+    margin: 0;
+  }
+
+  .button-area[data-provider="claude"] .selector-button {
+    gap: 2px;
+    padding: 4px 6px;
+    min-width: 28px;
+  }
+
+  .button-area[data-provider="claude"] .selector-button > .codicon-chevron-up,
+  .button-area[data-provider="claude"] .selector-button > .codicon-chevron-down {
+    display: none;
+  }
+}
+
+@media (max-width: 450px) {
   .button-area[data-provider="claude"] .selector-button-text {
     max-width: 0;
     opacity: 0;

--- a/webview/src/hooks/useDropdownPosition.ts
+++ b/webview/src/hooks/useDropdownPosition.ts
@@ -1,0 +1,162 @@
+import { useCallback, useState, type CSSProperties, type RefObject } from 'react';
+import { getAppViewport } from '../utils/viewport';
+
+type DropdownAlignment = 'left' | 'right';
+
+interface UseDropdownPositionOptions {
+  buttonRef: RefObject<HTMLElement | null>;
+  dropdownRef?: RefObject<HTMLElement | null>;
+  preferredAlignment?: DropdownAlignment;
+  minWidth?: number;
+  submenuMaxHeight?: number;
+  submenuBottomClearance?: number;
+  submenu?: boolean;
+}
+
+interface PositionState {
+  left?: number;
+  top?: number | string;
+  bottom?: number;
+  maxHeight: number;
+  submenuSide?: 'right' | 'left';
+  submenuOverlap?: number;
+}
+
+const FALLBACK_ABSOLUTE_LEFT: CSSProperties = {
+  position: 'absolute',
+  bottom: '100%',
+  marginBottom: '4px',
+  left: 0,
+};
+
+const FALLBACK_ABSOLUTE_RIGHT: CSSProperties = {
+  position: 'absolute',
+  bottom: '100%',
+  marginBottom: '4px',
+  right: 0,
+};
+
+const FALLBACK_SUBMENU_RIGHT: CSSProperties = {
+  position: 'absolute',
+  top: 0,
+  left: '100%',
+};
+
+export function useDropdownPosition({
+  buttonRef,
+  dropdownRef,
+  preferredAlignment = 'left',
+  minWidth = 200,
+  submenuMaxHeight = 300,
+  submenuBottomClearance = 96,
+  submenu = false,
+}: UseDropdownPositionOptions): {
+  positionedStyle: CSSProperties;
+  maxHeight: number | undefined;
+  recalculate: () => void;
+} {
+  const [positionState, setPositionState] = useState<PositionState | null>(null);
+
+  const recalculate = useCallback(() => {
+    const button = buttonRef.current;
+    if (!button) return;
+
+    const rect = button.getBoundingClientRect();
+    const { width: viewportWidth, height: viewportHeight, left: viewportLeft, top: viewportTop } = getAppViewport();
+    const padding = 8;
+    const gap = 4;
+    const buttonLeft = rect.left - viewportLeft;
+    const buttonRight = rect.right - viewportLeft;
+    const buttonTop = rect.top - viewportTop;
+    const dropdown = dropdownRef?.current;
+
+    if (submenu) {
+      const availableRight = Math.max(0, viewportWidth - padding - buttonRight);
+      const availableLeft = Math.max(0, buttonLeft - padding);
+      const side: 'right' | 'left' = availableRight >= minWidth
+        ? 'right'
+        : availableLeft >= minWidth
+          ? 'left'
+          : availableRight >= availableLeft ? 'right' : 'left';
+      const availableSideWidth = side === 'right' ? availableRight : availableLeft;
+      const submenuOverlap = Math.max(0, minWidth - availableSideWidth);
+      const measuredHeight = dropdown
+        ? Math.max(dropdown.getBoundingClientRect().height, dropdown.scrollHeight)
+        : submenuMaxHeight;
+      const desiredHeight = Math.min(submenuMaxHeight, Math.max(1, measuredHeight));
+      const availableBelow = viewportHeight - padding - buttonTop;
+      const minTopOffset = padding - buttonTop;
+      const topOffset = Math.max(
+        minTopOffset,
+        Math.min(0, availableBelow - desiredHeight - submenuBottomClearance),
+      );
+      const availableHeight = viewportHeight - padding - buttonTop - topOffset;
+      const maxHeight = Math.max(1, Math.min(submenuMaxHeight, availableHeight));
+
+      setPositionState({ top: topOffset, maxHeight, submenuSide: side, submenuOverlap });
+      return;
+    }
+
+    const dropdownWidth = dropdown
+      ? Math.min(
+          Math.max(minWidth, dropdown.getBoundingClientRect().width),
+          viewportWidth - (padding * 2),
+        )
+      : minWidth;
+    const leftAlignedLeft = buttonLeft;
+    const rightAlignedLeft = buttonRight - dropdownWidth;
+    let left: number;
+
+    if (preferredAlignment === 'right') {
+      left = rightAlignedLeft >= padding ? rightAlignedLeft : leftAlignedLeft;
+    } else {
+      left = leftAlignedLeft + dropdownWidth + padding <= viewportWidth ? leftAlignedLeft : rightAlignedLeft;
+    }
+    left = Math.max(padding, Math.min(left, viewportWidth - dropdownWidth - padding));
+
+    const bottomValue = viewportHeight - buttonTop + gap;
+    const dropdownMaxHeight = buttonTop - gap - padding;
+
+    setPositionState({ left, bottom: bottomValue, maxHeight: dropdownMaxHeight, submenuSide: 'right' });
+  }, [buttonRef, dropdownRef, preferredAlignment, minWidth, submenu, submenuBottomClearance, submenuMaxHeight]);
+
+  if (!positionState) {
+    if (submenu) {
+      return { positionedStyle: FALLBACK_SUBMENU_RIGHT, maxHeight: undefined, recalculate };
+    }
+    return {
+      positionedStyle: preferredAlignment === 'left' ? FALLBACK_ABSOLUTE_LEFT : FALLBACK_ABSOLUTE_RIGHT,
+      maxHeight: undefined,
+      recalculate,
+    };
+  }
+
+  if (submenu) {
+    const sideStyle: CSSProperties = positionState.submenuSide === 'left'
+      ? { right: '100%', marginRight: `-${positionState.submenuOverlap ?? 0}px` }
+      : { left: '100%', marginLeft: `-${positionState.submenuOverlap ?? 0}px` };
+
+    return {
+      positionedStyle: {
+        position: 'absolute',
+        top: positionState.top,
+        ...sideStyle,
+        zIndex: 10001,
+      },
+      maxHeight: positionState.maxHeight,
+      recalculate,
+    };
+  }
+
+  const { fixedPosDivisor } = getAppViewport();
+  return {
+    positionedStyle: {
+      position: 'fixed',
+      left: (positionState.left ?? 0) / fixedPosDivisor,
+      bottom: (positionState.bottom ?? 0) / fixedPosDivisor,
+      zIndex: 10000,
+    },
+    maxHeight: positionState.maxHeight / fixedPosDivisor,
+    recalculate,
+  };
+}

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -1564,6 +1564,9 @@
   },
   "models": {
     "addModel": "Add Model",
+    "searchPlaceholder": "Search models",
+    "noModelsFound": "No models found",
+    "hiddenModelCount": "+ {{count}} more models. Type to search.",
     "longContext": {
       "label": "1M",
       "shortLabel": "1M context",

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -1329,6 +1329,9 @@
   },
   "models": {
     "addModel": "Agregar modelo",
+    "searchPlaceholder": "Buscar modelos",
+    "noModelsFound": "No se encontraron modelos",
+    "hiddenModelCount": "+ {{count}} modelos más. Escribe para buscar.",
     "claude": {
       "sonnet46": {
         "label": "Sonnet 4.6",

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -1329,6 +1329,9 @@
   },
   "models": {
     "addModel": "Ajouter un modèle",
+    "searchPlaceholder": "Rechercher des modèles",
+    "noModelsFound": "Aucun modèle trouvé",
+    "hiddenModelCount": "+ {{count}} modèles supplémentaires. Tapez pour rechercher.",
     "claude": {
       "sonnet46": {
         "label": "Sonnet 4.6",

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -1328,6 +1328,9 @@
   },
   "models": {
     "addModel": "मॉडल जोड़ें",
+    "searchPlaceholder": "मॉडल खोजें",
+    "noModelsFound": "कोई मॉडल नहीं मिला",
+    "hiddenModelCount": "+ {{count}} और मॉडल. खोजने के लिए टाइप करें.",
     "claude": {
       "sonnet46": {
         "label": "Sonnet 4.6",

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -1334,6 +1334,9 @@
   },
   "models": {
     "addModel": "モデル追加",
+    "searchPlaceholder": "モデルを検索",
+    "noModelsFound": "モデルが見つかりません",
+    "hiddenModelCount": "+ {{count}} 件のモデルがあります。入力して検索してください。",
     "longContext": {
       "label": "1M",
       "shortLabel": "1Mコンテキスト",

--- a/webview/src/i18n/locales/ko.json
+++ b/webview/src/i18n/locales/ko.json
@@ -1446,6 +1446,9 @@
   },
   "models": {
     "addModel": "모델 추가",
+    "searchPlaceholder": "모델 검색",
+    "noModelsFound": "모델을 찾을 수 없습니다",
+    "hiddenModelCount": "+ {{count}}개 모델 더 있음. 입력하여 검색하세요.",
     "claude": {
       "sonnet46": {
         "label": "Sonnet 4.6",

--- a/webview/src/i18n/locales/pt-BR.json
+++ b/webview/src/i18n/locales/pt-BR.json
@@ -1501,6 +1501,9 @@
   },
   "models": {
     "addModel": "Adicionar Modelo",
+    "searchPlaceholder": "Pesquisar modelos",
+    "noModelsFound": "Nenhum modelo encontrado",
+    "hiddenModelCount": "+ {{count}} modelos adicionais. Digite para pesquisar.",
     "claude": {
       "sonnet46": {
         "label": "Sonnet 4.6",

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -1355,6 +1355,9 @@
   },
   "models": {
     "addModel": "Добавить модель",
+    "searchPlaceholder": "Поиск моделей",
+    "noModelsFound": "Модели не найдены",
+    "hiddenModelCount": "+ {{count}} дополнительных моделей. Введите текст для поиска.",
     "claude": {
       "sonnet46": {
         "label": "Sonnet 4.6",

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -1334,6 +1334,9 @@
   },
   "models": {
     "addModel": "新增模型",
+    "searchPlaceholder": "搜尋模型",
+    "noModelsFound": "找不到模型",
+    "hiddenModelCount": "+ 還有 {{count}} 個模型。輸入以搜尋。",
     "claude": {
       "sonnet46": {
         "label": "Sonnet 4.6",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -1569,6 +1569,9 @@
   },
   "models": {
     "addModel": "添加模型",
+    "searchPlaceholder": "搜索模型",
+    "noModelsFound": "未找到模型",
+    "hiddenModelCount": "+ 还有 {{count}} 个模型。输入以搜索。",
     "longContext": {
       "label": "1M",
       "shortLabel": "1M上下文",


### PR DESCRIPTION
**Summary**

Fixes chat input selector dropdown positioning and sizing so menus and nested submenus stay usable inside constrained JetBrains webview panels.

**Changes**

- Added shared dropdown positioning logic via `useDropdownPosition`.
- Updated config, provider, mode, model, reasoning, runtime-provider, and node-process selectors to keep dropdowns inside the visible webview.
- Fixed the node process submenu flip behavior so it no longer repeatedly toggles layout state near viewport edges.
- Added width/overflow handling for long selector labels and descriptions.
- Capped large model dropdown rendering to the first 100 visible matches while allowing search for hidden models.
- Added Playwright E2E coverage for selector viewport behavior in desktop, narrow, and short webview sizes.
- Added a focused regression test for the node-process submenu flip loop.
- Ignored Playwright test artifacts in `.gitignore`.

**Validation**

- Added `webview` script: `npm run test:e2e`.
- Added Playwright config and `@playwright/test`.
- E2E coverage checks:
  - Footer selector menus render inside the viewport.
  - Config submenus stay visible and anchored in constrained viewports.
  - Long model/mode text stays contained.
  - Large model lists stay capped and searchable.
