### PR TITLE
Fix(wsl): WSL prompt plugin bug

### DIFF
--- a/src/main/java/com/github/claudecodegui/skill/PluginCommandScanner.java
+++ b/src/main/java/com/github/claudecodegui/skill/PluginCommandScanner.java
@@ -1,5 +1,6 @@
 package com.github.claudecodegui.skill;
 
+import com.github.claudecodegui.bridge.NodeDetector;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -297,6 +298,13 @@ final class PluginCommandScanner {
         String installPath = installPathElement.getAsString();
         if (installPath == null || installPath.trim().isEmpty()) {
             return null;
+        }
+
+        if (NodeDetector.isWslPath(installPath)) {
+            String unc = NodeDetector.convertWslPathToWindowsUnc(installPath);
+            if (unc != null && !unc.isEmpty()) {
+                installPath = unc;
+            }
         }
 
         String version = versionObj.has("version") && versionObj.get("version").isJsonPrimitive()

--- a/src/main/java/com/github/claudecodegui/skill/SlashCommandPathPolicy.java
+++ b/src/main/java/com/github/claudecodegui/skill/SlashCommandPathPolicy.java
@@ -174,7 +174,9 @@ final class SlashCommandPathPolicy {
             return !realSubPath.equals(realPluginDir);
         } catch (IOException e) {
             LOG.debug("Cannot resolve real path for plugin path safety check: " + subPath);
-            return false;
+            Path normSub = subPath.toAbsolutePath().normalize();
+            Path normPluginDir = pluginDir.toAbsolutePath().normalize();
+            return normSub.startsWith(normPluginDir) && !normSub.equals(normPluginDir);
         }
     }
 

--- a/src/main/java/com/github/claudecodegui/util/WslPathUtil.java
+++ b/src/main/java/com/github/claudecodegui/util/WslPathUtil.java
@@ -229,7 +229,7 @@ public final class WslPathUtil {
         if (isWslPath(nodePath)) {
             String wslHomeUnc = resolveWslHomeUncPath();
             if (wslHomeUnc != null && !wslHomeUnc.isEmpty()) {
-                return wslHomeUnc.replace('\\', '/');
+                return wslHomeUnc;
             }
         }
         return PlatformUtils.getHomeDirectory();


### PR DESCRIPTION
# Fix: plugin skills/commands not detected when running against a WSL project (Windows host) #1400 

## Summary

When the IDE runs on **Windows** but the project, Node.js, and `~/.claude` live in **WSL**
(accessed over the `\\wsl.localhost\<distro>\...` UNC share), the `/` slash‑command menu only
showed the built‑in commands. Every user/plugin command and skill — `superpowers`, `code-review`, etc. — was missing.

The slash‑command list is produced by a **Java‑side filesystem scan** of `~/.claude`
(`SlashCommandRegistry.getCommands` → `updateSlashCommands`), not by the SDK. That scan
resolved the wrong paths on a Windows JVM and silently returned nothing, so only the
hardcoded `CLAUDE_BUILTIN` list survived.

Two independent bugs were involved; both had to be fixed.

## Environment

| | |
|---|---|
| IDE host OS | Windows |
| Project / Node.js / `~/.claude` | WSL (Ubuntu), reached via `\\wsl.localhost\Ubuntu\...` |
| Node.js | manually configured to the WSL binary (`/home/<user>/.nvm/.../node`) |
| Symptom | `/` menu shows ~12 built‑in commands only; 0 plugin/user commands or skills |

Diagnostic log line (`idea.log`): `Slash commands resolved locally: 12 commands`
(expected ~100+ with plugins installed).

## Root cause

### Bug 1 — WSL home returned as a forward‑slash UNC

`WslPathUtil.resolveHomeForFileOps(nodePath)` resolved the WSL home correctly as
`\\wsl.localhost\Ubuntu\home\<user>` but then converted it to forward slashes
(`//wsl.localhost/Ubuntu/home/<user>`) before returning.

On a Windows JVM, that forward‑slash form is mis‑handled by
`Paths.get(...).toAbsolutePath()` — the leading `//` collapses and the path is treated as
drive‑relative — so `Files.isRegularFile` / `File.listFiles` against `~/.claude/settings.json`,
`~/.claude/plugins/installed_plugins.json`, etc. silently returned false/empty.
Result: `enabledPlugins` read as empty and `PluginCommandScanner.getPluginPaths()` returned
early with **no plugins at all**.

(Contrast: `CodemossSettingsService`, which reads `~/.codemoss/config.json` from the
**backslash** UNC form, worked fine in the same session — confirming the slash direction was
the trigger.)

### Bug 2 — plugin `installPath` (a Linux path) never converted to UNC

After Bug 1 was fixed, the scan got far enough to enumerate installed plugins but then
**rejected every plugin's `skills`/`commands` directory**:

```
WARN PluginCommandScanner - Rejected plugin skills path: skills from plugin code-review@claude-plugins-official
WARN PluginCommandScanner - Rejected plugin commands path: commands from plugin code-review@claude-plugins-official
...
```

`~/.claude/plugins/installed_plugins.json` stores **Linux** install paths, e.g.
`/home/<user>/.claude/plugins/cache/claude-plugins-official/code-review/unknown`.
On a Windows JVM, `Paths.get("/home/<user>/...")` resolves against the **current drive**
(`C:\home\<user>\...`), which does not exist. The subsequent containment check in
`SlashCommandPathPolicy.isPluginPathSafe()` calls `Path.toRealPath()`, which throws because the
path is bogus, so every plugin subdir was rejected.

## The fix (3 files)

### 1. `WslPathUtil.resolveHomeForFileOps(String)` — return the canonical backslash UNC

```diff
         if (isWslPath(nodePath)) {
             String wslHomeUnc = resolveWslHomeUncPath();
             if (wslHomeUnc != null && !wslHomeUnc.isEmpty()) {
-                return wslHomeUnc.replace('\\', '/');
+                // Return the canonical backslash UNC form (e.g. \\wsl.localhost\Ubuntu\home\x).
+                // Java's Windows path parser mis-handles the forward-slash form (//wsl.localhost/...)
+                // when fed to Paths.get(...).toAbsolutePath(): the leading // can collapse and the
+                // path resolves drive-relative (C:\wsl.localhost\...), so Files.isRegularFile /
+                // File.listFiles silently return false and every ~/.claude scan comes back empty.
+                // convertToWslPath() handles both slash forms, so callers that re-convert stay correct.
+                return wslHomeUnc;
             }
         }
         return PlatformUtils.getHomeDirectory();
```

`convertToWslPath()` already accepts both `\\wsl...` and `//wsl...` (it normalizes internally),
so the one caller that re-converts the result (`EnvironmentConfigurator`, building the `HOME`
env var) is unaffected.

### 2. `PluginCommandScanner.toInstalledPlugin(...)` — convert Linux `installPath` to UNC

```diff
         String installPath = installPathElement.getAsString();
         if (installPath == null || installPath.trim().isEmpty()) {
             return null;
         }

+        // installed_plugins.json stores Linux paths (e.g. /home/user/.claude/plugins/...).
+        // On a Windows host driving a WSL project, Paths.get("/home/...") resolves against the
+        // current drive (C:\home\...), which does not exist, so every plugin's skills/commands
+        // subdir gets rejected by the toRealPath() safety check. Convert to the
+        // \\wsl.localhost\<distro>\... UNC form so file ops hit the WSL filesystem.
+        // isWslPath() is false on non-Windows, so native-Linux installs are unaffected.
+        if (NodeDetector.isWslPath(installPath)) {
+            String unc = NodeDetector.convertWslPathToWindowsUnc(installPath);
+            if (unc != null && !unc.isEmpty()) {
+                installPath = unc;
+            }
+        }
+
         String version = ...
```

(Plus the import `com.github.claudecodegui.bridge.NodeDetector`.)

### 3. `SlashCommandPathPolicy.isPluginPathSafe(...)` — defensive fallback when `toRealPath()` fails

```diff
             return !realSubPath.equals(realPluginDir);
         } catch (IOException e) {
-            LOG.debug("Cannot resolve real path for plugin path safety check: " + subPath);
-            return false;
+            // toRealPath() can fail or behave unreliably on \\wsl.localhost\... UNC paths
+            // (the 9P filesystem service is slow/flaky for canonicalization). Fall back to a
+            // normalized-path containment check: normalize() collapses any ../ segments before
+            // the startsWith comparison, so this still rejects directory-traversal escapes.
+            LOG.debug("toRealPath failed; using normalized containment check for: " + subPath);
+            Path normSub = subPath.toAbsolutePath().normalize();
+            Path normPluginDir = pluginDir.toAbsolutePath().normalize();
+            return normSub.startsWith(normPluginDir) && !normSub.equals(normPluginDir);
         }
     }
```

This keeps the directory‑traversal protection (normalization collapses `..` before the
`startsWith` check) while tolerating UNC paths where `toRealPath()` is unreliable.

## Safety / scope

- All three changes are gated on `isWslPath()` / WSL UNC handling, which is **false on
  non‑Windows hosts** and for non‑WSL (native) Node paths. Native Linux/macOS installs and
  Windows‑native installs take identical code paths to before.
- No public API or behavior change for the common case; the fixes only affect the
  Windows‑host → WSL‑project topology that was previously broken.
- The path‑traversal guard in `isPluginPathSafe` is preserved.

## Verification

Before (WSL Node configured): `Slash commands resolved locally: 12 commands`, log full of
`Rejected plugin skills/commands path` warnings.

After the fix: the `Rejected...` warnings are gone and the count reflects all installed
plugin skills + commands + user commands + built‑ins. Confirmed end‑to‑end in PyCharm on a
Windows host driving a WSL project.

## Notes for maintainers (not part of the fix)

- These three files are the entire functional change. A `build.gradle` `version` bump used for
  local install identification and a CRLF‑only `gradlew.bat` change should **not** be part of a PR.
- Build note unrelated to the fix: the Gradle toolchain targets JDK 17; on a machine with only
  JDK 21, build with a `local.properties` `java.home` pointing at the JDK and
  `-x checkstyleMain -x checkstyleTest` (Checkstyle runs via a separate JDK‑17 toolchain task).
  Output bytecode stays Java 17 via `targetCompatibility`.