### PR TITLE
fix(claude): make 1M context toggle take effect on live runtimes

### DIFF
--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -220,7 +220,7 @@ async function buildRequestContext(params, withAttachments, overrides = {}) {
 
   const userMessage = await buildUserMessage(params, withAttachments, requestedSessionId, resolvedModelId);
 
-  const runtimeSignature = buildRuntimeSignature(options, systemPromptAppend, streamingEnabled, runtimeSessionEpoch);
+  const runtimeSignature = buildRuntimeSignature(options, systemPromptAppend, streamingEnabled, runtimeSessionEpoch, modelId);
   console.log('[LIFECYCLE] buildRequestContext sessionId=' + (requestedSessionId || '(new)')
     + ' epoch=' + (runtimeSessionEpoch || '(none)')
     + ' signature=' + runtimeSignature);

--- a/ai-bridge/services/claude/runtime-lifecycle.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.js
@@ -83,7 +83,7 @@ export function createTurnSink() {
   };
 }
 
-export function buildRuntimeSignature(options, systemPromptAppend, streamingEnabled, runtimeSessionEpoch) {
+export function buildRuntimeSignature(options, systemPromptAppend, streamingEnabled, runtimeSessionEpoch, modelId) {
   const material = {
     cwd: options.cwd || '',
     additionalDirectories: options.additionalDirectories || [],
@@ -91,7 +91,12 @@ export function buildRuntimeSignature(options, systemPromptAppend, streamingEnab
     streamingEnabled: !!streamingEnabled,
     runtimeSessionEpoch: runtimeSessionEpoch || '',
     model: options.model || '',
-    effort: options.effort || ''
+    effort: options.effort || '',
+    // The [1m] suffix selects the 1M context window. The CLI subprocess locks
+    // the window in at spawn from its environment, and setModel() cannot change
+    // it afterwards (see shouldRecreateRuntimeForModel) — so toggling [1m] must
+    // change the signature and rebuild the runtime instead of reusing it.
+    contextWindow1M: (modelId || '').includes('[1m]')
   };
   return JSON.stringify(material);
 }
@@ -154,6 +159,7 @@ async function createRuntime(requestContext, callbacks) {
     runtimeSignature: requestContext.runtimeSignature,
     currentModel: requestContext.sdkModelName || null,
     modelId: requestContext.modelId || null, // Original model ID, may contain [1m] suffix
+    currentResolvedModel: requestContext.resolvedModelId || null,
     currentPermissionMode: initialPermissionMode,
     permissionModeState: { value: initialPermissionMode },
     currentMaxThinkingTokens: requestContext.maxThinkingTokens ?? null,
@@ -377,10 +383,21 @@ async function applyDynamicControls(runtime, requestContext) {
   }
 
   const targetModel = requestContext.sdkModelName || null;
-  if (runtime.currentModel !== targetModel && typeof runtime.query?.setModel === 'function') {
+  const targetResolvedModel = requestContext.resolvedModelId || null;
+  // Compare both the SDK short name AND the resolved model ID: a settings-side
+  // remap (e.g. sonnet -> "MiniMax-M2.5") changes only the resolved ID.
+  // Pass the resolved ID to setModel, not the short name: the CLI subprocess
+  // resolves short names against its OWN environment, which was frozen at spawn
+  // time — the daemon-side env update in setModelEnvironmentVariables never
+  // reaches a live subprocess. The resolved ID needs no env lookup. ([1m]
+  // toggles never get here: they change the runtime signature, so acquireRuntime
+  // rebuilds the runtime instead of reusing it.)
+  if ((runtime.currentModel !== targetModel || runtime.currentResolvedModel !== targetResolvedModel)
+      && typeof runtime.query?.setModel === 'function') {
     try {
-      await runtime.query.setModel(targetModel || undefined);
+      await runtime.query.setModel(targetResolvedModel || targetModel || undefined);
       runtime.currentModel = targetModel;
+      runtime.currentResolvedModel = targetResolvedModel;
     } catch (error) {
       console.error('[DAEMON] setModel failed:', error.message);
     }

--- a/ai-bridge/services/claude/runtime-lifecycle.test.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { createTurnSink } from './runtime-lifecycle.js';
+import { buildRuntimeSignature, applyDynamicControls, createTurnSink } from './runtime-lifecycle.js';
+import { __testing } from './persistent-query-service.js';
 
 // ============================================================================
 // TurnSink Tests - Core Message Queue Functionality
@@ -459,6 +460,162 @@ test('Memory: failed sink releases waiting promises', async () => {
 
   assert.equal(results.length, 100);
   results.forEach(r => assert.equal(r.status, 'rejected'));
+});
+
+// ============================================================================
+// Runtime Signature & Dynamic Controls - 1M Context Toggle
+// ============================================================================
+
+/**
+ * Create a fake SDK query whose message iterator is a REAL native async
+ * generator, mirroring the SDK's readSdkMessages(). It pends until close()
+ * is called (the real iterator stays open between turns), so the perpetual
+ * reader neither spins nor tears the runtime down mid-test.
+ */
+function createHangingQuery({ prompt, options }) {
+  let closeResolve;
+  const closedSignal = new Promise((resolve) => { closeResolve = resolve; });
+  async function* messages() {
+    await closedSignal;
+  }
+  const generator = messages();
+  return {
+    prompt,
+    options,
+    closed: false,
+    setPermissionMode: async () => {},
+    setModel: async () => {},
+    setMaxThinkingTokens: async () => {},
+    close() {
+      this.closed = true;
+      closeResolve();
+    },
+    next: () => generator.next(),
+  };
+}
+
+test('buildRuntimeSignature differs when the [1m] context suffix toggles', () => {
+  const options = { cwd: '/tmp/project', model: 'sonnet' };
+  const sigOff = buildRuntimeSignature(options, '', true, 'epoch-x', 'claude-sonnet-4-6');
+  const sigOn = buildRuntimeSignature(options, '', true, 'epoch-x', 'claude-sonnet-4-6[1m]');
+
+  assert.notEqual(sigOff, sigOn);
+  assert.match(sigOff, /"contextWindow1M":false/);
+  assert.match(sigOn, /"contextWindow1M":true/);
+});
+
+test('buildRuntimeSignature is stable for the same [1m] state', () => {
+  const options = { cwd: '/tmp/project', model: 'sonnet' };
+  const a = buildRuntimeSignature(options, '', true, 'epoch-x', 'claude-sonnet-4-6[1m]');
+  const b = buildRuntimeSignature(options, '', true, 'epoch-x', 'claude-sonnet-4-6[1m]');
+  assert.equal(a, b);
+});
+
+test('applyDynamicControls passes the resolved model id to setModel, not the short name', async () => {
+  // The CLI subprocess resolves short names ("sonnet") against its own env,
+  // which was frozen at spawn — a daemon-side env update never reaches it.
+  // The resolved id must therefore be sent verbatim.
+  const setModelCalls = [];
+  const runtime = {
+    closed: false,
+    currentPermissionMode: 'default',
+    currentModel: 'sonnet',
+    currentResolvedModel: 'claude-sonnet-4-6',
+    currentMaxThinkingTokens: null,
+    query: {
+      setModel: async (model) => { setModelCalls.push(model); },
+    },
+  };
+
+  await applyDynamicControls(runtime, {
+    permissionMode: 'default',
+    sdkModelName: 'sonnet',
+    resolvedModelId: 'MiniMax-M2.5',
+    maxThinkingTokens: null,
+  });
+
+  assert.deepEqual(setModelCalls, ['MiniMax-M2.5']);
+  assert.equal(runtime.currentModel, 'sonnet');
+  assert.equal(runtime.currentResolvedModel, 'MiniMax-M2.5');
+});
+
+test('applyDynamicControls skips setModel when short name and resolved id are unchanged', async () => {
+  const setModelCalls = [];
+  const runtime = {
+    closed: false,
+    currentPermissionMode: 'default',
+    currentModel: 'sonnet',
+    currentResolvedModel: 'claude-sonnet-4-6',
+    currentMaxThinkingTokens: null,
+    query: {
+      setModel: async (model) => { setModelCalls.push(model); },
+    },
+  };
+
+  await applyDynamicControls(runtime, {
+    permissionMode: 'default',
+    sdkModelName: 'sonnet',
+    resolvedModelId: 'claude-sonnet-4-6',
+    maxThinkingTokens: null,
+  });
+
+  assert.deepEqual(setModelCalls, []);
+});
+
+test('acquireRuntime rebuilds the runtime when the [1m] context toggle changes', async (t) => {
+  t.after(async () => {
+    await __testing.resetState();
+  });
+  let created = 0;
+  __testing.setQueryFn((args) => {
+    created += 1;
+    return createHangingQuery(args);
+  });
+
+  const baseParams = {
+    sessionId: '',
+    runtimeSessionEpoch: 'epoch-1m-toggle',
+    cwd: process.cwd(),
+    message: 'hello',
+  };
+  // Settings override keeps the resolved model deterministic regardless of the
+  // developer's real ~/.claude/settings.json.
+  const overrides = { settings: { env: {} } };
+
+  const ctxOff = await __testing.buildRequestContext(
+    { ...baseParams, model: 'claude-sonnet-4-6' }, false, overrides
+  );
+  const runtimeOff = await __testing.acquireRuntime(ctxOff);
+  const runtimeOffAgain = await __testing.acquireRuntime(ctxOff);
+  assert.equal(runtimeOff, runtimeOffAgain, 'same [1m] state must reuse the runtime');
+  assert.equal(created, 1);
+
+  const ctxOn = await __testing.buildRequestContext(
+    { ...baseParams, model: 'claude-sonnet-4-6[1m]' }, false, overrides
+  );
+  const runtimeOn = await __testing.acquireRuntime(ctxOn);
+  assert.notEqual(runtimeOff, runtimeOn, 'toggling [1m] on must build a runtime with a 1M window');
+  assert.equal(created, 2);
+
+  // The subprocess env is frozen at spawn — verify each runtime was spawned
+  // with the context window it serves. This is the end-to-end guarantee that
+  // the CLI resolves "sonnet" to the right window for its runtime.
+  const envOff = runtimeOff.query?.options?.env || {};
+  const envOn = runtimeOn.query?.options?.env || {};
+  assert.doesNotMatch(String(envOff.ANTHROPIC_DEFAULT_SONNET_MODEL || ''), /\[1m\]/,
+    'non-1M runtime must be spawned without the [1m] suffix in its env');
+  assert.match(String(envOn.ANTHROPIC_DEFAULT_SONNET_MODEL || ''), /\[1m\]$/,
+    '1M runtime must be spawned with the [1m] suffix in its env');
+
+  // Toggling back off routes to the still-alive non-1M runtime: anonymous
+  // runtimes are keyed by signature, and the old runtime's frozen env matches
+  // the requested window again, so reuse is correct (no rebuild needed).
+  const ctxOffAgain = await __testing.buildRequestContext(
+    { ...baseParams, model: 'claude-sonnet-4-6' }, false, overrides
+  );
+  const runtimeOff2 = await __testing.acquireRuntime(ctxOffAgain);
+  assert.equal(runtimeOff2, runtimeOff, 'toggling back off must route to the non-1M runtime');
+  assert.equal(created, 2);
 });
 
 console.log('\n✅ All TurnSink tests defined. Run with: node runtime-lifecycle.test.js');


### PR DESCRIPTION
## Problem

Toggling the 1M-context-window switch in the UI silently did nothing on an already-live persistent runtime.

Two independent bugs:

1. `applyDynamicControls` compared only the SDK short model name (`"sonnet"`), which is identical whether or not `[1m]` is set — so `setModel` was skipped entirely on toggle.
2. Even when `setModel` was called, it received the short name. The CLI subprocess resolves short names against its **own** environment, frozen at spawn time — the daemon's `setModelEnvironmentVariables` write to `process.env` never reaches a subprocess that's already running. And per the existing `shouldRecreateRuntimeForModel` contract, `setModel` cannot change a live runtime's context window at all, regardless of what's passed to it.

Net effect: users could flip the 1M toggle believing they'd get the larger context window and keep getting the old one, silently.

## Fix

- Include the `[1m]` state in `buildRuntimeSignature`, so toggling it changes the signature and `acquireRuntime` builds a fresh runtime (with a fresh env snapshot honoring the new window) instead of reusing an incompatible one.
- Pass the **resolved** model id to `setModel`, not the short name, so settings-side model remaps (`sonnet` → `"MiniMax-M2.5"`) also reach subprocesses with frozen envs.
- Compare resolved model ids (not just the short name) in `applyDynamicControls` so remap changes are detected and applied.

## Tests

- Signature differs/stays stable across `[1m]` toggle.
- `setModel` receives the resolved id, not the short name; is skipped when nothing changed.
- End-to-end: `acquireRuntime` rebuilds on toggle, and each spawned runtime's subprocess env actually carries the `[1m]` state it serves (`ANTHROPIC_DEFAULT_SONNET_MODEL` with/without the suffix).

## Context

Split out of #1410, reworked after review flagged the env-freeze issue in the original version of this fix. A live capture on a real runtime (confirming the resolved model id that actually reaches the API) would still be a good sanity check before merge.
