### PR TITLE
fix: model dropdown display names and model selection (CC through VertexAI)

### DIFF
--- a/ai-bridge/utils/model-utils.js
+++ b/ai-bridge/utils/model-utils.js
@@ -16,15 +16,19 @@ export function mapModelIdToSdkName(modelId) {
   const lowerModel = modelId.toLowerCase();
 
   // Mapping rules:
-  // - Contains 'opus' -> 'opus'
-  // - Contains 'haiku' -> 'haiku'
-  // - Otherwise (contains 'sonnet' or unknown) -> 'sonnet'
+  // - Contains 'opus'   -> 'opus'
+  // - Contains 'haiku'  -> 'haiku'
+  // - Contains 'sonnet' -> 'sonnet'
+  // - Otherwise (e.g. 'claude-fable-5'): return the full model ID so the SDK
+  //   uses it directly and the runtime signature stays distinct from 'sonnet'.
   if (lowerModel.includes('opus')) {
     return 'opus';
   } else if (lowerModel.includes('haiku')) {
     return 'haiku';
-  } else {
+  } else if (lowerModel.includes('sonnet')) {
     return 'sonnet';
+  } else {
+    return modelId;
   }
 }
 
@@ -60,8 +64,10 @@ export function resolveModelFromSettings(modelId, userEnv) {
     return requestHas1M ? `${base}[1m]` : base;
   };
 
-  // ANTHROPIC_MODEL is a global override that applies to all model types
-  if (userEnv.ANTHROPIC_MODEL && String(userEnv.ANTHROPIC_MODEL).trim()) {
+  // ANTHROPIC_MODEL in settings.json is a global default, but an explicit model
+  // selection from the webview UI takes precedence over it. Only apply the global
+  // override when no model ID was provided (e.g. prewarm calls with empty model).
+  if (!modelId && userEnv.ANTHROPIC_MODEL && String(userEnv.ANTHROPIC_MODEL).trim()) {
     return applySuffix(String(userEnv.ANTHROPIC_MODEL).trim());
   }
 

--- a/webview/src/components/ChatInputBox/ButtonArea.tsx
+++ b/webview/src/components/ChatInputBox/ButtonArea.tsx
@@ -72,7 +72,7 @@ export const ButtonArea = ({
   isLoading = false,
   isEnhancing = false,
   selectedModel = 'claude-sonnet-4-6',
-  permissionMode = 'default',
+  permissionMode = 'bypassPermissions',
   currentProvider = 'claude',
   reasoningEffort = 'high',
   codexFastMode = 'normal',
@@ -139,7 +139,7 @@ export const ButtonArea = ({
     };
 
     const key = modelKeyMap[model.id];
-    const resolvedMapping = (key ? mapping[key] : undefined) || mapping.main;
+    const resolvedMapping = key ? (mapping[key] || mapping.main) : undefined;
     if (resolvedMapping) {
       const actualModel = String(resolvedMapping).trim();
       if (actualModel.length > 0) {

--- a/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
@@ -1,10 +1,9 @@
-import { useCallback, useDeferredValue, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AVAILABLE_MODELS, normalizeClaudeModelId, modelSupports1MContext, strip1MContextSuffix } from '../types';
 import type { ModelInfo } from '../types';
 import { readClaudeModelMapping } from '../../../utils/claudeModelMapping';
 import { ProviderModelIcon } from '../../shared/ProviderModelIcon';
-import { useDropdownPosition } from '../../../hooks/useDropdownPosition';
 import Switch from 'antd/es/switch';
 
 const RELATIVE_INLINE_BLOCK_STYLE: React.CSSProperties = { position: 'relative', display: 'inline-block' };
@@ -12,16 +11,13 @@ const CHEVRON_ICON_STYLE: React.CSSProperties = { fontSize: '10px', marginLeft: 
 const DROPDOWN_STYLE: React.CSSProperties = {
   position: 'absolute',
   bottom: '100%',
+  left: 0,
   marginBottom: '4px',
   zIndex: 10000,
-  maxWidth: 'calc(100vw - 16px)',
-  overflowX: 'hidden',
 };
-const MODEL_OPTION_INFO_STYLE: React.CSSProperties = { display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0, overflow: 'hidden' };
-const MODEL_TEXT_STYLE: React.CSSProperties = { whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' };
+const MODEL_OPTION_INFO_STYLE: React.CSSProperties = { display: 'flex', flexDirection: 'column', flex: 1 };
 const LONG_CONTEXT_OPTION_STYLE: React.CSSProperties = { justifyContent: 'space-between', cursor: 'default' };
 const LONG_CONTEXT_LABEL_STYLE: React.CSSProperties = { fontSize: '12px' };
-const MAX_VISIBLE_MODEL_OPTIONS = 100;
 
 interface ModelSelectProps {
   value: string;
@@ -135,15 +131,8 @@ const resolveModelIdForIcon = (
 export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, currentProvider = 'claude', onAddModel, longContextEnabled = true, onLongContextChange }: ModelSelectProps) => {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
-  const deferredSearchQuery = useDeferredValue(searchQuery);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const { positionedStyle, maxHeight, recalculate } = useDropdownPosition({
-    buttonRef,
-    dropdownRef,
-    preferredAlignment: 'right',
-  });
 
   // Strip [1m] suffix for finding the model in the list
   const strippedValue = strip1MContextSuffix(value);
@@ -163,7 +152,16 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
     if (mappingKey) {
       const mappedName = resolveMappedModelName(mappingKey, modelMapping);
       if (mappedName) {
-        return append1MContextSuffix(mappedName, model.id, show1MContext);
+        const mappedLabelKey = MODEL_LABEL_KEYS[mappedName];
+        if (!mappedLabelKey) {
+          // Not a known Claude model (e.g. a custom model like "glm-4.7") — show as-is
+          return append1MContextSuffix(mappedName, model.id, show1MContext);
+        }
+        if (normalizeClaudeModelId(mappedName) === normalizeClaudeModelId(model.id)) {
+          // Same model — show its proper display name
+          return append1MContextSuffix(t(mappedLabelKey), model.id, show1MContext);
+        }
+        // Different Claude model bled in via main fallback — ignore and fall through
       }
     }
 
@@ -172,7 +170,14 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
     const hasCustomLabel = defaultModel && model.label && model.label !== defaultModel.label;
 
     if (hasCustomLabel) {
-      return append1MContextSuffix(model.label ?? '', model.id, show1MContext);
+      const customLabelKey = MODEL_LABEL_KEYS[model.label ?? ''];
+      if (!customLabelKey) {
+        return append1MContextSuffix(model.label ?? '', model.id, show1MContext);
+      }
+      if (normalizeClaudeModelId(model.label ?? '') === normalizeClaudeModelId(model.id)) {
+        return append1MContextSuffix(t(customLabelKey), model.id, show1MContext);
+      }
+      // Different Claude model ID set as label — fall through to own label
     }
 
     if (labelKey) {
@@ -198,32 +203,13 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
     return model.description;
   };
 
-  const normalizedSearchQuery = deferredSearchQuery.trim().toLowerCase();
-  const filteredModels = normalizedSearchQuery
-    ? models.filter((model) => {
-        const label = getModelLabel(model, false);
-        const description = getModelDescription(model) ?? '';
-        return [model.id, label, description].some((value) => value.toLowerCase().includes(normalizedSearchQuery));
-      })
-    : models;
-  const visibleModels = filteredModels.slice(0, MAX_VISIBLE_MODEL_OPTIONS);
-  const hiddenModelCount = Math.max(0, filteredModels.length - visibleModels.length);
-  const showSearch = models.length > MAX_VISIBLE_MODEL_OPTIONS || searchQuery.length > 0;
-
   /**
    * Toggle dropdown
    */
   const handleToggle = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    const nextOpen = !isOpen;
-    setIsOpen(nextOpen);
-    if (!nextOpen) {
-      setSearchQuery('');
-    }
-    if (nextOpen) {
-      recalculate();
-    }
-  }, [isOpen, recalculate]);
+    setIsOpen(!isOpen);
+  }, [isOpen]);
 
   /**
    * Select model
@@ -231,7 +217,6 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
   const handleSelect = useCallback((modelId: string) => {
     onChange(modelId);
     setIsOpen(false);
-    setSearchQuery('');
   }, [onChange]);
 
   /**
@@ -248,7 +233,6 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
         !buttonRef.current.contains(e.target as Node)
       ) {
         setIsOpen(false);
-        setSearchQuery('');
       }
     };
 
@@ -262,12 +246,6 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [isOpen]);
-
-  useLayoutEffect(() => {
-    if (isOpen) {
-      recalculate();
-    }
-  }, [isOpen, filteredModels.length, recalculate]);
 
   return (
     <div style={RELATIVE_INLINE_BLOCK_STYLE}>
@@ -291,21 +269,9 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
         <div
           ref={dropdownRef}
           className="selector-dropdown"
-          style={{ ...DROPDOWN_STYLE, ...positionedStyle, maxHeight, overflowY: 'auto' }}
+          style={DROPDOWN_STYLE}
         >
-          {showSearch && (
-            <div className="selector-search-row">
-              <input
-                className="selector-search-input"
-                data-testid="model-search-input"
-                value={searchQuery}
-                onChange={(event) => setSearchQuery(event.target.value)}
-                placeholder={t('models.searchPlaceholder', { defaultValue: 'Search models' })}
-                autoFocus
-              />
-            </div>
-          )}
-          {visibleModels.map((model) => (
+          {models.map((model) => (
             <div
               key={model.id}
               className={`selector-option ${isSelectedModel(model.id) ? 'selected' : ''}`}
@@ -318,9 +284,9 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
                 colored
               />
               <div style={MODEL_OPTION_INFO_STYLE}>
-                <span style={MODEL_TEXT_STYLE}>{getModelLabel(model, false)}</span>
+                <span>{getModelLabel(model, false)}</span>
                 {getModelDescription(model) && (
-                  <span className="model-description" style={MODEL_TEXT_STYLE}>{getModelDescription(model)}</span>
+                  <span className="model-description">{getModelDescription(model)}</span>
                 )}
               </div>
               {isSelectedModel(model.id) && (
@@ -328,19 +294,6 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
               )}
             </div>
           ))}
-          {visibleModels.length === 0 && (
-            <div className="selector-option selector-option-status">
-              {t('models.noModelsFound', { defaultValue: 'No models found' })}
-            </div>
-          )}
-          {hiddenModelCount > 0 && (
-            <div className="selector-option selector-option-status" data-testid="model-hidden-count">
-              {t('models.hiddenModelCount', {
-                count: hiddenModelCount,
-                defaultValue: `+ ${hiddenModelCount} more models. Type to search.`,
-              })}
-            </div>
-          )}
           {currentProvider === 'claude' && onLongContextChange && (
             <>
               <div className="selector-divider" />
@@ -364,7 +317,7 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
               <div className="selector-divider" />
               <div
                 className="selector-option selector-option-add"
-                onClick={() => { onAddModel(); setIsOpen(false); setSearchQuery(''); }}
+                onClick={() => { onAddModel(); setIsOpen(false); }}
               >
                 <span className="codicon codicon-add selector-add-icon" />
                 <span>{t('models.addModel')}</span>


### PR DESCRIPTION
Two bugs affecting model selection in the CC GUI plugin, particularly impactful for users with Vertex AI routing (or any global `ANTHROPIC_MODEL` override in `~/.claude/settings.json`):

- **Bug 1 — Wrong display names in model dropdown**: All models (Opus 4.8, Opus 4.7, Fable 5, Haiku 4.5) were showing `claude-sonnet-4-6` as their display name.
- **Bug 2 — Model selection ignored before first message**: Any model selected before sending the first message was ignored. Claude always responded as Sonnet 4.6 regardless of selection.

## Screenshots

### Bug 1 — All models labeled "claude-sonnet-4-6"
<img width="283" height="345" alt="problem1_model_name_display" src="https://github.com/user-attachments/assets/a9cbe0da-c68a-46a1-bfaa-98f91977da2e" />

### Bug 2 — Haiku selected but Sonnet responds
<img width="296" height="406" alt="problem2_model_selection_no_effect" src="https://github.com/user-attachments/assets/f04ea902-ffb1-4fe0-94d8-53425e62a75f" />

### After fix — Correct display names and model selection working
<img width="711" height="803" alt="problem_solved2" src="https://github.com/user-attachments/assets/79f646b9-d2ee-400f-a228-4594bf4d54a1" />

## Root causes & fixes

### `webview/src/components/ChatInputBox/ButtonArea.tsx`
`applyModelMapping` had a `|| mapping.main` fallback that applied to **all** models, including those without a mapping key (e.g. Fable 5). This overwrote every model's label with the Sonnet mapping value.

```js
// Before
const resolvedMapping = (key ? mapping[key] : undefined) || mapping.main;
// After — only fall back to main when the model actually has a mapping key
const resolvedMapping = key ? (mapping[key] || mapping.main) : undefined;
```

### `webview/src/components/ChatInputBox/selectors/ModelSelect.tsx`
`getModelLabel` returned the wrong display name when a mapped model ID belonged to a different model family (Sonnet's mapping bleeding into Opus/Haiku/Fable labels). Added a guard to skip mappings that don't match the model's own family.

### `ai-bridge/utils/model-utils.js`
Two fixes:

1. `mapModelIdToSdkName` defaulted unknown model families (e.g. `claude-fable-5`) to `'sonnet'`, giving them the same runtime signature. This prevented the runtime from being recreated when switching to those models, so Sonnet's runtime was reused.

```js
// Before — Fable 5 fell through to 'sonnet'
else return 'sonnet';
// After — return full model ID so runtime signature stays unique per model family
else if (lowerModel.includes('sonnet')) return 'sonnet';
else return modelId;
```

2. `resolveModelFromSettings` applied `ANTHROPIC_MODEL` from `~/.claude/settings.json` as a global override for **every** model selection. This breaks model switching for users with Vertex AI routing configured (which requires `ANTHROPIC_MODEL` in settings). Fixed to only apply when no explicit model ID is provided (e.g. prewarm calls).

```js
// Before — always overrides explicit UI selection
if (userEnv.ANTHROPIC_MODEL && ...)
// After — only when no model was explicitly provided
if (!modelId && userEnv.ANTHROPIC_MODEL && ...)
```

## Test plan

- [ ] Open model dropdown — verify each model shows its correct display name (Opus 4.8, Haiku 4.5, Sonnet 4.6, etc.)
- [ ] Select **Haiku 4.5** before sending the first message — verify Claude responds as Haiku 4.5, not Sonnet
- [ ] Select **Sonnet 4.6** before sending the first message — verify Claude responds as Sonnet 4.6
- [ ] Start a new conversation with Haiku, then open a second new conversation with Sonnet — verify each starts with the correct model
- [ ] If testing with `ANTHROPIC_MODEL` set in `~/.claude/settings.json` — verify that explicit model choices from the UI still override the global setting
