### PR TITLE
fix(codex): force model_supports_reasoning_summaries for custom models

### DIFF
--- a/ai-bridge/services/codex/message-service.js
+++ b/ai-bridge/services/codex/message-service.js
@@ -97,6 +97,13 @@ export async function sendMessage(
 
     const codexOptions = {};
 
+    // Always initialize config with reasoning summaries forced to true
+    // so custom models not in the SDK's known-reasoning-model allowlist
+    // still get thinking/reasoning parameters in API requests.
+    codexOptions.config = {
+      model_supports_reasoning_summaries: true
+    };
+
     if (baseUrl) {
       codexOptions.baseUrl = baseUrl;
     }
@@ -106,6 +113,7 @@ export async function sendMessage(
     if (serviceTier && serviceTier.trim() !== '') {
       const sdkServiceTier = serviceTier.trim();
       codexOptions.config = {
+        ...codexOptions.config,
         features: {
           fast_mode: true
         },


### PR DESCRIPTION
Codex SDK only enables reasoning for models in its hardcoded allowlist. Custom models added by users were excluded, causing the thinking parameter to be null in API requests and no reasoning content displayed.

Set model_supports_reasoning_summaries: true in codexOptions.config to force reasoning support for all models, including custom ones.

Closes #1375