### PR TITLE
fix(ai-bridge): never resolve working dir to the bridge install dir

### DIFF
--- a/ai-bridge/utils/path-utils.js
+++ b/ai-bridge/utils/path-utils.js
@@ -4,7 +4,8 @@
  */
 
 import fs from 'fs';
-import { resolve, join } from 'path';
+import { resolve, join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { homedir, tmpdir, platform } from 'os';
 
 // Cache the resolved home directory path to avoid redundant computation
@@ -119,6 +120,7 @@ export function getTempPathPrefixes() {
 /**
  * Normalize a path for comparison purposes.
  * On Windows: converts to lowercase and uses forward slashes.
+ * @internal Exposed for unit testing; not part of the public API.
  */
 export function normalizePathForComparison(pathValue) {
   if (!pathValue) return '';
@@ -163,6 +165,49 @@ export function isTempDirectory(pathValue) {
   });
 }
 
+// Cache the resolved ai-bridge install directory path.
+let cachedBridgeDir = null;
+
+/**
+ * Resolve the ai-bridge install directory from this module's own location.
+ * This file lives at <bridge>/utils/path-utils.js, so the bridge root is one
+ * level up from its directory. Deriving it from import.meta.url is reliable
+ * regardless of process.cwd(), which the daemon mutates via process.chdir()
+ * between turns.
+ * @returns {string} The resolved physical ai-bridge directory path
+ */
+function getBridgeDir() {
+  if (cachedBridgeDir) {
+    return cachedBridgeDir;
+  }
+  const bridgeDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  try {
+    // Match getRealHomeDir(): resolve symlinks/junctions so comparisons against
+    // a possibly-realpath'd process.cwd() stay consistent.
+    cachedBridgeDir = fs.realpathSync(bridgeDir);
+  } catch (err) {
+    console.warn('[WARN] getBridgeDir: realpathSync failed, using unresolved path:', err.message);
+    cachedBridgeDir = bridgeDir;
+  }
+  return cachedBridgeDir;
+}
+
+/**
+ * Check whether a path points at the ai-bridge install directory itself.
+ *
+ * The daemon launches with process.cwd() === the bridge dir, and a per-process
+ * worker falls back to it when no valid cwd is supplied. Resolving the working
+ * directory to it makes the Claude SDK persist sessions under
+ * ~/.claude/projects/<sanitized-bridge-dir>/, scattering every project's history
+ * into one bogus folder (issue #1343). Such a candidate must always be rejected.
+ * @param {string} pathValue - The path to check
+ * @returns {boolean}
+ */
+export function isBridgeDirectory(pathValue) {
+  if (!pathValue) return false;
+  return normalizePathForComparison(pathValue) === normalizePathForComparison(getBridgeDir());
+}
+
 /**
  * Intelligently select the working directory.
  * @param {string} requestedCwd - The requested working directory
@@ -189,6 +234,16 @@ export function selectWorkingDirectory(requestedCwd) {
     const normalized = sanitizePath(candidate);
     if (!normalized) continue;
 
+    // Never resolve the working directory to the ai-bridge install dir itself
+    // (issue #1343). The daemon launches with process.cwd() === the bridge dir,
+    // so an empty requestedCwd + missing IDEA_PROJECT_PATH would otherwise land
+    // here and make the SDK persist sessions under
+    // ~/.claude/projects/<sanitized-bridge-dir>/, hiding every project's history.
+    if (isBridgeDirectory(normalized)) {
+      console.log('[DEBUG] Skipping ai-bridge directory candidate:', normalized);
+      continue;
+    }
+
     if (isTempDirectory(normalized) && envProjectPath) {
       console.log('[DEBUG] Skipping temp directory candidate:', normalized);
       continue;
@@ -207,5 +262,12 @@ export function selectWorkingDirectory(requestedCwd) {
   }
 
   console.log('[DEBUG] selectWorkingDirectory fallback triggered');
-  return envProjectPath || getRealHomeDir();
+  // Guard: reject the bridge dir even from IDEA_PROJECT_PATH (e.g. when the user
+  // is developing the bridge itself). The home dir is always a safe fallback.
+  const fallback = envProjectPath || getRealHomeDir();
+  if (isBridgeDirectory(fallback)) {
+    console.log('[DEBUG] Fallback env path is bridge dir, using home dir instead');
+    return getRealHomeDir();
+  }
+  return fallback;
 }

--- a/ai-bridge/utils/path-utils.test.js
+++ b/ai-bridge/utils/path-utils.test.js
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { homedir } from 'os';
+import {
+  selectWorkingDirectory,
+  isBridgeDirectory,
+  normalizePathForComparison,
+} from './path-utils.js';
+
+// This test sits in <bridge>/utils/, so the bridge install dir is one level up.
+// Resolve symlinks the same way path-utils.js does so equality checks stay stable.
+function resolveBridgeDir() {
+  const dir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  try {
+    return fs.realpathSync(dir);
+  } catch {
+    return dir;
+  }
+}
+const BRIDGE_DIR = resolveBridgeDir();
+
+const samePath = (a, b) => normalizePathForComparison(a) === normalizePathForComparison(b);
+
+/**
+ * Runs `fn` with IDEA_PROJECT_PATH / PROJECT_PATH cleared, restoring them after
+ * so working-directory resolution is exercised without ambient project env.
+ */
+function withoutProjectEnv(fn) {
+  const keys = ['IDEA_PROJECT_PATH', 'PROJECT_PATH'];
+  const saved = {};
+  for (const k of keys) {
+    saved[k] = Object.prototype.hasOwnProperty.call(process.env, k) ? process.env[k] : undefined;
+    delete process.env[k];
+  }
+  try {
+    return fn();
+  } finally {
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+}
+
+test('isBridgeDirectory matches the ai-bridge install dir', () => {
+  assert.equal(isBridgeDirectory(BRIDGE_DIR), true);
+});
+
+test('isBridgeDirectory rejects unrelated, empty, and nullish paths', () => {
+  assert.equal(isBridgeDirectory(homedir()), false);
+  assert.equal(isBridgeDirectory(''), false);
+  assert.equal(isBridgeDirectory(null), false);
+  assert.equal(isBridgeDirectory(undefined), false);
+});
+
+test('selectWorkingDirectory never resolves to the bridge dir (issue #1343)', () => {
+  withoutProjectEnv(() => {
+    const result = selectWorkingDirectory(BRIDGE_DIR);
+    assert.ok(!samePath(result, BRIDGE_DIR), `expected a non-bridge dir, got ${result}`);
+  });
+});
+
+test('selectWorkingDirectory prefers IDEA_PROJECT_PATH over a bridge-dir request', () => {
+  withoutProjectEnv(() => {
+    const projectPath = homedir(); // a real, existing dir that is not the bridge dir
+    process.env.IDEA_PROJECT_PATH = projectPath;
+    assert.ok(samePath(selectWorkingDirectory(BRIDGE_DIR), projectPath));
+  });
+});
+
+test('selectWorkingDirectory returns a valid requested cwd unchanged', () => {
+  withoutProjectEnv(() => {
+    const home = homedir();
+    assert.ok(samePath(selectWorkingDirectory(home), resolve(home)));
+  });
+});
+
+test('selectWorkingDirectory rejects IDEA_PROJECT_PATH set to bridge dir (issue #1343)', () => {
+  // Simulates a developer working on the bridge itself with IDEA_PROJECT_PATH
+  // pointing at the bridge root — the fallback must not return the bridge dir.
+  const saved = process.env.IDEA_PROJECT_PATH;
+  process.env.IDEA_PROJECT_PATH = BRIDGE_DIR;
+  delete process.env.PROJECT_PATH;
+  try {
+    const result = selectWorkingDirectory('');
+    assert.ok(!samePath(result, BRIDGE_DIR), `expected non-bridge fallback, got ${result}`);
+  } finally {
+    if (saved === undefined) delete process.env.IDEA_PROJECT_PATH;
+    else process.env.IDEA_PROJECT_PATH = saved;
+  }
+});
+
+test('selectWorkingDirectory skips bridge dir when it appears as process.cwd() candidate', () => {
+  // When run from the bridge dir (typical daemon startup), an empty requestedCwd
+  // must not resolve to the bridge dir.
+  withoutProjectEnv(() => {
+    if (!samePath(process.cwd(), BRIDGE_DIR)) return; // only meaningful from bridge dir
+    const result = selectWorkingDirectory('');
+    assert.ok(!samePath(result, BRIDGE_DIR), `expected non-bridge dir, got ${result}`);
+  });
+});


### PR DESCRIPTION
Fixes #1343.

When the daemon starts without a project context it launches with `process.cwd()` equal to the ai-bridge install directory. With no IDEA_PROJECT_PATH set and an empty requestedCwd, `selectWorkingDirectory()` would previously pick up `process.cwd()` and return the bridge dir, causing the Claude SDK to persist every session under
`~/.claude/projects/<sanitized-bridge-dir>/` and hiding all real project history.

Changes:
- Add getBridgeDir(): derives the bridge root from import.meta.url so the result is stable even after the daemon calls process.chdir(). Resolves symlinks/junctions with realpathSync to stay consistent with getRealHomeDir().
- Add isBridgeDirectory(pathValue): exported predicate used both in the candidate loop and in the fallback path.
- selectWorkingDirectory(): skip any candidate that resolves to the bridge dir, including process.cwd() and an explicitly passed requestedCwd.
- Fallback guard: if IDEA_PROJECT_PATH itself points at the bridge dir (e.g. when developing the bridge), fall through to getRealHomeDir() instead of returning the bridge dir.
- Add @internal JSDoc to normalizePathForComparison, which is exported solely for unit-test use.
- Add path-utils.test.js (node:test, no extra deps) with 7 tests covering isBridgeDirectory, the candidate-loop fix, the IDEA_PROJECT_PATH edge case, and the process.cwd()-as-bridge-dir scenario.