### PR TITLE
fix(bridge): allow re-extraction from COMPLETED state when dir is invalid

### DIFF
--- a/src/main/java/com/github/claudecodegui/bridge/BridgeDirectoryResolver.java
+++ b/src/main/java/com/github/claudecodegui/bridge/BridgeDirectoryResolver.java
@@ -271,8 +271,12 @@ public class BridgeDirectoryResolver {
 
                 // Mark as in progress BEFORE checking EDT thread
                 // Also initialize extractionFutureRef to ensure waitForExtraction() works
+                // COMPLETED is allowed here because we only reach this point when the extracted
+                // directory is no longer valid (e.g. the plugin was updated under a running IDE
+                // and the old extracted dir was removed), so we must re-extract.
                 if (!this.extractionState.compareAndSet(ExtractionState.NOT_STARTED, ExtractionState.IN_PROGRESS) &&
-                    !this.extractionState.compareAndSet(ExtractionState.FAILED, ExtractionState.IN_PROGRESS)) {
+                    !this.extractionState.compareAndSet(ExtractionState.FAILED, ExtractionState.IN_PROGRESS) &&
+                    !this.extractionState.compareAndSet(ExtractionState.COMPLETED, ExtractionState.IN_PROGRESS)) {
                     // Another thread just started extraction, wait for it
                     LOG.debug("[BridgeResolver] Another thread just started extraction, waiting...");
                     return waitForExtraction();


### PR DESCRIPTION
## Problem

If the plugin is updated while the IDE is still running (the extracted `ai-bridge/` directory is removed and replaced), `BridgeDirectoryResolver`'s in-memory `extractionState` can still read `COMPLETED` from before the update, while the directory it points to no longer exists.

The CAS chain guarding re-extraction only allowed `NOT_STARTED` and `FAILED` → `IN_PROGRESS`. So every subsequent `findSdkDir()` call logged "starting extraction," immediately found no transition was possible, logged "No extraction future available," and returned `null` — surfacing as a permanent "Environment Check Failed" in the UI with no way to recover short of restarting the IDE.

## Fix

Add `COMPLETED` → `IN_PROGRESS` as a third allowed CAS transition. This is only reachable when the resolver has already determined the previously extracted directory is invalid, so re-extracting `ai-bridge.zip` is the correct recovery — not a stale-state bypass.

## Context

Split out of #1410 per review — a small, independently mergeable fix that doesn't need to wait on that PR's rework.
