### PR TITLE
feat(provider): multi-account Claude OAuth login switching

### DIFF
--- a/ai-bridge/config/api-config.js
+++ b/ai-bridge/config/api-config.js
@@ -219,6 +219,7 @@ const NETWORK_ENV_VARS = [
 
 const LOCAL_SETTINGS_PROVIDER_ID = '__local_settings_json__';
 const CLI_LOGIN_PROVIDER_ID = '__cli_login__';
+const CLI_ACCOUNT_PROVIDER_PREFIX = '__cli_account__:';
 const CODEX_CLI_LOGIN_PROVIDER_ID = '__codex_cli_login__';
 const injectedNetworkEnvVars = new Map();
 
@@ -274,7 +275,7 @@ export function getClaudeRuntimeState() {
     return { access: 'local', currentId };
   }
 
-  if (currentId === CLI_LOGIN_PROVIDER_ID) {
+  if (currentId === CLI_LOGIN_PROVIDER_ID || currentId.startsWith(CLI_ACCOUNT_PROVIDER_PREFIX)) {
     return { access: 'cli_login', currentId };
   }
 

--- a/ai-bridge/config/api-config.test.js
+++ b/ai-bridge/config/api-config.test.js
@@ -312,6 +312,19 @@ test('setupApiKey enters CLI login when config.json sets claude.current=__cli_lo
   assert.equal(result.result.apiKey, null);
 });
 
+test('setupApiKey enters CLI login for a saved multi-account profile', () => {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-api-config-'));
+  const claudeDir = path.join(tempHome, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  writeCodemossClaudeConfig(tempHome, '__cli_account__:account-1');
+  fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify({ env: {} }), 'utf8');
+
+  const result = runSetupApiKey(tempHome);
+  assert.equal(result.ok, true);
+  assert.equal(result.result.authType, 'cli_login');
+  assert.equal(result.result.apiKey, null);
+});
+
 test('setupApiKey CLI login takes priority over existing API keys (no fallback)', () => {
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-api-config-'));
   const claudeDir = path.join(tempHome, '.claude');

--- a/src/main/java/com/github/claudecodegui/handler/provider/ClaudeProviderOperations.java
+++ b/src/main/java/com/github/claudecodegui/handler/provider/ClaudeProviderOperations.java
@@ -10,10 +10,12 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.util.concurrency.AppExecutorUtil;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.concurrent.Executor;
 
 /**
  * Handles Claude provider CRUD operations and switching.
@@ -23,6 +25,16 @@ public class ClaudeProviderOperations {
     private static final Gson GSON = new Gson();
 
     private final HandlerContext context;
+
+    // Serialize all Claude provider operations on a single background thread.
+    // Callers invoke these handlers from invokeLater (EDT), and getClaudeProviders()
+    // now touches PasswordSafe / keychain / disk per saved account — running that on
+    // the EDT would freeze the UI ("Slow operations are prohibited on EDT").
+    // A single-thread executor also serializes read-modify-write on
+    // ~/.codemoss/config.json, preventing lost updates from interleaved operations.
+    private final Executor providerOpsExecutor =
+            AppExecutorUtil.createBoundedApplicationPoolExecutor(
+                    "ClaudeCodeGUI Claude provider operations", 1);
 
     public ClaudeProviderOperations(HandlerContext context) {
         this.context = context;
@@ -89,16 +101,18 @@ public class ClaudeProviderOperations {
      * Get all providers.
      */
     public void handleGetProviders() {
-        try {
-            java.util.List<JsonObject> providers = context.getSettingsService().getClaudeProviders();
-            String providersJson = GSON.toJson(providers);
+        providerOpsExecutor.execute(() -> {
+            try {
+                java.util.List<JsonObject> providers = context.getSettingsService().getClaudeProviders();
+                String providersJson = GSON.toJson(providers);
 
-            ApplicationManager.getApplication().invokeLater(() -> {
-                context.callJavaScript("window.updateProviders", context.escapeJs(providersJson));
-            });
-        } catch (Exception e) {
-            LOG.error("[ProviderHandler] Failed to get providers: " + e.getMessage(), e);
-        }
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    context.callJavaScript("window.updateProviders", context.escapeJs(providersJson));
+                });
+            } catch (Exception e) {
+                LOG.error("[ProviderHandler] Failed to get providers: " + e.getMessage(), e);
+            }
+        });
     }
 
     /**
@@ -226,9 +240,71 @@ public class ClaudeProviderOperations {
     }
 
     /**
+     * Save the account currently authenticated in Claude CLI into PasswordSafe.
+     */
+    public void handleSaveCurrentClaudeAccount() {
+        providerOpsExecutor.execute(() -> {
+            try {
+                JsonObject account = context.getSettingsService().saveCurrentClaudeOAuthAccount();
+                String email = account != null && account.has("emailAddress")
+                        ? account.get("emailAddress").getAsString()
+                        : "";
+                try {
+                    context.getClaudeSDKBridge().shutdownDaemon();
+                } catch (Exception e) {
+                    LOG.warn("[ProviderHandler] Failed to shut down daemon after saving OAuth account", e);
+                }
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    context.callJavaScript("window.showSwitchSuccess",
+                            context.escapeJs("Claude account saved" + (email.isBlank() ? "" : ": " + email)));
+                    handleGetProviders();
+                });
+            } catch (Exception e) {
+                LOG.error("[ProviderHandler] Failed to save current Claude OAuth account", e);
+                ApplicationManager.getApplication().invokeLater(() ->
+                        context.callJavaScript("window.showError", context.escapeJs(e.getMessage())));
+            }
+        });
+    }
+
+    /**
+     * Remove a saved OAuth account from plugin metadata and PasswordSafe.
+     */
+    public void handleDeleteClaudeAccount(String content) {
+        providerOpsExecutor.execute(() -> handleDeleteClaudeAccountInBackground(content));
+    }
+
+    private void handleDeleteClaudeAccountInBackground(String content) {
+        try {
+            JsonObject data = GSON.fromJson(content, JsonObject.class);
+            String id = data.get("id").getAsString();
+            context.getSettingsService().deleteClaudeOAuthAccount(id);
+            try {
+                context.getClaudeSDKBridge().shutdownDaemon();
+            } catch (Exception e) {
+                LOG.warn("[ProviderHandler] Failed to shut down daemon after deleting OAuth account", e);
+            }
+            ApplicationManager.getApplication().invokeLater(() -> {
+                context.callJavaScript("window.showSwitchSuccess",
+                        context.escapeJs("Claude account removed"));
+                handleGetProviders();
+                handleGetActiveProvider();
+            });
+        } catch (Exception e) {
+            LOG.error("[ProviderHandler] Failed to delete Claude OAuth account", e);
+            ApplicationManager.getApplication().invokeLater(() ->
+                    context.callJavaScript("window.showError", context.escapeJs(e.getMessage())));
+        }
+    }
+
+    /**
      * Switch provider.
      */
     public void handleSwitchProvider(String content) {
+        providerOpsExecutor.execute(() -> handleSwitchProviderInBackground(content));
+    }
+
+    private void handleSwitchProviderInBackground(String content) {
         try {
             JsonObject data = GSON.fromJson(content, JsonObject.class);
             String id = data.get("id").getAsString();
@@ -250,6 +326,7 @@ public class ClaudeProviderOperations {
             } catch (Exception e) {
                 LOG.warn("[ProviderHandler] Failed to shut down Claude daemon during switch", e);
             }
+            context.getSettingsService().refreshActiveClaudeOAuthAccount();
 
             if (ProviderManager.DISABLED_PROVIDER_ID.equals(id)) {
                 context.getSettingsService().deactivateClaudeProvider();
@@ -375,15 +452,17 @@ public class ClaudeProviderOperations {
      * Get the currently active provider.
      */
     public void handleGetActiveProvider() {
-        try {
-            JsonObject provider = context.getSettingsService().getActiveClaudeProvider();
-            String providerJson = GSON.toJson(provider);
+        providerOpsExecutor.execute(() -> {
+            try {
+                JsonObject provider = context.getSettingsService().getActiveClaudeProvider();
+                String providerJson = GSON.toJson(provider);
 
-            ApplicationManager.getApplication().invokeLater(() -> {
-                context.callJavaScript("window.updateActiveProvider", context.escapeJs(providerJson));
-            });
-        } catch (Exception e) {
-            LOG.error("[ProviderHandler] Failed to get active provider: " + e.getMessage(), e);
-        }
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    context.callJavaScript("window.updateActiveProvider", context.escapeJs(providerJson));
+                });
+            } catch (Exception e) {
+                LOG.error("[ProviderHandler] Failed to get active provider: " + e.getMessage(), e);
+            }
+        });
     }
 }

--- a/src/main/java/com/github/claudecodegui/handler/provider/ProviderHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/provider/ProviderHandler.java
@@ -20,6 +20,8 @@ public class ProviderHandler extends BaseMessageHandler {
             "update_provider",
             "delete_provider",
             "switch_provider",
+            "save_current_claude_account",
+            "delete_claude_account",
             "get_active_provider",
             "preview_cc_switch_import",
             "open_file_chooser_for_cc_switch",
@@ -82,6 +84,12 @@ public class ProviderHandler extends BaseMessageHandler {
                 return true;
             case "switch_provider":
                 claudeOps.handleSwitchProvider(content);
+                return true;
+            case "save_current_claude_account":
+                claudeOps.handleSaveCurrentClaudeAccount();
+                return true;
+            case "delete_claude_account":
+                claudeOps.handleDeleteClaudeAccount(content);
                 return true;
             case "get_active_provider":
                 claudeOps.handleGetActiveProvider();

--- a/src/main/java/com/github/claudecodegui/settings/ClaudeOAuthAccountManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/ClaudeOAuthAccountManager.java
@@ -1,0 +1,592 @@
+package com.github.claudecodegui.settings;
+
+import com.github.claudecodegui.bridge.NodeDetector;
+import com.github.claudecodegui.util.PlatformUtils;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.intellij.credentialStore.CredentialAttributes;
+import com.intellij.credentialStore.Credentials;
+import com.intellij.ide.passwordSafe.PasswordSafe;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Stores multiple Claude CLI OAuth accounts.
+ *
+ * <p>Account metadata is kept in {@code ~/.codemoss/config.json}; OAuth credentials
+ * and the matching {@code oauthAccount} payload are kept in JetBrains PasswordSafe.
+ * Switching accounts updates only Claude Code's live credential store and account
+ * metadata, so projects, history, settings, commands, and skills remain shared.</p>
+ */
+public class ClaudeOAuthAccountManager {
+    private static final Logger LOG = Logger.getInstance(ClaudeOAuthAccountManager.class);
+    private static final String ACCOUNTS_KEY = "oauthAccounts";
+    private static final String PASSWORD_SAFE_SERVICE_PREFIX = "ClaudeCodeGUI OAuth account ";
+    private static final String CHUNK_MARKER_PREFIX = "chunks:";
+    // Keep well below Windows Credential Manager's 2560-byte blob limit even
+    // when a chunk contains multi-byte UTF-8 account metadata.
+    private static final int PASSWORD_SAFE_CHUNK_SIZE = 512;
+    public static final String ACCOUNT_ID_PREFIX = "__cli_account__:";
+    // macOS Keychain entry the bundled claude-agent-sdk reads/writes. The SDK uses the
+    // suffix-less service name when the default config dir is active (no CLAUDE_CONFIG_DIR),
+    // which is how ai-bridge spawns it. Account label mirrors the SDK's $USER selection.
+    private static final String MAC_KEYCHAIN_SERVICE = "Claude Code-credentials";
+    private static final java.util.regex.Pattern KEYCHAIN_ACCOUNT_PATTERN =
+            java.util.regex.Pattern.compile("[a-zA-Z0-9._-]+");
+
+    private final Gson gson;
+    private final Function<Void, JsonObject> configReader;
+    private final Consumer<JsonObject> configWriter;
+
+    public ClaudeOAuthAccountManager(
+            Gson gson,
+            Function<Void, JsonObject> configReader,
+            Consumer<JsonObject> configWriter
+    ) {
+        this.gson = gson;
+        this.configReader = configReader;
+        this.configWriter = configWriter;
+    }
+
+    public boolean isAccountId(String id) {
+        return id != null && id.startsWith(ACCOUNT_ID_PREFIX);
+    }
+
+    public List<JsonObject> getAccounts(String currentId) {
+        JsonObject accounts = getAccountsObject(configReader.apply(null), false);
+        List<JsonObject> result = new ArrayList<>();
+        if (accounts == null) {
+            return result;
+        }
+
+        for (String id : accounts.keySet()) {
+            if (!accounts.get(id).isJsonObject()) {
+                continue;
+            }
+            JsonObject account = accounts.getAsJsonObject(id).deepCopy();
+            account.addProperty("id", id);
+            account.addProperty("isActive", id.equals(currentId));
+            account.addProperty("isCliAccountProvider", true);
+            account.addProperty("isAuthenticated", readStoredPayload(id) != null);
+            result.add(account);
+        }
+        return result;
+    }
+
+    public JsonObject getAccount(String id, boolean isActive) {
+        JsonObject accounts = getAccountsObject(configReader.apply(null), false);
+        if (accounts == null || !accounts.has(id) || !accounts.get(id).isJsonObject()) {
+            return null;
+        }
+        JsonObject account = accounts.getAsJsonObject(id).deepCopy();
+        account.addProperty("id", id);
+        account.addProperty("isActive", isActive);
+        account.addProperty("isCliAccountProvider", true);
+        account.addProperty("isAuthenticated", readStoredPayload(id) != null);
+        return account;
+    }
+
+    /**
+     * Capture the account currently logged in through Claude CLI.
+     * Existing entries with the same email are refreshed in place.
+     */
+    public JsonObject saveCurrentAccount() throws IOException {
+        String credentials = readLiveCredentials();
+        if (credentials == null || credentials.isBlank()) {
+            throw new IOException("Claude CLI is not logged in. Run 'claude auth login' first.");
+        }
+        validateCredentialJson(credentials);
+
+        JsonObject oauthAccount = readLiveOauthAccount();
+        String email = getString(oauthAccount, "emailAddress");
+        if (email == null || email.isBlank()) {
+            throw new IOException("Claude CLI account email is unavailable");
+        }
+
+        JsonObject config = configReader.apply(null);
+        JsonObject accounts = getAccountsObject(config, true);
+        String existingId = findAccountIdByEmail(accounts, email);
+        String id = existingId != null ? existingId : ACCOUNT_ID_PREFIX + UUID.randomUUID();
+
+        JsonObject metadata = existingId != null
+                ? accounts.getAsJsonObject(existingId)
+                : new JsonObject();
+        metadata.addProperty("name", displayName(oauthAccount, email));
+        metadata.addProperty("emailAddress", email);
+        if (!metadata.has("createdAt")) {
+            metadata.addProperty("createdAt", System.currentTimeMillis());
+        }
+        metadata.addProperty("updatedAt", System.currentTimeMillis());
+        accounts.add(id, metadata);
+        ensureClaudeSection(config).addProperty("current", id);
+
+        JsonObject payload = new JsonObject();
+        payload.addProperty("credentials", credentials);
+        payload.add("oauthAccount", oauthAccount.deepCopy());
+        writeStoredPayload(id, payload);
+        configWriter.accept(config);
+
+        return getAccount(id, false);
+    }
+
+    public void switchToAccount(String id) throws IOException {
+        if (!isAccountId(id)) {
+            throw new IllegalArgumentException("Invalid Claude OAuth account id");
+        }
+        JsonObject account = getAccount(id, false);
+        if (account == null) {
+            throw new IllegalArgumentException("Claude OAuth account not found");
+        }
+
+        JsonObject payload = readStoredPayload(id);
+        if (payload == null || !payload.has("credentials")) {
+            throw new IOException("Stored OAuth credentials are unavailable for this account");
+        }
+
+        String credentials = payload.get("credentials").getAsString();
+        validateCredentialJson(credentials);
+        String previousCredentials = readLiveCredentials();
+        JsonObject previousOauthAccount = readLiveOauthAccountOrNull();
+        try {
+            writeLiveCredentials(credentials);
+            if (payload.has("oauthAccount") && payload.get("oauthAccount").isJsonObject()) {
+                writeLiveOauthAccount(payload.getAsJsonObject("oauthAccount"));
+            }
+
+            JsonObject config = configReader.apply(null);
+            JsonObject claude = ensureClaudeSection(config);
+            claude.addProperty("current", id);
+            configWriter.accept(config);
+        } catch (Exception switchError) {
+            rollbackLiveAccount(previousCredentials, previousOauthAccount);
+            if (switchError instanceof IOException) {
+                throw (IOException) switchError;
+            }
+            throw new IOException("Failed to switch Claude OAuth account", switchError);
+        }
+        LOG.info("[ClaudeOAuthAccounts] Switched active account to: " + id);
+    }
+
+    /**
+     * Persist fresh live credentials before leaving a managed account. Claude Code
+     * may rotate access/refresh tokens while the account is active.
+     */
+    public void refreshActiveAccountIfNeeded() {
+        try {
+            JsonObject config = configReader.apply(null);
+            if (!config.has("claude") || !config.get("claude").isJsonObject()) {
+                return;
+            }
+            JsonObject claude = config.getAsJsonObject("claude");
+            String currentId = claude.has("current") && !claude.get("current").isJsonNull()
+                    ? claude.get("current").getAsString()
+                    : "";
+            if (isAccountId(currentId)) {
+                saveCurrentAccount();
+            }
+        } catch (Exception e) {
+            LOG.warn("[ClaudeOAuthAccounts] Failed to refresh active account snapshot: " + e.getMessage());
+        }
+    }
+
+    public void deleteAccount(String id) throws IOException {
+        JsonObject config = configReader.apply(null);
+        JsonObject claude = ensureClaudeSection(config);
+        JsonObject accounts = getAccountsObject(config, false);
+        if (accounts == null || !accounts.has(id)) {
+            throw new IllegalArgumentException("Claude OAuth account not found");
+        }
+
+        boolean wasActive = claude.has("current") && id.equals(claude.get("current").getAsString());
+        accounts.remove(id);
+        if (wasActive) {
+            claude.addProperty("current", "");
+        }
+        configWriter.accept(config);
+        if (wasActive) {
+            clearLiveCredentials();
+            removeLiveOauthAccount();
+        }
+        deleteStoredPayload(id);
+        LOG.info("[ClaudeOAuthAccounts] Deleted account: " + id);
+    }
+
+    private JsonObject readStoredPayload(String id) {
+        try {
+            Credentials credentials = PasswordSafe.getInstance().get(credentialAttributes(id));
+            if (credentials == null || credentials.getPasswordAsString() == null) {
+                return null;
+            }
+            String stored = credentials.getPasswordAsString();
+            if (stored.startsWith(CHUNK_MARKER_PREFIX)) {
+                ChunkMarker marker = parseChunkMarker(stored);
+                StringBuilder combined = new StringBuilder(marker.count * PASSWORD_SAFE_CHUNK_SIZE);
+                for (int i = 0; i < marker.count; i++) {
+                    Credentials chunk = PasswordSafe.getInstance().get(
+                            chunkAttributes(id, marker.generation, i));
+                    if (chunk == null || chunk.getPasswordAsString() == null) {
+                        return null;
+                    }
+                    combined.append(chunk.getPasswordAsString());
+                }
+                stored = combined.toString();
+            }
+            return JsonParser.parseString(stored).getAsJsonObject();
+        } catch (Exception e) {
+            LOG.warn("[ClaudeOAuthAccounts] Failed to read PasswordSafe entry for " + id + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    private void writeStoredPayload(String id, JsonObject payload) {
+        String serialized = gson.toJson(payload);
+        int chunkCount = (serialized.length() + PASSWORD_SAFE_CHUNK_SIZE - 1) / PASSWORD_SAFE_CHUNK_SIZE;
+        String generation = UUID.randomUUID().toString();
+        Credentials previousMarker = PasswordSafe.getInstance().get(credentialAttributes(id));
+        for (int i = 0; i < chunkCount; i++) {
+            int start = i * PASSWORD_SAFE_CHUNK_SIZE;
+            int end = Math.min(serialized.length(), start + PASSWORD_SAFE_CHUNK_SIZE);
+            PasswordSafe.getInstance().set(
+                    chunkAttributes(id, generation, i),
+                    new Credentials(id, serialized.substring(start, end))
+            );
+        }
+        PasswordSafe.getInstance().set(
+                credentialAttributes(id),
+                new Credentials(id, CHUNK_MARKER_PREFIX + generation + ":" + chunkCount)
+        );
+        deleteChunksFromMarker(id, previousMarker);
+    }
+
+    private CredentialAttributes credentialAttributes(String id) {
+        return new CredentialAttributes(PASSWORD_SAFE_SERVICE_PREFIX + id, id);
+    }
+
+    private CredentialAttributes chunkAttributes(String id, String generation, int index) {
+        String generationSuffix = generation == null ? "" : generation + " ";
+        return new CredentialAttributes(
+                PASSWORD_SAFE_SERVICE_PREFIX + id + " chunk " + generationSuffix + index,
+                id
+        );
+    }
+
+    private void deleteStoredPayload(String id) {
+        try {
+            Credentials marker = PasswordSafe.getInstance().get(credentialAttributes(id));
+            deleteChunksFromMarker(id, marker);
+        } catch (Exception e) {
+            LOG.warn("[ClaudeOAuthAccounts] Failed to clean old credential chunks: " + e.getMessage());
+        }
+        PasswordSafe.getInstance().set(credentialAttributes(id), null);
+    }
+
+    private void deleteChunksFromMarker(String id, Credentials credentials) {
+        if (credentials == null || credentials.getPasswordAsString() == null
+                || !credentials.getPasswordAsString().startsWith(CHUNK_MARKER_PREFIX)) {
+            return;
+        }
+        ChunkMarker marker = parseChunkMarker(credentials.getPasswordAsString());
+        for (int i = 0; i < marker.count; i++) {
+            PasswordSafe.getInstance().set(chunkAttributes(id, marker.generation, i), null);
+        }
+    }
+
+    private ChunkMarker parseChunkMarker(String value) {
+        String markerValue = value.substring(CHUNK_MARKER_PREFIX.length());
+        int separator = markerValue.lastIndexOf(':');
+        if (separator < 0) {
+            return new ChunkMarker(null, Integer.parseInt(markerValue));
+        }
+        String generation = markerValue.substring(0, separator);
+        int count = Integer.parseInt(markerValue.substring(separator + 1));
+        return new ChunkMarker(generation, count);
+    }
+
+    private String readLiveCredentials() throws IOException {
+        if (PlatformUtils.isMac()) {
+            // Match exactly what the bundled claude-agent-sdk reads: service
+            // "Claude Code-credentials", account = $USER (see macKeychainAccount).
+            // Reading without -a returns an arbitrary item when several accounts
+            // share the service, which can surface the wrong credential.
+            Process process = new ProcessBuilder(
+                    "/usr/bin/security",
+                    "find-generic-password",
+                    "-a", macKeychainAccount(),
+                    "-s", MAC_KEYCHAIN_SERVICE,
+                    "-w"
+            ).redirectErrorStream(true).start();
+            String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+            try {
+                if (process.waitFor() != 0) {
+                    return "";
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while reading macOS Keychain", e);
+            }
+            return output;
+        }
+
+        Path credentialsPath = getLiveCredentialsPath();
+        return Files.exists(credentialsPath)
+                ? Files.readString(credentialsPath, StandardCharsets.UTF_8)
+                : "";
+    }
+
+    private void writeLiveCredentials(String credentials) throws IOException {
+        if (PlatformUtils.isMac()) {
+            // `security add-generic-password -w` does NOT read the secret from stdin:
+            // with no value it prompts on the TTY, so a headless process silently
+            // stores an EMPTY secret (verified). Pass the secret as the -w argument so
+            // it is actually written. It is briefly visible to local `ps`, which is an
+            // acceptable trade-off for a credential that already lives in this keychain.
+            Process process = new ProcessBuilder(
+                    "/usr/bin/security",
+                    "add-generic-password",
+                    "-U",
+                    "-s", MAC_KEYCHAIN_SERVICE,
+                    "-a", macKeychainAccount(),
+                    "-w", credentials
+            ).redirectErrorStream(true).start();
+            String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+            try {
+                if (process.waitFor() != 0) {
+                    throw new IOException("Failed to update macOS Keychain: " + output);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while updating macOS Keychain", e);
+            }
+            return;
+        }
+
+        Path target = getLiveCredentialsPath();
+        Files.createDirectories(target.getParent());
+        writeAtomically(target, credentials);
+        setOwnerOnlyPermissions(target);
+    }
+
+    private JsonObject readLiveOauthAccount() throws IOException {
+        Path configPath = getGlobalClaudeConfigPath();
+        if (!Files.exists(configPath)) {
+            throw new IOException("Claude CLI global config not found: " + configPath);
+        }
+        JsonObject root = JsonParser.parseString(Files.readString(configPath, StandardCharsets.UTF_8))
+                .getAsJsonObject();
+        if (!root.has("oauthAccount") || !root.get("oauthAccount").isJsonObject()) {
+            throw new IOException("Claude CLI OAuth account metadata is unavailable");
+        }
+        return root.getAsJsonObject("oauthAccount");
+    }
+
+    private JsonObject readLiveOauthAccountOrNull() {
+        try {
+            return readLiveOauthAccount().deepCopy();
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private void writeLiveOauthAccount(JsonObject oauthAccount) throws IOException {
+        Path configPath = getGlobalClaudeConfigPath();
+        JsonObject root = Files.exists(configPath)
+                ? JsonParser.parseString(Files.readString(configPath, StandardCharsets.UTF_8)).getAsJsonObject()
+                : new JsonObject();
+        root.add("oauthAccount", oauthAccount.deepCopy());
+        writeAtomically(configPath, gson.toJson(root));
+        setOwnerOnlyPermissions(configPath);
+    }
+
+    private void removeLiveOauthAccount() throws IOException {
+        Path configPath = getGlobalClaudeConfigPath();
+        if (!Files.exists(configPath)) {
+            return;
+        }
+        JsonObject root = JsonParser.parseString(Files.readString(configPath, StandardCharsets.UTF_8))
+                .getAsJsonObject();
+        root.remove("oauthAccount");
+        writeAtomically(configPath, gson.toJson(root));
+        setOwnerOnlyPermissions(configPath);
+    }
+
+    private void clearLiveCredentials() throws IOException {
+        if (PlatformUtils.isMac()) {
+            Process process = new ProcessBuilder(
+                    "/usr/bin/security",
+                    "delete-generic-password",
+                    "-a", macKeychainAccount(),
+                    "-s", MAC_KEYCHAIN_SERVICE
+            ).redirectErrorStream(true).start();
+            try {
+                int exitCode = process.waitFor();
+                if (exitCode != 0 && exitCode != 44) {
+                    String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+                    throw new IOException("Failed to clear macOS Keychain: " + output.trim());
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while clearing macOS Keychain", e);
+            }
+            return;
+        }
+        Files.deleteIfExists(getLiveCredentialsPath());
+    }
+
+    private void rollbackLiveAccount(String credentials, JsonObject oauthAccount) {
+        try {
+            if (credentials == null || credentials.isBlank()) {
+                clearLiveCredentials();
+            } else {
+                writeLiveCredentials(credentials);
+            }
+            if (oauthAccount == null) {
+                removeLiveOauthAccount();
+            } else {
+                writeLiveOauthAccount(oauthAccount);
+            }
+        } catch (Exception rollbackError) {
+            LOG.error("[ClaudeOAuthAccounts] Failed to roll back partial account switch", rollbackError);
+        }
+    }
+
+    /**
+     * Mirror the bundled SDK's keychain account selection (f0): prefer $USER, fall back to
+     * the JVM login name, and use "claude-code-user" if neither is a safe label.
+     */
+    private String macKeychainAccount() {
+        String user = System.getenv("USER");
+        if (user == null || !KEYCHAIN_ACCOUNT_PATTERN.matcher(user).matches()) {
+            user = System.getProperty("user.name");
+        }
+        return (user != null && KEYCHAIN_ACCOUNT_PATTERN.matcher(user).matches())
+                ? user
+                : "claude-code-user";
+    }
+
+    private Path getLiveCredentialsPath() {
+        return Paths.get(NodeDetector.resolveHomeForFileOps(), ".claude", ".credentials.json");
+    }
+
+    private Path getGlobalClaudeConfigPath() {
+        return Paths.get(NodeDetector.resolveHomeForFileOps(), ".claude.json");
+    }
+
+    private void writeAtomically(Path target, String content) throws IOException {
+        Path parent = target.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        Path temp = Files.createTempFile(parent, target.getFileName().toString(), ".tmp");
+        try {
+            Files.writeString(temp, content, StandardCharsets.UTF_8);
+            try {
+                Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException ignored) {
+                Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } finally {
+            Files.deleteIfExists(temp);
+        }
+    }
+
+    private void setOwnerOnlyPermissions(Path path) {
+        try {
+            Set<PosixFilePermission> permissions = EnumSet.of(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE
+            );
+            Files.setPosixFilePermissions(path, permissions);
+        } catch (UnsupportedOperationException | IOException ignored) {
+            // Windows and non-POSIX filesystems use their native ACLs.
+        }
+    }
+
+    private void validateCredentialJson(String credentials) throws IOException {
+        try {
+            JsonObject root = JsonParser.parseString(credentials).getAsJsonObject();
+            if (!root.has("claudeAiOauth") || !root.get("claudeAiOauth").isJsonObject()) {
+                throw new IOException("Claude OAuth credential payload is missing");
+            }
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException("Claude OAuth credential payload is invalid", e);
+        }
+    }
+
+    private JsonObject getAccountsObject(JsonObject config, boolean create) {
+        JsonObject claude = create ? ensureClaudeSection(config)
+                : config.has("claude") && config.get("claude").isJsonObject()
+                    ? config.getAsJsonObject("claude") : null;
+        if (claude == null) {
+            return null;
+        }
+        if (!claude.has(ACCOUNTS_KEY) || !claude.get(ACCOUNTS_KEY).isJsonObject()) {
+            if (!create) {
+                return null;
+            }
+            claude.add(ACCOUNTS_KEY, new JsonObject());
+        }
+        return claude.getAsJsonObject(ACCOUNTS_KEY);
+    }
+
+    private JsonObject ensureClaudeSection(JsonObject config) {
+        if (!config.has("claude") || !config.get("claude").isJsonObject()) {
+            JsonObject claude = new JsonObject();
+            claude.add("providers", new JsonObject());
+            claude.addProperty("current", "");
+            config.add("claude", claude);
+        }
+        return config.getAsJsonObject("claude");
+    }
+
+    private String findAccountIdByEmail(JsonObject accounts, String email) {
+        for (String id : accounts.keySet()) {
+            JsonObject account = accounts.get(id).isJsonObject() ? accounts.getAsJsonObject(id) : null;
+            if (account != null && email.equalsIgnoreCase(getString(account, "emailAddress"))) {
+                return id;
+            }
+        }
+        return null;
+    }
+
+    private String displayName(JsonObject oauthAccount, String email) {
+        String name = getString(oauthAccount, "displayName");
+        if (name == null) {
+            name = getString(oauthAccount, "name");
+        }
+        return name == null || name.isBlank() ? email : name;
+    }
+
+    private String getString(JsonObject object, String key) {
+        return object != null && object.has(key) && !object.get(key).isJsonNull()
+                ? object.get(key).getAsString()
+                : null;
+    }
+
+    private static class ChunkMarker {
+        private final String generation;
+        private final int count;
+
+        private ChunkMarker(String generation, int count) {
+            this.generation = generation;
+            this.count = count;
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/settings/CodemossSettingsService.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodemossSettingsService.java
@@ -16,7 +16,6 @@ import com.intellij.openapi.project.Project;
 
 import java.io.File;
 import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -81,6 +80,7 @@ public class CodemossSettingsService {
     private final SkillManager skillManager;
     private final McpServerManager mcpServerManager;
     private final ProviderManager providerManager;
+    private final ClaudeOAuthAccountManager claudeOAuthAccountManager;
     private final CodexProviderManager codexProviderManager;
 
     public CodemossSettingsService() {
@@ -153,6 +153,24 @@ public class CodemossSettingsService {
         );
 
         // Initialize ProviderManager
+        this.claudeOAuthAccountManager = new ClaudeOAuthAccountManager(
+                gson,
+                (ignored) -> {
+                    try {
+                        return readConfig();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                },
+                (config) -> {
+                    try {
+                        writeConfig(config);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+        );
+
         this.providerManager = new ProviderManager(
                 gson,
                 (ignored) -> {
@@ -170,7 +188,8 @@ public class CodemossSettingsService {
                     }
                 },
                 pathManager,
-                claudeSettingsManager
+                claudeSettingsManager,
+                claudeOAuthAccountManager
         );
 
         // Initialize CodexSettingsManager
@@ -241,13 +260,28 @@ public class CodemossSettingsService {
         // Back up existing config
         backupConfig();
 
-        String configPath = getConfigPath();
-        try (FileWriter writer = new FileWriter(configPath, StandardCharsets.UTF_8)) {
-            gson.toJson(config, writer);
+        Path configPath = Paths.get(getConfigPath());
+        String serialized = gson.toJson(config);
+        // Write to a temp file and atomically swap it in. A plain FileWriter truncates
+        // the target before writing, so a concurrent reader could observe an empty or
+        // half-written file — and readConfig() silently falls back to a default config
+        // on a parse error, which would wipe the in-memory provider list.
+        Path parent = configPath.getParent();
+        Path temp = Files.createTempFile(parent, configPath.getFileName().toString(), ".tmp");
+        try {
+            Files.writeString(temp, serialized, StandardCharsets.UTF_8);
+            try {
+                Files.move(temp, configPath,
+                        StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (java.nio.file.AtomicMoveNotSupportedException ignored) {
+                Files.move(temp, configPath, StandardCopyOption.REPLACE_EXISTING);
+            }
             LOG.info("[CodemossSettings] Successfully wrote config to: " + configPath);
         } catch (Exception e) {
             LOG.warn("[CodemossSettings] Failed to write config: " + e.getMessage());
             throw e;
+        } finally {
+            Files.deleteIfExists(temp);
         }
     }
 
@@ -855,6 +889,22 @@ public class CodemossSettingsService {
 
     public void switchClaudeProvider(String id) throws IOException {
         providerManager.switchClaudeProvider(id);
+    }
+
+    public JsonObject saveCurrentClaudeOAuthAccount() throws IOException {
+        return claudeOAuthAccountManager.saveCurrentAccount();
+    }
+
+    public void deleteClaudeOAuthAccount(String id) throws IOException {
+        claudeOAuthAccountManager.deleteAccount(id);
+    }
+
+    public boolean isClaudeOAuthAccountId(String id) {
+        return claudeOAuthAccountManager.isAccountId(id);
+    }
+
+    public void refreshActiveClaudeOAuthAccount() {
+        claudeOAuthAccountManager.refreshActiveAccountIfNeeded();
     }
 
     public void deactivateClaudeProvider() throws IOException {

--- a/src/main/java/com/github/claudecodegui/settings/ProviderManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/ProviderManager.java
@@ -36,6 +36,7 @@ public class ProviderManager {
     private final java.util.function.Consumer<JsonObject> configWriter;
     private final ConfigPathManager pathManager;
     private final ClaudeSettingsManager claudeSettingsManager;
+    private final ClaudeOAuthAccountManager oauthAccountManager;
 
     public ProviderManager(
             Gson gson,
@@ -43,11 +44,22 @@ public class ProviderManager {
             java.util.function.Consumer<JsonObject> configWriter,
             ConfigPathManager pathManager,
             ClaudeSettingsManager claudeSettingsManager) {
+        this(gson, configReader, configWriter, pathManager, claudeSettingsManager, null);
+    }
+
+    public ProviderManager(
+            Gson gson,
+            Function<Void, JsonObject> configReader,
+            java.util.function.Consumer<JsonObject> configWriter,
+            ConfigPathManager pathManager,
+            ClaudeSettingsManager claudeSettingsManager,
+            ClaudeOAuthAccountManager oauthAccountManager) {
         this.gson = gson;
         this.configReader = configReader;
         this.configWriter = configWriter;
         this.pathManager = pathManager;
         this.claudeSettingsManager = claudeSettingsManager;
+        this.oauthAccountManager = oauthAccountManager;
     }
 
     /**
@@ -64,6 +76,9 @@ public class ProviderManager {
 
         // Add CLI login provider
         result.add(createCliLoginProviderObject(CLI_LOGIN_PROVIDER_ID.equals(currentId)));
+        if (oauthAccountManager != null) {
+            result.addAll(oauthAccountManager.getAccounts(currentId));
+        }
 
         if (!claude.has("providers")) {
             return result;
@@ -125,6 +140,9 @@ public class ProviderManager {
         // Return CLI login provider
         if (CLI_LOGIN_PROVIDER_ID.equals(currentId)) {
             return createCliLoginProviderObject(true);
+        }
+        if (oauthAccountManager != null && oauthAccountManager.isAccountId(currentId)) {
+            return oauthAccountManager.getAccount(currentId, true);
         }
 
         if (!claude.has("providers")) {
@@ -361,6 +379,13 @@ public class ProviderManager {
      * Switch to a different provider.
      */
     public void switchClaudeProvider(String id) throws IOException {
+        if (oauthAccountManager != null) {
+            oauthAccountManager.refreshActiveAccountIfNeeded();
+        }
+        if (oauthAccountManager != null && oauthAccountManager.isAccountId(id)) {
+            oauthAccountManager.switchToAccount(id);
+            return;
+        }
         JsonObject config = configReader.apply(null);
 
         if (!config.has("claude")) {
@@ -468,7 +493,8 @@ public class ProviderManager {
         if (config.has("claude") &&
                 config.getAsJsonObject("claude").has("current")) {
             String currentId = config.getAsJsonObject("claude").get("current").getAsString();
-            if (LOCAL_SETTINGS_PROVIDER_ID.equals(currentId) || CLI_LOGIN_PROVIDER_ID.equals(currentId)) {
+            if (LOCAL_SETTINGS_PROVIDER_ID.equals(currentId) || CLI_LOGIN_PROVIDER_ID.equals(currentId)
+                    || (oauthAccountManager != null && oauthAccountManager.isAccountId(currentId))) {
                 LOG.info("[ProviderManager] " + currentId + " provider active, skipping sync to settings.json");
                 return;
             }
@@ -760,6 +786,8 @@ public class ProviderManager {
         boolean invalidCurrent = currentId == null
                 || (!LOCAL_SETTINGS_PROVIDER_ID.equals(currentId)
                     && !CLI_LOGIN_PROVIDER_ID.equals(currentId)
+                    && !(oauthAccountManager != null && oauthAccountManager.isAccountId(currentId)
+                        && oauthAccountManager.getAccount(currentId, false) != null)
                     && !providers.has(currentId));
 
         // Marketplace-safe default:
@@ -805,6 +833,8 @@ public class ProviderManager {
         if (!claude.has("current")) {
             return false;
         }
-        return CLI_LOGIN_PROVIDER_ID.equals(claude.get("current").getAsString());
+        String currentId = claude.get("current").getAsString();
+        return CLI_LOGIN_PROVIDER_ID.equals(currentId)
+                || (oauthAccountManager != null && oauthAccountManager.isAccountId(currentId));
     }
 }

--- a/webview/src/components/settings/ProviderList/index.tsx
+++ b/webview/src/components/settings/ProviderList/index.tsx
@@ -61,7 +61,11 @@ export default function ProviderList({
   } = useDragSort({
     items: providers,
     onSort,
-    pinnedIds: [SPECIAL_PROVIDER_IDS.LOCAL_SETTINGS, SPECIAL_PROVIDER_IDS.CLI_LOGIN],
+    pinnedIds: [
+      SPECIAL_PROVIDER_IDS.LOCAL_SETTINGS,
+      SPECIAL_PROVIDER_IDS.CLI_LOGIN,
+      ...providers.filter((provider) => provider.isCliAccountProvider).map((provider) => provider.id),
+    ],
   });
 
   useEffect(() => {
@@ -555,6 +559,9 @@ export default function ProviderList({
               <div className={styles.website} title={t('settings.provider.cliLoginProviderDescription')}>
                 {t('settings.provider.cliLoginProviderDescription')}
               </div>
+              <div className={styles.website} style={CLI_ACCOUNT_INFO_STYLE}>
+                {t('settings.provider.multiAccountHint')}
+              </div>
               {cliLoginAccountEmail && localProviders.some(p => p.id === SPECIAL_PROVIDER_IDS.CLI_LOGIN && p.isActive) && (
                 <div className={styles.website} style={CLI_ACCOUNT_INFO_STYLE}>
                   {t('settings.provider.cliLoginAccountInfo', { email: cliLoginAccountEmail })}
@@ -563,6 +570,15 @@ export default function ProviderList({
             </div>
 
             <div className={styles.cardActions}>
+              <button
+                className={styles.useButton}
+                onClick={() => sendToJava('save_current_claude_account', {})}
+                title={t('settings.provider.saveCurrentAccountHint')}
+              >
+                <span className="codicon codicon-account" />
+                {t('settings.provider.saveCurrentAccount')}
+              </button>
+
               {localProviders.some(p => p.id === SPECIAL_PROVIDER_IDS.CLI_LOGIN && p.isActive) ? (
                 <button
                   className={styles.revokeButton}
@@ -583,8 +599,57 @@ export default function ProviderList({
             </div>
           </div>
 
+          {localProviders
+            .filter((provider) => provider.isCliAccountProvider)
+            .map((account) => (
+              <div
+                key={account.id}
+                className={`${styles.card} ${account.isActive ? styles.active : ''} ${styles.localProviderCard}`}
+              >
+                <div className={styles.cardInfo}>
+                  <div className={styles.name}>
+                    <span className="codicon codicon-account" style={ICON_MR_8_STYLE} />
+                    {account.name}
+                  </div>
+                  <div className={styles.website}>
+                    {account.emailAddress || t('settings.provider.oauthAccount')}
+                  </div>
+                </div>
+
+                <div className={styles.cardActions}>
+                  {account.isActive ? (
+                    <div className={styles.activeBadge}>
+                      <span className="codicon codicon-check" />
+                      {t('settings.provider.inUse')}
+                    </div>
+                  ) : (
+                    <button
+                      className={styles.useButton}
+                      disabled={!account.isAuthenticated}
+                      onClick={() => onSwitch(account.id)}
+                    >
+                      <span className="codicon codicon-arrow-swap" />
+                      {t('settings.provider.enable')}
+                    </button>
+                  )}
+                  <div className={styles.divider} />
+                  <button
+                    className={styles.iconBtn}
+                    onClick={() => onDelete(account)}
+                    title={t('common.delete')}
+                  >
+                    <span className="codicon codicon-trash" />
+                  </button>
+                </div>
+              </div>
+            ))}
+
           {(() => {
-            const regularProviders = localProviders.filter(p => p.id !== SPECIAL_PROVIDER_IDS.LOCAL_SETTINGS && p.id !== SPECIAL_PROVIDER_IDS.CLI_LOGIN);
+            const regularProviders = localProviders.filter(
+              p => p.id !== SPECIAL_PROVIDER_IDS.LOCAL_SETTINGS
+                && p.id !== SPECIAL_PROVIDER_IDS.CLI_LOGIN
+                && !p.isCliAccountProvider
+            );
             return regularProviders.length > 0 ? (
               regularProviders.map((provider) => (
             <div

--- a/webview/src/components/settings/hooks/useProviderManagement.ts
+++ b/webview/src/components/settings/hooks/useProviderManagement.ts
@@ -213,7 +213,10 @@ export function useProviderManagement(options: UseProviderManagementOptions = {}
     if (!provider) return;
 
     const data = { id: provider.id };
-    sendToJava(`delete_provider:${JSON.stringify(data)}`);
+    const messageType = provider.isCliAccountProvider
+      ? 'delete_claude_account'
+      : 'delete_provider';
+    sendToJava(`${messageType}:${JSON.stringify(data)}`);
     onSuccess?.(t('toast.providerDeleted'));
     setLoading(true);
     setDeleteConfirm({ isOpen: false, provider: null });

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -563,6 +563,10 @@
       "cliLoginDisableTitle": "Revoke CLI Login Authorization",
       "cliLoginDisableMessage": "This will stop using CLI login state and leave Claude with no active provider until you explicitly enable another one.",
       "cliLoginAccountInfo": "Logged in as: {{email}}",
+      "saveCurrentAccount": "Save account",
+      "saveCurrentAccountHint": "Save the Claude CLI account that is currently logged in",
+      "oauthAccount": "Claude OAuth account",
+      "multiAccountHint": "To add another account, sign in with Claude CLI, then click Save account.",
       "subscriptionTutorial": {
         "entry": "Subscription Account Guide",
         "dialogTitle": "How to use a subscription account",

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -489,6 +489,10 @@
       "cliLoginDisableTitle": "Отозвать авторизацию входа CLI",
       "cliLoginDisableMessage": "Это прекратит использование состояния входа CLI и оставит Claude без активного провайдера, пока вы явно не включите другой.",
       "cliLoginAccountInfo": "Вошел как: {{email}}",
+      "saveCurrentAccount": "Сохранить аккаунт",
+      "saveCurrentAccountHint": "Сохранить текущий аккаунт Claude CLI",
+      "oauthAccount": "OAuth-аккаунт Claude",
+      "multiAccountHint": "Чтобы добавить аккаунт, войдите в него через Claude CLI и нажмите «Сохранить аккаунт».",
       "subscriptionTutorial": {
         "entry": "Руководство по подписке",
         "dialogTitle": "Как использовать аккаунт подписки",

--- a/webview/src/types/provider.ts
+++ b/webview/src/types/provider.ts
@@ -130,6 +130,12 @@ export interface ProviderConfig {
   source?: 'cc-switch' | string;
   isLocalProvider?: boolean;
   isCliLoginProvider?: boolean;
+  /** Saved Claude CLI OAuth account backed by JetBrains PasswordSafe. */
+  isCliAccountProvider?: boolean;
+  /** Safe display-only account email. */
+  emailAddress?: string;
+  /** Whether PasswordSafe still contains credentials for this account. */
+  isAuthenticated?: boolean;
   /** Custom model list (displayed before built-in models in the selector) */
   customModels?: CodexCustomModel[];
   settingsConfig?: {


### PR DESCRIPTION
Save and switch between multiple Claude CLI OAuth accounts, backed by JetBrains PasswordSafe. Account metadata lives in ~/.codemoss/config.json; credentials are chunked into PasswordSafe. Projects, history, settings, commands and skills stay shared across accounts.

- ClaudeOAuthAccountManager: save / switch / delete accounts, snapshot live credentials, atomic file writes, chunked PasswordSafe storage
- Provider UI: account cards, "Save account" action, multi-account hint
- api-config: treat __cli_account__:* as cli_login runtime state

Reliability fixes:
- Run all Claude provider operations on a single background executor so PasswordSafe/keychain reads stay off the EDT and config read-modify-write is serialized (no UI freeze, no lost updates).
- Write config.json atomically (temp file + atomic move) so concurrent readers never observe a half-written file (which readConfig would fall back to a default for, wiping provider state).

macOS keychain fixes (switching previously stored empty credentials):
- Pass the secret as the `-w` argument; `security add-generic-password -w` does not read it from stdin and was silently storing an empty secret.
- Scope reads and deletes with `-a $USER` to match the account label used by the bundled claude-agent-sdk and avoid picking the wrong keychain item.