### PR TITLE
feat:Added Token consumption at the bottom of the dialogue indicator

### DIFF
--- a/src/main/java/com/github/claudecodegui/util/MessageJsonConverter.java
+++ b/src/main/java/com/github/claudecodegui/util/MessageJsonConverter.java
@@ -1,8 +1,8 @@
 package com.github.claudecodegui.util;
 
-import com.github.claudecodegui.session.ClaudeSession;
-import com.github.claudecodegui.handler.core.HandlerContext;
 import com.github.claudecodegui.handler.SettingsHandler;
+import com.github.claudecodegui.handler.core.HandlerContext;
+import com.github.claudecodegui.session.ClaudeSession;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -199,6 +199,8 @@ public class MessageJsonConverter {
         copyFieldIfPresent(raw, transport, "summarizeMetadata");
         // Origin field for distinguishing human input from synthetic messages
         copyFieldIfPresent(raw, transport, "origin");
+        // Usage field for per-message token display (Codex path: top-level usage)
+        copyFieldIfPresent(raw, transport, "usage");
 
         if (raw.has("content")) {
             transport.add("content", raw.get("content").deepCopy());
@@ -210,6 +212,8 @@ public class MessageJsonConverter {
             if (sourceMessage.has("content")) {
                 transportMessage.add("content", sourceMessage.get("content").deepCopy());
             }
+            // Usage inside message object (Claude path: raw.message.usage)
+            copyFieldIfPresent(sourceMessage, transportMessage, "usage");
             if (transportMessage.size() > 0) {
                 transport.add("message", transportMessage);
             }

--- a/src/test/java/com/github/claudecodegui/util/MessageJsonConverterTest.java
+++ b/src/test/java/com/github/claudecodegui/util/MessageJsonConverterTest.java
@@ -8,9 +8,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class MessageJsonConverterTest {
 
@@ -58,7 +56,8 @@ public class MessageJsonConverterTest {
         assertTrue(transportMessage.has("content"));
         assertFalse(transportMessage.has("id"));
         assertFalse(transportMessage.has("model"));
-        assertFalse(transportMessage.has("usage"));
+        assertTrue(transportMessage.has("usage"));
+        assertEquals(321, transportMessage.getAsJsonObject("usage").get("input_tokens").getAsInt());
     }
 
     @Test

--- a/webview/src/components/MessageItem/MessageItem.test.tsx
+++ b/webview/src/components/MessageItem/MessageItem.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
-import type { ClaudeContentBlock, ClaudeMessage, ToolResultBlock } from '../../types';
-import { extractMarkdownContent } from '../../utils/copyUtils';
-import { MessageItem } from './MessageItem';
+import {render, screen} from '@testing-library/react';
+import {describe, expect, it, vi} from 'vitest';
+import type {ClaudeContentBlock, ClaudeMessage, ToolResultBlock} from '../../types';
+import {extractMarkdownContent} from '../../utils/copyUtils';
+import {MessageItem} from './MessageItem';
 
 vi.mock('../MarkdownBlock', () => ({
   default: ({ content }: { content: string }) => <div data-testid="markdown-block">{content}</div>,
@@ -29,14 +29,21 @@ vi.mock('./ProviderNotConfiguredCard', () => ({
   isProviderNotConfiguredError: () => false,
 }));
 
-const t = ((key: string) => {
+const t = ((key: string, opts?: Record<string, string>) => {
   const translations: Record<string, string> = {
     'markdown.copyMessage': '复制消息',
     'markdown.copySuccess': '已复制',
     'chat.streamingConnected': '已连接',
     'chat.totalDuration': '本次耗时',
+    'chat.tokenUsage': '输入 {{input}} / 输出 {{output}}',
   };
-  return translations[key] ?? key;
+  let result = translations[key] ?? key;
+  if (opts) {
+    for (const [k, v] of Object.entries(opts)) {
+      result = result.replace(`{{${k}}}`, v);
+    }
+  }
+  return result;
 }) as any;
 
 const getMessageText = (message: ClaudeMessage) => message.content ?? '';
@@ -151,5 +158,113 @@ describe('MessageItem copy button visibility', () => {
 
     expect(screen.getByTestId('bash-tool-group-block')).toBeTruthy();
     expect(screen.queryAllByTestId('content-block-tool_use')).toHaveLength(0);
+  });
+});
+
+describe('MessageItem token usage display', () => {
+  it('shows token usage alongside duration when usage data is present', () => {
+    const message: ClaudeMessage = {
+      type: 'assistant',
+      content: 'Hello',
+      durationMs: 16000,
+      raw: {
+        message: {
+          content: [{type: 'text', text: 'Hello'}],
+          usage: {
+            input_tokens: 1200,
+            output_tokens: 456,
+          },
+        },
+      } as any,
+    };
+
+    renderMessageItem(message);
+
+    expect(screen.getByText('0:16')).toBeTruthy();
+    expect(screen.getByText('输入 1.2K / 输出 456')).toBeTruthy();
+  });
+
+  it('shows only billed input/output tokens, ignoring cache', () => {
+    const message: ClaudeMessage = {
+      type: 'assistant',
+      content: 'Hello',
+      durationMs: 10000,
+      raw: {
+        message: {
+          content: [{type: 'text', text: 'Hello'}],
+          usage: {
+            input_tokens: 37,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 36310,
+            output_tokens: 353,
+          },
+        },
+      } as any,
+    };
+
+    renderMessageItem(message);
+
+    // Only shows input_tokens (37) and output_tokens (353), not cache
+    expect(screen.getByText('输入 37 / 输出 353')).toBeTruthy();
+  });
+
+  it('shows token usage from top-level usage (Codex path)', () => {
+    const message: ClaudeMessage = {
+      type: 'assistant',
+      content: 'Hello',
+      durationMs: 5000,
+      raw: {
+        content: [{type: 'text', text: 'Hello'}],
+        usage: {
+          input_tokens: 500,
+          output_tokens: 200,
+        },
+      } as any,
+    };
+
+    renderMessageItem(message);
+
+    expect(screen.getByText('0:05')).toBeTruthy();
+    expect(screen.getByText('输入 500 / 输出 200')).toBeTruthy();
+  });
+
+  it('does not show token usage when no usage data is present', () => {
+    const message: ClaudeMessage = {
+      type: 'assistant',
+      content: 'Hello',
+      durationMs: 3000,
+      raw: {
+        message: {
+          content: [{type: 'text', text: 'Hello'}],
+        },
+      } as any,
+    };
+
+    renderMessageItem(message);
+
+    expect(screen.getByText('0:03')).toBeTruthy();
+    expect(screen.queryByText(/总/)).toBeNull();
+  });
+
+  it('does not show token usage when tokens are all zero', () => {
+    const message: ClaudeMessage = {
+      type: 'assistant',
+      content: 'Hello',
+      durationMs: 3000,
+      raw: {
+        message: {
+          content: [{type: 'text', text: 'Hello'}],
+          usage: {
+            input_tokens: 0,
+            output_tokens: 0,
+          },
+        },
+      } as any,
+    };
+
+    renderMessageItem(message);
+
+    expect(screen.getByText('0:03')).toBeTruthy();
+    expect(screen.queryByText(/总/)).toBeNull();
   });
 });

--- a/webview/src/components/MessageItem/MessageItem.tsx
+++ b/webview/src/components/MessageItem/MessageItem.tsx
@@ -1,24 +1,30 @@
-import { useState, useCallback, useMemo, memo, useEffect, useRef } from 'react';
-import type { TFunction } from 'i18next';
-import type { ClaudeMessage, ClaudeContentBlock, ToolResultBlock } from '../../types';
+import {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import type {TFunction} from 'i18next';
+import type {ClaudeContentBlock, ClaudeMessage, ToolResultBlock} from '../../types';
 
 import MarkdownBlock from '../MarkdownBlock';
-import { ProviderNotConfiguredCard, isProviderNotConfiguredError } from './ProviderNotConfiguredCard';
-import { ErrorDiagnosticCard } from './ErrorDiagnosticCard';
-import { matchErrorPattern } from '../../utils/errorMatcher';
+import {isProviderNotConfiguredError, ProviderNotConfiguredCard} from './ProviderNotConfiguredCard';
+import {ErrorDiagnosticCard} from './ErrorDiagnosticCard';
+import {matchErrorPattern} from '../../utils/errorMatcher';
 import {
+  BashToolBlock,
+  BashToolGroupBlock,
   EditToolBlock,
   EditToolGroupBlock,
   ReadToolBlock,
   ReadToolGroupBlock,
-  BashToolBlock,
-  BashToolGroupBlock,
   SearchToolGroupBlock,
 } from '../toolBlocks';
-import { ContentBlockRenderer } from './ContentBlockRenderer';
-import { formatTime } from '../../utils/helpers';
-import { copyToClipboard } from '../../utils/copyUtils';
-import { READ_TOOL_NAMES, EDIT_TOOL_NAMES, BASH_TOOL_NAMES, SEARCH_TOOL_NAMES, isToolName } from '../../utils/toolConstants';
+import {ContentBlockRenderer} from './ContentBlockRenderer';
+import {formatTime} from '../../utils/helpers';
+import {copyToClipboard} from '../../utils/copyUtils';
+import {
+  BASH_TOOL_NAMES,
+  EDIT_TOOL_NAMES,
+  isToolName,
+  READ_TOOL_NAMES,
+  SEARCH_TOOL_NAMES
+} from '../../utils/toolConstants';
 
 export interface MessageItemProps {
   message: ClaudeMessage;
@@ -101,6 +107,44 @@ function formatDurationMs(durationMs: number): string {
     return `${hours}:${String(minutes).padStart(2, '0')}:${String(remainder).padStart(2, '0')}`;
   }
   return `${minutes}:${String(remainder).padStart(2, '0')}`;
+}
+
+interface TokenUsageInfo {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/**
+ * Extract per-message billed token usage from a message's raw JSON.
+ * Tries `raw.message.usage` (Claude) then `raw.usage` (Codex).
+ * Returns null when no meaningful usage data is found.
+ *
+ * These are the actual `input_tokens` and `output_tokens` reported by the
+ * API provider — the tokens that are billed (cache tokens are separate).
+ */
+function extractTokenUsage(raw: ClaudeMessage['raw']): TokenUsageInfo | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const msgObj = raw as Record<string, unknown>;
+  const message = typeof msgObj.message === 'object' && msgObj.message !== null
+      ? msgObj.message as Record<string, unknown>
+      : null;
+  const usageSrc = (message && typeof message.usage === 'object' && message.usage !== null)
+      ? message.usage as Record<string, unknown>
+      : typeof msgObj.usage === 'object' && msgObj.usage !== null
+          ? msgObj.usage as Record<string, unknown>
+          : null;
+  if (!usageSrc) return null;
+  const input = typeof usageSrc.input_tokens === 'number' ? usageSrc.input_tokens : 0;
+  const output = typeof usageSrc.output_tokens === 'number' ? usageSrc.output_tokens : 0;
+  if (input === 0 && output === 0) return null;
+  return {inputTokens: input, outputTokens: output};
+}
+
+/** Format a token count for compact display (e.g., 1234 → "1.2K"). */
+function formatTokenCount(count: number): string {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}K`;
+  return String(count);
 }
 
 function isToolBlockOfType(block: ClaudeContentBlock, toolNames: Set<string>): boolean {
@@ -613,13 +657,28 @@ export const MessageItem = memo(function MessageItem({
         {renderGroupedBlocks()}
       </div>
 
-      {/* Duration display after last assistant message */}
+      {/* Duration and token display after last assistant message */}
       {message.type === 'assistant' && !isMessageStreaming && typeof message.durationMs === 'number' && (
         <div className="message-duration">
           <span className="message-duration-inner">
             <span className="message-duration-flag codicon codicon-clock"></span>
             <span className="message-duration-cost">{t('chat.totalDuration')}</span>
             <span className="message-duration-value">{formatDurationMs(message.durationMs)}</span>
+            {(() => {
+              const tokenInfo = extractTokenUsage(message.raw);
+              if (!tokenInfo) return null;
+              return (
+                  <>
+                    <span className="message-duration-separator">·</span>
+                    <span className="message-duration-tokens">
+                    {t('chat.tokenUsage', {
+                      input: formatTokenCount(tokenInfo.inputTokens),
+                      output: formatTokenCount(tokenInfo.outputTokens),
+                    })}
+                  </span>
+                  </>
+              );
+            })()}
           </span>
         </div>
       )}

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -91,6 +91,7 @@
     "streamingConnected": "{{provider}} connected, understanding your question",
     "showEarlierMessages": "Show {{count}} earlier messages",
     "totalDuration": "This reply took",
+    "tokenUsage": "{{input}} in / {{output}} out",
     "search": {
       "ariaLabel": "Search in conversation",
       "placeholder": "Search in conversation…",

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -91,6 +91,7 @@
     "streamingConnected": "{{provider}} conectado, entendiendo tu pregunta",
     "showEarlierMessages": "Mostrar {{count}} mensajes anteriores",
     "totalDuration": "Esta respuesta tardó",
+    "tokenUsage": "{{input}} entrada / {{output}} salida",
     "search": {
       "ariaLabel": "Buscar en la conversación",
       "placeholder": "Buscar en la conversación…",

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -91,6 +91,7 @@
     "streamingConnected": "{{provider}} connecté, en train de comprendre votre question",
     "showEarlierMessages": "Afficher {{count}} messages précédents",
     "totalDuration": "Cette réponse a pris",
+    "tokenUsage": "{{input}} entrée / {{output}} sortie",
     "search": {
       "ariaLabel": "Rechercher dans la conversation",
       "placeholder": "Rechercher dans la conversation…",

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -91,6 +91,7 @@
     "streamingConnected": "{{provider}} कनेक्ट हो गया, आपके प्रश्न को समझ रहा है",
     "showEarlierMessages": "{{count}} पुराने संदेश दिखाएं",
     "totalDuration": "इस जवाब में लगा समय",
+    "tokenUsage": "{{input}} इन / {{output}} आउट",
     "search": {
       "ariaLabel": "बातचीत में खोजें",
       "placeholder": "बातचीत में खोजें...",

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -91,6 +91,7 @@
     "streamingConnected": "{{provider}}に接続しました、質問を理解しています",
     "showEarlierMessages": "以前の{{count}}件のメッセージを表示",
     "totalDuration": "今回の応答時間",
+    "tokenUsage": "入力 {{input}} / 出力 {{output}}",
     "search": {
       "ariaLabel": "会話内を検索",
       "placeholder": "会話内を検索...",

--- a/webview/src/i18n/locales/ko.json
+++ b/webview/src/i18n/locales/ko.json
@@ -91,6 +91,7 @@
     "streamingConnected": "{{provider}} 연결됨, 질문을 이해하는 중",
     "showEarlierMessages": "이전 메시지 {{count}}개 보기",
     "totalDuration": "이번 응답 소요 시간",
+    "tokenUsage": "입력 {{input}} / 출력 {{output}}",
     "search": {
       "ariaLabel": "대화에서 검색",
       "placeholder": "대화에서 검색...",

--- a/webview/src/i18n/locales/pt-BR.json
+++ b/webview/src/i18n/locales/pt-BR.json
@@ -91,6 +91,7 @@
     "streamingConnected": "{{provider}} conectado, entendendo sua pergunta",
     "showEarlierMessages": "Mostrar {{count}} mensagens anteriores",
     "totalDuration": "Esta resposta levou",
+    "tokenUsage": "{{input}} entrada / {{output}} saída",
     "search": {
       "ariaLabel": "Pesquisar na conversa",
       "placeholder": "Pesquisar na conversa…",

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -91,6 +91,7 @@
     "streamingConnected": "{{provider}} обрабатывает запрос",
     "showEarlierMessages": "Показать предыдущие сообщения ({{count}})",
     "totalDuration": "Этот ответ занял",
+    "tokenUsage": "вход {{input}} / выход {{output}}",
     "search": {
       "ariaLabel": "Поиск в беседе",
       "placeholder": "Поиск в беседе…",

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -91,6 +91,7 @@
     "streamingConnected": "{{provider}} 已成功連接，正在理解問題",
     "showEarlierMessages": "顯示之前的 {{count}} 則訊息",
     "totalDuration": "本次耗時",
+    "tokenUsage": "輸入 {{input}} / 輸出 {{output}}",
     "search": {
       "ariaLabel": "在對話中搜尋",
       "placeholder": "在對話中搜尋...",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -91,6 +91,7 @@
     "streamingConnected": "{{provider}} 已成功连接，正在理解问题",
     "showEarlierMessages": "显示之前的 {{count}} 条消息",
     "totalDuration": "本次耗时",
+    "tokenUsage": "输入 {{input}} / 输出 {{output}}",
     "search": {
       "ariaLabel": "在对话中搜索",
       "placeholder": "在对话中搜索…",

--- a/webview/src/styles/less/components/message.less
+++ b/webview/src/styles/less/components/message.less
@@ -1289,6 +1289,14 @@
     .message-duration-value {
         font-family: var(--idea-editor-font-family, monospace);
     }
+
+    .message-duration-separator {
+        opacity: 0.5;
+    }
+
+    .message-duration-tokens {
+        font-family: var(--idea-editor-font-family, monospace);
+    }
 }
 
 /* Task Notification Block - matching CLI's UserAgentNotificationMessage */


### PR DESCRIPTION
After each conversation's 'time spent' segment, add consumed tokens (excluding cache tokens, only recorded billing tokens)

<img width="813" height="698" alt="image" src="https://github.com/user-attachments/assets/007215d6-6d5c-4918-aa30-3f1dd861c33a" />
