### PR TITLE
fix(session): pass selected reasoning effort to SDK

### DIFF
--- a/ai-bridge/config/api-config.js
+++ b/ai-bridge/config/api-config.js
@@ -93,6 +93,67 @@ export function getCliUserAgent() {
   return `claude-cli/${version} (${userType}, ${entrypoint})`;
 }
 
+// Env vars whose value the webview owns per request. Settings.json copies of
+// these must never be applied on top of the current request's selections.
+//
+// Model routing: chosen by the webview model selector and written to
+// process.env by setModelEnvironmentVariables() each turn.
+const MODEL_ROUTING_ENV_VARS = [
+  'ANTHROPIC_MODEL',
+  'ANTHROPIC_DEFAULT_OPUS_MODEL',
+  'ANTHROPIC_DEFAULT_SONNET_MODEL',
+  'ANTHROPIC_DEFAULT_HAIKU_MODEL',
+  'ANTHROPIC_SMALL_FAST_MODEL',
+  'CLAUDE_CODE_SUBAGENT_MODEL',
+];
+
+// Reasoning / context controls: explicit SDK options in this bridge. Claude Code
+// gives env vars higher priority than SDK args, so stale settings values must be
+// neutralized — stripped from the child env (buildCliEnv) and overridden inline
+// (buildWebviewControlledSettingsOverride). The 1M flag is set per request from
+// the selected model.
+const REASONING_CONTROL_ENV_VARS = [
+  'CLAUDE_CODE_EFFORT_LEVEL',
+  'MAX_THINKING_TOKENS',
+  'CLAUDE_CODE_DISABLE_1M_CONTEXT',
+];
+
+export const WEBVIEW_CONTROLLED_ENV_VARS = Object.freeze([
+  ...MODEL_ROUTING_ENV_VARS,
+  ...REASONING_CONTROL_ENV_VARS,
+]);
+
+const WEBVIEW_CONTROLLED_ENV_VAR_SET = new Set(
+  WEBVIEW_CONTROLLED_ENV_VARS.map((varName) => varName.toUpperCase())
+);
+
+// Subset stripped from the SDK child env: the reasoning/context controls must
+// reach the CLI only via SDK options + the inline settings override, never
+// inherited from process.env.
+const CLI_ENV_OVERRIDE_VAR_SET = new Set(
+  REASONING_CONTROL_ENV_VARS.map((varName) => varName.toUpperCase())
+);
+
+export function isWebviewControlledEnvVar(varName) {
+  return WEBVIEW_CONTROLLED_ENV_VAR_SET.has(String(varName ?? '').toUpperCase());
+}
+
+export function buildWebviewControlledSettingsOverride(modelId) {
+  const env = {
+    // Empty strings intentionally override settings.json env values while
+    // evaluating as "not set" in Claude Code's env-precedence checks.
+    CLAUDE_CODE_EFFORT_LEVEL: '',
+    MAX_THINKING_TOKENS: '',
+  };
+
+  const normalizedModel = typeof modelId === 'string' ? modelId.trim() : '';
+  if (normalizedModel) {
+    env.CLAUDE_CODE_DISABLE_1M_CONTEXT = /\[1m\]$/i.test(normalizedModel) ? '' : '1';
+  }
+
+  return { env };
+}
+
 /**
  * Build a clean env object for SDK child processes that identifies as CLI.
  *
@@ -103,12 +164,19 @@ export function getCliUserAgent() {
  * @returns {Object} Environment variables object for options.env
  */
 export function buildCliEnv() {
-  const env = {
-    ...process.env,
-    CLAUDE_CODE_ENTRYPOINT: 'cli',
-    USER_TYPE: 'external',
-  };
-  delete env.CLAUDE_AGENT_SDK_VERSION;
+  const env = {};
+  const skipKeys = new Set([...CLI_ENV_OVERRIDE_VAR_SET, 'CLAUDE_AGENT_SDK_VERSION']);
+  for (const [key, value] of Object.entries(process.env)) {
+    if (!skipKeys.has(key.toUpperCase())) {
+      env[key] = value;
+    }
+  }
+  env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+  env.USER_TYPE = 'external';
+  // Claude Code applies settings.json env with overwrite semantics. This flag
+  // makes the CLI strip settings-sourced provider/model vars so the host's
+  // request-scoped routing wins.
+  env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST = '1';
   return env;
 }
 

--- a/ai-bridge/config/api-config.test.js
+++ b/ai-bridge/config/api-config.test.js
@@ -4,8 +4,41 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+import {
+  buildCliEnv,
+  buildWebviewControlledSettingsOverride,
+  isWebviewControlledEnvVar,
+} from './api-config.js';
 
-const API_CONFIG_MODULE = path.resolve('ai-bridge/config/api-config.js');
+const API_CONFIG_MODULE = pathToFileURL(path.resolve('ai-bridge/config/api-config.js')).href;
+
+function buildChildEnv(homeDir) {
+  const env = {
+    ...process.env,
+    HOME: homeDir,
+    USERPROFILE: homeDir,
+  };
+
+  for (const key of [
+    'ANTHROPIC_API_KEY',
+    'ANTHROPIC_AUTH_TOKEN',
+    'ANTHROPIC_BASE_URL',
+    'ANTHROPIC_API_URL',
+    'HTTP_PROXY',
+    'HTTPS_PROXY',
+    'NO_PROXY',
+    'http_proxy',
+    'https_proxy',
+    'no_proxy',
+    'NODE_EXTRA_CA_CERTS',
+    'NODE_TLS_REJECT_UNAUTHORIZED',
+  ]) {
+    delete env[key];
+  }
+
+  return env;
+}
 
 function runSetupApiKey(homeDir) {
   const script = `
@@ -23,10 +56,7 @@ function runSetupApiKey(homeDir) {
     ['--input-type=module', '--eval', script],
     {
       cwd: path.resolve('.'),
-      env: {
-        ...process.env,
-        HOME: homeDir,
-      },
+      env: buildChildEnv(homeDir),
       encoding: 'utf8',
     }
   );
@@ -50,10 +80,7 @@ function runInjectNetworkEnv(homeDir) {
     ['--input-type=module', '--eval', script],
     {
       cwd: path.resolve('.'),
-      env: {
-        ...process.env,
-        HOME: homeDir,
-      },
+      env: buildChildEnv(homeDir),
       encoding: 'utf8',
     }
   );
@@ -99,10 +126,7 @@ function runResyncNetworkEnv(homeDir) {
     ['--input-type=module', '--eval', script],
     {
       cwd: path.resolve('.'),
-      env: {
-        ...process.env,
-        HOME: homeDir,
-      },
+      env: buildChildEnv(homeDir),
       encoding: 'utf8',
     }
   );
@@ -125,6 +149,84 @@ function writeCodemossClaudeConfig(homeDir, current, providers = {}) {
     'utf8'
   );
 }
+
+test('isWebviewControlledEnvVar classifies model, context, and reasoning controls correctly', () => {
+  assert.equal(isWebviewControlledEnvVar('ANTHROPIC_MODEL'), true);
+  assert.equal(isWebviewControlledEnvVar('anthropic_model'), true); // case-insensitive
+  assert.equal(isWebviewControlledEnvVar('CLAUDE_CODE_EFFORT_LEVEL'), true);
+  assert.equal(isWebviewControlledEnvVar('MAX_THINKING_TOKENS'), true);
+  assert.equal(isWebviewControlledEnvVar('CLAUDE_CODE_DISABLE_1M_CONTEXT'), true);
+  assert.equal(isWebviewControlledEnvVar('HTTPS_PROXY'), false);
+  assert.equal(isWebviewControlledEnvVar('ANTHROPIC_API_KEY'), false);
+});
+
+test('buildCliEnv preserves current model env but strips stale CLI override env vars', () => {
+  const previous = {
+    ANTHROPIC_MODEL: process.env.ANTHROPIC_MODEL,
+    ANTHROPIC_DEFAULT_SONNET_MODEL: process.env.ANTHROPIC_DEFAULT_SONNET_MODEL,
+    CLAUDE_CODE_EFFORT_LEVEL: process.env.CLAUDE_CODE_EFFORT_LEVEL,
+    MAX_THINKING_TOKENS: process.env.MAX_THINKING_TOKENS,
+    CLAUDE_CODE_DISABLE_1M_CONTEXT: process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT,
+    HTTPS_PROXY: process.env.HTTPS_PROXY,
+    CLAUDE_AGENT_SDK_VERSION: process.env.CLAUDE_AGENT_SDK_VERSION,
+  };
+
+  try {
+    process.env.ANTHROPIC_MODEL = 'current-webview-model';
+    process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'current-webview-model';
+    process.env.CLAUDE_CODE_EFFORT_LEVEL = 'max';
+    process.env.MAX_THINKING_TOKENS = '64000';
+    process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT = '1';
+    process.env.HTTPS_PROXY = 'http://proxy.example.com:8080';
+    process.env.CLAUDE_AGENT_SDK_VERSION = 'should-not-leak';
+
+    const env = buildCliEnv();
+
+    assert.equal(env.ANTHROPIC_MODEL, 'current-webview-model');
+    assert.equal(env.ANTHROPIC_DEFAULT_SONNET_MODEL, 'current-webview-model');
+    assert.equal(env.CLAUDE_CODE_EFFORT_LEVEL, undefined);
+    assert.equal(env.MAX_THINKING_TOKENS, undefined);
+    assert.equal(env.CLAUDE_CODE_DISABLE_1M_CONTEXT, undefined);
+    assert.equal(env.CLAUDE_AGENT_SDK_VERSION, undefined);
+    assert.equal(env.HTTPS_PROXY, 'http://proxy.example.com:8080');
+    assert.equal(env.CLAUDE_CODE_ENTRYPOINT, 'cli');
+    assert.equal(env.USER_TYPE, 'external');
+    assert.equal(env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST, '1');
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+});
+
+test('buildWebviewControlledSettingsOverride neutralizes Claude CLI settings env precedence', () => {
+  assert.deepEqual(buildWebviewControlledSettingsOverride('claude-sonnet-4-6[1m]'), {
+    env: {
+      CLAUDE_CODE_EFFORT_LEVEL: '',
+      MAX_THINKING_TOKENS: '',
+      CLAUDE_CODE_DISABLE_1M_CONTEXT: '',
+    },
+  });
+
+  assert.deepEqual(buildWebviewControlledSettingsOverride('claude-sonnet-4-6'), {
+    env: {
+      CLAUDE_CODE_EFFORT_LEVEL: '',
+      MAX_THINKING_TOKENS: '',
+      CLAUDE_CODE_DISABLE_1M_CONTEXT: '1',
+    },
+  });
+
+  assert.deepEqual(buildWebviewControlledSettingsOverride(), {
+    env: {
+      CLAUDE_CODE_EFFORT_LEVEL: '',
+      MAX_THINKING_TOKENS: '',
+    },
+  });
+});
 
 test('setupApiKey does not fall back to Claude CLI credentials on disk', () => {
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-api-config-'));

--- a/ai-bridge/daemon.js
+++ b/ai-bridge/daemon.js
@@ -36,7 +36,7 @@ import {
   resetRuntimePersistent,
   getContextUsagePersistent
 } from './services/claude/persistent-query-service.js';
-import { injectNetworkEnvVars } from './config/api-config.js';
+import { injectNetworkEnvVars, isWebviewControlledEnvVar } from './config/api-config.js';
 import { cleanupStaleTempImages } from './services/claude/attachment-service.js';
 
 // =============================================================================
@@ -303,6 +303,12 @@ async function processRequest(request) {
     // set here — they only return timestamps and memory usage.
     if (params.env && typeof params.env === 'object') {
       for (const [key, value] of Object.entries(params.env)) {
+        // Request env can include settings.json values. Do not let stale
+        // environment controls override the webview's per-turn model, context,
+        // or reasoning selections.
+        if (isWebviewControlledEnvVar(key)) {
+          continue;
+        }
         if (value !== undefined && value !== null) {
           // Save original value (undefined means key didn't exist)
           savedEnv[key] = process.env[key];

--- a/ai-bridge/services/claude/message-rewind.js
+++ b/ai-bridge/services/claude/message-rewind.js
@@ -6,7 +6,7 @@
 import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
-import { setupApiKey, buildCliEnv } from '../../config/api-config.js';
+import { setupApiKey, buildCliEnv, buildWebviewControlledSettingsOverride } from '../../config/api-config.js';
 import { getClaudeDir, getRealHomeDir, selectWorkingDirectory } from '../../utils/path-utils.js';
 import { ensureClaudeSdk, hasClaudeProjectSessionFile, waitForClaudeProjectSessionFile, isNoConversationFoundError } from './message-utils.js';
 import { getActiveQueryResult, getActiveSessionIds } from './message-session-registry.js';
@@ -56,6 +56,9 @@ export async function rewindFiles(sessionId, userMessageId, cwd = null) {
           enableFileCheckpointing: true,
           maxTurns: 1,
           env: buildCliEnv(),
+          // Rewind is a maxTurns:1 file-checkpointing call — no inference output,
+          // so 1M context state is irrelevant; only neutralize effort/thinking.
+          settings: buildWebviewControlledSettingsOverride(),
           tools: { type: 'preset', preset: 'claude_code' },
           settingSources: ['user', 'project', 'local'],
           additionalDirectories: Array.from(

--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -3,7 +3,13 @@
  * Handles plain text messages and multimodal messages with attachments.
  */
 
-import { isCustomBaseUrl, loadClaudeSettings, setupApiKey, buildCliEnv } from '../../config/api-config.js';
+import {
+  isCustomBaseUrl,
+  loadClaudeSettings,
+  setupApiKey,
+  buildCliEnv,
+  buildWebviewControlledSettingsOverride,
+} from '../../config/api-config.js';
 import { selectWorkingDirectory } from '../../utils/path-utils.js';
 import { mapModelIdToSdkName, resolveModelFromSettings, setModelEnvironmentVariables } from '../../utils/model-utils.js';
 import { AsyncStream } from '../../utils/async-stream.js';
@@ -62,7 +68,7 @@ function resolveThinkingConfig(settings) {
 /**
  * Build query options object shared by both send functions.
  */
-function buildQueryOptions({ workingDirectory, permissionMode, sdkModelName, maxThinkingTokens, streamingEnabled, systemPromptAppend, preToolUseHook, sdkStderrLines, mcpServers }) {
+function buildQueryOptions({ workingDirectory, permissionMode, sdkModelName, maxThinkingTokens, streamingEnabled, systemPromptAppend, preToolUseHook, sdkStderrLines, mcpServers, modelId }) {
   const claudeCliOverride = getClaudeCliPathOverride();
   return {
     cwd: workingDirectory,
@@ -71,6 +77,7 @@ function buildQueryOptions({ workingDirectory, permissionMode, sdkModelName, max
     maxTurns: 100,
     enableFileCheckpointing: true,
     env: buildCliEnv(),
+    settings: buildWebviewControlledSettingsOverride(modelId),
     ...(maxThinkingTokens !== undefined && { maxThinkingTokens }),
     ...(streamingEnabled && { includePartialMessages: true }),
     additionalDirectories: Array.from(
@@ -468,7 +475,7 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
 
     const preToolUseHook = createPreToolUseHook(effectivePermissionMode, workingDirectory);
     const mcpServers = await loadMcpServersConfigAsRecord(workingDirectory);
-    const options = buildQueryOptions({ workingDirectory, permissionMode: effectivePermissionMode, sdkModelName, maxThinkingTokens, streamingEnabled, systemPromptAppend, preToolUseHook, sdkStderrLines, mcpServers });
+    const options = buildQueryOptions({ workingDirectory, permissionMode: effectivePermissionMode, sdkModelName, maxThinkingTokens, streamingEnabled, systemPromptAppend, preToolUseHook, sdkStderrLines, mcpServers, modelId: model });
 
     if (normalizedReasoningEffort) {
       options.effort = normalizedReasoningEffort;
@@ -544,7 +551,7 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
     console.log('[DEBUG] (withAttachments) Config:', { normalizedPermissionMode, alwaysThinkingEnabled, maxThinkingTokens, streamingEnabled, reasoningEffort });
 
     const mcpServers = await loadMcpServersConfigAsRecord(workingDirectory);
-    const options = buildQueryOptions({ workingDirectory, permissionMode: normalizedPermissionMode, sdkModelName, maxThinkingTokens, streamingEnabled, systemPromptAppend, preToolUseHook, sdkStderrLines, mcpServers });
+    const options = buildQueryOptions({ workingDirectory, permissionMode: normalizedPermissionMode, sdkModelName, maxThinkingTokens, streamingEnabled, systemPromptAppend, preToolUseHook, sdkStderrLines, mcpServers, modelId: model });
 
     if (reasoningEffort) {
       options.effort = reasoningEffort;

--- a/ai-bridge/services/claude/persistent-query-service.context.test.mjs
+++ b/ai-bridge/services/claude/persistent-query-service.context.test.mjs
@@ -78,6 +78,15 @@ test('buildRequestContext preserves resolved model mapping for context usage run
       'resolved model state should honor mapped sonnet model settings',
     );
     assert.equal(requestContext.resolvedModelId, 'custom-sonnet-model');
+    assert.equal(requestContext.options.env.ANTHROPIC_MODEL, 'custom-sonnet-model');
+    assert.equal(requestContext.options.env.ANTHROPIC_DEFAULT_SONNET_MODEL, 'custom-sonnet-model');
+    assert.deepEqual(requestContext.options.settings, {
+      env: {
+        CLAUDE_CODE_EFFORT_LEVEL: '',
+        MAX_THINKING_TOKENS: '',
+        CLAUDE_CODE_DISABLE_1M_CONTEXT: '1',
+      },
+    });
     assert.equal(process.env.ANTHROPIC_MODEL, 'custom-sonnet-model');
     assert.equal(process.env.ANTHROPIC_DEFAULT_SONNET_MODEL, 'custom-sonnet-model');
     assert.equal(exactContext.options.model, 'custom-sonnet-model');
@@ -292,9 +301,11 @@ test('getContextUsagePersistent recreates runtime when existing runtime model is
   console.log = (...args) => { /* suppress */ };
 
   try {
+    const requestedModel = 'custom-context-model';
+
     await getContextUsagePersistent({
       sessionId: 'sess-unknown-model',
-      model: 'claude-opus-4-7',
+      model: requestedModel,
       cwd: process.cwd(),
     });
 
@@ -302,10 +313,10 @@ test('getContextUsagePersistent recreates runtime when existing runtime model is
 
     const runtime2 = __testing.getRuntimeForSession('sess-unknown-model');
     assert.notEqual(runtime2, runtime1, 'should replace the old runtime');
-    assert.equal(runtime2.modelId, 'claude-opus-4-7', 'new runtime should track exact requested modelId');
+    assert.equal(runtime2.modelId, requestedModel, 'new runtime should track exact requested modelId');
     assert.equal(
       factory.runtimes[1].options.model,
-      'claude-opus-4-7',
+      requestedModel,
       'recreated runtime should be created with exact model ID',
     );
   } finally {

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -3,7 +3,13 @@
  * Keeps Claude Query processes alive across turns to reduce per-request latency.
  */
 
-import { isCustomBaseUrl, loadClaudeSettings, setupApiKey, buildCliEnv } from '../../config/api-config.js';
+import {
+  isCustomBaseUrl,
+  loadClaudeSettings,
+  setupApiKey,
+  buildCliEnv,
+  buildWebviewControlledSettingsOverride,
+} from '../../config/api-config.js';
 import { selectWorkingDirectory } from '../../utils/path-utils.js';
 import {
   mapModelIdToSdkName,
@@ -114,7 +120,7 @@ function resolveRequestModelState(modelId, settingsEnv) {
   };
 }
 
-function buildQueryOptions(workingDirectory, sdkModelName, permissionMode, maxThinkingTokens, reasoningEffort, streamingEnabled, systemPromptAppend, requestedSessionId, mcpServers) {
+function buildQueryOptions(workingDirectory, sdkModelName, permissionMode, maxThinkingTokens, reasoningEffort, streamingEnabled, systemPromptAppend, requestedSessionId, mcpServers, modelId) {
   const claudeCliOverride = getClaudeCliPathOverride();
   return {
     cwd: workingDirectory,
@@ -123,6 +129,7 @@ function buildQueryOptions(workingDirectory, sdkModelName, permissionMode, maxTh
     maxTurns: 100,
     enableFileCheckpointing: true,
     env: buildCliEnv(),
+    settings: buildWebviewControlledSettingsOverride(modelId),
     ...(reasoningEffort && { effort: reasoningEffort }),
     ...(maxThinkingTokens !== undefined && { maxThinkingTokens }),
     ...(streamingEnabled && { includePartialMessages: true }),
@@ -203,7 +210,7 @@ async function buildRequestContext(params, withAttachments, overrides = {}) {
   const options = buildQueryOptions(
     workingDirectory, sdkModelName, permissionMode,
     maxThinkingTokens, reasoningEffort, streamingEnabled, systemPromptAppend, requestedSessionId,
-    mcpServers
+    mcpServers, modelId
   );
 
   const userMessage = await buildUserMessage(params, withAttachments, requestedSessionId, resolvedModelId);

--- a/ai-bridge/services/prompt-enhancer.js
+++ b/ai-bridge/services/prompt-enhancer.js
@@ -17,7 +17,7 @@ import {
   loadCodexSdk,
   isCodexSdkAvailable,
 } from '../utils/sdk-loader.js';
-import { setupApiKey, buildCliEnv } from '../config/api-config.js';
+import { setupApiKey, buildCliEnv, buildWebviewControlledSettingsOverride } from '../config/api-config.js';
 import { mapModelIdToSdkName } from '../utils/model-utils.js';
 import { getRealHomeDir } from '../utils/path-utils.js';
 import { getClaudeCliPathOverride } from '../utils/claude-cli-path.js';
@@ -320,6 +320,7 @@ async function enhancePromptWithClaude(originalPrompt, systemPrompt, model, cont
     model: sdkModelName,
     maxTurns: 1,
     env: buildCliEnv(),
+    settings: buildWebviewControlledSettingsOverride(model),
     systemPrompt,
     settingSources: ['user', 'project', 'local'],
     ...(claudeCliOverride && { pathToClaudeCodeExecutable: claudeCliOverride }),

--- a/ai-bridge/utils/model-utils.js
+++ b/ai-bridge/utils/model-utils.js
@@ -36,13 +36,13 @@ export function mapModelIdToSdkName(modelId) {
  *
  * Priority: ANTHROPIC_MODEL (global override) > ANTHROPIC_DEFAULT_*_MODEL > original modelId
  *
- * IMPORTANT: The `[1m]` suffix on the input modelId is preserved across the mapping.
+ * IMPORTANT: The `[1m]` suffix is controlled by the input modelId from the
+ * webview, not by stale settings.env mappings.
  * The 1M context window is selected by the Claude Code SDK based on whether the
  * model name ends with `[1m]` (it reads `process.env.ANTHROPIC_DEFAULT_*_MODEL`).
- * Stripping the suffix during settings resolution silently disables the 1M toggle
- * for any provider whose mapping value doesn't already carry `[1m]` (most third-party
- * presets like zhipu/kimi/qwen/minimax/xiaomi). If the mapped value already ends in
- * `[1m]`, it's kept as-is so we don't double-append.
+ * If the request enables 1M, preserve or append the suffix on the mapped model.
+ * If the request disables 1M, strip any suffix from the mapped value so an old
+ * settings.json env value cannot force the 1M context window back on.
  *
  * @param {string} modelId - Internal model ID from frontend (e.g. 'claude-sonnet-4-6' or 'claude-sonnet-4-6[1m]')
  * @param {object} userEnv - The env object from settings.json (settings.env)
@@ -53,11 +53,11 @@ export function resolveModelFromSettings(modelId, userEnv) {
 
   const lowerModel = modelId.toLowerCase();
   const requestHas1M = /\[1m\]$/i.test(modelId);
-  // Preserve the [1m] suffix from the original modelId across settings mapping.
-  // If the mapped value already carries [1m], don't double-append it.
+  // The request owns 1M state. Settings mappings may provide the provider's base
+  // model ID, but they must not force the context-window suffix.
   const applySuffix = (mapped) => {
-    if (!requestHas1M) return mapped;
-    return /\[1m\]$/i.test(mapped) ? mapped : `${mapped}[1m]`;
+    const base = String(mapped).trim().replace(/\[1m\]$/i, '');
+    return requestHas1M ? `${base}[1m]` : base;
   };
 
   // ANTHROPIC_MODEL is a global override that applies to all model types

--- a/ai-bridge/utils/model-utils.test.mjs
+++ b/ai-bridge/utils/model-utils.test.mjs
@@ -66,7 +66,7 @@ test('resolveModelFromSettings does NOT remap non-Anthropic model IDs', () => {
   assert.equal(resolveModelFromSettings('deepseek-v4-pro', env), 'deepseek-v4-pro');
 });
 
-// --- [1m] suffix preservation across settings mapping (regression) -------
+// --- [1m] suffix follows the webview request state ------------------------
 //
 // Bug: when a user opens the 1M context toggle in the UI, the frontend sends
 //   `claude-sonnet-4-6[1m]` to the backend. If `settings.json` contains a
@@ -74,7 +74,8 @@ test('resolveModelFromSettings does NOT remap non-Anthropic model IDs', () => {
 //   the old resolver returned `'glm-4.7'`, silently dropping the suffix.
 //   The Claude SDK then read the env var without [1m] and did NOT enable the
 //   1M context window even though the toggle was on.
-// Fix: preserve the [1m] suffix from the request modelId across the mapping.
+// Fix: make the request modelId the source of truth. Preserve/append [1m] when
+// the toggle is on, and strip stale mapping suffixes when the toggle is off.
 
 test('resolveModelFromSettings preserves [1m] suffix when mapping value lacks it', () => {
   const env = { ANTHROPIC_DEFAULT_SONNET_MODEL: 'glm-4.7' };
@@ -93,15 +94,17 @@ test('resolveModelFromSettings does not double-append [1m] when mapping already 
   );
 });
 
-test('resolveModelFromSettings drops nothing when 1M toggle is OFF', () => {
-  // No [1m] in request → no [1m] in output. Lets users disable 1M to stay
-  // compatible with proxies that don't recognize the suffix.
-  const env = { ANTHROPIC_DEFAULT_SONNET_MODEL: 'glm-4.7' };
-  assert.equal(resolveModelFromSettings('claude-sonnet-4-6', env), 'glm-4.7');
+test('resolveModelFromSettings strips stale [1m] suffix when 1M toggle is OFF', () => {
+  const env = { ANTHROPIC_DEFAULT_SONNET_MODEL: 'glm-4.7[1M]' };
+  assert.equal(
+    resolveModelFromSettings('claude-sonnet-4-6', env),
+    'glm-4.7',
+    'request did not ask for 1M, stale settings mapping suffix must not force it on'
+  );
 });
 
 test('resolveModelFromSettings preserves [1m] across ANTHROPIC_MODEL global override', () => {
-  const env = { ANTHROPIC_MODEL: 'override-model' };
+  const env = { ANTHROPIC_MODEL: 'override-model[1M]' };
   assert.equal(resolveModelFromSettings('claude-sonnet-4-6[1m]', env), 'override-model[1m]');
   assert.equal(resolveModelFromSettings('claude-sonnet-4-6', env), 'override-model');
 });

--- a/src/main/java/com/github/claudecodegui/handler/SessionHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SessionHandler.java
@@ -123,6 +123,7 @@ public class SessionHandler extends BaseMessageHandler {
         String agentPrompt = null;
         java.util.List<String> fileTagPaths = null;
         String requestedPermissionMode = null;
+        String requestedReasoningEffort = null;
         try {
             Gson gson = new Gson();
             JsonObject payload = gson.fromJson(content, JsonObject.class);
@@ -164,6 +165,8 @@ public class SessionHandler extends BaseMessageHandler {
                     LOG.warn("[SessionHandler] Ignoring invalid permissionMode from payload: " + mode);
                 }
             }
+
+            requestedReasoningEffort = extractReasoningEffort(payload);
         } catch (Exception e) {
             // If parsing fails, treat content as plain text (backward compatibility)
             LOG.debug("[SessionHandler] Message is plain text, not JSON: " + e.getMessage());
@@ -174,6 +177,7 @@ public class SessionHandler extends BaseMessageHandler {
         final String finalAgentPrompt = agentPrompt;
         final java.util.List<String> finalFileTagPaths = fileTagPaths;
         final String finalRequestedPermissionMode = requestedPermissionMode;
+        final String finalRequestedReasoningEffort = requestedReasoningEffort;
 
         CompletableFuture.runAsync(() -> {
             String currentWorkingDir = determineWorkingDirectory();
@@ -191,7 +195,8 @@ public class SessionHandler extends BaseMessageHandler {
             }
 
             // [FIX] Pass agent prompt and file tags directly to session
-            context.getSession().send(finalPrompt, finalAgentPrompt, finalFileTagPaths, finalRequestedPermissionMode)
+            context.getSession().send(finalPrompt, finalAgentPrompt, finalFileTagPaths,
+                            finalRequestedPermissionMode, finalRequestedReasoningEffort)
                 .thenRun(() -> {
                     // Claude now triggers success on actual stream_end callback.
                     // Codex has no stream_end event, keep success trigger at completion.
@@ -249,6 +254,7 @@ public class SessionHandler extends BaseMessageHandler {
             // [FIX] Extract agent prompt from the payload for per-tab agent selection
             String agentPrompt = null;
             String requestedPermissionMode = null;
+            String requestedReasoningEffort = null;
             if (payload != null && payload.has("agent") && !payload.get("agent").isJsonNull()) {
                 JsonObject agent = payload.getAsJsonObject("agent");
                 if (agent.has("prompt") && !agent.get("prompt").isJsonNull()) {
@@ -283,7 +289,10 @@ public class SessionHandler extends BaseMessageHandler {
                 }
             }
 
-            sendMessageWithAttachments(text, atts, agentPrompt, fileTagPaths, requestedPermissionMode);
+            requestedReasoningEffort = extractReasoningEffort(payload);
+
+            sendMessageWithAttachments(text, atts, agentPrompt, fileTagPaths, requestedPermissionMode,
+                    requestedReasoningEffort);
         } catch (Exception e) {
             LOG.error("[SessionHandler] 解析附件负载失败: " + e.getMessage(), e);
             handleSendMessage(content);
@@ -299,7 +308,8 @@ public class SessionHandler extends BaseMessageHandler {
         List<ClaudeSession.Attachment> attachments,
         String agentPrompt,
         java.util.List<String> fileTagPaths,
-        String requestedPermissionMode
+        String requestedPermissionMode,
+        String requestedReasoningEffort
     ) {
         // Version check (consistent with handleSendMessage)
         String nodeVersion = this.resolveNodeVersion();
@@ -321,6 +331,7 @@ public class SessionHandler extends BaseMessageHandler {
         final String finalAgentPrompt = agentPrompt;
         final java.util.List<String> finalFileTagPaths = fileTagPaths;
         final String finalRequestedPermissionMode = requestedPermissionMode;
+        final String finalRequestedReasoningEffort = requestedReasoningEffort;
 
         CompletableFuture.runAsync(() -> {
             String currentWorkingDir = determineWorkingDirectory();
@@ -337,7 +348,8 @@ public class SessionHandler extends BaseMessageHandler {
             }
 
             // [FIX] Pass agent prompt and file tags directly to session
-            context.getSession().send(prompt, attachments, finalAgentPrompt, finalFileTagPaths, finalRequestedPermissionMode)
+            context.getSession().send(prompt, attachments, finalAgentPrompt, finalFileTagPaths,
+                            finalRequestedPermissionMode, finalRequestedReasoningEffort)
                 .thenRun(() -> {
                     // Claude now triggers success on actual stream_end callback.
                     // Codex has no stream_end event, keep success trigger at completion.
@@ -435,6 +447,13 @@ public class SessionHandler extends BaseMessageHandler {
 
         // Use project root as the default working directory.
         return projectPath;
+    }
+
+    private String extractReasoningEffort(JsonObject payload) {
+        if (payload == null || !payload.has("reasoningEffort") || payload.get("reasoningEffort").isJsonNull()) {
+            return null;
+        }
+        return payload.get("reasoningEffort").getAsString();
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
@@ -356,7 +356,21 @@ public class ClaudeSession {
      * requestedPermissionMode priority: payload > sessionMode > default.
      */
     public CompletableFuture<Void> send(String input, String agentPrompt, List<String> fileTagPaths, String requestedPermissionMode) {
-        return send(input, null, agentPrompt, fileTagPaths, requestedPermissionMode);
+        return send(input, null, agentPrompt, fileTagPaths, requestedPermissionMode, null);
+    }
+
+    /**
+     * Send a message with a specific agent prompt, file tags, requested permission mode,
+     * and requested reasoning effort.
+     */
+    public CompletableFuture<Void> send(
+            String input,
+            String agentPrompt,
+            List<String> fileTagPaths,
+            String requestedPermissionMode,
+            String requestedReasoningEffort
+    ) {
+        return send(input, null, agentPrompt, fileTagPaths, requestedPermissionMode, requestedReasoningEffort);
     }
 
     /**
@@ -406,6 +420,23 @@ public class ClaudeSession {
             List<String> fileTagPaths,
             String requestedPermissionMode
     ) {
+        return send(input, attachments, agentPrompt, fileTagPaths, requestedPermissionMode, null);
+    }
+
+    /**
+     * Send a message with attachments, agent prompt, file tags, requested permission mode,
+     * and requested reasoning effort.
+     * The effective mode is resolved with priority:
+     * Priority: requestedPermissionMode > sessionMode > default.
+     */
+    public CompletableFuture<Void> send(
+            String input,
+            List<Attachment> attachments,
+            String agentPrompt,
+            List<String> fileTagPaths,
+            String requestedPermissionMode,
+            String requestedReasoningEffort
+    ) {
         String normalizedInput = (input != null) ? input.trim() : "";
         Message userMessage = contextService.buildUserMessage(normalizedInput, attachments);
         sendService.updateSessionStateForSend(userMessage, normalizedInput);
@@ -413,6 +444,7 @@ public class ClaudeSession {
         final String finalAgentPrompt = agentPrompt;
         final List<String> finalFileTagPaths = fileTagPaths;
         final String finalRequestedPermissionMode = requestedPermissionMode;
+        final String finalRequestedReasoningEffort = requestedReasoningEffort;
 
         return launchClaude().thenCompose(chId -> {
             sendService.prepareContextCollector(contextCollector);
@@ -425,7 +457,8 @@ public class ClaudeSession {
                             openedFilesJson,
                             finalAgentPrompt,
                             finalFileTagPaths,
-                            finalRequestedPermissionMode
+                            finalRequestedPermissionMode,
+                            finalRequestedReasoningEffort
                     )
             ).thenCompose(v -> syncUserMessageUuidsAfterSend());
         }).exceptionally(ex -> {

--- a/src/main/java/com/github/claudecodegui/session/SessionSendService.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionSendService.java
@@ -85,7 +85,8 @@ public class SessionSendService {
             JsonObject openedFilesJson,
             String externalAgentPrompt,
             List<String> fileTagPaths,
-            String requestedPermissionMode
+            String requestedPermissionMode,
+            String requestedReasoningEffort
     ) {
         String agentPrompt = externalAgentPrompt;
         if (agentPrompt == null) {
@@ -111,6 +112,8 @@ public class SessionSendService {
                         + ", effective=" + effectivePermissionMode
         );
 
+        String normalizedRequestedEffort = normalizeRequestedReasoningEffort(requestedReasoningEffort);
+
         if ("codex".equals(currentProvider)) {
             return sendToCodex(
                     channelId,
@@ -119,11 +122,28 @@ public class SessionSendService {
                     openedFilesJson,
                     agentPrompt,
                     fileTagPaths,
-                    effectivePermissionMode
+                    effectivePermissionMode,
+                    normalizedRequestedEffort
             );
         }
 
-        return sendToClaude(channelId, input, attachments, openedFilesJson, agentPrompt, effectivePermissionMode);
+        return sendToClaude(channelId, input, attachments, openedFilesJson, agentPrompt,
+                effectivePermissionMode, normalizedRequestedEffort);
+    }
+
+    public static String normalizeRequestedReasoningEffort(String effort) {
+        if (effort == null) {
+            return null;
+        }
+        String trimmed = effort.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        if (SessionState.isValidReasoningEffort(trimmed)) {
+            return trimmed;
+        }
+        LOG.warn("[ReasoningEffort][Backend] Invalid requested reasoningEffort ignored: " + effort);
+        return null;
     }
 
     public static String normalizeRequestedPermissionMode(String mode) {
@@ -171,7 +191,8 @@ public class SessionSendService {
             JsonObject openedFilesJson,
             String agentPrompt,
             List<String> fileTagPaths,
-            String effectivePermissionMode
+            String effectivePermissionMode,
+            String requestedReasoningEffort
     ) {
         CodexMessageHandler handler = new CodexMessageHandler(state, callbackFacade.getCallbackHandler());
         String accessMode = CodemossSettingsService.CODEX_RUNTIME_ACCESS_INACTIVE;
@@ -199,7 +220,7 @@ public class SessionSendService {
                 effectivePermissionMode,
                 state.getModel(),
                 agentPrompt,
-                state.getReasoningEffort(),
+                requestedReasoningEffort != null ? requestedReasoningEffort : state.getReasoningEffort(),
                 handler
         ).thenApply(result -> null);
     }
@@ -210,7 +231,8 @@ public class SessionSendService {
             List<ClaudeSession.Attachment> attachments,
             JsonObject openedFilesJson,
             String agentPrompt,
-            String effectivePermissionMode
+            String effectivePermissionMode,
+            String requestedReasoningEffort
     ) {
         ClaudeMessageHandler handler = new ClaudeMessageHandler(
                 project,
@@ -242,7 +264,7 @@ public class SessionSendService {
                         agentPrompt,
                         streaming,
                         false,
-                        state.getReasoningEffort(),
+                        requestedReasoningEffort != null ? requestedReasoningEffort : state.getReasoningEffort(),
                         handler
                 ).thenApply(result -> null);
     }

--- a/src/main/java/com/github/claudecodegui/session/SessionState.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionState.java
@@ -36,6 +36,27 @@ public class SessionState {
         return mode != null && VALID_PERMISSION_MODES.contains(mode.trim());
     }
 
+    /**
+     * Canonical whitelist of valid Claude/Codex reasoning effort levels.
+     */
+    public static final Set<String> VALID_REASONING_EFFORTS;
+    static {
+        Set<String> efforts = new HashSet<>();
+        efforts.add("low");
+        efforts.add("medium");
+        efforts.add("high");
+        efforts.add("xhigh");
+        efforts.add("max");
+        VALID_REASONING_EFFORTS = Collections.unmodifiableSet(efforts);
+    }
+
+    /**
+     * Check whether the given reasoning effort string is recognized.
+     */
+    public static boolean isValidReasoningEffort(String effort) {
+        return effort != null && VALID_REASONING_EFFORTS.contains(effort.trim());
+    }
+
     // Session identifiers
     private String sessionId;
     private String channelId;
@@ -61,8 +82,8 @@ public class SessionState {
     private volatile String permissionMode = "bypassPermissions";
     private volatile String model = "claude-sonnet-4-6";
     private volatile String provider = "claude";
-    // Reasoning effort (thinking depth)
-    private volatile String reasoningEffort = "high";
+    // Reasoning effort (thinking depth). Null means "do not override SDK/settings".
+    private volatile String reasoningEffort = null;
 
     // Slash commands — volatile for cross-thread visibility (same reason as permissionMode/model/provider)
     private volatile List<String> slashCommands = new ArrayList<>();
@@ -191,7 +212,15 @@ public class SessionState {
     }
 
     public void setReasoningEffort(String reasoningEffort) {
-        this.reasoningEffort = reasoningEffort;
+        if (reasoningEffort == null || reasoningEffort.trim().isEmpty()) {
+            this.reasoningEffort = null;
+            return;
+        }
+        String trimmed = reasoningEffort.trim();
+        if (!isValidReasoningEffort(trimmed)) {
+            return;
+        }
+        this.reasoningEffort = trimmed;
     }
 
     public void setRuntimeSessionEpoch(String runtimeSessionEpoch) {

--- a/src/test/java/com/github/claudecodegui/session/SessionSendServiceTest.java
+++ b/src/test/java/com/github/claudecodegui/session/SessionSendServiceTest.java
@@ -35,6 +35,16 @@ public class SessionSendServiceTest {
     }
 
     @Test
+    public void normalizeRequestedReasoningEffortRejectsBlankAndUnknownValues() {
+        assertNull(SessionSendService.normalizeRequestedReasoningEffort(null));
+        assertNull(SessionSendService.normalizeRequestedReasoningEffort(" "));
+        assertNull(SessionSendService.normalizeRequestedReasoningEffort("extreme"));
+        assertEquals("low", SessionSendService.normalizeRequestedReasoningEffort(" low "));
+        assertEquals("xhigh", SessionSendService.normalizeRequestedReasoningEffort("xhigh"));
+        assertEquals("max", SessionSendService.normalizeRequestedReasoningEffort("max"));
+    }
+
+    @Test
     public void getCodexRuntimeAccessErrorRequiresAuthorizationOrManagedProvider() {
         assertEquals(
                 "Codex local configuration access is not authorized. Please authorize local ~/.codex access or enable a managed Codex provider first.",
@@ -42,5 +52,12 @@ public class SessionSendServiceTest {
         );
         assertNull(SessionSendService.getCodexRuntimeAccessError("managed"));
         assertNull(SessionSendService.getCodexRuntimeAccessError("cli_login"));
+    }
+
+    @Test
+    public void newSessionStateDoesNotInjectDefaultClaudeReasoningEffort() {
+        SessionState state = new SessionState();
+
+        assertNull(state.getReasoningEffort());
     }
 }

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -319,7 +319,7 @@ const App = () => {
     interruptSession,
   } = useMessageSender({
     t, addToast,
-    currentProvider, selectedModel, permissionMode, selectedAgent,
+    currentProvider, selectedModel, permissionMode, reasoningEffort, selectedAgent,
     sdkStatusLoaded, currentSdkInstalled,
     sentAttachmentsRef, chatInputRef, messagesContainerRef,
     isUserAtBottomRef, userPausedRef, isStreamingRef,

--- a/webview/src/hooks/useMessageSender.context.test.ts
+++ b/webview/src/hooks/useMessageSender.context.test.ts
@@ -11,6 +11,7 @@ describe('useMessageSender - /context command', () => {
     currentProvider: 'claude',
     selectedModel: 'claude-opus-4-7',
     permissionMode: 'default',
+    reasoningEffort: 'high',
     selectedAgent: null,
     sdkStatusLoaded: true,
     currentSdkInstalled: true,
@@ -33,6 +34,14 @@ describe('useMessageSender - /context command', () => {
     closeContextUsageDialog: vi.fn().mockReturnValue(true),
     ...overrides,
   });
+
+  const getBridgePayload = (eventName: string) => {
+    const calls = (window.sendToJava as any).mock.calls.map((call: [string]) => call[0]);
+    const prefix = `${eventName}:`;
+    const sendCall = calls.find((call: string) => call.startsWith(prefix));
+    expect(sendCall).toBeTruthy();
+    return JSON.parse(sendCall!.substring(prefix.length));
+  };
 
   beforeEach(() => {
     window.sendToJava = vi.fn();
@@ -138,5 +147,96 @@ describe('useMessageSender - /context command', () => {
       expect.any(String),
       'error',
     );
+  });
+
+  it('includes explicit Claude high reasoning effort in plain message payload', () => {
+    const opts = createOptions({
+      currentProvider: 'claude',
+      selectedModel: 'claude-opus-4-7',
+      reasoningEffort: 'high',
+    });
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('hello');
+    });
+
+    const payload = getBridgePayload('send_message');
+    expect(payload.reasoningEffort).toBe('high');
+  });
+
+  it('includes explicit Claude high reasoning effort in attachment message payload', () => {
+    const opts = createOptions({
+      currentProvider: 'claude',
+      selectedModel: 'claude-opus-4-7',
+      reasoningEffort: 'high',
+    });
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('hello', [{
+        id: 'att-1',
+        fileName: 'note.txt',
+        mediaType: 'text/plain',
+        data: 'aGVsbG8=',
+      }]);
+    });
+
+    const payload = getBridgePayload('send_message_with_attachments');
+    expect(payload.reasoningEffort).toBe('high');
+  });
+
+  it('omits reasoning effort for Claude models without adaptive thinking support', () => {
+    const opts = createOptions({
+      currentProvider: 'claude',
+      selectedModel: 'claude-haiku-4-5',
+      reasoningEffort: 'low',
+    });
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('hello');
+    });
+
+    const payload = getBridgePayload('send_message');
+    expect(payload).not.toHaveProperty('reasoningEffort');
+  });
+
+  it('includes explicit non-default Claude reasoning effort in plain message payload', () => {
+    const opts = createOptions({
+      reasoningEffort: 'low',
+    });
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('hello');
+    });
+
+    const payload = getBridgePayload('send_message');
+    expect(payload.reasoningEffort).toBe('low');
+  });
+
+  it('includes explicit non-default Claude reasoning effort in attachment message payload', () => {
+    const opts = createOptions({
+      reasoningEffort: 'low',
+    });
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('hello', [{
+        id: 'att-1',
+        fileName: 'note.txt',
+        mediaType: 'text/plain',
+        data: 'aGVsbG8=',
+      }]);
+    });
+
+    const payload = getBridgePayload('send_message_with_attachments');
+    expect(payload.reasoningEffort).toBe('low');
   });
 });

--- a/webview/src/hooks/useMessageSender.ts
+++ b/webview/src/hooks/useMessageSender.ts
@@ -2,8 +2,11 @@ import { useCallback, type RefObject } from 'react';
 import type { TFunction } from 'i18next';
 import { sendBridgeEvent } from '../utils/bridge';
 import type { ClaudeContentBlock, ClaudeMessage } from '../types';
-import { apply1MContextSuffix } from '../components/ChatInputBox/types';
-import type { Attachment, ChatInputBoxHandle, PermissionMode, SelectedAgent } from '../components/ChatInputBox/types';
+import {
+  EFFORT_SUPPORTED_CLAUDE_MODELS,
+  apply1MContextSuffix,
+} from '../components/ChatInputBox/types';
+import type { Attachment, ChatInputBoxHandle, PermissionMode, ReasoningEffort, SelectedAgent } from '../components/ChatInputBox/types';
 import type { ViewMode } from './useModelProviderState';
 
 /**
@@ -24,12 +27,20 @@ function createContextUsageRequestId(): string {
   return `context-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
+function shouldSendReasoningEffort(provider: string, model: string): boolean {
+  if (provider !== 'claude') {
+    return true;
+  }
+  return EFFORT_SUPPORTED_CLAUDE_MODELS.has(model);
+}
+
 export interface UseMessageSenderOptions {
   t: TFunction;
   addToast: (message: string, type?: 'info' | 'success' | 'warning' | 'error') => void;
   currentProvider: string;
   selectedModel: string;
   permissionMode: PermissionMode;
+  reasoningEffort: ReasoningEffort;
   selectedAgent: SelectedAgent | null;
   sdkStatusLoaded: boolean;
   currentSdkInstalled: boolean;
@@ -61,6 +72,7 @@ export function useMessageSender({
   currentProvider,
   selectedModel,
   permissionMode,
+  reasoningEffort,
   selectedAgent,
   sdkStatusLoaded,
   currentSdkInstalled,
@@ -249,6 +261,10 @@ export function useMessageSender({
       effectiveMode: effectivePermissionMode,
     });
 
+    const reasoningEffortPayload = shouldSendReasoningEffort(currentProvider, selectedModel)
+      ? { reasoningEffort }
+      : {};
+
     if (hasAttachments) {
       try {
         const payload = JSON.stringify({
@@ -261,6 +277,7 @@ export function useMessageSender({
           agent: agentInfo,
           fileTags: fileTagsInfo,
           permissionMode: effectivePermissionMode,
+          ...reasoningEffortPayload,
         });
         sendBridgeEvent('send_message_with_attachments', payload);
       } catch (error) {
@@ -270,6 +287,7 @@ export function useMessageSender({
           agent: agentInfo,
           fileTags: fileTagsInfo,
           permissionMode: effectivePermissionMode,
+          ...reasoningEffortPayload,
         });
         sendBridgeEvent('send_message', fallbackPayload);
       }
@@ -279,10 +297,11 @@ export function useMessageSender({
         agent: agentInfo,
         fileTags: fileTagsInfo,
         permissionMode: effectivePermissionMode,
+        ...reasoningEffortPayload,
       });
       sendBridgeEvent('send_message', payload);
     }
-  }, [currentProvider]);
+  }, [currentProvider, selectedModel, reasoningEffort]);
 
   /**
    * Execute message sending (from queue or directly)


### PR DESCRIPTION
Previously, the WebView reasoning effort selector could update UI state without affecting the actual Claude/Codex request. The send payload omitted Claude's default high effort and the Java session pipeline only used the session-level effort value, so per-message selections were not reliably applied.

Include reasoningEffort in message payloads for supported Claude models, including high, parse it in SessionHandler, thread it through ClaudeSession and SessionSendService, and prefer the requested value over session state when invoking the provider bridges. Also stop injecting a default backend effort so the SDK/settings default is preserved unless the user explicitly selects one.

Fixes #1281