### PR TITLE
docs(opencode): draft documents for opencode implementation

### DIFF
--- a/docs/opencode/LESSONS-LEARNED.md
+++ b/docs/opencode/LESSONS-LEARNED.md
@@ -1,0 +1,225 @@
+# Lessons From The Opencode Support Experiment
+
+## Summary
+
+The opencode support experiment was valuable even though it should not be used as the long-term implementation shape.
+
+Public reference: [PR #1239](https://github.com/zhukunpenglinyutong/jetbrains-cc-gui/pull/1239).
+
+It proved that opencode can be wired into the plugin through a Java bridge, Node bridge, `@opencode-ai/sdk`, and `opencode serve`. It also showed that adapting a structured provider into the existing Claude/Codex-compatible marker stream creates too many local fixes: stream recovery, role buffering, block resets, diff dedupe, history conversion, task/subagent reconstruction, and UI-specific replay work.
+
+The main lesson is not that opencode is unsuitable. The lesson is that opencode should be integrated after the shared event, capture, replay, and rendering contracts are stronger.
+
+## What Worked
+
+The experiment confirmed several useful design choices:
+
+- opencode should be a first-class provider with explicit provider routing.
+- the CLI should remain user-managed.
+- managed-server mode can mean starting the user's installed `opencode serve`.
+- `@opencode-ai/sdk` is a reasonable bridge dependency.
+- model, provider, agent, history, and usage surfaces can be handled separately from streaming.
+- slash command and MCP display surfaces should not be bundled into the first event-contract slice.
+- permission and question requests can route through existing Java/webview dialogs if request IDs are preserved.
+- streaming event capture and replay fixtures are essential for debugging rendering bugs.
+
+## What Failed
+
+The failed part was the amount of compatibility glue needed to preserve opencode semantics through the old render contract.
+
+The experiment repeatedly fixed symptoms caused by flattening structured events into message markers:
+
+- streamed text and reasoning needed buffering until the message role was known
+- user-role text echoes had to be dropped after the fact
+- tool updates had to wait for preceding text parts to close
+- post-tool text needed explicit block-reset behavior
+- text part boundaries needed synthetic spaces to avoid fused sentences
+- stream completion needed idle-state polling instead of relying on connection close
+- `session.diff` events needed baseline seeding and path dedupe
+- live streaming and restored history needed separate normalization fixes
+- task/subagent output needed provider-aware history loading
+- context-window failures needed special recovery UX
+
+Those are exactly the problems a provider-neutral event model should make explicit.
+
+## Streaming Lessons
+
+Opencode streaming is not a simple sequence of text deltas.
+
+Observed lessons:
+
+- Subscribe to the event stream before creating or prompting a session.
+- Filter all events by `sessionID`; shared event streams include unrelated sessions.
+- Do not complete a turn just because the event stream closes.
+- Treat `session.status` or equivalent idle signals as the authoritative completion signal.
+- Keep a fallback for missing status events, but gate it on observed live activity.
+- Maintain an explicit event coverage matrix with each event marked `handled` or `ignored` and a reason for ignored events.
+- Buffer text and reasoning deltas when the message role is unknown.
+- Drop user-role text parts from assistant rendering.
+- Preserve part IDs so late snapshots can be reconciled with earlier deltas.
+
+Concrete experiment evidence:
+
+- The experiment covered final text recovery, post-tool ordering, role-gated text, idle completion, missing status, session filtering, reasoning fields, and diff behavior.
+- It introduced an explicit matrix for handled and intentionally ignored upstream events.
+- It captured a real class of bugs: user echo suppression, assistant role buffering, tool block reset, and post-tool text ordering.
+
+## Rendering Lessons
+
+Compatibility markers were not enough to express the UI state cleanly.
+
+Observed lessons:
+
+- The UI needs stable block identity, not only appended assistant text.
+- Tool calls need lifecycle state, not only final `tool_use` and `tool_result` blocks.
+- Text after a tool must be a distinct block, not merged into pre-tool prose.
+- Thinking blocks after tools need the same boundary logic as text blocks.
+- Backend snapshots can be stale, shorter, or structurally different from frontend streaming buffers.
+- Reconciliation must never move tool cards below later text just because a cumulative text buffer grows.
+
+The experiment added webview replay tests because bridge-level output passing was not enough. Rendering failures could still appear after Java/webview marker reconciliation.
+
+Preparation implication:
+
+- `chat_event` fixtures should test both provider normalizers and the frontend accumulator.
+
+## Replay And Logging Lessons
+
+The experiment's most useful debugging tool was capturing actual streams and turning them into fixtures.
+
+Observed lessons:
+
+- Logs need stable sequence numbers.
+- Logs should capture raw provider events, normalized output, and compatibility markers.
+- Fixture extraction should filter by session ID.
+- Fixtures should minimize unrelated status, heartbeat, and duplicate tool events.
+- A fixture should encode expected bridge output and final webview invariants.
+
+The experiment used stream capture and fixture extraction to turn live rendering bugs into repeatable tests. That approach should be generalized rather than kept as opencode-only debugging work.
+
+Preparation implication:
+
+- The streaming event log utility should be shared across Claude, Codex, and opencode.
+- Captured logs should be promotable into deterministic regression tests.
+
+## Diff Lessons
+
+Opencode diffs are session-level enough that naive rendering can show stale changes.
+
+Observed lessons:
+
+- Seed a baseline before emitting current-turn diffs.
+- Deduplicate equivalent relative and absolute paths.
+- Preserve patch metadata so restored history can rebuild edit blocks.
+- Include source metadata so UI can distinguish `session.diff` from tool metadata diffs.
+
+Preparation implication:
+
+- `chat_event` diff events need explicit scope, source, file identity, and sequence.
+- Diff fixtures should include baseline/no-op cases, path dedupe, and restored-history reconstruction.
+
+## History Lessons
+
+History was a separate integration, not a free consequence of live streaming.
+
+Observed lessons:
+
+- Root sessions and child task sessions must be distinguished.
+- Child task sessions should not pollute the root history sidebar.
+- Restored assistant steps need stable IDs and must not merge into unrelated turns.
+- Negative synthetic turn IDs were a workaround; the better answer is explicit event identity.
+- Usage/cost stats may need message-level aggregation for long-lived sessions.
+- Restored tool parts, images, apply-patch metadata, and task results need the same normalized structure as live events.
+
+Preparation implication:
+
+- Live and restored event paths should converge at `chat_event`, not at provider-specific message converters.
+
+## Discovery Lessons
+
+Provider/model/agent discovery is its own problem and should not be mixed with streaming.
+
+Observed lessons:
+
+- Keep an `opencode default` placeholder and do not parse it as a concrete model.
+- When `opencode default` is selected, omit the explicit model in prompts and let opencode resolve it.
+- Provider defaults should respect opencode provider-list order, not alphabetical order.
+- Stale configured default labels should not override provider defaults.
+- Connected provider catalogs should be merged carefully; disconnected providers should not appear as usable models.
+- `enabled_providers` and `disabled_providers` need explicit filtering rules.
+- Last-used project model can be useful, but it must be labeled as such.
+- Agent discovery needs a CLI default placeholder plus visible primary/all agents and built-in fallbacks.
+- Plan mode should map to opencode's native planning agent when possible.
+
+Preparation implication:
+
+- Model/agent discovery should have separate fixtures and should not be required to prove the event contract.
+
+## Permission And Question Lessons
+
+Permission and question handling worked best when treated as request/reply protocols.
+
+Observed lessons:
+
+- Preserve opencode request IDs exactly.
+- Deduplicate request IDs so the same question or permission is not answered twice.
+- Mode-aware auto behavior is necessary but should stay small and tested.
+- Java-side permission memory may still reply `once` to opencode while enforcing "always" in the plugin.
+- Question requests should use the existing AskUserQuestion UI rather than being rejected by default.
+- Cancellation should explicitly reject provider requests.
+
+Preparation implication:
+
+- `chat_event` needs `permission` and `question` kinds with request IDs, choices, and reply state.
+
+## Runtime Lifecycle Lessons
+
+The managed server path is useful but fragile.
+
+Observed lessons:
+
+- User-managed CLI path discovery must include opencode's own install directory.
+- Path discovery must avoid duplicate PATH entries.
+- Transport failures such as `fetch failed` or `ECONNRESET` should discard persistent runtimes.
+- Context-window errors are not transport failures and should not discard the runtime.
+- Post-stream daemon cleanup can race with successful completion and should not create false send errors.
+- Discovery endpoints need timeouts and retries.
+- Prompt execution may need much longer timeouts than discovery calls.
+
+Preparation implication:
+
+- Server lifecycle tests should distinguish setup errors, transport errors, context errors, and successful turns with cleanup noise.
+
+## Context Recovery Lessons
+
+Context-window failure is not an edge case for opencode; it needs product handling.
+
+Observed lessons:
+
+- Detect context-window errors separately from generic failures.
+- Offer recovery options: compact current session, start a new session with a summary handoff, or start empty.
+- Preserve the failed prompt so recovery can retry it automatically.
+- Keep recovery summaries bounded; a recovery prompt can itself exceed context.
+
+Preparation implication:
+
+- Context recovery should be a follow-up feature, but the event/error contract should leave room for structured recovery actions.
+
+## What To Do Differently Next Time
+
+1. Build `chat_event` and replayable event capture before the full opencode provider.
+2. Add event coverage fixtures before broad UI integration.
+3. Implement opencode send/stream/history as the first proving adapter, but keep model, agent, slash command, MCP, usage, and context recovery as separate slices.
+4. Treat live stream and restored history parity as a required acceptance check from the beginning.
+5. Avoid adding provider-specific frontend merge hacks; add missing concepts to the event model instead.
+6. Keep the opencode runtime user-managed and report setup failures clearly.
+7. Use the failed experiment's fixture approach (generate fixtures from logs as issues show up), but generalize it across providers.
+
+## Documentation Impact
+
+These lessons strengthen the existing draft docs:
+
+- [PREPARATION.md](./PREPARATION.md) should require replayable event capture and live/history parity.
+- [STREAMING-EVENT-LOGS.md](./STREAMING-EVENT-LOGS.md) should be treated as a core deliverable, not optional debugging polish.
+- [MULTI-PROVIDER-ARCHITECTURE.md](./MULTI-PROVIDER-ARCHITECTURE.md) should keep provider routing but move render semantics into `chat_event`.
+- [OPENCODE-INTEGRATION-QUICKSTART.md](./OPENCODE-INTEGRATION-QUICKSTART.md) should stay scoped to the first integration slice and avoid bundling every discovery/UI feature into the initial event infrastructure PR.

--- a/docs/opencode/MULTI-PROVIDER-ARCHITECTURE.md
+++ b/docs/opencode/MULTI-PROVIDER-ARCHITECTURE.md
@@ -1,0 +1,328 @@
+# Opencode Multi-Provider Architecture
+
+## Purpose
+
+This document updates the older Codex-era multi-provider architecture for opencode and other structured providers.
+
+The Codex-era architecture was good at adding providers that could be projected into a small set of message markers. Opencode needs the same explicit provider boundaries, but it also needs a richer shared event plane so provider adapters do not each reinvent streaming merge, tool lifecycle, permission, diff, and history logic.
+
+## Design Principles
+
+1. Keep provider boundaries explicit.
+2. Keep provider-specific runtime ownership in provider adapters.
+3. Normalize structured runtime events into a shared `chat_event` stream.
+4. Capture streaming events in a replayable log format for debugging and test generation.
+5. Keep `ClaudeMessage` compatibility during migration.
+6. Make live streaming and restored history use the same logical event model.
+
+## Architecture Overview
+
+```text
+Java Layer
+  ClaudeSDKBridge
+    provider: claude
+    session identity: sessionId
+    runtime: Claude Agent SDK / Claude Code
+
+  CodexSDKBridge
+    provider: codex
+    session identity: thread/session id
+    runtime: Codex bridge
+
+  OpenCodeSDKBridge
+    provider: opencode
+    session identity: opencode sessionID
+    runtime: @opencode-ai/sdk + opencode serve
+
+        |
+        | stdin JSON / process output / callback protocol
+        v
+
+Node ai-bridge
+  channel-manager.js
+    routes by provider: claude | codex | opencode
+
+  channels/
+    claude-channel.js
+    codex-channel.js
+    opencode-channel.js
+
+  services/
+    claude/
+    codex/
+    opencode/
+
+        |
+        | legacy markers + chat_event records
+        v
+
+Java message handlers
+  legacy marker handling for existing UI paths
+  chat_event forwarding for structured render path
+
+        |
+        v
+
+Webview
+  legacy ClaudeMessage renderer during migration
+  chat_event accumulator and structured renderer
+```
+
+## Provider Responsibilities
+
+Each provider adapter owns provider-specific details:
+
+- SDK or CLI resolution
+- runtime process lifecycle
+- provider-specific auth/config discovery
+- session creation, resume, abort, delete, and history lookup
+- model and agent discovery where supported
+- permission request/reply transport
+- conversion from native provider events to normalized `chat_event` records
+
+Provider adapters should not own shared UI merge policy. Once native events are normalized, ordering and grouping should be handled by the shared event accumulator.
+
+The failed [opencode support experiment](https://github.com/zhukunpenglinyutong/jetbrains-cc-gui/pull/1239) showed the cost of violating this boundary: provider code, Java handlers, and webview streaming hooks all accumulated special-case merge and recovery logic for the same turn.
+
+## Shared Event Plane
+
+The shared event plane uses `chat_event` records with stable identity fields.
+
+Core fields:
+
+- `provider`
+- `sessionId`
+- `turnId`
+- `runId`
+- `messageId`
+- `stepId`
+- `partId`
+- `blockId`
+- `toolCallId`
+- `sequence`
+- `parentId`
+- `phase`
+- `kind`
+
+Core phases:
+
+- `started`
+- `delta`
+- `updated`
+- `completed`
+- `failed`
+
+Core kinds:
+
+- `text`
+- `thinking`
+- `tool`
+- `diff`
+- `status`
+- `permission`
+- `question`
+- `plan`
+- `terminal`
+- `task`
+- `todo`
+- `usage`
+- `mode`
+
+The important change from the older marker-only architecture is that provider events keep their identity and lifecycle. The frontend should not infer ordering by merging assistant messages after the fact.
+
+Minimum invariants for the shared event plane:
+
+- assign `sequence` once at the adapter boundary and replay by `sequence`, not timestamp
+- keep `turnId`, `stepId`, `partId`, `blockId`, and `toolCallId` stable across deltas, snapshots, and restored history
+- use `parentId` to connect nested permissions, questions, diffs, terminals, and task/subagent sessions to the event that caused them
+- treat lifecycle `phase` as state for the same identity, not as permission to rebuild unrelated blocks
+- make legacy marker output derivable from `chat_event` during migration instead of making markers the only source of truth
+
+The event kinds above are intentionally broader than the first opencode slice. [Provider Compatibility Matrix](./PROVIDER-COMPATIBILITY-MATRIX.md) maps the same additions to ACP, Cursor, opencode, and Codex so the shared contract can be reviewed as provider-neutral infrastructure.
+
+## Compatibility Layer
+
+`chat_event` records use the same stdout transport as the existing markers: one `[CHAT_EVENT] <json>` line per event, forwarded by Java to the webview without reshaping (see the Transport section in [PREPARATION.md](./PREPARATION.md)).
+
+The current UI still depends on Claude-compatible messages and markers such as:
+
+- `[MESSAGE_START]`
+- `[CONTENT_DELTA]`
+- `[THINKING_DELTA]`
+- `[MESSAGE]`
+- `[STREAM_END]`
+- `[MESSAGE_END]`
+
+During migration, providers may emit both:
+
+- legacy markers for existing handlers
+- `chat_event` records for the structured path
+
+The long-term target is for rich provider output to be represented internally as `chat_event` first, with legacy messages derived only where compatibility requires them.
+
+## Streaming Event Capture
+
+Every provider should be able to write replayable streaming event logs. These logs should capture enough information to reproduce rendering bugs without attaching a debugger to a live provider run.
+
+Recommended capture stages:
+
+- `native_in`: raw provider event received by the bridge
+- `normalized_out`: emitted `chat_event`
+- `legacy_out`: emitted compatibility marker while migration is in progress
+- `handler_in`: optional Java handler input
+- `render_in`: optional frontend accumulator input
+
+The capture utility should write newline-delimited JSON envelopes with stable sequence numbers, provider/session metadata, event type, redacted payload, and redaction metadata. Replay should use `sequence`, not timestamps.
+
+Captured logs should support two important test paths:
+
+- raw native events replayed through a provider normalizer
+- normalized `chat_event` records replayed through the frontend accumulator
+
+See [Streaming Event Logs And Replay Fixtures](./STREAMING-EVENT-LOGS.md) for the envelope format and fixture-promotion workflow.
+
+## Permission Architecture
+
+Permission mode mapping remains provider-specific, but the UI event shape should be shared.
+
+```text
+Plugin mode
+  -> provider permission mapper
+  -> native provider request/reply transport
+  -> chat_event kind: permission
+  -> shared permission UI
+  -> reply correlated by provider request ID
+```
+
+Opencode-specific guidance:
+
+- `plan`: use opencode's planning agent or equivalent; deny or ask for edits, shell, external-directory, and network-like operations.
+- `default`: ask for edits, shell, external-directory, and network-like operations.
+- `acceptEdits`: allow workspace edits; keep shell and external actions on ask.
+- `autoEdit`: allow reads and workspace edits needed for autonomous changes; keep dangerous shell and external actions on ask.
+- `bypassPermissions`: allow broad workspace actions only when explicitly selected.
+
+The normalized permission event must preserve the provider request ID, requested tool/action, and available choices.
+
+## Session And History Architecture
+
+Each provider should use its own source of truth for history:
+
+- Claude uses Claude session/history APIs or readers.
+- Codex uses Codex session files and current Codex history normalization.
+- Opencode should use opencode session APIs.
+
+The shared target is that live and restored paths produce equivalent render groups:
+
+```text
+live provider events -> chat_event stream -> accumulator -> render groups
+restored history     -> chat_event list   -> accumulator -> render groups
+```
+
+Restored history is allowed to emit fewer intermediate deltas, but it should preserve the same logical identities for turns, blocks, tools, diffs, permissions, questions, and task links. Tests should compare accumulated render groups, not raw event counts.
+
+This avoids the Codex failure mode where live streaming and history replay each need separate field mappings for the same logical tool call.
+
+## Opencode Service Layout
+
+Expected Node service layout:
+
+```text
+ai-bridge/services/opencode/
+  sdk-loader.js
+  server-manager.js
+  message-service.js
+  event-normalizer.js
+  permission-mapper.js
+  model-service.js
+  agent-service.js
+  history-service.js
+  error-normalizer.js
+  event-capture.js
+```
+
+Expected channel commands:
+
+- `send`
+- `abort`
+- `deleteSession`
+- `getSessionMessages`
+- `listSessions`
+- `listModels`
+- `listAgents`
+
+## Opencode Message Flow
+
+```text
+1. User sends a prompt with provider opencode.
+2. Java OpenCodeSDKBridge serializes message, session ID, cwd, mode, model, agent, and attachments.
+3. channel-manager.js routes to opencode-channel.js.
+4. opencode-channel.js starts or connects to opencode serve.
+5. message-service subscribes to /event before prompt submission.
+6. message-service creates or resumes an opencode session.
+7. message-service sends text/file parts to the session message endpoint.
+8. event-normalizer filters events by sessionID.
+9. event-normalizer emits chat_event records and migration compatibility markers.
+10. Java/webview render from stable event identity.
+```
+
+## Adding Future Providers
+
+Future providers should follow the same split:
+
+1. Add a Java bridge only for provider runtime dispatch.
+2. Add a Node channel and service folder for provider-specific runtime logic.
+3. Normalize native events to `chat_event` records.
+4. Add fixtures for live stream and restored history parity.
+5. Add compatibility markers only when existing UI paths still require them.
+
+Simple providers can emit a tiny subset:
+
+```json
+{
+  "type": "chat_event",
+  "provider": "example",
+  "sessionId": "session_1",
+  "turnId": "turn_1",
+  "blockId": "text_1",
+  "sequence": 1,
+  "phase": "delta",
+  "kind": "text",
+  "text": "Hello"
+}
+```
+
+Structured providers should preserve richer identity instead of flattening into one assistant message.
+
+Broad provider feature surfaces should be added as separate slices. The opencode support experiment mixed streaming, history, model discovery, agent discovery, slash commands, MCP display, usage statistics, context recovery, and menu UX changes. That made failures harder to isolate.
+
+Recommended slice order:
+
+1. Shared `chat_event` schema, accumulator, and capture utility.
+2. Replay fixtures for provider-normalizer and frontend-accumulator paths.
+3. Codex or another existing-provider proving adapter that keeps current behavior compatible.
+4. Minimal opencode send/stream/history adapter using the structured event path.
+5. Opencode model/agent discovery and optional provider-specific UX surfaces.
+
+## Testing Strategy
+
+Tests should prove behavior at the contract boundary:
+
+- captured streaming logs can be sanitized and replayed as fixtures
+- provider event fixtures map to `chat_event` without losing identity
+- interleaved text, thinking, and tool events preserve order
+- tool lifecycle states render as pending/running/completed/failed
+- permission and question requests preserve provider request IDs
+- diffs preserve file scope and current-turn scope
+- task/subagent events preserve child session links when available
+- restored history fixtures produce the same render groups as live fixtures
+- legacy Claude/Codex rendering remains compatible during migration
+
+## Related Docs
+
+- [Preparation: Provider-Neutral Chat Events](./PREPARATION.md)
+- [Opencode Integration Quickstart](./OPENCODE-INTEGRATION-QUICKSTART.md)
+- [Provider Compatibility Matrix](./PROVIDER-COMPATIBILITY-MATRIX.md)
+- [Streaming Event Logs And Replay Fixtures](./STREAMING-EVENT-LOGS.md)
+- [Lessons From The Opencode Support Experiment](./LESSONS-LEARNED.md)
+- [Codex Multi-Provider Architecture](../codex/MULTI-PROVIDER-ARCHITECTURE.md)

--- a/docs/opencode/OPENCODE-INTEGRATION-QUICKSTART.md
+++ b/docs/opencode/OPENCODE-INTEGRATION-QUICKSTART.md
@@ -1,0 +1,237 @@
+# Opencode Integration Quickstart
+
+> Draft integration guide. This document describes the intended opencode provider shape and the checks that should pass when the integration lands.
+
+## What This Adds
+
+Opencode should become a first-class provider beside Claude and Codex, with an explicit provider boundary instead of a Claude fallback path.
+
+The integration should use the user's installed opencode CLI and existing opencode configuration. The plugin should discover or start `opencode serve`, talk to it through `@opencode-ai/sdk` and HTTP APIs, and map opencode runtime events into the plugin's shared chat UI.
+
+The important difference from the first Codex integration is that opencode should not be treated as only another text-message provider. The first complete implementation should preserve structured session, message, part, tool, permission, question, diff, and task/subagent events through the provider-neutral `chat_event` path described in [PREPARATION.md](./PREPARATION.md).
+
+The same event/interface additions also map to ACP, Cursor, and Codex. See [Provider Compatibility Matrix](./PROVIDER-COMPATIBILITY-MATRIX.md) for the cross-provider compatibility view.
+
+The failed [opencode support experiment](https://github.com/zhukunpenglinyutong/jetbrains-cc-gui/pull/1239) showed that the integration should be sliced carefully. Core send/stream/history and event replay should land before optional discovery surfaces such as slash commands, MCP display, usage dashboards, and context recovery UX.
+
+## Architecture Highlights
+
+```text
+Claude:   Java -> ClaudeSDKBridge   -> ai-bridge -> @anthropic-ai/claude-agent-sdk
+Codex:    Java -> CodexSDKBridge    -> ai-bridge -> Codex CLI/SDK integration
+Opencode: Java -> OpenCodeSDKBridge -> ai-bridge -> @opencode-ai/sdk -> opencode serve
+```
+
+Key boundaries:
+
+- Java provider bridge: `OpenCodeSDKBridge`
+- Node provider channel: `ai-bridge/channels/opencode-channel.js`
+- Node provider services: `ai-bridge/services/opencode/`
+- Shared provider router: `ai-bridge/channel-manager.js`
+- Shared render foundation: `chat_event` plus existing compatibility markers during migration
+
+## Runtime Ownership
+
+The plugin should not install or configure opencode for the user.
+
+Expected ownership model:
+
+- User installs the `opencode` CLI.
+- User configures opencode auth, providers, and model defaults through opencode.
+- Plugin resolves the installed CLI or connects to a configured external server.
+- Plugin may start the user's installed CLI with `opencode serve` in managed-server mode.
+- Plugin should not write opencode auth or provider configuration unless a future UI action explicitly says it will.
+
+## Dependencies
+
+Expected plugin-managed dependency:
+
+```json
+{
+  "opencode-sdk": "@opencode-ai/sdk"
+}
+```
+
+Expected user-managed dependency:
+
+```text
+opencode CLI executable
+```
+
+The bridge should fail with a user-facing setup error when the SDK or CLI cannot be resolved.
+
+## Configuration
+
+Supported runtime modes:
+
+| Mode | Behavior |
+| --- | --- |
+| Managed server | Plugin starts the user's installed CLI with `opencode serve`. |
+| External server | User provides `OPENCODE_BASE_URL`; plugin connects without owning the process. |
+
+Optional settings can be added later for host, port, server password, and inline server config. They should not replace opencode's own provider/auth configuration.
+
+## Message Flow
+
+```text
+1. User selects opencode in the provider selector.
+2. Java dispatches to OpenCodeSDKBridge.
+3. Java invokes ai-bridge channel-manager.js with provider "opencode".
+4. opencode-channel.js starts or connects to an opencode server.
+5. Bridge subscribes to /event before sending the prompt.
+6. Bridge creates or resumes a session through the current /session API.
+7. Bridge sends user input as text/file parts.
+8. Bridge maps opencode events to chat_event records and compatibility markers.
+9. Optional streaming event capture records raw events, normalized events, and compatibility markers.
+10. Frontend renders live stream, tools, diffs, permissions, questions, and tasks from stable event identity.
+11. Session restore reads through opencode session APIs and produces the same logical render groups as live streaming.
+```
+
+## Event Mapping
+
+> **API surface caveat (verify before implementation).** Opencode currently ships two parallel API generations, and event names differ between them. The names in the table below come from the newer (v2) SDK event surface (`message.part.delta`, `permission.asked`, `question.asked`). The older generated SDK types instead expose `message.part.updated`, `permission.updated`, and `permission.replied`, with no part-delta or question-asked events. As of the July 2026 source checkout, the v2 session `prompt` operation is implemented, while `wait`, `compact`, `shell`, and `skill` still return `Session.OperationUnavailableError`. At implementation start: pin the `@opencode-ai/sdk` version (npm was at 1.17.13 when this was written), decide which API generation the bridge targets, and regenerate this mapping table against that version. Do not treat this table as authoritative without that check.
+
+The bridge should subscribe before prompt submission and filter by `sessionID` because opencode events are shared over the server event stream.
+
+Expected mapping:
+
+| Opencode event | Normalized output |
+| --- | --- |
+| `message.part.delta` text fields | `chat_event` with `kind: text`, `phase: delta` |
+| `message.part.delta` reasoning fields | `chat_event` with `kind: thinking`, `phase: delta` |
+| `message.updated` | message or turn snapshot with `phase: updated` |
+| `message.part.updated` tool part | tool lifecycle update with stable `toolCallId` |
+| completed tool result | `kind: tool`, `phase: completed` |
+| `permission.asked` | `kind: permission`, preserving request ID and choices |
+| `permission.replied` | `kind: permission`, `phase: completed` |
+| `question.asked` | `kind: question`, preserving request ID |
+| `session.diff` | `kind: diff`, preserving file scope and hunks |
+| task/subagent metadata | `kind: task`, preserving child session IDs when available |
+
+During migration, the adapter may also emit existing markers such as `[MESSAGE_START]`, `[CONTENT_DELTA]`, `[THINKING_DELTA]`, `[MESSAGE]`, `[STREAM_END]`, and `[MESSAGE_END]` so current UI paths remain compatible.
+
+## Streaming Event Logs
+
+The opencode bridge should support replayable event capture from the start. This is useful for diagnosing rendering issues and for turning real provider streams into regression tests.
+
+Capture should include:
+
+- raw opencode events from `/event`
+- normalized `chat_event` records
+- legacy compatibility markers while they exist
+
+Captured logs should use the shared JSONL envelope described in [Streaming Event Logs And Replay Fixtures](./STREAMING-EVENT-LOGS.md). Logs must be redacted by default and should be easy to sanitize into fixture tests.
+
+## Permission Mapping
+
+Permission behavior should be explicit and mode-aware.
+
+| Plugin mode | Intended opencode behavior |
+| --- | --- |
+| `plan` | Use opencode's planning agent or equivalent. Deny or ask for edits, shell, network-like tools, and external directories. |
+| `default` | Ask for edits, shell, network-like tools, and external-directory access. |
+| `acceptEdits` | Allow workspace edits; keep shell and external actions on ask. |
+| `autoEdit` | Allow reads and workspace edits needed for autonomous changes; keep dangerous shell and external actions on ask. |
+| `bypassPermissions` | Allow broad workspace actions only when explicitly selected by the user. |
+
+Permission request and reply IDs from opencode must be preserved so UI decisions are applied to the right provider request.
+
+## Attachments
+
+Attachments should be converted to opencode file parts, not Codex-style prompt text.
+
+Expected file part fields:
+
+- MIME type
+- filename
+- `file://` URL
+- source metadata when available
+
+Attachment paths should be validated before sending.
+
+## Session History
+
+History should use opencode APIs, not Claude or Codex transcript readers.
+
+Expected behavior:
+
+- list project sessions through opencode's project-scoped session API
+- restore a session through opencode session messages
+- normalize restored messages through the same event model as live streaming
+- preserve completed tool parts, file-change metadata, diffs, and task/subagent links when available
+
+## Implementation Checklist
+
+Foundation before opencode parity:
+
+- Add the shared `chat_event` bridge marker, schema, TypeScript types, and frontend accumulator.
+- Add identity and sequencing tests for `turnId`, `stepId`, `partId`, `blockId`, `toolCallId`, `parentId`, `phase`, and `sequence`.
+- Add shared streaming event capture for raw provider events, normalized `chat_event` records, and legacy markers.
+- Add at least one replay fixture generated from or shaped like a captured streaming event log.
+- Prove that live-style events and restored-history-style event lists produce equivalent accumulated render groups.
+- Keep existing Claude and Codex behavior compatible while the new event path is introduced.
+
+Minimal opencode proving slice:
+
+- Register provider `opencode` in `ai-bridge/channel-manager.js`.
+- Add `ai-bridge/channels/opencode-channel.js`.
+- Add `ai-bridge/services/opencode/` for SDK resolution, server lifecycle, permissions, event normalization, capture, and history.
+- Add dependency metadata for `opencode-sdk` / `@opencode-ai/sdk`.
+- Add Java `OpenCodeSDKBridge` as a peer of Claude and Codex bridges.
+- Route Java sends through explicit provider dispatch, not `not codex means claude` logic.
+- Implement send, abort, and restore through opencode session APIs using the user-managed CLI/server model.
+- Add event normalization tests for text, reasoning, tools, diffs, permissions, questions, errors, and task/subagent metadata.
+- Add history restore tests for opencode session messages through the same accumulator used by live streaming.
+
+Later provider UX slices:
+
+- Add opencode model/provider discovery through opencode config/provider APIs.
+- Add opencode agent discovery through opencode agent APIs.
+
+Defer unless explicitly in scope:
+
+- slash command picker integration
+- MCP server/tool display
+- usage dashboards
+- context recovery UI
+- broad selector/menu redesigns
+- commit-message and prompt-enhancer provider routing
+
+## Manual Smoke Test
+
+After implementation, a minimal local smoke test should verify:
+
+1. Install and configure opencode outside the plugin.
+2. Start the IDE with no existing opencode server.
+3. Select provider `opencode`.
+4. Confirm managed-server mode starts the user's installed `opencode serve`.
+5. Send a text prompt and observe streaming text.
+6. Trigger a read/search tool and observe tool lifecycle UI.
+7. Trigger a permission request and verify allow once, always allow, and reject behavior.
+8. Trigger an edit and verify file-change UI and diff scope.
+9. Abort an in-flight response.
+10. Restore the session from history and confirm live/restored render parity.
+
+## Troubleshooting Targets
+
+Expected setup errors should be explicit:
+
+| Symptom | Likely cause | Expected guidance |
+| --- | --- | --- |
+| SDK cannot be loaded | `@opencode-ai/sdk` dependency missing | Install or repair plugin dependencies. |
+| CLI cannot be found | User has not installed `opencode` or it is not on PATH | Install opencode and ensure the IDE can resolve it. |
+| Server connection fails | Managed server failed or `OPENCODE_BASE_URL` is wrong | Show base URL and server startup diagnostics without secrets. |
+| No models found | User opencode provider config is incomplete | Ask user to verify opencode works outside the plugin. |
+| Permission dialog does not resolve | Request ID was not preserved | Inspect `permission.asked` and reply correlation. |
+| Restored history differs from live stream | Live and history paths use different normalization | Add or fix shared `chat_event` fixtures. |
+| Rendering bug cannot be reproduced | Event capture was disabled or incomplete | Enable streaming event logs and promote the capture into a replay fixture. |
+
+## Related Docs
+
+- [Preparation: Provider-Neutral Chat Events](./PREPARATION.md)
+- [Opencode Multi-Provider Architecture](./MULTI-PROVIDER-ARCHITECTURE.md)
+- [Provider Compatibility Matrix](./PROVIDER-COMPATIBILITY-MATRIX.md)
+- [Streaming Event Logs And Replay Fixtures](./STREAMING-EVENT-LOGS.md)
+- [Lessons From The Opencode Support Experiment](./LESSONS-LEARNED.md)
+- [Codex Integration Quickstart](../codex/CODEX-INTEGRATION-QUICKSTART.md)
+- [Codex Multi-Provider Architecture](../codex/MULTI-PROVIDER-ARCHITECTURE.md)

--- a/docs/opencode/PREPARATION.md
+++ b/docs/opencode/PREPARATION.md
@@ -1,0 +1,483 @@
+# Opencode Preparation: Provider-Neutral Chat Events
+
+## Summary
+
+Add a provider-neutral streaming and render event contract before treating opencode as a first-class provider in the JetBrains chat UI.
+
+This is not an argument that the existing architecture was wrong. The current Claude-compatible message model and stdout marker protocol made it practical to add providers quickly when their output could be projected into assistant/user messages, text deltas, `tool_use`, and `tool_result` blocks. That was useful for the original Claude-first UI and for the first Codex integration.
+
+The argument is narrower: opencode is not just another simple text provider. It exposes structured session, message, part, tool, permission, question, diff, and task/subagent events. Forcing those events into the existing Claude-shaped render contract may make the first demo faster, but it moves complexity into provider-specific merge, dedupe, history, permission, and diff-recovery code. A normalized `chat_event` layer should make the complete and maintainable opencode integration easier, not necessarily the first prototype smaller.
+
+The existing `ClaudeMessage` compatibility path should remain. The proposed work adds a richer event path alongside it so opencode, Codex, ACP-backed agents, Cursor, and simpler future providers can share one structured render foundation.
+
+## Decision
+
+Do not make opencode only another adapter that emits the existing Claude/Codex-compatible message markers.
+
+Instead:
+
+- keep explicit provider adapters and provider routing
+- keep centralized permission-mode mapping where it is still useful
+- introduce a provider-neutral `chat_event` stream for structured runtime events
+- add a shared streaming event capture log that can be promoted into replay fixtures
+- let existing providers continue emitting current markers while the new path is introduced
+- use opencode as the main design target, but prove the contract with fixtures and at least one existing provider surface such as Codex
+
+## Why This Is Not A Contradiction
+
+The old multi-provider architecture optimized for easy onboarding of providers that fit a simple shape:
+
+```text
+prompt -> assistant text -> done
+```
+
+That is why the previous Gemini example in `docs/codex/MULTI-PROVIDER-ARCHITECTURE.md` can be so small: create `GeminiSDKBridge`, create `ai-bridge/services/gemini/message-service.js`, add a permission mapper, route through `channel-manager.js`, and emit `[MESSAGE_START]`, `[CONTENT]`, and `[MESSAGE_END]`.
+
+Opencode has a different shape:
+
+```text
+session -> turn -> message -> part -> tool lifecycle -> permission/question -> diff -> task/subagent -> restored history
+```
+
+For this shape, the easy path is deceptive. A compatibility-only bridge would still need to answer hard questions later:
+
+- which text part belongs to which render block
+- whether progress narration and final answer text should merge
+- how pending, running, completed, and failed tool states are represented
+- how permission and question requests stay tied to provider request IDs
+- how diffs are scoped to the current turn
+- how task/subagent activity links to child sessions
+- how live streaming and restored history produce the same UI
+
+The proposal changes the shared render contract so those questions are answered once, not separately in every structured provider adapter.
+
+## Existing Architecture To Preserve
+
+The old docs still identify useful architectural boundaries:
+
+- Java has provider-specific bridges such as `ClaudeSDKBridge` and `CodexSDKBridge`.
+- Node has provider-specific services under `ai-bridge/services/`.
+- `channel-manager.js` routes by provider.
+- Permission modes are translated into provider-specific settings.
+- Session identity differences are hidden behind bridge-level mapping.
+
+Those are good extension points and should remain. The proposed change is about the rendering and streaming contract, not about removing provider adapters.
+
+## Existing Architecture To Change
+
+The current render contract mostly assumes:
+
+- one assistant turn becomes one renderable assistant message
+- text, thinking, and tool ordering can be recovered by frontend merge logic
+- tool calls can be flattened into `tool_use` plus `tool_result`
+- restored history can be loaded as raw user/assistant messages and then merged
+- `__turnId` can be used for both streaming isolation and merge behavior
+
+Those assumptions do not map cleanly to opencode, Codex, ACP agents, or Cursor.
+
+They are also only a partial fit for Claude itself. Claude Code / Claude Agent SDK output can include stream events such as message starts, content block deltas, thinking deltas, message deltas, usage updates, assistant content blocks, tool use blocks, user tool result blocks, permission hooks, and result messages. The current model works where those events can be projected into message/content blocks, but later streaming and multi-provider support has required additional merge, replay, and boundary logic around that projection.
+
+## Expected Opencode Pressure Points
+
+Opencode exposes structured session, message, and part events. If those events are immediately mapped into Claude/Codex-compatible markers, several rough edges are likely:
+
+- live ordering may require synthetic block-reset style heuristics after tool or diff results
+- restored history may contain multiple assistant step messages for one logical turn
+- frontend merge logic may accidentally combine assistant progress text into one giant answer block
+- accumulated session-level diffs may require baseline filtering to identify current-turn edits
+- progress narration and final answer text may not be explicitly distinguished
+- tool lifecycle state may be flattened too early into `tool_use` and `tool_result`
+- live streaming and restored history may diverge
+
+These are not opencode-specific UI problems. They are signs that the bridge and frontend need a richer provider-neutral event model.
+
+The failed [opencode support experiment](https://github.com/zhukunpenglinyutong/jetbrains-cc-gui/pull/1239) confirmed these pressure points in practice. It required repeated fixes for role-gated text, stream-end recovery, post-tool text ordering, diff baseline filtering, restored-history normalization, task/subagent reconstruction, context-window recovery, and streaming debug capture. See [Lessons From The Opencode Support Experiment](./LESSONS-LEARNED.md) for the detailed findings.
+
+## Codex Evidence
+
+Codex already emits structured lifecycle events through `runStreamed()` and `--json`/JSONL output:
+
+- `thread.started`
+- `turn.started`
+- `turn.completed`
+- `turn.failed`
+- `item.started`
+- `item.updated`
+- `item.completed`
+- `error`
+
+Codex item types include:
+
+- `agent_message`
+- `reasoning`
+- `command_execution`
+- `file_change`
+- `mcp_tool_call`
+- `web_search`
+- `todo_list`
+
+Today the Codex bridge flattens these into Claude-compatible message/tool blocks. It also has special recovery paths that read the local JSONL session file during live streaming to recover missing function calls and patch details.
+
+Historical context suggests this was a deliberate symmetry choice, not an accident. The first Codex bridge work introduced a shared `ai-bridge/channel-manager.js` and provider-specific adapters for Claude and Codex. The later Codex SDK adaptation documented the goal as using the "same elegant architecture as Claude", with "Symmetrical Design", a "Unified JSON Protocol", and provider services emitting unified console markers such as `[MESSAGE_START]`, `[CONTENT_DELTA]`, and `[MESSAGE_END]`. That was a practical way to add Codex quickly while reusing the existing UI and Java callback model.
+
+The cost is visible in later fixes: Codex `thinking`, `tool_use`, and `tool_result` blocks had to be preserved through Claude-compatible JSON messages, and history replay needed separate field-mapping fixes for raw Codex JSONL because the live path and restored-history path normalized different shapes. No PR discussion or review comments were found for the original Codex SDK adaptation, so the strongest evidence is the committed docs, code comments, and follow-up fixes.
+
+A provider-neutral turn/item model would let Codex preserve more native structure instead of reconstructing it through adapter-specific logic.
+
+Relevant current code:
+
+- `ai-bridge/services/codex/message-service.js`
+- `ai-bridge/services/codex/codex-event-handler.js`
+- `src/main/java/com/github/claudecodegui/session/CodexMessageHandler.java`
+- `src/main/java/com/github/claudecodegui/handler/CodexMessageConverter.java`
+- `src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java`
+
+## Prior Gemini Planning Docs
+
+The existing docs contain Gemini as a future-provider example, not as an implemented integration plan. `docs/codex/MULTI-PROVIDER-ARCHITECTURE.md` describes adding Gemini by creating `ai-bridge/services/gemini/message-service.js`, adding a `GeminiPermissionMapper`, updating `channel-manager.js`, and adding `GeminiSDKBridge`. `docs/codex/CODEX-INTEGRATION-QUICKSTART.md` similarly frames Gemini as a future symmetrical provider and says it would follow the same pattern.
+
+That prior plan is useful, but it also shows the limitation this proposal is trying to address. The old extension point was provider-oriented: Java bridge, Node service, permission mapper, and unified stdout markers. The example Gemini service emits only `[MESSAGE_START]`, `[CONTENT]`, and `[MESSAGE_END]`. That is enough for simple text providers, but not enough for providers or protocols with explicit turns, steps, tool lifecycles, permissions, diffs, plans, terminal output, usage updates, and subagent activity.
+
+No ACP integration plan was found under `docs/`. The ACP section below is therefore a new protocol-driven design input, not a continuation of an existing project doc.
+
+## Generic ACP Compatibility
+
+This foundation would also make it practical to support ACP-backed agents without building a new provider-specific merger for each one.
+
+ACP is explicitly structured around the same concepts this proposal needs to represent:
+
+- `session/prompt` starts a prompt turn
+- `session/update` streams progress and output
+- `agent_message_chunk` carries assistant text chunks with optional message identity
+- `tool_call` creates a tool call with a stable `toolCallId`
+- `tool_call_update` reports tool status and result content
+- tool statuses include `pending`, `in_progress`, `completed`, and `failed`
+- tool content can include regular content blocks, diffs, and terminal references
+- `session/request_permission` asks the client to choose from explicit permission options
+- permission options include `allow_once`, `allow_always`, `reject_once`, and `reject_always`
+- plan updates, session mode changes, usage updates, file-system requests, and terminal requests are first-class protocol concepts
+
+Junie is a concrete example of why this matters. Junie CLI supports ACP mode through `junie --acp true`, and Junie in JetBrains IDEs exposes agent behavior that includes planning, ask/code modes, approval-gated execution, diffs, terminal commands, MCP tool execution, and action allowlists.
+
+If this plugin can render ACP-shaped turns, chunks, tool calls, permissions, plans, diffs, and terminals through a normalized event contract, then Junie support can be implemented as an ACP adapter instead of a Junie-specific frontend model. The same work would also help any other ACP-capable agent.
+
+## Future Cursor Integration
+
+This would also strongly benefit a potential Cursor provider.
+
+Cursor exposes several integration surfaces that are already structured around runs, steps, deltas, tool lifecycle, and permissions.
+
+Cursor TypeScript SDK:
+
+- `Agent.create()` creates a durable agent
+- `agent.send()` starts a `Run`
+- `run.stream()` yields normalized `SDKMessage` events
+- events include `assistant`, `thinking`, `tool_call`, `status`, `task`, and `request`
+- tool calls have stable lifecycle fields like `call_id`, `name`, and `status`
+- `onDelta` exposes lower-level updates such as `text-delta`, `thinking-delta`, `tool-call-started`, `partial-tool-call`, `tool-call-completed`, `step-started`, `step-completed`, `turn-ended`, and `shell-output-delta`
+- `run.conversation()` returns structured turns with steps such as `assistantMessage`, `thinkingMessage`, and `toolCall`
+
+Cursor CLI:
+
+- `--output-format stream-json` emits structured NDJSON
+- events include `system`, `user`, `assistant`, `tool_call`, and `result`
+- `tool_call` events have `started` and `completed` subtypes
+- `--stream-partial-output` adds character-level text streaming
+- assistant messages are emitted between tool calls, which directly maps to a step/block model
+
+Cursor ACP:
+
+- `agent acp` exposes JSON-RPC over stdio
+- clients receive `session/update` notifications
+- clients handle `session/request_permission`
+- Cursor extensions include `cursor/ask_question`, `cursor/create_plan`, `cursor/update_todos`, `cursor/task`, and `cursor/generate_image`
+
+A provider-neutral event model would let a future Cursor integration map these surfaces directly instead of forcing Cursor into Claude-shaped raw messages.
+
+See [Provider Compatibility Matrix](./PROVIDER-COMPATIBILITY-MATRIX.md) for a cross-provider view of which proposed event kinds and interface fields are useful for ACP, Cursor, opencode, and Codex.
+
+## Proposed Event Contract
+
+Introduce a provider-neutral streaming/render event contract.
+
+Suggested normalized concepts:
+
+- `turn`
+- `step`
+- `part`
+- `block`
+- `tool_call`
+- `tool_result`
+- `diff`
+- `permission`
+- `question`
+- `plan`
+- `status`
+- `terminal`
+- `task`
+- `todo_update`
+- `usage_update`
+- `mode_change`
+
+Suggested event fields:
+
+- `type`: `chat_event`
+- `schemaVersion`
+- `provider`
+- `sessionId`
+- `turnId`
+- `runId`
+- `messageId`
+- `stepId`
+- `partId`
+- `blockId`
+- `toolCallId`
+- `sequence`
+- `parentId`
+- `phase`: `started | delta | updated | completed | failed`
+- `kind`: `text | thinking | tool | diff | status | permission | question | plan | terminal | task | todo | usage | mode`
+
+The frontend should render from stable event and block identity instead of relying on post-hoc assistant-message merging.
+
+### Transport
+
+`chat_event` records travel over the existing bridge stdout protocol as a new marker line beside the current markers:
+
+```text
+[CHAT_EVENT] {"type":"chat_event","provider":"opencode","sessionId":"ses_123",...}
+```
+
+Rules:
+
+- one event per marker line, JSON-encoded without embedded newlines
+- Java forwards `[CHAT_EVENT]` payloads to the webview without reshaping them; Java may additionally parse specific kinds (such as `permission`) where native dialogs need them
+- the schema carries an explicit `schemaVersion` field so replay fixtures and the accumulator can reject or adapt incompatible events
+
+### Contract Invariants
+
+The first implementation should treat these as acceptance rules, not later cleanup items:
+
+- `sequence` is assigned at the adapter boundary, is monotonic within one provider session stream, and is the only ordering value used for replay.
+- `turnId` identifies one user prompt or restored prompt turn; it must not also encode UI merge policy.
+- `stepId` identifies a provider lifecycle unit such as an opencode message/part group, Codex item, ACP update group, or synthesized equivalent.
+- `blockId` identifies one renderable text, thinking, diff, status, terminal, plan, or todo block and remains stable across deltas and snapshots.
+- `toolCallId` identifies one tool lifecycle and correlates tool start, input updates, permission requests, result updates, diffs, and terminal output when the provider exposes that relationship.
+- `partId` and `messageId` preserve native provider identity when available, but frontend grouping should not depend on provider-specific names.
+- `parentId` links nested entities such as task/subagent sessions, terminal streams, permission requests, or diffs back to the block, tool, step, or turn that created them.
+- A `completed` or `failed` event can close a block/tool/turn, but it must not reorder earlier deltas or rewrite unrelated blocks.
+- Restored history should emit completed `chat_event` records that use the same identity hierarchy as live streaming wherever the provider exposes enough information.
+
+### Accumulator Rules
+
+The shared frontend accumulator should be intentionally boring:
+
+- Ingest ordered `chat_event` records and group by `sessionId`, `turnId`, `stepId`, `blockId`, and `toolCallId`.
+- Append text and thinking deltas only to the block identified by `blockId`.
+- Apply snapshots only to the matching identity and never use a cumulative provider snapshot to move older tool cards below later text.
+- Render tools from lifecycle state (`started`, `updated`, `completed`, `failed`) rather than from a pair of finished `tool_use` / `tool_result` messages.
+- Render diffs, terminal streams, permissions, questions, tasks, plans, todos, usage, and mode updates as first-class blocks or side-channel records with explicit parent links.
+- Derive legacy `ClaudeMessage`-compatible blocks from accumulated events only where migration requires compatibility.
+
+## Streaming Event Capture
+
+The preparation work should also add a shared streaming event capture utility for existing and new providers. This was useful during opencode implementation work because rendering issues could be diagnosed from the actual provider stream instead of from screenshots or final UI state.
+
+The capture format should be replay-oriented, not just debug text. Prefer newline-delimited JSON envelopes with a version, provider, session ID, sequence number, capture stage, event type, redacted payload, and redaction metadata. Capture should include raw provider events, normalized `chat_event` records, and legacy markers while the compatibility path exists.
+
+Required capture stages:
+
+- `native_in`: raw provider event received by the bridge
+- `normalized_out`: emitted `chat_event`
+- `legacy_out`: emitted compatibility marker such as `[CONTENT_DELTA]` or `[MESSAGE]`
+
+The logs should be safe to persist in debug mode and easy to convert into test fixtures. A captured rendering bug should be reducible into a fixture that replays either raw provider events through the normalizer or normalized `chat_event` records through the frontend accumulator.
+
+See [Streaming Event Logs And Replay Fixtures](./STREAMING-EVENT-LOGS.md) for the proposed log envelope and replay workflow.
+
+## Opencode Mapping Sketch
+
+The exact mapping should be finalized against opencode's current HTTP event payloads, but the intended direction is:
+
+> Event names below come from opencode's newer API generation. Opencode is mid-migration between two API generations with different event vocabularies; see the API surface caveat in [OPENCODE-INTEGRATION-QUICKSTART.md](./OPENCODE-INTEGRATION-QUICKSTART.md) and re-verify names against the pinned SDK version at implementation start.
+
+- `message.part.delta` with text fields maps to `kind: text`, `phase: delta`.
+- `message.part.delta` with reasoning fields maps to `kind: thinking`, `phase: delta`.
+- `message.updated` maps to message or turn-level `phase: updated` snapshots.
+- `message.part.updated` for tool parts maps to `kind: tool`, with `phase` derived from the provider part state.
+- completed tool results map to `kind: tool`, `phase: completed`, preserving `toolCallId`.
+- `permission.asked` maps to `kind: permission`, `phase: started`, preserving the opencode request ID and available actions.
+- `permission.replied` maps to `kind: permission`, `phase: completed`.
+- `question.asked` maps to `kind: question`, `phase: started`, preserving the opencode request ID.
+- `session.diff` maps to `kind: diff`, preserving file paths, hunks, and turn/session scope.
+- task or subagent tool metadata maps to `kind: task`, preserving child session IDs when available.
+- restored `session.messages` output maps to completed `chat_event` records using the same identity fields as the live stream wherever possible.
+
+The adapter may still synthesize existing `ClaudeMessage`-compatible blocks during migration. That compatibility output should be derived from the structured events, not the only internal representation.
+
+## Possible Event Shape
+
+Text delta example:
+
+```json
+{
+  "type": "chat_event",
+  "provider": "opencode",
+  "sessionId": "ses_123",
+  "turnId": "turn_4",
+  "stepId": "step_2",
+  "blockId": "block_7",
+  "sequence": 42,
+  "phase": "delta",
+  "kind": "text",
+  "text": "I found the issue."
+}
+```
+
+Tool lifecycle start example:
+
+```json
+{
+  "type": "chat_event",
+  "provider": "codex",
+  "sessionId": "thread_123",
+  "turnId": "turn_1",
+  "stepId": "item_3",
+  "toolCallId": "call_abc",
+  "sequence": 17,
+  "phase": "started",
+  "kind": "tool",
+  "tool": {
+    "name": "command_execution",
+    "input": {
+      "command": "npm test"
+    }
+  }
+}
+```
+
+Tool lifecycle completion example:
+
+```json
+{
+  "type": "chat_event",
+  "provider": "cursor",
+  "sessionId": "agent_123",
+  "runId": "run_456",
+  "toolCallId": "call_abc",
+  "sequence": 18,
+  "phase": "completed",
+  "kind": "tool",
+  "tool": {
+    "name": "read_file",
+    "result": {
+      "path": "README.md",
+      "totalLines": 54
+    }
+  }
+}
+```
+
+Permission example:
+
+```json
+{
+  "type": "chat_event",
+  "provider": "opencode",
+  "sessionId": "ses_123",
+  "turnId": "turn_4",
+  "sequence": 51,
+  "phase": "started",
+  "kind": "permission",
+  "permission": {
+    "requestId": "perm_abc",
+    "tool": "bash",
+    "action": "run",
+    "choices": ["allow_once", "allow_always", "reject"]
+  }
+}
+```
+
+## Implementation Direction
+
+Keep the existing `ClaudeMessage` path for compatibility, but add a richer normalized event path alongside it.
+
+Suggested phases:
+
+1. Contract slice:
+   - Add a documented `chat_event` bridge marker, schema, and TypeScript type.
+   - Add identity, sequencing, phase, and parent-link invariants to the schema tests.
+   - Add a frontend accumulator/store that groups events by `turnId`, `stepId`, `blockId`, and `toolCallId`.
+   - Add shared streaming event capture for raw provider events, normalized `chat_event` records, and legacy markers.
+2. Fixture slice:
+   - Add hand-authored fixtures for text, thinking, tool lifecycle, permission, question, diff, terminal, task, and restored-history events.
+   - Add at least one captured-log fixture path that can replay either raw provider events through a normalizer or normalized events through the accumulator.
+   - Prove live-stream and restored-history parity with the same accumulator.
+3. Existing-provider proving slice:
+   - Keep existing provider adapters emitting current markers while the new path is introduced.
+   - Prove the new path with at least one existing provider surface, preferably Codex, because Codex already has structured `thread`, `turn`, and `item` lifecycle events in the current codebase.
+   - Keep Claude behavior unchanged initially; optionally wrap Claude stream events into the same model later.
+4. Opencode proving slice:
+   - Implement the minimal opencode send/stream/history path on top of `chat_event`.
+   - Cover opencode session/message/part identity, tool lifecycle, permission/question request IDs, diffs, and live/restored parity.
+   - Keep model discovery, agent discovery, slash commands, MCP display, usage statistics, and context recovery out of this slice unless explicitly required.
+5. Provider expansion slice:
+   - Add opencode model/agent discovery and optional UX surfaces after the event contract is proven.
+   - Use ACP and Cursor as design inputs for this preparatory work, not as required provider implementations in the infrastructure PR.
+   - Build later ACP-backed providers, such as Junie, as adapters onto this contract instead of adding a separate ACP-specific render model.
+
+Implementation slices should stay narrow. The failed opencode support experiment bundled core streaming, model discovery, agent discovery, slash commands, MCP display, usage statistics, context recovery, and multiple UI menu changes into one broad effort. The next attempt should prove the event contract first, then add discovery and UX surfaces as separate slices.
+
+## UX Goals
+
+- preserve text, thinking, and tool ordering without synthetic block-reset heuristics
+- render live streaming and restored history using the same structure
+- avoid provider-specific frontend merge hacks
+- represent tool calls as lifecycle events, not only as finished blocks
+- show pending, running, completed, and error tool states consistently
+- represent diffs as first-class events with clear scope
+- represent questions, permissions, plans, todos, usage updates, mode changes, terminal output, and subagent/task updates as structured UI events
+- avoid using `__turnId` for multiple unrelated concerns
+
+## Acceptance Criteria
+
+- A documented `chat_event` contract exists with required and optional fields, identity rules, sequencing rules, lifecycle phases, and supported event kinds.
+- Shared TypeScript types exist for the normalized event model and are covered by typecheck or schema tests.
+- A frontend accumulator/store can ingest ordered `chat_event` fixtures and produce stable render groups by `turnId`, `stepId`, `blockId`, and `toolCallId`.
+- Fixture tests cover text deltas, thinking deltas, interleaved tool lifecycle events, tool completion, diff/file-change events, permission/question events, plan updates, todo updates, terminal output references, usage updates, mode changes, and task/status updates.
+- Fixture tests prove that block ordering is preserved by explicit identity and `sequence`, not by assistant-message merge guesses.
+- Fixture tests prove that a live-style event stream and a restored-history-style event list can produce the same logical render groups.
+- A shared streaming event capture format exists and records raw provider events, normalized `chat_event` records, and legacy markers with stable sequence numbers.
+- Captured event logs are redacted by default and can be sanitized into deterministic replay fixtures.
+- At least one captured-log fixture can be replayed through a provider normalizer or frontend accumulator to reproduce a rendering issue.
+- Codex structured events can be mapped into `chat_event` fixtures or an adapter-level test without losing `thread`, `turn`, `item`, and tool lifecycle identity.
+- Opencode session/message/part events are mapped in documentation or adapter-level fixtures without losing part identity, tool lifecycle state, permission/question request IDs, diff scope, task metadata, or restored-history parity.
+- ACP `session/update` and `session/request_permission` examples can be mapped into `chat_event` fixtures or adapter-level tests without losing message chunk identity, `toolCallId`, tool status, diff content, terminal references, plan updates, mode changes, usage updates, or permission options.
+- The provider compatibility matrix identifies which event kinds and interface fields are needed by ACP, Cursor, opencode, and Codex, so additions are justified by concrete provider surfaces rather than opencode alone.
+- Existing Claude and Codex rendering behavior remains compatible while the new event path is introduced alongside the current `ClaudeMessage` path.
+- The infrastructure PR does not need to implement the full opencode provider, a generic ACP provider, Junie provider support, or Cursor provider support.
+- The implementation notes explain which opencode support experiment learnings are intentionally deferred, such as context recovery, MCP display, slash commands, and usage statistics.
+
+## Non-Goals
+
+- Do not implement Cursor provider support in this work.
+- Do not rewrite the entire chat UI at once.
+- Do not remove the existing `ClaudeMessage` compatibility path immediately.
+- Do not change provider authentication or model-selection behavior.
+- Do not require full opencode provider support in the same PR as the event infrastructure.
+- Do not implement a generic ACP provider or Junie provider support in this work.
+
+## Risks And Tradeoffs
+
+- This adds upfront infrastructure work before opencode's first complete integration.
+- During migration, adapters may emit both legacy markers and `chat_event` records.
+- The event model needs clear identity and sequencing rules or it will recreate the same merge problems in a new shape.
+- Simple providers will have slightly more structure than they strictly need, but they can emit a small subset of `chat_event` events.
+- Pulling every opencode support experiment feature into the first retry would repeat the failed experiment's scope problem.
+
+## Conclusion
+
+The previous architecture should be preserved where it helped: explicit provider adapters, provider routing, and permission translation. The render contract should change because opencode and other structured agents expose more than assistant text.
+
+The goal is lower long-term integration cost and higher correctness: one shared event model for live streaming, restored history, tools, permissions, questions, diffs, tasks, and future structured providers.
+
+The next opencode attempt should be treated as an event-contract proving slice first, not as a full provider-feature parity effort.

--- a/docs/opencode/PROVIDER-COMPATIBILITY-MATRIX.md
+++ b/docs/opencode/PROVIDER-COMPATIBILITY-MATRIX.md
@@ -1,0 +1,94 @@
+# Provider Compatibility Matrix
+
+## Purpose
+
+The proposed `chat_event` contract is not only an opencode requirement. ACP, Cursor, opencode, and Codex all expose structured runtime concepts that are awkward to preserve through a message-only render path.
+
+This matrix shows which proposed event kinds and interface additions are useful for each integration. It is intended to justify the shared event layer before implementing any single provider completely.
+
+Cells are intentionally conservative. If a concept exists only in one provider surface, an optional capability, an experimental API, or requires adapter synthesis, the cell is marked partial or optional rather than direct.
+
+## Legend
+
+| Icon | Value | Meaning |
+| --- | --- | --- |
+| ✓ | Direct | The provider or protocol has a native concept that maps directly for the base integration path. |
+| ◐ | Partial | The provider exposes related data, but at least one common path needs adapter mapping, synthesis, or fallback handling. |
+| ◇ | Optional | The concept is useful for some agents or modes, but not required for the base integration. |
+| × | Not core | The concept is not expected from the base integration. |
+
+## Provider Surface Summary
+
+| Integration | Structured surface | Why `chat_event` helps |
+| --- | --- | --- |
+| Generic ACP | `session/prompt`, `session/update`, `agent_message_chunk`, `tool_call`, `tool_call_update`, `session/request_permission` | ACP is already event-oriented. A shared event contract can map ACP without a provider-specific frontend renderer. |
+| Cursor | SDK `run.stream()` and `onDelta`, CLI `stream-json`, Cursor ACP and its `cursor/*` extension methods | Cursor exposes structured data across multiple surfaces, but the surfaces are not equivalent. For example, CLI `stream-json` suppresses thinking while the SDK exposes thinking deltas. |
+| Opencode | HTTP `/event`, `message.*`, `message.part.*`, `permission.*`, `question.*`, `todo.updated`, `session.diff`, session APIs | Opencode has session/message/part identity and shared event streams that should not be flattened too early. Its newer event surfaces also expose typed shell, step, text, reasoning, and tool lifecycle events. |
+| Codex | `codex exec --json` / SDK JSONL with `thread.*`, `turn.*`, `item.*`, `error`; app-server JSON-RPC for richer clients | Codex JSONL directly covers thread, turn, item, reasoning, command, file-change summary, MCP, web-search, todo, and usage concepts. Richer approvals, full diffs, plan deltas, user-input requests, and child-thread surfaces are app-server-specific or experimental. |
+
+## Event Kind Compatibility
+
+| `chat_event` kind | ACP | Cursor | Opencode | Codex | Interface value |
+| --- | --- | --- | --- | --- | --- |
+| `text` | ✓ `agent_message_chunk` | ✓ assistant events and text deltas | ✓ text parts and text deltas | ✓ agent message items | Replaces raw append-only text merging with block-scoped deltas. |
+| `thinking` | ✓ `agent_thought_chunk` | ◐ SDK thinking messages and deltas are direct, but CLI `stream-json` suppresses thinking | ✓ reasoning parts and reasoning deltas | ✓ reasoning items | Keeps reasoning separate from final answer text. |
+| `tool` | ✓ `tool_call`, `tool_call_update` | ✓ `tool_call`, partial tool-call deltas, completion events | ✓ tool parts, tool state, and newer tool lifecycle events | ✓ command, MCP, web-search, and other item lifecycle events | Adds stable `toolCallId`, lifecycle `phase`, and result state. |
+| `diff` | ✓ tool content can include diff content | ◐ write/edit surfaces expose file edits, but full diff metadata depends on Cursor surface and mode | ✓ `session.diff`, patch parts, and edit metadata | ◐ JSONL file-change items are summaries; app-server has richer diff notifications | Makes file changes first-class instead of reconstructing them from tool text. |
+| `terminal` | ◇ native only when the client advertises terminal capability | ◐ SDK exposes shell-output deltas, while CLI `stream-json` mainly reports shell/tool results | ◐ shell/PTY events exist, but current tool output may still need adapter mapping | ◐ command output is direct, but generic terminal stream/reference support is app-server-specific | Preserves terminal output as a stream/reference instead of a giant text block. |
+| `permission` | ✓ `session/request_permission` | ◐ Cursor ACP maps directly; SDK and CLI approval surfaces differ | ✓ `permission.asked` / `permission.replied` and v2 permission events | ◐ app-server approvals are structured, but SDK/CLI JSONL has no approval request event | Preserves provider request IDs, choices, and reply state. |
+| `question` | × no core question-request update | ◐ Cursor ACP has `cursor/ask_question`; other Cursor surfaces differ | ✓ `question.asked` / `question.replied` and v2 question events | ◇ app-server has experimental user-input request surfaces; JSONL has no core question item | Lets providers ask the user without faking a tool call. |
+| `plan` | ✓ `plan` updates, with complete replacement semantics | ◐ Cursor ACP has `cursor/create_plan` and product plan mode, but SDK/CLI plan output is surface-specific | ◐ planning agent and plan-like tool output, not a single stable plan event | ◐ app-server has plan notifications; SDK JSONL primarily exposes todo-list items | Gives planning UI a shared structure across providers. |
+| `todo` | × no core todo update separate from plan | ◐ Cursor ACP has `cursor/update_todos`; other surfaces are not equivalent | ✓ `todo.updated` | ✓ `todo_list` items | Avoids provider-specific todo rendering. |
+| `task` | × no core task/subagent session event | ✓ SDK task messages and Cursor ACP `cursor/task` | ✓ subtask parts and task/tool metadata when emitted | ◇ app-server subagent and child-thread surfaces exist; SDK JSONL has no base child-task item | Preserves child session/task identity without polluting root history. |
+| `usage` | ◇ native `usage_update`, but optional | ◐ token deltas, turn-ended usage, duration, and result metadata are surface-specific | ✓ step-finish tokens/cost and newer step-ended usage fields | ◐ `turn.completed.usage` and app-server token-usage notifications need normalization | Gives usage/cost UI one normalized source. |
+| `mode` | ◇ `current_mode_update` and session modes are optional/configurable | ◐ SDK/CLI/ACP support modes, but mode changes are mostly configuration rather than stream events | ◐ agent/model switch and plan/default mapping need adapter semantics | ◐ sandbox, permission, collaboration-mode, and effort settings are configuration/app-server concepts | Makes mode changes explicit instead of hidden in provider config. |
+| `status` | ◐ tool statuses are direct; prompt/session status is mostly inferred | ✓ run, step, and cloud status events | ✓ `session.status` and part/tool state | ✓ thread, turn, item lifecycle and error events | Provides one lifecycle model for running, idle, completed, and failed states. |
+
+## Interface Additions
+
+| Addition | ACP | Cursor | Opencode | Codex | Why it matters |
+| --- | --- | --- | --- | --- | --- |
+| `provider` and session identity | ◐ `sessionId` is direct; `provider` is adapter-assigned | ◐ agent/run/session IDs are direct by surface; `provider` is adapter-assigned | ◐ `sessionID` is direct; `provider` is adapter-assigned | ◐ `thread_id` / thread IDs are direct; `provider` is adapter-assigned | Required for routing, history lookup, event filtering, and replay. |
+| `turnId` and `runId` | ◐ prompt turns exist, but explicit turn/run IDs must be synthesized from JSON-RPC request context | ◐ SDK `run_id` is direct; CLI/ACP surfaces need mapping | ◐ synthesize from session and message flow | ◐ app-server has turn IDs, but exec JSONL does not expose a turn ID and has no run ID | Separates one user prompt from long-lived session history. |
+| `messageId`, `stepId`, `partId`, `blockId` | ◐ message identity is optional, so adapters may assign stable step/block IDs | ◐ run and step IDs exist in some SDK paths; message/block identity still needs mapping | ◐ `messageID` and `partID` are direct; UI block IDs still need mapping | ◐ `item.id` is direct; message/step/part/block IDs need mapping or synthesis | Prevents post-hoc merging from reordering text, tools, and snapshots. |
+| `toolCallId` | ✓ `toolCallId` on tool calls | ✓ `call_id` / `toolCallId` on tool events | ✓ `callID` on tool parts and permission-linked tools | ◐ command/MCP/web-search items have usable identity, but the adapter may need to synthesize one for item types without an explicit call ID | Correlates tool start, updates, result, permissions, and UI cards. |
+| Monotonic `sequence` | ◐ assign at adapter boundary | ◐ assign at adapter boundary | ◐ event IDs/timestamps exist, but replay-safe monotonic sequence should be assigned by the adapter | ◐ assign from JSONL or notification order | Makes replay deterministic and avoids timestamp-dependent rendering. |
+| Lifecycle `phase` | ◐ tool and plan statuses map directly; text and session phases need synthesis | ◐ SDK status and step updates map directly, but normalized phases still need adapter mapping | ◐ many part/tool states map directly, but snapshots and restored history may need phase synthesis | ✓ from turn and item lifecycle | Normalizes `started`, `delta`, `updated`, `completed`, and `failed`. |
+| `parentId` | ◐ parent links are not a stable core ACP primitive and may need synthesis | ◐ task/subagent and run-step relationships depend on the selected surface | ◐ session `parentID`, subtask, and tool-child data may need adapter correlation | ◐ app-server has some parent-thread linkage; SDK JSONL generally needs inference | Preserves nesting without provider-specific frontend logic. |
+| Permission request fields | ✓ `session/request_permission` carries session, tool call, and choices | ◐ Cursor ACP has request IDs and choices; SDK request surfaces may need adapter-specific correlation | ✓ permission events carry request/session/action and tool metadata | ◐ Codex approvals do not always expose the same request/choice shape | Standardizes request ID, action/tool, choices, and reply state. |
+| Diff metadata | ◐ ACP diff content has path/oldText/newText, while scope/source/hunks need adapter metadata | ◐ edit/diff metadata depends on Cursor surface and mode | ✓ `session.diff` carries file diffs and patch/edit metadata carries changed paths | ◐ SDK file-change metadata is summary-level; app-server has richer diff metadata | Preserves file identity, scope, source, hunks, and restored-history reconstruction. |
+| Task child session fields | × no core child-task session fields | ◐ Cursor task events include task and optional agent identity, but durable child-session identity depends on the selected surface | ◐ subtask/session metadata exists, but child session IDs are only present when emitted by the task surface | ◇ app-server subagent/child-thread surfaces exist; SDK JSONL has no base child-task session concept | Keeps child sessions linked without showing them as root history. |
+
+## Compatibility Impact
+
+The shared additions are not equally important for every provider, but they are reusable across enough structured providers to justify a common contract.
+
+High-value cross-provider additions:
+
+- stable identity fields: `sessionId`, `turnId`, `messageId`, `stepId`, `partId`, `blockId`, `toolCallId`
+- lifecycle fields: `sequence`, `phase`, `kind`, `parentId`
+- event kinds: `text`, `thinking`, `tool`, `diff`, `terminal`, `permission`, `plan`, `status`
+- surface-dependent event kinds: `question`, `todo`, `task`, `usage`, `mode`
+- replayable capture stages: `native_in`, `normalized_out`, `legacy_out`
+- live/restored history parity through the same accumulator
+
+Primary evidence checked:
+
+- ACP protocol docs and TypeScript SDK `SessionUpdate` schema.
+- Cursor TypeScript SDK docs, CLI `stream-json` docs, CLI parameters/usage docs, and Cursor ACP docs.
+- Local opencode source and generated SDK types under `/Users/moritz/Desktop/git/opencode`.
+- OpenAI Codex non-interactive docs, Codex TypeScript SDK event/item types, and Codex app-server README.
+
+Provider-specific additions should stay in adapters:
+
+- CLI or SDK process lifecycle
+- auth and local config discovery
+- model and agent discovery
+- provider-specific permission mode mapping
+- provider-native history lookup
+
+## Acceptance Use
+
+Preparatory work should be able to point at this matrix and show that each proposed `chat_event` field or event kind is needed by at least one target integration, and preferably by more than one.
+
+For the first infrastructure PR, the matrix does not require full ACP, Cursor, opencode, or Codex provider parity. It only requires enough fixtures or mapping sketches to prove that the shared event contract can represent their core structured events without provider-specific frontend merge hacks.

--- a/docs/opencode/README.md
+++ b/docs/opencode/README.md
@@ -1,0 +1,54 @@
+# Opencode Draft Docs
+
+This folder contains preparation notes for adding opencode as a first-class provider.
+
+## Status
+
+**Planning only. Nothing in this folder is implemented.**
+
+- There is no opencode code in this repository: no `ai-bridge/channels/opencode-channel.js`, no `ai-bridge/services/opencode/`, no Java `OpenCodeSDKBridge`, and no `@opencode-ai/sdk` dependency.
+- A previous marker-based integration experiment ([PR #1239](https://github.com/zhukunpenglinyutong/jetbrains-cc-gui/pull/1239)) was fully reverted. Its findings are captured in [LESSONS-LEARNED.md](./LESSONS-LEARNED.md).
+- The only remnant in the tree is a disabled provider entry in `webview/src/components/ChatInputBox/types.ts`.
+
+Current documents:
+
+- [Preparation: Provider-Neutral Chat Events](./PREPARATION.md)
+- [Opencode Integration Quickstart](./OPENCODE-INTEGRATION-QUICKSTART.md)
+- [Opencode Multi-Provider Architecture](./MULTI-PROVIDER-ARCHITECTURE.md)
+- [Provider Compatibility Matrix](./PROVIDER-COMPATIBILITY-MATRIX.md)
+- [Streaming Event Logs And Replay Fixtures](./STREAMING-EVENT-LOGS.md)
+- [Lessons From The Opencode Support Experiment](./LESSONS-LEARNED.md)
+
+## Purpose
+
+The immediate goal is not to document a finished opencode integration. The goal is to define the shared streaming and render infrastructure that should exist before the full provider lands.
+
+The main preparation question is whether opencode should be adapted directly into the existing Claude/Codex-compatible message markers, or whether the plugin should first add a provider-neutral `chat_event` layer for structured agent events.
+
+Current recommendation: proceed with opencode only after the shared `chat_event` contract, replayable event capture, frontend accumulator, and live/restored-history parity fixtures are defined. The first implementation slice should prove that contract with narrow streaming/history behavior before adding optional discovery, slash-command, MCP, usage, or recovery surfaces.
+
+## Open Questions
+
+Decisions that should be made (or at least owned) before implementation starts:
+
+1. **Opencode API surface**: target the current stable session/event API or the newer v2 API generation? Upstream is mid-migration; event names and route availability differ between generations (see the API surface caveat in [OPENCODE-INTEGRATION-QUICKSTART.md](./OPENCODE-INTEGRATION-QUICKSTART.md)). The SDK version must be pinned when this is decided.
+2. **`chat_event` transport**: the proposed default is a `[CHAT_EVENT] <json>` stdout marker line beside the existing markers (see [PREPARATION.md](./PREPARATION.md)). Confirm this against Java handler throughput before building the accumulator.
+3. **Accumulator ownership**: the accumulator lives in the webview; confirm whether Java stays a pass-through for `chat_event` lines or needs to parse them (e.g., for permission dialogs).
+4. **Schema evolution**: `chat_event` needs a version field or explicit compatibility rule before the first fixture is checked in, or replay fixtures will rot.
+5. **Existing-provider proving surface**: which Codex flow is wrapped first to prove the contract (live streaming, history restore, or both)?
+
+## Draft Structure
+
+This mirrors the useful shape of `docs/codex/` without copying upstream reference docs prematurely:
+
+- `README.md`: folder purpose, history context, and document index
+- `PREPARATION.md`: infrastructure proposal and acceptance criteria
+- `OPENCODE-INTEGRATION-QUICKSTART.md`: intended provider shape, implementation checklist, and smoke test
+- `MULTI-PROVIDER-ARCHITECTURE.md`: opencode-era provider architecture and shared event plane
+- `PROVIDER-COMPATIBILITY-MATRIX.md`: ACP, Cursor, opencode, and Codex mapping for proposed event/interface additions
+- `STREAMING-EVENT-LOGS.md`: replayable event logging format for debugging and fixture generation
+- `LESSONS-LEARNED.md`: findings from the failed opencode support implementation experiment, publicly referenced by [PR #1239](https://github.com/zhukunpenglinyutong/jetbrains-cc-gui/pull/1239)
+
+If opencode implementation proceeds, follow-up docs can be added in the same style as Codex:
+
+- focused debugging or troubleshooting notes when real issues appear

--- a/docs/opencode/STREAMING-EVENT-LOGS.md
+++ b/docs/opencode/STREAMING-EVENT-LOGS.md
@@ -1,0 +1,196 @@
+# Streaming Event Logs And Replay Fixtures
+
+## Purpose
+
+Streaming rendering bugs are hard to diagnose from screenshots or final messages. Provider integrations should be able to capture the exact event stream that produced a bad UI state, then turn that capture into a replayable test fixture.
+
+This should be part of the opencode preparation work and should apply to existing providers as well as new ones.
+
+## Goals
+
+- Capture raw provider events before normalization.
+- Capture normalized `chat_event` records after provider mapping.
+- Capture legacy markers while the compatibility path still exists.
+- Preserve event order with a monotonically increasing sequence number.
+- Redact secrets and volatile machine-specific data by default.
+- Make captured logs easy to promote into fixture tests.
+- Support both live-stream reproduction and restored-history reproduction.
+
+## Non-Goals
+
+- Do not log API keys, auth tokens, request headers, or raw environment variables.
+- Do not always persist logs; event capture should be opt-in or scoped to debug mode.
+- Do not make logs the primary storage format for user history.
+- Do not require every provider to expose identical raw event payloads.
+
+## Capture Points
+
+Each provider should support these capture stages where practical:
+
+| Stage | Meaning | Examples |
+| --- | --- | --- |
+| `native_in` | Raw provider event received by the bridge | opencode `/event`, Codex `item.completed`, Claude SDK event |
+| `normalized_out` | Provider event after mapping to `chat_event` | `kind: tool`, `phase: completed` |
+| `legacy_out` | Compatibility marker emitted for current handlers | `[CONTENT_DELTA]`, `[MESSAGE]` |
+| `handler_in` | Java handler receives marker or event | callback line or parsed message |
+| `render_in` | Webview accumulator receives event | optional frontend fixture capture |
+
+For the first infrastructure pass, `native_in`, `normalized_out`, and `legacy_out` provide the highest value.
+
+## Log Format
+
+Use newline-delimited JSON so logs can be streamed, sliced, redacted, and replayed without loading a large array.
+
+Each line should be one envelope:
+
+```json
+{
+  "schemaVersion": 1,
+  "captureId": "cap_2026_06_14_001",
+  "sequence": 42,
+  "timestamp": "2026-06-14T12:00:00.000Z",
+  "provider": "opencode",
+  "sessionId": "ses_123",
+  "turnId": "turn_1",
+  "stage": "normalized_out",
+  "eventType": "chat_event",
+  "payload": {
+    "type": "chat_event",
+    "kind": "tool",
+    "phase": "completed",
+    "toolCallId": "call_abc"
+  },
+  "redactions": []
+}
+```
+
+Recommended envelope fields:
+
+- `schemaVersion`: log format version.
+- `captureId`: stable ID shared by all lines from one captured run.
+- `sequence`: monotonic integer assigned by the bridge capture utility.
+- `timestamp`: ISO timestamp for diagnostics only; replay should use `sequence`.
+- `provider`: provider ID such as `claude`, `codex`, or `opencode`.
+- `sessionId`: provider session/thread ID when known.
+- `turnId`: normalized turn ID when known.
+- `stage`: capture stage.
+- `eventType`: native event type, marker name, or `chat_event`.
+- `payload`: captured event payload after redaction.
+- `redactions`: list of fields or patterns that were redacted.
+
+Optional fields:
+
+- `model`
+- `agent`
+- `permissionMode`
+- `cwdHash`
+- `projectHash`
+- `source`: file/module/function that emitted the capture line
+- `notes`: short diagnostic hint added by the capture utility
+
+## Redaction Rules
+
+Default redaction should remove or normalize:
+
+- API keys, auth tokens, cookies, passwords, and request headers.
+- Full environment maps.
+- Absolute home-directory paths, replaced with stable placeholders such as `<HOME>`.
+- Project root paths, replaced with `<PROJECT>`.
+- Temporary directory paths, replaced with `<TMP>`.
+- Large binary attachment payloads, replaced with metadata.
+- Very large tool outputs, truncated with original length preserved.
+
+Text content should not be blindly removed because rendering bugs often depend on exact text, whitespace, or ordering. Instead, fixture promotion should allow an explicit sanitization step when logs contain private content.
+
+## Replay Modes
+
+Captured logs should support at least two replay modes:
+
+1. `native_in` replay: feed raw provider events into the provider normalizer and assert produced `chat_event` records.
+2. `normalized_out` replay: feed `chat_event` records into the frontend accumulator and assert render groups.
+
+Legacy marker replay can remain useful during migration:
+
+3. `legacy_out` replay: feed compatibility markers into current Java/webview handlers and assert no regression.
+
+## Fixture Promotion
+
+A captured log should be convertible into a test fixture by removing volatile fields and keeping ordered payloads.
+
+Suggested workflow:
+
+1. Enable streaming event capture for a provider run.
+2. Reproduce the rendering issue.
+3. Save the captured JSONL file.
+4. Run a fixture sanitizer that removes timestamps, machine paths, capture IDs, and private text when needed.
+5. Check in the minimized fixture under provider-specific tests.
+6. Add a regression test that replays the fixture into the normalizer or accumulator.
+
+Example fixture shape:
+
+```json
+{
+  "name": "opencode-tool-result-before-text-boundary",
+  "provider": "opencode",
+  "source": "streaming-log",
+  "events": [
+    {
+      "sequence": 1,
+      "stage": "native_in",
+      "eventType": "message.part.delta",
+      "payload": { "field": "text", "text": "Running" }
+    },
+    {
+      "sequence": 2,
+      "stage": "normalized_out",
+      "eventType": "chat_event",
+      "payload": { "kind": "text", "phase": "delta", "text": "Running" }
+    }
+  ]
+}
+```
+
+## Provider Requirements
+
+Existing and new providers should use the same capture utility rather than ad hoc `console.log` debugging.
+
+Minimum requirement for each provider:
+
+- Capture raw incoming stream events at `native_in`.
+- Capture emitted `chat_event` records at `normalized_out`.
+- Capture emitted compatibility markers at `legacy_out` while those markers exist.
+- Share the same redaction utility.
+- Include capture tests that prove logs can be replayed or promoted into fixtures.
+
+## Opencode-Specific Notes
+
+For opencode, capture should start before session creation or prompt submission because `/event` is shared and the bridge subscribes before sending prompts.
+
+Useful raw events to capture:
+
+- `message.part.delta`
+- `message.part.updated`
+- `message.updated`
+- `permission.asked`
+- `permission.replied`
+- `question.asked`
+- `session.diff`
+- `session.error`
+
+Useful metadata to preserve:
+
+- opencode `sessionID`
+- message ID
+- part ID
+- tool call ID when available
+- permission/question request ID
+- child session ID for task/subagent runs
+
+## Acceptance Checks
+
+- A shared capture envelope schema is documented and versioned.
+- Capture can be enabled for Claude, Codex, and opencode without changing provider logic.
+- Captured logs contain raw provider events, normalized `chat_event` records, and legacy markers during migration.
+- Captured logs are redacted by default.
+- A captured log can be sanitized into a deterministic fixture.
+- At least one regression test replays a captured fixture into the normalizer or frontend accumulator.


### PR DESCRIPTION
After failing with [PR #1239](https://github.com/zhukunpenglinyutong/jetbrains-cc-gui/pull/1239), I tried to gather lessons learned and implementation ideas and collected them in similar fashion to what seems to have happened when the other agents (Codex, Claude) were integrated.

This can serve as both - a starting point for discussions about how to best integrate opencode as well as an implementation guide for when the actual implementation happens.

This is NOT a functional change, it only adds documentation and plans.