### PR TITLE
fix(webview): coerce non-string content before markdown render

### DIFF
--- a/webview/src/components/ErrorBoundary.tsx
+++ b/webview/src/components/ErrorBoundary.tsx
@@ -76,6 +76,25 @@ const CAUSES_LIST_STYLE: React.CSSProperties = {
   lineHeight: '1.6',
 };
 
+const HINTS_BOX_STYLE: React.CSSProperties = {
+  padding: '12px',
+  marginBottom: '16px',
+  backgroundColor: 'var(--vscode-textBlockQuote-background, rgba(127, 127, 127, 0.12))',
+  borderLeft: '3px solid var(--vscode-focusBorder, #4ea1ff)',
+  borderRadius: '4px',
+};
+
+const HINTS_TITLE_STYLE: React.CSSProperties = {
+  fontWeight: 600,
+  marginBottom: '8px',
+};
+
+const HINTS_LIST_STYLE: React.CSSProperties = {
+  margin: 0,
+  paddingLeft: '20px',
+  lineHeight: '1.6',
+};
+
 const DETAILS_STYLE: React.CSSProperties = {
   marginBottom: '16px',
 };
@@ -186,23 +205,64 @@ function getSystemInfo(): string {
   return info.join('\n');
 }
 
+function extractComponentNames(componentStack?: string | null): string[] {
+  if (!componentStack) {
+    return [];
+  }
+
+  return componentStack
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const match = line.match(/^at\s+([^\s(]+)/);
+      return match?.[1] ?? '';
+    })
+    .filter(Boolean);
+}
+
+function getErrorHints(error?: Error): string[] {
+  const message = error?.message ?? '';
+  const hints: string[] = [];
+
+  if (/\.replace is not a function/i.test(message)) {
+    hints.push('A non-string value reached code that expects plain text and calls string.replace().');
+    hints.push('Check dialog/message payload fields such as command, content, text, or markdown props for arrays/objects.');
+  }
+
+  if (/Cannot read properties of undefined/i.test(message) || /Cannot read properties of null/i.test(message)) {
+    hints.push('A required object was missing at render time; inspect optional chaining and async data guards.');
+  }
+
+  return hints;
+}
+
 /**
  * Format error details for display and copy
  */
 function formatErrorDetails(error?: Error, errorInfo?: React.ErrorInfo): string {
   const parts: string[] = [];
+  const componentNames = extractComponentNames(errorInfo?.componentStack ?? undefined);
+  const hints = getErrorHints(error);
 
-  parts.push('=== Error Information ===');
+  parts.push('=== Error Summary ===');
   if (error) {
     parts.push(`Error: ${error.name}`);
     parts.push(`Message: ${error.message}`);
+    if (hints.length > 0) {
+      parts.push('Likely Cause(s):');
+      hints.forEach((hint) => parts.push(`- ${hint}`));
+    }
+    if (componentNames.length > 0) {
+      parts.push(`Component Chain: ${componentNames.join(' -> ')}`);
+    }
     if (error.stack) {
-      parts.push(`\nStack Trace:\n${error.stack}`);
+      parts.push(`\nRaw Stack Trace:\n${error.stack}`);
     }
   }
 
   if (errorInfo?.componentStack) {
-    parts.push(`\nComponent Stack:${errorInfo.componentStack}`);
+    parts.push(`\nRaw Component Stack:${errorInfo.componentStack}`);
   }
 
   parts.push('\n=== System Information ===');
@@ -307,6 +367,8 @@ class ErrorBoundary extends Component<Props, State> {
 
       const errorDetails = formatErrorDetails(this.state.error, this.state.errorInfo);
       const copyButtonStyle = getCopyButtonStyle(this.state.copied);
+      const errorHints = getErrorHints(this.state.error);
+      const componentNames = extractComponentNames(this.state.errorInfo?.componentStack ?? undefined);
 
       // Default fallback UI — role/aria-live announce the error to assistive
       // tech, otherwise screen-reader users have no signal that the surface
@@ -348,6 +410,24 @@ class ErrorBoundary extends Component<Props, State> {
                 <li>{t('errorBoundary.cause4', 'Insufficient system resources')}</li>
               </ul>
             </div>
+
+            {(errorHints.length > 0 || componentNames.length > 0) && (
+              <div style={HINTS_BOX_STYLE}>
+                <div style={HINTS_TITLE_STYLE}>
+                  {t('errorBoundary.debugHints', 'Debug hints')}
+                </div>
+                <ul style={HINTS_LIST_STYLE}>
+                  {errorHints.map((hint) => (
+                    <li key={hint}>{hint}</li>
+                  ))}
+                  {componentNames.length > 0 && (
+                    <li>
+                      {t('errorBoundary.componentChain', 'Component chain')}: {componentNames.join(' → ')}
+                    </li>
+                  )}
+                </ul>
+              </div>
+            )}
 
             {/* Error Details */}
             {this.state.error && (

--- a/webview/src/components/MarkdownBlock.test.tsx
+++ b/webview/src/components/MarkdownBlock.test.tsx
@@ -81,6 +81,22 @@ describe('MarkdownBlock linkify integration', () => {
     expect(classLink.getAttribute('data-linkify')).toBe('class');
   });
 
+  it('coerces structured non-string content into readable text', () => {
+    render(
+      <MarkdownBlock
+        content={[
+          { text: 'Open src/components/App.tsx' },
+          { content: 'Visit https://example.com/docs' },
+          42,
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'src/components/App.tsx' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'https://example.com/docs' })).toBeTruthy();
+    expect(document.querySelector('.markdown-content')?.textContent).toContain('42');
+  });
+
   it('adds url-link styling to plain URLs and markdown links', () => {
     render(
       <MarkdownBlock content={'Visit https://example.com/docs and [guide](https://example.com/guide)'} />,

--- a/webview/src/components/MarkdownBlock.tsx
+++ b/webview/src/components/MarkdownBlock.tsx
@@ -217,8 +217,38 @@ marked.setOptions({
 });
 
 interface MarkdownBlockProps {
-  content?: string;
+  content?: unknown;
   isStreaming?: boolean;
+}
+
+function safeStringifyContent(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => safeStringifyContent(item)).filter(Boolean).join('\n');
+  }
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    if (typeof record.text === 'string') {
+      return record.text;
+    }
+    if (typeof record.content === 'string') {
+      return record.content;
+    }
+    try {
+      return JSON.stringify(value, null, 2) ?? String(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
 }
 
 /**
@@ -509,6 +539,7 @@ const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps
   );
   const containerRef = useRef<HTMLDivElement>(null);
   const { t, i18n } = useTranslation();
+  const normalizedContent = useMemo(() => safeStringifyContent(content), [content]);
 
   // Track previous isStreaming state to detect when streaming ends
   const prevIsStreamingRef = useRef(isStreaming);
@@ -609,7 +640,7 @@ const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps
   // Render mermaid diagrams after HTML updates (skip during streaming to prevent flicker)
   useEffect(() => {
     if (isStreaming) return;
-    if (!hasPossibleMermaidContent(content)) {
+    if (!hasPossibleMermaidContent(normalizedContent)) {
       mermaidRetryRef.current = 0;
       return;
     }
@@ -639,7 +670,7 @@ const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps
       if (retryTimeoutId) clearTimeout(retryTimeoutId);
       if (retryRafId) cancelAnimationFrame(retryRafId);
     };
-  }, [content, isStreaming, renderMermaidDiagrams]);
+  }, [normalizedContent, isStreaming, renderMermaidDiagrams]);
 
   // Copy to clipboard implementation
   const copyToClipboard = async (text: string) => {
@@ -669,7 +700,7 @@ const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps
 
   const html = useMemo(() => {
     try {
-      const trimmedContent = content.replace(/[\r\n]+$/, '');
+      const trimmedContent = normalizedContent.replace(/[\r\n]+$/, '');
 
       // During streaming, use lightweight renderer to avoid heavy parsing on every delta
       if (isStreaming) {
@@ -742,7 +773,7 @@ const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps
       if (typeof console !== 'undefined' && console.error) {
         console.error('[MarkdownBlock] Render failed, falling back to escaped text:', e);
       }
-      return content.replace(/[&<>"']/g, (ch) => {
+      return normalizedContent.replace(/[&<>"']/g, (ch) => {
         switch (ch) {
           case '&': return '&amp;';
           case '<': return '&lt;';
@@ -753,7 +784,7 @@ const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps
         }
       });
     }
-  }, [content, isStreaming, i18n.language, linkifyCapabilities, t]);
+  }, [normalizedContent, isStreaming, i18n.language, linkifyCapabilities, t]);
 
   // Force DOM refresh when streaming ends to fix potential layout corruption from streaming render
   useEffect(() => {

--- a/webview/src/components/PermissionDialog.test.tsx
+++ b/webview/src/components/PermissionDialog.test.tsx
@@ -80,6 +80,35 @@ describe('PermissionDialog', () => {
     expect(screen.getByRole('link', { name: 'https://example.com/docs' })).toBeTruthy();
   });
 
+  it('formats non-string command payloads before rendering markdown', () => {
+    const request: PermissionRequest = {
+      channelId: 'perm-2',
+      toolName: 'bash',
+      inputs: {
+        cwd: 'src/components',
+        command: [
+          { text: 'Read src/components/App.tsx' },
+          { content: 'Reference https://example.com/docs' },
+          7,
+        ],
+      },
+    };
+
+    render(
+      <PermissionDialog
+        isOpen
+        request={request}
+        onApprove={() => {}}
+        onSkip={() => {}}
+        onApproveAlways={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'src/components/App.tsx' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'https://example.com/docs' })).toBeTruthy();
+    expect(document.querySelector('.permission-dialog-v3-command-content')?.textContent).toContain('7');
+  });
+
   it('auto-denies with the original channelId after timeoutSeconds elapses', () => {
     vi.useFakeTimers();
     const onApprove = vi.fn();

--- a/webview/src/components/PermissionDialog.tsx
+++ b/webview/src/components/PermissionDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatCountdown } from '../utils/helpers';
 import { useDialogCountdownTimeout } from '../hooks/useDialogCountdownTimeout';
@@ -10,8 +10,8 @@ import { isEditableEventTarget } from '../utils/isEditableEventTarget';
 export interface PermissionRequest {
   channelId: string;
   toolName: string;
-  inputs: Record<string, any>;
-  suggestions?: any;
+  inputs: Record<string, unknown>;
+  suggestions?: unknown;
 }
 
 interface PermissionDialogProps {
@@ -22,6 +22,67 @@ interface PermissionDialogProps {
   onApproveAlways: (channelId: string) => void;
   timeoutSeconds?: number;
 }
+
+// Format a single tool-input value for display. Pure helper hoisted to module
+// scope so it is not recreated on every render (the dialog re-renders once per
+// second while the timeout countdown ticks).
+const formatInputValue = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => formatInputValue(item))
+      .filter(Boolean)
+      .join('\n');
+  }
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    if (typeof record.text === 'string') {
+      return record.text;
+    }
+    if (typeof record.content === 'string') {
+      return record.content;
+    }
+    return JSON.stringify(value, null, 2);
+  }
+  return String(value);
+};
+
+// Derive the primary command / action content from the tool inputs.
+const getCommandContent = (inputs: Record<string, unknown>): string => {
+  // Get primary content based on tool type
+  if ('command' in inputs && inputs.command !== undefined) {
+    return formatInputValue(inputs.command);
+  }
+  if ('content' in inputs && inputs.content !== undefined) {
+    return formatInputValue(inputs.content);
+  }
+  if ('text' in inputs && inputs.text !== undefined) {
+    return formatInputValue(inputs.text);
+  }
+  // For other tools, format all inputs
+  return Object.entries(inputs)
+    .map(([key, value]) => `${key}: ${formatInputValue(value)}`)
+    .join('\n');
+};
+
+// Derive the working-directory / path label from the tool inputs.
+const getWorkingDirectory = (inputs: Record<string, unknown>): string => {
+  if (typeof inputs.cwd === 'string' && inputs.cwd) {
+    return inputs.cwd;
+  }
+  if (typeof inputs.file_path === 'string' && inputs.file_path) {
+    return inputs.file_path;
+  }
+  if (typeof inputs.path === 'string' && inputs.path) {
+    return inputs.path;
+  }
+  return '~';
+};
 
 const PermissionDialog = ({
   isOpen,
@@ -109,55 +170,21 @@ const PermissionDialog = ({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [isOpen, request, handleApprove, handleApproveAlways, handleSkip]);
 
+  // Derived display values are memoized so the per-second countdown re-render
+  // does not re-run command formatting (which may JSON.stringify inputs).
+  // Hooks must run before the early return below, hence the null guard.
+  const commandContent = useMemo(
+    () => (request ? getCommandContent(request.inputs) : ''),
+    [request],
+  );
+  const workingDirectory = useMemo(
+    () => (request ? getWorkingDirectory(request.inputs) : '~'),
+    [request],
+  );
+
   if (!isOpen || !request) {
     return null;
   }
-
-  // Format input parameters for display
-  const formatInputValue = (value: any): string => {
-    if (value === null || value === undefined) {
-      return '';
-    }
-    if (typeof value === 'string') {
-      return value;
-    }
-    if (typeof value === 'object') {
-      return JSON.stringify(value, null, 2);
-    }
-    return String(value);
-  };
-
-  // Get the command or primary action content
-  const getCommandContent = (): string => {
-    // Get primary content based on tool type
-    if (request.inputs.command) {
-      return request.inputs.command;
-    }
-    if (request.inputs.content) {
-      return request.inputs.content;
-    }
-    if (request.inputs.text) {
-      return request.inputs.text;
-    }
-    // For other tools, format all inputs
-    return Object.entries(request.inputs)
-      .map(([key, value]) => `${key}: ${formatInputValue(value)}`)
-      .join('\n');
-  };
-
-  // Get working directory
-  const getWorkingDirectory = (): string => {
-    if (request.inputs.cwd) {
-      return request.inputs.cwd;
-    }
-    if (request.inputs.file_path) {
-      return request.inputs.file_path;
-    }
-    if (request.inputs.path) {
-      return request.inputs.path;
-    }
-    return '~';
-  };
 
   // Map tool name to display title
   const getToolTitle = (toolName: string): string => {
@@ -169,9 +196,6 @@ const PermissionDialog = ({
     }
     return translated;
   };
-
-  const commandContent = getCommandContent();
-  const workingDirectory = getWorkingDirectory();
 
   // Security (E): for command-execution tools the "always allow" memory is scoped to this
   // exact command (parameter-level), not the whole tool, so make the button say so —

--- a/webview/vite.config.ts
+++ b/webview/vite.config.ts
@@ -7,11 +7,12 @@ export default defineConfig({
     react(),
     viteSingleFile(),
   ],
+  esbuild: {
+    drop: ['debugger'],
+    keepNames: true,
+  },
   build: {
     minify: 'esbuild',
-    esbuild: {
-      drop: ['console', 'debugger'],
-    },
     assetsInlineLimit: 1024 * 1024,
     cssCodeSplit: false,
     sourcemap: false,


### PR DESCRIPTION
Non-string payloads (arrays, content blocks, numbers) reaching MarkdownBlock and PermissionDialog triggered ".replace is not a function" crashes. Normalize them to readable text before rendering, and surface debug hints in ErrorBoundary to diagnose such cases.

- MarkdownBlock: accept unknown content, normalize via memoized helper
- PermissionDialog: format non-string inputs; hoist pure formatters to module scope and memoize derived values to skip per-tick recompute
- ErrorBoundary: add debug hints and component-chain extraction
- vite: preserve names and retain console output for production diagnostics

Fixes #1334