### PR TITLE
fix(webview): keep the permission mode across a plugin reinstall (stop boot from clobbering it)

### DIFF
--- a/webview/src/hooks/providers/useModelStatePersistence.test.ts
+++ b/webview/src/hooks/providers/useModelStatePersistence.test.ts
@@ -1,0 +1,98 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useModelStatePersistence, type UseModelStatePersistenceOptions } from './useModelStatePersistence';
+import type { PermissionMode } from '../../components/ChatInputBox/types';
+
+const sendBridgeEventMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../utils/bridge', () => ({
+  sendBridgeEvent: (...args: unknown[]) => sendBridgeEventMock(...args),
+}));
+
+function makeOptions(overrides: Partial<UseModelStatePersistenceOptions> = {}): UseModelStatePersistenceOptions {
+  return {
+    setCurrentProvider: vi.fn(),
+    setSelectedClaudeModel: vi.fn(),
+    setSelectedCodexModel: vi.fn(),
+    setClaudePermissionMode: vi.fn(),
+    setCodexPermissionMode: vi.fn(),
+    setPermissionMode: vi.fn(),
+    setLongContextEnabled: vi.fn(),
+    setReasoningEffort: vi.fn(),
+    setCodexFastMode: vi.fn(),
+    currentProvider: 'claude',
+    selectedClaudeModel: 'claude-sonnet-4-5',
+    selectedCodexModel: 'gpt-5-codex',
+    claudePermissionMode: 'default' as PermissionMode,
+    codexPermissionMode: 'default' as PermissionMode,
+    longContextEnabled: false,
+    reasoningEffort: 'medium',
+    codexFastMode: 'normal',
+    ...overrides,
+  };
+}
+
+function bridgeEventsFor(name: string): unknown[][] {
+  return sendBridgeEventMock.mock.calls.filter((c) => c[0] === name);
+}
+
+describe('useModelStatePersistence — boot sync does not clobber the persisted permission mode', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sendBridgeEventMock.mockClear();
+    (window as unknown as { sendToJava?: unknown }).sendToJava = () => {};
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (window as unknown as { sendToJava?: unknown }).sendToJava;
+  });
+
+  it('does NOT send set_mode on boot when localStorage was wiped (reinstall)', () => {
+    // Reinstall wipes JCEF localStorage → the hook would fall back to 'default'.
+    // Pushing that to Java on boot would clobber the app-level PropertiesComponent
+    // value (e.g. bypassPermissions) that survives the reinstall — the reported
+    // "reinstall forgets Auto" bug. Java is the source of truth via get_mode.
+    renderHook(() => useModelStatePersistence(makeOptions()));
+    vi.advanceTimersByTime(200); // fire the deferred syncToBackend
+
+    expect(bridgeEventsFor('set_mode')).toHaveLength(0);
+    // Provider/model/codex-fast are webview-owned and must still sync.
+    expect(bridgeEventsFor('set_provider')).toHaveLength(1);
+    expect(bridgeEventsFor('set_model')).toHaveLength(1);
+    expect(bridgeEventsFor('set_codex_fast_mode')).toHaveLength(1);
+  });
+
+  it('does NOT send set_mode on boot even when localStorage carries a non-default mode', () => {
+    // Even when the webview snapshot has a valid mode, Java is authoritative on
+    // boot (it may hold a newer value); the webview seeds itself from Java via
+    // get_mode → onModeReceived, so the boot path must never push the mode down.
+    localStorage.setItem('model-selection-state', JSON.stringify({
+      provider: 'claude',
+      claudePermissionMode: 'bypassPermissions',
+      permissionMode: 'bypassPermissions',
+    }));
+
+    renderHook(() => useModelStatePersistence(makeOptions()));
+    vi.advanceTimersByTime(200);
+
+    expect(bridgeEventsFor('set_mode')).toHaveLength(0);
+  });
+
+  it('retries the boot sync until the JCEF bridge is ready, still without set_mode', () => {
+    // Bridge not ready yet → the hook retries every 100ms. Mode must never leak
+    // into any of the retried sync attempts either.
+    delete (window as unknown as { sendToJava?: unknown }).sendToJava;
+    renderHook(() => useModelStatePersistence(makeOptions()));
+
+    vi.advanceTimersByTime(200); // first attempt: bridge missing → schedules retry
+    expect(sendBridgeEventMock).not.toHaveBeenCalled();
+
+    (window as unknown as { sendToJava?: unknown }).sendToJava = () => {};
+    vi.advanceTimersByTime(100); // retry now succeeds
+
+    expect(bridgeEventsFor('set_provider')).toHaveLength(1);
+    expect(bridgeEventsFor('set_mode')).toHaveLength(0);
+  });
+});

--- a/webview/src/hooks/providers/useModelStatePersistence.ts
+++ b/webview/src/hooks/providers/useModelStatePersistence.ts
@@ -201,7 +201,14 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
             ? restoredCodexModel
             : apply1MContextSuffix(restoredClaudeModel, restoredLongContextEnabled);
           sendBridgeEvent('set_model', modelToSync);
-          sendBridgeEvent('set_mode', initialPermissionMode);
+          // Do NOT push the permission mode to Java on boot. Java is the source
+          // of truth for the mode (persisted app-level in PropertiesComponent,
+          // which survives a plugin reinstall) and the webview seeds its own mode
+          // FROM Java via get_mode → onModeReceived. Our localStorage copy is
+          // wiped on reinstall, so pushing it here would clobber the surviving
+          // Java value with 'default' — the reported "reinstall forgets Auto" bug.
+          // The mode is only sent to Java on an explicit user switch
+          // (handleModeSelect → set_mode).
           sendBridgeEvent('set_codex_fast_mode', restoredCodexFastMode);
         } else {
           syncRetryCount++;


### PR DESCRIPTION
## Symptom

Reinstalling the plugin reset the permission **Mode** to Default even though the user had set **Auto**.

## Root cause

The mode lives in **two stores** that are not reconciled:
- **Java, app-level** `PropertiesComponent` (`claude.code.permission.mode`) — lives in the IDE config and **survives** a plugin reinstall. This is the source of truth.
- **webview localStorage** (`model-selection-state`) — JCEF browser storage that is **wiped on reinstall**.

On mount, `useModelStatePersistence` hydrated its mode from localStorage (falling back to `'default'` when the snapshot was wiped) and then pushed it to Java via `sendBridgeEvent('set_mode', ...)`. Java's `handleSetMode` writes that into `PropertiesComponent`, so the boot downsync **clobbered** the surviving Auto value with `'default'`. Java had already restored Auto correctly at startup (`ChatWindowDelegate.loadPermissionModeFromSettings` → `session.setPermissionMode`); the webview then overwrote it.

## Fix

Drop `set_mode` from the boot `syncToBackend`. Java is authoritative for the mode; the webview seeds its own mode **from** Java via `get_mode → onModeReceived`. The mode is pushed to Java only on an explicit user switch (`handleModeSelect → set_mode`). Provider/model/codex-fast-mode are webview-owned and still sync on boot.

## Tests

`renderHook` coverage (new `useModelStatePersistence.test.ts`): the boot sync sends `set_provider`/`set_model`/`set_codex_fast_mode` but **never** `set_mode` — with wiped localStorage, with a non-default mode still in localStorage, and across the bridge-not-ready retry path. Full webview suite + tsc pass.

## Related

This is the persistence half of the "Auto mode not working after reinstall" report. The other half — a live switch into/out of Auto needing a runtime rebuild so it actually stops/starts prompting — is in #1430 (ai-bridge). Together they make Auto both survive a reinstall and take effect on switch.
