### PR TITLE
feat(models): support custom pricing for routed Claude models

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/provider/CustomModelPricingHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/provider/CustomModelPricingHandler.java
@@ -1,0 +1,119 @@
+package com.github.claudecodegui.handler.provider;
+
+import com.github.claudecodegui.handler.core.BaseMessageHandler;
+import com.github.claudecodegui.handler.core.HandlerContext;
+import com.github.claudecodegui.provider.CustomPricingProvider;
+import com.github.claudecodegui.settings.CodemossSettingsService;
+import com.github.claudecodegui.settings.ModelPricing;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Handles persistence of user-configured model pricing.
+ *
+ * <p>The frontend sends {@code set_custom_model_pricing} whenever plugin-level custom models or
+ * pricing-only Claude configured models change. The payload shape is:
+ * <pre>
+ * { "provider": "claude"|"codex", "models": [ { "id": "...", "pricing": { ... } } ] }
+ * </pre>
+ * Models without a {@code pricing} field are treated as "use default pricing" and omitted from
+ * the persisted map, so the aggregators fall back to their hardcoded tables.
+ */
+public class CustomModelPricingHandler extends BaseMessageHandler {
+
+    private static final Logger LOG = Logger.getInstance(CustomModelPricingHandler.class);
+
+    static final String SET_TYPE = "set_custom_model_pricing";
+
+    private final CodemossSettingsService settingsService;
+
+    public CustomModelPricingHandler(HandlerContext context, CodemossSettingsService settingsService) {
+        super(context);
+        this.settingsService = settingsService;
+    }
+
+    @Override
+    public boolean handle(String type, String content) {
+        if (!SET_TYPE.equals(type)) {
+            return false;
+        }
+        try {
+            JsonObject payload = JsonParser.parseString(content).getAsJsonObject();
+            String provider = payload.has("provider") && !payload.get("provider").isJsonNull()
+                    ? payload.get("provider").getAsString()
+                    : null;
+            if (!"claude".equals(provider) && !"codex".equals(provider)) {
+                LOG.warn("[CustomModelPricingHandler] Rejected unknown provider: " + provider);
+                return true;
+            }
+
+            Map<String, ModelPricing> pricingMap = new LinkedHashMap<>();
+            if (payload.has("models") && payload.get("models").isJsonArray()) {
+                JsonArray models = payload.getAsJsonArray("models");
+                for (JsonElement el : models) {
+                    if (!el.isJsonObject()) {
+                        continue;
+                    }
+                    JsonObject model = el.getAsJsonObject();
+                    if (!model.has("id") || model.get("id").isJsonNull()) {
+                        continue;
+                    }
+                    String id = model.get("id").getAsString().trim();
+                    if (id.isEmpty()) {
+                        continue;
+                    }
+                    ModelPricing pricing = parsePricing(model);
+                    if (pricing != null) {
+                        pricingMap.put(id, pricing);
+                    }
+                }
+            }
+
+            settingsService.setCustomModelPricing(provider, pricingMap);
+            CustomPricingProvider.getInstance().invalidateCache();
+            LOG.info("[CustomModelPricingHandler] Persisted " + pricingMap.size()
+                    + " custom model pricing entries for " + provider);
+        } catch (Exception e) {
+            LOG.error("[CustomModelPricingHandler] Failed to handle " + type + ": " + e.getMessage(), e);
+        }
+        return true;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return new String[]{SET_TYPE};
+    }
+
+    private ModelPricing parsePricing(JsonObject model) {
+        if (!model.has("pricing") || !model.get("pricing").isJsonObject()) {
+            return null;
+        }
+        JsonObject p = model.getAsJsonObject("pricing");
+        Double input = readDouble(p, "inputCostPer1M");
+        Double output = readDouble(p, "outputCostPer1M");
+        Double cacheWrite = readDouble(p, "cacheWriteCostPer1M");
+        Double cacheRead = readDouble(p, "cacheReadCostPer1M");
+        if (input == null && output == null && cacheWrite == null && cacheRead == null) {
+            return null;
+        }
+        return new ModelPricing(input, output, cacheWrite, cacheRead);
+    }
+
+    private static Double readDouble(JsonObject obj, String key) {
+        if (obj == null || !obj.has(key) || obj.get(key).isJsonNull()) {
+            return null;
+        }
+        try {
+            double v = obj.get(key).getAsDouble();
+            return Double.isFinite(v) && v >= 0 ? v : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/CustomPricingProvider.java
+++ b/src/main/java/com/github/claudecodegui/provider/CustomPricingProvider.java
@@ -1,0 +1,324 @@
+package com.github.claudecodegui.provider;
+
+import com.github.claudecodegui.settings.ConfigPathManager;
+import com.github.claudecodegui.settings.ModelPricing;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Reads user-configured model pricing from {@code ~/.codemoss/config.json}
+ * and exposes it to the usage aggregators.
+ *
+ * <p>The aggregators ({@link com.github.claudecodegui.provider.claude.ClaudeUsageAggregator}
+ * and {@link com.github.claudecodegui.provider.codex.CodexUsageAggregator}) are created in many
+ * places without dependency injection, so this provider is a process-wide singleton that reads
+ * the config file lazily and caches the parsed result keyed by the file's last-modified time.
+ * When the file changes (e.g. the frontend writes a new price), the cache is invalidated
+ * automatically on the next lookup.
+ *
+ * <p>This map is primarily for plugin-level custom models, plus pricing-only overrides for
+ * the active Claude provider/settings.json mapped model names. Built-in Claude/Codex default
+ * IDs still fall back to the aggregators' hardcoded tables unless the frontend explicitly
+ * sends a matching pricing entry.
+ */
+public final class CustomPricingProvider {
+
+    private static final Logger LOG = Logger.getInstance(CustomPricingProvider.class);
+    private static final String ROOT_KEY = "customModelPricing";
+
+    private static volatile CustomPricingProvider instance;
+
+    private final ConfigPathManager pathManager;
+    private final Gson gson;
+
+    /** Cached parsed pricing, together with the mtime of the file it was parsed from. */
+    private volatile CachedPricing cache;
+
+    private CustomPricingProvider() {
+        this(new ConfigPathManager());
+    }
+
+    CustomPricingProvider(ConfigPathManager pathManager) {
+        this.pathManager = pathManager;
+        this.gson = new Gson();
+    }
+
+    public static CustomPricingProvider getInstance() {
+        CustomPricingProvider local = instance;
+        if (local == null) {
+            synchronized (CustomPricingProvider.class) {
+                local = instance;
+                if (local == null) {
+                    local = new CustomPricingProvider();
+                    instance = local;
+                }
+            }
+        }
+        return local;
+    }
+
+    /**
+     * Look up custom pricing for a model under a given provider family.
+     *
+     * @param provider "claude" or "codex"
+     * @param modelId  the model ID
+     * @return the configured pricing, or {@link Optional#empty()} if not configured
+     */
+    public Optional<ModelPricing> getPricing(String provider, String modelId) {
+        if (provider == null || modelId == null || modelId.isBlank()) {
+            return Optional.empty();
+        }
+        Map<String, ModelPricing> forProvider = getOrLoad().forProvider(provider);
+        String trimmedModelId = modelId.trim();
+        ModelPricing exactPricing = forProvider.get(trimmedModelId);
+        if (exactPricing != null) {
+            return Optional.of(exactPricing);
+        }
+
+        // The webview can append "[1m]" to Claude model IDs when long-context mode
+        // is enabled. Custom models are configured by their base ID, so look up that
+        // base ID as a fallback while preserving exact-match precedence above.
+        String baseModelId = stripOneMillionContextSuffix(trimmedModelId);
+        if (!baseModelId.equals(trimmedModelId)) {
+            ModelPricing basePricing = forProvider.get(baseModelId);
+            if (basePricing != null) {
+                return Optional.of(basePricing);
+            }
+        }
+
+        // Some model platforms use a route prefix in the configured/requested model ID
+        // (for example "ppio/pa/gpt-5.5"), while Claude history may persist only the
+        // routed model ID ("pa/gpt-5.5"). Treat the first slash-separated segment of
+        // configured pricing keys as an optional route prefix, but only use this fallback
+        // when it resolves to one unique configured model. This keeps exact matches
+        // authoritative and avoids silently choosing between ambiguous providers such as
+        // "ppio/pa/gpt-5.5" and "openrouter/pa/gpt-5.5".
+        if ("claude".equals(provider)) {
+            Optional<ModelPricing> contextSuffixPricing =
+                    findUniqueConfiguredContextSuffixPricing(forProvider, trimmedModelId);
+            if (contextSuffixPricing.isPresent()) {
+                return contextSuffixPricing;
+            }
+
+            Optional<ModelPricing> routePrefixPricing = findUniqueRoutePrefixPricing(forProvider, trimmedModelId);
+            if (routePrefixPricing.isPresent()) {
+                return routePrefixPricing;
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Force-clear the in-memory cache. Used by the pricing update handler after writing
+     * config; automatic mtime-based invalidation remains the normal lookup fallback.
+     */
+    public void invalidateCache() {
+        cache = null;
+    }
+
+    private CachedPricing getOrLoad() {
+        CachedPricing local = cache;
+        Path configPath = pathManager.getConfigFilePath();
+        long currentMtime = readMtimeSafe(configPath);
+        if (local != null && local.mtime == currentMtime) {
+            return local;
+        }
+        synchronized (this) {
+            local = cache;
+            if (local != null && local.mtime == currentMtime) {
+                return local;
+            }
+            local = loadFromDisk(configPath, currentMtime);
+            cache = local;
+            return local;
+        }
+    }
+
+    private CachedPricing loadFromDisk(Path configPath, long mtime) {
+        Map<String, Map<String, ModelPricing>> empty = Map.of();
+        if (!Files.exists(configPath)) {
+            return new CachedPricing(mtime, empty);
+        }
+        try {
+            String content = Files.readString(configPath);
+            JsonObject root = gson.fromJson(content, JsonObject.class);
+            if (root == null || !root.has(ROOT_KEY) || !root.get(ROOT_KEY).isJsonObject()) {
+                return new CachedPricing(mtime, empty);
+            }
+            JsonObject rootObj = root.getAsJsonObject(ROOT_KEY);
+            Map<String, Map<String, ModelPricing>> result = new HashMap<>();
+            for (String provider : new String[]{"claude", "codex"}) {
+                if (!rootObj.has(provider) || !rootObj.get(provider).isJsonObject()) {
+                    continue;
+                }
+                JsonObject providerObj = rootObj.getAsJsonObject(provider);
+                Map<String, ModelPricing> modelMap = new HashMap<>();
+                for (String modelId : providerObj.keySet()) {
+                    if (!providerObj.get(modelId).isJsonObject()) {
+                        continue;
+                    }
+                    JsonObject p = providerObj.getAsJsonObject(modelId);
+                    ModelPricing pricing = new ModelPricing(
+                            readDouble(p, "inputCostPer1M"),
+                            readDouble(p, "outputCostPer1M"),
+                            readDouble(p, "cacheWriteCostPer1M"),
+                            readDouble(p, "cacheReadCostPer1M")
+                    );
+                    modelMap.put(modelId, pricing);
+                }
+                result.put(provider, Map.copyOf(modelMap));
+            }
+            return new CachedPricing(mtime, Map.copyOf(result));
+        } catch (IOException e) {
+            LOG.warn("[CustomPricingProvider] Failed to read config: " + e.getMessage());
+            return new CachedPricing(mtime, empty);
+        } catch (Exception e) {
+            LOG.warn("[CustomPricingProvider] Failed to parse config: " + e.getMessage());
+            return new CachedPricing(mtime, empty);
+        }
+    }
+
+    private static Double readDouble(JsonObject obj, String key) {
+        if (obj == null || !obj.has(key) || obj.get(key).isJsonNull()) {
+            return null;
+        }
+        try {
+            double value = obj.get(key).getAsDouble();
+            return Double.isFinite(value) && value >= 0 ? value : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static Optional<ModelPricing> findUniqueConfiguredContextSuffixPricing(
+            Map<String, ModelPricing> pricingByModel,
+            String requestedModelId
+    ) {
+        Set<String> requestedComparableIds = requestedComparableIds(requestedModelId);
+        ModelPricing matchedPricing = null;
+        String matchedModelId = null;
+
+        for (Map.Entry<String, ModelPricing> entry : pricingByModel.entrySet()) {
+            String configuredModelId = entry.getKey() == null ? "" : entry.getKey().trim();
+            String configuredBaseModelId = stripOneMillionContextSuffix(configuredModelId);
+            if (configuredBaseModelId.equals(configuredModelId)
+                    || !requestedComparableIds.contains(configuredBaseModelId)) {
+                continue;
+            }
+            if (matchedPricing != null && !entry.getKey().equals(matchedModelId)) {
+                return Optional.empty();
+            }
+            matchedPricing = entry.getValue();
+            matchedModelId = entry.getKey();
+        }
+
+        return Optional.ofNullable(matchedPricing);
+    }
+
+    private static Optional<ModelPricing> findUniqueRoutePrefixPricing(
+            Map<String, ModelPricing> pricingByModel,
+            String requestedModelId
+    ) {
+        Set<String> requestedComparableIds = requestedComparableIds(requestedModelId);
+        ModelPricing matchedPricing = null;
+        String matchedModelId = null;
+
+        for (Map.Entry<String, ModelPricing> entry : pricingByModel.entrySet()) {
+            if (!intersects(requestedComparableIds, configuredRouteComparableIds(entry.getKey()))) {
+                continue;
+            }
+            if (matchedPricing != null && !entry.getKey().equals(matchedModelId)) {
+                return Optional.empty();
+            }
+            matchedPricing = entry.getValue();
+            matchedModelId = entry.getKey();
+        }
+
+        return Optional.ofNullable(matchedPricing);
+    }
+
+    private static Set<String> requestedComparableIds(String modelId) {
+        Set<String> ids = new LinkedHashSet<>();
+        addIfNotBlank(ids, modelId);
+        addIfNotBlank(ids, stripOneMillionContextSuffix(modelId));
+        return ids;
+    }
+
+    private static Set<String> configuredRouteComparableIds(String modelId) {
+        Set<String> ids = new LinkedHashSet<>();
+        String trimmed = modelId == null ? "" : modelId.trim();
+        String withoutContextSuffix = stripOneMillionContextSuffix(trimmed);
+        addRouteStrippedIds(ids, trimmed);
+        addRouteStrippedIds(ids, withoutContextSuffix);
+        return ids;
+    }
+
+    private static void addRouteStrippedIds(Set<String> ids, String modelId) {
+        if (modelId == null || modelId.isBlank()) {
+            return;
+        }
+        int slashIndex = modelId.indexOf('/');
+        if (slashIndex <= 0 || slashIndex == modelId.length() - 1) {
+            return;
+        }
+        addIfNotBlank(ids, modelId.substring(slashIndex + 1));
+    }
+
+    private static boolean intersects(Set<String> left, Set<String> right) {
+        for (String value : left) {
+            if (right.contains(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void addIfNotBlank(Set<String> ids, String modelId) {
+        if (modelId == null) {
+            return;
+        }
+        String trimmed = modelId.trim();
+        if (!trimmed.isEmpty()) {
+            ids.add(trimmed);
+        }
+    }
+
+    private static String stripOneMillionContextSuffix(String modelId) {
+        return modelId.replaceFirst("(?i)\\[1m]$", "");
+    }
+
+    private static long readMtimeSafe(Path path) {
+        try {
+            FileTime t = Files.getLastModifiedTime(path);
+            return t == null ? 0L : t.toMillis();
+        } catch (IOException e) {
+            return 0L;
+        }
+    }
+
+    /** Immutable cache entry: parsed pricing keyed by provider, plus the source file mtime. */
+    private static final class CachedPricing {
+        final long mtime;
+        final Map<String, Map<String, ModelPricing>> byProvider;
+
+        CachedPricing(long mtime, Map<String, Map<String, ModelPricing>> byProvider) {
+            this.mtime = mtime;
+            this.byProvider = byProvider;
+        }
+
+        Map<String, ModelPricing> forProvider(String provider) {
+            return byProvider.getOrDefault(provider, Map.of());
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeUsageAggregator.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeUsageAggregator.java
@@ -1,5 +1,6 @@
 package com.github.claudecodegui.provider.claude;
 
+import com.github.claudecodegui.provider.CustomPricingProvider;
 import com.github.claudecodegui.util.PathUtils;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -271,7 +272,34 @@ class ClaudeUsageAggregator {
     }
 
     private Pricing resolvePricing(String model) {
+        // User-configured pricing takes precedence over the hardcoded table. It is used for
+        // plugin-level custom models and for pricing-only Claude mapped model entries. Cache
+        // is mtime-invalidated automatically.
+        Pricing customPricing = resolveCustomPricing(model);
+        if (customPricing != null) {
+            return customPricing;
+        }
         return MODEL_PRICING.getOrDefault(normalizeModel(model), DEFAULT_PRICING);
+    }
+
+    /**
+     * Build a {@link Pricing} from user-configured pricing, or {@code null} if the
+     * model has no configured pricing. The above-200K tier fields are left {@code null} so
+     * user-configured models are billed at a flat rate. Missing fields fall back to the {@link #DEFAULT_PRICING} corresponding
+     * dimension so users can specify only the rates they know.
+     */
+    private static Pricing resolveCustomPricing(String model) {
+        if (model == null || model.isBlank()) {
+            return null;
+        }
+        return CustomPricingProvider.getInstance().getPricing("claude", model)
+                .map(p -> new Pricing(
+                        p.inputCostPer1M() != null ? p.inputCostPer1M() : DEFAULT_PRICING.inputCostPer1M(),
+                        p.outputCostPer1M() != null ? p.outputCostPer1M() : DEFAULT_PRICING.outputCostPer1M(),
+                        p.cacheWriteCostPer1M() != null ? p.cacheWriteCostPer1M() : DEFAULT_PRICING.cacheWriteCostPer1M(),
+                        p.cacheReadCostPer1M() != null ? p.cacheReadCostPer1M() : DEFAULT_PRICING.cacheReadCostPer1M(),
+                        null, null, null, null))
+                .orElse(null);
     }
 
     private String normalizeModel(String model) {

--- a/src/main/java/com/github/claudecodegui/provider/codex/CodexUsageAggregator.java
+++ b/src/main/java/com/github/claudecodegui/provider/codex/CodexUsageAggregator.java
@@ -1,5 +1,6 @@
 package com.github.claudecodegui.provider.codex;
 
+import com.github.claudecodegui.provider.CustomPricingProvider;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
@@ -279,7 +280,31 @@ class CodexUsageAggregator {
     }
 
     private Pricing resolvePricing(String model) {
+        // User-configured pricing takes precedence over the hardcoded table. It is used for
+        // plugin-level custom models and for pricing-only Claude mapped model entries. Cache
+        // is mtime-invalidated automatically.
+        Pricing customPricing = resolveCustomPricing(model);
+        if (customPricing != null) {
+            return customPricing;
+        }
         return MODEL_PRICING.getOrDefault(normalizeModel(model), DEFAULT_PRICING);
+    }
+
+    /**
+     * Build a {@link Pricing} from user-configured pricing, or {@code null} if the
+     * model has no configured pricing. Missing fields fall back to the {@link #DEFAULT_PRICING}
+     * corresponding dimension so users can specify only the rates they know.
+     */
+    private static Pricing resolveCustomPricing(String model) {
+        if (model == null || model.isBlank()) {
+            return null;
+        }
+        return CustomPricingProvider.getInstance().getPricing("codex", model)
+                .map(p -> new Pricing(
+                        p.inputCostPer1M() != null ? p.inputCostPer1M() : DEFAULT_PRICING.inputCostPer1M(),
+                        p.outputCostPer1M() != null ? p.outputCostPer1M() : DEFAULT_PRICING.outputCostPer1M(),
+                        p.cacheReadCostPer1M() != null ? p.cacheReadCostPer1M() : DEFAULT_PRICING.cacheReadCostPer1M()))
+                .orElse(null);
     }
 
     private String normalizeModel(String model) {

--- a/src/main/java/com/github/claudecodegui/settings/CodemossSettingsService.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodemossSettingsService.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1822,5 +1823,113 @@ public class CodemossSettingsService {
 
     public void saveCodexProviderOrder(List<String> orderedIds) throws IOException {
         codexProviderManager.saveProviderOrder(orderedIds);
+    }
+
+    // ==================== User Model Pricing Management ====================
+
+    /**
+     * Read user-configured model pricing for a provider family.
+     *
+     * <p>Stored under the {@code customModelPricing.{provider}} node in config.json.
+     * Entries can come from plugin-level custom models or pricing-only Claude mapped models.
+     *
+     * @param provider {@code "claude"} or {@code "codex"}
+     * @return map of model ID → pricing; empty map if none configured
+     */
+    public Map<String, ModelPricing> getCustomModelPricing(String provider) throws IOException {
+        JsonObject config = readConfig();
+        if (!config.has("customModelPricing") || !config.get("customModelPricing").isJsonObject()) {
+            return Map.of();
+        }
+        JsonObject root = config.getAsJsonObject("customModelPricing");
+        if (!root.has(provider) || !root.get(provider).isJsonObject()) {
+            return Map.of();
+        }
+
+        JsonObject providerNode = root.getAsJsonObject(provider);
+        Map<String, ModelPricing> result = new HashMap<>();
+        for (String modelId : providerNode.keySet()) {
+            if (!providerNode.get(modelId).isJsonObject()) {
+                continue;
+            }
+            JsonObject pricingNode = providerNode.getAsJsonObject(modelId);
+            result.put(modelId, parseModelPricing(pricingNode));
+        }
+        return result;
+    }
+
+    /**
+     * Persist user-configured model pricing for a provider family, replacing the whole map.
+     *
+     * @param provider {@code "claude"} or {@code "codex"}
+     * @param pricing  map of model ID → pricing; empty or null clears the provider entry
+     */
+    public void setCustomModelPricing(String provider, Map<String, ModelPricing> pricing) throws IOException {
+        JsonObject config = readConfig();
+
+        JsonObject root;
+        if (config.has("customModelPricing") && config.get("customModelPricing").isJsonObject()) {
+            root = config.getAsJsonObject("customModelPricing");
+        } else {
+            root = new JsonObject();
+            config.add("customModelPricing", root);
+        }
+
+        if (pricing == null || pricing.isEmpty()) {
+            root.remove(provider);
+        } else {
+            JsonObject providerNode = new JsonObject();
+            for (Map.Entry<String, ModelPricing> entry : pricing.entrySet()) {
+                providerNode.add(entry.getKey(), serializeModelPricing(entry.getValue()));
+            }
+            root.add(provider, providerNode);
+        }
+
+        writeConfig(config);
+        LOG.info("[CodemossSettings] Set user model pricing for " + provider
+                + ": " + (pricing == null ? 0 : pricing.size()) + " models");
+    }
+
+    private ModelPricing parseModelPricing(JsonObject node) {
+        return new ModelPricing(
+                readNullableDouble(node, "inputCostPer1M"),
+                readNullableDouble(node, "outputCostPer1M"),
+                readNullableDouble(node, "cacheWriteCostPer1M"),
+                readNullableDouble(node, "cacheReadCostPer1M")
+        );
+    }
+
+    private JsonObject serializeModelPricing(ModelPricing pricing) {
+        JsonObject node = new JsonObject();
+        if (isValidPrice(pricing.inputCostPer1M())) {
+            node.addProperty("inputCostPer1M", pricing.inputCostPer1M());
+        }
+        if (isValidPrice(pricing.outputCostPer1M())) {
+            node.addProperty("outputCostPer1M", pricing.outputCostPer1M());
+        }
+        if (isValidPrice(pricing.cacheWriteCostPer1M())) {
+            node.addProperty("cacheWriteCostPer1M", pricing.cacheWriteCostPer1M());
+        }
+        if (isValidPrice(pricing.cacheReadCostPer1M())) {
+            node.addProperty("cacheReadCostPer1M", pricing.cacheReadCostPer1M());
+        }
+        return node;
+    }
+
+    private Double readNullableDouble(JsonObject node, String key) {
+        if (node == null || !node.has(key) || node.get(key).isJsonNull()) {
+            return null;
+        }
+        try {
+            double value = node.get(key).getAsDouble();
+            return isValidPrice(value) ? value : null;
+        } catch (Exception e) {
+            LOG.warn("[CodemossSettings] Failed to parse pricing field " + key + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    private static boolean isValidPrice(Double value) {
+        return value != null && Double.isFinite(value) && value >= 0;
     }
 }

--- a/src/main/java/com/github/claudecodegui/settings/ModelPricing.java
+++ b/src/main/java/com/github/claudecodegui/settings/ModelPricing.java
@@ -1,0 +1,35 @@
+package com.github.claudecodegui.settings;
+
+/**
+ * Pricing configuration for a custom model.
+ *
+ * <p>All fields are nullable: a {@code null} field means "not configured, fall back to
+ * the default pricing for that token kind". This keeps the structure backward-compatible
+ * when new pricing dimensions are introduced and lets users specify only the rates they know.
+ *
+ * <p>Units are USD per 1,000,000 tokens, consistent with the existing {@code *CostPer1M}
+ * fields in {@link com.github.claudecodegui.provider.claude.ClaudeUsageAggregator} and
+ * {@link com.github.claudecodegui.provider.codex.CodexUsageAggregator}.
+ */
+public record ModelPricing(
+        Double inputCostPer1M,
+        Double outputCostPer1M,
+        Double cacheWriteCostPer1M,
+        Double cacheReadCostPer1M
+) {
+    /**
+     * Build a Claude-style pricing (all four dimensions).
+     */
+    public static ModelPricing claude(double input, double output, double cacheWrite, double cacheRead) {
+        return new ModelPricing(input, output, cacheWrite, cacheRead);
+    }
+
+    /**
+     * Build a Codex-style pricing (no cache-write dimension; Codex sessions do not track
+     * cache-write tokens — see {@code cacheWriteTokens = 0} in
+     * {@link com.github.claudecodegui.provider.codex.CodexUsageAggregator}).
+     */
+    public static ModelPricing codex(double input, double output, double cacheRead) {
+        return new ModelPricing(input, output, null, cacheRead);
+    }
+}

--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -17,6 +17,7 @@ import com.github.claudecodegui.handler.NodeProcessHandler;
 import com.github.claudecodegui.handler.PermissionHandler;
 import com.github.claudecodegui.handler.PromptEnhancerHandler;
 import com.github.claudecodegui.handler.PromptHandler;
+import com.github.claudecodegui.handler.provider.CustomModelPricingHandler;
 import com.github.claudecodegui.handler.provider.ProviderHandler;
 import com.github.claudecodegui.handler.RewindHandler;
 import com.github.claudecodegui.handler.SessionHandler;
@@ -247,6 +248,7 @@ public class ChatWindowDelegate {
         host.setMessageDispatcher(messageDispatcher);
 
         messageDispatcher.registerHandler(new ProviderHandler(handlerContext));
+        messageDispatcher.registerHandler(new CustomModelPricingHandler(handlerContext, settingsService));
         messageDispatcher.registerHandler(new McpServerHandler(handlerContext));
         messageDispatcher.registerHandler(new CodexMcpServerHandler(handlerContext, settingsService.getCodexMcpServerManager()));
         messageDispatcher.registerHandler(new SkillHandler(handlerContext));

--- a/src/test/java/com/github/claudecodegui/handler/provider/CustomModelPricingHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/provider/CustomModelPricingHandlerTest.java
@@ -1,0 +1,81 @@
+package com.github.claudecodegui.handler.provider;
+
+import com.github.claudecodegui.settings.CodemossSettingsService;
+import com.github.claudecodegui.settings.ModelPricing;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class CustomModelPricingHandlerTest {
+
+    @Test
+    public void shouldPersistOnlyModelsWithValidPricing() {
+        CapturingSettingsService settings = new CapturingSettingsService();
+        CustomModelPricingHandler handler = new CustomModelPricingHandler(null, settings);
+
+        boolean handled = handler.handle(CustomModelPricingHandler.SET_TYPE, """
+                {
+                  "provider": "codex",
+                  "models": [
+                    {
+                      "id": "custom-codex",
+                      "pricing": {
+                        "inputCostPer1M": 0.2,
+                        "outputCostPer1M": 0.8,
+                        "cacheReadCostPer1M": 0.02
+                      }
+                    },
+                    {
+                      "id": "default-price-model"
+                    },
+                    {
+                      "id": "partial-price-model",
+                      "pricing": {
+                        "inputCostPer1M": 0.3,
+                        "outputCostPer1M": -1
+                      }
+                    }
+                  ]
+                }
+                """);
+
+        assertTrue(handled);
+        assertEquals("codex", settings.providerRef.get());
+        Map<String, ModelPricing> savedPricing = settings.pricingRef.get();
+        assertEquals(2, savedPricing.size());
+        assertEquals(0.2, savedPricing.get("custom-codex").inputCostPer1M(), 0.000001);
+        assertEquals(0.8, savedPricing.get("custom-codex").outputCostPer1M(), 0.000001);
+        assertEquals(0.02, savedPricing.get("custom-codex").cacheReadCostPer1M(), 0.000001);
+        assertEquals(0.3, savedPricing.get("partial-price-model").inputCostPer1M(), 0.000001);
+        assertNull(savedPricing.get("partial-price-model").outputCostPer1M());
+    }
+
+    @Test
+    public void shouldIgnoreUnknownProvider() {
+        CapturingSettingsService settings = new CapturingSettingsService();
+        CustomModelPricingHandler handler = new CustomModelPricingHandler(null, settings);
+
+        boolean handled = handler.handle(CustomModelPricingHandler.SET_TYPE, "{\"provider\":\"other\",\"models\":[]}");
+
+        assertTrue(handled);
+        assertNull(settings.providerRef.get());
+        assertNull(settings.pricingRef.get());
+    }
+
+    private static final class CapturingSettingsService extends CodemossSettingsService {
+        private final AtomicReference<String> providerRef = new AtomicReference<>();
+        private final AtomicReference<Map<String, ModelPricing>> pricingRef = new AtomicReference<>();
+
+        @Override
+        public void setCustomModelPricing(String provider, Map<String, ModelPricing> pricing) throws IOException {
+            providerRef.set(provider);
+            pricingRef.set(pricing);
+        }
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/CustomPricingProviderTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/CustomPricingProviderTest.java
@@ -1,0 +1,122 @@
+package com.github.claudecodegui.provider;
+
+import com.github.claudecodegui.settings.ConfigPathManager;
+import com.github.claudecodegui.settings.ModelPricing;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CustomPricingProviderTest {
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    @Test
+    public void shouldMatchRoutePrefixedPricingWhenHistoryStoresRoutedModel() throws IOException {
+        CustomPricingProvider provider = newProvider(config(entry("ppio/pa/gpt-5.5", 2.0)));
+
+        Optional<ModelPricing> pricing = provider.getPricing("claude", "pa/gpt-5.5");
+
+        assertInputRate(pricing, 2.0);
+    }
+
+    @Test
+    public void shouldKeepExactPricingBeforeRoutePrefixFallback() throws IOException {
+        CustomPricingProvider provider = newProvider(config(String.join(",",
+                entry("pa/gpt-5.5", 1.0),
+                entry("ppio/pa/gpt-5.5", 2.0)
+        )));
+
+        Optional<ModelPricing> pricing = provider.getPricing("claude", "pa/gpt-5.5");
+
+        assertInputRate(pricing, 1.0);
+    }
+
+    @Test
+    public void shouldKeepOneMillionContextSuffixFallback() throws IOException {
+        CustomPricingProvider provider = newProvider(config(entry("deepseek-v4-pro", 3.0)));
+
+        Optional<ModelPricing> pricing = provider.getPricing("claude", "deepseek-v4-pro[1m]");
+
+        assertInputRate(pricing, 3.0);
+    }
+
+    @Test
+    public void shouldMatchConfiguredOneMillionContextSuffixWhenHistoryStoresBaseModel() throws IOException {
+        CustomPricingProvider provider = newProvider(config(entry("deepseek-v4-pro[1m]", 3.5)));
+
+        Optional<ModelPricing> pricing = provider.getPricing("claude", "deepseek-v4-pro");
+
+        assertInputRate(pricing, 3.5);
+    }
+
+    @Test
+    public void shouldMatchRoutePrefixedPricingWithOneMillionContextSuffix() throws IOException {
+        CustomPricingProvider provider = newProvider(config(entry("ppio/deepseek-v4-pro[1m]", 4.0)));
+
+        Optional<ModelPricing> pricing = provider.getPricing("claude", "deepseek-v4-pro");
+
+        assertInputRate(pricing, 4.0);
+    }
+
+    @Test
+    public void shouldNotGuessRoutePrefixPricingWhenMultipleCandidatesMatch() throws IOException {
+        CustomPricingProvider provider = newProvider(config(String.join(",",
+                entry("ppio/pa/gpt-5.5", 2.0),
+                entry("openrouter/pa/gpt-5.5", 5.0)
+        )));
+
+        Optional<ModelPricing> pricing = provider.getPricing("claude", "pa/gpt-5.5");
+
+        assertTrue(pricing.isEmpty());
+    }
+
+    private CustomPricingProvider newProvider(String configJson) throws IOException {
+        Path configPath = temp.newFile("config.json").toPath();
+        Files.writeString(configPath, configJson, StandardCharsets.UTF_8);
+        return new CustomPricingProvider(new TestConfigPathManager(configPath));
+    }
+
+    private static String config(String claudeEntries) {
+        return """
+                {
+                  "customModelPricing": {
+                    "claude": {
+                      %s
+                    }
+                  }
+                }
+                """.formatted(claudeEntries);
+    }
+
+    private static String entry(String modelId, double inputCostPer1M) {
+        return "\"%s\": {\"inputCostPer1M\": %.1f}".formatted(modelId, inputCostPer1M);
+    }
+
+    private static void assertInputRate(Optional<ModelPricing> pricing, double expected) {
+        assertTrue(pricing.isPresent());
+        assertEquals(expected, pricing.get().inputCostPer1M(), 0.000001);
+    }
+
+    private static final class TestConfigPathManager extends ConfigPathManager {
+        private final Path configPath;
+
+        private TestConfigPathManager(Path configPath) {
+            this.configPath = configPath;
+        }
+
+        @Override
+        public Path getConfigFilePath() {
+            return configPath;
+        }
+    }
+}

--- a/webview/src/components/settings/CustomModelDialog/CustomModelDialog.test.tsx
+++ b/webview/src/components/settings/CustomModelDialog/CustomModelDialog.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import CustomModelDialog from './index';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+describe('CustomModelDialog', () => {
+  it('adds a custom model with optional pricing', () => {
+    const onModelsChange = vi.fn();
+
+    render(
+      <CustomModelDialog
+        isOpen
+        models={[]}
+        onModelsChange={onModelsChange}
+        onClose={vi.fn()}
+        initialAddMode
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('settings.codexProvider.dialog.modelIdPlaceholder'), {
+      target: { value: 'vendor/custom-model' },
+    });
+    fireEvent.change(screen.getByLabelText('settings.codexProvider.dialog.modelLabelPlaceholder'), {
+      target: { value: 'Custom Model' },
+    });
+    fireEvent.change(screen.getByLabelText('settings.pluginModels.pricing.inputLabel'), {
+      target: { value: '0.2' },
+    });
+    fireEvent.change(screen.getByLabelText('settings.pluginModels.pricing.outputLabel'), {
+      target: { value: '0.8' },
+    });
+    fireEvent.change(screen.getByLabelText('settings.pluginModels.pricing.cacheReadLabel'), {
+      target: { value: '0.02' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.add' }));
+
+    expect(onModelsChange).toHaveBeenCalledWith([
+      {
+        id: 'vendor/custom-model',
+        label: 'Custom Model',
+        description: undefined,
+        pricing: {
+          inputCostPer1M: 0.2,
+          outputCostPer1M: 0.8,
+          cacheReadCostPer1M: 0.02,
+        },
+      },
+    ]);
+  });
+
+  it('blocks saving when a pricing field is negative', () => {
+    const onModelsChange = vi.fn();
+
+    render(
+      <CustomModelDialog
+        isOpen
+        models={[]}
+        onModelsChange={onModelsChange}
+        onClose={vi.fn()}
+        initialAddMode
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('settings.codexProvider.dialog.modelIdPlaceholder'), {
+      target: { value: 'vendor/custom-model' },
+    });
+    fireEvent.change(screen.getByLabelText('settings.pluginModels.pricing.inputLabel'), {
+      target: { value: '-1' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.add' }));
+
+    expect(onModelsChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert').textContent).toBe('Pricing must be a non-negative number');
+  });
+
+  it('edits pricing only for Claude models configured by the active provider', () => {
+    const onModelsChange = vi.fn();
+    const onConfiguredModelPricingChange = vi.fn();
+
+    render(
+      <CustomModelDialog
+        isOpen
+        models={[{
+          id: 'user/custom-model',
+          label: 'User Custom Model',
+        }]}
+        configuredModels={[{
+          id: 'deepseek-v4-pro[1m]',
+          label: 'deepseek-v4-pro[1m]',
+        }]}
+        onModelsChange={onModelsChange}
+        onConfiguredModelPricingChange={onConfiguredModelPricingChange}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('deepseek-v4-pro[1m]')).toBeTruthy();
+    expect(screen.getByText('settings.pluginModels.pricing.defaultPricing')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', {
+      name: 'settings.pluginModels.editPricing deepseek-v4-pro[1m]',
+    }));
+
+    expect((screen.getByLabelText('settings.codexProvider.dialog.modelIdPlaceholder') as HTMLInputElement).disabled).toBe(true);
+    expect((screen.getByLabelText('settings.codexProvider.dialog.modelLabelPlaceholder') as HTMLInputElement).disabled).toBe(true);
+    expect((screen.getByLabelText('settings.codexProvider.dialog.modelDescPlaceholder') as HTMLInputElement).disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText('settings.pluginModels.pricing.inputLabel'), {
+      target: { value: '0.2' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }));
+
+    expect(onModelsChange).not.toHaveBeenCalled();
+    expect(onConfiguredModelPricingChange).toHaveBeenCalledWith('deepseek-v4-pro[1m]', {
+      inputCostPer1M: 0.2,
+    });
+  });
+});

--- a/webview/src/components/settings/CustomModelDialog/index.tsx
+++ b/webview/src/components/settings/CustomModelDialog/index.tsx
@@ -1,18 +1,64 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { CodexCustomModel } from '../../../types/provider';
+import type { CodexCustomModel, ModelPricing } from '../../../types/provider';
 // Model ID format is intentionally not restricted — see isValidModelId() JSDoc for rationale
 import styles from './style.module.less';
 
-const DIALOG_STYLE: React.CSSProperties = { maxWidth: '500px' };
+const DIALOG_STYLE: React.CSSProperties = { maxWidth: '640px' };
 const FLEX_1_STYLE: React.CSSProperties = { flex: 1 };
 const DESC_INPUT_STYLE: React.CSSProperties = { width: '100%', marginBottom: '8px' };
 const ADD_ICON_STYLE: React.CSSProperties = { marginRight: '4px' };
+
+type PricingFieldKey = keyof ModelPricing;
+
+interface PricingFieldConfig {
+  key: PricingFieldKey;
+  labelKey: string;
+  shortLabelKey: string;
+  placeholder: string;
+}
+
+const PRICING_FIELDS: PricingFieldConfig[] = [
+  {
+    key: 'inputCostPer1M',
+    labelKey: 'settings.pluginModels.pricing.inputLabel',
+    shortLabelKey: 'settings.pluginModels.pricing.inputShort',
+    placeholder: '3.00',
+  },
+  {
+    key: 'outputCostPer1M',
+    labelKey: 'settings.pluginModels.pricing.outputLabel',
+    shortLabelKey: 'settings.pluginModels.pricing.outputShort',
+    placeholder: '15.00',
+  },
+  {
+    key: 'cacheWriteCostPer1M',
+    labelKey: 'settings.pluginModels.pricing.cacheWriteLabel',
+    shortLabelKey: 'settings.pluginModels.pricing.cacheWriteShort',
+    placeholder: '3.75',
+  },
+  {
+    key: 'cacheReadCostPer1M',
+    labelKey: 'settings.pluginModels.pricing.cacheReadLabel',
+    shortLabelKey: 'settings.pluginModels.pricing.cacheReadShort',
+    placeholder: '0.30',
+  },
+];
+
+const EMPTY_PRICING_INPUTS: Record<PricingFieldKey, string> = {
+  inputCostPer1M: '',
+  outputCostPer1M: '',
+  cacheWriteCostPer1M: '',
+  cacheReadCostPer1M: '',
+};
 
 interface CustomModelDialogProps {
   isOpen: boolean;
   models: CodexCustomModel[];
   onModelsChange: (models: CodexCustomModel[]) => void;
+  /** Models from Claude provider/settings mappings. They are already selectable; only pricing is editable here. */
+  configuredModels?: CodexCustomModel[];
+  onConfiguredModelPricingChange?: (modelId: string, pricing?: ModelPricing) => void;
   onClose: () => void;
   /** If provided, opens in add-model mode directly */
   initialAddMode?: boolean;
@@ -29,6 +75,42 @@ function sanitizeInput(value: string): string {
     .replace(/\s+/g, ' ');
 }
 
+function parsePricingInput(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return Number(trimmed);
+}
+
+function isInvalidPricingValue(value: string): boolean {
+  const parsed = parsePricingInput(value);
+  return parsed !== undefined && (!Number.isFinite(parsed) || parsed < 0);
+}
+
+function hasPricing(pricing?: ModelPricing): boolean {
+  return !!pricing && PRICING_FIELDS.some(({ key }) => pricing[key] !== undefined);
+}
+
+function formatPricingValue(value: number | undefined): string {
+  return value === undefined ? '' : String(value);
+}
+
+function buildPricing(inputs: Record<PricingFieldKey, string>): ModelPricing | undefined {
+  const pricing = PRICING_FIELDS.reduce<ModelPricing>((acc, { key }) => {
+    const parsed = parsePricingInput(inputs[key]);
+    if (parsed === undefined || !Number.isFinite(parsed) || parsed < 0) {
+      return acc;
+    }
+    return {
+      ...acc,
+      [key]: parsed,
+    };
+  }, {});
+
+  return hasPricing(pricing) ? pricing : undefined;
+}
+
 /**
  * Custom Model Management Dialog
  * Full CRUD for plugin-level custom models in a modal dialog
@@ -37,6 +119,8 @@ export function CustomModelDialog({
   isOpen,
   models,
   onModelsChange,
+  configuredModels = [],
+  onConfiguredModelPricingChange,
   onClose,
   initialAddMode = false,
 }: CustomModelDialogProps) {
@@ -45,34 +129,40 @@ export function CustomModelDialog({
   // Form state
   const [isAdding, setIsAdding] = useState(false);
   const [editingModel, setEditingModel] = useState<CodexCustomModel | null>(null);
+  const [editingConfiguredModel, setEditingConfiguredModel] = useState<CodexCustomModel | null>(null);
   const [newModelId, setNewModelId] = useState('');
   const [newModelLabel, setNewModelLabel] = useState('');
   const [newModelDesc, setNewModelDesc] = useState('');
-  const [validationError, setValidationError] = useState<string | null>(null);
+  const [newPricingInputs, setNewPricingInputs] = useState<Record<PricingFieldKey, string>>({ ...EMPTY_PRICING_INPUTS });
+  const [modelIdError, setModelIdError] = useState<string | null>(null);
+  const [pricingError, setPricingError] = useState<string | null>(null);
+
+  const resetForm = useCallback(() => {
+    setIsAdding(false);
+    setEditingModel(null);
+    setEditingConfiguredModel(null);
+    setNewModelId('');
+    setNewModelLabel('');
+    setNewModelDesc('');
+    setNewPricingInputs({ ...EMPTY_PRICING_INPUTS });
+    setModelIdError(null);
+    setPricingError(null);
+  }, []);
 
   // Auto-open add form when initialAddMode is true
   useEffect(() => {
     if (isOpen && initialAddMode) {
+      resetForm();
       setIsAdding(true);
-      setEditingModel(null);
-      setNewModelId('');
-      setNewModelLabel('');
-      setNewModelDesc('');
-      setValidationError(null);
     }
-  }, [isOpen, initialAddMode]);
+  }, [isOpen, initialAddMode, resetForm]);
 
   // Reset form state when dialog closes
   useEffect(() => {
     if (!isOpen) {
-      setIsAdding(false);
-      setEditingModel(null);
-      setNewModelId('');
-      setNewModelLabel('');
-      setNewModelDesc('');
-      setValidationError(null);
+      resetForm();
     }
-  }, [isOpen]);
+  }, [isOpen, resetForm]);
 
   // ESC key handler
   useEffect(() => {
@@ -87,7 +177,7 @@ export function CustomModelDialog({
   }, [isOpen, onClose]);
 
   const validateModelId = useCallback((id: string): string | null => {
-    const trimmedId = id.trim();
+    const trimmedId = sanitizeInput(id).trim();
     if (!trimmedId || trimmedId.length > 256) {
       return t('settings.codexProvider.dialog.modelIdRequired') || 'Model ID is required';
     }
@@ -100,58 +190,119 @@ export function CustomModelDialog({
     return null;
   }, [models, editingModel, t]);
 
+  const validatePricingInputs = useCallback((): string | null => {
+    const hasInvalidPrice = PRICING_FIELDS.some(({ key }) => isInvalidPricingValue(newPricingInputs[key]));
+    if (!hasInvalidPrice) {
+      return null;
+    }
+    return t('settings.pluginModels.pricing.invalidValue', {
+      defaultValue: 'Pricing must be a non-negative number',
+    });
+  }, [newPricingInputs, t]);
+
+  const buildModelFromForm = useCallback((): CodexCustomModel => {
+    const sanitizedId = sanitizeInput(newModelId).trim();
+    const sanitizedLabel = sanitizeInput(newModelLabel).trim();
+    const sanitizedDescription = sanitizeInput(newModelDesc).trim();
+    const pricing = buildPricing(newPricingInputs);
+    const model: CodexCustomModel = {
+      id: sanitizedId,
+      label: sanitizedLabel || sanitizedId,
+      description: sanitizedDescription || undefined,
+    };
+
+    return pricing ? { ...model, pricing } : model;
+  }, [newModelId, newModelLabel, newModelDesc, newPricingInputs]);
+
+  const validateForm = useCallback((): boolean => {
+    if (editingConfiguredModel) {
+      const priceError = validatePricingInputs();
+      if (priceError) {
+        setModelIdError(null);
+        setPricingError(priceError);
+        return false;
+      }
+      setModelIdError(null);
+      setPricingError(null);
+      return true;
+    }
+
+    const idError = validateModelId(newModelId);
+    if (idError) {
+      setModelIdError(idError);
+      setPricingError(null);
+      return false;
+    }
+
+    const priceError = validatePricingInputs();
+    if (priceError) {
+      setModelIdError(null);
+      setPricingError(priceError);
+      return false;
+    }
+
+    setModelIdError(null);
+    setPricingError(null);
+    return true;
+  }, [editingConfiguredModel, newModelId, validateModelId, validatePricingInputs]);
+
   const handleAddModel = useCallback(() => {
-    const error = validateModelId(newModelId);
-    if (error) {
-      setValidationError(error);
+    if (!validateForm()) {
       return;
     }
-    const newModel: CodexCustomModel = {
-      id: sanitizeInput(newModelId).trim(),
-      label: sanitizeInput(newModelLabel).trim() || sanitizeInput(newModelId).trim(),
-      description: sanitizeInput(newModelDesc).trim() || undefined,
-    };
-    onModelsChange([...models, newModel]);
-    setNewModelId('');
-    setNewModelLabel('');
-    setNewModelDesc('');
-    setIsAdding(false);
-    setValidationError(null);
-  }, [models, newModelId, newModelLabel, newModelDesc, onModelsChange, validateModelId]);
+
+    onModelsChange([...models, buildModelFromForm()]);
+    resetForm();
+  }, [models, onModelsChange, buildModelFromForm, resetForm, validateForm]);
 
   const handleSaveEdit = useCallback(() => {
-    if (!editingModel) return;
-    const error = validateModelId(newModelId);
-    if (error) {
-      setValidationError(error);
-      return;
-    }
-    const updatedModels = models.map(m => {
-      if (m.id === editingModel.id) {
-        return {
-          id: sanitizeInput(newModelId).trim(),
-          label: sanitizeInput(newModelLabel).trim() || sanitizeInput(newModelId).trim(),
-          description: sanitizeInput(newModelDesc).trim() || undefined,
-        };
-      }
-      return m;
-    });
+    if (!editingModel || !validateForm()) return;
+
+    const updatedModel = buildModelFromForm();
+    const updatedModels = models.map(m => (m.id === editingModel.id ? updatedModel : m));
     onModelsChange(updatedModels);
-    setEditingModel(null);
-    setNewModelId('');
-    setNewModelLabel('');
-    setNewModelDesc('');
-    setIsAdding(false);
-    setValidationError(null);
-  }, [models, editingModel, newModelId, newModelLabel, newModelDesc, onModelsChange, validateModelId]);
+    resetForm();
+  }, [models, editingModel, onModelsChange, buildModelFromForm, resetForm, validateForm]);
+
+  const handleSaveConfiguredPricing = useCallback(() => {
+    if (!editingConfiguredModel || !validateForm()) return;
+
+    onConfiguredModelPricingChange?.(editingConfiguredModel.id, buildPricing(newPricingInputs));
+    resetForm();
+  }, [editingConfiguredModel, newPricingInputs, onConfiguredModelPricingChange, resetForm, validateForm]);
 
   const handleEditModel = useCallback((model: CodexCustomModel) => {
+    setEditingConfiguredModel(null);
     setEditingModel(model);
     setNewModelId(model.id);
     setNewModelLabel(model.label);
     setNewModelDesc(model.description || '');
+    setNewPricingInputs({
+      inputCostPer1M: formatPricingValue(model.pricing?.inputCostPer1M),
+      outputCostPer1M: formatPricingValue(model.pricing?.outputCostPer1M),
+      cacheWriteCostPer1M: formatPricingValue(model.pricing?.cacheWriteCostPer1M),
+      cacheReadCostPer1M: formatPricingValue(model.pricing?.cacheReadCostPer1M),
+    });
     setIsAdding(true);
-    setValidationError(null);
+    setModelIdError(null);
+    setPricingError(null);
+  }, []);
+
+  const handleEditConfiguredModelPricing = useCallback((model: CodexCustomModel) => {
+    setEditingModel(null);
+    setEditingConfiguredModel(model);
+    setNewModelId(model.id);
+    setNewModelLabel(model.label || model.id);
+    setNewModelDesc(model.description || '');
+    setNewPricingInputs({
+      inputCostPer1M: formatPricingValue(model.pricing?.inputCostPer1M),
+      outputCostPer1M: formatPricingValue(model.pricing?.outputCostPer1M),
+      cacheWriteCostPer1M: formatPricingValue(model.pricing?.cacheWriteCostPer1M),
+      cacheReadCostPer1M: formatPricingValue(model.pricing?.cacheReadCostPer1M),
+    });
+    setIsAdding(true);
+    setModelIdError(null);
+    setPricingError(null);
   }, []);
 
   const handleRemoveModel = useCallback((id: string) => {
@@ -159,13 +310,23 @@ export function CustomModelDialog({
   }, [models, onModelsChange]);
 
   const handleCancelEdit = useCallback(() => {
-    setEditingModel(null);
-    setNewModelId('');
-    setNewModelLabel('');
-    setNewModelDesc('');
-    setIsAdding(false);
-    setValidationError(null);
-  }, []);
+    resetForm();
+  }, [resetForm]);
+
+  const getPricingSummary = useCallback((pricing?: ModelPricing): string => {
+    if (!hasPricing(pricing)) {
+      return '';
+    }
+    return PRICING_FIELDS
+      .flatMap(({ key, shortLabelKey }) => {
+        const value = pricing?.[key];
+        return value === undefined ? [] : [`${t(shortLabelKey)} $${value}/1M`];
+      })
+      .join(' | ');
+  }, [t]);
+
+  const isEditingConfiguredModel = !!editingConfiguredModel;
+  const isEditingAnyModel = !!editingModel || isEditingConfiguredModel;
 
   if (!isOpen) return null;
 
@@ -174,7 +335,7 @@ export function CustomModelDialog({
       <div className="dialog provider-dialog" style={DIALOG_STYLE}>
         <div className="dialog-header">
           <h3>{t('settings.pluginModels.dialogTitle')}</h3>
-          <button className="close-btn" onClick={onClose} title={t('common.close')}>
+          <button type="button" className="close-btn" onClick={onClose} title={t('common.close')}>
             <span className="codicon codicon-close" />
           </button>
         </div>
@@ -182,56 +343,116 @@ export function CustomModelDialog({
         <div className="dialog-body">
           <p className="dialog-desc">{t('settings.pluginModels.description')}</p>
 
-          {/* Model list */}
-          <div className={styles.modelList} role="list" aria-label={t('settings.pluginModels.dialogTitle')}>
-            {models.length === 0 && !isAdding ? (
-              <div className={styles.emptyState} role="status">
-                {t('settings.codexProvider.dialog.noCustomModels')}
-              </div>
-            ) : (
-              models.map((model) => (
-                <div key={model.id} className={styles.modelItem} role="listitem">
-                  <div className={styles.modelItemContent}>
-                    <div className={styles.modelItemId}>{model.id}</div>
-                    {model.label !== model.id && (
-                      <span className={styles.modelItemLabel}>
-                        ({model.label})
-                      </span>
-                    )}
-                    {model.description && (
-                      <div className={styles.modelItemDesc}>
-                        {model.description}
+          {configuredModels.length > 0 && (
+            <section className={styles.configuredModelsSection} aria-labelledby="configured-models-heading">
+              <h4 id="configured-models-heading" className={styles.sectionHeader}>
+                {t('settings.pluginModels.configuredSectionTitle')}
+              </h4>
+              <p className={styles.sectionHint}>
+                {t('settings.pluginModels.configuredSectionDesc')}
+              </p>
+              <div className={styles.modelList} role="list" aria-label={t('settings.pluginModels.configuredSectionTitle')}>
+                {configuredModels.map((model) => (
+                  <div key={model.id} className={styles.modelItem} role="listitem">
+                    <div className={styles.modelItemContent}>
+                      <div className={styles.modelItemId}>{model.id}</div>
+                      {model.label && model.label !== model.id && (
+                        <span className={styles.modelItemLabel}>
+                          ({model.label})
+                        </span>
+                      )}
+                      {model.description && (
+                        <div className={styles.modelItemDesc}>
+                          {model.description}
+                        </div>
+                      )}
+                      <div className={styles.modelItemPricing}>
+                        {hasPricing(model.pricing)
+                          ? getPricingSummary(model.pricing)
+                          : t('settings.pluginModels.pricing.defaultPricing')}
                       </div>
-                    )}
+                    </div>
+                    <div className={styles.modelItemActions}>
+                      <button
+                        type="button"
+                        className={styles.iconBtn}
+                        onClick={() => handleEditConfiguredModelPricing(model)}
+                        title={t('settings.pluginModels.editPricing')}
+                        aria-label={`${t('settings.pluginModels.editPricing')} ${model.id}`}
+                      >
+                        <span className="codicon codicon-edit" aria-hidden="true" />
+                      </button>
+                    </div>
                   </div>
-                  <div className={styles.modelItemActions}>
-                    <button
-                      type="button"
-                      className={styles.iconBtn}
-                      onClick={() => handleEditModel(model)}
-                      title={t('common.edit')}
-                      aria-label={`${t('common.edit')} ${model.id}`}
-                    >
-                      <span className="codicon codicon-edit" aria-hidden="true" />
-                    </button>
-                    <button
-                      type="button"
-                      className={styles.iconBtnDanger}
-                      onClick={() => handleRemoveModel(model.id)}
-                      title={t('common.delete')}
-                      aria-label={`${t('common.delete')} ${model.id}`}
-                    >
-                      <span className="codicon codicon-trash" aria-hidden="true" />
-                    </button>
-                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          <section aria-labelledby="custom-models-heading">
+            <h4 id="custom-models-heading" className={styles.sectionHeader}>
+              {t('settings.pluginModels.customSectionTitle')}
+            </h4>
+            <div className={styles.modelList} role="list" aria-label={t('settings.pluginModels.customSectionTitle')}>
+              {models.length === 0 && !isAdding ? (
+                <div className={styles.emptyState} role="status">
+                  {t('settings.codexProvider.dialog.noCustomModels')}
                 </div>
-              ))
-            )}
-          </div>
+              ) : (
+                models.map((model) => (
+                  <div key={model.id} className={styles.modelItem} role="listitem">
+                    <div className={styles.modelItemContent}>
+                      <div className={styles.modelItemId}>{model.id}</div>
+                      {model.label !== model.id && (
+                        <span className={styles.modelItemLabel}>
+                          ({model.label})
+                        </span>
+                      )}
+                      {model.description && (
+                        <div className={styles.modelItemDesc}>
+                          {model.description}
+                        </div>
+                      )}
+                      {hasPricing(model.pricing) && (
+                        <div className={styles.modelItemPricing}>
+                          {getPricingSummary(model.pricing)}
+                        </div>
+                      )}
+                    </div>
+                    <div className={styles.modelItemActions}>
+                      <button
+                        type="button"
+                        className={styles.iconBtn}
+                        onClick={() => handleEditModel(model)}
+                        title={t('common.edit')}
+                        aria-label={`${t('common.edit')} ${model.id}`}
+                      >
+                        <span className="codicon codicon-edit" aria-hidden="true" />
+                      </button>
+                      <button
+                        type="button"
+                        className={styles.iconBtnDanger}
+                        onClick={() => handleRemoveModel(model.id)}
+                        title={t('common.delete')}
+                        aria-label={`${t('common.delete')} ${model.id}`}
+                      >
+                        <span className="codicon codicon-trash" aria-hidden="true" />
+                      </button>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
 
           {/* Add/edit form */}
           {isAdding ? (
-            <div className={styles.addEditForm} role="form" aria-label={editingModel ? t('common.edit') : t('common.add')}>
+            <div className={styles.addEditForm} role="form" aria-label={isEditingAnyModel ? t('common.edit') : t('common.add')}>
+              {isEditingConfiguredModel && (
+                <p className={styles.sectionHint}>
+                  {t('settings.pluginModels.configuredEditHint')}
+                </p>
+              )}
               <div className={styles.formRow}>
                 <label htmlFor="model-id-input" className="sr-only">
                   {t('settings.codexProvider.dialog.modelIdPlaceholder')}
@@ -239,14 +460,15 @@ export function CustomModelDialog({
                 <input
                   id="model-id-input"
                   type="text"
-                  className={`form-input ${validationError ? 'input-error' : ''}`}
+                  className={`form-input ${modelIdError ? 'input-error' : ''}`}
                   placeholder={t('settings.codexProvider.dialog.modelIdPlaceholder')}
                   value={newModelId}
-                  onChange={(e) => { setNewModelId(e.target.value); if (validationError) setValidationError(null); }}
+                  onChange={(e) => { setNewModelId(e.target.value); if (modelIdError) setModelIdError(null); }}
                   style={FLEX_1_STYLE}
-                  autoFocus
-                  aria-invalid={!!validationError}
-                  aria-describedby={validationError ? 'model-id-error' : undefined}
+                  autoFocus={!isEditingConfiguredModel}
+                  disabled={isEditingConfiguredModel}
+                  aria-invalid={!!modelIdError}
+                  aria-describedby={modelIdError ? 'model-id-error' : undefined}
                 />
                 <label htmlFor="model-label-input" className="sr-only">
                   {t('settings.codexProvider.dialog.modelLabelPlaceholder')}
@@ -259,11 +481,12 @@ export function CustomModelDialog({
                   value={newModelLabel}
                   onChange={(e) => setNewModelLabel(e.target.value)}
                   style={FLEX_1_STYLE}
+                  disabled={isEditingConfiguredModel}
                 />
               </div>
-              {validationError && (
+              {modelIdError && (
                 <div id="model-id-error" className={styles.validationError} role="alert">
-                  {validationError}
+                  {modelIdError}
                 </div>
               )}
               <label htmlFor="model-desc-input" className="sr-only">
@@ -277,17 +500,61 @@ export function CustomModelDialog({
                 value={newModelDesc}
                 onChange={(e) => setNewModelDesc(e.target.value)}
                 style={DESC_INPUT_STYLE}
+                disabled={isEditingConfiguredModel}
               />
+
+              <fieldset className={styles.pricingFieldset}>
+                <legend className={styles.pricingLegend}>{t('settings.pluginModels.pricing.title')}</legend>
+                <p id="model-pricing-hint" className={styles.pricingHint}>
+                  {t('settings.pluginModels.pricing.hint')}
+                </p>
+                <div className={styles.pricingGrid}>
+                  {PRICING_FIELDS.map((field) => {
+                    const value = newPricingInputs[field.key];
+                    const invalid = isInvalidPricingValue(value);
+                    return (
+                      <div key={field.key} className={styles.pricingField}>
+                        <label htmlFor={`model-pricing-${field.key}`}>
+                          {t(field.labelKey)}
+                        </label>
+                        <input
+                          id={`model-pricing-${field.key}`}
+                          type="number"
+                          min="0"
+                          step="0.000001"
+                          inputMode="decimal"
+                          className={`form-input ${invalid ? 'input-error' : ''}`}
+                          placeholder={field.placeholder}
+                          value={value}
+                          onChange={(e) => {
+                            setNewPricingInputs(prev => ({ ...prev, [field.key]: e.target.value }));
+                            if (pricingError) setPricingError(null);
+                          }}
+                          aria-invalid={invalid}
+                          aria-describedby={pricingError ? 'model-pricing-hint model-pricing-error' : 'model-pricing-hint'}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+                {pricingError && (
+                  <div id="model-pricing-error" className={styles.validationError} role="alert">
+                    {pricingError}
+                  </div>
+                )}
+              </fieldset>
+
               <div className={styles.formActions}>
-                <button className="btn btn-secondary btn-sm" onClick={handleCancelEdit}>
+                <button type="button" className="btn btn-secondary btn-sm" onClick={handleCancelEdit}>
                   {t('common.cancel')}
                 </button>
                 <button
+                  type="button"
                   className="btn btn-primary btn-sm"
-                  onClick={editingModel ? handleSaveEdit : handleAddModel}
+                  onClick={isEditingConfiguredModel ? handleSaveConfiguredPricing : editingModel ? handleSaveEdit : handleAddModel}
                   disabled={!newModelId.trim()}
                 >
-                  {editingModel ? t('common.save') : t('common.add')}
+                  {isEditingAnyModel ? t('common.save') : t('common.add')}
                 </button>
               </div>
             </div>
@@ -307,7 +574,7 @@ export function CustomModelDialog({
         <div className="dialog-footer">
           <div className={styles.dialogFooterSpacer} />
           <div className="footer-actions">
-            <button className="btn btn-primary" onClick={onClose}>
+            <button type="button" className="btn btn-primary" onClick={onClose}>
               {t('common.close')}
             </button>
           </div>

--- a/webview/src/components/settings/CustomModelDialog/style.module.less
+++ b/webview/src/components/settings/CustomModelDialog/style.module.less
@@ -2,6 +2,23 @@
   margin-bottom: 12px;
 }
 
+.configuredModelsSection {
+  margin-bottom: 16px;
+}
+
+.sectionHeader {
+  margin: 12px 0 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.sectionHint {
+  margin: 0 0 8px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
 .emptyState {
   padding: 16px;
   text-align: center;
@@ -40,6 +57,12 @@
   margin-top: 2px;
 }
 
+.modelItemPricing {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-top: 4px;
+}
+
 .modelItemActions {
   display: flex;
   gap: 4px;
@@ -76,6 +99,42 @@
   color: var(--error-color, #f44336);
   font-size: 12px;
   margin-bottom: 8px;
+}
+
+.pricingFieldset {
+  border: 1px solid var(--border-secondary);
+  border-radius: 4px;
+  padding: 10px;
+  margin: 0 0 12px;
+}
+
+.pricingLegend {
+  padding: 0 4px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.pricingHint {
+  margin: 0 0 8px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+.pricingGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.pricingField {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pricingField label {
+  font-size: 11px;
+  color: var(--text-secondary);
 }
 
 .formActions {

--- a/webview/src/components/settings/ProviderTabSection/index.tsx
+++ b/webview/src/components/settings/ProviderTabSection/index.tsx
@@ -6,6 +6,7 @@ import ProviderManageSection from '../ProviderManageSection';
 import CodexProviderSection from '../CodexProviderSection';
 import CustomModelDialog from '../CustomModelDialog';
 import { usePluginModels } from '../hooks/usePluginModels';
+import { useConfiguredClaudeModelPricing } from '../hooks/useConfiguredModelPricing';
 import styles from './style.module.less';
 
 const BLOCK_STYLE: React.CSSProperties = { display: 'block' };
@@ -60,6 +61,7 @@ const ProviderTabSection = ({
   // Plugin-level custom model management
   const claudeModels = usePluginModels(STORAGE_KEYS.CLAUDE_CUSTOM_MODELS);
   const codexModels = usePluginModels(STORAGE_KEYS.CODEX_CUSTOM_MODELS);
+  const claudeConfiguredModelPricing = useConfiguredClaudeModelPricing(claudeModels.models);
 
   // Dialog state
   const [modelDialogOpen, setModelDialogOpen] = useState(false);
@@ -184,6 +186,12 @@ const ProviderTabSection = ({
         isOpen={modelDialogOpen}
         models={activeModels.models}
         onModelsChange={activeModels.updateModels}
+        configuredModels={dialogTarget === 'claude' ? claudeConfiguredModelPricing.configuredModels : []}
+        onConfiguredModelPricingChange={
+          dialogTarget === 'claude'
+            ? claudeConfiguredModelPricing.updateConfiguredModelPricing
+            : undefined
+        }
         onClose={closeModelDialog}
         initialAddMode={modelDialogAddMode}
       />

--- a/webview/src/components/settings/hooks/useConfiguredModelPricing.test.ts
+++ b/webview/src/components/settings/hooks/useConfiguredModelPricing.test.ts
@@ -1,0 +1,131 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { STORAGE_KEYS } from '../../../types/provider';
+import { useConfiguredClaudeModelPricing } from './useConfiguredModelPricing';
+
+const sendBridgeEventMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../utils/bridge', () => ({
+  sendBridgeEvent: (...args: unknown[]) => sendBridgeEventMock(...args),
+}));
+
+describe('useConfiguredClaudeModelPricing', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sendBridgeEventMock.mockClear();
+  });
+
+  it('exposes unique active Claude mapping models with pricing-only metadata', () => {
+    localStorage.setItem(STORAGE_KEYS.CLAUDE_MODEL_MAPPING, JSON.stringify({
+      sonnet: 'deepseek-v4-pro[1m]',
+      opus: 'deepseek-v4-pro[1m]',
+      haiku: 'deepseek-v4-flash',
+    }));
+    localStorage.setItem(STORAGE_KEYS.CLAUDE_CONFIGURED_MODEL_PRICING, JSON.stringify({
+      'deepseek-v4-pro': { inputCostPer1M: 0.2 },
+    }));
+
+    const { result } = renderHook(() => useConfiguredClaudeModelPricing([]));
+
+    expect(result.current.configuredModels).toEqual([
+      {
+        id: 'deepseek-v4-flash',
+        label: 'deepseek-v4-flash',
+        pricing: undefined,
+      },
+      {
+        id: 'deepseek-v4-pro[1m]',
+        label: 'deepseek-v4-pro[1m]',
+        pricing: { inputCostPer1M: 0.2 },
+      },
+    ]);
+  });
+
+  it('persists configured model pricing by base model id and syncs it to Java', () => {
+    localStorage.setItem(STORAGE_KEYS.CLAUDE_MODEL_MAPPING, JSON.stringify({
+      sonnet: 'deepseek-v4-pro[1m]',
+    }));
+
+    const { result } = renderHook(() => useConfiguredClaudeModelPricing([]));
+
+    act(() => {
+      result.current.updateConfiguredModelPricing('deepseek-v4-pro[1m]', {
+        inputCostPer1M: 0.2,
+        outputCostPer1M: 0.8,
+      });
+    });
+
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEYS.CLAUDE_CONFIGURED_MODEL_PRICING) || '{}')).toEqual({
+      'deepseek-v4-pro': {
+        inputCostPer1M: 0.2,
+        outputCostPer1M: 0.8,
+      },
+    });
+    expect(sendBridgeEventMock).toHaveBeenLastCalledWith('set_custom_model_pricing', JSON.stringify({
+      provider: 'claude',
+      models: [{
+        id: 'deepseek-v4-pro',
+        label: 'deepseek-v4-pro',
+        pricing: {
+          inputCostPer1M: 0.2,
+          outputCostPer1M: 0.8,
+        },
+      }],
+    }));
+  });
+
+  it('keeps configured model pricing visible even if a user custom model has the same base id', () => {
+    localStorage.setItem(STORAGE_KEYS.CLAUDE_MODEL_MAPPING, JSON.stringify({
+      sonnet: 'deepseek-v4-pro[1m]',
+    }));
+
+    const { result } = renderHook(() => useConfiguredClaudeModelPricing([
+      {
+        id: 'deepseek-v4-pro',
+        label: 'DeepSeek Custom',
+      },
+    ]));
+
+    expect(result.current.configuredModels).toEqual([{
+      id: 'deepseek-v4-pro[1m]',
+      label: 'deepseek-v4-pro[1m]',
+      pricing: undefined,
+    }]);
+  });
+
+  it('keeps configured pricing in Java sync payload when user custom models exist', () => {
+    localStorage.setItem(STORAGE_KEYS.CLAUDE_MODEL_MAPPING, JSON.stringify({
+      sonnet: 'deepseek-v4-pro[1m]',
+    }));
+
+    const { result } = renderHook(() => useConfiguredClaudeModelPricing([
+      {
+        id: 'vendor/custom-claude',
+        label: 'Custom Claude',
+        pricing: { inputCostPer1M: 0.1 },
+      },
+    ]));
+
+    act(() => {
+      result.current.updateConfiguredModelPricing('deepseek-v4-pro[1m]', {
+        inputCostPer1M: 0.2,
+      });
+    });
+
+    expect(sendBridgeEventMock).toHaveBeenLastCalledWith('set_custom_model_pricing', JSON.stringify({
+      provider: 'claude',
+      models: [
+        {
+          id: 'vendor/custom-claude',
+          label: 'Custom Claude',
+          pricing: { inputCostPer1M: 0.1 },
+        },
+        {
+          id: 'deepseek-v4-pro',
+          label: 'deepseek-v4-pro',
+          pricing: { inputCostPer1M: 0.2 },
+        },
+      ],
+    }));
+  });
+});

--- a/webview/src/components/settings/hooks/useConfiguredModelPricing.ts
+++ b/webview/src/components/settings/hooks/useConfiguredModelPricing.ts
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { CodexCustomModel, ModelPricing } from '../../../types/provider';
+import { isValidModelPricing, STORAGE_KEYS } from '../../../types/provider';
+import type { ClaudeModelMapping } from '../../../utils/claudeModelMapping';
+import { readClaudeModelMapping } from '../../../utils/claudeModelMapping';
+import { sendBridgeEvent } from '../../../utils/bridge';
+
+function normalizeModelId(modelId: string): string {
+  return modelId.trim();
+}
+
+function normalizeComparableModelId(modelId: string): string {
+  return normalizeModelId(modelId).replace(/\[1m\]$/i, '');
+}
+
+function readPricingMap(storageKey: string): Record<string, ModelPricing> {
+  try {
+    const stored = localStorage.getItem(storageKey);
+    if (!stored) {
+      return {};
+    }
+    const parsed = JSON.parse(stored);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+
+    return Object.entries(parsed as Record<string, unknown>).reduce<Record<string, ModelPricing>>((acc, [modelId, pricing]) => {
+      const normalizedModelId = normalizeModelId(modelId);
+      const pricingModelId = normalizeComparableModelId(normalizedModelId);
+      if (pricingModelId && isValidModelPricing(pricing)) {
+        acc[pricingModelId] = pricing as ModelPricing;
+      }
+      return acc;
+    }, {});
+  } catch {
+    return {};
+  }
+}
+
+function pricingMapToModels(pricingByModel: Record<string, ModelPricing>): CodexCustomModel[] {
+  return Object.entries(pricingByModel).map(([id, pricing]) => ({
+    id,
+    label: id,
+    pricing,
+  }));
+}
+
+function writePricingMap(storageKey: string, pricingByModel: Record<string, ModelPricing>) {
+  try {
+    if (Object.keys(pricingByModel).length === 0) {
+      localStorage.removeItem(storageKey);
+    } else {
+      localStorage.setItem(storageKey, JSON.stringify(pricingByModel));
+    }
+    window.dispatchEvent(new CustomEvent('localStorageChange', { detail: { key: storageKey } }));
+  } catch {
+    // localStorage write failure (for example quota exceeded)
+  }
+}
+
+function mappingValues(mapping: ClaudeModelMapping): string[] {
+  const values = [mapping.main, mapping.haiku, mapping.sonnet, mapping.opus];
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  values.forEach(value => {
+    const modelId = normalizeModelId(value || '');
+    if (!modelId) {
+      return;
+    }
+    const comparable = normalizeComparableModelId(modelId).toLowerCase();
+    if (seen.has(comparable)) {
+      return;
+    }
+    seen.add(comparable);
+    result.push(modelId);
+  });
+
+  return result;
+}
+
+function mergeConfiguredPricingModels(
+  customModels: CodexCustomModel[],
+  configuredPricingModels: CodexCustomModel[],
+): CodexCustomModel[] {
+  return [...customModels, ...configuredPricingModels];
+}
+
+function syncClaudePricingModels(customModels: CodexCustomModel[], configuredPricingModels: CodexCustomModel[]) {
+  sendBridgeEvent('set_custom_model_pricing', JSON.stringify({
+    provider: 'claude',
+    models: mergeConfiguredPricingModels(customModels, configuredPricingModels),
+  }));
+}
+
+/**
+ * Manages pricing for Claude models that come from provider/settings.json mappings.
+ *
+ * These models are already selectable through the mapped built-in Claude entries, so this hook
+ * stores only pricing metadata and never adds them to the custom model selector list.
+ */
+export function useConfiguredClaudeModelPricing(customModels: CodexCustomModel[]) {
+  const [pricingByModel, setPricingByModel] = useState<Record<string, ModelPricing>>(
+    () => readPricingMap(STORAGE_KEYS.CLAUDE_CONFIGURED_MODEL_PRICING),
+  );
+  const [mappingVersion, setMappingVersion] = useState(0);
+
+  useEffect(() => {
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEYS.CLAUDE_CONFIGURED_MODEL_PRICING) {
+        setPricingByModel(readPricingMap(STORAGE_KEYS.CLAUDE_CONFIGURED_MODEL_PRICING));
+      }
+      if (e.key === STORAGE_KEYS.CLAUDE_MODEL_MAPPING) {
+        setMappingVersion(version => version + 1);
+      }
+    };
+    const handleCustomChange = (e: Event) => {
+      const detail = (e as CustomEvent<{ key?: string }>).detail;
+      if (detail?.key === STORAGE_KEYS.CLAUDE_CONFIGURED_MODEL_PRICING) {
+        setPricingByModel(readPricingMap(STORAGE_KEYS.CLAUDE_CONFIGURED_MODEL_PRICING));
+      }
+      if (detail?.key === STORAGE_KEYS.CLAUDE_MODEL_MAPPING) {
+        setMappingVersion(version => version + 1);
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    window.addEventListener('localStorageChange', handleCustomChange);
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+      window.removeEventListener('localStorageChange', handleCustomChange);
+    };
+  }, []);
+
+  const configuredModels = useMemo<CodexCustomModel[]>(() => {
+    const mappedModels = mappingValues(readClaudeModelMapping());
+    return mappedModels.map(modelId => ({
+      id: modelId,
+      label: modelId,
+      pricing: pricingByModel[normalizeComparableModelId(modelId)],
+    }));
+  }, [mappingVersion, pricingByModel]);
+
+  const updateConfiguredModelPricing = useCallback((modelId: string, pricing?: ModelPricing) => {
+    const normalizedModelId = normalizeModelId(modelId);
+    const pricingModelId = normalizeComparableModelId(normalizedModelId);
+    if (!pricingModelId) {
+      return;
+    }
+
+    const nextPricingByModel = {
+      ...readPricingMap(STORAGE_KEYS.CLAUDE_CONFIGURED_MODEL_PRICING),
+      ...pricingByModel,
+    };
+    if (pricing && isValidModelPricing(pricing)) {
+      nextPricingByModel[pricingModelId] = pricing;
+    } else {
+      delete nextPricingByModel[pricingModelId];
+    }
+
+    setPricingByModel(nextPricingByModel);
+    writePricingMap(STORAGE_KEYS.CLAUDE_CONFIGURED_MODEL_PRICING, nextPricingByModel);
+
+    syncClaudePricingModels(customModels, pricingMapToModels(nextPricingByModel));
+  }, [customModels, pricingByModel]);
+
+  return {
+    configuredModels,
+    updateConfiguredModelPricing,
+  };
+}

--- a/webview/src/components/settings/hooks/usePluginModels.test.ts
+++ b/webview/src/components/settings/hooks/usePluginModels.test.ts
@@ -1,0 +1,160 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { STORAGE_KEYS } from '../../../types/provider';
+import { usePluginModels } from './usePluginModels';
+
+const sendBridgeEventMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../utils/bridge', () => ({
+  sendBridgeEvent: (...args: unknown[]) => sendBridgeEventMock(...args),
+}));
+
+describe('usePluginModels', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sendBridgeEventMock.mockClear();
+  });
+
+  it('persists custom pricing locally and syncs it to Java for Claude models', () => {
+    const { result } = renderHook(() => usePluginModels(STORAGE_KEYS.CLAUDE_CUSTOM_MODELS));
+
+    act(() => {
+      result.current.updateModels([
+        {
+          id: 'vendor/custom-claude',
+          label: 'Custom Claude',
+          pricing: {
+            inputCostPer1M: 0.2,
+            outputCostPer1M: 0.8,
+            cacheWriteCostPer1M: 0.25,
+            cacheReadCostPer1M: 0.02,
+          },
+        },
+      ]);
+    });
+
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEYS.CLAUDE_CUSTOM_MODELS) || '[]')).toEqual([
+      {
+        id: 'vendor/custom-claude',
+        label: 'Custom Claude',
+        pricing: {
+          inputCostPer1M: 0.2,
+          outputCostPer1M: 0.8,
+          cacheWriteCostPer1M: 0.25,
+          cacheReadCostPer1M: 0.02,
+        },
+      },
+    ]);
+    expect(sendBridgeEventMock).toHaveBeenLastCalledWith('set_custom_model_pricing', JSON.stringify({
+      provider: 'claude',
+      models: [
+        {
+          id: 'vendor/custom-claude',
+          label: 'Custom Claude',
+          pricing: {
+            inputCostPer1M: 0.2,
+            outputCostPer1M: 0.8,
+            cacheWriteCostPer1M: 0.25,
+            cacheReadCostPer1M: 0.02,
+          },
+        },
+      ],
+    }));
+  });
+
+  it('keeps configured Claude model pricing when syncing user custom models', () => {
+    localStorage.setItem(STORAGE_KEYS.CLAUDE_CONFIGURED_MODEL_PRICING, JSON.stringify({
+      'deepseek-v4-pro': {
+        inputCostPer1M: 0.2,
+        outputCostPer1M: 0.8,
+      },
+    }));
+    const { result } = renderHook(() => usePluginModels(STORAGE_KEYS.CLAUDE_CUSTOM_MODELS));
+
+    act(() => {
+      result.current.updateModels([
+        {
+          id: 'vendor/custom-claude',
+          label: 'Custom Claude',
+          pricing: { inputCostPer1M: 0.1 },
+        },
+      ]);
+    });
+
+    expect(sendBridgeEventMock).toHaveBeenLastCalledWith('set_custom_model_pricing', JSON.stringify({
+      provider: 'claude',
+      models: [
+        {
+          id: 'vendor/custom-claude',
+          label: 'Custom Claude',
+          pricing: { inputCostPer1M: 0.1 },
+        },
+        {
+          id: 'deepseek-v4-pro',
+          label: 'deepseek-v4-pro',
+          pricing: {
+            inputCostPer1M: 0.2,
+            outputCostPer1M: 0.8,
+          },
+        },
+      ],
+    }));
+  });
+
+  it('syncs configured pricing after a same-base user custom model so configured model cost still wins', () => {
+    localStorage.setItem(STORAGE_KEYS.CLAUDE_CONFIGURED_MODEL_PRICING, JSON.stringify({
+      'deepseek-v4-pro': {
+        inputCostPer1M: 0.2,
+      },
+    }));
+    const { result } = renderHook(() => usePluginModels(STORAGE_KEYS.CLAUDE_CUSTOM_MODELS));
+
+    act(() => {
+      result.current.updateModels([
+        {
+          id: 'deepseek-v4-pro[1m]',
+          label: 'DeepSeek custom',
+          pricing: { inputCostPer1M: 0.3 },
+        },
+      ]);
+    });
+
+    expect(sendBridgeEventMock).toHaveBeenLastCalledWith('set_custom_model_pricing', JSON.stringify({
+      provider: 'claude',
+      models: [
+        {
+          id: 'deepseek-v4-pro[1m]',
+          label: 'DeepSeek custom',
+          pricing: { inputCostPer1M: 0.3 },
+        },
+        {
+          id: 'deepseek-v4-pro',
+          label: 'deepseek-v4-pro',
+          pricing: { inputCostPer1M: 0.2 },
+        },
+      ],
+    }));
+  });
+
+  it('filters invalid pricing before persisting and syncing Codex models', () => {
+    const { result } = renderHook(() => usePluginModels(STORAGE_KEYS.CODEX_CUSTOM_MODELS));
+
+    act(() => {
+      result.current.updateModels([
+        { id: 'valid-codex', label: 'Valid Codex', pricing: { inputCostPer1M: 0.1 } },
+        { id: 'invalid-codex', label: 'Invalid Codex', pricing: { inputCostPer1M: -1 } },
+      ]);
+    });
+
+    const expectedModels = [
+      { id: 'valid-codex', label: 'Valid Codex', pricing: { inputCostPer1M: 0.1 } },
+    ];
+
+    expect(result.current.models).toEqual(expectedModels);
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEYS.CODEX_CUSTOM_MODELS) || '[]')).toEqual(expectedModels);
+    expect(sendBridgeEventMock).toHaveBeenLastCalledWith('set_custom_model_pricing', JSON.stringify({
+      provider: 'codex',
+      models: expectedModels,
+    }));
+  });
+});

--- a/webview/src/components/settings/hooks/usePluginModels.ts
+++ b/webview/src/components/settings/hooks/usePluginModels.ts
@@ -1,6 +1,12 @@
 import { useState, useCallback, useEffect } from 'react';
-import type { CodexCustomModel } from '../../../types/provider';
-import { validateCodexCustomModels } from '../../../types/provider';
+import type { CodexCustomModel, ModelPricing } from '../../../types/provider';
+import { isValidModelPricing, STORAGE_KEYS, validateCodexCustomModels } from '../../../types/provider';
+import { sendBridgeEvent } from '../../../utils/bridge';
+
+const STORAGE_KEY_TO_PROVIDER: Partial<Record<string, 'claude' | 'codex'>> = {
+  [STORAGE_KEYS.CLAUDE_CUSTOM_MODELS]: 'claude',
+  [STORAGE_KEYS.CODEX_CUSTOM_MODELS]: 'codex',
+};
 
 /**
  * Read plugin-level custom models from localStorage
@@ -26,6 +32,57 @@ function writePluginModels(storageKey: string, models: CodexCustomModel[]) {
   } catch {
     // localStorage write failure (e.g. quota exceeded)
   }
+}
+
+function readConfiguredClaudePricingModels(): CodexCustomModel[] {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEYS.CLAUDE_CONFIGURED_MODEL_PRICING);
+    if (!stored) {
+      return [];
+    }
+    const parsed = JSON.parse(stored);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return [];
+    }
+    return Object.entries(parsed as Record<string, unknown>)
+      .filter(([id, pricing]) => id.trim() && isValidModelPricing(pricing))
+      .map(([id, pricing]) => ({
+        id: normalizeComparableModelId(id.trim()),
+        label: normalizeComparableModelId(id.trim()),
+        pricing: pricing as ModelPricing,
+      }))
+      .filter(model => model.id);
+  } catch {
+    return [];
+  }
+}
+
+function normalizeComparableModelId(modelId: string): string {
+  return modelId.trim().replace(/\[1m\]$/i, '');
+}
+
+/**
+ * Mirror custom model pricing into the Java config file used by usage aggregators.
+ * The complete model list is sent because deleting a model or clearing all pricing
+ * must replace the provider's persisted pricing map, not merge with stale entries.
+ */
+function syncCustomModelPricing(storageKey: string, models: CodexCustomModel[]) {
+  const provider = STORAGE_KEY_TO_PROVIDER[storageKey];
+  if (!provider) {
+    return;
+  }
+
+  const syncModels = provider === 'claude'
+    ? [
+      ...models,
+      ...readConfiguredClaudePricingModels(),
+    ]
+    : models;
+
+  sendBridgeEvent('set_custom_model_pricing', JSON.stringify({
+    provider,
+    models: syncModels,
+  }));
 }
 
 /** Custom event detail shape for localStorageChange */
@@ -61,8 +118,10 @@ export function usePluginModels(storageKey: string) {
   }, [storageKey]);
 
   const updateModels = useCallback((newModels: CodexCustomModel[]) => {
-    setModels(newModels);
-    writePluginModels(storageKey, newModels);
+    const validModels = validateCodexCustomModels(newModels);
+    setModels(validModels);
+    writePluginModels(storageKey, validModels);
+    syncCustomModelPricing(storageKey, validModels);
   }, [storageKey]);
 
   return { models, updateModels };

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -335,7 +335,26 @@
       "title": "Custom Models",
       "description": "Custom models added here will be visible under all providers, shown at the top of the model selector",
       "dialogTitle": "Manage Custom Models",
-      "manage": "Manage Models"
+      "manage": "Manage Models",
+      "pricing": {
+        "title": "Pricing (USD per 1M tokens)",
+        "hint": "Optional. Leave a field empty to use the default rate for that token type.",
+        "inputLabel": "Input",
+        "outputLabel": "Output",
+        "cacheWriteLabel": "Cache write",
+        "cacheReadLabel": "Cache read",
+        "inputShort": "In",
+        "outputShort": "Out",
+        "cacheWriteShort": "Cache write",
+        "cacheReadShort": "Cache read",
+        "invalidValue": "Pricing must be a non-negative number",
+        "defaultPricing": "Using default pricing"
+      },
+      "configuredSectionTitle": "Configured Claude models",
+      "configuredSectionDesc": "Models from the active Claude provider/settings.json are already in the selector. Only pricing can be changed here.",
+      "configuredEditHint": "This model is managed by the active Claude provider/settings.json. Only pricing can be changed here.",
+      "customSectionTitle": "Custom models",
+      "editPricing": "Edit pricing"
     },
     "dependencies": "SDK Dependencies",
     "dependenciesDesc": "Manage AI SDK dependency installations and updates",

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -282,7 +282,26 @@
       "title": "Modelos personalizados",
       "description": "Los modelos personalizados agregados aquí serán visibles en todos los proveedores, mostrados en la parte superior de la lista de selección de modelos",
       "dialogTitle": "Gestionar modelos personalizados",
-      "manage": "Gestionar modelos"
+      "manage": "Gestionar modelos",
+      "pricing": {
+        "title": "Precio (USD por 1M tokens)",
+        "hint": "Opcional. Deja un campo vacío para usar la tarifa predeterminada de ese tipo de token.",
+        "inputLabel": "Entrada",
+        "outputLabel": "Salida",
+        "cacheWriteLabel": "Escritura de caché",
+        "cacheReadLabel": "Lectura de caché",
+        "inputShort": "Entrada",
+        "outputShort": "Salida",
+        "cacheWriteShort": "Escritura de caché",
+        "cacheReadShort": "Lectura de caché",
+        "invalidValue": "El precio debe ser un número no negativo",
+        "defaultPricing": "Using default pricing"
+      },
+      "configuredSectionTitle": "Configured Claude models",
+      "configuredSectionDesc": "Models from the active Claude provider/settings.json are already in the selector. Only pricing can be changed here.",
+      "configuredEditHint": "This model is managed by the active Claude provider/settings.json. Only pricing can be changed here.",
+      "customSectionTitle": "Custom models",
+      "editPricing": "Edit pricing"
     },
     "dependencies": "Dependencias SDK",
     "dependenciesDesc": "Gestionar instalaciones y actualizaciones de dependencias AI SDK",

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -282,7 +282,26 @@
       "title": "Modèles personnalisés",
       "description": "Les modèles personnalisés ajoutés ici seront visibles sous tous les fournisseurs, affichés en haut de la liste de sélection de modèles",
       "dialogTitle": "Gérer les modèles personnalisés",
-      "manage": "Gérer les modèles"
+      "manage": "Gérer les modèles",
+      "pricing": {
+        "title": "Tarif (USD par 1M de tokens)",
+        "hint": "Facultatif. Laissez un champ vide pour utiliser le tarif par défaut de ce type de token.",
+        "inputLabel": "Entrée",
+        "outputLabel": "Sortie",
+        "cacheWriteLabel": "Écriture cache",
+        "cacheReadLabel": "Lecture cache",
+        "inputShort": "Entrée",
+        "outputShort": "Sortie",
+        "cacheWriteShort": "Écriture cache",
+        "cacheReadShort": "Lecture cache",
+        "invalidValue": "Le tarif doit être un nombre non négatif",
+        "defaultPricing": "Using default pricing"
+      },
+      "configuredSectionTitle": "Configured Claude models",
+      "configuredSectionDesc": "Models from the active Claude provider/settings.json are already in the selector. Only pricing can be changed here.",
+      "configuredEditHint": "This model is managed by the active Claude provider/settings.json. Only pricing can be changed here.",
+      "customSectionTitle": "Custom models",
+      "editPricing": "Edit pricing"
     },
     "dependencies": "Dépendances SDK",
     "dependenciesDesc": "Gérer les installations et mises à jour des dépendances AI SDK",

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -282,7 +282,26 @@
       "title": "कस्टम मॉडल",
       "description": "यहाँ जोड़े गए कस्टम मॉडल सभी प्रदाताओं के अंतर्गत दिखाई देंगे, मॉडल चयन सूची में सबसे ऊपर प्रदर्शित होंगे",
       "dialogTitle": "कस्टम मॉडल प्रबंधन",
-      "manage": "मॉडल प्रबंधन"
+      "manage": "मॉडल प्रबंधन",
+      "pricing": {
+        "title": "मूल्य (USD प्रति 1M tokens)",
+        "hint": "वैकल्पिक। उस token प्रकार के लिए डिफ़ॉल्ट दर उपयोग करने हेतु फ़ील्ड खाली छोड़ें।",
+        "inputLabel": "इनपुट",
+        "outputLabel": "आउटपुट",
+        "cacheWriteLabel": "कैश लेखन",
+        "cacheReadLabel": "कैश पठन",
+        "inputShort": "इनपुट",
+        "outputShort": "आउटपुट",
+        "cacheWriteShort": "कैश लेखन",
+        "cacheReadShort": "कैश पठन",
+        "invalidValue": "मूल्य एक गैर-ऋणात्मक संख्या होना चाहिए",
+        "defaultPricing": "Using default pricing"
+      },
+      "configuredSectionTitle": "Configured Claude models",
+      "configuredSectionDesc": "Models from the active Claude provider/settings.json are already in the selector. Only pricing can be changed here.",
+      "configuredEditHint": "This model is managed by the active Claude provider/settings.json. Only pricing can be changed here.",
+      "customSectionTitle": "Custom models",
+      "editPricing": "Edit pricing"
     },
     "dependencies": "SDK निर्भरताएं",
     "dependenciesDesc": "AI SDK निर्भरताओं की इंस्टॉलेशन और अपडेट प्रबंधित करें",

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -282,7 +282,26 @@
       "title": "カスタムモデル",
       "description": "ここで追加されたカスタムモデルは、すべてのプロバイダーで表示され、モデル選択リストの先頭に表示されます",
       "dialogTitle": "カスタムモデル管理",
-      "manage": "モデル管理"
+      "manage": "モデル管理",
+      "pricing": {
+        "title": "料金（USD/100万トークン）",
+        "hint": "任意です。空欄の項目はそのトークン種別の既定レートを使用します。",
+        "inputLabel": "入力",
+        "outputLabel": "出力",
+        "cacheWriteLabel": "キャッシュ書き込み",
+        "cacheReadLabel": "キャッシュ読み取り",
+        "inputShort": "入力",
+        "outputShort": "出力",
+        "cacheWriteShort": "キャッシュ書き込み",
+        "cacheReadShort": "キャッシュ読み取り",
+        "invalidValue": "料金は0以上の数値で入力してください",
+        "defaultPricing": "Using default pricing"
+      },
+      "configuredSectionTitle": "Configured Claude models",
+      "configuredSectionDesc": "Models from the active Claude provider/settings.json are already in the selector. Only pricing can be changed here.",
+      "configuredEditHint": "This model is managed by the active Claude provider/settings.json. Only pricing can be changed here.",
+      "customSectionTitle": "Custom models",
+      "editPricing": "Edit pricing"
     },
     "dependencies": "SDK依存関係",
     "dependenciesDesc": "AI SDK依存関係のインストールと更新を管理",

--- a/webview/src/i18n/locales/ko.json
+++ b/webview/src/i18n/locales/ko.json
@@ -304,7 +304,26 @@
       "title": "사용자 지정 모델",
       "description": "여기에 추가된 사용자 지정 모델은 모든 제공자에 표시되며, 모델 선택기 상단에 나타납니다",
       "dialogTitle": "사용자 지정 모델 관리",
-      "manage": "모델 관리"
+      "manage": "모델 관리",
+      "pricing": {
+        "title": "가격(USD/100만 토큰)",
+        "hint": "선택 사항입니다. 비워 두면 해당 토큰 유형의 기본 요금을 사용합니다.",
+        "inputLabel": "입력",
+        "outputLabel": "출력",
+        "cacheWriteLabel": "캐시 쓰기",
+        "cacheReadLabel": "캐시 읽기",
+        "inputShort": "입력",
+        "outputShort": "출력",
+        "cacheWriteShort": "캐시 쓰기",
+        "cacheReadShort": "캐시 읽기",
+        "invalidValue": "가격은 0 이상의 숫자여야 합니다",
+        "defaultPricing": "Using default pricing"
+      },
+      "configuredSectionTitle": "Configured Claude models",
+      "configuredSectionDesc": "Models from the active Claude provider/settings.json are already in the selector. Only pricing can be changed here.",
+      "configuredEditHint": "This model is managed by the active Claude provider/settings.json. Only pricing can be changed here.",
+      "customSectionTitle": "Custom models",
+      "editPricing": "Edit pricing"
     },
     "dependencies": "SDK 의존성",
     "dependenciesDesc": "AI SDK 의존성 설치 및 업데이트 관리",

--- a/webview/src/i18n/locales/pt-BR.json
+++ b/webview/src/i18n/locales/pt-BR.json
@@ -331,7 +331,26 @@
       "title": "Modelos Personalizados",
       "description": "Modelos personalizados adicionados aqui serão visíveis em todos os provedores, exibidos no topo do seletor de modelos",
       "dialogTitle": "Gerenciar Modelos Personalizados",
-      "manage": "Gerenciar Modelos"
+      "manage": "Gerenciar Modelos",
+      "pricing": {
+        "title": "Preço (USD por 1M tokens)",
+        "hint": "Opcional. Deixe um campo vazio para usar a tarifa padrão desse tipo de token.",
+        "inputLabel": "Entrada",
+        "outputLabel": "Saída",
+        "cacheWriteLabel": "Gravação de cache",
+        "cacheReadLabel": "Leitura de cache",
+        "inputShort": "Entrada",
+        "outputShort": "Saída",
+        "cacheWriteShort": "Gravação de cache",
+        "cacheReadShort": "Leitura de cache",
+        "invalidValue": "O preço deve ser um número não negativo",
+        "defaultPricing": "Using default pricing"
+      },
+      "configuredSectionTitle": "Configured Claude models",
+      "configuredSectionDesc": "Models from the active Claude provider/settings.json are already in the selector. Only pricing can be changed here.",
+      "configuredEditHint": "This model is managed by the active Claude provider/settings.json. Only pricing can be changed here.",
+      "customSectionTitle": "Custom models",
+      "editPricing": "Edit pricing"
     },
     "dependencies": "Dependências do SDK",
     "dependenciesDesc": "Gerenciar instalações e atualizações de dependências de SDK de IA",

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -282,7 +282,26 @@
       "title": "Пользовательские модели",
       "description": "Добавленные здесь пользовательские модели будут видны у всех провайдеров и отображаться в начале списка выбора моделей",
       "dialogTitle": "Управление пользовательскими моделями",
-      "manage": "Управление моделями"
+      "manage": "Управление моделями",
+      "pricing": {
+        "title": "Стоимость (USD за 1M токенов)",
+        "hint": "Необязательно. Оставьте поле пустым, чтобы использовать ставку по умолчанию для этого типа токенов.",
+        "inputLabel": "Ввод",
+        "outputLabel": "Вывод",
+        "cacheWriteLabel": "Запись кэша",
+        "cacheReadLabel": "Чтение кэша",
+        "inputShort": "Ввод",
+        "outputShort": "Вывод",
+        "cacheWriteShort": "Запись кэша",
+        "cacheReadShort": "Чтение кэша",
+        "invalidValue": "Стоимость должна быть неотрицательным числом",
+        "defaultPricing": "Using default pricing"
+      },
+      "configuredSectionTitle": "Configured Claude models",
+      "configuredSectionDesc": "Models from the active Claude provider/settings.json are already in the selector. Only pricing can be changed here.",
+      "configuredEditHint": "This model is managed by the active Claude provider/settings.json. Only pricing can be changed here.",
+      "customSectionTitle": "Custom models",
+      "editPricing": "Edit pricing"
     },
     "dependencies": "Зависимости SDK",
     "dependenciesDesc": "Управление установкой и обновлением зависимостей AI SDK",

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -282,7 +282,26 @@
       "title": "自訂模型",
       "description": "在此新增的自訂模型將在所有供應商下可見，顯示在模型選擇清單的最前面",
       "dialogTitle": "管理自訂模型",
-      "manage": "管理模型"
+      "manage": "管理模型",
+      "pricing": {
+        "title": "價格（美元/百萬 tokens）",
+        "hint": "選填。留空某項會使用該 token 類型的預設費率。",
+        "inputLabel": "輸入",
+        "outputLabel": "輸出",
+        "cacheWriteLabel": "快取寫入",
+        "cacheReadLabel": "快取讀取",
+        "inputShort": "輸入",
+        "outputShort": "輸出",
+        "cacheWriteShort": "快取寫入",
+        "cacheReadShort": "快取讀取",
+        "invalidValue": "價格必須是非負數字",
+        "defaultPricing": "使用預設價格"
+      },
+      "configuredSectionTitle": "已設定的 Claude 模型",
+      "configuredSectionDesc": "這些模型來自目前 Claude 供應商或 settings.json，已經會顯示在模型選擇器中。這裡只能修改價格。",
+      "configuredEditHint": "此模型由目前 Claude 供應商或 settings.json 管理，只能在這裡修改價格。",
+      "customSectionTitle": "自訂模型",
+      "editPricing": "編輯價格"
     },
     "dependencies": "SDK 依賴",
     "dependenciesDesc": "管理 AI SDK 依賴套件的安裝和更新",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -335,7 +335,26 @@
       "title": "自定义模型",
       "description": "添加的自定义模型将在所有供应商下可见，显示在模型选择列表的最前面",
       "dialogTitle": "管理自定义模型",
-      "manage": "管理模型"
+      "manage": "管理模型",
+      "pricing": {
+        "title": "价格（美元/百万 tokens）",
+        "hint": "可选。留空某项会使用该 token 类型的默认费率。",
+        "inputLabel": "输入",
+        "outputLabel": "输出",
+        "cacheWriteLabel": "缓存写入",
+        "cacheReadLabel": "缓存读取",
+        "inputShort": "输入",
+        "outputShort": "输出",
+        "cacheWriteShort": "缓存写入",
+        "cacheReadShort": "缓存读取",
+        "invalidValue": "价格必须是非负数字",
+        "defaultPricing": "使用默认价格"
+      },
+      "configuredSectionTitle": "已配置的 Claude 模型",
+      "configuredSectionDesc": "这些模型来自当前 Claude 供应商或 settings.json，已经会显示在模型选择器中。这里仅可修改价格。",
+      "configuredEditHint": "此模型由当前 Claude 供应商或 settings.json 管理，只能在这里修改价格。",
+      "customSectionTitle": "自定义模型",
+      "editPricing": "编辑价格"
     },
     "dependencies": "SDK 依赖",
     "dependenciesDesc": "管理 AI SDK 依赖包的安装和更新",

--- a/webview/src/types/provider.test.ts
+++ b/webview/src/types/provider.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { PROVIDER_PRESETS } from './provider';
+import {
+  isValidCodexCustomModel,
+  isValidModelPricing,
+  PROVIDER_PRESETS,
+  validateCodexCustomModels,
+} from './provider';
 
 describe('PROVIDER_PRESETS', () => {
   it('uses the current DeepSeek Anthropic-compatible defaults', () => {
@@ -23,5 +28,38 @@ describe('PROVIDER_PRESETS', () => {
       ANTHROPIC_DEFAULT_SONNET_MODEL: 'mimo-v2.5-pro',
       ANTHROPIC_DEFAULT_OPUS_MODEL: 'mimo-v2.5-pro',
     });
+  });
+});
+
+describe('custom model pricing validation', () => {
+  it('accepts optional non-negative per-million-token pricing fields', () => {
+    expect(isValidModelPricing({
+      inputCostPer1M: 1.25,
+      outputCostPer1M: 3,
+      cacheWriteCostPer1M: 0,
+      cacheReadCostPer1M: 0.1,
+    })).toBe(true);
+
+    expect(isValidCodexCustomModel({
+      id: 'vendor/custom-model',
+      label: 'Custom Model',
+      pricing: {
+        inputCostPer1M: 0.2,
+        outputCostPer1M: 0.8,
+      },
+    })).toBe(true);
+  });
+
+  it('rejects invalid custom pricing values', () => {
+    expect(isValidModelPricing({ inputCostPer1M: -1 })).toBe(false);
+    expect(isValidModelPricing({ outputCostPer1M: Number.POSITIVE_INFINITY })).toBe(false);
+    expect(isValidModelPricing({ cacheReadCostPer1M: '0.1' })).toBe(false);
+
+    expect(validateCodexCustomModels([
+      { id: 'valid-model', label: 'Valid', pricing: { inputCostPer1M: 0.1 } },
+      { id: 'invalid-model', label: 'Invalid', pricing: { outputCostPer1M: -2 } },
+    ])).toEqual([
+      { id: 'valid-model', label: 'Valid', pricing: { inputCostPer1M: 0.1 } },
+    ]);
   });
 });

--- a/webview/src/types/provider.ts
+++ b/webview/src/types/provider.ts
@@ -43,6 +43,8 @@ export const STORAGE_KEYS = {
   CLAUDE_MODEL_MAPPING: 'claude-model-mapping',
   /** Custom Claude model list */
   CLAUDE_CUSTOM_MODELS: 'claude-custom-models',
+  /** Pricing for Claude models configured by provider/settings.json, not shown as custom models */
+  CLAUDE_CONFIGURED_MODEL_PRICING: 'claude-configured-model-pricing',
 } as const;
 
 /**
@@ -101,6 +103,32 @@ export function isValidCodexCustomModel(model: unknown): model is CodexCustomMod
   // description is optional, but must be a string if present
   if (obj.description !== undefined && typeof obj.description !== 'string') return false;
 
+  // pricing is optional; when present every provided field must be a non-negative number
+  if (obj.pricing !== undefined) {
+    if (!isValidModelPricing(obj.pricing)) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Validate whether a ModelPricing object is valid.
+ * Every field is optional, but if present must be a finite number >= 0.
+ */
+export function isValidModelPricing(pricing: unknown): boolean {
+  if (!pricing || typeof pricing !== 'object') return false;
+  const p = pricing as Record<string, unknown>;
+  const fields: (keyof ModelPricing)[] = [
+    'inputCostPer1M',
+    'outputCostPer1M',
+    'cacheWriteCostPer1M',
+    'cacheReadCostPer1M',
+  ];
+  for (const f of fields) {
+    const v = p[f];
+    if (v === undefined) continue;
+    if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) return false;
+  }
   return true;
 }
 
@@ -161,6 +189,23 @@ export type ProviderCategory =
   | 'custom';       // Custom
 
 /**
+ * Per-million-token pricing for a custom model.
+ *
+ * All fields are optional: a missing field means "fall back to the default
+ * pricing for that token kind" in the backend cost calculation. Units are
+ * USD per 1,000,000 tokens, consistent with the backend `*CostPer1M` fields.
+ *
+ * cacheWrite is only meaningful for Claude-family models (Codex sessions do
+ * not track cache-write tokens).
+ */
+export interface ModelPricing {
+  inputCostPer1M?: number;
+  outputCostPer1M?: number;
+  cacheWriteCostPer1M?: number;
+  cacheReadCostPer1M?: number;
+}
+
+/**
  * Codex custom model configuration
  */
 export interface CodexCustomModel {
@@ -170,6 +215,8 @@ export interface CodexCustomModel {
   label: string;
   /** Model description */
   description?: string;
+  /** Optional per-million-token pricing for cost calculation */
+  pricing?: ModelPricing;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add custom pricing fields for Claude and Codex custom models.
- Persist user-configured model pricing to the plugin config and use it in usage aggregation.
- Allow pricing-only overrides for Claude models configured through provider/settings mappings.
- Support routed Claude model IDs such as `ppio/pa/gpt-5.5` when Claude history stores usage under the routed model ID such as `pa/gpt-5.5`.
- Preserve exact-match precedence and avoid guessing when multiple routed model candidates match the same history model.

## Why

Third-party Claude-compatible providers may require routed model IDs for request routing, for example `ppio/pa/gpt-5.5`.

However, Claude history can store the actual usage under a different model ID, for example `pa/gpt-5.5`. Without fallback matching, user-configured pricing does not apply to historical usage totals, which makes the displayed cost inaccurate.

## Implementation Notes

- Custom pricing is stored under `customModelPricing` in the plugin config.
- Usage aggregators check user-configured pricing before falling back to built-in pricing.
- Claude pricing lookup supports:
  - exact model ID matching;
  - `[1m]` suffix fallback;
  - routed model prefix fallback, for example `ppio/pa/gpt-5.5` -> `pa/gpt-5.5`;
  - ambiguous routed matches are ignored to avoid incorrect cost calculation.
- Claude provider/settings mapped models remain read-only except for pricing.

## Testing

- `gradle.bat --no-daemon --stacktrace test --tests com.github.claudecodegui.provider.CustomPricingProviderTest --tests com.github.claudecodegui.handler.provider.CustomModelPricingHandlerTest`
- `gradle.bat --no-daemon --stacktrace checkstyleMain`
- `gradle.bat --no-daemon --stacktrace buildPlugin`
- `npm test` in `webview`
- `git diff --check`