### PR TITLE
fix(provider): resolve Bedrock/Vertex/Foundry 403 since v0.4.5

### DIFF
--- a/ai-bridge/config/api-config.js
+++ b/ai-bridge/config/api-config.js
@@ -93,6 +93,32 @@ export function getCliUserAgent() {
   return `claude-cli/${version} (${userType}, ${entrypoint})`;
 }
 
+// Cloud-provider routing switches in settings.json. When any of these is
+// enabled, the user's settings.json — not the plugin — owns inference routing,
+// so the plugin must NOT advertise host-managed provider control (see
+// shouldHostManageProvider / buildCliEnv).
+const CLOUD_PROVIDER_FLAGS = [
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_VERTEX',
+  'CLAUDE_CODE_USE_FOUNDRY',
+];
+
+/**
+ * Whether a settings.json env flag is enabled.
+ *
+ * Claude Code reads these switches from both JSON booleans and stringified
+ * truthy values ("1"/"true"), so this normalizes every accepted spelling in one
+ * place. Shared by auth detection (setupApiKey) and provider-management gating
+ * (shouldHostManageProvider) so the two can never disagree on what "enabled"
+ * means.
+ *
+ * @param {*} value - Raw value from settings.json env.
+ * @returns {boolean} true for any accepted truthy spelling.
+ */
+function isEnvFlagEnabled(value) {
+  return value === '1' || value === 1 || value === 'true' || value === true;
+}
+
 // Env vars whose value the webview owns per request. Settings.json copies of
 // these must never be applied on top of the current request's selections.
 //
@@ -185,6 +211,34 @@ export function buildWebviewControlledSettingsOverride(modelId) {
 }
 
 /**
+ * Whether the host should hand off provider routing to Claude Code itself.
+ *
+ * When truthy, the CLI strips provider/model routing vars (CLAUDE_CODE_USE_BEDROCK,
+ * ANTHROPIC_*_BASE_URL, ANTHROPIC_API_KEY/AUTH_TOKEN, …) from every settings
+ * source, so a user's ~/.claude/settings.json cannot redirect requests away
+ * from the host-configured provider. That is exactly what we want when the
+ * plugin owns the API key and base URL.
+ *
+ * It is NOT what we want for cloud-provider auth (Bedrock/Vertex/Foundry):
+ * there the user's settings.json IS the source of truth for
+ * CLAUDE_CODE_USE_BEDROCK and its peers. Setting the flag there would make the
+ * CLI silently drop the very switch that turns Bedrock on → 403.
+ *
+ * The plugin's "host" role is conditional on who actually holds the
+ * credentials — for cloud providers that owner is AWS/GCP/Azure, so the plugin
+ * must step back and let Claude Code honor the user's settings.json switch.
+ *
+ * Reads settings via loadClaudeSettings() (same source as setupApiKey) so the
+ * auth-decision and the provider-management-decision always see the same env.
+ *
+ * @returns {boolean} true unless a cloud provider switch is active in settings.
+ */
+function shouldHostManageProvider() {
+  const settings = loadClaudeSettings();
+  return !CLOUD_PROVIDER_FLAGS.some((flag) => isEnvFlagEnabled(settings?.env?.[flag]));
+}
+
+/**
  * Build a clean env object for SDK child processes that identifies as CLI.
  *
  * The SDK's query() checks `options.env` — if absent, it copies process.env
@@ -195,7 +249,16 @@ export function buildWebviewControlledSettingsOverride(modelId) {
  */
 export function buildCliEnv() {
   const env = {};
+  // When a cloud provider owns routing, the host must NOT advertise provider
+  // management: otherwise Claude Code strips CLAUDE_CODE_USE_BEDROCK (and
+  // peers) from settings → 403. We skip setting it AND drop any copy inherited
+  // from this process's own env (the daemon may itself have been spawned under
+  // the flag, e.g. when run from inside another Claude Code host).
+  const hostManaged = shouldHostManageProvider();
   const skipKeys = new Set([...CLI_ENV_OVERRIDE_VAR_SET, 'CLAUDE_AGENT_SDK_VERSION']);
+  if (!hostManaged) {
+    skipKeys.add('CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST');
+  }
   for (const [key, value] of Object.entries(process.env)) {
     if (!skipKeys.has(key.toUpperCase())) {
       env[key] = value;
@@ -205,8 +268,12 @@ export function buildCliEnv() {
   env.USER_TYPE = 'external';
   // Claude Code applies settings.json env with overwrite semantics. This flag
   // makes the CLI strip settings-sourced provider/model vars so the host's
-  // request-scoped routing wins.
-  env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST = '1';
+  // request-scoped routing wins — but only when the plugin owns routing. For
+  // cloud-provider modes (Bedrock/Vertex/Foundry) the CLI must honor the
+  // user's settings.json switch, so we leave the flag unset there.
+  if (hostManaged) {
+    env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST = '1';
+  }
   return env;
 }
 
@@ -501,7 +568,7 @@ export function setupApiKey() {
     apiKey = settings.env.ANTHROPIC_API_KEY;
     authType = 'api_key';  // x-api-key authentication
     apiKeySource = 'settings.json (ANTHROPIC_API_KEY)';
-  } else if (settings?.env?.CLAUDE_CODE_USE_BEDROCK === '1' || settings?.env?.CLAUDE_CODE_USE_BEDROCK === 1 || settings?.env?.CLAUDE_CODE_USE_BEDROCK === 'true' || settings?.env?.CLAUDE_CODE_USE_BEDROCK === true) {
+  } else if (isEnvFlagEnabled(settings?.env?.CLAUDE_CODE_USE_BEDROCK)) {
     apiKey = settings?.env?.CLAUDE_CODE_USE_BEDROCK;
     authType = 'aws_bedrock';  // AWS Bedrock authentication
     apiKeySource = 'settings.json (AWS_BEDROCK)';

--- a/ai-bridge/config/api-config.test.js
+++ b/ai-bridge/config/api-config.test.js
@@ -163,6 +163,61 @@ function writeCodemossClaudeConfig(homeDir, current, providers = {}) {
   );
 }
 
+function writeClaudeSettingsEnv(homeDir, env) {
+  const claudeDir = path.join(homeDir, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(claudeDir, 'settings.json'),
+    JSON.stringify({ env }),
+    'utf8'
+  );
+}
+
+// Run buildCliEnv() in an isolated child process whose HOME points at tempHome,
+// so the provider-management decision is driven solely by the temp settings.json
+// — never by the developer's real ~/.claude/settings.json.
+function runBuildCliEnv(tempHome) {
+  const script = `
+    import { buildCliEnv } from ${JSON.stringify(API_CONFIG_MODULE)};
+    const env = buildCliEnv();
+    console.log(JSON.stringify({
+      ENTRYPOINT: env.CLAUDE_CODE_ENTRYPOINT,
+      USER_TYPE: env.USER_TYPE,
+      HOST_MANAGED: env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST,
+      EFFORT: env.CLAUDE_CODE_EFFORT_LEVEL,
+      MAX_THINKING: env.MAX_THINKING_TOKENS,
+      DISABLE_1M: env.CLAUDE_CODE_DISABLE_1M_CONTEXT,
+      SDK_VERSION: env.CLAUDE_AGENT_SDK_VERSION,
+    }));
+  `;
+
+  const output = execFileSync(
+    process.execPath,
+    ['--input-type=module', '--eval', script],
+    {
+      cwd: path.resolve('.'),
+      env: {
+        ...buildChildEnv(tempHome),
+        // Verify the "drop inherited copy" path: the daemon may itself carry
+        // the flag from a parent host. buildCliEnv must clear it for cloud
+        // providers even when it is already in process.env.
+        CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: '1',
+        CLAUDE_CODE_EFFORT_LEVEL: 'max',
+        MAX_THINKING_TOKENS: '64000',
+        CLAUDE_CODE_DISABLE_1M_CONTEXT: '1',
+        CLAUDE_AGENT_SDK_VERSION: 'should-not-leak',
+        ANTHROPIC_MODEL: 'current-webview-model',
+        ANTHROPIC_DEFAULT_SONNET_MODEL: 'current-webview-model',
+        HTTPS_PROXY: 'http://proxy.example.com:8080',
+      },
+      encoding: 'utf8',
+    }
+  );
+
+  const lastLine = output.trim().split('\n').filter(Boolean).pop();
+  return JSON.parse(lastLine);
+}
+
 test('isWebviewControlledEnvVar classifies model, context, and reasoning controls correctly', () => {
   assert.equal(isWebviewControlledEnvVar('ANTHROPIC_MODEL'), true);
   assert.equal(isWebviewControlledEnvVar('anthropic_model'), true); // case-insensitive
@@ -173,47 +228,26 @@ test('isWebviewControlledEnvVar classifies model, context, and reasoning control
   assert.equal(isWebviewControlledEnvVar('ANTHROPIC_API_KEY'), false);
 });
 
-test('buildCliEnv preserves current model env but strips stale CLI override env vars', () => {
-  const previous = {
-    ANTHROPIC_MODEL: process.env.ANTHROPIC_MODEL,
-    ANTHROPIC_DEFAULT_SONNET_MODEL: process.env.ANTHROPIC_DEFAULT_SONNET_MODEL,
-    CLAUDE_CODE_EFFORT_LEVEL: process.env.CLAUDE_CODE_EFFORT_LEVEL,
-    MAX_THINKING_TOKENS: process.env.MAX_THINKING_TOKENS,
-    CLAUDE_CODE_DISABLE_1M_CONTEXT: process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT,
-    HTTPS_PROXY: process.env.HTTPS_PROXY,
-    CLAUDE_AGENT_SDK_VERSION: process.env.CLAUDE_AGENT_SDK_VERSION,
-  };
+test('buildCliEnv strips stale CLI override env vars and sets host-managed for first-party auth', () => {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-api-config-'));
+  // Active managed provider so loadClaudeSettings() returns settings; no cloud
+  // flag set → host-managed should be '1'.
+  writeCodemossClaudeConfig(tempHome, 'provider-a', {
+    'provider-a': { name: 'Provider A', settingsConfig: { env: { ANTHROPIC_AUTH_TOKEN: 'sk-test' } } },
+  });
+  writeClaudeSettingsEnv(tempHome, { ANTHROPIC_AUTH_TOKEN: 'sk-test' });
 
-  try {
-    process.env.ANTHROPIC_MODEL = 'current-webview-model';
-    process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'current-webview-model';
-    process.env.CLAUDE_CODE_EFFORT_LEVEL = 'max';
-    process.env.MAX_THINKING_TOKENS = '64000';
-    process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT = '1';
-    process.env.HTTPS_PROXY = 'http://proxy.example.com:8080';
-    process.env.CLAUDE_AGENT_SDK_VERSION = 'should-not-leak';
+  const env = runBuildCliEnv(tempHome);
 
-    const env = buildCliEnv();
-
-    assert.equal(env.ANTHROPIC_MODEL, 'current-webview-model');
-    assert.equal(env.ANTHROPIC_DEFAULT_SONNET_MODEL, 'current-webview-model');
-    assert.equal(env.CLAUDE_CODE_EFFORT_LEVEL, undefined);
-    assert.equal(env.MAX_THINKING_TOKENS, undefined);
-    assert.equal(env.CLAUDE_CODE_DISABLE_1M_CONTEXT, undefined);
-    assert.equal(env.CLAUDE_AGENT_SDK_VERSION, undefined);
-    assert.equal(env.HTTPS_PROXY, 'http://proxy.example.com:8080');
-    assert.equal(env.CLAUDE_CODE_ENTRYPOINT, 'cli');
-    assert.equal(env.USER_TYPE, 'external');
-    assert.equal(env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST, '1');
-  } finally {
-    for (const [key, value] of Object.entries(previous)) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
-  }
+  // Reasoning/context controls stripped from the child env
+  assert.equal(env.EFFORT, undefined);
+  assert.equal(env.MAX_THINKING, undefined);
+  assert.equal(env.DISABLE_1M, undefined);
+  assert.equal(env.SDK_VERSION, undefined);
+  // Identity + host-managed flag set for first-party auth
+  assert.equal(env.ENTRYPOINT, 'cli');
+  assert.equal(env.USER_TYPE, 'external');
+  assert.equal(env.HOST_MANAGED, '1');
 });
 
 test('buildWebviewControlledSettingsOverride neutralizes Claude CLI settings env precedence', () => {
@@ -239,6 +273,27 @@ test('buildWebviewControlledSettingsOverride neutralizes Claude CLI settings env
       MAX_THINKING_TOKENS: '',
     },
   });
+});
+
+test('buildCliEnv leaves CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST unset for cloud providers', () => {
+  // Bedrock/Vertex/Foundry: the user's settings.json owns the provider switch.
+  // The host-managed flag would make Claude Code strip it → 403, so it must be
+  // absent — even when process.env already carries an inherited copy.
+  for (const flag of ['CLAUDE_CODE_USE_BEDROCK', 'CLAUDE_CODE_USE_VERTEX', 'CLAUDE_CODE_USE_FOUNDRY']) {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-api-config-'));
+    writeCodemossClaudeConfig(tempHome, 'provider-a', {
+      'provider-a': { name: 'Provider A', settingsConfig: { env: { [flag]: '1' } } },
+    });
+    writeClaudeSettingsEnv(tempHome, { [flag]: '1' });
+
+    const env = runBuildCliEnv(tempHome);
+
+    assert.equal(env.HOST_MANAGED, undefined,
+      `${flag} should suppress the host-managed flag (and clear any inherited copy)`);
+    // Identity env must still be present regardless of provider mode.
+    assert.equal(env.ENTRYPOINT, 'cli');
+    assert.equal(env.USER_TYPE, 'external');
+  }
 });
 
 test('setupApiKey does not fall back to Claude CLI credentials on disk', () => {


### PR DESCRIPTION
Since v0.4.5, buildCliEnv() unconditionally set
CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1, which makes Claude Code strip provider/model routing vars (CLAUDE_CODE_USE_BEDROCK and peers) from every settings source. For cloud-provider auth the user's ~/.claude/settings.json IS the source of truth for that switch, so stripping it silently disabled Bedrock/Vertex/Foundry, producing 403s.

Gate the host-managed flag on shouldHostManageProvider(): set it only when no cloud-provider switch is active in settings.json. Also drop any copy inherited from this process's own env (the daemon may itself have been spawned under the flag by a parent host).

Extract isEnvFlagEnabled() so auth detection (setupApiKey) and provider management gating share one definition of "enabled", covering both JSON booleans and stringified truthy spellings.

Refactor buildCliEnv tests to run in an isolated child process with a temp HOME so the provider-management decision is driven solely by the temp settings.json and never by the developer's real config. Add coverage for Bedrock/Vertex/Foundry suppressing the host-managed flag and clearing any inherited copy.