### PR TITLE
feat(permission): hot-swap permission mode on the live runtime mid-turn

### DIFF
--- a/ai-bridge/daemon.js
+++ b/ai-bridge/daemon.js
@@ -36,7 +36,8 @@ import {
   shutdownPersistentRuntimes,
   abortCurrentTurn,
   resetRuntimePersistent,
-  getContextUsagePersistent
+  getContextUsagePersistent,
+  setPermissionModePersistent
 } from './services/claude/persistent-query-service.js';
 import { injectStartupEnvVars, isWebviewControlledEnvVar, isDangerousEnvVar } from './config/api-config.js';
 import { cleanupStaleTempImages } from './services/claude/attachment-service.js';
@@ -240,6 +241,11 @@ process.stdout.write = function (chunk, encoding, callback) {
 // inter-turn 'session_updated' events; without it those events would be
 // misrouted to whatever request happens to be active. See startPerpetualReader().
 process.stdout._originalStdoutWrite = _originalStdoutWrite;
+// Expose the pre-interception stderr writer so out-of-band code (notably the
+// queue-bypassing setPermissionMode path, which runs while another turn's
+// processRequest is active) can log without being tagged with that turn's
+// activeRequestId and corrupting its stdout stream.
+process.stderr._originalStderrWrite = _originalStderrWrite;
 
 /**
  * Override console.log to go through our tagged stdout.
@@ -602,6 +608,31 @@ async function processRequest(request) {
         });
       }
       writeRawLine({ id: request.id || '0', done: true, success: true });
+      return;
+    }
+
+    // Live permission-mode switch bypasses the command queue: it targets the
+    // runtime backing the in-progress turn and must apply before that turn's
+    // next tool call. Queuing it behind the turn's own processRequest would
+    // defer the switch until the turn ends, defeating the purpose. Like abort,
+    // it runs fire-and-forget and emits its own done signal via writeRawLine.
+    if (request.method === 'claude.setPermissionMode') {
+      const switchId = request.id || '0';
+      if (!request.id) {
+        // Without a real request id the done signal carries id='0', which the
+        // Java side has no pending handler for — it would silently drop the
+        // signal and only surface via the 10s timeout. Warn so this is visible.
+        _originalStderrWrite(
+          '[daemon] setPermissionMode arrived without request.id; done signal may be orphaned\n',
+          'utf8'
+        );
+      }
+      setPermissionModePersistent(request.params || {})
+        .then(() => writeRawLine({ id: switchId, done: true, success: true }))
+        .catch((e) => {
+          _originalStderrWrite(`[daemon] setPermissionMode error: ${e.message}\n`, 'utf8');
+          writeRawLine({ id: switchId, done: true, success: false, error: e.message || String(e) });
+        });
       return;
     }
 

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -571,6 +571,97 @@ export async function resetRuntimePersistent(params = {}) {
   }
 }
 
+/**
+ * Hot-swap the permission mode of a live runtime mid-conversation.
+ *
+ * Finds the runtime backing the given session and calls the SDK's
+ * setPermissionMode() plus updates the reactive permissionModeState that the
+ * PreToolUse hook reads on every tool call. Subsequent tool invocations in the
+ * current turn therefore honor the new mode immediately — no runtime restart
+ * and no need to wait for the next user message.
+ *
+ * This is invoked via the daemon's command-queue bypass, so it may execute
+ * while another turn's processRequest is active (activeRequestId set). Any
+ * console.log/error here would be tagged with that turn's id and corrupt its
+ * stdout stream, so logging goes to the original stderr writer and no result
+ * JSON is emitted to stdout — the caller's done signal is the only response.
+ *
+ * When no live runtime exists yet (e.g. before the first message, or the daemon
+ * is recycling the runtime), this is a no-op: the next send_message already
+ * carries the requested mode via buildRequestContext.
+ *
+ * @param {object} params - { sessionId?: string, runtimeSessionEpoch?: string, permissionMode?: string }
+ */
+export async function setPermissionModePersistent(params = {}) {
+  const safeParams = params || {};
+  const sessionId = safeParams.sessionId || null;
+  const epoch = safeParams.runtimeSessionEpoch || null;
+  const targetPermissionMode = normalizePermissionMode(safeParams.permissionMode);
+
+  const log = (msg) => {
+    const w = process.stderr._originalStderrWrite;
+    if (typeof w === 'function') {
+      w(`[LIFECYCLE] ${msg}\n`, 'utf8');
+    } else {
+      process.stderr.write(`[LIFECYCLE] ${msg}\n`);
+    }
+  };
+
+  let runtime = null;
+  if (sessionId) {
+    runtime = getRuntimeForSession(sessionId);
+  }
+  // Fall back to the active turn runtime when it belongs to the same session,
+  // covering the brief window before the session id is promoted onto the runtime.
+  if (!runtime || runtime.closed) {
+    const active = getActiveTurnRuntime();
+    if (active && !active.closed && (!sessionId || active.sessionId === sessionId)) {
+      runtime = active;
+    }
+  }
+
+  if (!runtime || runtime.closed) {
+    log(`setPermissionModePersistent skipped: no live runtime sessionId=${sessionId || '(none)'}`
+      + ` epoch=${epoch || '(none)'} mode=${targetPermissionMode}`);
+    return;
+  }
+
+  if (runtime.currentPermissionMode === targetPermissionMode) {
+    log(`setPermissionModePersistent no-op: already ${targetPermissionMode}`
+      + ` sessionId=${sessionId || '(none)'} epoch=${epoch || '(none)'}`);
+    return;
+  }
+
+  // Push to the SDK first. Only update local state on success — otherwise the
+  // PreToolUse hook would read the new mode while the SDK still enforces the
+  // old one, diverging until the next turn's applyDynamicControls resyncs.
+  // Leaving local state untouched keeps hook and SDK in agreement, and the
+  // Java side's settings write is harmless since the next send_message will
+  // re-apply the requested mode via buildRequestContext.
+  if (typeof runtime.query?.setPermissionMode === 'function') {
+    try {
+      await runtime.query.setPermissionMode(targetPermissionMode);
+    } catch (error) {
+      log(`setPermissionMode failed, local state left unchanged (will resync next turn): ${error.message}`
+        + ` sessionId=${sessionId || '(none)'} epoch=${epoch || '(none)'}`
+        + ` mode=${targetPermissionMode}`);
+      return;
+    }
+  }
+  // Note: a narrow race exists between the await above and these assignments.
+  // If the in-progress turn ends mid-await and a new turn's applyDynamicControls
+  // resets currentPermissionMode, our assignment would clobber that newer value.
+  // The window is a single await tick and the next turn resyncs anyway, so we
+  // accept it rather than add a compare-and-swap against the runtime's epoch.
+  runtime.currentPermissionMode = targetPermissionMode;
+  if (runtime.permissionModeState) {
+    runtime.permissionModeState.value = targetPermissionMode;
+  }
+
+  log(`setPermissionModePersistent applied sessionId=${sessionId || '(none)'}`
+    + ` epoch=${epoch || '(none)'} mode=${targetPermissionMode}`);
+}
+
 export async function abortCurrentTurn() {
   // Atomic swap: clear first to prevent double-disposal from rapid abort calls.
   // JS is single-threaded so assignment is atomic — only the first caller gets

--- a/ai-bridge/services/claude/setPermissionModePersistent.test.mjs
+++ b/ai-bridge/services/claude/setPermissionModePersistent.test.mjs
@@ -1,0 +1,228 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { setPermissionModePersistent, __testing } from './persistent-query-service.js';
+
+/**
+ * Build a fake runtime with the shape setPermissionModePersistent reads.
+ * @param {object} overrides
+ * @returns {object}
+ */
+function createFakeRuntime(overrides = {}) {
+  const setPermissionMode = overrides.setPermissionMode || (async () => {});
+  return {
+    closed: overrides.closed ?? false,
+    sessionId: overrides.sessionId ?? 'sess-1',
+    runtimeSessionEpoch: overrides.runtimeSessionEpoch ?? 'epoch-1',
+    currentPermissionMode: overrides.currentPermissionMode ?? 'default',
+    permissionModeState: { value: overrides.currentPermissionMode ?? 'default' },
+    // disposeRuntime() tears down the perpetual reader via inputStream.done();
+    // supply a no-op so disposing a sentinel fake doesn't throw mid-test.
+    inputStream: { done() { } },
+    query: { setPermissionMode },
+    ...overrides.extra
+  };
+}
+
+test.beforeEach(async () => {
+  await __testing.resetState();
+});
+
+test.after(async () => {
+  await __testing.resetState();
+});
+
+test('setPermissionModePersistent skips when no live runtime exists', async () => {
+  // No active turn runtime and no session runtime registered for 'sess-none'.
+  let calls = 0;
+  const unreachable = createFakeRuntime({
+    sessionId: 'sess-other',
+    currentPermissionMode: 'default',
+    setPermissionMode: async () => { calls += 1; }
+  });
+  __testing.setActiveTurnRuntime(unreachable);
+
+  await setPermissionModePersistent({
+    sessionId: 'sess-none',
+    runtimeSessionEpoch: 'epoch-none',
+    permissionMode: 'acceptEdits'
+  });
+
+  // The unrelated active runtime must not be touched: no SDK call and no state change.
+  assert.equal(calls, 0);
+  assert.equal(unreachable.currentPermissionMode, 'default');
+  assert.equal(unreachable.permissionModeState.value, 'default');
+});
+
+test('setPermissionModePersistent applies the new mode to SDK and reactive state', async () => {
+  let appliedMode = null;
+  const runtime = createFakeRuntime({
+    currentPermissionMode: 'default',
+    setPermissionMode: async (mode) => { appliedMode = mode; }
+  });
+  __testing.setActiveTurnRuntime(runtime);
+
+  await setPermissionModePersistent({
+    sessionId: 'sess-1',
+    runtimeSessionEpoch: 'epoch-1',
+    permissionMode: 'acceptEdits'
+  });
+
+  assert.equal(appliedMode, 'acceptEdits');
+  assert.equal(runtime.currentPermissionMode, 'acceptEdits');
+  assert.equal(runtime.permissionModeState.value, 'acceptEdits');
+});
+
+test('setPermissionModePersistent is a no-op when the mode is unchanged', async () => {
+  let calls = 0;
+  const runtime = createFakeRuntime({
+    currentPermissionMode: 'plan',
+    setPermissionMode: async () => { calls += 1; }
+  });
+  __testing.setActiveTurnRuntime(runtime);
+
+  await setPermissionModePersistent({
+    sessionId: 'sess-1',
+    runtimeSessionEpoch: 'epoch-1',
+    permissionMode: 'plan'
+  });
+
+  assert.equal(calls, 0);
+  assert.equal(runtime.currentPermissionMode, 'plan');
+  assert.equal(runtime.permissionModeState.value, 'plan');
+});
+
+test('setPermissionModePersistent leaves local state unchanged when the SDK call fails', async () => {
+  const runtime = createFakeRuntime({
+    currentPermissionMode: 'default',
+    setPermissionMode: async () => { throw new Error('SDK rejected'); }
+  });
+  __testing.setActiveTurnRuntime(runtime);
+
+  await setPermissionModePersistent({
+    sessionId: 'sess-1',
+    runtimeSessionEpoch: 'epoch-1',
+    permissionMode: 'acceptEdits'
+  });
+
+  // On failure the hook and SDK must stay in agreement, so local state keeps
+  // the old mode until the next turn's applyDynamicControls resyncs.
+  assert.equal(runtime.currentPermissionMode, 'default');
+  assert.equal(runtime.permissionModeState.value, 'default');
+});
+
+test('setPermissionModePersistent normalizes an unknown mode to default', async () => {
+  let appliedMode = null;
+  const runtime = createFakeRuntime({
+    currentPermissionMode: 'plan',
+    setPermissionMode: async (mode) => { appliedMode = mode; }
+  });
+  __testing.setActiveTurnRuntime(runtime);
+
+  await setPermissionModePersistent({
+    sessionId: 'sess-1',
+    runtimeSessionEpoch: 'epoch-1',
+    permissionMode: 'bogus-mode'
+  });
+
+  assert.equal(appliedMode, 'default');
+  assert.equal(runtime.currentPermissionMode, 'default');
+  assert.equal(runtime.permissionModeState.value, 'default');
+});
+
+test('setPermissionModePersistent skips a closed active runtime', async () => {
+  let calls = 0;
+  const runtime = createFakeRuntime({
+    closed: true,
+    currentPermissionMode: 'default',
+    setPermissionMode: async () => { calls += 1; }
+  });
+  __testing.setActiveTurnRuntime(runtime);
+
+  await setPermissionModePersistent({
+    sessionId: 'sess-1',
+    runtimeSessionEpoch: 'epoch-1',
+    permissionMode: 'acceptEdits'
+  });
+
+  assert.equal(calls, 0);
+});
+
+test('setPermissionModePersistent still updates state when query has no setPermissionMode', async () => {
+  // A runtime whose query object lacks setPermissionMode (older SDK shape).
+  const runtime = createFakeRuntime({
+    currentPermissionMode: 'default',
+    setPermissionMode: undefined
+  });
+  runtime.query = {};
+  __testing.setActiveTurnRuntime(runtime);
+
+  await setPermissionModePersistent({
+    sessionId: 'sess-1',
+    runtimeSessionEpoch: 'epoch-1',
+    permissionMode: 'acceptEdits'
+  });
+
+  assert.equal(runtime.currentPermissionMode, 'acceptEdits');
+  assert.equal(runtime.permissionModeState.value, 'acceptEdits');
+});
+
+test('setPermissionModePersistent prefers a registered session runtime over the active-turn fallback', async () => {
+  // Register a real runtime in the session map via acquireRuntime so that
+  // getRuntimeForSession('sess-registered') resolves to it directly.
+  const factory = createTrackingQueryFactory();
+  __testing.setQueryFn(factory.queryFn);
+
+  const context = await __testing.buildRequestContext({
+    sessionId: 'sess-registered',
+    runtimeSessionEpoch: 'epoch-registered',
+    cwd: process.cwd(),
+    message: 'seed turn'
+  }, false);
+  const registered = await __testing.acquireRuntime(context);
+
+  // Place a *different* runtime as the active turn one — it must NOT be picked
+  // because the session-map lookup already resolved the registered runtime.
+  let sentinelCalls = 0;
+  const sentinel = createFakeRuntime({
+    sessionId: 'sess-active',
+    currentPermissionMode: 'default',
+    setPermissionMode: async () => { sentinelCalls += 1; }
+  });
+  __testing.setActiveTurnRuntime(sentinel);
+
+  await setPermissionModePersistent({
+    sessionId: 'sess-registered',
+    runtimeSessionEpoch: 'epoch-registered',
+    permissionMode: 'plan'
+  });
+
+  assert.equal(registered.currentPermissionMode, 'plan');
+  assert.equal(registered.permissionModeState.value, 'plan');
+  assert.equal(sentinelCalls, 0, 'active-turn fallback must not be used when session runtime exists');
+  assert.equal(sentinel.currentPermissionMode, 'default');
+});
+
+/**
+ * Query factory whose returned runtime records every setPermissionMode call.
+ * next() never resolves so the perpetual reader keeps the runtime alive
+ * (returning done immediately would let the reader dispose it pre-emptively,
+ * which is an unrelated, pre-existing test-infra quirk).
+ * @returns {{ queryFn: Function, setPermissionModeCalls: number[] }}
+ */
+function createTrackingQueryFactory() {
+  const setPermissionModeCalls = [];
+  const queryFn = ({ prompt, options }) => {
+    return {
+      prompt,
+      options,
+      closed: false,
+      async setPermissionMode(mode) { setPermissionModeCalls.push(mode); },
+      async setModel() { },
+      async setMaxThinkingTokens() { },
+      close() { this.closed = true; },
+      next() { return new Promise(() => { }); }
+    };
+  };
+  return { queryFn, setPermissionModeCalls };
+}

--- a/src/main/java/com/github/claudecodegui/handler/PermissionModeHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/PermissionModeHandler.java
@@ -32,8 +32,8 @@ public class PermissionModeHandler {
             String currentMode = "default";  // Default value (prompt on each tool call)
 
             // Prefer getting from session first
-            if (context.getSession() != null) {
-                String sessionMode = context.getSession().getPermissionMode();
+            if (this.context.getSession() != null) {
+                String sessionMode = this.context.getSession().getPermissionMode();
                 if (sessionMode != null && !sessionMode.trim().isEmpty()) {
                     currentMode = sessionMode;
                 }
@@ -49,7 +49,7 @@ public class PermissionModeHandler {
             final String modeToSend = currentMode;
 
             ApplicationManager.getApplication().invokeLater(() -> {
-                context.callJavaScript("window.onModeReceived", context.escapeJs(modeToSend));
+                this.context.callJavaScript("window.onModeReceived", this.context.escapeJs(modeToSend));
             });
         } catch (Exception e) {
             LOG.error("[PermissionModeHandler] Failed to get mode: " + e.getMessage(), e);
@@ -64,7 +64,7 @@ public class PermissionModeHandler {
             String mode = content;
             if (content != null && !content.isEmpty()) {
                 try {
-                    JsonObject json = gson.fromJson(content, JsonObject.class);
+                    JsonObject json = this.gson.fromJson(content, JsonObject.class);
                     if (json.has("mode")) {
                         mode = json.get("mode").getAsString();
                     }
@@ -74,19 +74,61 @@ public class PermissionModeHandler {
             }
 
             // Check if session exists
-            if (context.getSession() != null) {
-                context.getSession().setPermissionMode(mode);
+            if (this.context.getSession() != null) {
+                this.context.getSession().setPermissionMode(mode);
 
                 // Save permission mode to persistent storage
                 PropertiesComponent props = PropertiesComponent.getInstance();
                 props.setValue(PERMISSION_MODE_PROPERTY_KEY, mode);
                 LOG.info("Saved permission mode to settings: " + mode);
-                com.github.claudecodegui.notifications.ClaudeNotifier.setMode(context.getProject(), mode);
+                com.github.claudecodegui.notifications.ClaudeNotifier.setMode(this.context.getProject(), mode);
+
+                // Push the new mode to the live runtime so it takes effect on the
+                // next tool call in the current turn, mirroring the TUI's instant
+                // mode switch instead of waiting for the next user message.
+                pushPermissionModeLive(mode);
             } else {
                 LOG.warn("[PermissionModeHandler] WARNING: Session is null! Cannot set permission mode");
             }
         } catch (Exception e) {
             LOG.error("[PermissionModeHandler] Failed to set mode: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Notify the live AI Bridge runtime of a mode change so it applies
+     * immediately to the in-progress conversation.
+     */
+    private void pushPermissionModeLive(String mode) {
+        try {
+            String provider = this.context.getCurrentProvider();
+            if (provider == null || provider.isEmpty()) {
+                provider = com.github.claudecodegui.handler.core.HandlerContext.DEFAULT_PROVIDER;
+            }
+
+            // Only the Claude persistent runtime supports hot-swapping the mode
+            // on a live query today; Codex rebuilds thread options per turn.
+            // TODO: implement live permission-mode switch for the Codex provider
+            // (verify whether the Codex SDK supports reconfiguring approvalPolicy
+            // / sandbox on an active thread without recreating it).
+            if (!"claude".equals(provider)) {
+                return;
+            }
+
+            com.github.claudecodegui.session.ClaudeSession session = this.context.getSession();
+            if (session == null) {
+                return;
+            }
+            String sessionId = session.getSessionId();
+            String epoch = session.getRuntimeSessionEpoch();
+
+            this.context.getClaudeSDKBridge().setPermissionModeLive(sessionId, epoch, mode)
+                    .exceptionally(ex -> {
+                        LOG.warn("[PermissionModeHandler] Live mode push failed: " + ex.getMessage());
+                        return null;
+                    });
+        } catch (Exception e) {
+            LOG.warn("[PermissionModeHandler] Live mode push skipped: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridge.java
@@ -592,6 +592,103 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
         });
     }
 
+    /**
+     * Hot-swap the permission mode of the live daemon runtime mid-conversation.
+     *
+     * Pushes the new mode to the SDK query and the reactive state the PreToolUse
+     * hook reads, so subsequent tool calls in the current turn honor it
+     * immediately instead of waiting for the next user message.
+     *
+     * Fire-and-forget with a short guard timeout: when no daemon or no live
+     * runtime is present this is a graceful no-op, and the next send_message
+     * already carries the mode via the request payload.
+     *
+     * @param sessionId           The session whose runtime should be updated.
+     * @param runtimeSessionEpoch The runtime epoch for logging/diagnostics (optional).
+     * @param permissionMode      The normalized permission mode to apply.
+     */
+    public CompletableFuture<JsonObject> setPermissionModeLive(
+            String sessionId, String runtimeSessionEpoch, String permissionMode) {
+        // Use the non-spawning accessor: this is a best-effort push to whatever
+        // daemon is already running. Spawning a fresh daemon here would block the
+        // JCEF message thread and serve no purpose — a freshly started daemon has
+        // no live runtime, so setPermissionModePersistent would be a no-op anyway.
+        DaemonBridge db = this.daemonCoordinator.getCurrentDaemonBridge();
+        if (db == null || !db.isAlive()) {
+            JsonObject skipped = new JsonObject();
+            skipped.addProperty("success", true);
+            skipped.addProperty("applied", false);
+            skipped.addProperty("reason", "no-daemon");
+            return CompletableFuture.completedFuture(skipped);
+        }
+
+        JsonObject params = new JsonObject();
+        if (sessionId != null && !sessionId.isEmpty()) {
+            params.addProperty("sessionId", sessionId);
+        }
+        if (runtimeSessionEpoch != null && !runtimeSessionEpoch.isEmpty()) {
+            params.addProperty("runtimeSessionEpoch", runtimeSessionEpoch);
+        }
+        if (permissionMode != null && !permissionMode.isEmpty()) {
+            params.addProperty("permissionMode", permissionMode);
+        }
+
+        CompletableFuture<JsonObject> resultFuture = new CompletableFuture<>();
+
+        // The setPermissionMode path only emits a {id, done, success} signal —
+        // no streaming line output — so onLine is never invoked; we complete
+        // purely from onComplete/onError.
+        DaemonBridge.DaemonOutputCallback callback = new DaemonBridge.DaemonOutputCallback() {
+            @Override
+            public void onLine(String line) { }
+            @Override
+            public void onStderr(String text) { }
+            @Override
+            public void onError(String error) {
+                if (!resultFuture.isDone()) {
+                    JsonObject err = new JsonObject();
+                    err.addProperty("success", false);
+                    err.addProperty("error", error);
+                    resultFuture.complete(err);
+                }
+            }
+            @Override
+            public void onComplete(boolean success) {
+                if (!resultFuture.isDone()) {
+                    JsonObject ok = new JsonObject();
+                    ok.addProperty("success", success);
+                    resultFuture.complete(ok);
+                }
+            }
+        };
+
+        try {
+            CompletableFuture<Boolean> commandFuture = db.sendCommand("claude.setPermissionMode", params, callback);
+            commandFuture.exceptionally(ex -> {
+                if (!resultFuture.isDone()) {
+                    JsonObject err = new JsonObject();
+                    err.addProperty("success", false);
+                    err.addProperty("error", ex.getMessage());
+                    resultFuture.complete(err);
+                }
+                return false;
+            });
+        } catch (Exception e) {
+            LOG.error("[ClaudeSDKBridge] setPermissionModeLive failed: " + e.getMessage(), e);
+            JsonObject err = new JsonObject();
+            err.addProperty("success", false);
+            err.addProperty("error", e.getMessage());
+            return CompletableFuture.completedFuture(err);
+        }
+
+        return resultFuture.orTimeout(10, TimeUnit.SECONDS).exceptionally(ex -> {
+            JsonObject err = new JsonObject();
+            err.addProperty("success", false);
+            err.addProperty("error", "setPermissionMode timed out after 10 seconds");
+            return err;
+        });
+    }
+
     // ============================================================================
     // Daemon mode message sending
     // ============================================================================


### PR DESCRIPTION
Switching the permission mode previously only wrote the value to settings and the session, so it took effect on the NEXT user message — the in-progress turn kept running under the old mode until buildRequestContext re-applied it. This mirrors the gap the TUI closes with an instant mode switch.

Wire a fire-and-forget push from the Java handler down to the daemon runtime so subsequent tool calls in the current turn honor the new mode immediately, no runtime restart and no waiting for the next send_message.

Java layer:
- PermissionModeHandler.handleSetMode now calls pushPermissionModeLive(mode) after saving the mode. It is Claude-only (Codex rebuilds thread options per turn; a TODO tracks verifying whether the Codex SDK can reconfigure approvalPolicy/sandbox on an active thread). No daemon or no session => graceful no-op; the next send_message already carries the mode.
- ClaudeSDKBridge.setPermissionModeLive sends a "claude.setPermissionMode" command via the non-spawning DaemonBridge accessor (spawning a fresh daemon here would block the JCEF message thread and serve no purpose — a brand-new daemon has no live runtime). Guarded by a 10s orTimeout so a lost done signal cannot hang the future forever.

AI Bridge layer:
- daemon.js intercepts "claude.setPermissionMode" BEFORE the command queue, right after the abort path. Queueing it behind the turn's own processRequest would defer the switch until the turn ends, defeating the purpose. Like abort it is fire-and-forget and emits its own {id, done, success} signal via writeRawLine so the Java side's onComplete resolves. Warns to stderr when a request arrives without an id, since the done signal would otherwise be orphaned (no pending handler) and only surface via the 10s timeout.
- Exposes process.stderr._originalStderrWrite so this queue-bypassing path can log without being tagged with the active turn's activeRequestId and corrupting its stdout stream.
- persistent-query-service.js exports setPermissionModePersistent(params): resolves the runtime by sessionId (falling back to the active-turn runtime when it belongs to the same session, covering the window before the session id is promoted onto the runtime), pushes the mode to the SDK via query.setPermissionMode(), and updates the reactive permissionModeState the PreToolUse hook reads on every tool call.

  State consistency: the SDK is pushed FIRST and local state is updated only on success. If the SDK call fails, local state is left untouched so the hook and the SDK stay in agreement until the next turn's applyDynamicControls resyncs (the Java settings write is harmless — the next send_message re-applies the requested mode via buildRequestContext). A narrow race exists between the await and the state assignment (a new turn's applyDynamicControls could reset the field mid-await); the window is a single tick and the next turn resyncs, so it is accepted rather than adding a compare-and-swap against the runtime epoch.

  No live runtime yet (before the first message, or while the daemon is recycling) => no-op; buildRequestContext already carries the mode.

Tests:
- setPermissionModePersistent.test.mjs covers 8 cases: no live runtime (must not touch an unrelated active runtime), apply to SDK + reactive state, no-op when unchanged, local state unchanged on SDK failure, unknown mode normalized to default, closed runtime skipped, runtime whose query lacks setPermissionMode (older SDK shape) still updates state, and a registered session runtime preferred over the active-turn fallback. All 8 pass; ./gradlew checkstyleMain passes.