### PR TITLE
fix(webview): repair message-rendering glitches (lost user message, duplicated answer, hidden error)

### DIFF
--- a/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
@@ -159,7 +159,6 @@ public class ClaudeMessageHandler implements MessageCallback {
             return;
         }
 
-        boolean wasStreaming = isStreaming;
         isStreaming = false;
         streamEndedThisTurn = false;
         errorReportedThisTurn = true;
@@ -178,10 +177,21 @@ public class ClaudeMessageHandler implements MessageCallback {
 
         Message errorMessage = new Message(Message.Type.ERROR, error);
         state.addMessage(errorMessage);
+
+        // Signal stream-end BEFORE pushing the error snapshot, and do it
+        // unconditionally (not only when wasStreaming):
+        //  - Ordering: the webview's onStreamEnd cancels any pending
+        //    updateMessages rAF. If we pushed the error snapshot first, that
+        //    cancellation could drop it and the error would never render. Ending
+        //    the stream first lets the subsequent snapshot land normally.
+        //  - Unconditional: a non-streaming turn, or a turn that failed before
+        //    [STREAM_START], has wasStreaming=false — but its last tool_use may
+        //    still be unresolved. onStreamEnd is what marks dangling tool_use as
+        //    denied, so skipping it leaves the tool card spinning forever. The
+        //    webview side treats a no-active-stream onStreamEnd as exactly this
+        //    finalize-only case.
+        callbackHandler.notifyStreamEnd();
         callbackHandler.notifyMessageUpdate(state.getMessages());
-        if (wasStreaming) {
-            callbackHandler.notifyStreamEnd();
-        }
         callbackHandler.notifyStateChange(state.isBusy(), state.isLoading(), state.getError());
 
         // Show error in status bar

--- a/webview/src/hooks/windowCallbacks/__tests__/messageSync.test.ts
+++ b/webview/src/hooks/windowCallbacks/__tests__/messageSync.test.ts
@@ -366,10 +366,12 @@ describe('appendOptimisticMessageIfMissing', () => {
     expect(hasAttachment).toBe(true);
   });
 
-  it('does not append optimistic message when it is newer than everything in nextList (stale update)', () => {
-    // Simulates race condition: a stale backend update (from compaction)
-    // arrives after the user has already sent a new optimistic message.
-    // The stale update's newest timestamp is before the optimistic message.
+  it('keeps the optimistic user message when a lagging snapshot omits it entirely', () => {
+    // Regression for "my message disappears but the agent answers it": a snapshot
+    // (e.g. a background session_updated reload) arrives that does NOT yet contain
+    // the just-sent user message — every message in it predates the send. The
+    // optimistic bubble must be KEPT (not dropped) so the user still sees what
+    // they sent; a later snapshot containing the persisted message replaces it.
     const optimisticTime = Date.now();
     const staleTime = optimisticTime - 10000; // 10 seconds older
 
@@ -385,9 +387,10 @@ describe('appendOptimisticMessageIfMissing', () => {
     const next: ClaudeMessage[] = [staleAssistant];
 
     const result = appendOptimisticMessageIfMissing(prev, next);
-    // Stale update should NOT append the optimistic message
-    expect(result).toHaveLength(1);
+    // The snapshot has no user message with this text → keep the optimistic one.
+    expect(result).toHaveLength(2);
     expect(result[0]).toBe(staleAssistant);
+    expect(result[1]).toBe(optimistic);
   });
 
   it('matches backend user message when Java sends numeric timestamp (millis)', () => {
@@ -494,12 +497,12 @@ describe('appendOptimisticMessageIfMissing', () => {
     expect(result[0]).toBe(backendMsg);
   });
 
-  it('does not append optimistic when it is newer than all messages in nextList (stale update)', () => {
-    // When optimistic message timestamp is newer than the newest message in nextList,
-    // this indicates a stale update - the backend hasn't yet received the user message.
-    // Should NOT append to avoid showing duplicates.
+  it('does not append optimistic when a backend copy with the same text exists (timestamp skew)', () => {
+    // The snapshot DOES contain the backend copy of the just-sent message, but
+    // its timestamp skewed past the match window (clock skew / async delay). It
+    // must be recognized by CONTENT and NOT duplicated by appending the optimistic.
     const nowMs = Date.now();
-    const oldBackendTimestamp = nowMs - 10000; // 10 seconds older
+    const oldBackendTimestamp = nowMs - 10000; // 10 seconds older, outside window
 
     const optimistic = makeUserMsg('new message', {
       isOptimistic: true,
@@ -511,7 +514,6 @@ describe('appendOptimisticMessageIfMissing', () => {
       timestamp: '',
       raw: { timestamp: new Date(oldBackendTimestamp).toISOString() },
     };
-    // newerMsg is older than optimistic but newer than backendMsg
     const newerMsg: ClaudeMessage = {
       type: 'assistant',
       content: 'response',
@@ -521,7 +523,7 @@ describe('appendOptimisticMessageIfMissing', () => {
     const next = [newerMsg, backendMsg];
 
     const result = appendOptimisticMessageIfMissing(prev, next);
-    // Should NOT append because optimistic is newer than maxNextTime (stale update guard)
+    // Backend copy present by content → no duplicate appended.
     expect(result).toHaveLength(2);
     expect(result[0]).toBe(newerMsg);
     expect(result[1]).toBe(backendMsg);
@@ -847,6 +849,54 @@ describe('preserveLatestMessagesOnShrink', () => {
     expect(result[0]).toBe(compactSummary);
     expect(result[1]).toBe(historyUser);
   });
+
+  it('does NOT re-append a finalized streaming assistant the snapshot already contains (turn-id match)', () => {
+    // Regression for duplicated response: after a turn ends, the finalized bubble
+    // keeps its __turnId for the merge-guard window. A background reload snapshot
+    // that is transiently shorter must not have that assistant preserved on top of
+    // its own copy of the same turn.
+    const user = makeUserMsg('question', { timestamp: '2024-01-01T00:00:00.000Z' });
+    const finalizedAssistant = makeAssistantMsg('THE ANSWER', { __turnId: 7, isStreaming: false });
+    const prev = [user, finalizedAssistant]; // length 2
+
+    // Snapshot from reload: same turn present (backend copy, no __turnId), but the
+    // list is momentarily shorter (e.g. tool_result tail not flushed yet).
+    const snapshotAssistant = makeAssistantMsg('THE ANSWER');
+    const next = [snapshotAssistant]; // length 1 < 2, triggers shrink
+
+    const result = preserveLatestMessagesOnShrink(prev, next, 'claude');
+    // Must NOT duplicate the answer.
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(snapshotAssistant);
+  });
+
+  it('does NOT re-append a finalized assistant matched by text when turn ids differ', () => {
+    const user = makeUserMsg('question', { timestamp: '2024-01-01T00:00:00.000Z' });
+    const finalizedAssistant = makeAssistantMsg('duplicated answer', { __turnId: 12 });
+    const prev = [user, finalizedAssistant];
+
+    // Backend copy carries no __turnId; only the text identifies it.
+    const snapshotAssistant = makeAssistantMsg('duplicated answer');
+    const next = [snapshotAssistant];
+
+    const result = preserveLatestMessagesOnShrink(prev, next, 'claude');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(snapshotAssistant);
+  });
+
+  it('still preserves a tail assistant the snapshot does NOT contain', () => {
+    // Guard against over-dedup: a genuinely missing turn must still be preserved.
+    const user = makeUserMsg('question', { timestamp: '2024-01-01T00:00:00.000Z' });
+    const tailAssistant = makeAssistantMsg('unique tail answer', { __turnId: 9 });
+    const prev = [user, tailAssistant];
+
+    const unrelated = makeAssistantMsg('a completely different earlier answer');
+    const next = [unrelated]; // shorter, and does not contain the tail turn
+
+    const result = preserveLatestMessagesOnShrink(prev, next, 'claude');
+    expect(result).toHaveLength(2);
+    expect(result[1]).toBe(tailAssistant);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1020,6 +1070,32 @@ describe('ensureStreamingAssistantInList', () => {
     const prev = [makeUserMsg('q'), makeAssistantMsg('done', { isStreaming: false })];
     const result = [makeUserMsg('q')];
 
+    const { list, streamingIndex } = ensureStreamingAssistantInList(prev, result, false, 0);
+    expect(list).toBe(result);
+    expect(streamingIndex).toBe(-1);
+  });
+
+  it('does not duplicate when the snapshot copy matches by TEXT but lacks __turnId (primary path)', () => {
+    // Regression for duplicated response: the backend's persisted copy carries a
+    // fresh timestamp and no __turnId. A turn-id-only check would append the
+    // streaming bubble on top of it. Text match must recognize it as present.
+    const streamingMsg = makeAssistantMsg('THE ANSWER', { __turnId: 4, isStreaming: true });
+    const prev = [makeUserMsg('q'), streamingMsg];
+    const backendCopy = makeAssistantMsg('THE ANSWER', { timestamp: '2024-09-09T09:09:09.000Z' });
+    const result = [makeUserMsg('q'), backendCopy];
+
+    const { list, streamingIndex } = ensureStreamingAssistantInList(prev, result, true, 4);
+    expect(list).toBe(result);
+    expect(streamingIndex).toBe(1);
+  });
+
+  it('does not duplicate when the snapshot copy matches by TEXT but lacks __turnId (fallback path)', () => {
+    const streamingMsg = makeAssistantMsg('THE ANSWER', { __turnId: 8, isStreaming: true });
+    const prev = [makeUserMsg('q'), streamingMsg];
+    const backendCopy = makeAssistantMsg('THE ANSWER', { timestamp: '2024-09-09T09:09:09.000Z' });
+    const result = [makeUserMsg('q'), backendCopy];
+
+    // Refs cleared → fallback path.
     const { list, streamingIndex } = ensureStreamingAssistantInList(prev, result, false, 0);
     expect(list).toBe(result);
     expect(streamingIndex).toBe(-1);

--- a/webview/src/hooks/windowCallbacks/messageSync.ts
+++ b/webview/src/hooks/windowCallbacks/messageSync.ts
@@ -124,20 +124,30 @@ export const appendOptimisticMessageIfMissing = (
     }
   }
   if (matchedIndex < 0) {
-    // Guard against stale backend updates: if the optimistic message was
-    // created after the newest message in nextList, this update was
-    // generated before the user sent the message — a future update will
-    // include it. Don't append, otherwise the UI shows a duplicate until
-    // the real update arrives.
-    if (nextList.length > 0 && Number.isFinite(optimisticTime)) {
-      let maxNextTime = 0;
-      for (const m of nextList) {
-        const ts = getMessageTimestampMs(m) ?? 0;
-        if (Number.isFinite(ts) && ts > maxNextTime) {
-          maxNextTime = ts;
-        }
-      }
-      if (maxNextTime > 0 && optimisticTime > maxNextTime) {
+    // No timestamp-window match. Distinguish two cases by CONTENT, not by time:
+    //
+    // 1. The snapshot already contains a user message with identical text — that
+    //    IS the backend copy of this optimistic message, whose timestamp merely
+    //    skewed outside the match window. Appending would duplicate it, so drop
+    //    the optimistic bubble and let the backend copy stand.
+    //
+    // 2. The snapshot contains no user message with this text — the just-sent
+    //    message simply hasn't been persisted into this snapshot yet (the COMMON
+    //    case: snapshots are generated before the send lands, and even more so
+    //    now that a turn can be deferred behind an in-flight CLI run or a
+    //    background session_updated reload arrives mid-send). Keep the optimistic
+    //    bubble so the user's own message never vanishes while it's being
+    //    answered. A later snapshot that includes the persisted message matches
+    //    above and replaces it.
+    //
+    // The previous "optimistic is newer than everything in the snapshot" time
+    // heuristic could not tell these apart and dropped case 2 as well — that was
+    // the "my message disappears but the agent answers it" bug.
+    if (optimisticText) {
+      const backendCopyExists = nextList.some(
+        (m) => m.type === 'user' && getUserMessageComparableContent(m) === optimisticText,
+      );
+      if (backendCopyExists) {
         return nextList;
       }
     }
@@ -190,6 +200,33 @@ const getUserMessageComparableContent = (message: ClaudeMessage): string => {
     .map((block: any) => block.text)
     .join('\n');
   return rawText || message.content || '';
+};
+
+/**
+ * Extract comparable text from an assistant message for duplicate detection.
+ * Prefers the top-level `content` string; falls back to concatenating the text
+ * blocks in `raw` (object or JSON-string form). Trimmed; empty when no text.
+ */
+const getAssistantComparableContent = (message: ClaudeMessage): string => {
+  if (typeof message.content === 'string' && message.content.trim()) {
+    return message.content.trim();
+  }
+  let raw: unknown = message.raw;
+  if (typeof raw === 'string') {
+    try {
+      raw = JSON.parse(raw);
+    } catch {
+      return '';
+    }
+  }
+  const content = (raw as any)?.message?.content ?? (raw as any)?.content;
+  if (!Array.isArray(content)) return '';
+  const text = content
+    .filter((b: any) => b && typeof b === 'object' && b.type === 'text' && typeof b.text === 'string')
+    .map((b: any) => b.text)
+    .join('\n')
+    .trim();
+  return text;
 };
 
 /**
@@ -545,27 +582,54 @@ export const preserveLatestMessagesOnShrink = (
     return nextList;
   }
 
-  // FIX: Filter out optimistic messages from preservedTail if nextList already
-  // has a matching user message. This prevents duplicate display when compact
-  // sends a shorter list but includes the backend version of the optimistic.
+  // FIX: Filter out messages from preservedTail that nextList already contains,
+  // to avoid duplicate display when a shorter snapshot (compact / background
+  // reload) still carries its own copy of the tail turn.
   const nextListUserTexts = new Set<string>();
+  const nextListAssistantTurnIds = new Set<number>();
+  const nextListAssistantTexts = new Set<string>();
   for (const msg of nextList) {
     if (msg.type === 'user') {
       const text = getUserMessageComparableContent(msg);
       if (text) nextListUserTexts.add(text);
+    } else if (msg.type === 'assistant') {
+      if (typeof msg.__turnId === 'number' && msg.__turnId > 0) {
+        nextListAssistantTurnIds.add(msg.__turnId);
+      }
+      const text = getAssistantComparableContent(msg);
+      if (text) nextListAssistantTexts.add(text);
     }
   }
 
   const filteredTail = preservedTail.filter((msg) => {
-    // Always preserve assistant and other non-user messages
-    if (msg.type !== 'user') return true;
-    // Don't preserve optimistic if nextList has matching content
-    if (msg.isOptimistic) {
-      const optimisticText = getUserMessageComparableContent(msg);
-      if (optimisticText && nextListUserTexts.has(optimisticText)) {
-        return false; // Skip this optimistic to avoid duplicate
+    // Don't preserve optimistic user messages if nextList has matching content.
+    if (msg.type === 'user') {
+      if (msg.isOptimistic) {
+        const optimisticText = getUserMessageComparableContent(msg);
+        if (optimisticText && nextListUserTexts.has(optimisticText)) {
+          return false; // Skip this optimistic to avoid duplicate
+        }
       }
+      return true;
     }
+    // Don't re-append an assistant turn the snapshot already contains. A
+    // finalized streaming bubble keeps its __turnId for the merge-guard window,
+    // so hasStreamingTail pulls it into the preserved tail even though the same
+    // turn is already present in the (shorter) snapshot. Re-appending it renders
+    // the answer twice, and the __turnId merge-guard then refuses to collapse the
+    // two — so drop it here, matched by turn id or by identical text.
+    if (msg.type === 'assistant') {
+      if (typeof msg.__turnId === 'number' && msg.__turnId > 0
+          && nextListAssistantTurnIds.has(msg.__turnId)) {
+        return false;
+      }
+      const text = getAssistantComparableContent(msg);
+      if (text && nextListAssistantTexts.has(text)) {
+        return false;
+      }
+      return true;
+    }
+    // Preserve all other message types (tool results, notifications, …).
     return true;
   });
 
@@ -595,19 +659,25 @@ export const ensureStreamingAssistantInList = (
 ): { list: ClaudeMessage[]; streamingIndex: number } => {
   // Primary path: refs are still valid
   if (isStreaming && streamingTurnId > 0) {
-    const existingIdx = resultList.findIndex(
-      (m) => m.__turnId === streamingTurnId && m.type === 'assistant',
-    );
-    if (existingIdx >= 0) {
-      return { list: resultList, streamingIndex: existingIdx };
-    }
-
     let streamingAssistant: ClaudeMessage | undefined;
     for (let i = prevList.length - 1; i >= 0; i--) {
       if (prevList[i].__turnId === streamingTurnId && prevList[i].type === 'assistant') {
         streamingAssistant = prevList[i];
         break;
       }
+    }
+
+    // Match the current turn's assistant already in the snapshot by turn id OR by
+    // identical text — the backend's persisted copy carries no __turnId, so a
+    // turn-id-only check would miss it and append a duplicate.
+    const streamingText = streamingAssistant ? getAssistantComparableContent(streamingAssistant) : '';
+    const existingIdx = resultList.findIndex(
+      (m) => m.type === 'assistant'
+        && (m.__turnId === streamingTurnId
+          || (!!streamingText && getAssistantComparableContent(m) === streamingText)),
+    );
+    if (existingIdx >= 0) {
+      return { list: resultList, streamingIndex: existingIdx };
     }
 
     if (streamingAssistant) {
@@ -623,10 +693,14 @@ export const ensureStreamingAssistantInList = (
   for (let i = prevList.length - 1; i >= 0; i--) {
     const msg = prevList[i];
     if (msg.type === 'assistant' && msg.isStreaming && msg.__turnId && msg.__turnId > 0) {
+      const msgText = getAssistantComparableContent(msg);
       const alreadyPresent = resultList.some((m) => {
         if (m.type !== 'assistant') return false;
         if (m.__turnId === msg.__turnId) return true;
         if (msg.timestamp && m.timestamp === msg.timestamp) return true;
+        // Backend copy carries a fresh timestamp and no __turnId — match by text
+        // so the finalized bubble is not appended on top of its persisted copy.
+        if (msgText && getAssistantComparableContent(m) === msgText) return true;
         return false;
       });
       const assistantAlreadyAtOrAfterPosition =

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.test.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.test.ts
@@ -1,0 +1,259 @@
+/**
+ * streamingCallbacks.test.ts
+ *
+ * onStreamStart bubble routing:
+ * - a still-streaming assistant from an OLDER turn (dropped onStreamEnd) is
+ *   finalized and new deltas land on a fresh bubble;
+ * - a replay start REUSES the last assistant bubble — the stale-bubble
+ *   finalize must not hijack that path (it would strand the replayed turn's
+ *   earlier content in a duplicate bubble);
+ * - the normal path appends a fresh streaming bubble.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { registerStreamingCallbacks } from './streamingCallbacks';
+import type { UseWindowCallbacksOptions } from '../../useWindowCallbacks';
+import type { ClaudeMessage } from '../../../types';
+
+type Ref<T> = { current: T };
+const ref = <T,>(value: T): Ref<T> => ({ current: value });
+
+function createHarness(initialMessages: ClaudeMessage[], turnIdCounter: number) {
+  let messages = [...initialMessages];
+
+  const refs = {
+    streamingContentRef: ref(''),
+    streamingThinkingRef: ref(''),
+    isStreamingRef: ref(false),
+    useBackendStreamingRenderRef: ref(false),
+    autoExpandedThinkingKeysRef: ref(new Set<string>()),
+    streamingMessageIndexRef: ref(-1),
+    streamingTurnIdRef: ref(-1),
+    turnIdCounterRef: ref(turnIdCounter),
+    lastContentUpdateRef: ref(0),
+    contentUpdateTimeoutRef: ref<number | null>(null),
+    lastThinkingUpdateRef: ref(0),
+    thinkingUpdateTimeoutRef: ref<number | null>(null),
+    currentProviderRef: ref('claude'),
+  };
+
+  const options = {
+    ...refs,
+    setMessages: (updater: ClaudeMessage[] | ((prev: ClaudeMessage[]) => ClaudeMessage[])) => {
+      messages = typeof updater === 'function' ? updater(messages) : updater;
+    },
+    setStreamingActive: () => {},
+    setLoading: () => {},
+    setLoadingStartTime: () => {},
+    setIsThinking: () => {},
+    setExpandedThinking: () => {},
+    getOrCreateStreamingAssistantIndex: () => -1,
+    patchAssistantForStreaming: (message: ClaudeMessage) => message,
+  } as unknown as UseWindowCallbacksOptions;
+
+  registerStreamingCallbacks(options);
+  return { refs, getMessages: () => messages };
+}
+
+describe('onStreamStart bubble routing', () => {
+  beforeEach(() => {
+    window.__sessionTransitioning = false;
+  });
+
+  afterEach(() => {
+    // registerStreamingCallbacks starts a stall watchdog on stream start.
+    if (window.__stallWatchdogInterval != null) {
+      clearInterval(window.__stallWatchdogInterval);
+      window.__stallWatchdogInterval = null;
+    }
+  });
+
+  const olderTurnStreamingAssistant: ClaudeMessage = {
+    type: 'assistant',
+    content: 'partial answer from turn 1',
+    isStreaming: true,
+    __turnId: 1,
+  };
+
+  it('finalizes a still-streaming assistant from an older turn and opens a fresh bubble', () => {
+    const { refs, getMessages } = createHarness(
+      [{ type: 'user', content: 'q1' }, { ...olderTurnStreamingAssistant }],
+      1,
+    );
+
+    window.onStreamStart!();
+
+    const messages = getMessages();
+    expect(messages).toHaveLength(3);
+    // The orphaned bubble is closed with its content intact...
+    expect(messages[1].isStreaming).toBe(false);
+    expect(messages[1].content).toBe('partial answer from turn 1');
+    // ...and the new turn streams into a fresh bubble.
+    expect(messages[2].type).toBe('assistant');
+    expect(messages[2].isStreaming).toBe(true);
+    expect(messages[2].content).toBe('');
+    expect(messages[2].__turnId).toBe(2);
+    expect(refs.streamingMessageIndexRef.current).toBe(2);
+  });
+
+  it('replay start reuses the last assistant bubble even when it is a stale streaming one', () => {
+    // Regression: the stale-bubble finalize must not run before the replay
+    // branch. A replay re-delivers the last turn into the LAST bubble; adding
+    // a fresh bubble here would duplicate the partial content on screen.
+    const { refs, getMessages } = createHarness(
+      [{ type: 'user', content: 'q1' }, { ...olderTurnStreamingAssistant }],
+      1,
+    );
+
+    window.onStreamStart!('replay');
+
+    const messages = getMessages();
+    expect(messages).toHaveLength(2);
+    expect(messages[1].isStreaming).toBe(true);
+    expect(messages[1].content).toBe('partial answer from turn 1');
+    expect(messages[1].__turnId).toBe(2);
+    expect(refs.streamingMessageIndexRef.current).toBe(1);
+  });
+
+  it('appends a fresh streaming bubble on the normal path (last assistant already finalized)', () => {
+    const { refs, getMessages } = createHarness(
+      [
+        { type: 'user', content: 'q1' },
+        { type: 'assistant', content: 'finished answer', isStreaming: false, __turnId: 1 },
+      ],
+      1,
+    );
+
+    window.onStreamStart!();
+
+    const messages = getMessages();
+    expect(messages).toHaveLength(3);
+    expect(messages[1].isStreaming).toBe(false);
+    expect(messages[1].content).toBe('finished answer');
+    expect(messages[2].isStreaming).toBe(true);
+    expect(messages[2].__turnId).toBe(2);
+    expect(refs.streamingMessageIndexRef.current).toBe(2);
+  });
+
+  it('does not finalize history assistants without a __turnId', () => {
+    // History messages loaded from JSONL have no __turnId; they are never
+    // "streaming leftovers" of this webview instance and must be left as-is.
+    const { getMessages } = createHarness(
+      [{ type: 'assistant', content: 'history entry', isStreaming: true }],
+      1,
+    );
+
+    window.onStreamStart!();
+
+    const messages = getMessages();
+    expect(messages).toHaveLength(2);
+    expect(messages[0].isStreaming).toBe(true);
+    expect(messages[1].isStreaming).toBe(true);
+    expect(messages[1].__turnId).toBe(2);
+  });
+
+  it('reuses an EMPTY older streaming bubble instead of leaving a blank ghost', () => {
+    // Regression for duplicated/ghost bubbles: an empty streaming bubble from an
+    // older turn (a redundant STREAM_START, or one with no deltas yet) must be
+    // reused for the new turn — not finalized as a blank message with a fresh
+    // bubble appended after it.
+    const { refs, getMessages } = createHarness(
+      [
+        { type: 'user', content: 'q1' },
+        { type: 'assistant', content: '', isStreaming: true, __turnId: 1 },
+      ],
+      1,
+    );
+
+    window.onStreamStart!();
+
+    const messages = getMessages();
+    // No extra bubble: the empty placeholder is reused for turn 2.
+    expect(messages).toHaveLength(2);
+    expect(messages[1].type).toBe('assistant');
+    expect(messages[1].isStreaming).toBe(true);
+    expect(messages[1].content).toBe('');
+    expect(messages[1].__turnId).toBe(2);
+    expect(refs.streamingMessageIndexRef.current).toBe(1);
+  });
+
+  it('does not create a ghost bubble when onStreamStart fires twice with no deltas', () => {
+    // Duplicate STREAM_START delivery: two starts back-to-back before any delta.
+    // Must end with exactly one streaming bubble, not two.
+    const { refs, getMessages } = createHarness(
+      [{ type: 'user', content: 'q1' }],
+      0,
+    );
+
+    window.onStreamStart!(); // turn 1 bubble (empty)
+    window.onStreamStart!(); // duplicate — must reuse, not append
+
+    const messages = getMessages();
+    const assistantBubbles = messages.filter((m) => m.type === 'assistant');
+    expect(assistantBubbles).toHaveLength(1);
+    expect(assistantBubbles[0].isStreaming).toBe(true);
+    expect(assistantBubbles[0].__turnId).toBe(2);
+    expect(refs.streamingMessageIndexRef.current).toBe(1);
+  });
+});
+
+describe('onStreamEnd finalizes dangling tool_use when the turn never streamed', () => {
+  beforeEach(() => {
+    window.__sessionTransitioning = false;
+    window.__deniedToolIds = undefined;
+  });
+
+  afterEach(() => {
+    if (window.__stallWatchdogInterval != null) {
+      clearInterval(window.__stallWatchdogInterval);
+      window.__stallWatchdogInterval = null;
+    }
+    window.__deniedToolIds = undefined;
+  });
+
+  const assistantWithToolUse = (id: string): ClaudeMessage => ({
+    type: 'assistant',
+    content: '',
+    raw: { message: { content: [{ type: 'tool_use', id, name: 'Bash', input: { command: 'ls' } }] } },
+  });
+
+  it('marks an unresolved tool_use as denied on a non-streaming/error turn (skip mode)', () => {
+    // Reproduces "API request failed but the last tool just spins": the turn
+    // never streamed (isStreaming=false, turnId=-1 → skip mode), an assistant
+    // emitted a tool_use, and the error arrives before any tool_result. The
+    // tool must be marked denied so it stops spinning.
+    const { getMessages } = createHarness(
+      [{ type: 'user', content: 'run ls' }, assistantWithToolUse('tool-1')],
+      0,
+    );
+
+    // No onStreamStart happened; streaming refs are at their idle defaults.
+    window.onStreamEnd!();
+
+    expect(window.__deniedToolIds).toBeDefined();
+    expect(window.__deniedToolIds!.has('tool-1')).toBe(true);
+    // The list gets a new reference so the denied tool card re-renders.
+    expect(getMessages()).toHaveLength(2);
+  });
+
+  it('is a no-op when the tool_use already has a matching tool_result', () => {
+    const { getMessages } = createHarness(
+      [
+        { type: 'user', content: 'run ls' },
+        assistantWithToolUse('tool-2'),
+        {
+          type: 'user',
+          content: '[tool_result]',
+          raw: { message: { content: [{ type: 'tool_result', tool_use_id: 'tool-2', content: 'ok' }] } },
+        },
+      ],
+      0,
+    );
+    const before = getMessages();
+
+    window.onStreamEnd!();
+
+    // Nothing dangling → no id denied, and the list reference is unchanged.
+    expect(window.__deniedToolIds?.has('tool-2') ?? false).toBe(false);
+    expect(getMessages()).toBe(before);
+  });
+});

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
@@ -144,6 +144,24 @@ export function collectUnresolvedToolUseIds(
 const STREAM_STALL_TIMEOUT_MS = 60_000;
 const STREAM_STALL_CHECK_INTERVAL_MS = 5_000;
 
+/**
+ * Whether a streaming assistant bubble has any renderable content yet.
+ * An empty bubble (no text, no raw blocks) is an unfilled placeholder that can
+ * be safely reused for a new turn instead of being left behind as a ghost.
+ */
+function streamingBubbleHasContent(message: ClaudeMessage): boolean {
+  if (typeof message.content === 'string' && message.content.trim().length > 0) {
+    return true;
+  }
+  const raw = message.raw;
+  if (raw && typeof raw === 'object') {
+    const content = (raw as { message?: { content?: unknown }; content?: unknown }).message?.content
+      ?? (raw as { content?: unknown }).content;
+    if (Array.isArray(content) && content.length > 0) return true;
+  }
+  return false;
+}
+
 // Helper to measure total text length from raw blocks (for comparing completeness).
 // Handles both object and JSON string formats of raw.
 type TextBlock = { type: 'text'; text: string };
@@ -280,6 +298,50 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
         };
         return updated;
       }
+      // If the last streaming assistant belongs to an OLDER turn, its onStreamEnd
+      // was likely dropped (e.g., JCEF async chain breakage). Handle it so new
+      // deltas land on a fresh bubble rather than appending to the previous
+      // turn's message. This must stay BELOW the replay branch: a replay start
+      // reuses the last assistant bubble, and finalizing it here instead would
+      // strand the replayed turn's earlier content in a duplicate bubble.
+      if (last?.type === 'assistant' && last?.isStreaming) {
+        const lastTurnId = (last as { __turnId?: number }).__turnId;
+        const currentTurnId = streamingTurnIdRef.current;
+        if (typeof lastTurnId === 'number' && lastTurnId > 0 && lastTurnId < currentTurnId) {
+          // An EMPTY older streaming bubble is an unfilled placeholder — a
+          // duplicate/redundant STREAM_START, or a start that produced no deltas
+          // before the next one. Reuse it for this turn instead of finalizing it
+          // and appending a second bubble, which would leave a blank ghost behind
+          // (and, once the real content lands, read as a duplicated response).
+          if (!streamingBubbleHasContent(last)) {
+            const reused = [...prev];
+            reused[prev.length - 1] = {
+              ...last,
+              content: '',
+              isStreaming: true,
+              timestamp: new Date().toISOString(),
+              __turnId: currentTurnId,
+            };
+            streamingMessageIndexRef.current = prev.length - 1;
+            return reused;
+          }
+          // A non-empty older bubble carries real content from a turn whose
+          // stream-end was lost — finalize it and open a fresh bubble.
+          const finalized = [...prev];
+          finalized[prev.length - 1] = { ...last, isStreaming: false };
+          streamingMessageIndexRef.current = finalized.length;
+          return [
+            ...finalized,
+            {
+              type: 'assistant',
+              content: '',
+              isStreaming: true,
+              timestamp: new Date().toISOString(),
+              __turnId: currentTurnId,
+            },
+          ];
+        }
+      }
       streamingMessageIndexRef.current = prev.length;
       return [
         ...prev,
@@ -357,6 +419,30 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     scheduleThinkingRaf();
   };
 
+  // Mark any tool_use block that never received a tool_result as denied, so its
+  // card stops spinning. Runs against the current message list; a no-op on a
+  // fully-resolved turn. Used both on normal stream end and on the turn-ended-
+  // without-a-stream paths (errors, non-streaming turns) so a failed turn never
+  // leaves the agent's last tool hanging forever.
+  const finalizeUnresolvedToolUses = () => {
+    if (!window.__deniedToolIds) {
+      window.__deniedToolIds = new Set<string>();
+    }
+    setMessages((currentMessages) => {
+      try {
+        const interruptedIds = collectUnresolvedToolUseIds(currentMessages);
+        if (interruptedIds.length === 0) return currentMessages;
+        const denied = window.__deniedToolIds!;
+        for (const id of interruptedIds) denied.add(id);
+        // New array ref so the now-denied tool cards re-render out of "pending".
+        return [...currentMessages];
+      } catch (error) {
+        console.error('[Frontend] Failed to finalize unresolved tool ids:', error);
+        return currentMessages;
+      }
+    });
+  };
+
   window.onStreamEnd = (sequence?: string | number) => {
     if (window.__sessionTransitioning) return;
 
@@ -379,7 +465,13 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
       return;
     }
     if (handlingMode === 'skip') {
-      // Streaming refs already cleared by a previous onStreamEnd — nothing to do
+      // No active stream to finalize (refs already cleared by a prior
+      // onStreamEnd, OR the turn never streamed — a non-streaming turn or one
+      // that failed before [STREAM_START]). Either way, still mark any dangling
+      // tool_use as denied: on an errored/aborted turn the tool_result never
+      // arrives, and without this the last tool card spins forever. Idempotent
+      // (a no-op when everything is already resolved or already denied).
+      finalizeUnresolvedToolUses();
       return;
     }
 


### PR DESCRIPTION
Three user-reported display bugs in the chat transcript, each with a distinct root cause in the optimistic-add / streaming / snapshot-reconcile interaction. Diagnosed by tracing that flow end-to-end; every fix has regression tests.

Split out of the turn-accounting PR (#1410) so this frontend set (webview + one Java file) can be reviewed and merged independently. Note: #1410's backend gate widens the timing windows behind symptoms 1–2, so these two changes are complementary — merging this alongside (or ahead of) #1410 avoids a temporary UX regression, but each stands on its own.

## Bugs & fixes

**1. User message not shown though the agent answered it.**
`appendOptimisticMessageIfMissing` dropped the optimistic user bubble whenever it was newer than everything in the incoming snapshot — a time heuristic that cannot tell a genuinely stale snapshot from one that simply hasn't caught up (the common case: snapshots are generated before the just-sent message is persisted; a background `session_updated` reload can also land mid-send). Now decided by **content**: if the snapshot already contains a same-text user message it's the backend copy (drop, no dup); otherwise keep the optimistic bubble so the user's own message never vanishes.

**2. Agent response duplicated.**
- `preserveLatestMessagesOnShrink` re-appended a finalized streaming bubble (kept tagged with `__turnId` for the merge-guard window) on top of the same turn already present in a shorter reload snapshot. Now dedups tail assistants against the snapshot by `__turnId` or text.
- `onStreamStart` left a blank ghost bubble when an **empty** older streaming placeholder was finalized-and-appended (duplicate `STREAM_START`, or a start with no deltas). An empty placeholder is now reused for the new turn; only a non-empty orphaned bubble is finalized + replaced.
- `ensureStreamingAssistantInList` matched the snapshot copy only by `__turnId`/timestamp; the backend copy has neither, so it was appended as a duplicate. Now also matched by text, on both primary and fallback paths.

**3. "API request failed" not shown, last tool spins forever.**
- `ClaudeMessageHandler.onError` now signals stream-end **before** pushing the error snapshot (so the webview `onStreamEnd` rAF-cancel can't drop the error message) and does so unconditionally, not only when the turn was streaming.
- `onStreamEnd`'s no-active-stream path (a non-streaming turn, or a failure before `STREAM_START`) now still marks dangling `tool_use` as denied, so an errored turn's last tool card stops spinning instead of hanging.

## Tests

`messageSync.test.ts` +5, `streamingCallbacks.test.ts` +5. `npm run test` (vitest + tsc): full webview suite passing (722). `./gradlew checkstyleMain test`: passing. `./gradlew buildPlugin`: succeeds.
