### PR TITLE
fix(session): render background-turn answers live by deferring reload to stream end

### DIFF
--- a/src/main/java/com/github/claudecodegui/session/StreamMessageCoalescer.java
+++ b/src/main/java/com/github/claudecodegui/session/StreamMessageCoalescer.java
@@ -79,6 +79,15 @@ public class StreamMessageCoalescer {
         JBCefBrowser getBrowser();
         boolean isDisposed();
         HandlerContext getHandlerContext();
+
+        /**
+         * Fired when the stream transitions to inactive (end of a turn's
+         * streaming segment). Lets the host run work that was deferred while the
+         * stream was active — e.g. a session_updated reload held back so it does
+         * not disturb the streaming bubble or race SessionState mutations.
+         * Default no-op so existing targets need not implement it.
+         */
+        default void onStreamEnded() {}
     }
 
     public StreamMessageCoalescer(JsCallbackTarget callbackTarget) {
@@ -125,6 +134,11 @@ public class StreamMessageCoalescer {
             streamActive = false;
             lastPayloadChars = 0;  // Reset so post-stream flush uses normal interval
         }
+        // Notify the host that the stream went inactive, so it can drain work
+        // deferred during streaming (e.g. a background session_updated reload).
+        // Done outside the lock: the host may synchronously schedule EDT work,
+        // and holding `lock` across a foreign callback risks lock-ordering issues.
+        callbackTarget.onStreamEnded();
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -86,6 +86,9 @@ public class ClaudeChatWindow {
     private final Object sessionReloadLock = new Object();
     private boolean sessionReloadInFlight = false;
     private boolean sessionReloadPending = false;
+    // A session_updated reload that arrived while a turn was streaming is parked
+    // here and drained at stream end (onStreamEnded). See {@link DeferredReload}.
+    private final DeferredReload deferredReload = new DeferredReload();
 
     private HandlerContext handlerContext;
     private MessageDispatcher messageDispatcher;
@@ -132,6 +135,11 @@ public class ClaudeChatWindow {
             @Override
             public HandlerContext getHandlerContext() {
                 return handlerContext;
+            }
+
+            @Override
+            public void onStreamEnded() {
+                ClaudeChatWindow.this.drainDeferredReload();
             }
         });
 
@@ -658,9 +666,14 @@ public class ClaudeChatWindow {
                         return;
                     }
 
-                    // Check if session has active turn in progress; skip reload if true
+                    // If a turn is streaming, DON'T reload now (clearMessages() off
+                    // the EDT would race the streaming append and disturb the live
+                    // bubble). DON'T drop it either, or a background-turn answer would
+                    // stay invisible until the user reopens the session. Park the id
+                    // and drain it at stream end (onStreamEnded).
                     if (sessionCallbackAdapter != null && streamCoalescer != null && streamCoalescer.isStreamActive()) {
-                        LOG.info("[ClaudeChatWindow] session_updated event received during active turn, skipping reload");
+                        deferredReload.defer(updatedSessionId);
+                        LOG.info("[ClaudeChatWindow] session_updated during active turn, deferring reload to stream end");
                         return;
                     }
 
@@ -710,6 +723,72 @@ public class ClaudeChatWindow {
             sessionReloadInFlight = true;
         }
         driveSessionReload(targetSessionId);
+    }
+
+    /**
+     * Run a session_updated reload that was deferred because a turn was
+     * streaming (see the session_updated handler). Called from the coalescer's
+     * onStreamEnded hook when the stream goes inactive — the safe point to
+     * reload, since SessionState is no longer being mutated by a streaming turn.
+     * A no-op when nothing was deferred. The reload still validates the target
+     * session before touching anything (driveSessionReload), so a session the
+     * user has navigated away from is never reloaded.
+     */
+    private void drainDeferredReload() {
+        String target = deferredReload.takeIfRunnable(disposed);
+        if (target == null) {
+            return;
+        }
+        LOG.info("[ClaudeChatWindow] draining deferred session_updated reload after stream end, sessionId=" + target);
+        requestSessionReload(target);
+    }
+
+    /**
+     * Coordinates a session_updated reload that arrived while a turn was
+     * streaming. Reloading mid-stream is unsafe: {@code loadFromServer()} runs
+     * {@code clearMessages()} on SessionState off the EDT, which would race the
+     * streaming append and disturb the live streaming bubble. So the target
+     * session id is parked here and drained at stream end (onStreamEnded),
+     * making background-turn answers appear at the next turn boundary instead of
+     * only after the user reopens the session.
+     *
+     * <p>Thread-safety: {@code defer} is called from the daemon event thread,
+     * {@code takeIfRunnable} from the coalescer's onStreamEnded hook; both are
+     * fully synchronized so a defer/drain interleave never loses or duplicates a
+     * pending reload. {@code take} atomically reads-clears-and-gates in one
+     * critical section (no read/clear window). Coalescing is last-writer-wins:
+     * overlapping background completions collapse into a single reload, which is
+     * correct because a reload always reflects the latest JSONL. Extracted as a
+     * static nested class so the coordination is unit-testable without a full
+     * ClaudeChatWindow (which needs a Project, JBCefBrowser, etc.).
+     */
+    static final class DeferredReload {
+        private String pendingSessionId;
+
+        /** Park a reload for {@code sessionId} (last writer wins). */
+        synchronized void defer(String sessionId) {
+            this.pendingSessionId = sessionId;
+        }
+
+        /**
+         * Atomically take-and-clear the parked reload, returning its target only
+         * when it should actually run: something was deferred AND the window is
+         * still alive. Returns {@code null} otherwise (and still clears, so a
+         * stale parked id from a disposed window is not left behind). The target
+         * is re-validated against the active session later in
+         * driveSessionReload(), so this only gates the coarse "is there anything
+         * to drain" question.
+         */
+        synchronized String takeIfRunnable(boolean disposed) {
+            String target = pendingSessionId;
+            pendingSessionId = null;
+            return (target != null && !disposed) ? target : null;
+        }
+
+        /** Visible for testing: whether a reload is currently parked. */
+        synchronized boolean hasPending() {
+            return pendingSessionId != null;
+        }
     }
 
     private void driveSessionReload(String targetSessionId) {

--- a/src/test/java/com/github/claudecodegui/session/StreamMessageCoalescerStreamEndHookTest.java
+++ b/src/test/java/com/github/claudecodegui/session/StreamMessageCoalescerStreamEndHookTest.java
@@ -1,0 +1,88 @@
+package com.github.claudecodegui.session;
+
+import com.github.claudecodegui.handler.core.HandlerContext;
+import com.intellij.ui.jcef.JBCefBrowser;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration tests for the {@code onStreamEnded()} host hook on the REAL
+ * {@link StreamMessageCoalescer} — the signal ClaudeChatWindow uses to drain a
+ * deferred background-turn reload at the safe point (stream inactive).
+ *
+ * <p>These drive the production coalescer (not a re-implementation), so they
+ * catch regressions in the actual onStreamStart/onStreamEnd lifecycle: the hook
+ * firing, the {@code streamActive} transition, and per-turn repetition.
+ */
+public class StreamMessageCoalescerStreamEndHookTest {
+
+    /** Minimal JsCallbackTarget that counts onStreamEnded() firings. */
+    private static final class CountingTarget implements StreamMessageCoalescer.JsCallbackTarget {
+        final AtomicInteger streamEndedCount = new AtomicInteger();
+
+        @Override public void callJavaScript(String functionName, String... args) {}
+        @Override public JBCefBrowser getBrowser() { return null; }
+        @Override public boolean isDisposed() { return false; }
+        @Override public HandlerContext getHandlerContext() { return null; }
+        @Override public void onStreamEnded() { streamEndedCount.incrementAndGet(); }
+    }
+
+    @Test
+    public void onStreamEndFiresHookAndClearsActive() {
+        CountingTarget target = new CountingTarget();
+        StreamMessageCoalescer coalescer = new StreamMessageCoalescer(target);
+        try {
+            coalescer.onStreamStart();
+            assertTrue("stream active after start", coalescer.isStreamActive());
+            assertEquals("hook not fired yet", 0, target.streamEndedCount.get());
+
+            coalescer.onStreamEnd();
+            assertFalse("stream inactive after end", coalescer.isStreamActive());
+            assertEquals("onStreamEnd fires the host hook exactly once", 1, target.streamEndedCount.get());
+        } finally {
+            coalescer.dispose();
+        }
+    }
+
+    @Test
+    public void hookFiresOncePerTurnAcrossMultipleTurns() {
+        // A long session fans out many turns; the deferred-reload drain must get
+        // a signal at EACH turn boundary, not just the first.
+        CountingTarget target = new CountingTarget();
+        StreamMessageCoalescer coalescer = new StreamMessageCoalescer(target);
+        try {
+            for (int i = 0; i < 5; i++) {
+                coalescer.onStreamStart();
+                coalescer.onStreamEnd();
+            }
+            assertEquals("hook fires once per turn", 5, target.streamEndedCount.get());
+            assertFalse(coalescer.isStreamActive());
+        } finally {
+            coalescer.dispose();
+        }
+    }
+
+    @Test
+    public void resetStreamStateClearsActiveWithoutFiringHook() {
+        // resetStreamState() (new-session / restart) also drops streamActive, but
+        // it is NOT a turn boundary — it must not fire the drain hook, or a reload
+        // could run against a session the user just navigated away from.
+        CountingTarget target = new CountingTarget();
+        StreamMessageCoalescer coalescer = new StreamMessageCoalescer(target);
+        try {
+            coalescer.onStreamStart();
+            assertTrue(coalescer.isStreamActive());
+
+            coalescer.resetStreamState();
+            assertFalse("reset clears active", coalescer.isStreamActive());
+            assertEquals("reset must NOT fire the drain hook", 0, target.streamEndedCount.get());
+        } finally {
+            coalescer.dispose();
+        }
+    }
+}

--- a/src/test/java/com/github/claudecodegui/ui/toolwindow/DeferredReloadTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/toolwindow/DeferredReloadTest.java
@@ -1,0 +1,166 @@
+package com.github.claudecodegui.ui.toolwindow;
+
+import org.junit.Test;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link ClaudeChatWindow.DeferredReload} — the coordinator that
+ * parks a session_updated reload arriving during an active stream and drains it
+ * at stream end.
+ *
+ * <p>Why this matters: reloading mid-stream runs {@code clearMessages()} on
+ * SessionState off the EDT, racing the streaming append and disturbing the live
+ * bubble; dropping the reload instead leaves a background-turn answer invisible
+ * until the user reopens the session. This coordinator is the fix, so its
+ * park / take-and-clear / gate / coalescing / thread-safety semantics are
+ * pinned down here.
+ */
+public class DeferredReloadTest {
+
+    // ── Park + take-and-clear ────────────────────────────────────────────────
+
+    @Test
+    public void deferThenTakeReturnsTargetAndClears() {
+        ClaudeChatWindow.DeferredReload d = new ClaudeChatWindow.DeferredReload();
+        assertFalse("nothing parked initially", d.hasPending());
+
+        d.defer("session-A");
+        assertTrue("defer parks a pending reload", d.hasPending());
+
+        assertEquals("take returns the parked target", "session-A", d.takeIfRunnable(false));
+        assertFalse("take clears the parked reload", d.hasPending());
+    }
+
+    @Test
+    public void secondTakeAfterDrainReturnsNull() {
+        ClaudeChatWindow.DeferredReload d = new ClaudeChatWindow.DeferredReload();
+        d.defer("session-A");
+        d.takeIfRunnable(false);
+
+        assertNull("a second drain with nothing parked returns null", d.takeIfRunnable(false));
+    }
+
+    @Test
+    public void takeWithNothingDeferredReturnsNull() {
+        ClaudeChatWindow.DeferredReload d = new ClaudeChatWindow.DeferredReload();
+        assertNull("draining an empty coordinator is a no-op", d.takeIfRunnable(false));
+    }
+
+    // ── Coalescing (last writer wins) ────────────────────────────────────────
+
+    @Test
+    public void overlappingDefersCollapseToLatest() {
+        // Several background completions arriving during one stream must collapse
+        // into a single reload reflecting the latest JSONL — not a burst of reloads.
+        ClaudeChatWindow.DeferredReload d = new ClaudeChatWindow.DeferredReload();
+        d.defer("session-A");
+        d.defer("session-B");
+        d.defer("session-C");
+
+        assertEquals("last writer wins", "session-C", d.takeIfRunnable(false));
+        assertFalse("all coalesced into one drain", d.hasPending());
+    }
+
+    // ── Disposed gate ────────────────────────────────────────────────────────
+
+    @Test
+    public void takeWhenDisposedReturnsNullButStillClears() {
+        // A disposed window must not run the reload — but the parked id must not
+        // be left behind either, or a later drain on a reused coordinator could
+        // resurrect it.
+        ClaudeChatWindow.DeferredReload d = new ClaudeChatWindow.DeferredReload();
+        d.defer("session-A");
+
+        assertNull("disposed window does not run the deferred reload", d.takeIfRunnable(true));
+        assertFalse("disposed take still clears the parked reload", d.hasPending());
+    }
+
+    @Test
+    public void deferAfterDisposedTakeCanStillRunWhenAlive() {
+        // Defensive: a fresh defer after a disposed-drain is independent.
+        ClaudeChatWindow.DeferredReload d = new ClaudeChatWindow.DeferredReload();
+        d.defer("stale");
+        d.takeIfRunnable(true); // disposed → dropped
+
+        d.defer("fresh");
+        assertEquals("a new defer is independent of the prior disposed drain",
+                "fresh", d.takeIfRunnable(false));
+    }
+
+    // ── Thread-safety: concurrent defer/take never loses or duplicates ───────
+
+    @Test
+    public void concurrentDeferAndTakeNeverLosesOrDuplicates() throws InterruptedException {
+        // Model the real interleave: the daemon event thread defers while the
+        // stream-end hook drains. Invariant: every id that is ever taken was
+        // deferred, and no id is taken twice. (Coalescing means not every
+        // deferred id is taken — that's fine; we assert no phantom/duplicate.)
+        final ClaudeChatWindow.DeferredReload d = new ClaudeChatWindow.DeferredReload();
+        final int rounds = 20_000;
+        final ConcurrentHashMap<String, Integer> takenCounts = new ConcurrentHashMap<>();
+        final AtomicInteger deferSeq = new AtomicInteger();
+        final CountDownLatch start = new CountDownLatch(1);
+        ExecutorService pool = Executors.newFixedThreadPool(3);
+
+        Runnable deferrer = () -> {
+            awaitQuietly(start);
+            for (int i = 0; i < rounds; i++) {
+                d.defer("s" + deferSeq.incrementAndGet());
+            }
+        };
+        Runnable drainer = () -> {
+            awaitQuietly(start);
+            for (int i = 0; i < rounds; i++) {
+                String t = d.takeIfRunnable(false);
+                if (t != null) {
+                    takenCounts.merge(t, 1, Integer::sum);
+                }
+            }
+        };
+
+        pool.submit(deferrer);
+        pool.submit(deferrer);
+        pool.submit(drainer);
+        start.countDown();
+        pool.shutdown();
+        assertTrue("workers finished", pool.awaitTermination(30, TimeUnit.SECONDS));
+
+        // Final drain to flush any last parked id.
+        String tail = d.takeIfRunnable(false);
+        if (tail != null) {
+            takenCounts.merge(tail, 1, Integer::sum);
+        }
+
+        // No id taken more than once (atomic take-and-clear).
+        for (var e : takenCounts.entrySet()) {
+            assertEquals("id " + e.getKey() + " must not be taken twice", Integer.valueOf(1), e.getValue());
+        }
+        // Every taken id was within the deferred range (no phantom ids).
+        int maxDeferred = deferSeq.get();
+        for (String id : takenCounts.keySet()) {
+            int n = Integer.parseInt(id.substring(1));
+            assertTrue("taken id " + id + " must be a real deferred id (<= " + maxDeferred + ")",
+                    n >= 1 && n <= maxDeferred);
+        }
+        assertFalse("coordinator is drained at the end", d.hasPending());
+    }
+
+    private static void awaitQuietly(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}


### PR DESCRIPTION
## Symptom

When the agent delegates a sub-agent to run in the **background** (a worktree / `run_in_background` Task), the user's messages and the assistant's replies are generated by the backend and persisted to the session JSONL, but are **not rendered live** in the chat. The user re-sends ("не вижу ответа" / "статус?") and still sees nothing until the session is reopened, at which point everything appears at once.

Diagnosed from a real session JSONL: every reply is present in the log (data is not lost), and prompts/replies are flushed together with near-identical timestamps when the long foreground turn finally ends — the classic signature of updates held back during a long stream.

## Root cause

A background sub-agent completing emits a `session_updated` event → `ClaudeChatWindow` reloads the session from JSONL. But the handler **skipped** the reload whenever a turn was streaming:

```java
if (streamCoalescer.isStreamActive()) { /* skipping reload */ return; }
```

During a long foreground turn that fans out background work, the stream stays active for a long time, so every background completion's reload is skipped and those answers stay invisible until the turn ends (or the user reopens the session).

The skip is not gratuitous: `loadFromServer()` runs `clearMessages()` on `SessionState` **off the EDT**, which would race the streaming append and disturb the live streaming bubble. So we must not reload mid-stream.

## Fix — defer, don't drop

Instead of dropping the reload during streaming, park it and run it at the safe point (stream end):

- `session_updated` during an active stream stores the target session id (`deferredReloadSessionId`) instead of returning early;
- `StreamMessageCoalescer` gains an `onStreamEnded()` host hook (default no-op), fired when the stream goes inactive;
- `ClaudeChatWindow.drainDeferredReload()` runs the deferred reload there — the point where `SessionState` is no longer being mutated by a stream.

Background-turn answers now appear at the **next turn boundary** instead of only after a manual reopen, with no mid-stream `clearMessages()` race and no disturbance to the streaming bubble. The reload target is still re-validated against the active session in `driveSessionReload()`, so a session the user navigated away from is never reloaded.

## Known limitation

Within a **single uninterrupted** long-streaming turn (no intermediate stream end), the background answer still waits until that turn ends. Fully-live mid-stream rendering would need an incremental, non-clearing merge path (read only the new inter-turn records and append without `clearMessages()`), which is a larger change and out of scope here.

## Not the turn-accounting PRs

This is pre-existing plugin behavior (the streaming-active reload skip), independent of the `cliTurnInFlight` turn-accounting work — that gate routes background output onto the inter-turn path and does not touch the webview loading/reload path.

## Tests

`shouldRunDeferredReload` gate extracted as a pure static (mirroring the existing `decideReloadCompletion` pattern) and covered: deferred+alive runs; nothing-deferred and disposed are no-ops. Full Java test suite (`./gradlew test`) + `checkstyleMain` pass.
