### PR TITLE
fix(stream): stop snapshot-mode lock on duplicate incremental deltas

### DIFF
--- a/ai-bridge/services/claude/stream-delta-normalizer.js
+++ b/ai-bridge/services/claude/stream-delta-normalizer.js
@@ -21,7 +21,7 @@ function modeKey(kind, blockIndex) {
   return `${kind}:${blockIndex}`;
 }
 
-function computeNovelDelta(previous, incoming, mode) {
+function computeNovelDelta(previous, incoming, mode, origin) {
   if (!incoming) {
     return { novel: '', next: previous, mode };
   }
@@ -31,8 +31,35 @@ function computeNovelDelta(previous, incoming, mode) {
 
   // Cumulative-snapshot path: incoming is previous + new content. Confirms the
   // block is in snapshot mode for any subsequent corrective rewrites.
+  //
+  // Special case `incoming === previous` (novel === ''): meaning depends on
+  // which path the caller is on, distinguished by `origin`:
+  //
+  //   • origin === 'snapshot' — assistant-message snapshot re-delivering the
+  //     fully-accumulated block. The whole block has already been emitted via
+  //     live deltas. Always absorb: re-emitting would duplicate the entire
+  //     block in the UI (issue tracker streaming-duplication-fix). This was
+  //     the legacy unconditional behavior, and is correct for THIS path.
+  //
+  //   • origin === 'stream' — a live content_block_delta. Each call is one
+  //     fresh delta from the provider. An identical delta is a real duplicate
+  //     (repeated characters like "刚刚", "谢谢", "慢慢", or any token
+  //     boundary that emits the same token twice). The legacy code wrongly
+  //     absorbed these AND locked snapshot mode, swallowing the rest of the
+  //     reply — issue #1371's "除第一个字都会被吞掉". Treat it as an
+  //     incremental delta: emit the duplicate as novel content and DO NOT
+  //     lock snapshot mode. A real snapshot provider would never emit an
+  //     identical re-send as its first ambiguous signal — its defining trait
+  //     is monotonically GROWING accumulated content.
   if (incoming.startsWith(previous)) {
-    return { novel: incoming.slice(previous.length), next: incoming, mode: 'snapshot' };
+    const novel = incoming.slice(previous.length);
+    if (!novel) {
+      if (origin === 'snapshot' || mode === 'snapshot' || mode === 'incremental') {
+        return { novel: '', next: previous, mode };
+      }
+      return { novel: incoming, next: previous + incoming, mode };
+    }
+    return { novel, next: incoming, mode: 'snapshot' };
   }
 
   // Stale replay: incoming is fully contained at the start or end of previous.
@@ -71,7 +98,32 @@ function computeNovelDelta(previous, incoming, mode) {
   return { novel: incoming, next: previous + incoming, mode: 'incremental' };
 }
 
-export function normalizeStreamDelta(turnState, kind, index, incoming) {
+/**
+ * Normalise an incoming delta against the block's accumulated content and
+ * return the novel slice to emit (empty string when nothing new to deliver).
+ *
+ * Maintains two pieces of per-block state on `turnState`:
+ *   • blockMap (kind+index → accumulated content)
+ *   • modeMap  (kind+index → 'snapshot' | 'incremental' | undefined)
+ *
+ * @param {object} turnState  Per-turn streaming state (see createTurnState).
+ * @param {'text'|'thinking'} kind  Which block channel.
+ * @param {number|string} index  Content block index from the SDK event.
+ * @param {string} incoming  The payload to normalise.
+ * @param {'stream'|'snapshot'} [origin='stream']  Call-site semantics —
+ *   determines how `incoming === previous` is interpreted:
+ *     • 'stream'   — one fresh content_block_delta from the provider; an
+ *                    identical re-send is a real duplicate token (e.g. "刚刚",
+ *                    "谢谢") and must emit. Pass this from the live event
+ *                    handler. Default.
+ *     • 'snapshot' — an assistant-message snapshot re-delivering the fully
+ *                    accumulated block; an identical match means "nothing new"
+ *                    and must absorb to avoid duplicating the whole block in
+ *                    the UI. Used internally by {@link resolveSnapshotDelta} —
+ *                    direct callers should prefer that wrapper.
+ * @returns {string}  The novel suffix to emit, or '' to skip emission.
+ */
+export function normalizeStreamDelta(turnState, kind, index, incoming, origin = 'stream') {
   const text = typeof incoming === 'string' ? incoming : '';
   const key = kind === 'thinking' ? 'thinkingBlockContentByIndex' : 'textBlockContentByIndex';
   const blockMap = getBlockMap(turnState, key);
@@ -82,7 +134,7 @@ export function normalizeStreamDelta(turnState, kind, index, incoming) {
   const mKey = modeKey(kind, blockIndex);
   const mode = modeMap.get(mKey);
 
-  const result = computeNovelDelta(previous, text, mode);
+  const result = computeNovelDelta(previous, text, mode, origin);
   blockMap.set(blockIndex, result.next);
   if (result.mode && result.mode !== mode) {
     modeMap.set(mKey, result.mode);
@@ -111,7 +163,7 @@ export function resolveSnapshotDelta(turnState, kind, index, snapshot) {
   const blockMap = getBlockMap(turnState, key);
   const blockIndex = getBlockIndex(index);
   const hadPrevious = (blockMap.get(blockIndex) || '').length > 0;
-  const delta = normalizeStreamDelta(turnState, kind, index, snapshot);
+  const delta = normalizeStreamDelta(turnState, kind, index, snapshot, 'snapshot');
   return { delta, hadPrevious };
 }
 

--- a/ai-bridge/services/claude/stream-event-processor.test.js
+++ b/ai-bridge/services/claude/stream-event-processor.test.js
@@ -964,3 +964,201 @@ test('BLOCK_RESET: emitted at each message_start in multi-turn tool_use loop', (
   const blockResetLines = tagLines(captured, '[BLOCK_RESET]');
   assert.equal(blockResetLines.length, 2, 'BLOCK_RESET must be emitted at each message_start in multi-turn loop');
 });
+
+// =========================================================================
+// REGRESSION (issue #1371 — duplicate-leading-char absorber lock).
+//
+// Pre-fix: computeNovelDelta's `incoming.startsWith(previous)` branch
+// unconditionally locked the block into 'snapshot' mode, EVEN WHEN the
+// computed novel slice was empty (incoming === previous). That ambiguous
+// signal — far more often a coincidental duplicate from an incremental
+// provider (repeated characters like "刚刚", "谢谢", "慢慢", or any
+// tokenizer that emits the same delta twice) than an actual snapshot
+// heartbeat — flipped the absorber on, and every following genuine
+// incremental delta hit the snapshot-mode correction branch and was
+// silently swallowed. User-visible: only the first character of the reply
+// rendered. Keep these green.
+// =========================================================================
+
+test('REGRESSION (#1371): duplicate-leading-char incremental stream "刚","刚","我","在" streams every char', () => {
+  // The exact reproduction from the bug report. "刚刚我在" — the first two
+  // deltas are identical ("刚"), then truly novel content follows. Pre-fix
+  // the second "刚" locked snapshot mode and the rest of the message was
+  // absorbed. After the fix, the second "刚" is recognised as zero-novel
+  // and mode stays unconfirmed, so subsequent incremental deltas flow.
+  const state = makeTurnState(true);
+
+  const captured = captureStdout(() => {
+    for (const fragment of ['刚', '刚', '我', '在']) {
+      processStreamEvent(
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'text_delta', text: fragment },
+          },
+        },
+        state,
+      );
+    }
+  });
+
+  const emitted = tagLines(captured, '[CONTENT_DELTA]')
+    .map((line) => JSON.parse(line.replace(/^\[CONTENT_DELTA\]\s+/, '').trim()))
+    .join('');
+
+  assert.equal(emitted, '刚刚我在', `expected full stream "刚刚我在", got "${emitted}"`);
+  assert.equal(state.lastAssistantContent, '刚刚我在');
+});
+
+test('REGRESSION (#1371): repeated-token thinking deltas "谢谢" must not lock absorber and drop later content', () => {
+  // Same shape on the thinking channel. A model that starts a chain-of-thought
+  // with "谢谢" + further reasoning must not have the reasoning dropped.
+  const state = makeTurnState(true);
+
+  const captured = captureStdout(() => {
+    for (const fragment of ['谢', '谢', '，让我想想']) {
+      processStreamEvent(
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'thinking_delta', thinking: fragment },
+          },
+        },
+        state,
+      );
+    }
+  });
+
+  const emitted = tagLines(captured, '[THINKING_DELTA]')
+    .map((line) => JSON.parse(line.replace(/^\[THINKING_DELTA\]\s+/, '').trim()))
+    .join('');
+
+  assert.equal(emitted, '谢谢，让我想想', `expected full thinking stream, got "${emitted}"`);
+  assert.equal(state.lastThinkingContent, '谢谢，让我想想');
+});
+
+test('REGRESSION (#1371): forced-prefix CLAUDE.md scenario "咕咕嘎嘎..." streams intact', () => {
+  // From the bug report's repro steps: CLAUDE.md forces the model to prefix
+  // every reply with "咕咕嘎嘎". The first two deltas duplicate ("咕"), which
+  // pre-fix vaporised everything after them.
+  const state = makeTurnState(true);
+
+  const captured = captureStdout(() => {
+    for (const fragment of ['咕', '咕', '嘎', '嘎', '，我开始处理']) {
+      processStreamEvent(
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'text_delta', text: fragment },
+          },
+        },
+        state,
+      );
+    }
+  });
+
+  const emitted = tagLines(captured, '[CONTENT_DELTA]')
+    .map((line) => JSON.parse(line.replace(/^\[CONTENT_DELTA\]\s+/, '').trim()))
+    .join('');
+
+  assert.equal(emitted, '咕咕嘎嘎，我开始处理', `expected full reply, got "${emitted}"`);
+});
+
+test('REGRESSION (#1371): ambiguous zero-novel duplicate is treated as incremental until a non-empty extension confirms snapshot mode', () => {
+  // Documents the tie-breaker introduced by the #1371 fix. When the first
+  // ambiguous signal (incoming === previous, novel === '') arrives BEFORE the
+  // block's stream mode has been confirmed, we now treat it as an incremental
+  // duplicate (emit the delta, do NOT lock snapshot mode). Rationale:
+  //   1. Anthropic-standard incremental is the dominant protocol.
+  //   2. Real snapshot providers progressively GROW their cumulative content;
+  //      sending an identical re-send as the first non-bootstrap delta is not
+  //      a documented behavior for any provider we support.
+  //   3. The user-visible cost of guessing wrong incremental→snapshot is one
+  //      lost character. The cost of guessing wrong snapshot→incremental is
+  //      one duplicated character. Both are tiny and self-correcting on the
+  //      very next non-empty extension. Whereas the LEGACY behavior (always
+  //      lock snapshot) destroyed the entire rest of the message — issue #1371.
+  //
+  // Once a later delta extends the accumulated content with non-empty novel
+  // bytes, snapshot mode locks correctly and corrective rewrites are absorbed
+  // — that path is already covered by the
+  // "snapshot-mode block absorbs corrective rewrites" test above.
+  const state = makeTurnState(true);
+
+  const captured = captureStdout(() => {
+    processStreamEvent(
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 0,
+        delta: { type: 'text_delta', text: 'Hello' } } },
+      state,
+    );
+    // Duplicate before mode confirmation → treated as incremental, emitted.
+    processStreamEvent(
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 0,
+        delta: { type: 'text_delta', text: 'Hello' } } },
+      state,
+    );
+  });
+
+  const emitted = tagLines(captured, '[CONTENT_DELTA]')
+    .map((line) => JSON.parse(line.replace(/^\[CONTENT_DELTA\]\s+/, '').trim()))
+    .join('');
+
+  assert.equal(emitted, 'HelloHello', `duplicate before mode lock must emit; got "${emitted}"`);
+});
+
+test('REGRESSION (#1371) companion: snapshot path absorbs incoming === previous even when mode is unconfirmed', () => {
+  // Dual of the stream-path tie-breaker above. The two paths interpret
+  // `incoming === previous` in OPPOSITE directions:
+  //
+  //   • stream path: identical incoming = a real duplicate provider delta →
+  //     EMIT (the #1371 fix).
+  //   • snapshot path: identical incoming = "nothing new to deliver beyond
+  //     what's already accumulated" → ABSORB.
+  //
+  // This test pins the snapshot side of that contract independently from the
+  // cross-turn-pollution tests (eb1786) so a future refactor of those cannot
+  // accidentally unlock duplicate snapshot emits.
+  //
+  // Scenario: a fully-streamed block ('Hello world') is then re-delivered by
+  // the assistant snapshot. processMessageContent calls resolveSnapshotDelta
+  // which threads origin='snapshot' into the normalizer. Mode is still
+  // 'incremental' (locked by the second stream delta), but even if it weren't,
+  // origin='snapshot' alone must trigger absorb.
+  const state = makeTurnState(true);
+
+  const captured = captureStdout(() => {
+    processStreamEvent(
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 0,
+        delta: { type: 'text_delta', text: 'Hello' } } },
+      state,
+    );
+    processStreamEvent(
+      { type: 'stream_event', event: { type: 'content_block_delta', index: 0,
+        delta: { type: 'text_delta', text: ' world' } } },
+      state,
+    );
+    state.hasStreamEvents = true;
+
+    // Assistant snapshot carries the full accumulated text. Must absorb —
+    // re-emitting would duplicate the entire block in the UI.
+    processMessageContent(
+      { type: 'assistant', message: { content: [{ type: 'text', text: 'Hello world' }] } },
+      state,
+    );
+  });
+
+  const deltaLines = tagLines(captured, '[CONTENT_DELTA]');
+  const emitted = deltaLines
+    .map((line) => JSON.parse(line.replace(/^\[CONTENT_DELTA\]\s+/, '').trim()))
+    .join('');
+
+  // Exactly two stream deltas emitted; snapshot replay added nothing.
+  assert.equal(deltaLines.length, 2, `snapshot replay must not emit; got ${JSON.stringify(deltaLines)}`);
+  assert.equal(emitted, 'Hello world', `accumulated content must remain "Hello world"; got "${emitted}"`);
+});


### PR DESCRIPTION
Issue #1371: repeated leading characters ('刚刚', '谢谢', '咕咕嘎嘎', or any tokenizer emitting two identical deltas in a row) caused every character after the first to vanish from the rendered reply.

Root cause: computeNovelDelta's 'incoming.startsWith(previous)' branch unconditionally locked the block into 'snapshot' mode even when the computed novel slice was empty (incoming === previous). That ambiguous signal flipped the absorber on, and every subsequent genuine incremental delta hit the snapshot-mode correction branch and was silently swallowed.

Fix: thread an 'origin' parameter ('stream' | 'snapshot') through normalizeStreamDelta so the two call paths interpret the zero-novel match in opposite directions:

  * origin='stream' (live content_block_delta): an identical incoming is a real duplicate provider token — emit it as novel content and do NOT lock snapshot mode. A real snapshot provider would never send an identical re-send as its first ambiguous signal; its defining trait is monotonically growing accumulated content.

  * origin='snapshot' (assistant-message snapshot replay via resolveSnapshotDelta): an identical incoming means 'nothing new to deliver beyond what's already accumulated' — absorb silently to avoid duplicating the whole block in the UI. This preserves the legacy behaviour for the snapshot path.

Add five regression tests covering:
  * the bug-report scenario '刚刚我在'
  * thinking-channel equivalent '谢谢，让我想想'
  * the CLAUDE.md forced-prefix repro '咕咕嘎嘎...'
  * tie-breaker contract: ambiguous zero-novel before mode confirmation is treated as incremental
  * dual contract: snapshot path absorbs incoming === previous even when mode is unconfirmed

All 33 tests in stream-event-processor.test.js pass.