### PR TITLE
feat(models): add Fable 5 model and ultracode reasoning effort

### DIFF
--- a/ai-bridge/channels/codex-channel.js
+++ b/ai-bridge/channels/codex-channel.js
@@ -34,7 +34,7 @@ export async function handleCodexCommand(command, args, stdinData) {
           model || '',
           baseUrl || '',
           apiKey || '',
-          (reasoningEffort === 'max' ? 'xhigh' : (reasoningEffort || 'medium')),
+          ((reasoningEffort === 'max' || reasoningEffort === 'ultracode') ? 'xhigh' : (reasoningEffort || 'medium')),
           serviceTier || '',
           attachments || []  // Pass attachments to message service
         );

--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -42,7 +42,7 @@ import { getClaudeCliPathOverride } from '../../utils/claude-cli-path.js';
 
 // ========== Internal helpers for deduplication ==========
 
-const SUPPORTED_EFFORT_LEVELS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
+const SUPPORTED_EFFORT_LEVELS = new Set(['low', 'medium', 'high', 'xhigh', 'max', 'ultracode']);
 
 function normalizeReasoningEffort(reasoningEffort) {
   const effort = typeof reasoningEffort === 'string' ? reasoningEffort.trim() : '';

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -60,7 +60,7 @@ import {
 import { generateSessionTitle } from '../session-title-service.js';
 import { getClaudeCliPathOverride } from '../../utils/claude-cli-path.js';
 
-const SUPPORTED_EFFORT_LEVELS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
+const SUPPORTED_EFFORT_LEVELS = new Set(['low', 'medium', 'high', 'xhigh', 'max', 'ultracode']);
 
 function resolveReasoningEffort(params) {
   const effort = typeof params.reasoningEffort === 'string'

--- a/src/main/java/com/github/claudecodegui/handler/provider/ModelProviderHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/provider/ModelProviderHandler.java
@@ -27,11 +27,13 @@ public class ModelProviderHandler {
     static {
         // Claude models with 1M context (base IDs)
         MODEL_CONTEXT_LIMITS.put("claude-sonnet-4-6", 200_000);
+        MODEL_CONTEXT_LIMITS.put("claude-fable-5", 200_000);
         MODEL_CONTEXT_LIMITS.put("claude-opus-4-8", 200_000);
         MODEL_CONTEXT_LIMITS.put("claude-opus-4-7", 200_000);
         MODEL_CONTEXT_LIMITS.put("claude-opus-4-6", 200_000);
         // Claude models with [1m] suffix - 1M context
         MODEL_CONTEXT_LIMITS.put("claude-sonnet-4-6[1m]", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("claude-fable-5[1m]", 1_000_000);
         MODEL_CONTEXT_LIMITS.put("claude-opus-4-8[1m]", 1_000_000);
         MODEL_CONTEXT_LIMITS.put("claude-opus-4-7[1m]", 1_000_000);
         MODEL_CONTEXT_LIMITS.put("claude-opus-4-6[1m]", 1_000_000);

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeUsageAggregator.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeUsageAggregator.java
@@ -38,9 +38,11 @@ class ClaudeUsageAggregator {
     private static final Pricing TIERED_SONNET_PRICING = new Pricing(3.0, 15.0, 3.75, 0.30, 6.0, 22.5, 7.5, 0.60);
     private static final Pricing LEGACY_OPUS_PRICING = new Pricing(15.0, 75.0, 18.75, 1.50);
     private static final Pricing OPUS_4_5_PRICING = new Pricing(5.0, 25.0, 6.25, 0.50);
+    private static final Pricing FABLE_5_PRICING = new Pricing(10.0, 50.0, 12.5, 1.0);
     private static final Pricing HAIKU_4_5_PRICING = new Pricing(1.0, 5.0, 1.25, 0.10);
 
     private static final Map<String, Pricing> MODEL_PRICING = Map.ofEntries(
+            Map.entry("claude-fable-5", FABLE_5_PRICING),
             Map.entry("claude-opus-4", LEGACY_OPUS_PRICING),
             Map.entry("claude-opus-4-1", LEGACY_OPUS_PRICING),
             Map.entry("claude-opus-4-20250514", LEGACY_OPUS_PRICING),
@@ -56,6 +58,7 @@ class ClaudeUsageAggregator {
             Map.entry("claude-haiku-4-5", HAIKU_4_5_PRICING)
     );
     private static final List<String> MODEL_PREFIXES = List.of(
+            "claude-fable-5",
             "claude-opus-4-20250514",
             "claude-opus-4-8",
             "claude-opus-4-7",

--- a/src/main/java/com/github/claudecodegui/session/SessionState.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionState.java
@@ -47,6 +47,7 @@ public class SessionState {
         efforts.add("high");
         efforts.add("xhigh");
         efforts.add("max");
+        efforts.add("ultracode");
         VALID_REASONING_EFFORTS = Collections.unmodifiableSet(efforts);
     }
 

--- a/src/test/java/com/github/claudecodegui/handler/provider/ModelProviderHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/provider/ModelProviderHandlerTest.java
@@ -75,10 +75,14 @@ public class ModelProviderHandlerTest {
     public void shouldReturnCorrectContextLimitsForClaudeModels() {
         // Base IDs without [1m] suffix - 200k context by default
         assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-sonnet-4-6"));
+        assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-fable-5"));
+        assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-8"));
         assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-7"));
         assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-6"));
         // IDs with [1m] suffix - 1M context
         assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("claude-sonnet-4-6[1m]"));
+        assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("claude-fable-5[1m]"));
+        assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-8[1m]"));
         assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-7[1m]"));
         assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-6[1m]"));
         // Haiku - no 1M context available

--- a/src/test/java/com/github/claudecodegui/session/SessionSendServiceTest.java
+++ b/src/test/java/com/github/claudecodegui/session/SessionSendServiceTest.java
@@ -42,6 +42,7 @@ public class SessionSendServiceTest {
         assertEquals("low", SessionSendService.normalizeRequestedReasoningEffort(" low "));
         assertEquals("xhigh", SessionSendService.normalizeRequestedReasoningEffort("xhigh"));
         assertEquals("max", SessionSendService.normalizeRequestedReasoningEffort("max"));
+        assertEquals("ultracode", SessionSendService.normalizeRequestedReasoningEffort("ultracode"));
     }
 
     @Test

--- a/webview/src/components/ChatInputBox/selectors/ModelSelect.test.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ModelSelect.test.tsx
@@ -79,6 +79,16 @@ describe('ModelSelect', () => {
     expect(CLAUDE_MODELS.map((model) => model.id)).not.toContain('claude-opus-4-6[1m]');
   });
 
+  it('Claude 内置模型列表应包含 Fable 5', () => {
+    expect(CLAUDE_MODELS.map((model) => model.id)).toContain('claude-fable-5');
+    const fable = CLAUDE_MODELS.find((model) => model.id === 'claude-fable-5');
+    expect(fable?.description).toContain('2x token');
+  });
+
+  it('Claude 内置模型列表应包含 Opus 4.8', () => {
+    expect(CLAUDE_MODELS.map((model) => model.id)).toContain('claude-opus-4-8');
+  });
+
   it('Codex 内置模型列表应与目标设计一致', () => {
     expect(CODEX_MODELS.map((model) => model.id)).toEqual([
       'gpt-5.5',

--- a/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
@@ -39,6 +39,7 @@ const DEFAULT_MODEL_MAP: Record<string, ModelInfo> = AVAILABLE_MODELS.reduce(
 
 const MODEL_LABEL_KEYS: Record<string, string> = {
   'claude-sonnet-4-6': 'models.claude.sonnet46.label',
+  'claude-fable-5': 'models.claude.fable5.label',
   'claude-opus-4-8': 'models.claude.opus48.label',
   'claude-opus-4-7': 'models.claude.opus46.label',
   'claude-opus-4-6': 'models.claude.opus46_1m.label',
@@ -57,6 +58,7 @@ const MODEL_LABEL_KEYS: Record<string, string> = {
 
 const MODEL_DESCRIPTION_KEYS: Record<string, string> = {
   'claude-sonnet-4-6': 'models.claude.sonnet46.description',
+  'claude-fable-5': 'models.claude.fable5.description',
   'claude-opus-4-8': 'models.claude.opus48.description',
   'claude-opus-4-7': 'models.claude.opus46.description',
   'claude-opus-4-6': 'models.claude.opus46_1m.description',

--- a/webview/src/components/ChatInputBox/selectors/ReasoningSelect.test.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ReasoningSelect.test.tsx
@@ -9,6 +9,70 @@ vi.mock('react-i18next', () => ({
 }));
 
 describe('ReasoningSelect', () => {
+  it('shows ultracode for Claude Fable 5', () => {
+    render(
+      <ReasoningSelect
+        value="high"
+        onChange={vi.fn()}
+        currentProvider="claude"
+        selectedModel="claude-fable-5"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('XHigh')).toBeTruthy();
+    expect(screen.getByText('Max')).toBeTruthy();
+    expect(screen.getByText('Ultracode')).toBeTruthy();
+  });
+
+  it('shows ultracode for Claude Opus 4.8', () => {
+    render(
+      <ReasoningSelect
+        value="high"
+        onChange={vi.fn()}
+        currentProvider="claude"
+        selectedModel="claude-opus-4-8"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('XHigh')).toBeTruthy();
+    expect(screen.getByText('Ultracode')).toBeTruthy();
+  });
+
+  it('hides ultracode for Claude Sonnet 4.6', () => {
+    render(
+      <ReasoningSelect
+        value="high"
+        onChange={vi.fn()}
+        currentProvider="claude"
+        selectedModel="claude-sonnet-4-6"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.queryByText('Ultracode')).toBeNull();
+  });
+
+  it('hides ultracode for Codex provider', () => {
+    render(
+      <ReasoningSelect
+        value="high"
+        onChange={vi.fn()}
+        currentProvider="codex"
+        selectedModel="gpt-5.5"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.queryByText('Ultracode')).toBeNull();
+    expect(screen.queryByText('Max')).toBeNull();
+  });
+
   it('shows xhigh and max for Claude Opus 4.7', () => {
     render(
       <ReasoningSelect

--- a/webview/src/components/ChatInputBox/selectors/ReasoningSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ReasoningSelect.tsx
@@ -5,6 +5,7 @@ import {
   EFFORT_SUPPORTED_CLAUDE_MODELS,
   MAX_EFFORT_CLAUDE_MODELS,
   XHIGH_EFFORT_CLAUDE_MODELS,
+  ULTRACODE_EFFORT_CLAUDE_MODELS,
   type ReasoningEffort,
 } from '../types';
 
@@ -32,7 +33,7 @@ interface ReasoningSelectProps {
  * Controls the depth of reasoning for AI models.
  * Visibility and available levels depend on the selected model:
  * - Codex: low/medium/high/xhigh
- * - Claude Opus 4.7: low/medium/high/xhigh/max
+ * - Claude Fable 5 and Opus 4.7/4.8: low/medium/high/xhigh/max/ultracode
  * - Claude Opus 4.6 and Sonnet 4.6: low/medium/high/max
  * - Claude Haiku 4.5 and legacy models: hidden (no adaptive thinking support)
  */
@@ -48,16 +49,19 @@ export const ReasoningSelect = ({ value, onChange, disabled, selectedModel, curr
   // Build the list of available levels for the current model
   const availableLevels = REASONING_LEVELS.filter(level => {
     if (currentProvider !== 'claude') {
-      return level.id !== 'max';
+      return level.id !== 'max' && level.id !== 'ultracode';
     }
     if (!selectedModel) {
-      return true;
+      return level.id !== 'ultracode';
     }
     if (level.id === 'xhigh') {
       return XHIGH_EFFORT_CLAUDE_MODELS.has(selectedModel);
     }
     if (level.id === 'max') {
       return MAX_EFFORT_CLAUDE_MODELS.has(selectedModel);
+    }
+    if (level.id === 'ultracode') {
+      return ULTRACODE_EFFORT_CLAUDE_MODELS.has(selectedModel);
     }
     return true;
   });

--- a/webview/src/components/ChatInputBox/types.ts
+++ b/webview/src/components/ChatInputBox/types.ts
@@ -319,6 +319,11 @@ export const CLAUDE_MODELS: ModelInfo[] = [
     description: 'Sonnet 4.6 · Use the default model',
   },
   {
+    id: 'claude-fable-5',
+    label: 'Fable 5',
+    description: 'Fable 5 · Built for long-running, complex work · 2x token usage',
+  },
+  {
     id: 'claude-opus-4-8',
     label: 'Opus 4.8',
     description: 'Opus 4.8 · Latest and most capable',
@@ -421,6 +426,7 @@ export const AVAILABLE_PROVIDERS: ProviderInfo[] = [
  * Based on: https://code.claude.com/docs/en/model-config#adjust-effort-level
  */
 export const EFFORT_SUPPORTED_CLAUDE_MODELS = new Set([
+  'claude-fable-5',
   'claude-opus-4-8',
   'claude-opus-4-7',
   'claude-opus-4-6',
@@ -433,6 +439,7 @@ export const EFFORT_SUPPORTED_CLAUDE_MODELS = new Set([
  * Opus 4.7 is currently the only Claude Code model with xhigh support.
  */
 export const XHIGH_EFFORT_CLAUDE_MODELS = new Set([
+  'claude-fable-5',
   'claude-opus-4-8',
   'claude-opus-4-7',
 ]);
@@ -441,6 +448,7 @@ export const XHIGH_EFFORT_CLAUDE_MODELS = new Set([
  * Claude models that support the 'max' effort level.
  */
 export const MAX_EFFORT_CLAUDE_MODELS = new Set([
+  'claude-fable-5',
   'claude-opus-4-8',
   'claude-opus-4-7',
   'claude-opus-4-6',
@@ -449,12 +457,22 @@ export const MAX_EFFORT_CLAUDE_MODELS = new Set([
 ]);
 
 /**
+ * Claude models that support the 'ultracode' effort level
+ * (xhigh effort plus workflows): Fable 5 and Opus 4.7/4.8.
+ */
+export const ULTRACODE_EFFORT_CLAUDE_MODELS = new Set([
+  'claude-fable-5',
+  'claude-opus-4-8',
+  'claude-opus-4-7',
+]);
+
+/**
  * Reasoning Effort (thinking depth)
  * Controls the depth of reasoning for AI models
- * Claude API values: low, medium, high, xhigh, max
+ * Claude API values: low, medium, high, xhigh, max, ultracode
  * Codex API values: low, medium, high, xhigh
  */
-export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultracode';
 
 /**
  * Codex execution speed mode.
@@ -505,6 +523,12 @@ export const REASONING_LEVELS: ReasoningInfo[] = [
     label: 'Max',
     icon: 'codicon-rocket',
     description: 'Maximum reasoning depth',
+  },
+  {
+    id: 'ultracode',
+    label: 'Ultracode',
+    icon: 'codicon-sparkle',
+    description: 'XHigh effort plus workflows',
   },
 ];
 

--- a/webview/src/components/ChatInputBox/types.ts
+++ b/webview/src/components/ChatInputBox/types.ts
@@ -527,7 +527,7 @@ export const REASONING_LEVELS: ReasoningInfo[] = [
   {
     id: 'ultracode',
     label: 'Ultracode',
-    icon: 'codicon-sparkle',
+    icon: 'codicon-code-oss',
     description: 'XHigh effort plus workflows',
   },
 ];

--- a/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
+++ b/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
@@ -80,14 +80,14 @@ function parseSpawnAgentMeta(input: ToolInput, result?: ToolResultBlock | null):
   const model = getString(
     parsed?.model,
     input.model,
-  ) ?? (text?.match(/\(([A-Za-z0-9._:-]+)(?:\s+(low|medium|high|xhigh))?\)/i)?.[1]);
+  ) ?? (text?.match(/\(([A-Za-z0-9._:-]+)(?:\s+(low|medium|high|xhigh|max|ultracode))?\)/i)?.[1]);
 
   const reasoningEffort = getString(
     parsed?.reasoning_effort,
     parsed?.reasoningEffort,
     input.reasoning_effort,
     input.reasoningEffort,
-  ) ?? (text?.match(/\(([A-Za-z0-9._:-]+)(?:\s+(low|medium|high|xhigh))?\)/i)?.[2]);
+  ) ?? (text?.match(/\(([A-Za-z0-9._:-]+)(?:\s+(low|medium|high|xhigh|max|ultracode))?\)/i)?.[2]);
 
   return { agentId, nickname, model, reasoningEffort };
 }

--- a/webview/src/hooks/providers/useModelStatePersistence.ts
+++ b/webview/src/hooks/providers/useModelStatePersistence.ts
@@ -11,7 +11,7 @@ import {
 import type { CodexFastMode, PermissionMode, ReasoningEffort } from '../../components/ChatInputBox/types';
 
 const STORAGE_KEY = 'model-selection-state';
-const REASONING_VALUES = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+const REASONING_VALUES = ['low', 'medium', 'high', 'xhigh', 'max', 'ultracode'] as const;
 const CODEX_FAST_MODE_VALUES = ['normal', 'fast'] as const;
 
 const getCustomModels = (key: string): { id: string }[] => {

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -1560,6 +1560,10 @@
     "max": {
       "label": "Max",
       "description": "Maximum reasoning for demanding tasks (session only)"
+    },
+    "ultracode": {
+      "label": "Ultracode",
+      "description": "XHigh effort plus workflows"
     }
   },
   "models": {
@@ -1590,6 +1594,10 @@
       "opus48": {
         "label": "Opus 4.8",
         "description": "Opus 4.8 · Latest and most capable"
+      },
+      "fable5": {
+        "label": "Fable 5",
+        "description": "Fable 5 · Built for long-running, complex work · 2x token usage"
       }
     },
     "codex": {
@@ -1786,6 +1794,10 @@
     "max": {
       "label": "Max",
       "description": "Maximum reasoning depth"
+    },
+    "ultracode": {
+      "label": "Ultracode",
+      "description": "XHigh effort plus workflows"
     }
   },
   "errorBoundary": {

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -1539,33 +1539,6 @@
       }
     }
   },
-  "claudeEffort": {
-    "title": "Select effort level",
-    "low": {
-      "label": "Low",
-      "description": "Short, scoped, latency-sensitive tasks"
-    },
-    "medium": {
-      "label": "Medium",
-      "description": "Cost-sensitive work, trades off some intelligence"
-    },
-    "high": {
-      "label": "High",
-      "description": "Balanced token usage and intelligence"
-    },
-    "xhigh": {
-      "label": "XHigh",
-      "description": "Best results for most coding tasks (recommended)"
-    },
-    "max": {
-      "label": "Max",
-      "description": "Maximum reasoning for demanding tasks (session only)"
-    },
-    "ultracode": {
-      "label": "Ultracode",
-      "description": "XHigh effort plus workflows"
-    }
-  },
   "models": {
     "addModel": "Add Model",
     "longContext": {

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -1518,6 +1518,10 @@
       "label": "Máximo",
       "description": "Profundidad máxima de razonamiento"
     },
+    "max": {
+      "label": "max",
+      "description": "Razonamiento máximo para tareas exigentes"
+    },
     "ultracode": {
       "label": "Ultracode",
       "description": "Esfuerzo XHigh más flujos de trabajo"

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -1349,6 +1349,10 @@
       "opus48": {
         "label": "Opus 4.8",
         "description": "Opus 4.8 · El más reciente y capaz"
+      },
+      "fable5": {
+        "label": "Fable 5",
+        "description": "Fable 5 · Diseñado para trabajos largos y complejos · Consumo de tokens 2x"
       }
     },
     "longContext": {
@@ -1513,6 +1517,10 @@
     "xhigh": {
       "label": "Máximo",
       "description": "Profundidad máxima de razonamiento"
+    },
+    "ultracode": {
+      "label": "Ultracode",
+      "description": "Esfuerzo XHigh más flujos de trabajo"
     }
   },
   "errorBoundary": {

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -1518,6 +1518,10 @@
       "label": "Maximum",
       "description": "Profondeur de raisonnement maximale"
     },
+    "max": {
+      "label": "max",
+      "description": "Raisonnement maximal pour les tâches exigeantes"
+    },
     "ultracode": {
       "label": "Ultracode",
       "description": "Effort XHigh plus workflows"

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -1349,6 +1349,10 @@
       "opus48": {
         "label": "Opus 4.8",
         "description": "Opus 4.8 · Le plus récent et le plus performant"
+      },
+      "fable5": {
+        "label": "Fable 5",
+        "description": "Fable 5 · Conçu pour les tâches longues et complexes · Consommation de jetons 2x"
       }
     },
     "longContext": {
@@ -1513,6 +1517,10 @@
     "xhigh": {
       "label": "Maximum",
       "description": "Profondeur de raisonnement maximale"
+    },
+    "ultracode": {
+      "label": "Ultracode",
+      "description": "Effort XHigh plus workflows"
     }
   },
   "errorBoundary": {

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -1517,6 +1517,10 @@
       "label": "अधिकतम",
       "description": "अधिकतम तर्क गहराई"
     },
+    "max": {
+      "label": "max",
+      "description": "कठिन कार्यों के लिए अधिकतम तर्क"
+    },
     "ultracode": {
       "label": "Ultracode",
       "description": "XHigh प्रयास और वर्कफ़्लो"

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -1348,6 +1348,10 @@
       "opus48": {
         "label": "Opus 4.8",
         "description": "Opus 4.8 · नवीनतम और सबसे सक्षम"
+      },
+      "fable5": {
+        "label": "Fable 5",
+        "description": "Fable 5 · लंबे, जटिल कार्यों के लिए निर्मित · 2x टोकन खपत"
       }
     },
     "longContext": {
@@ -1512,6 +1516,10 @@
     "xhigh": {
       "label": "अधिकतम",
       "description": "अधिकतम तर्क गहराई"
+    },
+    "ultracode": {
+      "label": "Ultracode",
+      "description": "XHigh प्रयास और वर्कफ़्लो"
     }
   },
   "errorBoundary": {

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -1523,6 +1523,10 @@
       "label": "最大",
       "description": "最大の推論深度"
     },
+    "max": {
+      "label": "max",
+      "description": "高難度タスク向けの最大推論"
+    },
     "ultracode": {
       "label": "Ultracode",
       "description": "XHigh 推論とワークフロー"

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -1360,6 +1360,10 @@
       "opus48": {
         "label": "Opus 4.8",
         "description": "Opus 4.8 · 最新かつ最も優れたモデル"
+      },
+      "fable5": {
+        "label": "Fable 5",
+        "description": "Fable 5 · 長時間の複雑な作業向けに構築 · トークン消費 2 倍"
       }
     },
     "codex": {
@@ -1518,6 +1522,10 @@
     "xhigh": {
       "label": "最大",
       "description": "最大の推論深度"
+    },
+    "ultracode": {
+      "label": "Ultracode",
+      "description": "XHigh 推論とワークフロー"
     }
   },
   "errorBoundary": {

--- a/webview/src/i18n/locales/ko.json
+++ b/webview/src/i18n/locales/ko.json
@@ -1635,6 +1635,10 @@
       "label": "최대",
       "description": "최대 추론 깊이"
     },
+    "max": {
+      "label": "max",
+      "description": "고난도 작업을 위한 최대 추론"
+    },
     "ultracode": {
       "label": "Ultracode",
       "description": "XHigh 추론과 워크플로우"

--- a/webview/src/i18n/locales/ko.json
+++ b/webview/src/i18n/locales/ko.json
@@ -1466,6 +1466,10 @@
       "opus48": {
         "label": "Opus 4.8",
         "description": "Opus 4.8 · 최신 및 가장 강력한 모델"
+      },
+      "fable5": {
+        "label": "Fable 5",
+        "description": "Fable 5 · 장시간 복잡한 작업을 위해 설계 · 토큰 2배 소모"
       }
     },
     "longContext": {
@@ -1630,6 +1634,10 @@
     "xhigh": {
       "label": "최대",
       "description": "최대 추론 깊이"
+    },
+    "ultracode": {
+      "label": "Ultracode",
+      "description": "XHigh 추론과 워크플로우"
     }
   },
   "errorBoundary": {

--- a/webview/src/i18n/locales/pt-BR.json
+++ b/webview/src/i18n/locales/pt-BR.json
@@ -1690,6 +1690,10 @@
       "label": "Máximo",
       "description": "Profundidade máxima de raciocínio"
     },
+    "max": {
+      "label": "max",
+      "description": "Raciocínio máximo para tarefas exigentes"
+    },
     "ultracode": {
       "label": "Ultracode",
       "description": "Esforço XHigh mais fluxos de trabalho"

--- a/webview/src/i18n/locales/pt-BR.json
+++ b/webview/src/i18n/locales/pt-BR.json
@@ -1521,6 +1521,10 @@
       "opus48": {
         "label": "Opus 4.8",
         "description": "Opus 4.8 · O mais recente e capaz"
+      },
+      "fable5": {
+        "label": "Fable 5",
+        "description": "Fable 5 · Projetado para trabalhos longos e complexos · Consumo de tokens 2x"
       }
     },
     "longContext": {
@@ -1685,6 +1689,10 @@
     "xhigh": {
       "label": "Máximo",
       "description": "Profundidade máxima de raciocínio"
+    },
+    "ultracode": {
+      "label": "Ultracode",
+      "description": "Esforço XHigh mais fluxos de trabalho"
     }
   },
   "errorBoundary": {

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -1375,6 +1375,10 @@
       "opus48": {
         "label": "Opus 4.8",
         "description": "Opus 4.8 · Новейшая и самая мощная"
+      },
+      "fable5": {
+        "label": "Fable 5",
+        "description": "Fable 5 · Создан для длительной сложной работы · Расход токенов 2x"
       }
     },
     "longContext": {
@@ -1539,6 +1543,10 @@
     "xhigh": {
       "label": "Максимальная",
       "description": "Максимальная глубина рассуждений"
+    },
+    "ultracode": {
+      "label": "Ultracode",
+      "description": "Усилие XHigh плюс рабочие процессы"
     }
   },
   "errorBoundary": {

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -1544,6 +1544,10 @@
       "label": "Максимальная",
       "description": "Максимальная глубина рассуждений"
     },
+    "max": {
+      "label": "max",
+      "description": "Максимальное рассуждение для сложных задач"
+    },
     "ultracode": {
       "label": "Ultracode",
       "description": "Усилие XHigh плюс рабочие процессы"

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -1354,6 +1354,10 @@
       "opus48": {
         "label": "Opus 4.8",
         "description": "Opus 4.8 · 最新最強大的模型"
+      },
+      "fable5": {
+        "label": "Fable 5",
+        "description": "Fable 5 · 專為長時間複雜任務打造 · 消耗 2 倍 Token"
       }
     },
     "longContext": {
@@ -1518,6 +1522,10 @@
     "xhigh": {
       "label": "最多",
       "description": "最深推理，最高精度"
+    },
+    "ultracode": {
+      "label": "Ultracode",
+      "description": "XHigh 推理 + 工作流，最全面"
     }
   },
   "errorBoundary": {

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -1523,6 +1523,10 @@
       "label": "最多",
       "description": "最深推理，最高精度"
     },
+    "max": {
+      "label": "max",
+      "description": "最大推理深度"
+    },
     "ultracode": {
       "label": "Ultracode",
       "description": "XHigh 推理 + 工作流，最全面"

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -1565,6 +1565,10 @@
     "max": {
       "label": "max",
       "description": "高难度任务的最大推理深度（仅当前会话）"
+    },
+    "ultracode": {
+      "label": "Ultracode",
+      "description": "XHigh 推理 + 工作流，最全面"
     }
   },
   "models": {
@@ -1595,6 +1599,10 @@
       "opus48": {
         "label": "Opus 4.8",
         "description": "Opus 4.8 · 最新最强大的模型"
+      },
+      "fable5": {
+        "label": "Fable 5",
+        "description": "Fable 5 · 专为长时间复杂任务打造 · 消耗 2 倍 Token"
       }
     },
     "codex": {
@@ -1791,6 +1799,10 @@
     "max": {
       "label": "max",
       "description": "最大推理深度"
+    },
+    "ultracode": {
+      "label": "Ultracode",
+      "description": "XHigh 推理 + 工作流，最全面"
     }
   },
   "errorBoundary": {

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -1544,33 +1544,6 @@
       }
     }
   },
-  "claudeEffort": {
-    "title": "选择推理强度",
-    "low": {
-      "label": "low",
-      "description": "短小、范围明确、对延迟敏感的任务"
-    },
-    "medium": {
-      "label": "medium",
-      "description": "成本敏感型工作，可牺牲部分智能"
-    },
-    "high": {
-      "label": "high",
-      "description": "平衡 Token 用量与智能水平"
-    },
-    "xhigh": {
-      "label": "xhigh",
-      "description": "大多数编程任务的最佳效果（推荐）"
-    },
-    "max": {
-      "label": "max",
-      "description": "高难度任务的最大推理深度（仅当前会话）"
-    },
-    "ultracode": {
-      "label": "Ultracode",
-      "description": "XHigh 推理 + 工作流，最全面"
-    }
-  },
   "models": {
     "addModel": "添加模型",
     "longContext": {


### PR DESCRIPTION
## Summary

- Add `claude-fable-5` model: registered in model selector, context limits (200K/1M), usage pricing ($10/$50/$12.5/$1 per MTok — 2× Opus 4.7/4.8), and i18n labels across all 10 locales (with 2x token usage noted in description)
- Add `Ultracode` reasoning effort level, gated to Fable 5 and Opus 4.7/4.8; maps to `xhigh` on the Codex channel; uses the `code-oss` codicon
- Add missing `max` reasoning entry to 7 locales (zh-TW, ja, ko, ru, fr, es, pt-BR, hi) that previously ended at `xhigh`
- Extend effort whitelists in ai-bridge (`SUPPORTED_EFFORT_LEVELS`), Java (`VALID_REASONING_EFFORTS`), persistence hook, and `TaskExecutionBlock` effort regex
- Remove the dead `claudeEffort` i18n section from en/zh (see below)

## Why the dead `claudeEffort` lines are removed

The `claudeEffort` section existed only in `en.json` and `zh.json` and is referenced nowhere in the codebase — there is no `t('claudeEffort.*')` call anywhere (the live effort selector uses the `reasoning.*` keys). Beyond being dead weight, its `max` entry said "(session only)" / "（仅当前会话）", which describes Claude Code **CLI** behavior: this plugin persists the selected reasoning effort in `localStorage` (`model-selection-state`) and restores it on startup, so there is no session-scoped reset. Keeping an unused section whose wording contradicts actual plugin behavior risked future copy-paste of misleading text, so it is dropped in a dedicated commit (`refactor(i18n)`) for easy review/revert.

## Questions for the maintainer

In the official Claude desktop app, reasoning effort behaves differently from this plugin in a few ways:

1. **Ultracode is session-scoped**: changing the session resets the effort from Ultracode back to the regular extra-high (XHigh) level. This plugin currently persists Ultracode across sessions like every other effort level.
2. **Reasoning effort binds to each session**: every session carries its own effort setting, whereas this plugin stores a single global value (`model-selection-state` in localStorage) shared by all sessions.
3. **Ultracode is styled violet**: the desktop app renders the Ultracode label/slider in violet (`#A78BFA`). This PR keeps the default theme color — should Ultracode be colored violet to match the original look? (The change is trivial: a conditional style on the icon/label in `ReasoningSelect.tsx`.)

**For 1 and 2: would you like a follow-up PR implementing the official behavior — per-session reasoning effort, with Ultracode resetting to XHigh on session change?** Happy to send it if so.

## Test plan

- [x] `./gradlew test` — all passing (2 pre-existing `NodeDetectorWslTest` failures unrelated)
- [x] `npm test` (webview) — 669/669 pass
- [x] `node --test` (ai-bridge) — model-utils 14/14 pass (10 pre-existing credential failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)