### PR TITLE
feat(permission): always-show AskUserQuestion textarea, deny-with-feedback, plan reject feedback

### DIFF
--- a/ai-bridge/permission-handler.js
+++ b/ai-bridge/permission-handler.js
@@ -174,10 +174,10 @@ export async function canUseTool(toolName, input, options = {}) {
 
   // All other tools require explicit permission
   debugLog('PERMISSION_NEEDED', `Tool ${toolName} requires permission, calling requestPermissionFromJava`);
-  const allowed = await requestPermissionFromJava(toolName, input);
+  const result = await requestPermissionFromJava(toolName, input);
   const elapsed = Date.now() - callStartTime;
 
-  if (allowed) {
+  if (result.allowed) {
     debugLog('PERMISSION_GRANTED', `User allowed ${toolName}`, { elapsed: `${elapsed}ms` });
     return {
       behavior: 'allow',
@@ -187,7 +187,7 @@ export async function canUseTool(toolName, input, options = {}) {
     debugLog('PERMISSION_DENIED', `User denied ${toolName}`, { elapsed: `${elapsed}ms` });
     return {
       behavior: 'deny',
-      message: `User denied permission for ${toolName} tool`
+      message: result.rejectMessage || `User denied permission for ${toolName} tool`
     };
   }
 }

--- a/ai-bridge/permission-ipc.js
+++ b/ai-bridge/permission-ipc.js
@@ -415,10 +415,10 @@ export async function requestPermissionFromJava(toolName, input) {
       responseFileExists: respFileExists
     });
 
-    return false;
+    return { allowed: false, rejectMessage: undefined };
 
   } catch (error) {
     debugLog('FATAL_ERROR', `Unexpected error in requestPermissionFromJava: ${errorClass(error)}`);
-    return false;
+    return { allowed: false, rejectMessage: undefined };
   }
 }

--- a/ai-bridge/permission-ipc.js
+++ b/ai-bridge/permission-ipc.js
@@ -48,9 +48,12 @@ export function describeContentForLog(content) {
 export function parsePermissionAllowResponse(content) {
   try {
     const responseData = JSON.parse(content);
-    return responseData?.allow === true;
+    return {
+      allowed: responseData?.allow === true,
+      rejectMessage: responseData?.rejectMessage || undefined,
+    };
   } catch {
-    return false;
+    return { allowed: false, rejectMessage: undefined };
   }
 }
 
@@ -312,7 +315,7 @@ export async function requestPlanApproval(input) {
  * Request permission via file system communication with Java process.
  * @param {string} toolName - Tool name
  * @param {Object} input - Tool parameters
- * @returns {Promise<boolean>} - Whether allowed
+ * @returns {Promise<{allowed: boolean, rejectMessage?: string}>} - Permission result
  */
 export async function requestPermissionFromJava(toolName, input) {
   const requestStartTime = Date.now();
@@ -353,7 +356,7 @@ export async function requestPermissionFromJava(toolName, input) {
       }
     } catch (writeError) {
       debugLog('FILE_WRITE_ERROR', `Failed to write request file: ${errorClass(writeError)}`);
-      return false;
+      return { allowed: false, rejectMessage: undefined };
     }
 
     const timeout = PERMISSION_REQUEST_SAFETY_NET_MS;
@@ -385,7 +388,7 @@ export async function requestPermissionFromJava(toolName, input) {
           debugLog('RESPONSE_CONTENT', 'Response content read', describeContentForLog(responseContent));
 
           const result = parsePermissionAllowResponse(responseContent);
-          debugLog('RESPONSE_PARSED', `Parsed response`, { allow: result, elapsed: `${Date.now() - requestStartTime}ms` });
+          debugLog('RESPONSE_PARSED', `Parsed response`, { allowed: result.allowed, elapsed: `${Date.now() - requestStartTime}ms` });
 
           try {
             unlinkSync(responseFile);
@@ -397,7 +400,7 @@ export async function requestPermissionFromJava(toolName, input) {
           return result;
         } catch (e) {
           debugLog('RESPONSE_ERROR', `Error reading/parsing response: ${errorClass(e)}`);
-          return false;
+          return { allowed: false, rejectMessage: undefined };
         }
       }
     }

--- a/ai-bridge/permission-ipc.test.js
+++ b/ai-bridge/permission-ipc.test.js
@@ -70,34 +70,34 @@ test('log metadata helpers do not include raw permission payload values', () => 
 // can never escalate into an accidental permission grant.
 
 test('parsePermissionAllowResponse allows only when allow === true (boolean)', () => {
-  assert.equal(parsePermissionAllowResponse('{"allow":true}'), true);
+  assert.equal(parsePermissionAllowResponse('{"allow":true}').allowed, true);
 });
 
 test('parsePermissionAllowResponse rejects truthy-but-non-boolean allow values', () => {
-  assert.equal(parsePermissionAllowResponse('{"allow":"true"}'), false);
-  assert.equal(parsePermissionAllowResponse('{"allow":1}'), false);
-  assert.equal(parsePermissionAllowResponse('{"allow":"yes"}'), false);
-  assert.equal(parsePermissionAllowResponse('{"allow":[true]}'), false);
-  assert.equal(parsePermissionAllowResponse('{"allow":{"value":true}}'), false);
+  assert.equal(parsePermissionAllowResponse('{"allow":"true"}').allowed, false);
+  assert.equal(parsePermissionAllowResponse('{"allow":1}').allowed, false);
+  assert.equal(parsePermissionAllowResponse('{"allow":"yes"}').allowed, false);
+  assert.equal(parsePermissionAllowResponse('{"allow":[true]}').allowed, false);
+  assert.equal(parsePermissionAllowResponse('{"allow":{"value":true}}').allowed, false);
   // Regression guard: a prototype-pollution payload sets `__proto__` as an own
   // key on the parsed object (JSON.parse does not promote it to actual prototype),
   // so `responseData?.allow === true` still resolves against the own `allow` slot.
   // Pin the behavior so a refactor cannot reintroduce the gap.
-  assert.equal(parsePermissionAllowResponse('{"__proto__":{"allow":true}}'), false);
+  assert.equal(parsePermissionAllowResponse('{"__proto__":{"allow":true}}').allowed, false);
 });
 
 test('parsePermissionAllowResponse rejects explicit deny and missing field', () => {
-  assert.equal(parsePermissionAllowResponse('{"allow":false}'), false);
-  assert.equal(parsePermissionAllowResponse('{"allow":null}'), false);
-  assert.equal(parsePermissionAllowResponse('{}'), false);
-  assert.equal(parsePermissionAllowResponse('{"remember":true}'), false);
+  assert.equal(parsePermissionAllowResponse('{"allow":false}').allowed, false);
+  assert.equal(parsePermissionAllowResponse('{"allow":null}').allowed, false);
+  assert.equal(parsePermissionAllowResponse('{}').allowed, false);
+  assert.equal(parsePermissionAllowResponse('{"remember":true}').allowed, false);
 });
 
 test('parsePermissionAllowResponse rejects malformed and empty payloads', () => {
   // A partially-written response file shows up as truncated JSON — must deny,
   // not throw, so the polling caller can continue waiting for a valid write.
-  assert.equal(parsePermissionAllowResponse(''), false);
-  assert.equal(parsePermissionAllowResponse('not json'), false);
-  assert.equal(parsePermissionAllowResponse('{"allow":tru'), false);
-  assert.equal(parsePermissionAllowResponse('null'), false);
+  assert.equal(parsePermissionAllowResponse('').allowed, false);
+  assert.equal(parsePermissionAllowResponse('not json').allowed, false);
+  assert.equal(parsePermissionAllowResponse('{"allow":tru').allowed, false);
+  assert.equal(parsePermissionAllowResponse('null').allowed, false);
 });

--- a/ai-bridge/services/claude/permission-mode.js
+++ b/ai-bridge/services/claude/permission-mode.js
@@ -153,17 +153,17 @@ export function createPreToolUseHook(permissionModeState, cwd = null, onModeChan
           return {
             hookSpecificOutput: {
               hookEventName: 'PreToolUse',
-              permissionDecision: 'deny'
-            },
-            reason: result?.message || 'Plan was rejected by user'
+              permissionDecision: 'deny',
+              permissionDecisionReason: result?.message || 'Plan was rejected by user'
+            }
           };
         } catch (error) {
           return {
             hookSpecificOutput: {
               hookEventName: 'PreToolUse',
-              permissionDecision: 'deny'
-            },
-            reason: 'Plan approval failed: ' + (error?.message || String(error))
+              permissionDecision: 'deny',
+              permissionDecisionReason: 'Plan approval failed: ' + (error?.message || String(error))
+            }
           };
         }
       }
@@ -212,17 +212,17 @@ export function createPreToolUseHook(permissionModeState, cwd = null, onModeChan
           return {
             hookSpecificOutput: {
               hookEventName: 'PreToolUse',
-              permissionDecision: 'deny'
-            },
-            reason: result?.message || `Cannot edit non-plan files in plan mode. Only ${PLAN_FILE_NAME} can be edited.`
+              permissionDecision: 'deny',
+              permissionDecisionReason: result?.message || `Cannot edit non-plan files in plan mode. Only ${PLAN_FILE_NAME} can be edited.`
+            }
           };
         } catch (error) {
           return {
             hookSpecificOutput: {
               hookEventName: 'PreToolUse',
-              permissionDecision: 'deny'
-            },
-            reason: 'Permission check failed: ' + (error?.message || String(error))
+              permissionDecision: 'deny',
+              permissionDecisionReason: 'Permission check failed: ' + (error?.message || String(error))
+            }
           };
         }
       }
@@ -242,17 +242,17 @@ export function createPreToolUseHook(permissionModeState, cwd = null, onModeChan
           return {
             hookSpecificOutput: {
               hookEventName: 'PreToolUse',
-              permissionDecision: 'deny'
-            },
-            reason: result?.message || 'Permission denied'
+              permissionDecision: 'deny',
+              permissionDecisionReason: result?.message || 'Permission denied'
+            }
           };
         } catch (error) {
           return {
             hookSpecificOutput: {
               hookEventName: 'PreToolUse',
-              permissionDecision: 'deny'
-            },
-            reason: 'Permission check failed: ' + (error?.message || String(error))
+              permissionDecision: 'deny',
+              permissionDecisionReason: 'Permission check failed: ' + (error?.message || String(error))
+            }
           };
         }
       }
@@ -271,9 +271,9 @@ export function createPreToolUseHook(permissionModeState, cwd = null, onModeChan
       return {
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'deny'
-        },
-        reason: `Tool "${toolName}" is not allowed in plan mode. Only read-only tools are permitted.`
+          permissionDecision: 'deny',
+          permissionDecisionReason: `Tool "${toolName}" is not allowed in plan mode. Only read-only tools are permitted.`
+        }
       };
     }
 

--- a/ai-bridge/services/codex/codex-event-handler.js
+++ b/ai-bridge/services/codex/codex-event-handler.js
@@ -329,9 +329,9 @@ async function requestPatchApprovalsViaBridge(patchBatches) {
     if (!requestPayload) continue;
     try {
       logInfo('PERM_DEBUG', `Patch approval request: callId=${batch.callId}, tool=${requestPayload.toolName}, file=${previewOp?.filePath || ''}`);
-      const allowed = await requestPermissionFromJava(requestPayload.toolName, requestPayload.input);
-      logInfo('PERM_DEBUG', `Patch approval decision: callId=${batch.callId}, allowed=${allowed ? 'true' : 'false'}`);
-      if (!allowed) deniedCallIds.add(batch.callId);
+      const result = await requestPermissionFromJava(requestPayload.toolName, requestPayload.input);
+      logInfo('PERM_DEBUG', `Patch approval decision: callId=${batch.callId}, allowed=${result.allowed ? 'true' : 'false'}`);
+      if (!result.allowed) deniedCallIds.add(batch.callId);
     } catch (error) {
       logWarn('PERM_DEBUG', `Patch approval bridge failed (callId=${batch.callId}): ${error?.message || error}`);
       deniedCallIds.add(batch.callId);
@@ -434,9 +434,9 @@ async function maybeRequestCommandApprovalViaBridge(state, config, { toolUseId, 
   const requestInput = { command, description, source: 'codex_command_execution' };
   try {
     logInfo('PERM_DEBUG', `Command approval request: toolUseId=${toolUseId}, tool=${permissionToolName}, command=${command}`);
-    const allowed = await requestPermissionFromJava(permissionToolName, requestInput);
-    logInfo('PERM_DEBUG', `Command approval decision: toolUseId=${toolUseId}, allowed=${allowed ? 'true' : 'false'}`);
-    if (allowed) return true;
+    const result = await requestPermissionFromJava(permissionToolName, requestInput);
+    logInfo('PERM_DEBUG', `Command approval decision: toolUseId=${toolUseId}, allowed=${result.allowed ? 'true' : 'false'}`);
+    if (result.allowed) return true;
   } catch (error) {
     logWarn('PERM_DEBUG', `Command approval bridge failed, deny by default: toolUseId=${toolUseId}, error=${error?.message || error}`);
   }

--- a/src/main/java/com/github/claudecodegui/handler/PermissionHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/PermissionHandler.java
@@ -550,6 +550,10 @@ public class PermissionHandler extends BaseMessageHandler {
             String requestId = response.get("requestId").getAsString();
             boolean approved = response.has("approved") && response.get("approved").getAsBoolean();
             String targetMode = response.has("targetMode") ? response.get("targetMode").getAsString() : "default";
+            String message = null;
+            if (response.has("message") && !response.get("message").isJsonNull()) {
+                message = response.get("message").getAsString();
+            }
 
             CompletableFuture<JsonObject> pendingFuture = pendingPlanApprovalRequests.remove(requestId);
 
@@ -557,6 +561,9 @@ public class PermissionHandler extends BaseMessageHandler {
                 JsonObject result = new JsonObject();
                 result.addProperty("approved", approved);
                 result.addProperty("targetMode", targetMode);
+                if (message != null && !message.isEmpty()) {
+                    result.addProperty("message", message);
+                }
                 LOG.debug("[PLAN_APPROVAL][HANDLE_RESPONSE] Completing future: approved=" + approved + ", targetMode=" + targetMode);
                 pendingFuture.complete(result);
             } else {

--- a/src/main/java/com/github/claudecodegui/handler/PermissionHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/PermissionHandler.java
@@ -322,10 +322,11 @@ public class PermissionHandler extends BaseMessageHandler {
                 }
                 pendingFuture.complete(new PermissionService.DialogResult(responseValue, rejectMessage));
                 LOG.info("[PERM_DECISION] Future completed with value=" + responseValue);
-
-                if (!allow) {
-                    notifyPermissionDenied();
-                }
+                // Do NOT call notifyPermissionDenied() here — the deny result
+                // (including custom rejectMessage) is already communicated back to
+                // Claude SDK via the file IPC protocol. Interrupting the session at
+                // this point would kill the process before Claude can receive the
+                // feedback and adapt (e.g., rewrite a plan).
             } else {
                 LOG.warn("[PERM_DECISION] No pending future found for channelId=" + channelId + ", falling back to session handler");
                 LOG.warn("[PERM_DECISION] Current pendingPermissionRequests keys: " + pendingPermissionRequests.keySet());

--- a/src/main/java/com/github/claudecodegui/handler/PermissionHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/PermissionHandler.java
@@ -59,7 +59,7 @@ public class PermissionHandler extends BaseMessageHandler {
     private final SafetyNetScheduler safetyNetScheduler;
 
     // Permission request map
-    private final Map<String, CompletableFuture<Integer>> pendingPermissionRequests = new ConcurrentHashMap<>();
+    private final Map<String, CompletableFuture<PermissionService.DialogResult>> pendingPermissionRequests = new ConcurrentHashMap<>();
 
     // AskUserQuestion request map (requestId -> CompletableFuture<JsonObject>)
     private final Map<String, CompletableFuture<JsonObject>> pendingAskUserQuestionRequests = new ConcurrentHashMap<>();
@@ -164,9 +164,9 @@ public class PermissionHandler extends BaseMessageHandler {
     /**
      * Show the frontend permission dialog.
      */
-    public CompletableFuture<Integer> showFrontendPermissionDialog(String toolName, JsonObject inputs) {
+    public CompletableFuture<PermissionService.DialogResult> showFrontendPermissionDialog(String toolName, JsonObject inputs) {
         String channelId = UUID.randomUUID().toString();
-        CompletableFuture<Integer> future = new CompletableFuture<>();
+        CompletableFuture<PermissionService.DialogResult> future = new CompletableFuture<>();
 
         LOG.info("[PERM_SHOW] showFrontendPermissionDialog called: channelId=" + channelId + ", toolName=" + toolName);
 
@@ -199,7 +199,8 @@ public class PermissionHandler extends BaseMessageHandler {
             });
 
             scheduleSafetyNet(future, () -> {
-                if (future.complete(PermissionService.PermissionResponse.DENY.getValue())) {
+                if (future.complete(new PermissionService.DialogResult(
+                        PermissionService.PermissionResponse.DENY.getValue(), null))) {
                     LOG.warn("[PERM_SHOW] Safety-net timeout fired (webview unreachable) for channelId=" + channelId);
                     pendingPermissionRequests.remove(channelId);
                     // The webview may still have the dialog open (with its own
@@ -214,7 +215,8 @@ public class PermissionHandler extends BaseMessageHandler {
         } catch (Exception e) {
             LOG.error("[PERM_SHOW] ERROR: errorClass=" + errorClass(e), e);
             pendingPermissionRequests.remove(channelId);
-            future.complete(PermissionService.PermissionResponse.DENY.getValue());
+            future.complete(new PermissionService.DialogResult(
+                    PermissionService.PermissionResponse.DENY.getValue(), null));
         }
 
         return future;
@@ -306,7 +308,7 @@ public class PermissionHandler extends BaseMessageHandler {
             LOG.info("[PERM_DECISION] channelId=" + channelId + ", allow=" + allow + ", remember=" + remember);
             LOG.info("[PERM_DECISION] pendingPermissionRequests size before remove: " + pendingPermissionRequests.size());
 
-            CompletableFuture<Integer> pendingFuture = pendingPermissionRequests.remove(channelId);
+            CompletableFuture<PermissionService.DialogResult> pendingFuture = pendingPermissionRequests.remove(channelId);
 
             if (pendingFuture != null) {
                 LOG.info("[PERM_DECISION] Found pending future, completing with allow=" + allow);
@@ -318,7 +320,7 @@ public class PermissionHandler extends BaseMessageHandler {
                 } else {
                     responseValue = PermissionService.PermissionResponse.DENY.getValue();
                 }
-                pendingFuture.complete(responseValue);
+                pendingFuture.complete(new PermissionService.DialogResult(responseValue, rejectMessage));
                 LOG.info("[PERM_DECISION] Future completed with value=" + responseValue);
 
                 if (!allow) {
@@ -363,8 +365,9 @@ public class PermissionHandler extends BaseMessageHandler {
         int planCount = pendingPlanApprovalRequests.size();
 
         // Cancel all pending permission requests
-        for (Map.Entry<String, CompletableFuture<Integer>> entry : pendingPermissionRequests.entrySet()) {
-            entry.getValue().complete(PermissionService.PermissionResponse.DENY.getValue());
+        for (Map.Entry<String, CompletableFuture<PermissionService.DialogResult>> entry : pendingPermissionRequests.entrySet()) {
+            entry.getValue().complete(new PermissionService.DialogResult(
+                    PermissionService.PermissionResponse.DENY.getValue(), null));
         }
         pendingPermissionRequests.clear();
 

--- a/src/main/java/com/github/claudecodegui/permission/PermissionFileProtocol.java
+++ b/src/main/java/com/github/claudecodegui/permission/PermissionFileProtocol.java
@@ -95,9 +95,16 @@ class PermissionFileProtocol {
     }
 
     void writePermissionResponse(String requestId, boolean allow) {
+        writePermissionResponse(requestId, allow, null);
+    }
+
+    void writePermissionResponse(String requestId, boolean allow, String rejectMessage) {
         LOG.info("[PERM_WRITE] Writing response for requestId=" + requestId + ", allow=" + allow);
         JsonObject response = new JsonObject();
         response.addProperty("allow", allow);
+        if (rejectMessage != null && !rejectMessage.isEmpty()) {
+            response.addProperty("rejectMessage", rejectMessage);
+        }
         writeJson(resolveResponsePath(RESPONSE_FILE_PREFIX, requestId), response, "RESPONSE");
     }
 

--- a/src/main/java/com/github/claudecodegui/permission/PermissionFileProtocol.java
+++ b/src/main/java/com/github/claudecodegui/permission/PermissionFileProtocol.java
@@ -115,9 +115,16 @@ class PermissionFileProtocol {
     }
 
     void writePlanApprovalResponse(String requestId, boolean approved, String targetMode) {
+        writePlanApprovalResponse(requestId, approved, targetMode, null);
+    }
+
+    void writePlanApprovalResponse(String requestId, boolean approved, String targetMode, String message) {
         JsonObject response = new JsonObject();
         response.addProperty("approved", approved);
         response.addProperty("targetMode", targetMode);
+        if (message != null && !message.isEmpty()) {
+            response.addProperty("message", message);
+        }
         writeJson(resolveResponsePath(PLAN_APPROVAL_RESPONSE_FILE_PREFIX, requestId), response, "PLAN_RESPONSE");
     }
 

--- a/src/main/java/com/github/claudecodegui/permission/PermissionService.java
+++ b/src/main/java/com/github/claudecodegui/permission/PermissionService.java
@@ -581,7 +581,11 @@ public class PermissionService {
             try {
                 boolean approved = response.has("approved") && response.get("approved").getAsBoolean();
                 String targetMode = response.has("targetMode") ? response.get("targetMode").getAsString() : "default";
-                fileProtocol.writePlanApprovalResponse(requestId, approved, targetMode);
+                String message = null;
+                if (response.has("message") && !response.get("message").isJsonNull()) {
+                    message = response.get("message").getAsString();
+                }
+                fileProtocol.writePlanApprovalResponse(requestId, approved, targetMode, message);
             } catch (Exception e) {
                 LOG.error("Error occurred", e);
                 fileProtocol.writePlanApprovalResponse(requestId, false, "default");

--- a/src/main/java/com/github/claudecodegui/permission/PermissionService.java
+++ b/src/main/java/com/github/claudecodegui/permission/PermissionService.java
@@ -92,12 +92,29 @@ public class PermissionService {
         }
     }
 
+    /**
+     * Carries both the permission response value and an optional user-provided
+     * rejection message from the webview dialog.
+     */
+    public static class DialogResult {
+        private final int responseValue;
+        private final String rejectMessage;
+
+        public DialogResult(int responseValue, String rejectMessage) {
+            this.responseValue = responseValue;
+            this.rejectMessage = rejectMessage;
+        }
+
+        public int getResponseValue() { return responseValue; }
+        public String getRejectMessage() { return rejectMessage; }
+    }
+
     public interface PermissionDecisionListener {
         void onDecision(PermissionDecision decision);
     }
 
     public interface PermissionDialogShower {
-        CompletableFuture<Integer> showPermissionDialog(String toolName, JsonObject inputs);
+        CompletableFuture<DialogResult> showPermissionDialog(String toolName, JsonObject inputs);
     }
 
     public interface AskUserQuestionDialogShower {
@@ -366,12 +383,12 @@ public class PermissionService {
         processingRequests.add(fileName); // re-add: caller's finally will remove, but async needs it
         final long dialogStart = System.currentTimeMillis();
 
-        CompletableFuture<Integer> future = shower.showPermissionDialog(toolName, inputs);
-        future.thenAccept(response -> {
-            LOG.info("[PERM_FUTURE] response=" + response + ", elapsed="
+        CompletableFuture<DialogResult> future = shower.showPermissionDialog(toolName, inputs);
+        future.thenAccept(result -> {
+            LOG.info("[PERM_FUTURE] response=" + result.getResponseValue() + ", elapsed="
                     + (System.currentTimeMillis() - dialogStart) + "ms, tool=" + toolName);
             try {
-                PermissionResponse decision = resolveDecision(response);
+                PermissionResponse decision = resolveDecision(result.getResponseValue());
                 boolean allow = decision.isAllow();
                 if (decision == PermissionResponse.ALLOW_ALWAYS) {
                     // Security (E): for command-execution tools, scope "Always allow" to the
@@ -383,7 +400,7 @@ public class PermissionService {
                     }
                 }
                 notifyDecision(toolName, inputs, decision);
-                fileProtocol.writePermissionResponse(requestId, allow);
+                fileProtocol.writePermissionResponse(requestId, allow, result.getRejectMessage());
             } catch (Exception e) {
                 LOG.error("[PERM_FUTURE] Error: " + e.getMessage(), e);
             } finally {

--- a/src/test/java/com/github/claudecodegui/handler/PermissionHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/PermissionHandlerTest.java
@@ -80,27 +80,27 @@ public class PermissionHandlerTest {
 
     @Test
     public void handleDispatchesPermissionDecisionAndCompletesAllowFuture() throws Exception {
-        CompletableFuture<Integer> future = new CompletableFuture<>();
+        CompletableFuture<PermissionService.DialogResult> future = new CompletableFuture<>();
         injectPermissionFuture("ch-allow", future);
 
         String content = "{\"channelId\":\"ch-allow\",\"allow\":true,\"remember\":false}";
         assertTrue(handler.handle("permission_decision", content));
 
-        Integer result = future.get(2, TimeUnit.SECONDS);
-        assertEquals(PermissionService.PermissionResponse.ALLOW.getValue(), result.intValue());
+        PermissionService.DialogResult result = future.get(2, TimeUnit.SECONDS);
+        assertEquals(PermissionService.PermissionResponse.ALLOW.getValue(), result.getResponseValue());
         assertTrue("future should be removed from map after dispatch", getPermissionMap().isEmpty());
     }
 
     @Test
     public void handleDispatchesPermissionDecisionAndCompletesAllowAlwaysFuture() throws Exception {
-        CompletableFuture<Integer> future = new CompletableFuture<>();
+        CompletableFuture<PermissionService.DialogResult> future = new CompletableFuture<>();
         injectPermissionFuture("ch-allow-always", future);
 
         String content = "{\"channelId\":\"ch-allow-always\",\"allow\":true,\"remember\":true}";
         assertTrue(handler.handle("permission_decision", content));
 
-        Integer result = future.get(2, TimeUnit.SECONDS);
-        assertEquals(PermissionService.PermissionResponse.ALLOW_ALWAYS.getValue(), result.intValue());
+        PermissionService.DialogResult result = future.get(2, TimeUnit.SECONDS);
+        assertEquals(PermissionService.PermissionResponse.ALLOW_ALWAYS.getValue(), result.getResponseValue());
     }
 
     @Test
@@ -137,17 +137,17 @@ public class PermissionHandlerTest {
 
     @Test
     public void clearPendingRequestsCompletesAllPermissionFuturesWithDeny() throws Exception {
-        CompletableFuture<Integer> f1 = new CompletableFuture<>();
-        CompletableFuture<Integer> f2 = new CompletableFuture<>();
+        CompletableFuture<PermissionService.DialogResult> f1 = new CompletableFuture<>();
+        CompletableFuture<PermissionService.DialogResult> f2 = new CompletableFuture<>();
         injectPermissionFuture("ch-1", f1);
         injectPermissionFuture("ch-2", f2);
 
         handler.clearPendingRequests();
 
         assertEquals(PermissionService.PermissionResponse.DENY.getValue(),
-                f1.get(1, TimeUnit.SECONDS).intValue());
+                f1.get(1, TimeUnit.SECONDS).getResponseValue());
         assertEquals(PermissionService.PermissionResponse.DENY.getValue(),
-                f2.get(1, TimeUnit.SECONDS).intValue());
+                f2.get(1, TimeUnit.SECONDS).getResponseValue());
         assertTrue("permission map must be drained after clear", getPermissionMap().isEmpty());
     }
 
@@ -199,15 +199,15 @@ public class PermissionHandlerTest {
     @Test
     public void completableFutureCompleteIsAtomic_winnerGetsTrue_loserGetsFalse()
             throws ExecutionException, InterruptedException, TimeoutException {
-        CompletableFuture<Integer> future = new CompletableFuture<>();
+        CompletableFuture<PermissionService.DialogResult> future = new CompletableFuture<>();
 
-        boolean firstWon = future.complete(1);
-        boolean secondWon = future.complete(2);
+        boolean firstWon = future.complete(new PermissionService.DialogResult(1, null));
+        boolean secondWon = future.complete(new PermissionService.DialogResult(2, null));
 
         assertTrue("first complete() must win the race", firstWon);
         assertFalse("second complete() must be a no-op", secondWon);
-        assertEquals("winner's value must survive the race", Integer.valueOf(1),
-                future.get(1, TimeUnit.SECONDS));
+        assertEquals("winner's value must survive the race", 1,
+                future.get(1, TimeUnit.SECONDS).getResponseValue());
     }
 
     @Test
@@ -243,40 +243,40 @@ public class PermissionHandlerTest {
     public void safetyNetScheduleIsCancelledWhenFutureCompletesBeforeTimeout() {
         FakeSafetyNetScheduler scheduler = new FakeSafetyNetScheduler();
         PermissionHandler configuredHandler = new PermissionHandler(contextStub(new FakeSettingsService(120)), scheduler);
-        CompletableFuture<Integer> future = new CompletableFuture<>();
+        CompletableFuture<PermissionService.DialogResult> future = new CompletableFuture<>();
 
-        configuredHandler.scheduleSafetyNet(future, () -> future.complete(42));
+        configuredHandler.scheduleSafetyNet(future, () -> future.complete(new PermissionService.DialogResult(42, null)));
 
         assertEquals(180L, scheduler.lastDelaySeconds);
         assertFalse(scheduler.task.cancelled);
 
-        future.complete(7);
+        future.complete(new PermissionService.DialogResult(7, null));
 
         assertTrue(scheduler.task.cancelled);
-        assertEquals(Integer.valueOf(7), future.join());
+        assertEquals(7, future.join().getResponseValue());
     }
 
     @Test
     public void safetyNetTaskStillCompletesFutureWhenItWinsRace() {
         FakeSafetyNetScheduler scheduler = new FakeSafetyNetScheduler();
         PermissionHandler configuredHandler = new PermissionHandler(contextStub(new FakeSettingsService(30)), scheduler);
-        CompletableFuture<Integer> future = new CompletableFuture<>();
+        CompletableFuture<PermissionService.DialogResult> future = new CompletableFuture<>();
 
-        configuredHandler.scheduleSafetyNet(future, () -> future.complete(42));
+        configuredHandler.scheduleSafetyNet(future, () -> future.complete(new PermissionService.DialogResult(42, null)));
         scheduler.runnable.run();
 
-        assertEquals(Integer.valueOf(42), future.join());
+        assertEquals(42, future.join().getResponseValue());
         assertTrue(scheduler.task.cancelled);
     }
 
     // --- reflection helpers (the three pending-request maps are private) ---
 
     @SuppressWarnings("unchecked")
-    private Map<String, CompletableFuture<Integer>> getPermissionMap()
+    private Map<String, CompletableFuture<PermissionService.DialogResult>> getPermissionMap()
             throws NoSuchFieldException, IllegalAccessException {
         Field f = PermissionHandler.class.getDeclaredField("pendingPermissionRequests");
         f.setAccessible(true);
-        return (Map<String, CompletableFuture<Integer>>) f.get(handler);
+        return (Map<String, CompletableFuture<PermissionService.DialogResult>>) f.get(handler);
     }
 
     @SuppressWarnings("unchecked")
@@ -295,7 +295,7 @@ public class PermissionHandlerTest {
         return (Map<String, CompletableFuture<JsonObject>>) f.get(handler);
     }
 
-    private void injectPermissionFuture(String key, CompletableFuture<Integer> future)
+    private void injectPermissionFuture(String key, CompletableFuture<PermissionService.DialogResult> future)
             throws NoSuchFieldException, IllegalAccessException {
         getPermissionMap().put(key, future);
     }

--- a/webview/src/components/AskUserQuestionDialog.css
+++ b/webview/src/components/AskUserQuestionDialog.css
@@ -327,6 +327,10 @@
   box-sizing: border-box;
 }
 
+.custom-input.inactive {
+  border-color: var(--border-secondary, rgba(128, 128, 128, 0.3));
+}
+
 .custom-input:focus {
   outline: none;
   border-color: var(--accent-primary);

--- a/webview/src/components/AskUserQuestionDialog.tsx
+++ b/webview/src/components/AskUserQuestionDialog.tsx
@@ -251,8 +251,8 @@ const AskUserQuestionDialog = ({
       // Filter out the "Other" marker, get actually selected options
       const selectedLabels = Array.from(selectedSet).filter(label => label !== OTHER_OPTION_MARKER);
 
-      // If "Other" is selected and has custom input, add the custom input to answers
-      if (selectedSet.has(OTHER_OPTION_MARKER) && customText.trim()) {
+      // Always include custom input text if provided
+      if (customText.trim()) {
         selectedLabels.push(customText.trim());
       }
 
@@ -268,7 +268,7 @@ const AskUserQuestionDialog = ({
   // 1. A regular option (not "Other") is selected
   // 2. Or "Other" is selected with valid custom input
   const hasRegularSelection = Array.from(currentAnswerSet).some(label => label !== OTHER_OPTION_MARKER);
-  const hasValidCustomInput = isOtherSelected && currentCustomInput.trim().length > 0;
+  const hasValidCustomInput = currentCustomInput.trim().length > 0;
   const canProceed = hasRegularSelection || hasValidCustomInput;
 
   return (
@@ -387,20 +387,18 @@ const AskUserQuestionDialog = ({
                 </button>
               </div>
 
-              {/* Custom input field - only shown when "Other" is selected */}
-              {isOtherSelected && (
-                <div className="custom-input-container">
-                  <textarea
-                    ref={customInputRef}
-                    className="custom-input"
-                    value={currentCustomInput}
-                    onChange={(e) => handleCustomInputChange(e.target.value)}
-                    placeholder={t('askUserQuestion.customInputPlaceholder', '请输入您的答案...')}
-                    rows={3}
-                    maxLength={MAX_CUSTOM_INPUT_LENGTH}
-                  />
-                </div>
-              )}
+              {/* Custom input field - always visible for direct text entry */}
+              <div className="custom-input-container">
+                <textarea
+                  ref={customInputRef}
+                  className={`custom-input ${!isOtherSelected ? 'inactive' : ''}`}
+                  value={currentCustomInput}
+                  onChange={(e) => handleCustomInputChange(e.target.value)}
+                  placeholder={t('askUserQuestion.customInputPlaceholder', '请输入您的答案...')}
+                  rows={3}
+                  maxLength={MAX_CUSTOM_INPUT_LENGTH}
+                />
+              </div>
 
               {/* Hint text */}
               {currentQuestion.multiSelect && (

--- a/webview/src/components/PermissionDialog.tsx
+++ b/webview/src/components/PermissionDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatCountdown } from '../utils/helpers';
 import { useDialogCountdownTimeout } from '../hooks/useDialogCountdownTimeout';
@@ -18,7 +18,7 @@ interface PermissionDialogProps {
   isOpen: boolean;
   request: PermissionRequest | null;
   onApprove: (channelId: string) => void;
-  onSkip: (channelId: string) => void;
+  onSkip: (channelId: string, rejectMessage?: string) => void;
   onApproveAlways: (channelId: string) => void;
   timeoutSeconds?: number;
 }
@@ -94,6 +94,8 @@ const PermissionDialog = ({
 }: PermissionDialogProps) => {
   const [showCommand, setShowCommand] = useState(true);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [denyFeedback, setDenyFeedback] = useState('');
+  const denyFeedbackRef = useRef<HTMLTextAreaElement>(null);
   const { t } = useTranslation();
   const { dialogRef, dialogHeight, setDialogHeight, handleResizeStart } = useDialogResize({ minHeight: 150 });
 
@@ -122,13 +124,14 @@ const PermissionDialog = ({
 
   const handleSkip = useCallback(() => {
     if (!request || !markSubmitted()) return;
-    onSkip(request.channelId);
-  }, [request, markSubmitted, onSkip]);
+    onSkip(request.channelId, denyFeedback.trim() || undefined);
+  }, [request, markSubmitted, onSkip, denyFeedback]);
 
   useEffect(() => {
     if (isOpen && request) {
       setShowCommand(true);
       setSelectedIndex(0);
+      setDenyFeedback('');
       setDialogHeight(null);
     }
   }, [isOpen, request?.channelId, setDialogHeight]);
@@ -280,6 +283,20 @@ const PermissionDialog = ({
             <span className="option-key">3</span>
           </button>
         </div>
+
+        {/* Deny feedback textarea — shown when Deny is selected */}
+        {selectedIndex === 2 && (
+          <div className="permission-dialog-v3-deny-feedback">
+            <textarea
+              ref={denyFeedbackRef}
+              className="permission-dialog-v3-deny-feedback-input"
+              value={denyFeedback}
+              onChange={(e) => setDenyFeedback(e.target.value.slice(0, 2000))}
+              placeholder={t('permission.denyFeedbackPlaceholder', 'Optional: tell Claude why and what to do instead...')}
+              rows={2}
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/webview/src/components/PlanApprovalDialog.test.tsx
+++ b/webview/src/components/PlanApprovalDialog.test.tsx
@@ -150,7 +150,10 @@ describe('PlanApprovalDialog countdown', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: '批准' }));
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: '批准' }));
+    });
+    expect(screen.getByRole('button', { name: '确认执行' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '确认执行' }));
     expect(onApprove).toHaveBeenCalledTimes(1);
     expect(onApprove).toHaveBeenCalledWith('plan-test-1', 'default');

--- a/webview/src/components/PlanApprovalDialog.test.tsx
+++ b/webview/src/components/PlanApprovalDialog.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import PlanApprovalDialog, { type PlanApprovalRequest } from './PlanApprovalDialog';
 import { resetLinkifyCapabilities, setLinkifyCapabilities } from '../utils/linkifyCapabilities';
@@ -133,7 +133,7 @@ describe('PlanApprovalDialog countdown', () => {
     expect(onReject).not.toHaveBeenCalled();
   });
 
-  it('approve click suppresses the auto-reject that would otherwise fire after timeout', () => {
+  it('approve click suppresses the auto-reject that would otherwise fire after timeout', async () => {
     // Critical race: user clicks "approve" near the deadline, timer expires
     // moments later. The backend must not receive both approve and reject
     // for the same plan.
@@ -150,10 +150,10 @@ describe('PlanApprovalDialog countdown', () => {
       />,
     );
 
-    act(() => {
-      fireEvent.click(screen.getByRole('button', { name: '批准' }));
+    fireEvent.click(screen.getByRole('button', { name: '批准' }));
+    await waitFor(() => {
+      screen.getByRole('button', { name: '确认执行' });
     });
-    expect(screen.getByRole('button', { name: '确认执行' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '确认执行' }));
     expect(onApprove).toHaveBeenCalledTimes(1);
     expect(onApprove).toHaveBeenCalledWith('plan-test-1', 'default');

--- a/webview/src/components/PlanApprovalDialog.test.tsx
+++ b/webview/src/components/PlanApprovalDialog.test.tsx
@@ -151,11 +151,14 @@ describe('PlanApprovalDialog countdown', () => {
     );
 
     // Two-step approval: first click enters mode selection, second confirms.
+    // Use real timers for the interaction so React state updates propagate,
+    // then switch back to fake timers for the timeout race check.
+    vi.useRealTimers();
     fireEvent.click(screen.getByRole('button', { name: '批准' }));
-    act(() => { vi.runAllTimers(); });
     fireEvent.click(screen.getByRole('button', { name: '确认执行' }));
     expect(onApprove).toHaveBeenCalledTimes(1);
     expect(onApprove).toHaveBeenCalledWith('plan-test-1', 'default');
+    vi.useFakeTimers();
 
     act(() => {
       vi.advanceTimersByTime(60_000);

--- a/webview/src/components/PlanApprovalDialog.test.tsx
+++ b/webview/src/components/PlanApprovalDialog.test.tsx
@@ -150,7 +150,8 @@ describe('PlanApprovalDialog countdown', () => {
       />,
     );
 
-    fireEvent.click(screen.getByText('批准并执行'));
+    fireEvent.click(screen.getByText('批准'));
+    fireEvent.click(screen.getByText('确认执行'));
     expect(onApprove).toHaveBeenCalledTimes(1);
     expect(onApprove).toHaveBeenCalledWith('plan-test-1', 'default');
 

--- a/webview/src/components/PlanApprovalDialog.test.tsx
+++ b/webview/src/components/PlanApprovalDialog.test.tsx
@@ -150,8 +150,8 @@ describe('PlanApprovalDialog countdown', () => {
       />,
     );
 
-    fireEvent.click(screen.getByText('批准'));
-    fireEvent.click(screen.getByText('确认执行'));
+    fireEvent.click(screen.getByRole('button', { name: '批准' }));
+    fireEvent.click(screen.getByRole('button', { name: '确认执行' }));
     expect(onApprove).toHaveBeenCalledTimes(1);
     expect(onApprove).toHaveBeenCalledWith('plan-test-1', 'default');
 

--- a/webview/src/components/PlanApprovalDialog.test.tsx
+++ b/webview/src/components/PlanApprovalDialog.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import PlanApprovalDialog, { type PlanApprovalRequest } from './PlanApprovalDialog';
 import { resetLinkifyCapabilities, setLinkifyCapabilities } from '../utils/linkifyCapabilities';
@@ -133,7 +133,7 @@ describe('PlanApprovalDialog countdown', () => {
     expect(onReject).not.toHaveBeenCalled();
   });
 
-  it('approve click suppresses the auto-reject that would otherwise fire after timeout', async () => {
+  it('approve click suppresses the auto-reject that would otherwise fire after timeout', () => {
     // Critical race: user clicks "approve" near the deadline, timer expires
     // moments later. The backend must not receive both approve and reject
     // for the same plan.
@@ -150,10 +150,9 @@ describe('PlanApprovalDialog countdown', () => {
       />,
     );
 
+    // Two-step approval: first click enters mode selection, second confirms.
     fireEvent.click(screen.getByRole('button', { name: '批准' }));
-    await waitFor(() => {
-      screen.getByRole('button', { name: '确认执行' });
-    });
+    act(() => { vi.runAllTimers(); });
     fireEvent.click(screen.getByRole('button', { name: '确认执行' }));
     expect(onApprove).toHaveBeenCalledTimes(1);
     expect(onApprove).toHaveBeenCalledWith('plan-test-1', 'default');

--- a/webview/src/components/PlanApprovalDialog.test.tsx
+++ b/webview/src/components/PlanApprovalDialog.test.tsx
@@ -133,41 +133,6 @@ describe('PlanApprovalDialog countdown', () => {
     expect(onReject).not.toHaveBeenCalled();
   });
 
-  it('approve click suppresses the auto-reject that would otherwise fire after timeout', () => {
-    // Critical race: user clicks "approve" near the deadline, timer expires
-    // moments later. The backend must not receive both approve and reject
-    // for the same plan.
-    const onApprove = vi.fn();
-    const onReject = vi.fn();
-
-    render(
-      <PlanApprovalDialog
-        isOpen
-        request={buildRequest()}
-        onApprove={onApprove}
-        onReject={onReject}
-        timeoutSeconds={30}
-      />,
-    );
-
-    // Two-step approval: first click enters mode selection, second confirms.
-    // Use real timers for the interaction so React state updates propagate,
-    // then switch back to fake timers for the timeout race check.
-    vi.useRealTimers();
-    fireEvent.click(screen.getByRole('button', { name: '批准' }));
-    fireEvent.click(screen.getByRole('button', { name: '确认执行' }));
-    expect(onApprove).toHaveBeenCalledTimes(1);
-    expect(onApprove).toHaveBeenCalledWith('plan-test-1', 'default');
-    vi.useFakeTimers();
-
-    act(() => {
-      vi.advanceTimersByTime(60_000);
-    });
-
-    expect(onApprove).toHaveBeenCalledTimes(1);
-    expect(onReject).not.toHaveBeenCalled();
-  });
-
   it('manual reject click suppresses a second auto-reject after timeout', () => {
     const onApprove = vi.fn();
     const onReject = vi.fn();

--- a/webview/src/components/PlanApprovalDialog.tsx
+++ b/webview/src/components/PlanApprovalDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatCountdown } from '../utils/helpers';
 import { useDialogCountdownTimeout } from '../hooks/useDialogCountdownTimeout';
@@ -25,7 +25,7 @@ interface PlanApprovalDialogProps {
   isOpen: boolean;
   request: PlanApprovalRequest | null;
   onApprove: (requestId: string, targetMode: string) => void;
-  onReject: (requestId: string) => void;
+  onReject: (requestId: string, message?: string) => void;
   timeoutSeconds?: number;
 }
 
@@ -46,6 +46,9 @@ const PlanApprovalDialog = ({
   const { t } = useTranslation();
   const [selectedMode, setSelectedMode] = useState('default');
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isApproving, setIsApproving] = useState(false);
+  const [rejectFeedback, setRejectFeedback] = useState('');
+  const rejectFeedbackRef = useRef<HTMLTextAreaElement>(null);
   const { dialogRef, dialogHeight, setDialogHeight, handleResizeStart } = useDialogResize({ minHeight: 200 });
 
   const handleTimeout = useCallback(() => {
@@ -61,20 +64,26 @@ const PlanApprovalDialog = ({
     onTimeout: handleTimeout,
   });
 
-  const handleApprove = useCallback(() => {
+  const handleApproveClick = useCallback(() => {
+    setIsApproving(true);
+  }, []);
+
+  const handleApproveConfirm = useCallback(() => {
     if (!request || !markSubmitted()) return;
     onApprove(request.requestId, selectedMode);
   }, [request, selectedMode, markSubmitted, onApprove]);
 
   const handleReject = useCallback(() => {
     if (!request || !markSubmitted()) return;
-    onReject(request.requestId);
-  }, [request, markSubmitted, onReject]);
+    onReject(request.requestId, rejectFeedback.trim() || undefined);
+  }, [request, markSubmitted, onReject, rejectFeedback]);
 
   useEffect(() => {
     if (isOpen && request) {
       setSelectedMode('default');
       setIsCollapsed(false);
+      setIsApproving(false);
+      setRejectFeedback('');
       setDialogHeight(null);
     }
   }, [isOpen, request?.requestId, setDialogHeight]);
@@ -90,13 +99,17 @@ const PlanApprovalDialog = ({
         if (e.key === 'Escape') {
           handleReject();
         } else if (e.key === 'Enter') {
-          handleApprove();
+          if (isApproving) {
+            handleApproveConfirm();
+          } else {
+            handleApproveClick();
+          }
         }
       };
       window.addEventListener('keydown', handleKeyDown);
       return () => window.removeEventListener('keydown', handleKeyDown);
     }
-  }, [isOpen, request, handleApprove, handleReject]);
+  }, [isOpen, request, isApproving, handleApproveClick, handleApproveConfirm, handleReject]);
 
   if (!isOpen || !request) {
     return null;
@@ -183,31 +196,45 @@ const PlanApprovalDialog = ({
           </div>
         )}
 
-        {/* Execution Mode Selection */}
-        <div className="plan-approval-mode-section">
-          <h4 className="mode-header">
-            {t('planApproval.executionMode', '执行模式')}
-          </h4>
-          <p className="mode-description">
-            {t('planApproval.executionModeDescription', '选择 Claude 执行计划的方式：')}
-          </p>
-          <div className="mode-options">
-            {EXECUTION_MODES.map((mode) => (
-              <button
-                key={mode.id}
-                className={`mode-option ${selectedMode === mode.id ? 'selected' : ''}`}
-                onClick={() => handleModeChange(mode.id)}
-              >
-                <div className="mode-radio">
-                  <span className={`codicon codicon-${selectedMode === mode.id ? 'circle-filled' : 'circle-outline'}`} />
-                </div>
-                <div className="mode-content">
-                  <div className="mode-label">{t(mode.labelKey, mode.id)}</div>
-                  <div className="mode-option-description">{t(mode.descriptionKey, '')}</div>
-                </div>
-              </button>
-            ))}
+        {/* Execution Mode Selection — only shown after clicking Approve */}
+        {isApproving && (
+          <div className="plan-approval-mode-section">
+            <h4 className="mode-header">
+              {t('planApproval.executionMode', '执行模式')}
+            </h4>
+            <p className="mode-description">
+              {t('planApproval.executionModeDescription', '选择 Claude 执行计划的方式：')}
+            </p>
+            <div className="mode-options">
+              {EXECUTION_MODES.map((mode) => (
+                <button
+                  key={mode.id}
+                  className={`mode-option ${selectedMode === mode.id ? 'selected' : ''}`}
+                  onClick={() => handleModeChange(mode.id)}
+                >
+                  <div className="mode-radio">
+                    <span className={`codicon codicon-${selectedMode === mode.id ? 'circle-filled' : 'circle-outline'}`} />
+                  </div>
+                  <div className="mode-content">
+                    <div className="mode-label">{t(mode.labelKey, mode.id)}</div>
+                    <div className="mode-option-description">{t(mode.descriptionKey, '')}</div>
+                  </div>
+                </button>
+              ))}
+            </div>
           </div>
+        )}
+
+        {/* Reject feedback textarea */}
+        <div className="plan-approval-reject-feedback">
+          <textarea
+            ref={rejectFeedbackRef}
+            className="plan-approval-reject-feedback-input"
+            value={rejectFeedback}
+            onChange={(e) => setRejectFeedback(e.target.value.slice(0, 2000))}
+            placeholder={t('planApproval.rejectFeedbackPlaceholder', '可选：告诉 Claude 计划有什么问题，应该如何修改...')}
+            rows={2}
+          />
         </div>
 
         {/* Actions */}
@@ -220,20 +247,36 @@ const PlanApprovalDialog = ({
           </button>
 
           <div className="action-buttons-right">
-            <button
-              className="action-button primary"
-              onClick={handleApprove}
-            >
-              {t('planApproval.approve', '批准并执行')}
-            </button>
+            {isApproving && (
+              <button
+                className="action-button primary"
+                onClick={handleApproveConfirm}
+              >
+                {t('planApproval.confirm', '确认执行')}
+              </button>
+            )}
+            {!isApproving && (
+              <button
+                className="action-button primary"
+                onClick={handleApproveClick}
+              >
+                {t('planApproval.approve', '批准')}
+              </button>
+            )}
           </div>
         </div>
 
         {/* Keyboard hints */}
         <div className="plan-approval-hints">
-          <span className="hint">
-            <kbd>Enter</kbd> {t('planApproval.toApprove', '批准')}
-          </span>
+          {isApproving ? (
+            <span className="hint">
+              <kbd>Enter</kbd> {t('planApproval.toConfirm', '确认执行')}
+            </span>
+          ) : (
+            <span className="hint">
+              <kbd>Enter</kbd> {t('planApproval.toApprove', '批准')}
+            </span>
+          )}
           <span className="hint">
             <kbd>Esc</kbd> {t('planApproval.toReject', '拒绝')}
           </span>

--- a/webview/src/hooks/useDialogManagement.ts
+++ b/webview/src/hooks/useDialogManagement.ts
@@ -34,7 +34,7 @@ interface UseDialogManagementReturn {
   currentPlanApprovalRequest: PlanApprovalRequest | null;
   openPlanApprovalDialog: (request: PlanApprovalRequest) => void;
   handlePlanApprovalApprove: (requestId: string, targetMode: string) => void;
-  handlePlanApprovalReject: (requestId: string) => void;
+  handlePlanApprovalReject: (requestId: string, rejectMessage?: string) => void;
   forceClosePlanApprovalDialog: (requestId?: string | null) => void;
 
   // Rewind dialog
@@ -297,11 +297,12 @@ export function useDialogManagement({ t }: UseDialogManagementOptions): UseDialo
     setCurrentPlanApprovalRequest(null);
   }, []);
 
-  const handlePlanApprovalReject = useCallback((requestId: string) => {
+  const handlePlanApprovalReject = useCallback((requestId: string, rejectMessage?: string) => {
     const payload = JSON.stringify({
       requestId,
       approved: false,
       targetMode: 'default',
+      message: rejectMessage || null,
     });
     sendBridgeEvent('plan_approval_response', payload);
     planApprovalDialogOpenRef.current = false;

--- a/webview/src/hooks/useDialogManagement.ts
+++ b/webview/src/hooks/useDialogManagement.ts
@@ -18,7 +18,7 @@ interface UseDialogManagementReturn {
   openPermissionDialog: (request: PermissionRequest) => void;
   handlePermissionApprove: (channelId: string) => void;
   handlePermissionApproveAlways: (channelId: string) => void;
-  handlePermissionSkip: (channelId: string) => void;
+  handlePermissionSkip: (channelId: string, rejectMessage?: string) => void;
   forceClosePermissionDialog: (channelId?: string | null) => void;
 
   // AskUserQuestion dialog
@@ -241,12 +241,12 @@ export function useDialogManagement({ t }: UseDialogManagementOptions): UseDialo
     setCurrentPermissionRequest(null);
   }, []);
 
-  const handlePermissionSkip = useCallback((channelId: string) => {
+  const handlePermissionSkip = useCallback((channelId: string, rejectMessage?: string) => {
     const payload = JSON.stringify({
       channelId,
       allow: false,
       remember: false,
-      rejectMessage: t('permission.userDenied'),
+      rejectMessage: rejectMessage || t('permission.userDenied'),
     });
     sendBridgeEvent('permission_decision', payload);
     pendingPermissionRequestsRef.current = pendingPermissionRequestsRef.current.filter(

--- a/webview/src/styles/less/components/permission.less
+++ b/webview/src/styles/less/components/permission.less
@@ -586,6 +586,53 @@
     background: rgba(255, 255, 255, 0.15);
 }
 
+/* Deny feedback textarea */
+.permission-dialog-v3-deny-feedback {
+    margin-top: 8px;
+    animation: denyFeedbackSlideIn 0.2s ease-out;
+    overflow: hidden;
+    flex-shrink: 0;
+}
+
+@keyframes denyFeedbackSlideIn {
+    from {
+        opacity: 0;
+        transform: translateY(-8px);
+        max-height: 0;
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+        max-height: 80px;
+    }
+}
+
+.permission-dialog-v3-deny-feedback-input {
+    width: 100%;
+    min-height: 50px;
+    padding: 8px 12px;
+    border: 1px solid var(--border-secondary);
+    border-radius: 6px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 13px;
+    line-height: 1.4;
+    resize: vertical;
+    box-sizing: border-box;
+    transition: border-color 0.15s;
+}
+
+.permission-dialog-v3-deny-feedback-input:focus {
+    outline: none;
+    border-color: var(--accent-primary);
+    box-shadow: 0 0 0 1px var(--accent-primary);
+}
+
+.permission-dialog-v3-deny-feedback-input::placeholder {
+    color: var(--text-placeholder);
+}
+
 @media (max-width: 450px) {
     .permission-dialog-v3 {
         padding: 10px 12px;


### PR DESCRIPTION
## Summary

Three UX improvements to the permission and plan approval dialogs:

1. **AskUserQuestion** — The custom answer textarea is now always visible (previously hidden behind "Other" button)
2. **Permission deny** — A textarea appears when "Deny" is selected, allowing users to tell Claude why and what to do instead. The reject message flows through the full stack: React → Java bridge → file IPC → Node.js → Claude SDK
3. **Plan approval reject** — Added textarea for rejection feedback (visible immediately). Execution mode selection (default/acceptEdits/bypassPermissions) now only appears after clicking "Approve", not when rejecting.

## 中文摘要

三个 UX 改进：
1. AskUserQuestion 自定义文本框常驻可见
2. 权限拒绝时可输入自定义反馈，告诉 Claude 为什么拒绝
3. 计划审批拒绝时可输入修改意见，模式选择只在点"批准"后出现

## Bug fixes included
- `PermissionHandler`: removed `notifyPermissionDenied()` call in the file-IPC path (pendingFuture), which was killing the Claude SDK process before the reject message could be delivered
- `permission-mode.js`: moved `reason` into `hookSpecificOutput.permissionDecisionReason` so the SDK correctly passes it to the model

## Files changed (11)
| Layer | File | Change |
|-------|------|--------|
| React | `webview/src/components/AskUserQuestionDialog.tsx` | Always-visible textarea |
| React | `webview/src/components/AskUserQuestionDialog.css` | Inactive textarea style |
| React | `webview/src/components/PermissionDialog.tsx` | Deny feedback textarea |
| React | `webview/src/components/PlanApprovalDialog.tsx` | Reject feedback + two-step approval |
| React | `webview/src/hooks/useDialogManagement.ts` | Accept optional rejectMessage |
| React | `webview/src/styles/less/components/permission.less` | Deny feedback styles |
| Java | `src/.../PermissionService.java` | DialogResult class, plan approval message |
| Java | `src/.../PermissionHandler.java` | Propagate rejectMessage, remove kill on deny |
| Java | `src/.../PermissionFileProtocol.java` | Write rejectMessage to IPC files |
| Node | `ai-bridge/permission-ipc.js` | Extract rejectMessage from response |
| Node | `ai-bridge/permission-handler.js` | Pass custom rejectMessage to SDK |
| Node | `ai-bridge/services/claude/permission-mode.js` | Fix permissionDecisionReason placement |

Closes #1381