### PR TITLE
fix: background turn rendering for CLI-initiated session updates

### DIFF
--- a/ai-bridge/daemon.js
+++ b/ai-bridge/daemon.js
@@ -234,6 +234,13 @@ process.stdout.write = function (chunk, encoding, callback) {
   return true;
 };
 
+// Expose the pre-interception writer so out-of-band emitters can write
+// process-level NDJSON that must NOT be wrapped with activeRequestId.
+// The per-runtime perpetual reader (runtime-lifecycle.js) uses this to emit
+// inter-turn 'session_updated' events; without it those events would be
+// misrouted to whatever request happens to be active. See startPerpetualReader().
+process.stdout._originalStdoutWrite = _originalStdoutWrite;
+
 /**
  * Override console.log to go through our tagged stdout.
  */

--- a/ai-bridge/services/claude/perpetual-reader-integration.test.js
+++ b/ai-bridge/services/claude/perpetual-reader-integration.test.js
@@ -1,0 +1,279 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { startPerpetualReader, createTurnSink } from './runtime-lifecycle.js';
+
+/**
+ * Integration tests for the REAL perpetual reader (startPerpetualReader).
+ *
+ * Unlike a re-implementation of the loop, these tests drive the actual
+ * production function so they catch regressions in routing, inter-turn event
+ * emission, abort handling, and stream completion.
+ *
+ * A controlled query lets each test deliver messages deterministically (the
+ * reader blocks in query.next() until we deliver or end), so there is no race.
+ */
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * A query stub whose next() resolves only when the test delivers a message,
+ * ends the stream, or raises an error. This removes timing races: the reader
+ * cannot run ahead of what the test explicitly hands it.
+ */
+function createControlledQuery() {
+  const pending = [];
+  const waiters = [];
+  let ended = false;
+
+  const settleNext = () => {
+    if (waiters.length === 0 || pending.length === 0) return;
+    const waiter = waiters.shift();
+    const item = pending.shift();
+    if (item.error) waiter.reject(item.error);
+    else waiter.resolve(item.result);
+  };
+
+  return {
+    query: {
+      next() {
+        if (pending.length > 0) {
+          const item = pending.shift();
+          return item.error ? Promise.reject(item.error) : Promise.resolve(item.result);
+        }
+        if (ended) return Promise.resolve({ done: true });
+        return new Promise((resolve, reject) => {
+          waiters.push({ resolve, reject });
+        });
+      },
+      close() { ended = true; },
+    },
+    deliver(msg) {
+      pending.push({ result: { value: msg, done: false } });
+      settleNext();
+    },
+    deliverError(err) {
+      pending.push({ error: err });
+      settleNext();
+    },
+    end() {
+      ended = true;
+      pending.push({ result: { done: true } });
+      settleNext();
+    },
+  };
+}
+
+/** Capture inter-turn events written via process.stdout._originalStdoutWrite. */
+function captureInterTurnEvents() {
+  const list = [];
+  const original = process.stdout._originalStdoutWrite;
+  process.stdout._originalStdoutWrite = (str) => {
+    try { list.push(JSON.parse(str)); } catch (_) { /* ignore non-JSON */ }
+    return true;
+  };
+  return {
+    list,
+    restore() {
+      if (original === undefined) delete process.stdout._originalStdoutWrite;
+      else process.stdout._originalStdoutWrite = original;
+    },
+  };
+}
+
+/** Yield long enough for the reader to drain a delivered message. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+// ============================================================================
+// In-Turn Routing
+// ============================================================================
+
+test('Integration: perpetual reader routes in-turn messages to turnSink', async () => {
+  const ctl = createControlledQuery();
+  const runtime = { closed: false, sessionId: 'sess-1', turnSink: createTurnSink(), query: ctl.query, inputStream: { done() {} } };
+
+  const reader = startPerpetualReader(runtime);
+
+  ctl.deliver({ type: 'system', session_id: 'sess-1' });
+  ctl.deliver({ type: 'assistant', content: 'Hello' });
+  ctl.deliver({ type: 'result', is_error: false });
+
+  const received = [];
+  for (let i = 0; i < 3; i++) {
+    received.push((await runtime.turnSink.take()).value);
+  }
+
+  runtime.closed = true;
+  ctl.end();
+  await reader;
+
+  assert.deepEqual(received.map((m) => m.type), ['system', 'assistant', 'result']);
+});
+
+// ============================================================================
+// Inter-Turn Event Emission (regression guard for the daemon writer wiring)
+// ============================================================================
+
+test('Integration: inter-turn result emits a session_updated event for a registered runtime', async () => {
+  const ctl = createControlledQuery();
+  const runtime = { closed: false, sessionId: 'sess-bg', turnSink: null, query: ctl.query };
+  const events = captureInterTurnEvents();
+
+  const reader = startPerpetualReader(runtime);
+  try {
+    // No active turn (turnSink == null): a completed turn from the CLI.
+    ctl.deliver({ type: 'user', content: '<task-notification>' });
+    ctl.deliver({ type: 'assistant', content: 'Task completed' });
+    ctl.deliver({ type: 'result', is_error: false });
+    await settle();
+  } finally {
+    runtime.closed = true;
+    ctl.end();
+    await reader;
+    events.restore();
+  }
+
+  const updates = events.list.filter((e) => e.event === 'session_updated');
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].type, 'daemon');
+  assert.equal(updates[0].sessionId, 'sess-bg');
+});
+
+test('Integration: inter-turn result on anonymous runtime emits no event', async () => {
+  const ctl = createControlledQuery();
+  const runtime = { closed: false, sessionId: null, turnSink: null, query: ctl.query };
+  const events = captureInterTurnEvents();
+
+  const reader = startPerpetualReader(runtime);
+  try {
+    ctl.deliver({ type: 'result', is_error: false });
+    await settle();
+  } finally {
+    runtime.closed = true;
+    ctl.end();
+    await reader;
+    events.restore();
+  }
+
+  assert.equal(events.list.filter((e) => e.event === 'session_updated').length, 0);
+});
+
+test('Integration: non-result inter-turn messages do not emit events', async () => {
+  const ctl = createControlledQuery();
+  const runtime = { closed: false, sessionId: 'sess-x', turnSink: null, query: ctl.query };
+  const events = captureInterTurnEvents();
+
+  const reader = startPerpetualReader(runtime);
+  try {
+    ctl.deliver({ type: 'assistant', content: 'partial' });
+    ctl.deliver({ type: 'user', content: 'noise' });
+    await settle();
+  } finally {
+    runtime.closed = true;
+    ctl.end();
+    await reader;
+    events.restore();
+  }
+
+  assert.equal(events.list.filter((e) => e.event === 'session_updated').length, 0);
+});
+
+// ============================================================================
+// Abort / Stream Completion / Errors
+// ============================================================================
+
+test('Integration: query.next() error is forwarded to the active turnSink', async () => {
+  const ctl = createControlledQuery();
+  const runtime = { closed: false, sessionId: 'sess-1', turnSink: createTurnSink(), query: ctl.query, inputStream: { done() {} } };
+
+  const reader = startPerpetualReader(runtime);
+
+  ctl.deliverError(new Error('SDK connection lost'));
+
+  await assert.rejects(async () => runtime.turnSink.take(), /SDK connection lost/);
+  await reader; // reader exits after the error
+});
+
+test('Integration: stream completion fails the active turnSink', async () => {
+  const ctl = createControlledQuery();
+  const runtime = { closed: false, sessionId: 'sess-1', turnSink: createTurnSink(), query: ctl.query, inputStream: { done() {} } };
+
+  const reader = startPerpetualReader(runtime);
+
+  ctl.end();
+
+  await assert.rejects(async () => runtime.turnSink.take(), /stream ended/);
+  await reader;
+});
+
+test('Integration: runtime.closed stops the reader after the in-flight next() resolves', async () => {
+  const ctl = createControlledQuery();
+  const runtime = { closed: false, sessionId: 'sess-1', turnSink: createTurnSink(), query: ctl.query, inputStream: { done() {} } };
+
+  const reader = startPerpetualReader(runtime);
+
+  ctl.deliver({ type: 'assistant', content: 'first' });
+  const first = await runtime.turnSink.take();
+  assert.equal(first.value.content, 'first');
+
+  // Close, then unblock the pending next() so the loop observes closed.
+  runtime.closed = true;
+  ctl.end();
+  await reader; // resolves => reader exited cleanly
+  assert.ok(true);
+});
+
+// ============================================================================
+// Concurrency: independent readers per runtime
+// ============================================================================
+
+test('Integration: concurrent runtimes keep their inter-turn events isolated', async () => {
+  const events = captureInterTurnEvents();
+  const runtimes = ['a', 'b', 'c'].map((id) => {
+    const ctl = createControlledQuery();
+    const runtime = { closed: false, sessionId: 'sess-' + id, turnSink: null, query: ctl.query };
+    return { ctl, runtime, reader: startPerpetualReader(runtime) };
+  });
+
+  try {
+    for (const { ctl } of runtimes) ctl.deliver({ type: 'result', is_error: false });
+    await settle();
+  } finally {
+    for (const { runtime, ctl } of runtimes) { runtime.closed = true; ctl.end(); }
+    await Promise.all(runtimes.map((r) => r.reader));
+    events.restore();
+  }
+
+  const ids = events.list
+    .filter((e) => e.event === 'session_updated')
+    .map((e) => e.sessionId)
+    .sort();
+  assert.deepEqual(ids, ['sess-a', 'sess-b', 'sess-c']);
+});
+
+test('Integration: reader disposes a still-live runtime when the stream ends inter-turn', async () => {
+  // Regression guard: if the SDK stream ends while idle (no active turn) and the
+  // runtime is not already closed, the reader must evict it. Otherwise the next
+  // request would reuse a runtime whose reader is dead and hang on take().
+  const ctl = createControlledQuery();
+  let inputDone = false;
+  let queryClosed = false;
+  const runtime = {
+    closed: false,
+    sessionId: 'sess-zombie',
+    turnSink: null, // inter-turn (no active turn)
+    query: { next: ctl.query.next, close() { queryClosed = true; ctl.query.close(); } },
+    inputStream: { done() { inputDone = true; } },
+  };
+
+  const reader = startPerpetualReader(runtime, undefined);
+  ctl.end(); // stream ends out-of-band while idle
+  await reader;
+
+  assert.equal(runtime.closed, true, 'runtime should be disposed (closed) on inter-turn stream end');
+  assert.equal(inputDone, true, 'inputStream.done() should be called');
+  assert.equal(queryClosed, true, 'query.close() should be called');
+});
+
+console.log('\n✅ Perpetual reader integration tests exercise the real startPerpetualReader');

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -36,6 +36,7 @@ import {
   resetCachedQueryFn,
   setCachedQueryFn,
   touchRuntime,
+  createTurnSink,
 } from './runtime-lifecycle.js';
 import {
   SESSION_CLEANUP_INTERVAL_MS,
@@ -262,13 +263,20 @@ async function executeTurn(runtime, requestContext, turnMeta) {
 
   try {
     beginRuntimeTurn(runtime);
+
+    // Create and register turnSink after beginRuntimeTurn to avoid race
+    // (ensures executeTurn is ready to consume before perpetual reader can push)
+    runtime.turnSink = createTurnSink();
+
     console.log('[MESSAGE_START]');
     runtime.inputStream.enqueue(requestContext.userMessage);
 
     while (true) {
       let next;
       try {
-        next = await runtime.query.next();
+        // Receive message from perpetual reader via turnSink
+        // (perpetual reader owns runtime.query.next())
+        next = await runtime.turnSink.take();
       } catch (error) {
         const wrapped = new Error(error?.message || String(error));
         wrapped.runtimeTerminated = true;
@@ -295,6 +303,7 @@ async function executeTurn(runtime, requestContext, turnMeta) {
         continue;
       }
 
+      // Preserve all existing message processing logic
       if (shouldOutputMessage(msg, turnState)) {
         console.log('[MESSAGE]', JSON.stringify(msg));
       }
@@ -364,6 +373,8 @@ async function executeTurn(runtime, requestContext, turnMeta) {
     }
   } finally {
     endRuntimeTurn(runtime);
+    // Clear turnSink after endRuntimeTurn (reverse of creation order)
+    runtime.turnSink = null;
     // Only clear if this runtime still owns the pointer (not cleared by abort)
     clearActiveTurnRuntimeIf(runtime);
   }
@@ -563,7 +574,18 @@ export async function abortCurrentTurn() {
   const runtime = getActiveTurnRuntime();
   if (!runtime) return;
   console.log('[LIFECYCLE] abortCurrentTurn epoch=' + (runtime.runtimeSessionEpoch || '(none)'));
+
+  // Clear turnSink first to stop incoming messages, then fail it to unblock waiting take()
+  const sinkToClose = runtime.turnSink;
+  runtime.turnSink = null;
+
+  if (sinkToClose) {
+    sinkToClose.fail(new Error('Turn aborted'));
+  }
+
+  // Mark abort after sink is cleared
   runtime.abortRequested = true;
+
   clearActiveTurnRuntime();
 
   try {
@@ -698,6 +720,9 @@ export const __testing = {
   },
   setActiveTurnRuntime(runtime) {
     setActiveTurnRuntime(runtime);
+  },
+  getActiveTurnRuntime() {
+    return getActiveTurnRuntime();
   },
   getRuntimeForSession(sessionId) {
     return getRuntimeForSession(sessionId);

--- a/ai-bridge/services/claude/persistent-query-service.test.js
+++ b/ai-bridge/services/claude/persistent-query-service.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { __testing } from './persistent-query-service.js';
+import { createTurnSink } from './runtime-lifecycle.js';
 
 test('abortCurrentTurn marks runtime as user-aborted before disposing it', async () => {
   let disposed = false;
@@ -27,3 +28,276 @@ test('abortCurrentTurn marks runtime as user-aborted before disposing it', async
   assert.equal(runtime.closed, true);
   assert.equal(disposed, true);
 });
+
+// ============================================================================
+// Tests for Issue #1305 Fix - TurnSink and Abort Coordination
+// ============================================================================
+
+test('abortCurrentTurn clears turnSink before marking abort', async () => {
+  let disposed = false;
+  const runtime = {
+    closed: false,
+    sessionId: 'test-session',
+    runtimeSessionEpoch: 'epoch-test',
+    activeTurnCount: 1,
+    turnSink: createTurnSink(),
+    inputStream: {
+      done() {
+        disposed = true;
+      },
+    },
+    query: {
+      close() {},
+    },
+  };
+
+  __testing.setActiveTurnRuntime(runtime);
+
+  // Verify turnSink exists before abort
+  assert.ok(runtime.turnSink !== null);
+
+  await __testing.abortCurrentTurn();
+
+  // turnSink should be cleared
+  assert.equal(runtime.turnSink, null);
+  assert.equal(runtime.abortRequested, true);
+  assert.equal(disposed, true);
+});
+
+test('abortCurrentTurn fails turnSink to unblock waiting take()', async () => {
+  let disposed = false;
+  const runtime = {
+    closed: false,
+    sessionId: 'test-session',
+    runtimeSessionEpoch: 'epoch-test',
+    activeTurnCount: 1,
+    turnSink: createTurnSink(),
+    inputStream: {
+      done() {
+        disposed = true;
+      },
+    },
+    query: {
+      close() {},
+    },
+  };
+
+  __testing.setActiveTurnRuntime(runtime);
+
+  // Start a waiting take()
+  const takePromise = runtime.turnSink.take();
+
+  // Abort in parallel
+  const abortPromise = __testing.abortCurrentTurn();
+
+  // The take() should reject (not hang forever)
+  await assert.rejects(
+    async () => await takePromise,
+    (err) => {
+      assert.match(err.message, /aborted/i);
+      return true;
+    }
+  );
+
+  await abortPromise;
+
+  assert.equal(runtime.turnSink, null);
+  assert.equal(runtime.abortRequested, true);
+});
+
+test('abortCurrentTurn handles null turnSink gracefully', async () => {
+  let disposed = false;
+  const runtime = {
+    closed: false,
+    sessionId: 'test-session',
+    runtimeSessionEpoch: 'epoch-test',
+    activeTurnCount: 1,
+    turnSink: null, // No active turnSink
+    inputStream: {
+      done() {
+        disposed = true;
+      },
+    },
+    query: {
+      close() {},
+    },
+  };
+
+  __testing.setActiveTurnRuntime(runtime);
+
+  // Should not throw even without turnSink
+  await assert.doesNotReject(async () => {
+    await __testing.abortCurrentTurn();
+  });
+
+  assert.equal(runtime.abortRequested, true);
+  assert.equal(disposed, true);
+});
+
+test('abortCurrentTurn prevents perpetual reader from pushing to cleared sink', async () => {
+  const runtime = {
+    closed: false,
+    sessionId: 'test-session',
+    runtimeSessionEpoch: 'epoch-test',
+    activeTurnCount: 1,
+    turnSink: createTurnSink(),
+    inputStream: {
+      done() {},
+    },
+    query: {
+      close() {},
+    },
+  };
+
+  __testing.setActiveTurnRuntime(runtime);
+
+  // Save reference to original sink
+  const originalSink = runtime.turnSink;
+
+  // Abort
+  await __testing.abortCurrentTurn();
+
+  // runtime.turnSink should be null (stops perpetual reader)
+  assert.equal(runtime.turnSink, null);
+
+  // Pushing to originalSink should be ignored (sink is failed)
+  originalSink.push({ type: 'test', content: 'should be ignored' });
+
+  // take() should throw, not return the pushed message
+  await assert.rejects(
+    async () => await originalSink.take(),
+    /aborted/i
+  );
+});
+
+test('abortCurrentTurn is idempotent (double abort is safe)', async () => {
+  let disposeCount = 0;
+  const runtime = {
+    closed: false,
+    sessionId: 'test-session',
+    runtimeSessionEpoch: 'epoch-test',
+    activeTurnCount: 1,
+    turnSink: createTurnSink(),
+    inputStream: {
+      done() {
+        disposeCount++;
+      },
+    },
+    query: {
+      close() {},
+    },
+  };
+
+  __testing.setActiveTurnRuntime(runtime);
+
+  // First abort
+  await __testing.abortCurrentTurn();
+
+  // Active runtime should be cleared
+  const activeRuntime = __testing.getActiveTurnRuntime();
+  assert.equal(activeRuntime, null);
+
+  // Second abort should be no-op (no active runtime)
+  await __testing.abortCurrentTurn();
+
+  // Dispose should only be called once
+  assert.equal(disposeCount, 1);
+});
+
+// ============================================================================
+// Tests for TurnSink Lifecycle in executeTurn
+// ============================================================================
+
+test('turnSink creation happens after beginRuntimeTurn', () => {
+  // This test verifies the order documented in the fix
+  // Actual executeTurn flow:
+  // 1. beginRuntimeTurn(runtime)
+  // 2. runtime.turnSink = createTurnSink()
+  // This ensures executeTurn is ready to consume before perpetual reader can push
+
+  const runtime = {
+    closed: false,
+    turnSink: null,
+    activeTurnCount: 0,
+  };
+
+  // Simulate beginRuntimeTurn
+  runtime.activeTurnCount++;
+
+  // Simulate turnSink creation AFTER beginRuntimeTurn
+  runtime.turnSink = createTurnSink();
+
+  assert.equal(runtime.activeTurnCount, 1);
+  assert.ok(runtime.turnSink !== null);
+
+  // This order prevents race: perpetual reader checks runtime.turnSink
+  // and only pushes if non-null, by which time executeTurn is ready
+});
+
+test('turnSink cleanup happens after endRuntimeTurn', () => {
+  // This test verifies the cleanup order documented in the fix
+  // Actual executeTurn finally block:
+  // 1. endRuntimeTurn(runtime)
+  // 2. runtime.turnSink = null
+  // This follows LIFO principle (reverse of creation order)
+
+  const runtime = {
+    closed: false,
+    turnSink: createTurnSink(),
+    activeTurnCount: 1,
+  };
+
+  // Simulate endRuntimeTurn
+  runtime.activeTurnCount--;
+
+  // Simulate turnSink cleanup AFTER endRuntimeTurn
+  runtime.turnSink = null;
+
+  assert.equal(runtime.activeTurnCount, 0);
+  assert.equal(runtime.turnSink, null);
+});
+
+// ============================================================================
+// Tests for Message Routing Logic
+// ============================================================================
+
+test('messages route to turnSink when active, not when null', () => {
+  const runtime = {
+    turnSink: null,
+  };
+
+  const messages = [];
+
+  // Simulate perpetual reader routing logic
+  const routeMessage = (msg) => {
+    if (runtime.turnSink) {
+      // In-turn mode: push to turnSink
+      runtime.turnSink.push(msg);
+      return 'in-turn';
+    } else {
+      // Inter-turn mode: handle separately
+      messages.push(msg);
+      return 'inter-turn';
+    }
+  };
+
+  // Before turn starts (no turnSink)
+  const route1 = routeMessage({ type: 'test1' });
+  assert.equal(route1, 'inter-turn');
+  assert.equal(messages.length, 1);
+
+  // Turn starts
+  runtime.turnSink = createTurnSink();
+
+  const route2 = routeMessage({ type: 'test2' });
+  assert.equal(route2, 'in-turn');
+
+  // Turn ends
+  runtime.turnSink = null;
+
+  const route3 = routeMessage({ type: 'test3' });
+  assert.equal(route3, 'inter-turn');
+  assert.equal(messages.length, 2);
+});
+
+console.log('\n✅ All persistent-query-service tests updated with turnSink coverage');

--- a/ai-bridge/services/claude/runtime-lifecycle.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.js
@@ -16,6 +16,73 @@ import {
 
 let cachedQueryFn = null;
 
+/**
+ * TurnSink: A simple queue/channel for passing messages from the perpetual reader to executeTurn.
+ * Used to coordinate message flow during active turns.
+ *
+ * The turnSink acts as a bridge between the perpetual reader (which owns runtime.query.next())
+ * and executeTurn (which processes messages). This design ensures:
+ * 1. Only one consumer (perpetual reader) calls query.next(), preventing buffering issues
+ * 2. executeTurn receives messages via a simple queue without blocking the reader
+ * 3. Clean separation between in-turn and inter-turn message routing
+ */
+export function createTurnSink() {
+  const queue = [];
+  const waiters = []; // FIFO queue of pending take() resolvers
+  let failed = false;
+  let failureError = null;
+
+  return {
+    /**
+     * Push a message into the sink (called by perpetual reader during active turn).
+     * Hands the message to the oldest pending take() if any, otherwise queues it.
+     */
+    push(msg) {
+      if (failed) return; // Ignore pushes after failure
+      const waiter = waiters.shift();
+      if (waiter) {
+        waiter.resolve({ value: msg, done: false });
+      } else {
+        queue.push(msg);
+      }
+    },
+
+    /**
+     * Take the next message from the sink (called by executeTurn).
+     * Returns a promise that resolves to { value, done }.
+     * If no messages are queued, waits for the next push. Concurrent takers are
+     * served in FIFO order so none are ever orphaned.
+     */
+    async take() {
+      if (failed) {
+        throw failureError;
+      }
+      if (queue.length > 0) {
+        return { value: queue.shift(), done: false };
+      }
+      // Wait for next push
+      return new Promise((resolve, reject) => {
+        waiters.push({ resolve, reject });
+      });
+    },
+
+    /**
+     * Signal that the stream has failed or completed.
+     * Idempotent: the first error wins, and every pending take() is rejected
+     * once so none hang. After failure, take() throws synchronously, so no new
+     * waiter can be enqueued.
+     */
+    fail(error) {
+      if (failed) return; // Keep the first failure reason
+      failed = true;
+      failureError = error;
+      while (waiters.length > 0) {
+        waiters.shift().reject(error);
+      }
+    }
+  };
+}
+
 export function buildRuntimeSignature(options, systemPromptAppend, streamingEnabled, runtimeSessionEpoch) {
   const material = {
     cwd: options.cwd || '',
@@ -148,7 +215,147 @@ async function createRuntime(requestContext, callbacks) {
     + ' epoch=' + (runtime.runtimeSessionEpoch || '(none)')
     + ' signature=' + runtime.runtimeSignature);
 
+  // Start the perpetual reader for this runtime
+  // The reader will continuously consume runtime.query.next() for the runtime's lifetime
+  startPerpetualReader(runtime, callbacks);
+
   return runtime;
+}
+
+/**
+ * Start the perpetual reader for a runtime.
+ * The reader continuously consumes runtime.query.next() for the runtime's lifetime,
+ * routing messages to either the active turn (via turnSink) or inter-turn handling.
+ *
+ * This is the single source of truth for consuming the SDK query iterator.
+ * executeTurn() no longer calls query.next() directly - it receives messages via turnSink.
+ *
+ * Exported for testing; returns the reader loop promise.
+ */
+export function startPerpetualReader(runtime, callbacks) {
+  /**
+   * Emit an inter-turn event using daemon.js's writeRawLine mechanism.
+   *
+   * IMPORTANT: Must bypass activeRequestId interception to avoid misrouting.
+   *
+   * Why writeRawLine is required:
+   * - daemon.js intercepts process.stdout.write and wraps output with activeRequestId
+   * - If we used console.log() here, the event would be tagged with whatever request
+   *   is currently active (possibly from a different session)
+   * - This would cause the session_updated event to be delivered to the wrong session
+   * - writeRawLine (_originalStdoutWrite) bypasses the interception layer and outputs
+   *   directly to stdout, ensuring the event is process-level and not request-scoped
+   *
+   * The event format {type: 'daemon', event: 'session_updated', sessionId} is recognized
+   * by Java's DaemonBridge.handleDaemonEvent() which routes it to registered listeners.
+   */
+  const emitInterTurnEvent = (sessionId) => {
+    try {
+      // Access the global writeRawLine from daemon.js
+      // daemon.js stores the original stdout.write as _originalStdoutWrite
+      // We must use _originalStdoutWrite to bypass activeRequestId wrapping
+      const originalWrite = process.stdout._originalStdoutWrite;
+      if (!originalWrite) {
+        console.error('[PERPETUAL_READER] _originalStdoutWrite not available (daemon.js not initialized?), cannot emit session_updated event');
+        return;
+      }
+      const eventPayload = {
+        type: 'daemon',
+        event: 'session_updated',
+        sessionId: sessionId
+      };
+      originalWrite.call(process.stdout, JSON.stringify(eventPayload) + '\n', 'utf8');
+    } catch (err) {
+      console.error('[PERPETUAL_READER] Failed to emit session_updated event:', err);
+    }
+  };
+
+  // Start the perpetual reader loop; return the promise so callers (and tests)
+  // can await its completion.
+  return (async () => {
+    console.log('[PERPETUAL_READER] Starting for sessionId=' + (runtime.sessionId || '(new)'));
+
+    try {
+      while (!runtime.closed) {
+        let next;
+
+        try {
+          next = await runtime.query.next();
+        } catch (error) {
+          console.error('[PERPETUAL_READER] query.next() error:', error?.message || error);
+          // Forward error to turnSink if active turn exists
+          if (runtime.turnSink) {
+            runtime.turnSink.fail(error);
+          }
+          break; // Exit loop on error
+        }
+
+        // Check for iterator completion
+        if (next.done) {
+          console.log('[PERPETUAL_READER] Iterator completed (done: true)');
+          if (runtime.turnSink) {
+            runtime.turnSink.fail(new Error('stream ended'));
+          }
+          break; // Exit loop
+        }
+
+        const msg = next.value;
+
+        // Keep the runtime's idle timer fresh while it actively produces output.
+        // cleanupStaleSessionRuntimes reaps runtimes idle past SESSION_RUNTIME_MAX_IDLE_MS
+        // and only spares those with activeTurnCount > 0 — which is 0 between turns.
+        // Without this, a long-running background task (inter-turn) would be reaped
+        // mid-flight, killing the SDK subprocess and losing its completion. In-turn
+        // messages are also touched by executeTurn; touching here is idempotent and
+        // additionally covers the inter-turn path executeTurn cannot see.
+        touchRuntime(runtime);
+
+        // Dual-mode routing: check if we're in an active turn or inter-turn period
+        if (runtime.turnSink) {
+          // IN-TURN MODE: Forward message to executeTurn via turnSink
+          runtime.turnSink.push(msg);
+        } else {
+          // INTER-TURN MODE: Handle message outside of active turn
+          // For phase 1: only emit event when we see a 'result' message
+          // This indicates a complete turn has been generated by CLI
+          if (msg?.type === 'result') {
+            // Validate sessionId: only emit events for registered runtimes
+            if (runtime.sessionId) {
+              console.log('[PERPETUAL_READER] Inter-turn result detected, emitting session_updated for sessionId=' + runtime.sessionId);
+              emitInterTurnEvent(runtime.sessionId);
+            } else {
+              // Anonymous runtime - silently consume
+              console.log('[PERPETUAL_READER] Inter-turn result for anonymous runtime, consuming silently');
+            }
+          }
+          // For other message types during inter-turn, we silently consume
+          // (they've already been persisted to JSONL by the CLI)
+        }
+      }
+    } catch (error) {
+      console.error('[PERPETUAL_READER] Unexpected error in reader loop:', error);
+      if (runtime.turnSink) {
+        runtime.turnSink.fail(error);
+      }
+    } finally {
+      console.log('[PERPETUAL_READER] Exiting for sessionId=' + (runtime.sessionId || '(new)'));
+      // The reader only exits on a terminal condition (query error, stream end,
+      // or runtime closed) — never after a normal turn, where it blocks on the
+      // next query.next() instead. If the runtime is still live here, the SDK
+      // stream ended out-of-band (e.g. the subprocess died while idle between
+      // turns). Evict it so the next request builds a fresh runtime rather than
+      // reusing this one, whose dead reader would hang executeTurn's
+      // turnSink.take() forever. disposeRuntime() is idempotent, so this is safe
+      // even when the active-turn error path disposes the runtime too.
+      if (!runtime.closed) {
+        try {
+          await disposeRuntime(runtime, callbacks);
+        } catch (err) {
+          console.error('[PERPETUAL_READER] dispose on exit failed:', err?.message || err);
+        }
+      }
+    }
+  })();
 }
 
 async function applyDynamicControls(runtime, requestContext) {

--- a/ai-bridge/services/claude/runtime-lifecycle.test.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.test.js
@@ -1,0 +1,464 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createTurnSink } from './runtime-lifecycle.js';
+
+// ============================================================================
+// TurnSink Tests - Core Message Queue Functionality
+// ============================================================================
+
+test('TurnSink: push and take single message', async () => {
+  const sink = createTurnSink();
+  const testMsg = { type: 'test', content: 'hello' };
+
+  sink.push(testMsg);
+  const result = await sink.take();
+
+  assert.deepEqual(result, { value: testMsg, done: false });
+});
+
+test('TurnSink: take waits for push when queue is empty', async () => {
+  const sink = createTurnSink();
+  const testMsg = { type: 'test', content: 'async' };
+
+  // Start take before push
+  const takePromise = sink.take();
+
+  // Push after a delay
+  setTimeout(() => sink.push(testMsg), 10);
+
+  const result = await takePromise;
+  assert.deepEqual(result, { value: testMsg, done: false });
+});
+
+test('TurnSink: multiple pushes queue correctly', async () => {
+  const sink = createTurnSink();
+  const msg1 = { type: 'msg1' };
+  const msg2 = { type: 'msg2' };
+  const msg3 = { type: 'msg3' };
+
+  sink.push(msg1);
+  sink.push(msg2);
+  sink.push(msg3);
+
+  const result1 = await sink.take();
+  const result2 = await sink.take();
+  const result3 = await sink.take();
+
+  assert.deepEqual(result1.value, msg1);
+  assert.deepEqual(result2.value, msg2);
+  assert.deepEqual(result3.value, msg3);
+});
+
+test('TurnSink: push resolves waiting take immediately', async () => {
+  const sink = createTurnSink();
+  const testMsg = { type: 'immediate' };
+
+  // Start waiting
+  const takePromise = sink.take();
+
+  // Push immediately (should resolve takePromise synchronously)
+  sink.push(testMsg);
+
+  const result = await takePromise;
+  assert.deepEqual(result, { value: testMsg, done: false });
+});
+
+// ============================================================================
+// TurnSink Tests - Failure Handling
+// ============================================================================
+
+test('TurnSink: fail prevents further pushes', async () => {
+  const sink = createTurnSink();
+  const error = new Error('Stream failed');
+
+  sink.fail(error);
+
+  // Pushes after failure should be ignored
+  sink.push({ type: 'ignored' });
+
+  // Take should throw the error
+  await assert.rejects(
+    async () => await sink.take(),
+    (err) => {
+      assert.equal(err.message, 'Stream failed');
+      return true;
+    }
+  );
+});
+
+test('TurnSink: fail unblocks waiting take', async () => {
+  const sink = createTurnSink();
+  const error = new Error('Aborted');
+
+  // Start waiting
+  const takePromise = sink.take();
+
+  // Fail the sink
+  setTimeout(() => sink.fail(error), 10);
+
+  // Take should reject with the error
+  await assert.rejects(
+    async () => await takePromise,
+    (err) => {
+      assert.equal(err.message, 'Aborted');
+      return true;
+    }
+  );
+});
+
+test('TurnSink: multiple takes after failure all throw', async () => {
+  const sink = createTurnSink();
+  const error = new Error('Failed');
+
+  sink.fail(error);
+
+  // All subsequent takes should throw
+  await assert.rejects(async () => await sink.take());
+  await assert.rejects(async () => await sink.take());
+  await assert.rejects(async () => await sink.take());
+});
+
+test('TurnSink: fail with waiting take does not process subsequent pushes', async () => {
+  const sink = createTurnSink();
+
+  // Start waiting
+  const takePromise = sink.take();
+
+  // Fail immediately
+  sink.fail(new Error('Failed'));
+
+  // Try to push (should be ignored)
+  sink.push({ type: 'should_be_ignored' });
+
+  // Take should reject, not resolve with the pushed message
+  await assert.rejects(async () => await takePromise);
+});
+
+// ============================================================================
+// TurnSink Tests - Edge Cases
+// ============================================================================
+
+test('TurnSink: empty queue behavior', async () => {
+  const sink = createTurnSink();
+
+  // Take from empty queue should wait
+  const takePromise = sink.take();
+
+  // Verify it's still pending after a short delay
+  await new Promise(resolve => setTimeout(resolve, 10));
+
+  // Resolve it
+  sink.push({ type: 'test' });
+  const result = await takePromise;
+
+  assert.equal(result.done, false);
+});
+
+test('TurnSink: interleaved push/take operations', async () => {
+  const sink = createTurnSink();
+
+  sink.push({ id: 1 });
+  const r1 = await sink.take();
+
+  sink.push({ id: 2 });
+  sink.push({ id: 3 });
+  const r2 = await sink.take();
+
+  sink.push({ id: 4 });
+  const r3 = await sink.take();
+  const r4 = await sink.take();
+
+  assert.equal(r1.value.id, 1);
+  assert.equal(r2.value.id, 2);
+  assert.equal(r3.value.id, 3);
+  assert.equal(r4.value.id, 4);
+});
+
+test('TurnSink: large queue does not lose messages', async () => {
+  const sink = createTurnSink();
+  const messageCount = 1000;
+
+  // Push many messages
+  for (let i = 0; i < messageCount; i++) {
+    sink.push({ id: i });
+  }
+
+  // Take all messages and verify order
+  for (let i = 0; i < messageCount; i++) {
+    const result = await sink.take();
+    assert.equal(result.value.id, i, `Message ${i} out of order`);
+  }
+});
+
+// ============================================================================
+// TurnSink Tests - Concurrent Operations
+// ============================================================================
+
+test('TurnSink: concurrent takes are resolved in order', async () => {
+  const sink = createTurnSink();
+
+  // Start multiple concurrent takes
+  const take1 = sink.take();
+  const take2 = sink.take();
+  const take3 = sink.take();
+
+  // Push messages
+  sink.push({ id: 1 });
+  sink.push({ id: 2 });
+  sink.push({ id: 3 });
+
+  // All takes should resolve correctly
+  const [r1, r2, r3] = await Promise.all([take1, take2, take3]);
+
+  assert.equal(r1.value.id, 1);
+  assert.equal(r2.value.id, 2);
+  assert.equal(r3.value.id, 3);
+});
+
+test('TurnSink: rapid push/take cycles maintain consistency', async () => {
+  const sink = createTurnSink();
+  const iterations = 100;
+
+  for (let i = 0; i < iterations; i++) {
+    sink.push({ id: i });
+    const result = await sink.take();
+    assert.equal(result.value.id, i);
+  }
+});
+
+// ============================================================================
+// Integration Tests - Simulating executeTurn and Perpetual Reader
+// ============================================================================
+
+test('Integration: simulate in-turn message flow', async () => {
+  const sink = createTurnSink();
+
+  // Simulate perpetual reader pushing messages
+  const messages = [
+    { type: 'system', session_id: 'test-123' },
+    { type: 'assistant', content: 'Hello' },
+    { type: 'assistant', tool_use: { name: 'read' } },
+    { type: 'tool_result', content: 'file content' },
+    { type: 'assistant', content: 'Done' },
+    { type: 'result', is_error: false }
+  ];
+
+  // Simulate perpetual reader (async producer)
+  const producer = (async () => {
+    for (const msg of messages) {
+      sink.push(msg);
+      await new Promise(resolve => setTimeout(resolve, 5)); // Simulate delay
+    }
+  })();
+
+  // Simulate executeTurn (consumer)
+  const received = [];
+  while (true) {
+    const next = await sink.take();
+    received.push(next.value);
+
+    if (next.value.type === 'result') {
+      break;
+    }
+  }
+
+  await producer;
+
+  assert.equal(received.length, messages.length);
+  assert.deepEqual(received, messages);
+});
+
+test('Integration: simulate abort during active turn', async () => {
+  const sink = createTurnSink();
+
+  // Simulate perpetual reader pushing messages
+  sink.push({ type: 'assistant', content: 'Starting...' });
+
+  // Simulate executeTurn consuming
+  const r1 = await sink.take();
+  assert.equal(r1.value.type, 'assistant');
+
+  // Simulate abort
+  sink.fail(new Error('Turn aborted'));
+
+  // Next take should throw
+  await assert.rejects(
+    async () => await sink.take(),
+    /Turn aborted/
+  );
+});
+
+test('Integration: simulate rapid turn transitions', async () => {
+  // Simulate multiple turns with different sinks
+  const turn1Sink = createTurnSink();
+  const turn2Sink = createTurnSink();
+
+  // Turn 1
+  turn1Sink.push({ type: 'assistant', content: 'Turn 1' });
+  turn1Sink.push({ type: 'result' });
+
+  const t1m1 = await turn1Sink.take();
+  const t1m2 = await turn1Sink.take();
+
+  assert.equal(t1m1.value.content, 'Turn 1');
+  assert.equal(t1m2.value.type, 'result');
+
+  // Turn 2 (new sink)
+  turn2Sink.push({ type: 'assistant', content: 'Turn 2' });
+  turn2Sink.push({ type: 'result' });
+
+  const t2m1 = await turn2Sink.take();
+  const t2m2 = await turn2Sink.take();
+
+  assert.equal(t2m1.value.content, 'Turn 2');
+  assert.equal(t2m2.value.type, 'result');
+});
+
+// ============================================================================
+// Stress Tests - Boundary Conditions
+// ============================================================================
+
+test('Stress: high-frequency push/take cycles', async () => {
+  const sink = createTurnSink();
+  const iterations = 1000;
+
+  const producer = (async () => {
+    for (let i = 0; i < iterations; i++) {
+      sink.push({ id: i });
+    }
+  })();
+
+  const consumer = (async () => {
+    for (let i = 0; i < iterations; i++) {
+      const result = await sink.take();
+      assert.equal(result.value.id, i);
+    }
+  })();
+
+  await Promise.all([producer, consumer]);
+});
+
+test('Stress: many concurrent waiting takes resolved by single fail', async () => {
+  const sink = createTurnSink();
+  const waitCount = 100;
+
+  // Start many concurrent takes
+  const takes = Array.from({ length: waitCount }, () => sink.take());
+
+  // Fail the sink
+  setTimeout(() => sink.fail(new Error('Mass abort')), 10);
+
+  // All takes should reject
+  const results = await Promise.allSettled(takes);
+
+  results.forEach(result => {
+    assert.equal(result.status, 'rejected');
+    assert.match(result.reason.message, /Mass abort/);
+  });
+});
+
+test('Stress: alternating push-wait-take pattern', async () => {
+  const sink = createTurnSink();
+  const rounds = 50;
+
+  for (let i = 0; i < rounds; i++) {
+    // Push
+    sink.push({ round: i, phase: 'push' });
+
+    // Wait a bit
+    await new Promise(resolve => setTimeout(resolve, 1));
+
+    // Take
+    const result = await sink.take();
+    assert.equal(result.value.round, i);
+    assert.equal(result.value.phase, 'push');
+  }
+});
+
+// ============================================================================
+// Error Handling Tests
+// ============================================================================
+
+test('Error: take after fail with custom error', async () => {
+  const sink = createTurnSink();
+  const customError = new Error('Custom failure');
+  customError.code = 'CUSTOM_ERR';
+
+  sink.fail(customError);
+
+  await assert.rejects(
+    async () => await sink.take(),
+    (err) => {
+      assert.equal(err.message, 'Custom failure');
+      assert.equal(err.code, 'CUSTOM_ERR');
+      return true;
+    }
+  );
+});
+
+test('Error: push after fail does not throw', () => {
+  const sink = createTurnSink();
+
+  sink.fail(new Error('Failed'));
+
+  // Push should silently be ignored (no throw)
+  assert.doesNotThrow(() => {
+    sink.push({ type: 'test' });
+    sink.push({ type: 'test2' });
+  });
+});
+
+test('Error: multiple fails keep first error', async () => {
+  const sink = createTurnSink();
+
+  const error1 = new Error('First error');
+  const error2 = new Error('Second error');
+
+  sink.fail(error1);
+  sink.fail(error2); // Should be ignored
+
+  await assert.rejects(
+    async () => await sink.take(),
+    (err) => {
+      assert.equal(err.message, 'First error');
+      return true;
+    }
+  );
+});
+
+// ============================================================================
+// Memory Tests
+// ============================================================================
+
+test('Memory: sink does not leak on rapid creation/disposal', async () => {
+  const iterations = 1000;
+
+  for (let i = 0; i < iterations; i++) {
+    const sink = createTurnSink();
+    sink.push({ id: i });
+    const result = await sink.take();
+    assert.equal(result.value.id, i);
+    // Sink should be garbage collected after this iteration
+  }
+
+  // If this test completes without OOM, memory management is OK
+  assert.ok(true, 'No memory leak detected');
+});
+
+test('Memory: failed sink releases waiting promises', async () => {
+  const sink = createTurnSink();
+
+  // Create many waiting takes
+  const takes = Array.from({ length: 100 }, () => sink.take());
+
+  // Fail immediately
+  sink.fail(new Error('Release all'));
+
+  // All promises should settle (not hang)
+  const results = await Promise.allSettled(takes);
+
+  assert.equal(results.length, 100);
+  results.forEach(r => assert.equal(r.status, 'rejected'));
+});
+
+console.log('\n✅ All TurnSink tests defined. Run with: node runtime-lifecycle.test.js');

--- a/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
@@ -623,6 +623,27 @@ public class DaemonBridge {
                 break;
             }
 
+            case "session_updated": {
+                // Extract and validate sessionId
+                String sessionId = obj.has("sessionId") ? obj.get("sessionId").getAsString() : null;
+                if (sessionId == null || sessionId.isEmpty()) {
+                    LOG.warn("[DaemonBridge] session_updated event missing sessionId, skipping");
+                    break;
+                }
+
+                LOG.info("[DaemonBridge] Session updated: sessionId=" + sessionId);
+
+                // Iterate through registered eventListeners and dispatch
+                for (DaemonEventListener listener : eventListeners) {
+                    try {
+                        listener.onDaemonEvent(event, obj);
+                    } catch (Exception ex) {
+                        LOG.warn("[DaemonBridge] Listener threw while handling " + event, ex);
+                    }
+                }
+                break;
+            }
+
             default:
                 LOG.debug("[DaemonBridge] Unhandled daemon event: " + event);
         }

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -64,7 +64,9 @@ public class ClaudeChatWindow {
     private String permissionServiceKey = null;
 
     private JBCefBrowser browser;
-    private ClaudeSession session;
+    // volatile: read from the daemon reader thread by the session_updated listener
+    // and its loadFromServer continuation, while reassigned on the EDT.
+    private volatile ClaudeSession session;
     private final WebviewWatchdog webviewWatchdog;
     private final StreamMessageCoalescer streamCoalescer;
 
@@ -78,6 +80,13 @@ public class ClaudeChatWindow {
     // Daemon event listener for AI title forwarding. Held so it can be removed on dispose.
     private DaemonBridge.DaemonEventListener titleEventListener;
     private volatile int fetchedSlashCommandsCount = 0;
+
+    // Coalesces session_updated reloads. SessionState's message list is not
+    // thread-safe and loadFromServer() runs async, so concurrent background-task
+    // completions must not reload at the same time. Guarded by sessionReloadLock.
+    private final Object sessionReloadLock = new Object();
+    private boolean sessionReloadInFlight = false;
+    private boolean sessionReloadPending = false;
 
     private HandlerContext handlerContext;
     private MessageDispatcher messageDispatcher;
@@ -625,12 +634,90 @@ public class ClaudeChatWindow {
                             }
                         });
                     }
+                } else if ("session_updated".equals(event)) {
+                    // Handle inter-turn session updates (background task completion)
+                    String updatedSessionId = data.has("sessionId") ? data.get("sessionId").getAsString() : null;
+                    if (updatedSessionId == null) {
+                        LOG.warn("[ClaudeChatWindow] session_updated event missing sessionId");
+                        return;
+                    }
+
+                    // Compare with current active session
+                    String currentSessionId = session != null ? session.getSessionId() : null;
+                    if (currentSessionId == null || !currentSessionId.equals(updatedSessionId)) {
+                        // Event is for a different session, ignore
+                        return;
+                    }
+
+                    // Check if session has active turn in progress; skip reload if true
+                    if (sessionCallbackAdapter != null && streamCoalescer != null && streamCoalescer.isStreamActive()) {
+                        LOG.info("[ClaudeChatWindow] session_updated event received during active turn, skipping reload");
+                        return;
+                    }
+
+                    LOG.info("[ClaudeChatWindow] session_updated for sessionId=" + updatedSessionId + ", reloading from server");
+
+                    // Reuse the canonical reload path (same as history-load / rewind):
+                    // loadFromServer() reads the session via the bridge, converts each
+                    // record with MessageParser.parseServerMessage(), and pushes a full
+                    // refresh through the callback facade. Coalesced so overlapping
+                    // background-task completions never reload concurrently.
+                    requestSessionReload();
                 }
             };
             this.claudeSDKBridge.addDaemonEventListener(this.titleEventListener);
         }
 
         persistTabSessionState();
+    }
+
+    /**
+     * Request a reload of the current session from the server, coalescing
+     * concurrent requests. Multiple session_updated events (e.g. several
+     * background tasks finishing at once) must not run loadFromServer()
+     * concurrently — SessionState's message list is not thread-safe and the
+     * reload runs on a background thread. At most one reload is in flight;
+     * requests arriving during a reload collapse into a single follow-up reload
+     * that reflects the latest JSONL.
+     */
+    private void requestSessionReload() {
+        synchronized (sessionReloadLock) {
+            if (sessionReloadInFlight) {
+                sessionReloadPending = true;
+                return;
+            }
+            sessionReloadInFlight = true;
+        }
+        driveSessionReload();
+    }
+
+    private void driveSessionReload() {
+        ClaudeSession current = session;
+        if (disposed || current == null) {
+            synchronized (sessionReloadLock) {
+                sessionReloadInFlight = false;
+                sessionReloadPending = false;
+            }
+            return;
+        }
+        current.loadFromServer().whenComplete((v, ex) -> {
+            if (ex != null) {
+                LOG.warn("[ClaudeChatWindow] session reload failed", ex);
+            }
+            boolean runAgain;
+            synchronized (sessionReloadLock) {
+                if (sessionReloadPending && !disposed) {
+                    sessionReloadPending = false;
+                    runAgain = true;
+                } else {
+                    sessionReloadInFlight = false;
+                    runAgain = false;
+                }
+            }
+            if (runAgain) {
+                driveSessionReload();
+            }
+        });
     }
 
     private void onStreamEnded() {


### PR DESCRIPTION
- Add TurnSink channel to coordinate message flow from perpetual reader to executeTurn
- Start perpetual reader in createRuntime to continuously consume query.next()
- Route inter-turn result messages as session_updated daemon events
- Expose _originalStdoutWrite for bypassing activeRequestId interception
- Handle session_updated events in DaemonBridge and ClaudeChatWindow
- Coalesce concurrent session reloads to protect non-thread-safe SessionState
- Clear turnSink before marking abort to prevent perpetual reader pushes
- Fail turnSink on abort to unblock waiting take() calls

Fixes #1305