### PR TITLE
fix(history): preserve Codex tool call UI after restart （重启后保持Codex工具调用UI）

### DIFF
--- a/src/main/java/com/github/claudecodegui/session/MessageParser.java
+++ b/src/main/java/com/github/claudecodegui/session/MessageParser.java
@@ -17,6 +17,7 @@ public class MessageParser {
      */
     public ClaudeSession.Message parseServerMessage(JsonObject msg) {
         String type = msg.has("type") ? msg.get("type").getAsString() : null;
+        JsonObject rawMessage = resolveRawMessage(msg);
 
         // Filter out isMeta messages
         if (msg.has("isMeta") && msg.get("isMeta").getAsBoolean()) {
@@ -33,21 +34,34 @@ public class MessageParser {
             String content = extractMessageContent(msg);
             // Check if it contains a tool_result
             if (content == null || content.trim().isEmpty()) {
-                if (hasToolResult(msg)) {
-                    return new ClaudeSession.Message(ClaudeSession.Message.Type.USER, "[tool_result]", msg);
+                if (hasToolResult(rawMessage)) {
+                    return new ClaudeSession.Message(ClaudeSession.Message.Type.USER, "[tool_result]", rawMessage);
                 }
-                if (hasImageContent(msg)) {
-                    return new ClaudeSession.Message(ClaudeSession.Message.Type.USER, "", msg);
+                if (hasImageContent(rawMessage)) {
+                    return new ClaudeSession.Message(ClaudeSession.Message.Type.USER, "", rawMessage);
                 }
                 return null;
             }
-            return new ClaudeSession.Message(ClaudeSession.Message.Type.USER, content, msg);
+            return new ClaudeSession.Message(ClaudeSession.Message.Type.USER, content, rawMessage);
         } else if ("assistant".equals(type)) {
             String content = extractMessageContent(msg);
-            return new ClaudeSession.Message(ClaudeSession.Message.Type.ASSISTANT, content, msg);
+            return new ClaudeSession.Message(ClaudeSession.Message.Type.ASSISTANT, content, rawMessage);
         }
 
         return null;
+    }
+
+    /**
+     * Provider history adapters may return an already-normalized frontend envelope whose
+     * structured SDK payload lives in {@code raw}. Keep only that payload in session state;
+     * otherwise MessageJsonConverter sees the envelope's display-only content and drops
+     * nested tool_use/tool_result blocks during auto-restore.
+     */
+    private JsonObject resolveRawMessage(JsonObject msg) {
+        if (msg.has("raw") && msg.get("raw").isJsonObject()) {
+            return msg.getAsJsonObject("raw");
+        }
+        return msg;
     }
 
     /**
@@ -119,16 +133,24 @@ public class MessageParser {
     }
 
     private boolean hasContentBlockType(JsonObject msg, String blockType) {
-        if (!msg.has("message") || !msg.get("message").isJsonObject()) {
+        if (msg.has("content") && containsContentBlockType(msg.get("content"), blockType)) {
+            return true;
+        }
+        if (msg.has("message") && msg.get("message").isJsonObject()) {
+            JsonObject message = msg.getAsJsonObject("message");
+            if (message.has("content") && containsContentBlockType(message.get("content"), blockType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean containsContentBlockType(JsonElement contentElement, String blockType) {
+        if (contentElement == null || !contentElement.isJsonArray()) {
             return false;
         }
 
-        JsonObject message = msg.getAsJsonObject("message");
-        if (!message.has("content") || !message.get("content").isJsonArray()) {
-            return false;
-        }
-
-        JsonArray contentArray = message.getAsJsonArray("content");
+        JsonArray contentArray = contentElement.getAsJsonArray();
         for (int i = 0; i < contentArray.size(); i++) {
             JsonElement element = contentArray.get(i);
             if (element.isJsonObject()) {

--- a/src/test/java/com/github/claudecodegui/provider/codex/CodexSDKBridgeHistoryTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/codex/CodexSDKBridgeHistoryTest.java
@@ -2,8 +2,10 @@ package com.github.claudecodegui.provider.codex;
 
 import com.github.claudecodegui.session.ClaudeSession;
 import com.github.claudecodegui.session.MessageParser;
+import com.github.claudecodegui.util.MessageJsonConverter;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -70,6 +72,56 @@ public class CodexSDKBridgeHistoryTest {
             assertNotNull(restored);
             assertEquals(ClaudeSession.Message.Type.USER, restored.type);
             assertEquals("[tool_result]", restored.content);
+            assertEquals("tool_result", restored.raw.getAsJsonArray("content").get(0).getAsJsonObject().get("type").getAsString());
+        } finally {
+            deleteDirectory(sessionsDir);
+        }
+    }
+
+    @Test
+    public void autoRestoreTransportPreservesToolUseAndResultBlocks() throws IOException {
+        Path sessionsDir = Files.createTempDirectory("codex-sdk-bridge-auto-restore-transport");
+        try {
+            writeSessionFile(
+                    sessionsDir,
+                    "session-auto-restore-transport",
+                    line("2026-03-10T10:00:00Z", "response_item",
+                            "{\"type\":\"function_call\",\"call_id\":\"call-search-1\",\"name\":\"shell_command\",\"arguments\":\"{\\\"command\\\":\\\"rg TODO src\\\"}\"}"),
+                    line("2026-03-10T10:00:01Z", "response_item",
+                            "{\"type\":\"function_call_output\",\"call_id\":\"call-search-1\",\"output\":\"src/Main.java:10: TODO\"}")
+            );
+
+            CodexSDKBridge bridge = new CodexSDKBridge(sessionsDir);
+            List<JsonObject> historyMessages =
+                    bridge.getSessionMessages("session-auto-restore-transport", sessionsDir.toString());
+            MessageParser parser = new MessageParser();
+            List<ClaudeSession.Message> restoredMessages = historyMessages.stream()
+                    .map(parser::parseServerMessage)
+                    .toList();
+
+            JsonArray transported = JsonParser.parseString(
+                    MessageJsonConverter.convertMessagesToJson(restoredMessages)
+            ).getAsJsonArray();
+
+            JsonObject transportedToolUse = transported.get(0)
+                    .getAsJsonObject()
+                    .getAsJsonObject("raw")
+                    .getAsJsonArray("content")
+                    .get(0)
+                    .getAsJsonObject();
+            assertEquals("tool_use", transportedToolUse.get("type").getAsString());
+            assertEquals("glob", transportedToolUse.get("name").getAsString());
+            assertEquals("rg TODO src", transportedToolUse.getAsJsonObject("input").get("command").getAsString());
+
+            JsonObject transportedToolResult = transported.get(1)
+                    .getAsJsonObject()
+                    .getAsJsonObject("raw")
+                    .getAsJsonArray("content")
+                    .get(0)
+                    .getAsJsonObject();
+            assertEquals("tool_result", transportedToolResult.get("type").getAsString());
+            assertEquals("call-search-1", transportedToolResult.get("tool_use_id").getAsString());
+            assertEquals("src/Main.java:10: TODO", transportedToolResult.get("content").getAsString());
         } finally {
             deleteDirectory(sessionsDir);
         }

--- a/src/test/java/com/github/claudecodegui/session/MessageParserTest.java
+++ b/src/test/java/com/github/claudecodegui/session/MessageParserTest.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 public class MessageParserTest {
@@ -33,5 +34,67 @@ public class MessageParserTest {
         assertEquals(ClaudeSession.Message.Type.USER, parsed.type);
         assertEquals("", parsed.content);
         assertEquals(raw, parsed.raw);
+    }
+
+    @Test
+    public void parseServerMessageUnwrapsNormalizedToolUseRawPayload() {
+        MessageParser parser = new MessageParser();
+
+        JsonObject toolUse = new JsonObject();
+        toolUse.addProperty("type", "tool_use");
+        toolUse.addProperty("id", "call-1");
+        toolUse.addProperty("name", "glob");
+        JsonObject input = new JsonObject();
+        input.addProperty("command", "rg TODO");
+        toolUse.add("input", input);
+
+        JsonArray content = new JsonArray();
+        content.add(toolUse);
+
+        JsonObject normalizedRaw = new JsonObject();
+        normalizedRaw.add("content", content);
+        normalizedRaw.addProperty("role", "assistant");
+
+        JsonObject envelope = new JsonObject();
+        envelope.addProperty("type", "assistant");
+        envelope.addProperty("content", "Tool: glob");
+        envelope.add("raw", normalizedRaw);
+
+        ClaudeSession.Message parsed = parser.parseServerMessage(envelope);
+
+        assertNotNull(parsed);
+        assertEquals(ClaudeSession.Message.Type.ASSISTANT, parsed.type);
+        assertEquals("Tool: glob", parsed.content);
+        assertEquals(normalizedRaw, parsed.raw);
+        assertFalse(parsed.raw.has("raw"));
+        assertEquals("tool_use", parsed.raw.getAsJsonArray("content").get(0).getAsJsonObject().get("type").getAsString());
+    }
+
+    @Test
+    public void parseServerMessageKeepsNormalizedImageOnlyMessage() {
+        MessageParser parser = new MessageParser();
+
+        JsonObject imageBlock = new JsonObject();
+        imageBlock.addProperty("type", "image");
+        imageBlock.addProperty("src", "data:image/png;base64,abc123");
+
+        JsonArray content = new JsonArray();
+        content.add(imageBlock);
+
+        JsonObject normalizedRaw = new JsonObject();
+        normalizedRaw.add("content", content);
+        normalizedRaw.addProperty("role", "user");
+
+        JsonObject envelope = new JsonObject();
+        envelope.addProperty("type", "user");
+        envelope.addProperty("content", "");
+        envelope.add("raw", normalizedRaw);
+
+        ClaudeSession.Message parsed = parser.parseServerMessage(envelope);
+
+        assertNotNull(parsed);
+        assertEquals(ClaudeSession.Message.Type.USER, parsed.type);
+        assertEquals("", parsed.content);
+        assertEquals(normalizedRaw, parsed.raw);
     }
 }

--- a/src/test/java/com/github/claudecodegui/session/SessionMessageOrchestratorTest.java
+++ b/src/test/java/com/github/claudecodegui/session/SessionMessageOrchestratorTest.java
@@ -126,6 +126,55 @@ public class SessionMessageOrchestratorTest {
     }
 
     @Test
+    public void loadFromServerPreservesNormalizedCodexToolBlocks() {
+        SessionState state = new SessionState();
+        state.setProvider("codex");
+        state.setSessionId("session-codex-tools");
+        state.setCwd("/workspace");
+
+        JsonObject toolUse = new JsonObject();
+        toolUse.addProperty("type", "tool_use");
+        toolUse.addProperty("id", "call-1");
+        toolUse.addProperty("name", "glob");
+        JsonObject input = new JsonObject();
+        input.addProperty("command", "rg TODO");
+        toolUse.add("input", input);
+
+        JsonArray rawContent = new JsonArray();
+        rawContent.add(toolUse);
+        JsonObject normalizedRaw = new JsonObject();
+        normalizedRaw.add("content", rawContent);
+        normalizedRaw.addProperty("role", "assistant");
+
+        JsonObject envelope = new JsonObject();
+        envelope.addProperty("type", "assistant");
+        envelope.addProperty("content", "Tool: glob");
+        envelope.add("raw", normalizedRaw);
+
+        RecordingHistoryAccess historyAccess = new RecordingHistoryAccess();
+        historyAccess.providerHistory = List.of(envelope);
+        SessionMessageOrchestrator orchestrator = new SessionMessageOrchestrator(
+                state,
+                new MessageParser(),
+                new SessionCallbackFacade(null),
+                historyAccess,
+                (usedTokens, maxTokens) -> {
+                },
+                0,
+                0
+        );
+
+        orchestrator.loadFromServer().join();
+
+        assertEquals(1, state.getMessages().size());
+        ClaudeSession.Message restored = state.getMessages().get(0);
+        assertEquals("Tool: glob", restored.content);
+        assertFalse(restored.raw.has("raw"));
+        assertEquals("tool_use", restored.raw.getAsJsonArray("content")
+                .get(0).getAsJsonObject().get("type").getAsString());
+    }
+
+    @Test
     public void syncUserMessageUuidsShortCircuitsForCodexProvider() {
         SessionState state = new SessionState();
         state.setProvider("codex");


### PR DESCRIPTION
closes #1285 

## Summary

Fixes Codex tool-call UI disappearing after restarting IDEA and restoring a session. Tool calls previously degraded into plain `Tool: ...` text without inputs or results.

## Root Cause

Codex history messages already contained normalized tool blocks under `raw.content`. During automatic session restoration, `MessageParser` incorrectly stored the entire outer envelope as `raw`, causing nested `tool_use` and `tool_result` blocks to be dropped during frontend transport.

## Changes

- Unwrap normalized Codex history `raw` payloads during session restoration.
- Preserve tool calls, results, inputs, and command output.
- Support both direct `content` and Claude-style `message.content` structures.
- Preserve image-only Codex history messages.
- Add regression tests covering parsing, session restoration, and the complete history-to-webview transport path.

## Verification

- `compileJava` passed.
- `git diff --check` passed.
- Targeted Codex auto-restoration regression tests passed.
- The full test suite remains blocked by an existing `CodexSubscriptionQuotaHandlerTest` compilation error.
- Existing `checkstyleTest` violations are unrelated to this change.

## 概述

修复 IDEA 重启并自动恢复 Codex 会话后，工具调用 UI 消失、退化为普通 `Tool: ...` 文本且无法显示调用详情的问题。

## 根因

Codex 历史消息已经包含标准化的 `raw.content` 工具块，但自动恢复流程再次经过 `MessageParser` 时，将整个外层消息信封保存为 `raw`。

后续传输仅保留了外层 `Tool: ...` 文本，导致内层 `tool_use`、`tool_result`、调用参数和输出丢失。

## 修改内容

- 自动解包标准化 Codex 历史消息中的内层 `raw`。
- 保留工具调用、工具结果、调用参数和输出内容。
- 同时支持直接 `content` 和 Claude `message.content` 结构。
- 修复纯图片 Codex 历史消息在自动恢复时被过滤的问题。
- 增加消息解析、会话恢复及完整历史传输链路的回归测试。

## 验证

- `compileJava` 通过。
- `git diff --check` 通过。
- Codex 自动恢复目标回归测试全部通过。
- 完整测试仍被仓库现有的 `CodexSubscriptionQuotaHandlerTest` 编译错误阻塞。
- `checkstyleTest` 的既有违规均不涉及本次修改。