### PR TITLE
fix(claude): route persistent-runtime turns by CLI turn accounting, not iterator draining

### DIFF
--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -38,7 +38,7 @@ import {
   touchRuntime,
   createTurnSink,
   emitSessionUpdated,
-  waitForCliQuiet,
+  waitForReaderQuiescent,
 } from './runtime-lifecycle.js';
 import {
   SESSION_CLEANUP_INTERVAL_MS,
@@ -278,19 +278,24 @@ async function executeTurn(runtime, requestContext, turnMeta) {
     // closing `result` — to this turn. Consuming a foreign result ends this
     // turn early, the real answer then completes unobserved between turns,
     // and every later answer shifts back by one ("answer to the previous
-    // phrase"). Wait for the in-flight turn's result instead: its events take
-    // the inter-turn path (background rendering) where they belong. The CLI
-    // would queue our message behind that turn anyway, so this adds no real
-    // latency. Interruptible: abort disposes the runtime, which resolves the
-    // wait; we re-check `closed` after waking.
-    if (runtime.cliTurnInFlight) {
-      console.log('[LIFECYCLE] In-flight CLI turn detected — deferring new turn until its result arrives');
-      await waitForCliQuiet(runtime);
-      if (runtime.closed) {
-        const err = new Error('Runtime closed while waiting for an in-flight CLI turn to finish');
-        err.runtimeTerminated = true;
-        throw err;
-      }
+    // phrase").
+    //
+    // Wait until the reader has drained the pipe and parked on query.next().
+    // This covers not just a turn that is mid-flight now (waitForCliQuiet), but
+    // also a tail that lands in the gap after the previous result — a bare
+    // in-flight check is level-triggered on a flag the closing result already
+    // cleared, so a late background `assistant` (no result yet) would slip past
+    // it and contaminate this turn. We do this BEFORE enqueueing our user
+    // message: nothing in the pipe yet can be a response to it, so anything
+    // buffered is prior-turn tail and belongs on the inter-turn (background
+    // render) path. The CLI would queue our message behind that turn anyway, so
+    // this adds no real latency. Interruptible: abort disposes the runtime,
+    // which resolves the wait; we re-check `closed` after waking.
+    await waitForReaderQuiescent(runtime);
+    if (runtime.closed) {
+      const err = new Error('Runtime closed while waiting for an in-flight CLI turn to finish');
+      err.runtimeTerminated = true;
+      throw err;
     }
 
     // Create and register turnSink after beginRuntimeTurn to avoid race
@@ -372,13 +377,15 @@ async function executeTurn(runtime, requestContext, turnMeta) {
           // A successful turn always produces messages (at minimum one
           // assistant snapshot) before its result, so a success result
           // arriving as the FIRST message of this turn must be the closing
-          // result of a previous/background turn that slipped past the
-          // in-flight gate above (read only after this turn's sink opened).
-          // Consuming it as ours would end this turn before it produced
-          // anything, leave the real answer to complete unobserved between
-          // turns, and shift every later answer back by one. Skip it — this
-          // turn's real messages follow. session_updated still lets the UI
-          // render the background turn this result actually closed.
+          // result of a previous/background turn. The quiescence wait above
+          // drains anything already in the pipe before the sink opens, so this
+          // now only fires for the residual network window — a foreign run
+          // whose result lands after the sink opened. Consuming it as ours
+          // would end this turn before it produced anything, leave the real
+          // answer to complete unobserved between turns, and shift every later
+          // answer back by one. Skip it — this turn's real messages follow.
+          // session_updated still lets the UI render the background turn this
+          // result actually closed.
           console.log('[LIFECYCLE] Skipping foreign result that closed a background turn');
           if (runtime.sessionId) {
             emitSessionUpdated(runtime.sessionId);

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -37,6 +37,8 @@ import {
   setCachedQueryFn,
   touchRuntime,
   createTurnSink,
+  emitSessionUpdated,
+  waitForCliQuiet,
 } from './runtime-lifecycle.js';
 import {
   SESSION_CLEANUP_INTERVAL_MS,
@@ -268,12 +270,40 @@ async function executeTurn(runtime, requestContext, turnMeta) {
   try {
     beginRuntimeTurn(runtime);
 
+    // A previous turn can still be in flight on the CLI when this one starts:
+    // a CLI-initiated background turn (e.g. a background-task completion
+    // notification, #1305) or a late-finishing turn whose events are still in
+    // the pipe. The turnSink routes by existence, not by message identity, so
+    // opening it now would attribute that turn's output — and, worse, its
+    // closing `result` — to this turn. Consuming a foreign result ends this
+    // turn early, the real answer then completes unobserved between turns,
+    // and every later answer shifts back by one ("answer to the previous
+    // phrase"). Wait for the in-flight turn's result instead: its events take
+    // the inter-turn path (background rendering) where they belong. The CLI
+    // would queue our message behind that turn anyway, so this adds no real
+    // latency. Interruptible: abort disposes the runtime, which resolves the
+    // wait; we re-check `closed` after waking.
+    if (runtime.cliTurnInFlight) {
+      console.log('[LIFECYCLE] In-flight CLI turn detected — deferring new turn until its result arrives');
+      await waitForCliQuiet(runtime);
+      if (runtime.closed) {
+        const err = new Error('Runtime closed while waiting for an in-flight CLI turn to finish');
+        err.runtimeTerminated = true;
+        throw err;
+      }
+    }
+
     // Create and register turnSink after beginRuntimeTurn to avoid race
     // (ensures executeTurn is ready to consume before perpetual reader can push)
     runtime.turnSink = createTurnSink();
 
     console.log('[MESSAGE_START]');
     runtime.inputStream.enqueue(requestContext.userMessage);
+
+    // Guards the foreign-result check below: flips true once ANY message of
+    // this turn has been observed. A successful turn always produces output
+    // (at minimum one assistant message) before its result.
+    let sawTurnMessage = false;
 
     while (true) {
       let next;
@@ -295,6 +325,9 @@ async function executeTurn(runtime, requestContext, turnMeta) {
 
       touchRuntime(runtime);
       const msg = next.value;
+      if (msg?.type !== 'result') {
+        sawTurnMessage = true;
+      }
 
       if (turnState.streamingEnabled && !turnState.streamStarted) {
         process.stdout.write('[STREAM_START]\n');
@@ -329,7 +362,28 @@ async function executeTurn(runtime, requestContext, turnMeta) {
 
       if (msg?.type === 'result') {
         if (msg.is_error) {
+          // NOTE: error results are accepted even as the first message of the
+          // turn — an immediately-failing request (auth, rate limit, invalid
+          // model) legitimately produces a bare error result with no prior
+          // output. Only SUCCESS results are subject to the foreign check.
           throw new Error(msg.result || msg.message || 'API request failed');
+        }
+        if (!sawTurnMessage) {
+          // A successful turn always produces messages (at minimum one
+          // assistant snapshot) before its result, so a success result
+          // arriving as the FIRST message of this turn must be the closing
+          // result of a previous/background turn that slipped past the
+          // in-flight gate above (read only after this turn's sink opened).
+          // Consuming it as ours would end this turn before it produced
+          // anything, leave the real answer to complete unobserved between
+          // turns, and shift every later answer back by one. Skip it — this
+          // turn's real messages follow. session_updated still lets the UI
+          // render the background turn this result actually closed.
+          console.log('[LIFECYCLE] Skipping foreign result that closed a background turn');
+          if (runtime.sessionId) {
+            emitSessionUpdated(runtime.sessionId);
+          }
+          continue;
         }
         break;
       }

--- a/ai-bridge/services/claude/persistent-query-service.lifecycle.test.js
+++ b/ai-bridge/services/claude/persistent-query-service.lifecycle.test.js
@@ -2,77 +2,38 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { __testing } from './persistent-query-service.js';
+import {
+  createScriptedQuery,
+  assistantText,
+  RESULT_OK,
+} from './testing/scripted-query.js';
 
 /**
- * Create a Promise that can be manually resolved.
- * @returns {{ promise: Promise, resolve: Function, reject: Function }}
+ * Runtime lifecycle tests (epoch isolation, idle cleanup, abort) against the
+ * perpetual-reader architecture.
+ *
+ * Successor of persistent-query-service.test.mjs, which predated the
+ * perpetual reader and mocked query.next() with plain functions. Under the
+ * reader those mocks broke down: an immediately-done iterator makes the
+ * reader dispose the runtime at creation, and an infinitely-yielding one
+ * makes it spin. The scripted query used here keeps the iterator pending
+ * between deliveries — the real SDK's behavior — and is a native async
+ * generator, so iterator-consumer bugs surface instead of hiding in the mock
+ * (see testing/scripted-query.js). The .mjs suite also never ran in CI, whose
+ * glob only matches *.test.js.
  */
-function createDeferred() {
-  let resolve;
-  let reject;
-  const promise = new Promise((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
 
-function createQueryFactory() {
-  const runtimes = [];
-  return {
-    runtimes,
-    queryFn({ prompt, options }) {
-      const runtime = {
-        prompt,
-        options,
-        closed: false,
-        setPermissionMode: async () => {},
-        setModel: async () => {},
-        setMaxThinkingTokens: async () => {},
-        close() {
-          this.closed = true;
-        },
-        async next() {
-          return { done: true, value: undefined };
-        }
-      };
-      runtimes.push(runtime);
-      return runtime;
-    }
-  };
-}
+const OVERRIDES = { settings: { env: {} } };
 
-/**
- * Create a query factory that returns next() results in sequence.
- * @param {Array<(() => Promise<{done: boolean, value?: any}>) | {done: boolean, value?: any}>} steps
- */
-function createSequencedQueryFactory(steps) {
-  const runtimes = [];
+function trackingFactory(turnScripts = []) {
+  const queries = [];
   return {
-    runtimes,
-    queryFn({ prompt, options }) {
-      let index = 0;
-      const runtime = {
-        prompt,
-        options,
-        closed: false,
-        setPermissionMode: async () => {},
-        setModel: async () => {},
-        setMaxThinkingTokens: async () => {},
-        close() {
-          this.closed = true;
-        },
-        async next() {
-          const step = steps[index++];
-          if (!step) {
-            return { done: false, value: { type: 'result', is_error: false } };
-          }
-          return typeof step === 'function' ? await step() : step;
-        }
-      };
-      runtimes.push(runtime);
-      return runtime;
-    }
+    queries,
+    queryFn(args) {
+      const query = createScriptedQuery(args, turnScripts);
+      queries.push(query);
+      return query;
+    },
   };
 }
 
@@ -91,7 +52,7 @@ test('reasoningEffort is passed as SDK effort and disables fixed thinking tokens
     cwd: process.cwd(),
     message: 'use adaptive effort',
     reasoningEffort: 'xhigh'
-  }, false);
+  }, false, OVERRIDES);
 
   assert.equal(context.options.effort, 'xhigh');
   assert.equal(Object.hasOwn(context.options, 'maxThinkingTokens'), false);
@@ -105,7 +66,7 @@ test('fixed thinking tokens remain configured when no reasoningEffort is provide
     runtimeSessionEpoch: 'epoch-thinking',
     cwd: process.cwd(),
     message: 'use default thinking config'
-  }, false);
+  }, false, OVERRIDES);
 
   assert.equal(context.options.effort, undefined);
   assert.equal(context.options.maxThinkingTokens, 10000);
@@ -113,43 +74,43 @@ test('fixed thinking tokens remain configured when no reasoningEffort is provide
 });
 
 test('anonymous runtime is isolated by runtimeSessionEpoch', async () => {
-  const factory = createQueryFactory();
-  __testing.setQueryFn(factory.queryFn);
+  const factory = trackingFactory();
+  __testing.setQueryFn((args) => factory.queryFn(args));
 
   const firstContext = await __testing.buildRequestContext({
     sessionId: '',
     runtimeSessionEpoch: 'epoch-1',
     cwd: process.cwd(),
     message: 'hello'
-  }, false);
+  }, false, OVERRIDES);
 
   const runtime1 = await __testing.acquireRuntime(firstContext);
   const runtime1Again = await __testing.acquireRuntime(firstContext);
   assert.equal(runtime1, runtime1Again);
-  assert.equal(factory.runtimes.length, 1);
+  assert.equal(factory.queries.length, 1);
 
   const secondContext = await __testing.buildRequestContext({
     sessionId: '',
     runtimeSessionEpoch: 'epoch-2',
     cwd: process.cwd(),
     message: 'hello again'
-  }, false);
+  }, false, OVERRIDES);
 
   const runtime2 = await __testing.acquireRuntime(secondContext);
   assert.notEqual(runtime1, runtime2);
-  assert.equal(factory.runtimes.length, 2);
+  assert.equal(factory.queries.length, 2);
 });
 
 test('same-tab new-session isolation matches fresh runtime isolation expectations', async () => {
-  const factory = createQueryFactory();
-  __testing.setQueryFn(factory.queryFn);
+  const factory = trackingFactory();
+  __testing.setQueryFn((args) => factory.queryFn(args));
 
   const firstContext = await __testing.buildRequestContext({
     sessionId: '',
     runtimeSessionEpoch: 'epoch-a',
     cwd: process.cwd(),
     message: 'first turn'
-  }, false);
+  }, false, OVERRIDES);
   const runtimeA = await __testing.acquireRuntime(firstContext);
 
   await __testing.resetRuntimePersistent({ runtimeSessionEpoch: 'epoch-a' });
@@ -159,24 +120,25 @@ test('same-tab new-session isolation matches fresh runtime isolation expectation
     runtimeSessionEpoch: 'epoch-b',
     cwd: process.cwd(),
     message: 'new session turn'
-  }, false);
+  }, false, OVERRIDES);
   const runtimeB = await __testing.acquireRuntime(secondContext);
 
   assert.notEqual(runtimeA, runtimeB);
-  assert.equal(factory.runtimes.length, 2);
+  assert.equal(runtimeA.closed, true);
+  assert.equal(factory.queries.length, 2);
   assert.equal(__testing.getSnapshot().anonymousRuntimeCount, 1);
 });
 
 test('resetRuntimePersistent disposes active turn runtime for interrupted old epoch before next first send', async () => {
-  const factory = createQueryFactory();
-  __testing.setQueryFn(factory.queryFn);
+  const factory = trackingFactory();
+  __testing.setQueryFn((args) => factory.queryFn(args));
 
   const oldContext = await __testing.buildRequestContext({
     sessionId: '',
     runtimeSessionEpoch: 'epoch-old',
     cwd: process.cwd(),
     message: 'streaming turn'
-  }, false);
+  }, false, OVERRIDES);
   const oldRuntime = await __testing.acquireRuntime(oldContext);
   __testing.setActiveTurnRuntime(oldRuntime);
 
@@ -187,7 +149,7 @@ test('resetRuntimePersistent disposes active turn runtime for interrupted old ep
     runtimeSessionEpoch: 'epoch-new',
     cwd: process.cwd(),
     message: 'first send after interrupt'
-  }, false);
+  }, false, OVERRIDES);
   const nextRuntime = await __testing.acquireRuntime(nextContext);
 
   assert.equal(oldRuntime.closed, true);
@@ -196,15 +158,15 @@ test('resetRuntimePersistent disposes active turn runtime for interrupted old ep
 });
 
 test('restore-history continuation keeps runtime bound to restored session after reset of prior epoch', async () => {
-  const factory = createQueryFactory();
-  __testing.setQueryFn(factory.queryFn);
+  const factory = trackingFactory();
+  __testing.setQueryFn((args) => factory.queryFn(args));
 
   const oldAnonymousContext = await __testing.buildRequestContext({
     sessionId: '',
     runtimeSessionEpoch: 'epoch-stale',
     cwd: process.cwd(),
     message: 'stale anonymous'
-  }, false);
+  }, false, OVERRIDES);
   await __testing.acquireRuntime(oldAnonymousContext);
   await __testing.resetRuntimePersistent({ runtimeSessionEpoch: 'epoch-stale' });
 
@@ -213,7 +175,7 @@ test('restore-history continuation keeps runtime bound to restored session after
     runtimeSessionEpoch: 'epoch-restore',
     cwd: process.cwd(),
     message: 'restored continuation'
-  }, false);
+  }, false, OVERRIDES);
   const restoredRuntime = await __testing.acquireRuntime(restoredContext);
   const restoredRuntimeAgain = await __testing.acquireRuntime(restoredContext);
 
@@ -222,48 +184,44 @@ test('restore-history continuation keeps runtime bound to restored session after
 });
 
 test('active session runtime is not disposed by idle cleanup while a turn is executing', async () => {
-  const nextDeferred = createDeferred();
-  const enteredDeferred = createDeferred();
-  const factory = createSequencedQueryFactory([
-    async () => {
-      enteredDeferred.resolve();
-      return nextDeferred.promise;
-    },
-    { done: false, value: { type: 'result', is_error: false } }
-  ]);
-  __testing.setQueryFn(factory.queryFn);
+  // First user message produces no events yet — the turn blocks on take()
+  // until the test delivers the finishing messages through the channel.
+  const factory = trackingFactory([[]]);
+  __testing.setQueryFn((args) => factory.queryFn(args));
 
   const context = await __testing.buildRequestContext({
     sessionId: 'session-active',
     runtimeSessionEpoch: 'epoch-active',
     cwd: process.cwd(),
     message: 'long running turn'
-  }, false);
+  }, false, OVERRIDES);
   const runtime = await __testing.acquireRuntime(context);
   runtime.lastUsedAt = Date.now() - (31 * 60 * 1000);
 
-  const turnPromise = __testing.executeTurn(runtime, context);
-  await enteredDeferred.promise;
+  const turnPromise = __testing.executeTurn(runtime, context, { state: null });
+  const query = factory.queries[0];
+  await query.waitForInput();
 
   await __testing.cleanupSessionRuntimes();
 
   assert.equal(runtime.closed, false);
   assert.equal(__testing.getRuntimeForSession('session-active'), runtime);
 
-  nextDeferred.resolve({ done: false, value: { type: 'assistant', message: { content: [{ type: 'text', text: 'done' }] } } });
+  query.channel.enqueue(assistantText('done'));
+  query.channel.enqueue(RESULT_OK);
   await turnPromise;
 });
 
 test('idle session runtime is still disposed by idle cleanup', async () => {
-  const factory = createQueryFactory();
-  __testing.setQueryFn(factory.queryFn);
+  const factory = trackingFactory();
+  __testing.setQueryFn((args) => factory.queryFn(args));
 
   const context = await __testing.buildRequestContext({
     sessionId: 'session-idle',
     runtimeSessionEpoch: 'epoch-idle',
     cwd: process.cwd(),
     message: 'idle turn'
-  }, false);
+  }, false, OVERRIDES);
   const runtime = await __testing.acquireRuntime(context);
   runtime.lastUsedAt = Date.now() - (31 * 60 * 1000);
 
@@ -274,83 +232,71 @@ test('idle session runtime is still disposed by idle cleanup', async () => {
 });
 
 test('active anonymous runtime is not disposed by idle cleanup while a turn is executing', async () => {
-  const nextDeferred = createDeferred();
-  const enteredDeferred = createDeferred();
-  const factory = createSequencedQueryFactory([
-    async () => {
-      enteredDeferred.resolve();
-      return nextDeferred.promise;
-    },
-    { done: false, value: { type: 'result', is_error: false } }
-  ]);
-  __testing.setQueryFn(factory.queryFn);
+  const factory = trackingFactory([[]]);
+  __testing.setQueryFn((args) => factory.queryFn(args));
 
   const context = await __testing.buildRequestContext({
     sessionId: '',
     runtimeSessionEpoch: 'epoch-anon-active',
     cwd: process.cwd(),
     message: 'anonymous long running turn'
-  }, false);
+  }, false, OVERRIDES);
   const runtime = await __testing.acquireRuntime(context);
   runtime.lastUsedAt = Date.now() - (11 * 60 * 1000);
 
-  const turnPromise = __testing.executeTurn(runtime, context);
-  await enteredDeferred.promise;
+  const turnPromise = __testing.executeTurn(runtime, context, { state: null });
+  const query = factory.queries[0];
+  await query.waitForInput();
 
   await __testing.cleanupAnonymousRuntimes();
 
   assert.equal(runtime.closed, false);
   assert.equal(__testing.getSnapshot().anonymousRuntimeCount, 1);
 
-  nextDeferred.resolve({ done: false, value: { type: 'assistant', message: { content: [{ type: 'text', text: 'done' }] } } });
+  query.channel.enqueue(assistantText('done'));
+  query.channel.enqueue(RESULT_OK);
   await turnPromise;
 });
 
 test('executeTurn refreshes lastUsedAt while processing query events', async () => {
-  const factory = createSequencedQueryFactory([
-    { done: false, value: { type: 'assistant', message: { content: [{ type: 'text', text: 'partial' }] } } },
-    { done: false, value: { type: 'result', is_error: false } }
-  ]);
-  __testing.setQueryFn(factory.queryFn);
+  const factory = trackingFactory([[
+    assistantText('partial'),
+    RESULT_OK,
+  ]]);
+  __testing.setQueryFn((args) => factory.queryFn(args));
 
   const context = await __testing.buildRequestContext({
     sessionId: 'session-refresh',
     runtimeSessionEpoch: 'epoch-refresh',
     cwd: process.cwd(),
     message: 'refresh lastUsedAt'
-  }, false);
+  }, false, OVERRIDES);
   const runtime = await __testing.acquireRuntime(context);
   runtime.lastUsedAt = 1;
 
-  await __testing.executeTurn(runtime, context);
+  await __testing.executeTurn(runtime, context, { state: null });
 
   assert.ok(runtime.lastUsedAt > 1);
 });
 
-test('abortCurrentTurn still disposes an active runtime explicitly', async () => {
-  const nextDeferred = createDeferred();
-  const enteredDeferred = createDeferred();
-  const factory = createSequencedQueryFactory([
-    async () => {
-      enteredDeferred.resolve();
-      return nextDeferred.promise;
-    }
-  ]);
-  __testing.setQueryFn(factory.queryFn);
+test('abortCurrentTurn fails the pending take() and disposes the runtime', async () => {
+  const factory = trackingFactory([[]]);
+  __testing.setQueryFn((args) => factory.queryFn(args));
 
   const context = await __testing.buildRequestContext({
     sessionId: 'session-abort',
     runtimeSessionEpoch: 'epoch-abort',
     cwd: process.cwd(),
     message: 'abort me'
-  }, false);
+  }, false, OVERRIDES);
   const runtime = await __testing.acquireRuntime(context);
-  const turnPromise = __testing.executeTurn(runtime, context);
-  await enteredDeferred.promise;
+  const turnPromise = __testing.executeTurn(runtime, context, { state: null });
+  await factory.queries[0].waitForInput();
 
+  __testing.setActiveTurnRuntime(runtime);
   await __testing.abortCurrentTurn();
-  nextDeferred.reject(new Error('runtime terminated'));
 
-  await assert.rejects(turnPromise, /runtime terminated/);
+  // The abort fails the turnSink; executeTurn wraps that as a terminated turn.
+  await assert.rejects(turnPromise, /Turn aborted/);
   assert.equal(runtime.closed, true);
 });

--- a/ai-bridge/services/claude/persistent-query-service.lifecycle.test.js
+++ b/ai-bridge/services/claude/persistent-query-service.lifecycle.test.js
@@ -1,3 +1,7 @@
+// Redirect HOME to a temp CLI-login config BEFORE importing modules that call
+// setupApiKey(), so buildRequestContext() does not throw on a credential-less CI
+// runner. Must stay the first import (see testing/cli-login-home.js).
+import './testing/cli-login-home.js';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/ai-bridge/services/claude/runtime-lifecycle.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.js
@@ -177,7 +177,11 @@ async function createRuntime(requestContext, callbacks) {
     // an unfinished message run — substantive output seen, closing `result`
     // not yet. executeTurn defers opening its sink while this is set.
     cliTurnInFlight: false,
-    cliQuietWaiters: []
+    cliQuietWaiters: [],
+    // Monotonic count of messages the perpetual reader has pulled from the SDK
+    // iterator. waitForReaderQuiescent watches this to tell when the reader has
+    // drained everything already in the pipe and parked on query.next().
+    readerReadCount: 0
   };
 
   const options = {
@@ -334,6 +338,47 @@ export function waitForCliQuiet(runtime, capMs = 120_000) {
   });
 }
 
+/**
+ * Wait until the perpetual reader has drained everything already in the SDK
+ * pipe and is parked on query.next() — i.e. no CLI turn is in flight AND the
+ * reader made no progress across a macrotask.
+ *
+ * Called by executeTurn BEFORE it opens its turnSink and enqueues the user
+ * message. At that point the user message has not been sent, so nothing the
+ * pipe holds can be a response to it: anything still buffered is prior-turn
+ * tail (a late summary, a background turn's assistant/result, #1305). Letting
+ * the reader consume it via the inter-turn path first keeps it out of this
+ * turn's sink — which routes by existence and would otherwise misattribute it,
+ * ending the turn on a foreign result and shifting every later answer back by
+ * one ("answer to the previous phrase").
+ *
+ * waitForCliQuiet only parks on a result and cannot see a not-yet-closed tail
+ * that arrives in the gap after the previous result; the progress-tick check
+ * closes that gap. Bounded by capMs so a chatty background task cannot starve
+ * turn start; abort resolves it immediately via the closed check.
+ */
+export async function waitForReaderQuiescent(runtime, capMs = 120_000) {
+  if (!runtime || runtime.closed) return;
+  const deadline = Date.now() + capMs;
+  let lastCount = -1;
+  while (!runtime.closed) {
+    // Park cheaply on the in-flight turn's closing result instead of spinning.
+    if (runtime.cliTurnInFlight) {
+      await waitForCliQuiet(runtime, Math.max(0, deadline - Date.now()));
+      if (runtime.closed) return;
+    }
+    const count = runtime.readerReadCount || 0;
+    // No progress across a macrotask and no turn in flight → pipe drained.
+    if (count === lastCount && !runtime.cliTurnInFlight) return;
+    lastCount = count;
+    if (Date.now() >= deadline) {
+      console.warn('[LIFECYCLE] waitForReaderQuiescent cap (' + capMs + 'ms) hit — opening sink with the pipe possibly non-empty');
+      return;
+    }
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
 export function startPerpetualReader(runtime, callbacks) {
   // Start the perpetual reader loop; return the promise so callers (and tests)
   // can await its completion.
@@ -365,6 +410,11 @@ export function startPerpetualReader(runtime, callbacks) {
         }
 
         const msg = next.value;
+
+        // Progress tick for waitForReaderQuiescent: a change means the reader
+        // pulled a message this round; a steady value means it is parked on
+        // query.next() with an empty pipe.
+        runtime.readerReadCount = (runtime.readerReadCount || 0) + 1;
 
         // Keep the runtime's idle timer fresh while it actively produces output.
         // cleanupStaleSessionRuntimes reaps runtimes idle past SESSION_RUNTIME_MAX_IDLE_MS

--- a/ai-bridge/services/claude/runtime-lifecycle.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.js
@@ -131,6 +131,9 @@ export async function disposeRuntime(runtime, callbacks) {
     + ' signature=' + (runtime.runtimeSignature || '(none)'));
   runtime.closed = true;
   runtime.activeTurnCount = 0;
+  // Wake any executeTurn parked in waitForCliQuiet — it re-checks
+  // runtime.closed and fails the turn instead of hanging on a dead runtime.
+  resolveCliQuietWaiters(runtime);
 
   try {
     runtime.inputStream.done();
@@ -169,7 +172,12 @@ async function createRuntime(requestContext, callbacks) {
     stderrLines: [],
     query: null,
     inputStream: new AsyncStream(),
-    titleGenerationAttempted: false
+    titleGenerationAttempted: false,
+    // CLI turn accounting (see startPerpetualReader): true while the CLI has
+    // an unfinished message run — substantive output seen, closing `result`
+    // not yet. executeTurn defers opening its sink while this is set.
+    cliTurnInFlight: false,
+    cliQuietWaiters: []
   };
 
   const options = {
@@ -238,44 +246,95 @@ async function createRuntime(requestContext, callbacks) {
  *
  * Exported for testing; returns the reader loop promise.
  */
-export function startPerpetualReader(runtime, callbacks) {
-  /**
-   * Emit an inter-turn event using daemon.js's writeRawLine mechanism.
-   *
-   * IMPORTANT: Must bypass activeRequestId interception to avoid misrouting.
-   *
-   * Why writeRawLine is required:
-   * - daemon.js intercepts process.stdout.write and wraps output with activeRequestId
-   * - If we used console.log() here, the event would be tagged with whatever request
-   *   is currently active (possibly from a different session)
-   * - This would cause the session_updated event to be delivered to the wrong session
-   * - writeRawLine (_originalStdoutWrite) bypasses the interception layer and outputs
-   *   directly to stdout, ensuring the event is process-level and not request-scoped
-   *
-   * The event format {type: 'daemon', event: 'session_updated', sessionId} is recognized
-   * by Java's DaemonBridge.handleDaemonEvent() which routes it to registered listeners.
-   */
-  const emitInterTurnEvent = (sessionId) => {
-    try {
-      // Access the global writeRawLine from daemon.js
-      // daemon.js stores the original stdout.write as _originalStdoutWrite
-      // We must use _originalStdoutWrite to bypass activeRequestId wrapping
-      const originalWrite = process.stdout._originalStdoutWrite;
-      if (!originalWrite) {
-        console.error('[PERPETUAL_READER] _originalStdoutWrite not available (daemon.js not initialized?), cannot emit session_updated event');
-        return;
-      }
-      const eventPayload = {
-        type: 'daemon',
-        event: 'session_updated',
-        sessionId: sessionId
-      };
-      originalWrite.call(process.stdout, JSON.stringify(eventPayload) + '\n', 'utf8');
-    } catch (err) {
-      console.error('[PERPETUAL_READER] Failed to emit session_updated event:', err);
+/**
+ * Emit a session_updated event using daemon.js's writeRawLine mechanism.
+ *
+ * IMPORTANT: Must bypass activeRequestId interception to avoid misrouting.
+ *
+ * Why writeRawLine is required:
+ * - daemon.js intercepts process.stdout.write and wraps output with activeRequestId
+ * - If we used console.log() here, the event would be tagged with whatever request
+ *   is currently active (possibly from a different session)
+ * - This would cause the session_updated event to be delivered to the wrong session
+ * - writeRawLine (_originalStdoutWrite) bypasses the interception layer and outputs
+ *   directly to stdout, ensuring the event is process-level and not request-scoped
+ *
+ * The event format {type: 'daemon', event: 'session_updated', sessionId} is recognized
+ * by Java's DaemonBridge.handleDaemonEvent() which routes it to registered listeners.
+ *
+ * Used by the perpetual reader for inter-turn results, and by executeTurn when
+ * it skips a foreign result that closes a background turn.
+ */
+export function emitSessionUpdated(sessionId) {
+  try {
+    // Access the global writeRawLine from daemon.js
+    // daemon.js stores the original stdout.write as _originalStdoutWrite
+    // We must use _originalStdoutWrite to bypass activeRequestId wrapping
+    const originalWrite = process.stdout._originalStdoutWrite;
+    if (!originalWrite) {
+      console.error('[PERPETUAL_READER] _originalStdoutWrite not available (daemon.js not initialized?), cannot emit session_updated event');
+      return;
     }
-  };
+    const eventPayload = {
+      type: 'daemon',
+      event: 'session_updated',
+      sessionId: sessionId
+    };
+    originalWrite.call(process.stdout, JSON.stringify(eventPayload) + '\n', 'utf8');
+  } catch (err) {
+    console.error('[PERPETUAL_READER] Failed to emit session_updated event:', err);
+  }
+}
 
+/**
+ * Resolve every waiter parked in waitForCliQuiet on this runtime.
+ * Called by the reader when a `result` closes the in-flight CLI turn, on
+ * reader exit, and by disposeRuntime.
+ */
+function resolveCliQuietWaiters(runtime) {
+  if (!runtime?.cliQuietWaiters?.length) return;
+  // Copy first: each resolve() removes itself from the array.
+  for (const waiter of [...runtime.cliQuietWaiters]) {
+    waiter.resolve();
+  }
+}
+
+/**
+ * Wait until the CLI has no message run in flight on this runtime — i.e. the
+ * last substantive message the perpetual reader saw has been closed by a
+ * `result` — or until the runtime closes.
+ *
+ * The cap is a protocol-anomaly backstop, not a tuning knob: every CLI message
+ * run (user-initiated or CLI-initiated) ends with exactly one `result`, so the
+ * wait normally ends when that result is read. If the cap ever fires, turn
+ * accounting is off — we log loudly and fall back to today's behavior rather
+ * than blocking the user's send forever. Abort remains responsive throughout:
+ * disposing the runtime resolves the wait immediately.
+ */
+export function waitForCliQuiet(runtime, capMs = 120_000) {
+  if (!runtime || runtime.closed || !runtime.cliTurnInFlight) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const waiter = {
+      timer: null,
+      resolve() {
+        if (waiter.timer) clearTimeout(waiter.timer);
+        const index = runtime.cliQuietWaiters.indexOf(waiter);
+        if (index >= 0) runtime.cliQuietWaiters.splice(index, 1);
+        resolve();
+      }
+    };
+    waiter.timer = setTimeout(() => {
+      console.warn('[LIFECYCLE] waitForCliQuiet cap (' + capMs + 'ms) hit — proceeding without the closing result; turn accounting may be off');
+      waiter.resolve();
+    }, capMs);
+    if (typeof waiter.timer?.unref === 'function') waiter.timer.unref();
+    runtime.cliQuietWaiters.push(waiter);
+  });
+}
+
+export function startPerpetualReader(runtime, callbacks) {
   // Start the perpetual reader loop; return the promise so callers (and tests)
   // can await its completion.
   return (async () => {
@@ -316,6 +375,24 @@ export function startPerpetualReader(runtime, callbacks) {
         // additionally covers the inter-turn path executeTurn cannot see.
         touchRuntime(runtime);
 
+        // CLI turn accounting. Every CLI message run — user-initiated or
+        // CLI-initiated (e.g. a background-task completion notification,
+        // #1305) — ends with exactly one `result`, and the pipe preserves
+        // order. So "substantive output seen, result not yet" means a turn is
+        // still in flight, and executeTurn must not open a new sink yet:
+        // the sink routes by existence, not by message identity, so a foreign
+        // in-flight turn's output — and, worse, its closing result — would be
+        // attributed to the new turn ("answer to the previous phrase" bug).
+        // `system` and other control-ish messages deliberately do not arm the
+        // flag: they can arrive outside any turn (e.g. init on a prewarmed
+        // runtime) and never carry a closing result of their own.
+        if (msg?.type === 'result') {
+          runtime.cliTurnInFlight = false;
+          resolveCliQuietWaiters(runtime);
+        } else if (msg?.type === 'assistant' || msg?.type === 'user' || msg?.type === 'stream_event') {
+          runtime.cliTurnInFlight = true;
+        }
+
         // Dual-mode routing: check if we're in an active turn or inter-turn period
         if (runtime.turnSink) {
           // IN-TURN MODE: Forward message to executeTurn via turnSink
@@ -328,7 +405,7 @@ export function startPerpetualReader(runtime, callbacks) {
             // Validate sessionId: only emit events for registered runtimes
             if (runtime.sessionId) {
               console.log('[PERPETUAL_READER] Inter-turn result detected, emitting session_updated for sessionId=' + runtime.sessionId);
-              emitInterTurnEvent(runtime.sessionId);
+              emitSessionUpdated(runtime.sessionId);
             } else {
               // Anonymous runtime - silently consume
               console.log('[PERPETUAL_READER] Inter-turn result for anonymous runtime, consuming silently');
@@ -345,6 +422,9 @@ export function startPerpetualReader(runtime, callbacks) {
       }
     } finally {
       console.log('[PERPETUAL_READER] Exiting for sessionId=' + (runtime.sessionId || '(new)'));
+      // No more results will ever arrive — never leave a turn parked in
+      // waitForCliQuiet on a dead stream.
+      resolveCliQuietWaiters(runtime);
       // The reader only exits on a terminal condition (query error, stream end,
       // or runtime closed) — never after a normal turn, where it blocks on the
       // next query.next() instead. If the runtime is still live here, the SDK

--- a/ai-bridge/services/claude/stale-turn-isolation.test.js
+++ b/ai-bridge/services/claude/stale-turn-isolation.test.js
@@ -323,6 +323,63 @@ test('abort while gated on an in-flight CLI turn fails the turn instead of hangi
   assert.equal(runtime.closed, true);
 });
 
+test('a background-turn tail already in the pipe does not contaminate the next user turn', async () => {
+  // The scheduler-race that survives the level-triggered in-flight gate: turn 1
+  // ends, then the CLI emits a background turn (assistant + its OWN result,
+  // #1305) whose events are already buffered in the pipe — but the reader has
+  // not yet been scheduled to consume them into the inter-turn path. Turn 2
+  // starts in that window.
+  //
+  // Without deferring the sink until the pipe is quiet, turn 2 would open its
+  // sink, receive the background assistant (arming sawTurnMessage), then take
+  // the background *result* as its own — ending turn 2 before its real answer,
+  // which then completes unobserved between turns. Every later answer shifts
+  // back by one ("answer to the previous / pre-previous phrase").
+  const turn1 = [messageStart(), streamTextDelta('answer ONE'), assistantText('answer ONE'), RESULT_OK];
+
+  let query;
+  __testing.setQueryFn((args) => {
+    query = createScriptedQuery(args, [turn1]);
+    return query;
+  });
+
+  const params = baseParams('bg-tail');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+  const meta1 = { state: null };
+  await __testing.executeTurn(runtime, ctx1, meta1);
+  assert.equal(meta1.state.lastAssistantContent, 'answer ONE');
+  await query.waitForInput(); // consume turn 1's user message from the FIFO tracker
+
+  // A complete CLI-initiated background turn lands in the pipe.
+  query.channel.enqueue(assistantText('BACKGROUND task summary — not an answer the user asked for'));
+  query.channel.enqueue(RESULT_OK);
+
+  // Turn 2 begins immediately — NO settleReader, so the reader has not drained
+  // the background turn yet. executeTurn must defer its sink until quiescent.
+  const ctx2 = await __testing.buildRequestContext({ ...params, message: 'q2' }, false, OVERRIDES);
+  const runtime2 = await __testing.acquireRuntime(ctx2);
+  assert.equal(runtime2, runtime, 'runtime is reused across turns');
+  const meta2 = { state: null };
+  const turn2 = __testing.executeTurn(runtime2, ctx2, meta2);
+
+  // Deliver turn 2's real answer only AFTER the CLI has read our user message —
+  // mirroring real ordering, where a response cannot precede its request.
+  await query.waitForInput();
+  query.channel.enqueue(messageStart());
+  query.channel.enqueue(streamTextDelta('answer TWO'));
+  query.channel.enqueue(assistantText('answer TWO'));
+  query.channel.enqueue(RESULT_OK);
+
+  await turn2;
+
+  assert.equal(meta2.state.lastAssistantContent, 'answer TWO');
+  assert.ok(
+    !meta2.state.lastAssistantContent.includes('BACKGROUND'),
+    'the background turn must not be attributed to turn 2'
+  );
+});
+
 test('the perpetual reader is the only query.next() consumer across turns', async () => {
   // Architectural invariant that makes swallowed events impossible: native
   // async generators serve queued next() callers in FIFO order, so ANY second

--- a/ai-bridge/services/claude/stale-turn-isolation.test.js
+++ b/ai-bridge/services/claude/stale-turn-isolation.test.js
@@ -52,10 +52,12 @@ test('post-result stragglers from turn 1 are consumed between turns and never re
     streamTextDelta('turn 1 reply'),
     assistantText('turn 1 reply'),
     RESULT_OK,
-    // Post-result stragglers: late events the SDK can emit after executeTurn
-    // already broke out of its loop on the result message.
+    // A CLI-initiated follow-up run right after the turn (e.g. a background
+    // task notification): its messages arrive after executeTurn already broke
+    // out of its loop, and per protocol it closes with its own result.
     assistantText('STALE turn 1 trailing snapshot that must never surface again'),
     streamTextDelta('STALE tail'),
+    RESULT_OK,
   ];
   const turn2 = [
     messageStart(),
@@ -151,8 +153,10 @@ test('the first event of a new turn is delivered to that turn, never swallowed',
 test('a turn ending in is_error leaves the runtime reusable and the next turn clean', async () => {
   const turn1 = [
     { type: 'result', is_error: true, result: 'rate limited' },
-    // Straggler after the errored result.
+    // CLI-initiated follow-up run after the errored result; closes with its
+    // own result per protocol.
     assistantText('STALE post-error snapshot'),
+    RESULT_OK,
   ];
   const turn2 = [
     messageStart(),
@@ -185,12 +189,146 @@ test('a turn ending in is_error leaves the runtime reusable and the next turn cl
   assert.ok(!meta2.state.lastAssistantContent.includes('STALE'));
 });
 
+test('a new turn waits for an in-flight CLI-initiated turn and never absorbs its result', async () => {
+  // Reproduces the "answer to the previous phrase" ratchet trigger: a
+  // CLI-initiated run (e.g. a background-task completion notification) is
+  // still streaming when the user sends the next message. Without the
+  // in-flight gate, the new turn's sink absorbs that run's output and breaks
+  // on its result; the real answer then completes unobserved between turns
+  // and every later answer shifts back by one.
+  const turn1 = [messageStart(), streamTextDelta('answer one'), assistantText('answer one'), RESULT_OK];
+  const turn2 = [messageStart(), streamTextDelta('answer two'), assistantText('answer two'), RESULT_OK];
+
+  let query;
+  __testing.setQueryFn((args) => {
+    query = createScriptedQuery(args, [turn1, turn2]);
+    return query;
+  });
+
+  const params = baseParams('inflight-gate');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+  await __testing.executeTurn(runtime, ctx1, { state: null });
+  await settleReader();
+
+  // A CLI-initiated run starts between turns: output arrives, no result yet.
+  query.channel.enqueue(assistantText('background notification body'));
+  await settleReader();
+  assert.equal(runtime.cliTurnInFlight, true, 'reader must mark the CLI busy after un-closed output');
+
+  const ctx2 = await __testing.buildRequestContext({ ...params, message: 'q2' }, false, OVERRIDES);
+  const meta2 = { state: null };
+  const turn2Promise = __testing.executeTurn(runtime, ctx2, meta2);
+  await settleReader();
+
+  assert.equal(query.inputs.length, 1,
+    'the new turn must not enqueue its user message while a CLI turn is in flight');
+
+  // The in-flight run closes; only now may the new turn proceed.
+  query.channel.enqueue(RESULT_OK);
+  await settleReader();
+  assert.equal(query.inputs.length, 2, 'the gated turn must proceed once the result arrives');
+
+  await turn2Promise;
+  assert.equal(meta2.state.lastAssistantContent, 'answer two');
+  assert.ok(!meta2.state.lastAssistantContent.includes('background notification'));
+});
+
+test('a foreign success result arriving first in a new turn is skipped, not treated as the turn end', async () => {
+  // The boundary straddle the gate cannot see: the background run's closing
+  // result is read only AFTER the new turn's sink opened. Consuming it as the
+  // new turn's own result would end the turn with empty output and seed the
+  // one-behind shift.
+  const turn1 = [messageStart(), streamTextDelta('answer one'), assistantText('answer one'), RESULT_OK];
+  const turn2 = []; // driven manually below
+
+  let query;
+  __testing.setQueryFn((args) => {
+    query = createScriptedQuery(args, [turn1, turn2]);
+    return query;
+  });
+
+  const params = baseParams('foreign-result');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+  await __testing.executeTurn(runtime, ctx1, { state: null });
+  await settleReader();
+
+  const ctx2 = await __testing.buildRequestContext({ ...params, message: 'q2' }, false, OVERRIDES);
+  const meta2 = { state: null };
+  const turn2Promise = __testing.executeTurn(runtime, ctx2, meta2);
+  await settleReader();
+  assert.equal(query.inputs.length, 2, 'gate must not trigger: the CLI was quiet at turn start');
+
+  // Foreign result lands in the fresh sink before any of this turn's output.
+  query.channel.enqueue({ type: 'result', is_error: false });
+  await settleReader();
+
+  // The real answer follows — the turn must still be alive to receive it.
+  query.channel.enqueue(messageStart());
+  query.channel.enqueue(streamTextDelta('real answer two'));
+  query.channel.enqueue(assistantText('real answer two'));
+  query.channel.enqueue(RESULT_OK);
+
+  await turn2Promise;
+  assert.equal(meta2.state.lastAssistantContent, 'real answer two',
+    'a bare foreign success result must not terminate the turn');
+});
+
+test('an error result as the first message of a turn still fails the turn (not treated as foreign)', async () => {
+  // Immediately-failing requests (auth, rate limit, invalid model) produce a
+  // bare error result with no prior output — that is OUR turn's result and
+  // must keep surfacing as an error, not be skipped by the foreign check.
+  const turn1 = [{ type: 'result', is_error: true, result: 'invalid api key' }];
+
+  __testing.setQueryFn((args) => createScriptedQuery(args, [turn1]));
+
+  const params = baseParams('bare-error');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+
+  await assert.rejects(
+    __testing.executeTurn(runtime, ctx1, { state: null }),
+    /invalid api key/
+  );
+});
+
+test('abort while gated on an in-flight CLI turn fails the turn instead of hanging', async () => {
+  const turn1 = [messageStart(), assistantText('answer one'), RESULT_OK];
+
+  let query;
+  __testing.setQueryFn((args) => {
+    query = createScriptedQuery(args, [turn1]);
+    return query;
+  });
+
+  const params = baseParams('gate-abort');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+  await __testing.executeTurn(runtime, ctx1, { state: null });
+  await settleReader();
+
+  // Arm the gate: CLI output with no closing result.
+  query.channel.enqueue(assistantText('background run output'));
+  await settleReader();
+
+  const ctx2 = await __testing.buildRequestContext({ ...params, message: 'q2' }, false, OVERRIDES);
+  const turn2Promise = __testing.executeTurn(runtime, ctx2, { state: null });
+  await settleReader();
+  assert.equal(query.inputs.length, 1, 'turn must be parked in the gate');
+
+  // User hits stop: dispose resolves the gate, the turn fails fast.
+  await __testing.abortCurrentTurn();
+  await assert.rejects(turn2Promise, /Runtime closed while waiting/);
+  assert.equal(runtime.closed, true);
+});
+
 test('the perpetual reader is the only query.next() consumer across turns', async () => {
   // Architectural invariant that makes swallowed events impossible: native
   // async generators serve queued next() callers in FIFO order, so ANY second
   // concurrent consumer (a drain, a probe, an abandoned racing read) steals
   // events from the reader. maxInflight > 1 is that second consumer.
-  const turn1 = [messageStart(), assistantText('one'), RESULT_OK, assistantText('straggler')];
+  const turn1 = [messageStart(), assistantText('one'), RESULT_OK, assistantText('straggler'), RESULT_OK];
   const turn2 = [messageStart(), assistantText('two'), RESULT_OK];
 
   let query;

--- a/ai-bridge/services/claude/stale-turn-isolation.test.js
+++ b/ai-bridge/services/claude/stale-turn-isolation.test.js
@@ -1,0 +1,217 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __testing } from './persistent-query-service.js';
+import {
+  createScriptedQuery,
+  assistantText,
+  streamTextDelta,
+  messageStart,
+  RESULT_OK,
+  settleReader,
+} from './testing/scripted-query.js';
+
+/**
+ * Regression suite for stale-event isolation between turns on a persistent
+ * runtime — the "AI answered the previous question" bug (#1410).
+ *
+ * On a reused runtime the SDK iterator lives across turns, so events the CLI
+ * emits after a turn's result message (late snapshots, trailing deltas,
+ * stream cleanup) are still in flight when the next turn starts. These tests
+ * pin down the intended routing: the perpetual reader (the iterator's ONLY
+ * consumer) must absorb those stragglers between turns, and every event of a
+ * new turn — including the very first one — must reach that turn's sink.
+ *
+ * The fake SDK query is a native async generator over a single-slot queue,
+ * the same shape as the SDK's readSdkMessages() (see testing/scripted-query.js
+ * for why plain-function mocks cannot catch this class of bug).
+ */
+
+const OVERRIDES = { settings: { env: {} } };
+
+function baseParams(tag) {
+  return {
+    sessionId: `session-${tag}`,
+    runtimeSessionEpoch: `epoch-${tag}`,
+    cwd: process.cwd(),
+    streaming: true,
+  };
+}
+
+test.beforeEach(async () => {
+  await __testing.resetState();
+});
+
+test.after(async () => {
+  await __testing.resetState();
+});
+
+test('post-result stragglers from turn 1 are consumed between turns and never reach turn 2', async () => {
+  const turn1 = [
+    messageStart(),
+    streamTextDelta('turn 1 reply'),
+    assistantText('turn 1 reply'),
+    RESULT_OK,
+    // Post-result stragglers: late events the SDK can emit after executeTurn
+    // already broke out of its loop on the result message.
+    assistantText('STALE turn 1 trailing snapshot that must never surface again'),
+    streamTextDelta('STALE tail'),
+  ];
+  const turn2 = [
+    messageStart(),
+    streamTextDelta('turn 2 reply'),
+    assistantText('turn 2 reply'),
+    RESULT_OK,
+  ];
+
+  let query;
+  __testing.setQueryFn((args) => {
+    query = createScriptedQuery(args, [turn1, turn2]);
+    return query;
+  });
+
+  const params = baseParams('straggler');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'first question' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+  const meta1 = { state: null };
+  await __testing.executeTurn(runtime, ctx1, meta1);
+  assert.equal(meta1.state.lastAssistantContent, 'turn 1 reply');
+
+  // Inter-turn gap: the perpetual reader must drain the stragglers here.
+  await settleReader();
+
+  const ctx2 = await __testing.buildRequestContext({ ...params, message: 'second question' }, false, OVERRIDES);
+  const runtime2 = await __testing.acquireRuntime(ctx2);
+  assert.equal(runtime2, runtime, 'the persistent runtime must be reused across turns');
+
+  const meta2 = { state: null };
+  await __testing.executeTurn(runtime2, ctx2, meta2);
+
+  assert.equal(meta2.state.lastAssistantContent, 'turn 2 reply');
+  assert.ok(
+    !meta2.state.lastAssistantContent.includes('STALE'),
+    'previous-turn straggler content must not be re-emitted in the new turn'
+  );
+});
+
+test('the first event of a new turn is delivered to that turn, never swallowed', async () => {
+  // Regression for the abandoned-next() failure mode: a stray consumer left
+  // waiting on the iterator between turns would receive (and lose) the new
+  // turn's first event. message_start is that first event, and it drives the
+  // [BLOCK_RESET] emission — so its arrival is observable on stdout.
+  const turn1 = [
+    messageStart(),
+    streamTextDelta('first answer'),
+    assistantText('first answer'),
+    RESULT_OK,
+  ];
+  const turn2 = [
+    messageStart(),
+    streamTextDelta('Hello'),
+    streamTextDelta(' world'),
+    assistantText('Hello world'),
+    RESULT_OK,
+  ];
+
+  __testing.setQueryFn((args) => createScriptedQuery(args, [turn1, turn2]));
+
+  const params = baseParams('first-event');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+  await __testing.executeTurn(runtime, ctx1, { state: null });
+
+  // Idle inter-turn gap with nothing buffered — the exact scenario where a
+  // timed-out drain used to leave an abandoned next() queued on the iterator.
+  await settleReader();
+
+  const ctx2 = await __testing.buildRequestContext({ ...params, message: 'q2' }, false, OVERRIDES);
+  const runtime2 = await __testing.acquireRuntime(ctx2);
+  const meta2 = { state: null };
+
+  const written = [];
+  const originalWrite = process.stdout.write;
+  process.stdout.write = function capture(chunk, ...rest) {
+    written.push(String(chunk));
+    return originalWrite.call(this, chunk, ...rest);
+  };
+  try {
+    await __testing.executeTurn(runtime2, ctx2, meta2);
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+
+  assert.ok(
+    written.some((line) => line.includes('[BLOCK_RESET]')),
+    'turn 2 must observe its message_start (first event) — it drives [BLOCK_RESET]'
+  );
+  assert.equal(meta2.state.lastAssistantContent, 'Hello world',
+    'every delta of the new turn must arrive, starting from the first event');
+});
+
+test('a turn ending in is_error leaves the runtime reusable and the next turn clean', async () => {
+  const turn1 = [
+    { type: 'result', is_error: true, result: 'rate limited' },
+    // Straggler after the errored result.
+    assistantText('STALE post-error snapshot'),
+  ];
+  const turn2 = [
+    messageStart(),
+    streamTextDelta('recovered'),
+    assistantText('recovered'),
+    RESULT_OK,
+  ];
+
+  __testing.setQueryFn((args) => createScriptedQuery(args, [turn1, turn2]));
+
+  const params = baseParams('is-error');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+
+  await assert.rejects(
+    __testing.executeTurn(runtime, ctx1, { state: null }),
+    /rate limited/
+  );
+  assert.equal(runtime.closed, false, 'an is_error result must not tear the runtime down');
+
+  await settleReader();
+
+  const ctx2 = await __testing.buildRequestContext({ ...params, message: 'q2' }, false, OVERRIDES);
+  const runtime2 = await __testing.acquireRuntime(ctx2);
+  assert.equal(runtime2, runtime, 'the runtime must be reused after an is_error turn');
+
+  const meta2 = { state: null };
+  await __testing.executeTurn(runtime2, ctx2, meta2);
+  assert.equal(meta2.state.lastAssistantContent, 'recovered');
+  assert.ok(!meta2.state.lastAssistantContent.includes('STALE'));
+});
+
+test('the perpetual reader is the only query.next() consumer across turns', async () => {
+  // Architectural invariant that makes swallowed events impossible: native
+  // async generators serve queued next() callers in FIFO order, so ANY second
+  // concurrent consumer (a drain, a probe, an abandoned racing read) steals
+  // events from the reader. maxInflight > 1 is that second consumer.
+  const turn1 = [messageStart(), assistantText('one'), RESULT_OK, assistantText('straggler')];
+  const turn2 = [messageStart(), assistantText('two'), RESULT_OK];
+
+  let query;
+  __testing.setQueryFn((args) => {
+    query = createScriptedQuery(args, [turn1, turn2]);
+    return query;
+  });
+
+  const params = baseParams('single-consumer');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+  await __testing.executeTurn(runtime, ctx1, { state: null });
+
+  await settleReader();
+
+  const ctx2 = await __testing.buildRequestContext({ ...params, message: 'q2' }, false, OVERRIDES);
+  await __testing.executeTurn(await __testing.acquireRuntime(ctx2), ctx2, { state: null });
+
+  assert.ok(query.stats.nextCalls > 0);
+  assert.equal(
+    query.stats.maxInflight, 1,
+    'exactly one consumer may read the SDK iterator; a second one loses events'
+  );
+});

--- a/ai-bridge/services/claude/stale-turn-isolation.test.js
+++ b/ai-bridge/services/claude/stale-turn-isolation.test.js
@@ -1,3 +1,7 @@
+// Redirect HOME to a temp CLI-login config BEFORE importing modules that call
+// setupApiKey(), so buildRequestContext() does not throw on a credential-less CI
+// runner. Must stay the first import (see testing/cli-login-home.js).
+import './testing/cli-login-home.js';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 

--- a/ai-bridge/services/claude/stream-event-processor.js
+++ b/ai-bridge/services/claude/stream-event-processor.js
@@ -97,6 +97,32 @@ export function processMessageContent(msg, turnState) {
   }
 }
 
+// Defensive telemetry threshold: a first emission larger than this in a turn
+// that has not seen any stream_event yet is treated as a possible leak of a
+// full-text assistant snapshot from a previous turn.
+const SUSPICIOUS_INITIAL_DELTA_CHARS = 2000;
+
+/**
+ * Flag a suspiciously large first emission in a streaming-enabled turn where
+ * no stream_event has arrived yet. In normal streaming, content arrives
+ * incrementally via content_block_delta; a large initial jump from an empty
+ * accumulator suggests a previous turn's full-text assistant message was
+ * misattributed to this one (the "AI answered the previous question"
+ * symptom). Log-only; does not alter behavior.
+ */
+function warnOnSuspiciousInitialDelta(turnState, delta, kind) {
+  if (
+    !turnState.hasStreamEvents &&
+    delta.length > SUSPICIOUS_INITIAL_DELTA_CHARS &&
+    turnState.lastAssistantContent.length === 0 &&
+    turnState.lastThinkingContent.length === 0
+  ) {
+    console.warn('[DEFENSIVE] Large initial ' + kind + ' delta without prior stream events ('
+      + delta.length + ' chars). Possible stale content leak from previous turn. Preview='
+      + JSON.stringify(delta.slice(0, 120)));
+  }
+}
+
 /**
  * Emit a text block carried by an assistant snapshot.
  *
@@ -117,6 +143,7 @@ function emitSnapshotText(currentText, turnState, blockIndex) {
   }
   const { delta, hadPrevious } = resolveSnapshotDelta(turnState, 'text', blockIndex, currentText);
   if (delta && (!turnState.hasStreamEvents || hadPrevious)) {
+    warnOnSuspiciousInitialDelta(turnState, delta, 'text');
     process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(delta)}\n`);
   }
   turnState.lastAssistantContent = currentText;
@@ -130,6 +157,7 @@ function emitSnapshotThinking(thinkingText, turnState, blockIndex) {
   }
   const { delta, hadPrevious } = resolveSnapshotDelta(turnState, 'thinking', blockIndex, thinkingText);
   if (delta && (!turnState.hasStreamEvents || hadPrevious)) {
+    warnOnSuspiciousInitialDelta(turnState, delta, 'thinking');
     process.stdout.write(`[THINKING_DELTA] ${JSON.stringify(delta)}\n`);
   }
   turnState.lastThinkingContent = thinkingText;

--- a/ai-bridge/services/claude/testing/cli-login-home.js
+++ b/ai-bridge/services/claude/testing/cli-login-home.js
@@ -1,0 +1,46 @@
+/**
+ * Test setup side-effect: point HOME at a throwaway temp dir carrying a
+ * CLI-login config, so buildRequestContext() -> setupApiKey() resolves as
+ * "cli_login" instead of throwing "API Key not configured" on a clean CI
+ * runner that has no ~/.codemoss / ~/.claude credentials.
+ *
+ * Why this shape:
+ * - setupApiKey() reads credentials ONLY from ~/.codemoss + ~/.claude under the
+ *   real home dir (it deliberately ignores shell env vars), and getRealHomeDir()
+ *   CACHES that path on its first call. So HOME must be redirected BEFORE any
+ *   code calls getRealHomeDir(). Importing this module first — above the import
+ *   of persistent-query-service.js — guarantees that: ES module imports execute
+ *   in source order, and this file has no dependency that touches the home dir.
+ * - It is the lightweight, single-process equivalent of the child-process
+ *   harness used by runtime-lifecycle.test.js / api-config.test.js for the same
+ *   reason. Test-only; no production code is involved.
+ *
+ * A `claude.current === "__cli_login__"` config makes getClaudeRuntimeState()
+ * report access === 'cli_login', which setupApiKey() treats as a valid auth
+ * mode and returns without throwing.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-test-home-'));
+fs.mkdirSync(path.join(tempHome, '.codemoss'), { recursive: true });
+fs.writeFileSync(
+  path.join(tempHome, '.codemoss', 'config.json'),
+  JSON.stringify({ claude: { current: '__cli_login__', providers: {} } }),
+  'utf8'
+);
+
+process.env.HOME = tempHome;
+process.env.USERPROFILE = tempHome;
+
+// Best-effort cleanup when the test process exits.
+process.on('exit', () => {
+  try {
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  } catch {
+    // ignore — OS will reclaim the temp dir
+  }
+});
+
+export const testHomeDir = tempHome;

--- a/ai-bridge/services/claude/testing/scripted-query.js
+++ b/ai-bridge/services/claude/testing/scripted-query.js
@@ -1,0 +1,160 @@
+/**
+ * Test doubles for the SDK query object used by persistent-runtime tests.
+ *
+ * The message iterator here is a NATIVE async generator over a single-slot
+ * message queue — the same shape as the SDK's readSdkMessages() in sdk.mjs:
+ *
+ *   async *readSdkMessages() {
+ *     try { for await (const e of this.inputStream) yield e; }
+ *     finally { await this.cleanup(); }
+ *   }
+ *
+ * The shape matters. Native async generators queue concurrent next() callers
+ * and hand each queued caller a distinct value in FIFO order, so an abandoned
+ * next() (e.g. from a timeout race) invisibly consumes the next produced
+ * value. Plain-function mocks whose next() independently returns a fresh
+ * value cannot express that failure mode — which is exactly how the
+ * swallowed-first-event bug in the original drain approach slipped past its
+ * tests (PR #1410 review).
+ */
+
+export class MessageQueue {
+  queue = [];
+  readResolve = null;
+  isDone = false;
+
+  next() {
+    if (this.queue.length > 0) {
+      return Promise.resolve({ done: false, value: this.queue.shift() });
+    }
+    if (this.isDone) {
+      return Promise.resolve({ done: true, value: undefined });
+    }
+    return new Promise((resolve) => { this.readResolve = resolve; });
+  }
+
+  enqueue(value) {
+    if (this.readResolve) {
+      const resolve = this.readResolve;
+      this.readResolve = null;
+      resolve({ done: false, value });
+    } else {
+      this.queue.push(value);
+    }
+  }
+
+  end() {
+    this.isDone = true;
+    if (this.readResolve) {
+      const resolve = this.readResolve;
+      this.readResolve = null;
+      resolve({ done: true, value: undefined });
+    }
+  }
+
+  [Symbol.asyncIterator]() { return this; }
+}
+
+/**
+ * Fake SDK query that consumes the runtime's input stream and answers the
+ * i-th user message with turnScripts[i] (an array of SDK messages, enqueued
+ * in order). Events listed after a result message model post-result
+ * stragglers. With an empty script list the query simply pends — the real
+ * iterator's behavior between turns — until close() ends the stream.
+ *
+ * Also records next() concurrency: maxInflight > 1 means something other
+ * than the perpetual reader consumed the iterator concurrently, which is the
+ * exact condition that loses events on the real SDK.
+ */
+export function createScriptedQuery({ prompt, options }, turnScripts = []) {
+  const channel = new MessageQueue();
+  const inputs = [];
+  const inputWaiters = [];
+  let waitIndex = 0;
+
+  (async () => {
+    for await (const userMessage of prompt) {
+      inputs.push(userMessage);
+      const waiter = inputWaiters.shift();
+      if (waiter) waiter(userMessage);
+      const script = turnScripts[inputs.length - 1] || [];
+      for (const event of script) {
+        channel.enqueue(event);
+      }
+    }
+  })().catch(() => { /* input stream errored on dispose — irrelevant to tests */ });
+
+  // Same shape as the SDK's readSdkMessages(): a native async generator over
+  // the internal message stream.
+  async function* readMessages() {
+    for await (const event of channel) yield event;
+  }
+  const generator = readMessages();
+
+  const stats = { nextCalls: 0, inflight: 0, maxInflight: 0 };
+
+  return {
+    options,
+    channel,
+    inputs,
+    stats,
+    /** Resolves with the next not-yet-awaited user message (FIFO). */
+    waitForInput() {
+      if (waitIndex < inputs.length) {
+        const message = inputs[waitIndex];
+        waitIndex += 1;
+        return Promise.resolve(message);
+      }
+      return new Promise((resolve) => {
+        inputWaiters.push((message) => {
+          waitIndex += 1;
+          resolve(message);
+        });
+      });
+    },
+    setPermissionMode: async () => {},
+    setModel: async () => {},
+    setMaxThinkingTokens: async () => {},
+    close() {
+      channel.end();
+    },
+    next() {
+      stats.nextCalls += 1;
+      stats.inflight += 1;
+      stats.maxInflight = Math.max(stats.maxInflight, stats.inflight);
+      return generator.next().finally(() => { stats.inflight -= 1; });
+    },
+  };
+}
+
+/** Common SDK message shapes. */
+export function assistantText(text) {
+  return { type: 'assistant', message: { content: [{ type: 'text', text }] } };
+}
+
+export function streamTextDelta(text) {
+  return {
+    type: 'stream_event',
+    event: { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } },
+  };
+}
+
+export function messageStart() {
+  return {
+    type: 'stream_event',
+    event: { type: 'message_start', message: { usage: { input_tokens: 1, output_tokens: 0 } } },
+  };
+}
+
+export const RESULT_OK = { type: 'result', is_error: false };
+
+/**
+ * Let the perpetual reader run: it pulls from the iterator across macrotask
+ * boundaries (an I/O boundary in production), so inter-turn stragglers need a
+ * few ticks to be consumed.
+ */
+export async function settleReader(ticks = 5) {
+  for (let i = 0; i < ticks; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}


### PR DESCRIPTION
## History

This PR started as a drain fix for stale SDK-iterator events between turns on a persistent runtime. Review (thank you @zhukunpenglinyutong) found a critical flaw in that approach; the full write-up is below, plus what replaced it after rebasing onto `feature/v0.4.7` and the deeper turn-attribution bug that the reviewer's original symptom report pointed to.

**Scope note:** this PR is now **backend-only (ai-bridge)**. The frontend message-rendering fixes that were briefly bundled here (lost user message, duplicated answer, hidden API error) have moved to a separate PR — they touch webview + Java and are independently mergeable. `BridgeDirectoryResolver.java` (#1415) and the 1M-context-toggle `setModel` fix (#1416) are likewise split out per review.

## Symptom

A response from Claude arrives and is buffered but never displayed correctly — or worse, arrives late and attributed to the wrong turn, so the chat appears to answer the *previous* (or pre-previous) message. Users re-send, which confuses Claude with redundant prompts.

## Original fix and why it was dropped

The original approach added `drainPendingEvents()`: race `query.next()` against a 50ms timeout before each new turn to flush events the SDK iterator buffered after the previous turn's `result`.

Review found: an abandoned `next()` from a timed-out race is not a cancelled one — it stays queued on the SDK's iterator (a native async generator, confirmed against the shipped `@anthropic-ai/claude-agent-sdk`). On the common path (nothing to drain) that abandoned read silently consumes the **first event of the next turn**, which is exactly the class of bug this set out to fix. The original tests used plain-function mocks that cannot express this; a native-async-generator PoC reproduces it in a few lines.

Meanwhile `feature/v0.4.7` landed a perpetual-reader architecture (`runtime-lifecycle.js`) that gives the SDK iterator a single permanent consumer and routes messages to the active turn via a `turnSink`. That supersedes the drain outright — reintroducing it means a second reader racing the perpetual one, the same hazard the review flagged. **The drain is dropped, not rebased.**

## The real bug the rebase surfaced

The perpetual reader routes messages purely temporally ("a `turnSink` exists right now ⇒ this message belongs to it"), with no identity on the messages. So a still-in-flight CLI run — including a CLI-initiated one, e.g. a `run_in_background` completion notification (#1305) — has its output, and worse its closing `result`, attributed to whichever turn's sink happens to be open when the reader gets to it. Consuming a foreign `result` ends the new turn early; the real answer then completes unobserved between turns, and every subsequent answer shifts back by one. Reproduced against the real `executeTurn` + perpetual reader (not a reimplementation): a delayed prior-run message is emitted verbatim as the new turn's `[CONTENT_DELTA]`, and a foreign result terminates the new turn.

## Fix (ai-bridge)

- **CLI turn accounting in the reader**: substantive output (`assistant` / `user` / `stream_event`) marks a run in flight; its closing `result` clears it (order guaranteed by the pipe). `system`/control messages never arm it, so prewarmed runtimes are unaffected.
- **Gate in `executeTurn`**: defer opening the sink and sending the user message while a run is in flight (`waitForCliQuiet` / `waitForReaderQuiescent`) — the CLI would queue the send behind that run anyway, so no added latency; it only aligns the daemon's accounting with the CLI's actual order. The wait resolves on the closing result, on dispose (abort stays responsive), or on a loud 120s protocol-anomaly backstop.
- **Foreign-result skip (defense in depth)**: a bare *success* result with no prior turn output is provably foreign (a successful run always emits output first) and is skipped rather than ending the turn; `session_updated` still lets the background run it closed render via the #1305 path. Bare *error* results keep failing the turn (immediately-failing requests legitimately produce them).
- **Defensive telemetry**: `warnOnSuspiciousInitialDelta` flags a large first emission in a turn with no stream events yet — the signature of a stale full-text snapshot leak — so any future regression is visible in logs.

## Tests

All new/rewritten tests use a fake SDK query built on a **native async generator** over a single-slot queue — the SDK's `readSdkMessages()` shape — because that's the only mock shape that surfaces stolen-read / misattribution bugs.

- `stale-turn-isolation.test.js` (new): post-result stragglers never leak into the next turn; the first event of a new turn is never swallowed; an `is_error` turn leaves the runtime reusable; a new turn waits for an in-flight CLI-initiated run and never absorbs its result; a foreign bare-success result is skipped, not treated as turn-end; a bare error result still fails the turn; abort while gated fails fast; the perpetual reader stays the *only* iterator consumer (`maxInflight === 1`) as a standing invariant.
- `persistent-query-service.lifecycle.test.js` (renamed from `.test.mjs`): migrated off pre-perpetual-reader mocks (6/11 were failing against the current architecture, and — separately — the CI glob only matches `*.test.js`, so this suite wasn't running in CI at all). `persistent-query-service.context.test.mjs` has the same problem (8/9 failing on a clean `feature/v0.4.7` checkout) but is out of scope here; flagging for a follow-up.

`node --test "ai-bridge/**/*.test.js"`: 183/183 passing.

## Known residual

A foreign run whose events arrive from the network strictly after this turn's message is enqueued (a true send/receive race, not a scheduling artifact) can still, in principle, interleave. Fully closing that needs message-level turn identity from the CLI/SDK itself.
