### PR TITLE
fix(history): resolve history against the normalized working directory

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/SessionHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SessionHandler.java
@@ -415,32 +415,20 @@ public class SessionHandler extends BaseMessageHandler {
     private String determineWorkingDirectory() {
         String projectPath = context.getProject().getBasePath();
 
-        // Prefer the user-configured working directory first
-        // (relative paths are resolved only when projectPath is valid).
+        // Prefer the user-configured working directory first, normalized so that
+        // relative segments (e.g. "..") are collapsed. This must match the directory
+        // history is stored under (see WorkingDirectoryManager#resolveEffectiveWorkingDirectory).
         if (projectPath != null && new File(projectPath).exists()) {
             try {
                 com.github.claudecodegui.settings.CodemossSettingsService settingsService =
                         new com.github.claudecodegui.settings.CodemossSettingsService();
-                String customWorkingDir = settingsService.getCustomWorkingDirectory(projectPath);
-
-                if (customWorkingDir != null && !customWorkingDir.isEmpty()) {
-                    // Resolve relative paths against the project root.
-                    File workingDirFile = new File(customWorkingDir);
-                    if (!workingDirFile.isAbsolute()) {
-                        workingDirFile = new File(projectPath, customWorkingDir);
-                    }
-
-                    // Validate that the directory exists.
-                    if (workingDirFile.exists() && workingDirFile.isDirectory()) {
-                        String resolvedPath = workingDirFile.getAbsolutePath();
-                        LOG.info("[SessionHandler] Using custom working directory: " + resolvedPath);
-                        return resolvedPath;
-                    } else {
-                        LOG.warn("[SessionHandler] Custom working directory does not exist: " + workingDirFile.getAbsolutePath() + ", falling back");
-                    }
+                String resolvedPath = settingsService.getEffectiveWorkingDirectory(projectPath);
+                if (resolvedPath != null && !resolvedPath.isEmpty()) {
+                    LOG.info("[SessionHandler] Using working directory: " + resolvedPath);
+                    return resolvedPath;
                 }
             } catch (Exception e) {
-                LOG.warn("[SessionHandler] Failed to read custom working directory: " + e.getMessage());
+                LOG.warn("[SessionHandler] Failed to resolve working directory: " + e.getMessage());
             }
         }
 

--- a/src/main/java/com/github/claudecodegui/handler/core/HandlerContext.java
+++ b/src/main/java/com/github/claudecodegui/handler/core/HandlerContext.java
@@ -69,6 +69,22 @@ public class HandlerContext {
         return settingsService;
     }
 
+    /**
+     * Resolve the normalized effective working directory for the current project —
+     * the custom working directory when configured and valid, otherwise the project
+     * base path. This is the directory Claude runs in and the key history is stored
+     * under, so history readers must use this instead of the raw base path.
+     *
+     * <p>Null-safe: returns the raw base path when no settings service is wired.
+     */
+    public String resolveEffectiveWorkingDirectory() {
+        String basePath = project != null ? project.getBasePath() : null;
+        if (settingsService == null) {
+            return basePath;
+        }
+        return settingsService.getEffectiveWorkingDirectory(basePath);
+    }
+
     public ClaudeSession getSession() {
         return session;
     }

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryDeleteService.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryDeleteService.java
@@ -179,7 +179,7 @@ class HistoryDeleteService {
             return new DeleteResult(deleteCodexSession(sessionId), 0);
         }
 
-        String rawPath = context.getProject().getBasePath();
+        String rawPath = context.resolveEffectiveWorkingDirectory();
         String nodePath = NodeDetector.getInstance().getCachedNodePath();
         String projectPath = NodeDetector.isWslPath(nodePath) ? NodeDetector.convertToWslPath(rawPath) : rawPath;
         if (projectPath == null) {
@@ -301,7 +301,7 @@ class HistoryDeleteService {
 
     private void cleanupCache(String currentProvider) {
         try {
-            String rawPath2 = context.getProject().getBasePath();
+            String rawPath2 = context.resolveEffectiveWorkingDirectory();
             String nodePath2 = NodeDetector.getInstance().getCachedNodePath();
             String projectPath = NodeDetector.isWslPath(nodePath2) ? NodeDetector.convertToWslPath(rawPath2) : rawPath2;
             if ("codex".equals(currentProvider)) {

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryExportService.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryExportService.java
@@ -42,7 +42,7 @@ class HistoryExportService {
                 String sessionId = exportRequest.get("sessionId").getAsString();
                 String title = exportRequest.get("title").getAsString();
 
-                String rawPath = context.getProject().getBasePath();
+                String rawPath = context.resolveEffectiveWorkingDirectory();
                 String nodePath = NodeDetector.getInstance().getCachedNodePath();
                 String projectPath = NodeDetector.isWslPath(nodePath) ? NodeDetector.convertToWslPath(rawPath) : rawPath;
                 if (projectPath == null) {

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryLoadService.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryLoadService.java
@@ -48,7 +48,7 @@ class HistoryLoadService {
                 String historyJson;
 
                 // Get current project path
-                String rawPath = context.getProject().getBasePath();
+                String rawPath = context.resolveEffectiveWorkingDirectory();
                 String nodePath = NodeDetector.getInstance().getCachedNodePath();
                 String projectPath = NodeDetector.isWslPath(nodePath) ? NodeDetector.convertToWslPath(rawPath) : rawPath;
                 if (projectPath == null) {
@@ -131,7 +131,7 @@ class HistoryLoadService {
      * @param provider the provider identifier ("claude" or "codex")
      */
     void handleDeepSearchHistory(String provider) {
-        String rawPath = context.getProject().getBasePath();
+        String rawPath = context.resolveEffectiveWorkingDirectory();
         String nodePath = NodeDetector.getInstance().getCachedNodePath();
         String projectPath = NodeDetector.isWslPath(nodePath) ? NodeDetector.convertToWslPath(rawPath) : rawPath;
         LOG.info("[HistoryHandler] ========== 开始深度搜索 ========== provider=" + provider);

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
@@ -57,7 +57,7 @@ public class HistoryMessageInjector {
             // Backward compatible: legacy payload is the raw sessionId string.
         }
 
-        String rawPath = context.getProject().getBasePath();
+        String rawPath = context.resolveEffectiveWorkingDirectory();
         String nodePath = NodeDetector.getInstance().getCachedNodePath();
         String projectPath = NodeDetector.isWslPath(nodePath) ? NodeDetector.convertToWslPath(rawPath) : rawPath;
         if (projectPath == null) {

--- a/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
@@ -297,24 +297,16 @@ public class SessionLifecycleManager {
 
         try {
             CodemossSettingsService settingsService = new CodemossSettingsService();
-            String customWorkingDir = settingsService.getCustomWorkingDirectory(projectPath);
-
-            if (customWorkingDir != null && !customWorkingDir.isEmpty()) {
-                File workingDirFile = new File(customWorkingDir);
-                if (!workingDirFile.isAbsolute()) {
-                    workingDirFile = new File(projectPath, customWorkingDir);
-                }
-                if (workingDirFile.exists() && workingDirFile.isDirectory()) {
-                    String resolvedPath = workingDirFile.getAbsolutePath();
-                    LOG.info("Using custom working directory: " + resolvedPath);
-                    return resolvedPath;
-                } else {
-                    LOG.warn("Custom working directory does not exist: "
-                                     + workingDirFile.getAbsolutePath() + ", falling back to project root");
-                }
+            // Normalized effective working directory (custom dir if valid, else the
+            // project path). Collapsing relative segments here keeps the launched cwd
+            // consistent with the directory history is read from.
+            String resolvedPath = settingsService.getEffectiveWorkingDirectory(projectPath);
+            if (resolvedPath != null && !resolvedPath.isEmpty()) {
+                LOG.info("Using working directory: " + resolvedPath);
+                return resolvedPath;
             }
         } catch (Exception e) {
-            LOG.warn("Failed to read custom working directory: " + e.getMessage());
+            LOG.warn("Failed to resolve working directory: " + e.getMessage());
         }
 
         return projectPath;

--- a/src/main/java/com/github/claudecodegui/settings/CodemossSettingsService.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodemossSettingsService.java
@@ -418,6 +418,15 @@ public class CodemossSettingsService {
         workingDirectoryManager.setCustomWorkingDirectory(projectPath, customWorkingDir);
     }
 
+    /**
+     * Resolve the normalized effective working directory for a project (custom
+     * directory if configured and valid, otherwise the normalized project path).
+     * This is the directory Claude runs in and the key history is stored under.
+     */
+    public String getEffectiveWorkingDirectory(String projectPath) {
+        return workingDirectoryManager.resolveEffectiveWorkingDirectory(projectPath);
+    }
+
     public Map<String, String> getAllWorkingDirectories() throws IOException {
         return workingDirectoryManager.getAllWorkingDirectories();
     }

--- a/src/main/java/com/github/claudecodegui/settings/WorkingDirectoryManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/WorkingDirectoryManager.java
@@ -1,8 +1,10 @@
 package com.github.claudecodegui.settings;
 
+import com.github.claudecodegui.util.PathUtils;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -71,6 +73,54 @@ public class WorkingDirectoryManager {
 
         configWriter.accept(config);
         LOG.info("[WorkingDirectoryManager] Set custom working directory for " + projectPath + ": " + customWorkingDir);
+    }
+
+    /**
+     * Resolve the effective working directory for a project — the same directory
+     * Claude is launched in, normalized so that {@code ..}/{@code .} are collapsed.
+     *
+     * <p>This is the single source of truth used by both the session launchers and
+     * the history readers. Keying history off this value (instead of the raw IDE
+     * base path) ensures the {@code ~/.claude/projects/<key>} directory the GUI reads
+     * matches the one the SDK writes to when a custom working directory is set.
+     *
+     * <p>Resolution order:
+     * <ol>
+     *   <li>No custom directory configured → the normalized project path.</li>
+     *   <li>Custom directory (absolute, or relative to the project root) that exists
+     *       and is a directory → that normalized directory.</li>
+     *   <li>Custom directory missing/invalid → fall back to the normalized project
+     *       path.</li>
+     * </ol>
+     *
+     * @param projectPath the project root path
+     * @return the normalized effective working directory, or {@code projectPath}
+     *         unchanged when it is null/empty
+     */
+    public String resolveEffectiveWorkingDirectory(String projectPath) {
+        if (projectPath == null || projectPath.isEmpty()) {
+            return projectPath;
+        }
+
+        String customWorkingDir = getCustomWorkingDirectory(projectPath);
+        if (customWorkingDir == null || customWorkingDir.trim().isEmpty()) {
+            return PathUtils.normalizeAbsolute(projectPath);
+        }
+
+        File workingDirFile = new File(customWorkingDir.trim());
+        if (!workingDirFile.isAbsolute()) {
+            workingDirFile = new File(projectPath, customWorkingDir.trim());
+        }
+
+        String normalized = PathUtils.normalizeAbsolute(workingDirFile.getPath());
+        File normalizedFile = new File(normalized);
+        if (normalizedFile.exists() && normalizedFile.isDirectory()) {
+            return normalized;
+        }
+
+        LOG.warn("[WorkingDirectoryManager] Custom working directory does not exist: "
+                + normalized + ", falling back to project root");
+        return PathUtils.normalizeAbsolute(projectPath);
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/util/PathUtils.java
+++ b/src/main/java/com/github/claudecodegui/util/PathUtils.java
@@ -39,6 +39,31 @@ public class PathUtils {
     }
 
     /**
+     * Resolve a path to an absolute, normalized form, collapsing {@code .} and
+     * {@code ..} segments without resolving symlinks.
+     *
+     * <p>This mirrors Node's {@code path.resolve()} (used by the ai-bridge when it
+     * decides the working directory), so the {@code ~/.claude/projects/<key>}
+     * directory derived on the Java side matches the one the Claude SDK writes to.
+     * {@code getCanonicalPath()} is deliberately avoided: it resolves
+     * symlinks/junctions and may change case, which would re-introduce divergence.
+     *
+     * @param path the original path
+     * @return the absolute, normalized path; or the input unchanged when null/blank
+     *         or when normalization fails
+     */
+    public static String normalizeAbsolute(String path) {
+        if (path == null || path.isEmpty()) {
+            return path;
+        }
+        try {
+            return java.nio.file.Paths.get(path).toAbsolutePath().normalize().toString();
+        } catch (Exception e) {
+            return path;
+        }
+    }
+
+    /**
      * Normalize a path to Unix style (for internal storage and comparison).
      * Converts Windows backslashes to forward slashes.
      *

--- a/src/test/java/com/github/claudecodegui/settings/WorkingDirectoryManagerResolveTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/WorkingDirectoryManagerResolveTest.java
@@ -1,0 +1,71 @@
+package com.github.claudecodegui.settings;
+
+import com.github.claudecodegui.util.PathUtils;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class WorkingDirectoryManagerResolveTest {
+
+    private WorkingDirectoryManager managerWithCustom(String projectPath, String customDir) {
+        JsonObject config = new JsonObject();
+        if (customDir != null) {
+            JsonObject workingDirs = new JsonObject();
+            workingDirs.addProperty(projectPath, customDir);
+            config.add("workingDirectories", workingDirs);
+        }
+        return new WorkingDirectoryManager((ignored) -> config, (written) -> { });
+    }
+
+    @Test
+    public void relativeDotDotResolvesToNormalizedParent() throws Exception {
+        Path root = Files.createTempDirectory("wdm-root");
+        Path child = Files.createDirectory(root.resolve("child"));
+
+        WorkingDirectoryManager manager = managerWithCustom(child.toString(), "..");
+
+        assertEquals(PathUtils.normalizeAbsolute(root.toString()),
+                manager.resolveEffectiveWorkingDirectory(child.toString()));
+    }
+
+    @Test
+    public void noCustomReturnsNormalizedProjectPath() throws Exception {
+        Path root = Files.createTempDirectory("wdm-root");
+        Path child = Files.createDirectory(root.resolve("child"));
+
+        WorkingDirectoryManager manager = managerWithCustom(child.toString(), null);
+
+        assertEquals(PathUtils.normalizeAbsolute(child.toString()),
+                manager.resolveEffectiveWorkingDirectory(child.toString()));
+    }
+
+    @Test
+    public void nonExistentCustomFallsBackToProjectPath() throws Exception {
+        Path root = Files.createTempDirectory("wdm-root");
+        Path child = Files.createDirectory(root.resolve("child"));
+
+        WorkingDirectoryManager manager = managerWithCustom(child.toString(), "does-not-exist-xyz");
+
+        assertEquals(PathUtils.normalizeAbsolute(child.toString()),
+                manager.resolveEffectiveWorkingDirectory(child.toString()));
+    }
+
+    @Test
+    public void absoluteExistingCustomIsReturnedNormalized() throws Exception {
+        Path root = Files.createTempDirectory("wdm-root");
+        Path child = Files.createDirectory(root.resolve("child"));
+        Path other = Files.createTempDirectory("wdm-other");
+
+        WorkingDirectoryManager manager = managerWithCustom(child.toString(), other.toString());
+
+        String resolved = manager.resolveEffectiveWorkingDirectory(child.toString());
+        assertEquals(PathUtils.normalizeAbsolute(other.toString()), resolved);
+        // sanity: it really is the other dir, not the project path
+        assertEquals(true, new File(resolved).exists());
+    }
+}

--- a/src/test/java/com/github/claudecodegui/util/PathUtilsNormalizeAbsoluteTest.java
+++ b/src/test/java/com/github/claudecodegui/util/PathUtilsNormalizeAbsoluteTest.java
@@ -1,0 +1,31 @@
+package com.github.claudecodegui.util;
+
+import org.junit.Test;
+
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class PathUtilsNormalizeAbsoluteTest {
+
+    @Test
+    public void collapsesTrailingDotDot() {
+        String base = Paths.get(System.getProperty("java.io.tmpdir")).toAbsolutePath().toString();
+        String input = base + java.io.File.separator + "a" + java.io.File.separator + "b"
+                + java.io.File.separator + "..";
+        String expected = Paths.get(base, "a").toString();
+
+        assertEquals(expected, PathUtils.normalizeAbsolute(input));
+    }
+
+    @Test
+    public void nullReturnsNull() {
+        assertNull(PathUtils.normalizeAbsolute(null));
+    }
+
+    @Test
+    public void blankReturnsBlankUnchanged() {
+        assertEquals("", PathUtils.normalizeAbsolute(""));
+    }
+}


### PR DESCRIPTION
## Problem

When a custom working directory is set to a relative path such as `..`, the **History panel is always empty** — for both Claude and Codex.

## Root cause

The GUI loaded history keyed on the **IDE project base path**, but Claude/Codex persist sessions keyed on the **normalized working directory** they actually run in. When a custom working directory differs from the base path (which `..` always does), the two keys diverge, so the panel reads an empty/wrong location.

Two defects combined:

1. `determineWorkingDirectory()` resolved a relative custom dir with `new File(projectPath, custom).getAbsolutePath()`, which **does not collapse `..`** (only `getCanonicalPath()` would) — so the launched cwd carried a literal `..`.
2. All history services keyed off `getProject().getBasePath()` instead of the directory Claude actually runs in.

Neither fix alone is sufficient — normalizing only fixes storage; re-pointing history only computes a `…-jetbrains-cc-gui--` dir that doesn't exist. Both must change together.

### Evidence
- Claude session files record `cwd` = the working dir and store under `~/.claude/projects/<sanitize(cwd)>/`; a custom sub-dir gets its own directory the base-path-scoped panel never reads.
- Codex session files record `cwd` as normalized Windows paths (e.g. `C:\Users\liuyh`), matched by equality/subdir — so they too rely on the caller passing a normalized path.
- Same class of bug as #1343 (`e0182689`, "never resolve working dir to the bridge install dir").

## Fix

Single principle: **everywhere the GUI derives a session-storage key it uses the same normalized effective working directory Claude runs in** — never the bare base path.

- `PathUtils.normalizeAbsolute()` — `Paths.toAbsolutePath().normalize()`, mirroring the ai-bridge's `path.resolve()`. Deliberately **not** `getCanonicalPath()` (which resolves symlinks/junctions and changes case, re-introducing divergence with the SDK).
- `WorkingDirectoryManager.resolveEffectiveWorkingDirectory()` — single source of truth (custom dir if valid, else project path; always normalized), exposed via `CodemossSettingsService.getEffectiveWorkingDirectory()` and a null-safe `HandlerContext.resolveEffectiveWorkingDirectory()`.
- Routed both session launchers (`SessionHandler`, `SessionLifecycleManager`) and all history services (load, deep-search, delete, export, inject) through it.

### Both providers covered
- **Claude:** sanitized projects dir now matches (`C--Users-...-IdeaProjects`).
- **Codex:** `getSessionsForProjectAsJson` filters by recorded `cwd` (equals/subdir); it now receives the normalized effective dir that matches the stored `cwd`.

### No regression for the default case
With no custom dir, the resolver returns `normalizeAbsolute(basePath)`. `sanitizePath` maps `/` and `\` identically, so the storage key is byte-for-byte unchanged.

## Tests
- New: `PathUtilsNormalizeAbsoluteTest` (3), `WorkingDirectoryManagerResolveTest` (4) — written test-first (RED→GREEN).
- Full suite: **582 tests, BUILD SUCCESSFUL** (incl. Claude + Codex history suites).

> Not exercisable in CI: the live IDE rendering the panel end-to-end. The path-key math, routing, and on-disk `cwd` formats are verified by tests and filesystem inspection.

## Out of scope (YAGNI)
Subagent-log key derivation, `ProjectConfigHandler` validation cosmetics, and migrating already-misfiled sessions.
