### PR TITLE
fix(daemon): normalize WSL-style HOME (/mnt/c/...) on native Windows

### DIFF
--- a/ai-bridge/daemon.js
+++ b/ai-bridge/daemon.js
@@ -92,6 +92,16 @@ const _originalConsoleError = console.error.bind(console);
 // Claude's Bash tool, Codex, MCP servers, any future tool — automatically
 // sees the user's full environment without per-tool Java-side patches.
 
+// Fix WSL-style HOME on native Windows: when the IDE/launcher injects a WSL mount
+// path (e.g. HOME=/mnt/c/Users/me) but the daemon's Bash tool is Git Bash (MSYS,
+// which uses /c/...), tools like git can't resolve it and fall back to a phantom
+// ~/.gitconfig, breaking config/credentials. Normalize it to the native Windows home
+// before any subprocess is spawned.
+if (process.platform === 'win32' && /^\/mnt\/[a-z]\//i.test(process.env.HOME || '')) {
+  const m = process.env.HOME.match(/^\/mnt\/([a-z])\/(.*)$/i);
+  if (m) process.env.HOME = `${m[1].toUpperCase()}:/${m[2]}`;
+}
+
 if (process.platform !== 'win32' && !process.env.__AI_BRIDGE_ENV_PROBED) {
   // PATH is critical; runtime homes let tools resolve config/data dirs correctly
   const VARS_TO_INHERIT = new Set([


### PR DESCRIPTION
## Problem
On native Windows, the plugin's Java launcher injects a WSL-style HOME(e.g. `HOME=/mnt/c/Users/<user>`) into the daemon's environment, which is inherited by every subprocess. But Claude's Bash tool here is Git Bash(MSYS), whose mount prefix is `/c/...`, not WSL's `/mnt/c/...`. So tools that rely on HOME break — most visibly git, which can't lock `<HOME>/.gitconfig`, falls back to a phantom path, and fails to persist credentials (repeated "credentials incorrect or have expired" on push).

The daemon.js "GUI Login Environment Fix" block already centralizes env normalization so tools work "without per-tool Java-side patches", but it is gated to non-win32 and doesn't touch HOME.

## Fix
Add a tiny win32-only guard at the top of daemon.js that rewrites a `/mnt/<drive>/...` HOME back to the native Windows form (`/mnt/c/Users/me` → `C:/Users/me`) before any subprocess is spawned. No-op when HOME is already a normal path.

## Notes
- Runs before subprocess spawn, so it propagates to Claude's Bash tool, Codex, MCP servers, etc.
- The root cause is the Java side injecting the WSL path on Windows; this daemon-side normalization is a minimal, self-contained safety net that matches the file's existing responsibility.