### PR TITLE
Fix bug with CLI-login mode

### DIFF
--- a/ai-bridge/config/api-config.js
+++ b/ai-bridge/config/api-config.js
@@ -233,10 +233,15 @@ export function buildWebviewControlledSettingsOverride(modelId) {
  *
  * @returns {boolean} true unless a cloud provider switch is active in settings.
  */
+
 function shouldHostManageProvider() {
+  if (getClaudeRuntimeState().access === 'cli_login') {
+    return false;
+  }
   const settings = loadClaudeSettings();
   return !CLOUD_PROVIDER_FLAGS.some((flag) => isEnvFlagEnabled(settings?.env?.[flag]));
 }
+
 
 /**
  * Build a clean env object for SDK child processes that identifies as CLI.


### PR DESCRIPTION
Claude code found and fixed this bug for me.  Here's what Claude said about it: 
shouldHostManageProvider() returns true for CLI-login mode whenever no
  cloud-provider flag (Bedrock/Vertex/Foundry) is set in settings.json, which is
  the common case. This causes buildCliEnv() to set
  CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1 even when the plugin isn't managing a
  provider at all — it's relying on the CLI's native OAuth login.

  That flag makes the CLI strip its own credential lookup, so authenticated users
  get Not logged in · Please run /login even with valid, unexpired OAuth
  credentials. Verified by isolating the flag: setting only
  CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1 against an otherwise-authenticated CLI
  session reproduces the failure; removing it restores normal login.

  Fixes #1327.