### PR TITLE
fix(markdown): align inline code font-size with surrounding text and …

### DIFF
--- a/webview/src/styles/less/components/message.less
+++ b/webview/src/styles/less/components/message.less
@@ -750,7 +750,7 @@
     background-color: var(--color-code-inline-bg);
     padding: 2px 4px;
     border-radius: 3px;
-    font-size: 12.5px;
+    font-size: inherit;
     word-wrap: break-word;
     overflow-wrap: break-word;
 }
@@ -759,6 +759,15 @@
     background-color: transparent;
     padding: 0;
     color: var(--text-secondary);
+    font-family: inherit;
+    font-size: inherit;
+}
+
+/* Ensure syntax-highlighting spans inside code blocks inherit the monospace
+ * font from <pre>.  The global * { font-family: … } rule in base.less cuts
+ * the inheritance chain — every element gets the UI font.  Without this
+ * override, highlight.js <span> tokens would render in the proportional font. */
+.markdown-content pre code span {
     font-family: inherit;
 }
 


### PR DESCRIPTION
…preserve monospace in syntax-highlighted spans

- Replace hardcoded 12.5px font-size on .markdown-content code with inherit so inline code tracks the parent element's size instead of exceeding it when the Java-injected --idea-editor-font-size is smaller than 12.5px.
- Add font-size: inherit to .markdown-content pre code so code-block text reliably inherits from the <pre> element.
- Add .markdown-content pre code span rule with font-family: inherit to prevent the global * selector in base.less from overriding the monospace font on highlight.js <span> tokens.