### PR TITLE
fix(actions): avoid lazy content creation in tab action updates

### DIFF
--- a/src/main/java/com/github/claudecodegui/action/tab/CreateNewTabAction.java
+++ b/src/main/java/com/github/claudecodegui/action/tab/CreateNewTabAction.java
@@ -33,7 +33,7 @@ public class CreateNewTabAction extends AnAction {
 
     @Override
     public @NotNull ActionUpdateThread getActionUpdateThread() {
-        return ActionUpdateThread.BGT;
+        return ActionUpdateThread.EDT;
     }
 
     @Override

--- a/src/main/java/com/github/claudecodegui/action/tab/DetachTabAction.java
+++ b/src/main/java/com/github/claudecodegui/action/tab/DetachTabAction.java
@@ -54,7 +54,11 @@ public class DetachTabAction extends AnAction implements DumbAware {
             return;
         }
 
-        ContentManager contentManager = toolWindow.getContentManager();
+        ContentManager contentManager = toolWindow.getContentManagerIfCreated();
+        if (contentManager == null) {
+            LOG.warn("[DetachTabAction] Tool window content manager is not created");
+            return;
+        }
         Content selectedContent = contentManager.getSelectedContent();
         if (selectedContent == null) {
             LOG.warn("[DetachTabAction] No tab selected");
@@ -180,7 +184,12 @@ public class DetachTabAction extends AnAction implements DumbAware {
             return;
         }
 
-        ContentManager contentManager = toolWindow.getContentManager();
+        // Avoid lazily creating tool window contents during action updates.
+        ContentManager contentManager = toolWindow.getContentManagerIfCreated();
+        if (contentManager == null) {
+            e.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
         Content selectedContent = contentManager.getSelectedContent();
 
         // Enable only if there's a selected content and it's not the last tab

--- a/src/main/java/com/github/claudecodegui/action/tab/RenameTabAction.java
+++ b/src/main/java/com/github/claudecodegui/action/tab/RenameTabAction.java
@@ -50,20 +50,24 @@ public class RenameTabAction extends AnAction implements DumbAware {
     public void actionPerformed(@NotNull AnActionEvent e) {
         Project project = e.getProject();
         if (project == null) {
-            LOG.error("[RenameTabAction] Project is null");
+            LOG.warn("[RenameTabAction] Project is null");
             return;
         }
 
         ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow("CCG");
         if (toolWindow == null) {
-            LOG.error("[RenameTabAction] Tool window not found");
+            LOG.warn("[RenameTabAction] Tool window not found");
             return;
         }
 
-        ContentManager contentManager = toolWindow.getContentManager();
+        ContentManager contentManager = toolWindow.getContentManagerIfCreated();
+        if (contentManager == null) {
+            LOG.warn("[RenameTabAction] Tool window content manager is not created");
+            return;
+        }
         Content selectedContent = contentManager.getSelectedContent();
         if (selectedContent == null) {
-            LOG.error("[RenameTabAction] No tab selected");
+            LOG.warn("[RenameTabAction] No tab selected");
             return;
         }
 
@@ -120,7 +124,14 @@ public class RenameTabAction extends AnAction implements DumbAware {
             return;
         }
 
-        Content selectedContent = toolWindow.getContentManager().getSelectedContent();
+        // Avoid lazily creating tool window contents during action updates.
+        ContentManager contentManager = toolWindow.getContentManagerIfCreated();
+        if (contentManager == null) {
+            e.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
+
+        Content selectedContent = contentManager.getSelectedContent();
         e.getPresentation().setEnabledAndVisible(selectedContent != null);
     }
 


### PR DESCRIPTION
DetachTabAction and RenameTabAction called getContentManager() inside the high-frequency EDT update(), which forces tool window content creation even while the tool window is closed. Switch both update() and actionPerformed() to getContentManagerIfCreated() with null guards.

Also align the sibling tab actions:
- CreateNewTabAction: BGT -> EDT, matching Detach/Rename which read ContentManager UI state in update().
- RenameTabAction: unify defensive early-return logs from error to warn, consistent with DetachTabAction and the new guard.

Fixes #1340