### PR TITLE
fix(webview): show the user's message immediately when queued during a busy turn

### DIFF
--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -375,11 +375,30 @@ const App = () => {
     }
     // If loading, add to queue
     if (loading) {
+      // Render the message immediately as a queued optimistic bubble so the
+      // user sees it was accepted (instead of only a small queue chip). It is
+      // flagged isQueued; executeMessage activates this exact bubble when the
+      // queue drains (dedup by text), so it is never duplicated. A blank message
+      // still only goes to the queue (executeMessage would drop it anyway).
+      const queuedText = content.replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
+      if (queuedText) {
+        setMessages((prev) => [
+          ...prev,
+          {
+            type: 'user',
+            content: queuedText,
+            timestamp: new Date().toISOString(),
+            isOptimistic: true,
+            isQueued: true,
+            raw: { message: { content: [{ type: 'text', text: queuedText }] } },
+          },
+        ]);
+      }
       enqueueMessage(content, attachments);
       return;
     }
     hookHandleSubmit(content, attachments);
-  }, [loading, enqueueMessage, hookHandleSubmit, forceCreateNewSession, currentProvider, handleModeSelect, setCurrentView, addToast, t]);
+  }, [loading, enqueueMessage, hookHandleSubmit, forceCreateNewSession, currentProvider, handleModeSelect, setCurrentView, addToast, t, setMessages]);
 
   // ── Chat-view computations (stage 5 of TASK-P1-01) ──
   const {

--- a/webview/src/components/ChatInputBox/ChatInputBoxHeader.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBoxHeader.tsx
@@ -3,6 +3,7 @@ import type { Attachment, SelectedAgent, QueuedMessage } from './types.js';
 import { AttachmentList } from './AttachmentList.js';
 import { ContextBar } from './ContextBar.js';
 import { MessageQueue } from './MessageQueue.js';
+import { queueItemsNeedingChip } from '../../hooks/useMessageQueue';
 import { useUIState } from '../../contexts/UIStateContext';
 import { copyToClipboard } from '../../utils/copyUtils';
 
@@ -74,6 +75,10 @@ export function ChatInputBoxHeader({
     }
   };
 
+  // Only attachment-only queued messages (no transcript bubble) get a chip;
+  // text messages are already shown as queued bubbles in the transcript.
+  const chipQueue = queueItemsNeedingChip(messageQueue ?? []);
+
   return (
     <>
       {/* Open source banner */}
@@ -134,10 +139,16 @@ export function ChatInputBoxHeader({
         </div>
       )}
 
-      {/* Message queue */}
-      {messageQueue && messageQueue.length > 0 && (
+      {/* Message queue.
+          Only messages with NO text bubble are shown here: a queued message
+          with text is already rendered in the transcript as an optimistic
+          "queued" bubble (see App enqueue path + reconcileOptimisticUserMessage),
+          so showing it here too would duplicate it. Attachment-only queued
+          messages (empty text, no bubble) still surface here so they remain
+          visible and removable. */}
+      {chipQueue.length > 0 && (
         <MessageQueue
-          queue={messageQueue}
+          queue={chipQueue}
           onRemove={onRemoveFromQueue ?? (() => {})}
         />
       )}

--- a/webview/src/hooks/useMessageQueue.test.ts
+++ b/webview/src/hooks/useMessageQueue.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { queueItemsNeedingChip } from './useMessageQueue';
+import type { QueuedMessage } from './useMessageQueue';
+
+/**
+ * Tests for queueItemsNeedingChip — decides which queued messages still need the
+ * queue chip above the input. A queued message WITH text is already shown as an
+ * optimistic "queued" bubble in the transcript, so a chip would duplicate it;
+ * only attachment-only (empty-text) queued messages need the chip.
+ */
+
+const item = (content: string, extra: Partial<QueuedMessage> = {}): QueuedMessage => ({
+  id: `q-${content}`,
+  content,
+  queuedAt: 0,
+  ...extra,
+});
+
+describe('queueItemsNeedingChip', () => {
+  it('excludes queued messages with text (already shown as a bubble)', () => {
+    const queue = [item('run tests'), item('статус?')];
+    expect(queueItemsNeedingChip(queue)).toEqual([]);
+  });
+
+  it('keeps attachment-only queued messages (empty text, no bubble)', () => {
+    const attachmentOnly = item('', { attachments: [{ fileName: 'a.png', mediaType: 'image/png' } as never] });
+    const queue = [item('has text'), attachmentOnly];
+    const result = queueItemsNeedingChip(queue);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(attachmentOnly);
+  });
+
+  it('treats whitespace-only text as no bubble (keeps the chip)', () => {
+    const queue = [item('   ')];
+    expect(queueItemsNeedingChip(queue)).toHaveLength(1);
+  });
+
+  it('returns empty for an empty queue', () => {
+    expect(queueItemsNeedingChip([])).toEqual([]);
+  });
+
+  it('preserves order and only drops the text items', () => {
+    const a = item('');
+    const b = item('typed');
+    const c = item('  ');
+    expect(queueItemsNeedingChip([a, b, c])).toEqual([a, c]);
+  });
+});

--- a/webview/src/hooks/useMessageQueue.ts
+++ b/webview/src/hooks/useMessageQueue.ts
@@ -8,6 +8,17 @@ export interface QueuedMessage {
   queuedAt: number;
 }
 
+/**
+ * Queue items that are NOT already rendered as a transcript bubble and so still
+ * need the queue chip. A queued message WITH text is shown in the transcript as
+ * an optimistic "queued" bubble (App enqueue path), so its chip would duplicate
+ * it. An attachment-only message (empty text) has no bubble, so it must still
+ * surface in the chip to stay visible and removable.
+ */
+export function queueItemsNeedingChip(queue: QueuedMessage[]): QueuedMessage[] {
+  return queue.filter((item) => !item.content.trim());
+}
+
 export interface UseMessageQueueOptions {
   /** Whether AI is currently processing */
   isLoading: boolean;

--- a/webview/src/hooks/useMessageSender.reconcile.test.ts
+++ b/webview/src/hooks/useMessageSender.reconcile.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { reconcileOptimisticUserMessage } from './useMessageSender';
+import type { ClaudeContentBlock, ClaudeMessage } from '../types';
+
+/**
+ * Tests for reconcileOptimisticUserMessage — the dedup that lets a message
+ * queued while a turn is loading (shown immediately as an optimistic bubble so
+ * the user sees it, not just a chip) be activated in place when the queue
+ * drains, instead of appearing twice.
+ */
+
+const blocks = (text: string): ClaudeContentBlock[] => [{ type: 'text', text }];
+
+function queuedUser(text: string, extra: Partial<ClaudeMessage> = {}): ClaudeMessage {
+  return {
+    type: 'user',
+    content: text,
+    isOptimistic: true,
+    isQueued: true,
+    timestamp: '2026-01-01T00:00:00.000Z',
+    raw: { message: { content: blocks(text) } },
+    ...extra,
+  };
+}
+
+function sentUser(text: string): ClaudeMessage {
+  return {
+    type: 'user',
+    content: text,
+    isOptimistic: true,
+    timestamp: '2026-01-01T00:05:00.000Z',
+    raw: { message: { content: blocks(text) } },
+  };
+}
+
+describe('reconcileOptimisticUserMessage', () => {
+  it('appends normally when there is no queued bubble (immediate send)', () => {
+    const prev: ClaudeMessage[] = [{ type: 'assistant', content: 'hi' }];
+    const msg = sentUser('hello');
+
+    const result = reconcileOptimisticUserMessage(prev, msg, 'hello', blocks('hello'));
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toBe(msg);
+  });
+
+  it('activates the queued bubble in place instead of duplicating on drain', () => {
+    const queued = queuedUser('run the tests');
+    const prev: ClaudeMessage[] = [{ type: 'assistant', content: 'working' }, queued];
+    const msg = sentUser('run the tests');
+
+    const result = reconcileOptimisticUserMessage(prev, msg, 'run the tests', blocks('run the tests'));
+
+    // No duplicate: still 2 messages, the queued one activated (isQueued cleared).
+    expect(result).toHaveLength(2);
+    expect(result[1].type).toBe('user');
+    expect(result[1].content).toBe('run the tests');
+    expect((result[1] as { isQueued?: boolean }).isQueued).toBe(false);
+    expect(result[1].isOptimistic).toBe(true);
+    expect(result[1].timestamp).toBe(msg.timestamp); // refreshed to send time
+  });
+
+  it('activates the EARLIEST queued bubble with matching text (FIFO drain)', () => {
+    const first = queuedUser('статус?', { timestamp: 't1' });
+    const second = queuedUser('статус?', { timestamp: 't2' });
+    const prev: ClaudeMessage[] = [first, second];
+    const msg = sentUser('статус?');
+
+    const result = reconcileOptimisticUserMessage(prev, msg, 'статус?', blocks('статус?'));
+
+    // Only the first is activated; the second stays queued for its own drain.
+    expect(result).toHaveLength(2);
+    expect((result[0] as { isQueued?: boolean }).isQueued).toBe(false);
+    expect((result[1] as { isQueued?: boolean }).isQueued).toBe(true);
+  });
+
+  it('does not touch a queued bubble with different text; appends the new send', () => {
+    const queued = queuedUser('other question');
+    const prev: ClaudeMessage[] = [queued];
+    const msg = sentUser('new question');
+
+    const result = reconcileOptimisticUserMessage(prev, msg, 'new question', blocks('new question'));
+
+    expect(result).toHaveLength(2);
+    expect((result[0] as { isQueued?: boolean }).isQueued).toBe(true); // untouched
+    expect(result[1]).toBe(msg); // appended
+  });
+
+  it('matches by trimmed content (queued bubble text vs trimmed send text)', () => {
+    const queued = queuedUser('  spaced  '); // rendered with surrounding space
+    const prev: ClaudeMessage[] = [queued];
+    const msg = sentUser('spaced');
+
+    const result = reconcileOptimisticUserMessage(prev, msg, 'spaced', blocks('spaced'));
+
+    expect(result).toHaveLength(1);
+    expect((result[0] as { isQueued?: boolean }).isQueued).toBe(false);
+  });
+
+  it('ignores an already-activated (non-queued) optimistic bubble', () => {
+    // A prior optimistic user bubble that is NOT queued must not be re-used.
+    const activated = sentUser('done earlier');
+    const prev: ClaudeMessage[] = [activated];
+    const msg = sentUser('done earlier');
+
+    const result = reconcileOptimisticUserMessage(prev, msg, 'done earlier', blocks('done earlier'));
+
+    expect(result).toHaveLength(2); // appended, not merged
+  });
+});

--- a/webview/src/hooks/useMessageSender.ts
+++ b/webview/src/hooks/useMessageSender.ts
@@ -20,6 +20,44 @@ export const CONTEXT_COMMANDS = new Set(['/context']);
 // Hoisted regex to avoid creating new RegExp on every call
 const WHITESPACE_REGEX = /\s+/;
 
+/**
+ * Reconcile the optimistic user bubble when a message is actually sent.
+ *
+ * If the message was already rendered as a QUEUED optimistic bubble (the App
+ * enqueue path shows it immediately while a turn is loading, so the user sees
+ * their message instead of only a queue chip), activate that exact bubble
+ * (clear isQueued, refresh timestamp + raw blocks) instead of appending a
+ * duplicate when the queue drains. The earliest queued bubble with matching
+ * trimmed text is chosen, mirroring the FIFO queue drain order. When there is
+ * no queued bubble (a normal immediate send), the message is appended as usual.
+ *
+ * Exported for unit testing.
+ */
+export function reconcileOptimisticUserMessage(
+  prev: ClaudeMessage[],
+  userMessage: ClaudeMessage,
+  text: string,
+  userContentBlocks: ClaudeContentBlock[],
+): ClaudeMessage[] {
+  const queuedIdx = prev.findIndex(
+    (m) => m.type === 'user'
+      && m.isOptimistic
+      && (m as { isQueued?: boolean }).isQueued === true
+      && (m.content ?? '').trim() === text,
+  );
+  if (queuedIdx >= 0) {
+    const updated = [...prev];
+    updated[queuedIdx] = {
+      ...updated[queuedIdx],
+      isQueued: false,
+      timestamp: userMessage.timestamp,
+      raw: { message: { content: userContentBlocks } },
+    };
+    return updated;
+  }
+  return [...prev, userMessage];
+}
+
 function createContextUsageRequestId(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
@@ -354,7 +392,7 @@ export function useMessageSender({
       })));
     }
 
-    // Create and add user message (optimistic update)
+    // Create and add user message (optimistic update).
     const userMessage: ClaudeMessage = {
       type: 'user',
       content: text || '',
@@ -362,7 +400,7 @@ export function useMessageSender({
       isOptimistic: true,
       raw: { message: { content: userContentBlocks } },
     };
-    setMessages((prev) => [...prev, userMessage]);
+    setMessages((prev) => reconcileOptimisticUserMessage(prev, userMessage, text || '', userContentBlocks));
 
     // Set loading state
     setLoading(true);


### PR DESCRIPTION
## Symptom

While a turn is loading, a newly typed prompt was routed into the webview message queue and rendered only as a small pending **chip** — no chat bubble. During a long turn (e.g. a background-delegation session that keeps `loading` true for a long time), users saw nothing after hitting send, assumed the message was lost, and re-sent it ("не вижу свои сообщения").

## Fix

On the enqueue path (`App.tsx`, `if (loading)`), render the message right away as an **optimistic bubble flagged `isQueued`**, so the user immediately sees it was accepted. When the queue drains and `executeMessage` actually sends it, `reconcileOptimisticUserMessage` **activates that same bubble** (clears `isQueued`, refreshes timestamp + raw blocks) instead of appending a duplicate — matched by the earliest queued bubble with the same trimmed text (FIFO drain order).

A normal immediate send still appends as before; a blank message still only goes to the queue.

The dedup is extracted into the pure, exported `reconcileOptimisticUserMessage` so it is unit-testable without the full sender hook.

## Tests

`useMessageSender.reconcile.test.ts` (6): immediate send appends; drain activates the queued bubble in place (no duplicate); FIFO picks the earliest of same-text queued bubbles; a different-text queued bubble is untouched and the new send appends; trimmed-content matching; an already-activated (non-queued) optimistic bubble is not re-used. Full webview suite + tsc pass.

## Scope

This is the "user's own message not visible while busy" half of the background-delegation report. The complementary "background answers not visible live" half is #1431 (Java deferred reload).
