### PR TITLE
fix(claude): rebuild runtime when switching into/out of Auto (bypassPermissions)

### DIFF
--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -632,6 +632,30 @@ export async function setPermissionModePersistent(params = {}) {
     return;
   }
 
+  // Entering or leaving Auto (bypassPermissions) cannot be applied live:
+  // allowDangerouslySkipPermissions is a process-launch argv flag frozen at
+  // spawn, and setPermissionMode() (a control request) can neither add nor
+  // remove it. Calling setPermissionMode here would log "applied" while the
+  // subprocess keeps prompting (or keeps skipping, when leaving Auto). So for a
+  // bypass-bit change, DON'T call setPermissionMode — invalidate the runtime
+  // signature so the next send_message rebuilds the runtime with the correct
+  // launch flag (mirrors buildRuntimeSignature's bypassPermissions bit). Update
+  // local state so the intent is recorded; the rebuild spawns fresh regardless.
+  const bypassBitChanged =
+    (targetPermissionMode === 'bypassPermissions')
+      !== (runtime.currentPermissionMode === 'bypassPermissions');
+  if (bypassBitChanged) {
+    runtime.runtimeSignature = '__rebuild-pending-bypass-change__';
+    runtime.currentPermissionMode = targetPermissionMode;
+    if (runtime.permissionModeState) {
+      runtime.permissionModeState.value = targetPermissionMode;
+    }
+    log(`setPermissionModePersistent: bypass bit changed to ${targetPermissionMode};`
+      + ` runtime marked for rebuild on next send sessionId=${sessionId || '(none)'}`
+      + ` epoch=${epoch || '(none)'}`);
+    return;
+  }
+
   // Push to the SDK first. Only update local state on success — otherwise the
   // PreToolUse hook would read the new mode while the SDK still enforces the
   // old one, diverging until the next turn's applyDynamicControls resyncs.

--- a/ai-bridge/services/claude/runtime-lifecycle.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.js
@@ -96,7 +96,17 @@ export function buildRuntimeSignature(options, systemPromptAppend, streamingEnab
     // the window in at spawn from its environment, and setModel() cannot change
     // it afterwards (see shouldRecreateRuntimeForModel) — so toggling [1m] must
     // change the signature and rebuild the runtime instead of reusing it.
-    contextWindow1M: (modelId || '').includes('[1m]')
+    contextWindow1M: (modelId || '').includes('[1m]'),
+    // bypassPermissions (Auto mode) requires allowDangerouslySkipPermissions,
+    // which the SDK passes as a process-launch argv flag — it is frozen at spawn
+    // and setPermissionMode() (a runtime control request) cannot add it to a
+    // live subprocess. So a runtime spawned in another mode keeps prompting via
+    // canUseTool even after switching to Auto. Put the bypass state in the
+    // signature so entering/leaving Auto rebuilds the runtime with the correct
+    // launch flag. The other modes (default/plan/acceptEdits) need no launch
+    // flag and keep applying live via setPermissionMode, so they intentionally
+    // do NOT change the signature.
+    bypassPermissions: options.permissionMode === 'bypassPermissions'
   };
   return JSON.stringify(material);
 }

--- a/ai-bridge/services/claude/runtime-lifecycle.test.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.test.js
@@ -572,4 +572,37 @@ test('acquireRuntime rebuilds the runtime when the [1m] context toggle changes',
   }
 });
 
+// ============================================================================
+// buildRuntimeSignature — bypassPermissions (Auto mode) rebuild
+// ============================================================================
+
+test('buildRuntimeSignature differs when entering/leaving bypassPermissions (Auto)', () => {
+  const base = { cwd: '/w', model: 'sonnet' };
+  const sigDefault = buildRuntimeSignature({ ...base, permissionMode: 'default' }, '', true, 'ep');
+  const sigAuto = buildRuntimeSignature({ ...base, permissionMode: 'bypassPermissions' }, '', true, 'ep');
+
+  // Entering Auto must change the signature so acquireRuntime rebuilds the
+  // runtime with allowDangerouslySkipPermissions at spawn.
+  assert.notEqual(sigDefault, sigAuto);
+  assert.match(sigDefault, /"bypassPermissions":false/);
+  assert.match(sigAuto, /"bypassPermissions":true/);
+});
+
+test('buildRuntimeSignature is stable across non-bypass mode changes (default/plan/acceptEdits apply live)', () => {
+  const base = { cwd: '/w', model: 'sonnet' };
+  const sigDefault = buildRuntimeSignature({ ...base, permissionMode: 'default' }, '', true, 'ep');
+  const sigPlan = buildRuntimeSignature({ ...base, permissionMode: 'plan' }, '', true, 'ep');
+  const sigAccept = buildRuntimeSignature({ ...base, permissionMode: 'acceptEdits' }, '', true, 'ep');
+
+  // These modes need no launch flag and are applied live via setPermissionMode,
+  // so they must NOT force a runtime rebuild.
+  assert.equal(sigDefault, sigPlan);
+  assert.equal(sigDefault, sigAccept);
+});
+
+test('buildRuntimeSignature treats a missing permissionMode as non-bypass', () => {
+  const sig = buildRuntimeSignature({ cwd: '/w', model: 'sonnet' }, '', true, 'ep');
+  assert.match(sig, /"bypassPermissions":false/);
+});
+
 console.log('\n✅ All TurnSink tests defined. Run with: node runtime-lifecycle.test.js');

--- a/ai-bridge/services/claude/setPermissionModePersistent.bypass.test.js
+++ b/ai-bridge/services/claude/setPermissionModePersistent.bypass.test.js
@@ -1,0 +1,107 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { setPermissionModePersistent, __testing } from './persistent-query-service.js';
+
+/**
+ * Tests for the live permission-mode switch's handling of the Auto
+ * (bypassPermissions) transition.
+ *
+ * Entering or leaving Auto cannot be applied to a running subprocess:
+ * allowDangerouslySkipPermissions is a spawn-time launch flag, and
+ * setPermissionMode() (a control request) can neither add nor remove it. So a
+ * bypass-bit change must NOT call setPermissionMode (which would falsely report
+ * "applied" while the subprocess keeps prompting / keeps skipping) — it must
+ * invalidate the runtime signature so the next send_message rebuilds the
+ * runtime with the correct launch flag. Non-bypass transitions keep applying
+ * live via setPermissionMode.
+ *
+ * This suite does not touch buildRequestContext/setupApiKey, so it is CI-safe
+ * without credentials.
+ */
+
+function createFakeRuntime(overrides = {}) {
+  const setPermissionModeCalls = [];
+  const mode = overrides.currentPermissionMode ?? 'default';
+  return {
+    closed: false,
+    sessionId: overrides.sessionId ?? 'sess-1',
+    runtimeSessionEpoch: 'epoch-1',
+    runtimeSignature: overrides.runtimeSignature ?? 'sig-original',
+    currentPermissionMode: mode,
+    permissionModeState: { value: mode },
+    inputStream: { done() {} },
+    query: {
+      setPermissionMode: async (m) => { setPermissionModeCalls.push(m); },
+    },
+    __setPermissionModeCalls: setPermissionModeCalls,
+    ...overrides.extra,
+  };
+}
+
+test.beforeEach(async () => {
+  await __testing.resetState();
+});
+
+test.after(async () => {
+  await __testing.resetState();
+});
+
+test('entering Auto marks the runtime for rebuild and does NOT call setPermissionMode', async () => {
+  const runtime = createFakeRuntime({ currentPermissionMode: 'default' });
+  __testing.setActiveTurnRuntime(runtime);
+
+  await setPermissionModePersistent({ sessionId: 'sess-1', permissionMode: 'bypassPermissions' });
+
+  assert.deepEqual(runtime.__setPermissionModeCalls, [],
+    'setPermissionMode must not be called for a bypass-bit change (the launch flag is frozen at spawn)');
+  assert.notEqual(runtime.runtimeSignature, 'sig-original',
+    'the runtime signature must be invalidated so the next send rebuilds with allowDangerouslySkipPermissions');
+  assert.equal(runtime.currentPermissionMode, 'bypassPermissions');
+  assert.equal(runtime.permissionModeState.value, 'bypassPermissions');
+});
+
+test('leaving Auto also marks the runtime for rebuild (flag cannot be removed live)', async () => {
+  const runtime = createFakeRuntime({ currentPermissionMode: 'bypassPermissions' });
+  __testing.setActiveTurnRuntime(runtime);
+
+  await setPermissionModePersistent({ sessionId: 'sess-1', permissionMode: 'default' });
+
+  assert.deepEqual(runtime.__setPermissionModeCalls, [],
+    'leaving Auto must not call setPermissionMode — the subprocess was spawned WITH the skip flag');
+  assert.notEqual(runtime.runtimeSignature, 'sig-original');
+  assert.equal(runtime.currentPermissionMode, 'default');
+});
+
+test('non-bypass transition (default -> acceptEdits) applies live via setPermissionMode, signature untouched', async () => {
+  const runtime = createFakeRuntime({ currentPermissionMode: 'default' });
+  __testing.setActiveTurnRuntime(runtime);
+
+  await setPermissionModePersistent({ sessionId: 'sess-1', permissionMode: 'acceptEdits' });
+
+  assert.deepEqual(runtime.__setPermissionModeCalls, ['acceptEdits'],
+    'modes that need no launch flag still switch live');
+  assert.equal(runtime.runtimeSignature, 'sig-original',
+    'a non-bypass switch must not force a runtime rebuild');
+  assert.equal(runtime.currentPermissionMode, 'acceptEdits');
+});
+
+test('non-bypass transition (plan -> acceptEdits) also stays live', async () => {
+  const runtime = createFakeRuntime({ currentPermissionMode: 'plan' });
+  __testing.setActiveTurnRuntime(runtime);
+
+  await setPermissionModePersistent({ sessionId: 'sess-1', permissionMode: 'acceptEdits' });
+
+  assert.deepEqual(runtime.__setPermissionModeCalls, ['acceptEdits']);
+  assert.equal(runtime.runtimeSignature, 'sig-original');
+});
+
+test('switching to the mode already active is a no-op (no call, no rebuild)', async () => {
+  const runtime = createFakeRuntime({ currentPermissionMode: 'bypassPermissions' });
+  __testing.setActiveTurnRuntime(runtime);
+
+  await setPermissionModePersistent({ sessionId: 'sess-1', permissionMode: 'bypassPermissions' });
+
+  assert.deepEqual(runtime.__setPermissionModeCalls, []);
+  assert.equal(runtime.runtimeSignature, 'sig-original', 'no rebuild when the mode did not change');
+});


### PR DESCRIPTION
Switching the permission Mode to **Auto (`bypassPermissions`)** mid-session has no effect: the agent keeps prompting for confirmation on every action, even after the switch and even on subsequent messages.

## Root cause

`bypassPermissions` requires `allowDangerouslySkipPermissions`, which the SDK passes to the CLI as a **process-launch argv flag frozen at spawn**. The live-switch path (`setPermissionMode()`) only sends a runtime `set_permission_mode` control request — it cannot add the flag to a subprocess that was launched without it. A runtime spawned in Default therefore keeps routing tool calls through `canUseTool` (the confirmation dialog) no matter how many times it is switched to Auto, because `permissionMode` was not part of the runtime signature, so `acquireRuntime` reused the same flag-less subprocess.

The full live-apply plumbing (webview `set_mode` → Java `setPermissionModeLive` → daemon `claude.setPermissionMode` → `runtime.query.setPermissionMode()`) is otherwise correct and works for the modes that need no launch flag.

## Fix

Mirrors the `[1m]`-context rebuild already in this codebase: put the bypass state in `buildRuntimeSignature`, so entering/leaving Auto changes the signature and `acquireRuntime` disposes and rebuilds the runtime with the correct launch flag. The other modes (`default`/`plan`/`acceptEdits`) need no launch flag and keep applying live via `setPermissionMode`, so they intentionally do NOT change the signature (no needless subprocess restart). Applies on the next send after the switch.

**Chosen over** unconditionally spawning with `allowDangerouslySkipPermissions` and gating purely via the PreToolUse hook: that would make Default-mode safety depend on an unverifiable assumption about how the CLI orders a hook `ask` decision against the launch flag (the flag is consumed inside the CLI bundle, which is extracted from bunfs and not readable), and a wrong guess silently disables confirmation. Rebuilding gives each mode the correct flag at spawn with no such assumption.

## Tests

`buildRuntimeSignature` changes on entering/leaving Auto and stays stable across `default`/`plan`/`acceptEdits`. Full `ai-bridge/**/*.test.js` passes.
