### PR TITLE
fix(stream): keep cross-turn thinking deltas streaming

### DIFF
--- a/webview/src/hooks/useStreamingMessages.test.ts
+++ b/webview/src/hooks/useStreamingMessages.test.ts
@@ -504,6 +504,106 @@ describe('useStreamingMessages', () => {
     // Turn 2 block now streams the latest suffix live.
     expect(rawAfter[2]).toMatchObject({ thinking: 'Turn2ab' });
   });
+
+  it('does not overwrite a closed pre-tool text block when the content buffer diverges', () => {
+    // Content-path mirror of the thinking trailing-block guard. The pre-tool
+    // text block is finalized (a tool_use follows it). The cumulative content
+    // buffer has diverged from that block (no prefix relationship — e.g. a
+    // snapshot-mode provider dedup-rewrote the closed block). The sync function
+    // must leave the closed block untouched and wait for updateMessages, NOT
+    // overwrite it with the new turn's post-tool content. Before the guard, the
+    // single-block happy path overwrote block[0] with the whole buffer.
+    const { result } = renderHook(() => useStreamingMessages());
+
+    result.current.streamingContentRef.current = 'Completely different post-tool content';
+
+    const assistant: ClaudeMessage = {
+      type: 'assistant',
+      content: 'XYZ',
+      isStreaming: true,
+      raw: {
+        message: {
+          content: [
+            { type: 'text', text: 'XYZ' },
+            { type: 'tool_use', id: 't1', name: 'run', input: {} },
+          ],
+        },
+      },
+    };
+
+    const patched = result.current.patchAssistantForStreaming(assistant);
+    const rawContent = (patched.raw as any).message.content as ContentBlockTest[];
+
+    // Closed pre-tool block preserved (NOT overwritten with the diverged buffer).
+    expect(rawContent[0]).toMatchObject({ type: 'text', text: 'XYZ' });
+    // Structure unchanged — no leak into the previous segment.
+    expect(rawContent.map((b) => b.type)).toEqual(['text', 'tool_use']);
+  });
+
+  it('keeps backend raw structure intact when the cumulative content buffer cannot be reconciled (multi-block)', () => {
+    // Content-path mirror of the thinking "cannot be reconciled" regression.
+    // prefixText is 'A' (the earlier text block); the buffer 'disjoint' does not
+    // start with it, so the structure must be returned untouched.
+    const { result } = renderHook(() => useStreamingMessages());
+
+    result.current.streamingContentRef.current = 'disjoint';
+
+    const assistant: ClaudeMessage = {
+      type: 'assistant',
+      content: '',
+      isStreaming: true,
+      raw: {
+        message: {
+          content: [
+            { type: 'text', text: 'A' },
+            { type: 'tool_use', id: 't1', name: 'run', input: {} },
+            { type: 'text', text: 'B' },
+          ],
+        },
+      },
+    };
+
+    const patched = result.current.patchAssistantForStreaming(assistant);
+    const rawContent = (patched.raw as any).message.content as ContentBlockTest[];
+
+    expect(rawContent.map((b) => b.type)).toEqual(['text', 'tool_use', 'text']);
+    expect(rawContent[0]).toMatchObject({ type: 'text', text: 'A' });
+    expect(rawContent[2]).toMatchObject({ type: 'text', text: 'B' });
+  });
+
+  it('streams post-tool text into its own trailing block, never the pre-tool block (cross-turn)', () => {
+    // Happy-path cross-turn regression anchor: the boundary mechanism routes the
+    // new turn's text into a freshly fabricated trailing block instead of growing
+    // (or overwriting) the closed pre-tool block. Passes before AND after the
+    // guard change — locks the correct streaming behavior in place.
+    const { result } = renderHook(() => useStreamingMessages());
+
+    result.current.streamingContentRef.current = 'Turn1Content';
+    const beforeTurn2: ClaudeMessage = {
+      type: 'assistant',
+      content: 'Turn1Content',
+      isStreaming: true,
+      raw: {
+        message: {
+          content: [
+            { type: 'text', text: 'Turn1Content' },
+            { type: 'tool_use', id: 'b1', name: 'run', input: {} },
+          ],
+        },
+      },
+    };
+    const patchedBefore = result.current.patchAssistantForStreaming(beforeTurn2);
+    expect((patchedBefore.raw as any).message.content.map((b: ContentBlockTest) => b.type))
+      .toEqual(['text', 'tool_use']);
+
+    result.current.streamingContentRef.current = 'Turn1ContentTurn2Content';
+    const patchedAfter = result.current.patchAssistantForStreaming(patchedBefore);
+    const rawAfter = (patchedAfter.raw as any).message.content as ContentBlockTest[];
+
+    expect(rawAfter.map((b) => b.type)).toEqual(['text', 'tool_use', 'text']);
+    expect(rawAfter[0]).toMatchObject({ type: 'text', text: 'Turn1Content' });
+    expect(rawAfter[2]).toMatchObject({ type: 'text', text: 'Turn2Content' });
+  });
 });
 
 interface ContentBlockTest {

--- a/webview/src/hooks/useStreamingMessages.test.ts
+++ b/webview/src/hooks/useStreamingMessages.test.ts
@@ -387,6 +387,123 @@ describe('useStreamingMessages', () => {
     expect(rawContent[0]).toMatchObject({ thinking: 'Original first' });
     expect(rawContent[2]).toMatchObject({ thinking: 'Original second' });
   });
+
+  it('does not overwrite a finalized thinking block when the new turn block has not arrived yet', () => {
+    // Problem 2 (regression): Turn 1 ended with a tool_use so its thinking
+    // block is finalized. Turn 2's thinking delta arrives BEFORE the backend
+    // snapshot appended Turn 2's own block. streamingThinkingRef now carries
+    // both turns (onBlockReset no longer clears it). The sync function must
+    // leave Turn 1's block untouched and wait for updateMessages — NOT leak
+    // Turn 2's content into Turn 1's block.
+    const { result } = renderHook(() => useStreamingMessages());
+
+    result.current.streamingThinkingRef.current = 'Turn1ThinkingTurn2Thinking';
+
+    const assistant: ClaudeMessage = {
+      type: 'assistant',
+      content: '',
+      isStreaming: true,
+      raw: {
+        message: {
+          content: [
+            { type: 'thinking', thinking: 'Turn1Thinking', text: 'Turn1Thinking' },
+            { type: 'text', text: 'Turn1Content' },
+            { type: 'tool_use', id: 'bash-1', name: 'run', input: {} },
+          ],
+        },
+      },
+    };
+
+    const patched = result.current.patchAssistantForStreaming(assistant);
+    const rawContent = (patched.raw as any).message.content as ContentBlockTest[];
+
+    // Turn 1's thinking block preserved (NOT overwritten with the cumulative buffer).
+    expect(rawContent[0]).toMatchObject({ type: 'thinking', thinking: 'Turn1Thinking' });
+    // Structure unchanged — no premature Turn 2 block fabricated from the buffer.
+    expect(rawContent.map((b) => b.type)).toEqual(['thinking', 'text', 'tool_use']);
+  });
+
+  it('streams the new turn thinking into its own trailing block once the backend delivers it', () => {
+    // Problem 1 (regression): same cumulative buffer, but the backend snapshot
+    // HAS appended Turn 2's thinking block at the tail. Prefix reconciliation
+    // must assign only the Turn 2 suffix to that trailing block, restoring
+    // live streaming instead of dropping every Turn 2 delta.
+    const { result } = renderHook(() => useStreamingMessages());
+
+    result.current.streamingThinkingRef.current = 'Turn1ThinkingTurn2Thinking';
+
+    const assistant: ClaudeMessage = {
+      type: 'assistant',
+      content: '',
+      isStreaming: true,
+      raw: {
+        message: {
+          content: [
+            { type: 'thinking', thinking: 'Turn1Thinking', text: 'Turn1Thinking' },
+            { type: 'tool_use', id: 'bash-1', name: 'run', input: {} },
+            { type: 'thinking', thinking: '', text: '' },
+          ],
+        },
+      },
+    };
+
+    const patched = result.current.patchAssistantForStreaming(assistant);
+    const rawContent = (patched.raw as any).message.content as ContentBlockTest[];
+
+    expect(rawContent).toHaveLength(3);
+    expect(rawContent[0]).toMatchObject({ type: 'thinking', thinking: 'Turn1Thinking' });
+    expect(rawContent[1]).toMatchObject({ type: 'tool_use', id: 'bash-1' });
+    // Turn 2's block receives exactly its suffix — streaming resumed.
+    expect(rawContent[2]).toMatchObject({ type: 'thinking', thinking: 'Turn2Thinking' });
+  });
+
+  it('cross-turn thinking: waits patiently, then streams as the turn 2 block grows', () => {
+    // End-to-end pacing for both regressions together.
+    const { result } = renderHook(() => useStreamingMessages());
+
+    // Turn 2's first delta arrives before its block exists in the snapshot.
+    result.current.streamingThinkingRef.current = 'Turn1ThinkingTurn2a';
+    const beforeTurn2Block: ClaudeMessage = {
+      type: 'assistant',
+      content: '',
+      isStreaming: true,
+      raw: {
+        message: {
+          content: [
+            { type: 'thinking', thinking: 'Turn1Thinking', text: 'Turn1Thinking' },
+            { type: 'tool_use', id: 'bash-1', name: 'run', input: {} },
+          ],
+        },
+      },
+    };
+    const patchedBefore = result.current.patchAssistantForStreaming(beforeTurn2Block);
+    expect((patchedBefore.raw as any).message.content[0]).toMatchObject({ thinking: 'Turn1Thinking' });
+    expect((patchedBefore.raw as any).message.content.map((b: ContentBlockTest) => b.type))
+      .toEqual(['thinking', 'tool_use']);
+
+    // A second Turn 2 delta arrives; ref keeps accumulating across the turn.
+    result.current.streamingThinkingRef.current = 'Turn1ThinkingTurn2ab';
+    const withTurn2Block: ClaudeMessage = {
+      type: 'assistant',
+      content: '',
+      isStreaming: true,
+      raw: {
+        message: {
+          content: [
+            { type: 'thinking', thinking: 'Turn1Thinking', text: 'Turn1Thinking' },
+            { type: 'tool_use', id: 'bash-1', name: 'run', input: {} },
+            { type: 'thinking', thinking: 'Turn2a', text: 'Turn2a' },
+          ],
+        },
+      },
+    };
+    const patchedAfter = result.current.patchAssistantForStreaming(withTurn2Block);
+    const rawAfter = (patchedAfter.raw as any).message.content as ContentBlockTest[];
+    expect(rawAfter).toHaveLength(3);
+    expect(rawAfter[0]).toMatchObject({ thinking: 'Turn1Thinking' });
+    // Turn 2 block now streams the latest suffix live.
+    expect(rawAfter[2]).toMatchObject({ thinking: 'Turn2ab' });
+  });
 });
 
 interface ContentBlockTest {

--- a/webview/src/hooks/useStreamingMessages.ts
+++ b/webview/src/hooks/useStreamingMessages.ts
@@ -166,17 +166,27 @@ export function useStreamingMessages(): UseStreamingMessagesReturn {
       trailingStructuralTextBoundaryRef.current = null;
     }
 
+    // Cannot reconcile the cumulative buffer with the split blocks — e.g. the
+    // backend dedup rewrote an earlier block, or a new turn's text has not yet
+    // been delivered as its own block.  Leave the structure untouched and let
+    // the next backend snapshot author the correct blocks.  Mirror of
+    // syncThinkingBlocksWithContent's prefix guard.  (The previous single-block
+    // overwrite branch here was unreachable: a single text block makes
+    // prefixText '' so content.startsWith('') is always true.)
     if (!content.startsWith(prefixText)) {
-      if (textIndices.length !== 1) {
-        return blocks;
-      }
-      const currentText = typeof blocks[lastTextIdx]?.text === 'string' ? blocks[lastTextIdx].text : '';
-      if (currentText === content) {
-        return blocks;
-      }
-      const nextBlocks = [...blocks];
-      nextBlocks[lastTextIdx] = { ...nextBlocks[lastTextIdx], text: content };
-      return nextBlocks;
+      return blocks;
+    }
+
+    // Trailing-block guard: only grow the message's final text block, the single
+    // active prose segment of the current turn.  When any later block (tool_use,
+    // tool_result, thinking) already follows it, the segment is closed — post-tool
+    // growth is handled by the trailingStructuralTextBoundaryRef branch above, so
+    // reaching here means the cumulative buffer diverged from the snapshot.  Wait
+    // for updateMessages instead of overwriting the closed pre-tool block with the
+    // new turn's content.  Mirror of syncThinkingBlocksWithContent's trailing-block
+    // guard.
+    if (lastTextIdx !== blocks.length - 1) {
+      return blocks;
     }
 
     const desiredLastText = content.slice(prefixText.length);

--- a/webview/src/hooks/useStreamingMessages.ts
+++ b/webview/src/hooks/useStreamingMessages.ts
@@ -225,24 +225,26 @@ export function useStreamingMessages(): UseStreamingMessagesReturn {
       .map((index) => getThinkingText(blocks[index]))
       .join('');
 
+    // Cannot reconcile the cumulative buffer with the split blocks — e.g. the
+    // backend dedup rewrote an earlier block, or a new turn's thinking has not
+    // yet been delivered as its own block.  Leave the structure untouched and
+    // let the next backend snapshot author the correct blocks.  Overwriting a
+    // finalized segment here was the source of the cross-turn "last thinking
+    // block briefly shows the next turn's content" flicker.
     if (!thinking.startsWith(prefixThinking)) {
-      // Cannot reconcile cumulative buffer with split blocks (e.g., backend
-      // dedup rewrote earlier blocks).  For a single block we still try to
-      // overwrite directly; otherwise leave structure untouched.
-      if (thinkingIndices.length !== 1) {
-        return blocks;
-      }
-      const currentThinking = getThinkingText(blocks[lastThinkingIdx]);
-      if (currentThinking === thinking) {
-        return blocks;
-      }
-      const nextBlocks = [...blocks];
-      nextBlocks[lastThinkingIdx] = {
-        ...nextBlocks[lastThinkingIdx],
-        thinking,
-        text: thinking,
-      };
-      return nextBlocks;
+      return blocks;
+    }
+
+    // Trailing-block guard: only grow the message's final thinking block, which
+    // is the single active segment of the current turn.  When any later block
+    // (text, tool_use, tool_result) already follows it, the segment is closed —
+    // the buffered suffix belongs to a NEW turn whose own thinking block the
+    // backend snapshot has not delivered yet.  Overwriting the closed block
+    // would leak the new turn's content into the previous turn.  The Java layer
+    // keeps one assistant message across the whole turn and appends each turn's
+    // thinking as a fresh block, so waiting for updateMessages is always safe.
+    if (lastThinkingIdx !== blocks.length - 1) {
+      return blocks;
     }
 
     const desiredLastThinking = thinking.slice(prefixThinking.length);

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -1246,7 +1246,7 @@ describe('useWindowCallbacks integration', () => {
       });
     });
 
-    it('onBlockReset clears streaming refs to prevent cross-turn content merging', () => {
+    it('onBlockReset keeps streaming refs cumulative across turns (single assistant message)', () => {
       stubSynchronousTimers();
 
       const opts = createOptions();
@@ -1256,33 +1256,33 @@ describe('useWindowCallbacks integration', () => {
       act(() => { window.onStreamStart!(); });
       expect(opts.isStreamingRef.current).toBe(true);
 
-      // Simulate first turn's thinking delta
+      // Simulate first turn's thinking + content deltas
       act(() => { window.onThinkingDelta!('Turn1Thinking'); });
-      expect(opts.streamingThinkingRef.current).toBe('Turn1Thinking');
-
-      // Simulate first turn's content delta
       act(() => { window.onContentDelta!('Turn1Content'); });
-      expect(opts.streamingContentRef.current).toBe('Turn1Content');
 
-      // Block reset signal arrives (new assistant message in stream)
+      // Block reset signal arrives (a new assistant turn within the same
+      // stream). The Java layer keeps ONE assistant message for the whole
+      // turn and appends each turn's text/thinking as additional raw blocks,
+      // so the frontend must keep accumulating to preserve the prefix earlier
+      // turns contributed. Clearing here would break prefix reconciliation.
       act(() => { window.onBlockReset!(); });
 
-      // Streaming refs should be cleared
-      expect(opts.streamingThinkingRef.current).toBe('');
-      expect(opts.streamingContentRef.current).toBe('');
-
-      // But streaming should still be active
+      // Refs are intentionally retained, NOT cleared.
+      expect(opts.streamingThinkingRef.current).toBe('Turn1Thinking');
+      expect(opts.streamingContentRef.current).toBe('Turn1Content');
       expect(opts.isStreamingRef.current).toBe(true);
 
-      // Second turn's deltas arrive - should NOT merge with first turn
+      // Second turn's deltas append to the cumulative buffer.
       act(() => { window.onThinkingDelta!('Turn2Thinking'); });
-      expect(opts.streamingThinkingRef.current).toBe('Turn2Thinking');
+      expect(opts.streamingThinkingRef.current).toBe('Turn1ThinkingTurn2Thinking');
 
       act(() => { window.onContentDelta!('Turn2Content'); });
-      expect(opts.streamingContentRef.current).toBe('Turn2Content');
+      expect(opts.streamingContentRef.current).toBe('Turn1ContentTurn2Content');
 
-      // If onBlockReset was NOT called, we would have "Turn1ThinkingTurn2Thinking"
-      // and "Turn1ContentTurn2Content" (merged content)
+      // Cross-turn separation is enforced downstream by the sync functions'
+      // trailing-block guard (see useStreamingMessages.test.ts: "does not
+      // overwrite a finalized thinking block when the new turn's own block has
+      // not arrived yet"), NOT by clearing the buffers here.
     });
 
     it('onBlockReset is ignored when stream is not active', () => {

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
@@ -728,13 +728,18 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
       // Stream not active, ignore (could be stale signal after stream ended)
       return;
     }
-    // Clear content buffers - new deltas will start fresh
-    streamingContentRef.current = '';
-    streamingThinkingRef.current = '';
-    // Intentionally NOT resetting streamingMessageIndexRef here: the backend will
-    // send a new updateMessages snapshot for this turn, which will eventually set
-    // the correct index via the isStaleSnapshot guard. Resetting the index now
-    // would leave a window where incoming deltas have nowhere to land.
+    // NOTE: content/thinking buffers are intentionally NOT cleared here.
+    // The Java layer keeps ONE assistant message for the whole turn (including
+    // every tool_use loop iteration), appending each turn's text/thinking as
+    // additional raw blocks. Clearing the buffers on BLOCK_RESET would discard
+    // the prefix carried by earlier turns and break sync*BlocksWithContent's
+    // prefix reconciliation: a multi-block turn would drop new deltas (prefix
+    // no longer matches) and a single-block turn would overwrite the prior
+    // turn's block with the new turn's content. Keep the cumulative buffer; the
+    // sync functions' trailing-block guard routes each turn's content into its
+    // own block once the backend snapshot delivers it.
+    // Intentionally NOT resetting streamingMessageIndexRef either: the assistant
+    // message is shared across turns, so the index already points at it.
     // Reset throttle timeouts to ensure clean state for new deltas
     if (contentUpdateTimeoutRef.current != null) {
       cancelAnimationFrame(contentUpdateTimeoutRef.current);


### PR DESCRIPTION
After the first assistant turn, subsequent thinking deltas were silently dropped (only surfacing via updateMessages) and a new turn's thinking briefly overwrote the previous turn's thinking block until updateMessages corrected it.

Root cause: onBlockReset cleared streamingThinkingRef / streamingContentRef, but the Java layer keeps ONE assistant message for the whole turn (including every tool_use loop iteration), appending each turn's text/thinking as additional raw blocks. Clearing the buffers discarded the prefix earlier turns contributed, so sync*BlocksWithContent's prefix reconciliation could no longer place the new deltas: multi-block turns dropped them, and a single trailing thinking block got overwritten with the new turn's content.

Fix:
- onBlockReset no longer clears the content/thinking buffers; they keep accumulating across turns so prefix reconciliation stays aligned with the single multi-block assistant message.
- syncThinkingBlocksWithContent gains a trailing-block guard: only the message's final thinking block (the active segment) is grown. When a later block already follows it, the segment is finalized and we wait for updateMessages to deliver the new turn's own block instead of leaking its content into the previous turn. Also removes the unreachable single-block overwrite branch (single block => prefix is always '', so the mismatch path never ran).

Tests: add cross-turn regressions in useStreamingMessages.test.ts and update the onBlockReset contract test to match the cumulative-buffer semantics.