### PR TITLE
fix(model-routing): sync all three ANTHROPIC_DEFAULT_*_MODEL tiers from provider config to child process env

### DIFF
--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -461,7 +461,7 @@ export async function sendMessage(message, resumeSessionId = null, cwd = null, p
     const settings = loadClaudeSettings();
     const resolvedModel = resolveModelFromSettings(model, settings?.env);
     console.log('[DEBUG] Model:', model, '->', sdkModelName, '(API:', resolvedModel + ')');
-    setModelEnvironmentVariables(resolvedModel, model);
+    setModelEnvironmentVariables(resolvedModel, model, settings?.env);
 
     const systemPromptAppend = buildSystemPromptAppend(openedFiles, agentPrompt, message);
 
@@ -531,7 +531,7 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
     const settings = loadClaudeSettings();
     const resolvedAttachModel = resolveModelFromSettings(model, settings?.env);
     console.log('[DEBUG] (withAttachments) Model:', model, '->', resolvedAttachModel);
-    setModelEnvironmentVariables(resolvedAttachModel, model);
+    setModelEnvironmentVariables(resolvedAttachModel, model, settings?.env);
 
     const contentBlocks = await buildContentBlocks(attachments, message, resolvedAttachModel);
     const userMessage = {

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -197,7 +197,7 @@ async function buildRequestContext(params, withAttachments, overrides = {}) {
   const settings = overrides.settings ?? loadClaudeSettings();
   const modelId = params.model || null;
   const { sdkModelName, resolvedModelId } = resolveRequestModelState(modelId, settings?.env);
-  setModelEnvironmentVariables(resolvedModelId, modelId);
+  setModelEnvironmentVariables(resolvedModelId, modelId, settings?.env);
 
   const permissionMode = normalizePermissionMode(params.permissionMode);
   const streamingEnabled = resolveStreamingEnabled(params, settings);
@@ -621,7 +621,7 @@ export async function getContextUsagePersistent(params = {}) {
       // Fast path: reuse existing runtime with minimal model sync.
       // Only map the model ID and call setModel if needed - skip full buildRequestContext
       // which would unnecessarily load MCP config, settings, etc.
-      setModelEnvironmentVariables(targetModel, modelId);
+      setModelEnvironmentVariables(targetModel, modelId, settings?.env);
     }
 
     if (typeof runtime.query?.setModel === 'function') {

--- a/ai-bridge/utils/model-utils.js
+++ b/ai-bridge/utils/model-utils.js
@@ -105,8 +105,38 @@ export function resolveModelFromSettings(modelId, userEnv) {
  * @param {string} [baseModelId] - The original internal model ID used to determine which env var to set.
  *                                  Required when modelId is a custom name that doesn't contain 'opus'/'haiku'/'sonnet'.
  *                                  Falls back to modelId if not provided.
+ * @param {object} [providerEnv] - The provider settings.env object. When supplied, all three
+ *                                  ANTHROPIC_DEFAULT_*_MODEL tiers are written to process.env from
+ *                                  provider config so subagents requesting a different alias (e.g.
+ *                                  Explore → haiku) still resolve to the user's mapped model.
+ *                                  Without this, only the currently-selected tier is set and the
+ *                                  other two fall back to official defaults.
  */
-export function setModelEnvironmentVariables(modelId, baseModelId) {
+export function setModelEnvironmentVariables(modelId, baseModelId, providerEnv) {
+  // Sync all three ANTHROPIC_DEFAULT_*_MODEL tiers from provider config into
+  // process.env before the modelId guard. Preconnect (tab warm-up) requests may
+  // send no model yet, but we still need the provider mapping in process.env so
+  // buildCliEnv() can forward it to the child process.
+  // Overwrite-style reset on each request prevents stale values from a previous
+  // TAB leaking across the persistent daemon; filling in non-current tiers lets
+  // subagents requesting a different alias (e.g. Explore → haiku) resolve
+  // correctly to the user's mapped model.
+  if (providerEnv && typeof providerEnv === 'object') {
+    const tierVars = [
+      'ANTHROPIC_DEFAULT_SONNET_MODEL',
+      'ANTHROPIC_DEFAULT_HAIKU_MODEL',
+      'ANTHROPIC_DEFAULT_OPUS_MODEL',
+    ];
+    for (const varName of tierVars) {
+      const raw = providerEnv[varName];
+      const value = raw && String(raw).trim();
+      if (value) {
+        process.env[varName] = value;
+        console.log('[MODEL_ENV] Set', varName, '=', value, '(from provider env)');
+      }
+    }
+  }
+
   if (!modelId || typeof modelId !== 'string') {
     return;
   }


### PR DESCRIPTION
### Summary

`setModelEnvironmentVariables()` previously only wrote the **currently selected** tier's `ANTHROPIC_DEFAULT_*_MODEL` to `process.env`. The other two tiers were left unset, so when a subagent explicitly requested a different alias (e.g. Explore → `haiku`, statusline-setup → `sonnet`), Claude Code fell back to the official default model instead of the user's mapped model.

Additionally, the provider env sync was placed **after** the `modelId` guard, which meant preconnect (tab warm-up) requests — where the Java side sends `model: ""` — never reached it, leaving the first `claude.exe` process without any tier mapping at all.

### Changes

**`ai-bridge/utils/model-utils.js`** — `setModelEnvironmentVariables()`:
- Added a `providerEnv` parameter sourced from the provider's `settings.env`.
- Before setting `ANTHROPIC_MODEL`, all three `ANTHROPIC_DEFAULT_{SONNET,HAIKU,OPUS}_MODEL` tiers are written to `process.env` from the provider config.
- This block runs **before** the `modelId` guard, so preconnect requests without a model also get the mapping.
- Overwrite-style reset prevents stale values from a previous TAB leaking across the persistent daemon.

**`ai-bridge/services/claude/message-sender.js`** — Two call sites now pass `settings?.env`.

**`ai-bridge/services/claude/persistent-query-service.js`** — Two call sites (including the fast path in `getContextUsagePersistent`) now pass `settings?.env`.

### Related

- Fixes #1361
