### PR TITLE
fix(usage): show turn cost and cache hits

### DIFF
--- a/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
@@ -6,6 +6,7 @@ import com.github.claudecodegui.notifications.ClaudeNotifier;
 import com.github.claudecodegui.provider.common.MessageCallback;
 import com.github.claudecodegui.provider.common.SDKResult;
 import com.github.claudecodegui.util.TokenUsageUtils;
+import com.github.claudecodegui.util.UsageCostCalculator;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -610,7 +611,12 @@ public class ClaudeMessageHandler implements MessageCallback {
                 // top-level turnUsage field for the per-turn token display in the webview.
                 // Distinct from message.usage below, which tracks per-call context occupancy
                 // for the status bar and must keep its semantics.
-                currentAssistantMessage.raw.add("turnUsage", resultJson.getAsJsonObject("usage").deepCopy());
+                JsonObject turnUsage = resultJson.getAsJsonObject("usage");
+                currentAssistantMessage.raw.add("turnUsage", turnUsage.deepCopy());
+                Double turnCostUsd = UsageCostCalculator.calculateTurnCostUsd(state.getProvider(), turnUsage, state.getModel());
+                if (turnCostUsd != null) {
+                    currentAssistantMessage.raw.addProperty("turnCostUsd", turnCostUsd);
+                }
 
                 // Fallback: only update usage from result if no usage was received via [USAGE] tag or assistant message
                 JsonObject msg = currentAssistantMessage.raw.has("message")
@@ -628,6 +634,7 @@ public class ClaudeMessageHandler implements MessageCallback {
                     callbackHandler.notifyUsageUpdate(usedTokens, maxTokens);
                     LOG.debug("Fallback: updated token usage from result message: " + usedTokens);
                 }
+                callbackHandler.notifyMessageUpdate(state.getMessages());
             }
         } catch (Exception e) {
             LOG.warn("Failed to parse result message: " + e.getMessage());

--- a/src/main/java/com/github/claudecodegui/session/CodexMessageHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/CodexMessageHandler.java
@@ -4,6 +4,7 @@ import com.github.claudecodegui.handler.CodexMessageConverter;
 import com.github.claudecodegui.provider.common.MessageCallback;
 import com.github.claudecodegui.provider.common.SDKResult;
 import com.github.claudecodegui.session.ClaudeSession.Message;
+import com.github.claudecodegui.util.UsageCostCalculator;
 import com.intellij.openapi.diagnostic.Logger;
 
 /**
@@ -299,15 +300,24 @@ public class CodexMessageHandler implements MessageCallback {
      * @since 1.0.0
      */
     private static com.google.gson.JsonObject buildTurnUsage(com.google.gson.JsonObject usage) {
-        int input = usage.has("input_tokens") ? usage.get("input_tokens").getAsInt() : 0;
-        int output = usage.has("output_tokens") ? usage.get("output_tokens").getAsInt() : 0;
-        int cacheRead = usage.has("cache_read_input_tokens") ? usage.get("cache_read_input_tokens").getAsInt() : 0;
+        int input = readInt(usage, "input_tokens");
+        int output = readInt(usage, "output_tokens");
+        int cacheRead = readInt(usage, "cache_read_input_tokens", "cached_input_tokens");
         com.google.gson.JsonObject turnUsage = new com.google.gson.JsonObject();
         turnUsage.addProperty("input_tokens", Math.max(0, input - cacheRead));
         turnUsage.addProperty("cache_creation_input_tokens", 0);
         turnUsage.addProperty("cache_read_input_tokens", cacheRead);
         turnUsage.addProperty("output_tokens", output);
         return turnUsage;
+    }
+
+    private static int readInt(com.google.gson.JsonObject json, String... keys) {
+        for (String key : keys) {
+            if (json.has(key) && !json.get(key).isJsonNull()) {
+                return Math.max(0, json.get(key).getAsInt());
+            }
+        }
+        return 0;
     }
 
     /**
@@ -383,6 +393,10 @@ public class CodexMessageHandler implements MessageCallback {
                 msg.raw.add("usage", usage);
                 if (turnUsage != null) {
                     msg.raw.add("turnUsage", turnUsage);
+                    Double turnCostUsd = UsageCostCalculator.calculateTurnCostUsd("codex", turnUsage, state.getModel());
+                    if (turnCostUsd != null) {
+                        msg.raw.addProperty("turnCostUsd", turnCostUsd);
+                    }
                 }
                 return true;
             }

--- a/src/main/java/com/github/claudecodegui/util/MessageJsonConverter.java
+++ b/src/main/java/com/github/claudecodegui/util/MessageJsonConverter.java
@@ -201,10 +201,13 @@ public class MessageJsonConverter {
         copyFieldIfPresent(raw, transport, "origin");
         // Whole-turn aggregated usage stamped by ClaudeMessageHandler.handleResult /
         // CodexMessageHandler.handleResultMessage, for the per-turn token display.
+        // Whole-turn estimated cost is calculated by the backend from the same pricing
+        // configuration used by Usage Statistics; the frontend only formats it.
         // Deliberately NOT copying the top-level usage or message.usage fields:
         // those carry per-call / session-cumulative values for the status bar and
         // would be misleading if rendered per message.
         copyFieldIfPresent(raw, transport, "turnUsage");
+        copyFieldIfPresent(raw, transport, "turnCostUsd");
 
         if (raw.has("content")) {
             transport.add("content", raw.get("content").deepCopy());

--- a/src/main/java/com/github/claudecodegui/util/UsageCostCalculator.java
+++ b/src/main/java/com/github/claudecodegui/util/UsageCostCalculator.java
@@ -1,0 +1,249 @@
+package com.github.claudecodegui.util;
+
+import com.github.claudecodegui.provider.CustomPricingProvider;
+import com.google.gson.JsonObject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Calculates estimated per-turn usage cost using the same pricing tables as usage statistics.
+ */
+public final class UsageCostCalculator {
+
+    private static final double ONE_MILLION = 1_000_000.0;
+
+    private static final long CLAUDE_TIER_THRESHOLD = 200_000;
+    private static final ClaudePricing CLAUDE_DEFAULT_PRICING = new ClaudePricing(3.0, 15.0, 3.75, 0.30);
+    private static final ClaudePricing CLAUDE_TIERED_SONNET_PRICING = new ClaudePricing(3.0, 15.0, 3.75, 0.30, 6.0, 22.5, 7.5, 0.60);
+    private static final ClaudePricing CLAUDE_LEGACY_OPUS_PRICING = new ClaudePricing(15.0, 75.0, 18.75, 1.50);
+    private static final ClaudePricing CLAUDE_OPUS_4_5_PRICING = new ClaudePricing(5.0, 25.0, 6.25, 0.50);
+    private static final ClaudePricing CLAUDE_FABLE_5_PRICING = new ClaudePricing(10.0, 50.0, 12.5, 1.0);
+    private static final ClaudePricing CLAUDE_HAIKU_4_5_PRICING = new ClaudePricing(1.0, 5.0, 1.25, 0.10);
+    private static final Map<String, ClaudePricing> CLAUDE_MODEL_PRICING = Map.ofEntries(
+            Map.entry("claude-opus-4", CLAUDE_LEGACY_OPUS_PRICING),
+            Map.entry("claude-opus-4-1", CLAUDE_LEGACY_OPUS_PRICING),
+            Map.entry("claude-opus-4-20250514", CLAUDE_LEGACY_OPUS_PRICING),
+            Map.entry("claude-opus-4-5", CLAUDE_OPUS_4_5_PRICING),
+            Map.entry("claude-opus-4-6", CLAUDE_OPUS_4_5_PRICING),
+            Map.entry("claude-opus-4-7", CLAUDE_OPUS_4_5_PRICING),
+            Map.entry("claude-opus-4-8", CLAUDE_OPUS_4_5_PRICING),
+            Map.entry("claude-fable-5", CLAUDE_FABLE_5_PRICING),
+            Map.entry("claude-sonnet-4", CLAUDE_TIERED_SONNET_PRICING),
+            Map.entry("claude-sonnet-4-20250514", CLAUDE_TIERED_SONNET_PRICING),
+            Map.entry("claude-sonnet-4-5", CLAUDE_TIERED_SONNET_PRICING),
+            Map.entry("claude-sonnet-4-6", CLAUDE_DEFAULT_PRICING),
+            Map.entry("claude-sonnet-5", CLAUDE_DEFAULT_PRICING),
+            Map.entry("claude-haiku-4", CLAUDE_HAIKU_4_5_PRICING),
+            Map.entry("claude-haiku-4-5", CLAUDE_HAIKU_4_5_PRICING)
+    );
+    private static final List<String> CLAUDE_MODEL_PREFIXES = List.of(
+            "claude-fable-5",
+            "claude-opus-4-20250514",
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+            "claude-opus-4-6",
+            "claude-opus-4-5",
+            "claude-opus-4-1",
+            "claude-opus-4",
+            "claude-sonnet-4-20250514",
+            "claude-sonnet-5",
+            "claude-sonnet-4-6",
+            "claude-sonnet-4-5",
+            "claude-sonnet-4",
+            "claude-haiku-4-5",
+            "claude-haiku-4"
+    );
+
+    private static final Pattern CODEX_SNAPSHOT_SUFFIX = Pattern.compile("-\\d{4}-\\d{2}-\\d{2}$");
+    private static final CodexPricing CODEX_DEFAULT_PRICING = new CodexPricing(1.25, 10.0, 0.125);
+    private static final Map<String, CodexPricing> CODEX_MODEL_PRICING = Map.ofEntries(
+            Map.entry("gpt-5", CODEX_DEFAULT_PRICING),
+            Map.entry("gpt-5.1", CODEX_DEFAULT_PRICING),
+            Map.entry("gpt-5-codex", CODEX_DEFAULT_PRICING),
+            Map.entry("gpt-5.1-codex", CODEX_DEFAULT_PRICING),
+            Map.entry("gpt-5.2-codex", new CodexPricing(1.75, 14.0, 0.175)),
+            Map.entry("gpt-5.4", new CodexPricing(2.5, 15.0, 0.25)),
+            Map.entry("gpt-5.4-mini", new CodexPricing(0.75, 4.5, 0.075))
+    );
+    private static final Map<String, String> CODEX_MODEL_ALIASES = Map.of(
+            "gpt-5-codex", "gpt-5",
+            "gpt-5.3-codex", "gpt-5.2-codex"
+    );
+    private static final List<String> CODEX_MODEL_PREFIXES = List.of(
+            "gpt-5.4-mini",
+            "gpt-5.4",
+            "gpt-5.3-codex",
+            "gpt-5.2-codex",
+            "gpt-5.1-codex",
+            "gpt-5-codex",
+            "gpt-5.1",
+            "gpt-5"
+    );
+
+    private UsageCostCalculator() {
+    }
+
+    public static Double calculateTurnCostUsd(String provider, JsonObject turnUsage, String model) {
+        if (turnUsage == null) {
+            return null;
+        }
+        long inputTokens = readLong(turnUsage, "input_tokens");
+        long outputTokens = readLong(turnUsage, "output_tokens");
+        long cacheWriteTokens = readLong(turnUsage, "cache_creation_input_tokens");
+        long cacheReadTokens = readLong(turnUsage, "cache_read_input_tokens", "cached_input_tokens");
+        if ("codex".equalsIgnoreCase(provider)) {
+            return calculateCodexTurnCost(inputTokens, outputTokens, cacheReadTokens, model);
+        }
+        return calculateClaudeCost(inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens, model);
+    }
+
+    private static Double calculateClaudeCost(
+            long inputTokens,
+            long outputTokens,
+            long cacheWriteTokens,
+            long cacheReadTokens,
+            String model
+    ) {
+        ClaudePricing pricing = resolveClaudePricing(model);
+        if (pricing == null) {
+            return null;
+        }
+        long requestTokens = inputTokens + outputTokens + cacheWriteTokens + cacheReadTokens;
+        return bill(inputTokens, pricing.inputRate(requestTokens))
+                + bill(outputTokens, pricing.outputRate(requestTokens))
+                + bill(cacheWriteTokens, pricing.cacheWriteRate(requestTokens))
+                + bill(cacheReadTokens, pricing.cacheReadRate(requestTokens));
+    }
+
+    private static Double calculateCodexTurnCost(long inputTokensExcludingCache, long outputTokens, long cacheReadTokens, String model) {
+        CodexPricing pricing = resolveCodexPricing(model);
+        if (pricing == null) {
+            return null;
+        }
+        return bill(inputTokensExcludingCache, pricing.inputCostPer1M)
+                + bill(outputTokens, pricing.outputCostPer1M)
+                + bill(cacheReadTokens, pricing.cacheReadCostPer1M);
+    }
+
+    private static ClaudePricing resolveClaudePricing(String model) {
+        ClaudePricing customPricing = resolveCustomClaudePricing(model);
+        if (customPricing != null) {
+            return customPricing;
+        }
+        String normalizedModel = normalizeClaudeModel(model);
+        return normalizedModel == null ? null : CLAUDE_MODEL_PRICING.get(normalizedModel);
+    }
+
+    private static ClaudePricing resolveCustomClaudePricing(String model) {
+        if (model == null || model.isBlank()) {
+            return null;
+        }
+        return CustomPricingProvider.getInstance().getPricing("claude", model)
+                .map(p -> new ClaudePricing(
+                        p.inputCostPer1M() != null ? p.inputCostPer1M() : CLAUDE_DEFAULT_PRICING.inputCostPer1M,
+                        p.outputCostPer1M() != null ? p.outputCostPer1M() : CLAUDE_DEFAULT_PRICING.outputCostPer1M,
+                        p.cacheWriteCostPer1M() != null ? p.cacheWriteCostPer1M() : CLAUDE_DEFAULT_PRICING.cacheWriteCostPer1M,
+                        p.cacheReadCostPer1M() != null ? p.cacheReadCostPer1M() : CLAUDE_DEFAULT_PRICING.cacheReadCostPer1M,
+                        null, null, null, null))
+                .orElse(null);
+    }
+
+    private static String normalizeClaudeModel(String model) {
+        if (model == null || model.isBlank()) {
+            return null;
+        }
+        return CLAUDE_MODEL_PREFIXES.stream()
+                .filter(model::startsWith)
+                .findFirst()
+                .orElse(model);
+    }
+
+    private static CodexPricing resolveCodexPricing(String model) {
+        CodexPricing customPricing = resolveCustomCodexPricing(model);
+        if (customPricing != null) {
+            return customPricing;
+        }
+        String normalizedModel = normalizeCodexModel(model);
+        return normalizedModel == null ? null : CODEX_MODEL_PRICING.get(normalizedModel);
+    }
+
+    private static CodexPricing resolveCustomCodexPricing(String model) {
+        if (model == null || model.isBlank()) {
+            return null;
+        }
+        return CustomPricingProvider.getInstance().getPricing("codex", model)
+                .map(p -> new CodexPricing(
+                        p.inputCostPer1M() != null ? p.inputCostPer1M() : CODEX_DEFAULT_PRICING.inputCostPer1M,
+                        p.outputCostPer1M() != null ? p.outputCostPer1M() : CODEX_DEFAULT_PRICING.outputCostPer1M,
+                        p.cacheReadCostPer1M() != null ? p.cacheReadCostPer1M() : CODEX_DEFAULT_PRICING.cacheReadCostPer1M))
+                .orElse(null);
+    }
+
+    private static String normalizeCodexModel(String model) {
+        if (model == null || model.isBlank()) {
+            return null;
+        }
+        String normalized = CODEX_MODEL_ALIASES.getOrDefault(CODEX_SNAPSHOT_SUFFIX.matcher(model).replaceFirst(""), model);
+        return CODEX_MODEL_PREFIXES.stream()
+                .filter(normalized::startsWith)
+                .findFirst()
+                .map(prefix -> CODEX_MODEL_ALIASES.getOrDefault(prefix, prefix))
+                .orElse(normalized);
+    }
+
+    private static double bill(long tokens, double ratePer1M) {
+        return (tokens / ONE_MILLION) * ratePer1M;
+    }
+
+    private static long readLong(JsonObject json, String... keys) {
+        if (json == null) {
+            return 0;
+        }
+        for (String key : keys) {
+            if (json.has(key) && !json.get(key).isJsonNull()) {
+                return Math.max(0, json.get(key).getAsLong());
+            }
+        }
+        return 0;
+    }
+
+    private record ClaudePricing(
+            double inputCostPer1M,
+            double outputCostPer1M,
+            double cacheWriteCostPer1M,
+            double cacheReadCostPer1M,
+            Double inputCostPer1MAbove200K,
+            Double outputCostPer1MAbove200K,
+            Double cacheWriteCostPer1MAbove200K,
+            Double cacheReadCostPer1MAbove200K
+    ) {
+        private ClaudePricing(double input, double output, double cacheWrite, double cacheRead) {
+            this(input, output, cacheWrite, cacheRead, null, null, null, null);
+        }
+
+        private double inputRate(long requestTokens) {
+            return rate(requestTokens, inputCostPer1M, inputCostPer1MAbove200K);
+        }
+
+        private double outputRate(long requestTokens) {
+            return rate(requestTokens, outputCostPer1M, outputCostPer1MAbove200K);
+        }
+
+        private double cacheWriteRate(long requestTokens) {
+            return rate(requestTokens, cacheWriteCostPer1M, cacheWriteCostPer1MAbove200K);
+        }
+
+        private double cacheReadRate(long requestTokens) {
+            return rate(requestTokens, cacheReadCostPer1M, cacheReadCostPer1MAbove200K);
+        }
+
+        private double rate(long requestTokens, double baseRate, Double tierRate) {
+            return requestTokens > CLAUDE_TIER_THRESHOLD && tierRate != null ? tierRate : baseRate;
+        }
+    }
+
+    private record CodexPricing(double inputCostPer1M, double outputCostPer1M, double cacheReadCostPer1M) {
+    }
+}

--- a/src/test/java/com/github/claudecodegui/session/ClaudeMessageHandlerResultUsageTest.java
+++ b/src/test/java/com/github/claudecodegui/session/ClaudeMessageHandlerResultUsageTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -31,18 +32,23 @@ import static org.junit.Assert.assertTrue;
 public class ClaudeMessageHandlerResultUsageTest {
 
     private ClaudeMessageHandler handler;
+    private SessionState state;
+    private RecordingCallback callback;
 
     @Before
     public void setUp() {
-        SessionState state = new SessionState();
+        state = new SessionState();
         MessageParser messageParser = new MessageParser();
         MessageMerger messageMerger = new MessageMerger();
         Gson gson = new GsonBuilder().create();
+        CallbackHandler callbackHandler = new CallbackHandler();
+        callback = new RecordingCallback();
+        callbackHandler.setCallback(callback);
 
         handler = new ClaudeMessageHandler(
                 null,
                 state,
-                new CallbackHandler(),
+                callbackHandler,
                 messageParser,
                 messageMerger,
                 gson
@@ -66,12 +72,29 @@ public class ClaudeMessageHandlerResultUsageTest {
         assertEquals(4096, turnUsage.get("cache_creation_input_tokens").getAsInt());
         assertEquals(363100, turnUsage.get("cache_read_input_tokens").getAsInt());
         assertEquals(4560, turnUsage.get("output_tokens").getAsInt());
+        assertEquals(0.19629, msg.raw.get("turnCostUsd").getAsDouble(), 0.000001);
 
         // The status-bar channel (message.usage = per-call context occupancy)
         // must keep the assistant message's own value, NOT the turn aggregate.
         JsonObject messageUsage = msg.raw.getAsJsonObject("message").getAsJsonObject("usage");
         assertEquals(37, messageUsage.get("input_tokens").getAsInt());
         assertEquals(353, messageUsage.get("output_tokens").getAsInt());
+    }
+
+    @Test
+    public void resultPushesMessageUpdateAfterStampingTurnUsage() throws Exception {
+        Message msg = newAssistantMessageWithUsage(37, 353);
+        setCurrentAssistantMessage(msg);
+        addMessageToState(msg);
+
+        invokeHandleResult("{\"type\":\"result\",\"subtype\":\"success\",\"usage\":{"
+                + "\"input_tokens\":1200,\"cache_creation_input_tokens\":4096,"
+                + "\"cache_read_input_tokens\":363100,\"output_tokens\":4560}}");
+
+        assertEquals(1, callback.messageUpdateCount);
+        assertEquals(1, callback.lastMessages.size());
+        assertTrue(callback.lastMessages.get(0).raw.has("turnUsage"));
+        assertTrue(callback.lastMessages.get(0).raw.has("turnCostUsd"));
     }
 
     @Test
@@ -91,6 +114,19 @@ public class ClaudeMessageHandlerResultUsageTest {
         // Must not throw even though there is no message to stamp.
         invokeHandleResult("{\"type\":\"result\",\"subtype\":\"success\",\"usage\":{"
                 + "\"input_tokens\":1200,\"output_tokens\":456}}");
+    }
+
+    @Test
+    public void resultDoesNotStampTurnCostWhenModelHasNoPricing() throws Exception {
+        state.setModel("custom-claude-without-pricing");
+        Message msg = newAssistantMessageWithUsage(37, 353);
+        setCurrentAssistantMessage(msg);
+
+        invokeHandleResult("{\"type\":\"result\",\"subtype\":\"success\",\"usage\":{"
+                + "\"input_tokens\":1200,\"output_tokens\":456}}");
+
+        assertTrue(msg.raw.has("turnUsage"));
+        assertFalse(msg.raw.has("turnCostUsd"));
     }
 
     // --- helpers -----------------------------------------------------------
@@ -127,5 +163,51 @@ public class ClaudeMessageHandlerResultUsageTest {
         Field field = ClaudeMessageHandler.class.getDeclaredField("currentAssistantMessage");
         field.setAccessible(true);
         field.set(handler, message);
+    }
+
+    private void addMessageToState(Message message) throws Exception {
+        Field field = ClaudeMessageHandler.class.getDeclaredField("state");
+        field.setAccessible(true);
+        SessionState state = (SessionState) field.get(handler);
+        state.addMessage(message);
+    }
+
+    private static final class RecordingCallback implements ClaudeSession.SessionCallback {
+        int messageUpdateCount = 0;
+        List<Message> lastMessages = List.of();
+
+        @Override
+        public void onMessageUpdate(List<Message> messages) {
+            messageUpdateCount++;
+            lastMessages = List.copyOf(messages);
+        }
+
+        @Override
+        public void onStateChange(boolean busy, boolean loading, String error) {
+        }
+
+        @Override
+        public void onSessionIdReceived(String sessionId) {
+        }
+
+        @Override
+        public void onPermissionRequested(com.github.claudecodegui.permission.PermissionRequest request) {
+        }
+
+        @Override
+        public void onThinkingStatusChanged(boolean isThinking) {
+        }
+
+        @Override
+        public void onSlashCommandsReceived(List<String> slashCommands) {
+        }
+
+        @Override
+        public void onNodeLog(String log) {
+        }
+
+        @Override
+        public void onSummaryReceived(String summary) {
+        }
     }
 }

--- a/src/test/java/com/github/claudecodegui/session/CodexMessageHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/session/CodexMessageHandlerTest.java
@@ -283,6 +283,7 @@ public class CodexMessageHandlerTest {
     @Test
     public void resultMessageStampsNormalizedTurnUsageOnLastAssistant() {
         SessionState state = new SessionState();
+        state.setModel("gpt-5.1");
 
         CallbackHandler callbackHandler = new CallbackHandler();
         RecordingCallback callback = new RecordingCallback();
@@ -304,6 +305,47 @@ public class CodexMessageHandlerTest {
         assertEquals(36310, turnUsage.get("cache_read_input_tokens").getAsInt());
         assertEquals(0, turnUsage.get("cache_creation_input_tokens").getAsInt());
         assertEquals(353, turnUsage.get("output_tokens").getAsInt());
+        assertEquals(0.00893125, message.raw.get("turnCostUsd").getAsDouble(), 0.0000001);
+    }
+
+    @Test
+    public void resultMessageAcceptsCodexCachedInputTokenAlias() {
+        SessionState state = new SessionState();
+        state.setModel("gpt-5.1");
+
+        CallbackHandler callbackHandler = new CallbackHandler();
+        RecordingCallback callback = new RecordingCallback();
+        callbackHandler.setCallback(callback);
+
+        CodexMessageHandler handler = new CodexMessageHandler(state, callbackHandler);
+        handler.onMessage("assistant", "{\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"done\"}]}}");
+        handler.onMessage("result", "{\"type\":\"result\",\"subtype\":\"usage\",\"usage\":{"
+                + "\"input_tokens\":37000,\"output_tokens\":353,\"cached_input_tokens\":36310}}");
+
+        Message message = state.getMessages().get(0);
+        var turnUsage = message.raw.getAsJsonObject("turnUsage");
+        assertEquals(690, turnUsage.get("input_tokens").getAsInt());
+        assertEquals(36310, turnUsage.get("cache_read_input_tokens").getAsInt());
+        assertEquals(0.00893125, message.raw.get("turnCostUsd").getAsDouble(), 0.0000001);
+    }
+
+    @Test
+    public void resultMessageDoesNotStampTurnCostWhenModelHasNoPricing() {
+        SessionState state = new SessionState();
+        state.setModel("custom-codex-without-pricing");
+
+        CallbackHandler callbackHandler = new CallbackHandler();
+        RecordingCallback callback = new RecordingCallback();
+        callbackHandler.setCallback(callback);
+
+        CodexMessageHandler handler = new CodexMessageHandler(state, callbackHandler);
+        handler.onMessage("assistant", "{\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"done\"}]}}");
+        handler.onMessage("result", "{\"type\":\"result\",\"subtype\":\"usage\",\"usage\":{"
+                + "\"input_tokens\":1200,\"output_tokens\":456}}");
+
+        Message message = state.getMessages().get(0);
+        assertTrue(message.raw.has("turnUsage"));
+        assertFalse(message.raw.has("turnCostUsd"));
     }
 
     @Test

--- a/src/test/java/com/github/claudecodegui/util/MessageJsonConverterTest.java
+++ b/src/test/java/com/github/claudecodegui/util/MessageJsonConverterTest.java
@@ -42,6 +42,7 @@ public class MessageJsonConverterTest {
         turnUsage.addProperty("cache_read_input_tokens", 36310);
         turnUsage.addProperty("output_tokens", 456);
         raw.add("turnUsage", turnUsage);
+        raw.addProperty("turnCostUsd", 0.0123);
 
         ClaudeSession.Message sessionMessage = new ClaudeSession.Message(
                 ClaudeSession.Message.Type.ASSISTANT,
@@ -62,6 +63,8 @@ public class MessageJsonConverterTest {
         // turnUsage (whole-turn aggregate) is transported for the per-turn token display
         assertTrue(transportRaw.has("turnUsage"));
         assertEquals(1200, transportRaw.getAsJsonObject("turnUsage").get("input_tokens").getAsInt());
+        assertTrue(transportRaw.has("turnCostUsd"));
+        assertEquals(0.0123, transportRaw.get("turnCostUsd").getAsDouble(), 0.000001);
 
         JsonObject transportMessage = transportRaw.getAsJsonObject("message");
         assertTrue(transportMessage.has("content"));

--- a/src/test/java/com/github/claudecodegui/util/UsageCostCalculatorTest.java
+++ b/src/test/java/com/github/claudecodegui/util/UsageCostCalculatorTest.java
@@ -1,0 +1,59 @@
+package com.github.claudecodegui.util;
+
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class UsageCostCalculatorTest {
+
+    @Test
+    public void calculatesClaudeTurnCostWithCacheBreakdown() {
+        JsonObject usage = new JsonObject();
+        usage.addProperty("input_tokens", 1200);
+        usage.addProperty("cache_creation_input_tokens", 4096);
+        usage.addProperty("cache_read_input_tokens", 363100);
+        usage.addProperty("output_tokens", 4560);
+
+        double cost = UsageCostCalculator.calculateTurnCostUsd("claude", usage, "claude-sonnet-4-6");
+
+        assertEquals(0.19629, cost, 0.000001);
+    }
+
+    @Test
+    public void calculatesCodexTurnCostFromNormalizedTurnUsage() {
+        JsonObject usage = new JsonObject();
+        usage.addProperty("input_tokens", 690);
+        usage.addProperty("cache_creation_input_tokens", 0);
+        usage.addProperty("cache_read_input_tokens", 36310);
+        usage.addProperty("output_tokens", 353);
+
+        double cost = UsageCostCalculator.calculateTurnCostUsd("codex", usage, "gpt-5.1");
+
+        assertEquals(0.00893125, cost, 0.0000001);
+    }
+
+    @Test
+    public void acceptsCodexCachedInputTokenAliasForTurnCost() {
+        JsonObject usage = new JsonObject();
+        usage.addProperty("input_tokens", 690);
+        usage.addProperty("cached_input_tokens", 36310);
+        usage.addProperty("output_tokens", 353);
+
+        double cost = UsageCostCalculator.calculateTurnCostUsd("codex", usage, "gpt-5.1");
+
+        assertEquals(0.00893125, cost, 0.0000001);
+    }
+
+    @Test
+    public void returnsNullWhenNoBuiltInOrCustomPriceMatches() {
+        JsonObject usage = new JsonObject();
+        usage.addProperty("input_tokens", 1200);
+        usage.addProperty("output_tokens", 456);
+
+        assertNull(UsageCostCalculator.calculateTurnCostUsd("claude", usage, "custom-claude-without-pricing"));
+        assertNull(UsageCostCalculator.calculateTurnCostUsd("codex", usage, "custom-codex-without-pricing"));
+        assertNull(UsageCostCalculator.calculateTurnCostUsd("codex", usage, null));
+    }
+}

--- a/webview/src/components/MessageItem/MessageItem.test.tsx
+++ b/webview/src/components/MessageItem/MessageItem.test.tsx
@@ -37,6 +37,7 @@ const t = ((key: string, opts?: Record<string, string>) => {
     'chat.totalDuration': '本次耗时',
     'chat.tokenUsage': '输入 {{input}} / 输出 {{output}}',
     'chat.tokenUsageDetail': '本轮合计 — 输入 {{input}} · 缓存写入 {{cacheWrite}} · 缓存读取 {{cacheRead}} · 输出 {{output}}',
+    'chat.cacheHitsWithRatio': '缓存命中 {{tokens}} ({{ratio}})',
   };
   let result = translations[key] ?? key;
   if (opts) {
@@ -176,13 +177,14 @@ describe('MessageItem token usage display', () => {
           input_tokens: 1200,
           output_tokens: 456,
         },
+        turnCostUsd: 0.006,
       } as any,
     };
 
     renderMessageItem(message);
 
     expect(screen.getByText('0:16')).toBeTruthy();
-    expect(screen.getByText('输入 1.2K / 输出 456')).toBeTruthy();
+    expect(screen.getByText(/输入 1\.2K \/ 输出 456 \/ \$0\.0060/)).toBeTruthy();
   });
 
   it('counts cache tokens in the input total and details them in the tooltip', () => {
@@ -212,6 +214,7 @@ describe('MessageItem token usage display', () => {
     expect(tokens.getAttribute('title')).toBe(
       '本轮合计 — 输入 37 · 缓存写入 0 · 缓存读取 36.3K · 输出 353'
     );
+    expect(screen.getByText('缓存命中 36.3K (100%)')).toBeTruthy();
   });
 
   it('ignores per-call usage fields (message.usage / top-level usage)', () => {

--- a/webview/src/components/MessageItem/MessageItem.tsx
+++ b/webview/src/components/MessageItem/MessageItem.tsx
@@ -112,6 +112,7 @@ interface TokenUsageInfo {
   nonCacheInputTokens: number;
   cacheCreationTokens: number;
   cacheReadTokens: number;
+  costUsd?: number;
 }
 
 /**
@@ -140,12 +141,15 @@ function extractTokenUsage(raw: ClaudeMessage['raw']): TokenUsageInfo | null {
   const output = num(usage.output_tokens);
   const input = nonCacheInput + cacheCreation + cacheRead;
   if (input === 0 && output === 0) return null;
+  const rawCost = (raw as Record<string, unknown>).turnCostUsd;
+  const costUsd = typeof rawCost === 'number' && Number.isFinite(rawCost) && rawCost > 0 ? rawCost : undefined;
   return {
     inputTokens: input,
     outputTokens: output,
     nonCacheInputTokens: nonCacheInput,
     cacheCreationTokens: cacheCreation,
     cacheReadTokens: cacheRead,
+    ...(costUsd !== undefined ? { costUsd } : {}),
   };
 }
 
@@ -154,6 +158,19 @@ function formatTokenCount(count: number): string {
   if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
   if (count >= 1_000) return `${(count / 1_000).toFixed(1)}K`;
   return String(count);
+}
+
+function formatUsdCost(cost: number): string {
+  if (cost > 0 && cost < 0.0001) return '<$0.0001';
+  if (cost < 0.01) return `$${cost.toFixed(4)}`;
+  if (cost < 1) return `$${cost.toFixed(3)}`;
+  return `$${cost.toFixed(2)}`;
+}
+
+function formatCacheHitRatio(tokenInfo: TokenUsageInfo): string | null {
+  if (tokenInfo.cacheReadTokens <= 0 || tokenInfo.inputTokens <= 0) return null;
+  const ratio = Math.round((tokenInfo.cacheReadTokens / tokenInfo.inputTokens) * 100);
+  return `${Math.min(100, Math.max(0, ratio))}%`;
 }
 
 function isToolBlockOfType(block: ClaudeContentBlock, toolNames: Set<string>): boolean {
@@ -742,6 +759,7 @@ export const MessageItem = memo(function MessageItem({
             {(() => {
               const tokenInfo = extractTokenUsage(message.raw);
               if (!tokenInfo) return null;
+              const cacheHitRatio = formatCacheHitRatio(tokenInfo);
               return (
                 <>
                   <span className="message-duration-separator">·</span>
@@ -758,7 +776,19 @@ export const MessageItem = memo(function MessageItem({
                       input: formatTokenCount(tokenInfo.inputTokens),
                       output: formatTokenCount(tokenInfo.outputTokens),
                     })}
+                    {tokenInfo.costUsd !== undefined ? ` / ${formatUsdCost(tokenInfo.costUsd)}` : ''}
                   </span>
+                  {cacheHitRatio && (
+                    <>
+                      <span className="message-duration-separator">·</span>
+                      <span className="message-duration-tokens">
+                        {t('chat.cacheHitsWithRatio', {
+                          tokens: formatTokenCount(tokenInfo.cacheReadTokens),
+                          ratio: cacheHitRatio,
+                        })}
+                      </span>
+                    </>
+                  )}
                 </>
               );
             })()}

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -96,6 +96,7 @@
     "totalDuration": "This reply took",
     "tokenUsage": "{{input}} in / {{output}} out",
     "tokenUsageDetail": "Turn total — input {{input}} · cache write {{cacheWrite}} · cache read {{cacheRead}} · output {{output}}",
+    "cacheHitsWithRatio": "{{tokens}} cache hits ({{ratio}})",
     "search": {
       "ariaLabel": "Search in conversation",
       "placeholder": "Search in conversation…",

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -96,6 +96,7 @@
     "totalDuration": "Esta respuesta tardó",
     "tokenUsage": "{{input}} entrada / {{output}} salida",
     "tokenUsageDetail": "Total del turno — entrada {{input}} · escritura caché {{cacheWrite}} · lectura caché {{cacheRead}} · salida {{output}}",
+    "cacheHitsWithRatio": "{{tokens}} aciertos de caché ({{ratio}})",
     "search": {
       "ariaLabel": "Buscar en la conversación",
       "placeholder": "Buscar en la conversación…",

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -96,6 +96,7 @@
     "totalDuration": "Cette réponse a pris",
     "tokenUsage": "{{input}} entrée / {{output}} sortie",
     "tokenUsageDetail": "Total du tour — entrée {{input}} · écriture cache {{cacheWrite}} · lecture cache {{cacheRead}} · sortie {{output}}",
+    "cacheHitsWithRatio": "{{tokens}} cache touché ({{ratio}})",
     "search": {
       "ariaLabel": "Rechercher dans la conversation",
       "placeholder": "Rechercher dans la conversation…",

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -96,6 +96,7 @@
     "totalDuration": "इस जवाब में लगा समय",
     "tokenUsage": "{{input}} इन / {{output}} आउट",
     "tokenUsageDetail": "टर्न कुल — इनपुट {{input}} · कैश लेखन {{cacheWrite}} · कैश पठन {{cacheRead}} · आउटपुट {{output}}",
+    "cacheHitsWithRatio": "{{tokens}} कैश हिट ({{ratio}})",
     "search": {
       "ariaLabel": "बातचीत में खोजें",
       "placeholder": "बातचीत में खोजें...",

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -96,6 +96,7 @@
     "totalDuration": "今回の応答時間",
     "tokenUsage": "入力 {{input}} / 出力 {{output}}",
     "tokenUsageDetail": "ターン合計 — 入力 {{input}} · キャッシュ書き込み {{cacheWrite}} · キャッシュ読み取り {{cacheRead}} · 出力 {{output}}",
+    "cacheHitsWithRatio": "キャッシュヒット {{tokens}} ({{ratio}})",
     "search": {
       "ariaLabel": "会話内を検索",
       "placeholder": "会話内を検索...",

--- a/webview/src/i18n/locales/ko.json
+++ b/webview/src/i18n/locales/ko.json
@@ -96,6 +96,7 @@
     "totalDuration": "이번 응답 소요 시간",
     "tokenUsage": "입력 {{input}} / 출력 {{output}}",
     "tokenUsageDetail": "턴 합계 — 입력 {{input}} · 캐시 쓰기 {{cacheWrite}} · 캐시 읽기 {{cacheRead}} · 출력 {{output}}",
+    "cacheHitsWithRatio": "캐시 히트 {{tokens}} ({{ratio}})",
     "search": {
       "ariaLabel": "대화에서 검색",
       "placeholder": "대화에서 검색...",

--- a/webview/src/i18n/locales/pt-BR.json
+++ b/webview/src/i18n/locales/pt-BR.json
@@ -96,6 +96,7 @@
     "totalDuration": "Esta resposta levou",
     "tokenUsage": "{{input}} entrada / {{output}} saída",
     "tokenUsageDetail": "Total do turno — entrada {{input}} · gravação de cache {{cacheWrite}} · leitura de cache {{cacheRead}} · saída {{output}}",
+    "cacheHitsWithRatio": "{{tokens}} acertos de cache ({{ratio}})",
     "search": {
       "ariaLabel": "Pesquisar na conversa",
       "placeholder": "Pesquisar na conversa…",

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -96,6 +96,7 @@
     "totalDuration": "Этот ответ занял",
     "tokenUsage": "вход {{input}} / выход {{output}}",
     "tokenUsageDetail": "Итог хода — вход {{input}} · запись кэша {{cacheWrite}} · чтение кэша {{cacheRead}} · выход {{output}}",
+    "cacheHitsWithRatio": "{{tokens}} попаданий в кэш ({{ratio}})",
     "search": {
       "ariaLabel": "Поиск в беседе",
       "placeholder": "Поиск в беседе…",

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -96,6 +96,7 @@
     "totalDuration": "本次耗時",
     "tokenUsage": "輸入 {{input}} / 輸出 {{output}}",
     "tokenUsageDetail": "本輪合計 — 輸入 {{input}} · 快取寫入 {{cacheWrite}} · 快取讀取 {{cacheRead}} · 輸出 {{output}}",
+    "cacheHitsWithRatio": "快取命中 {{tokens}} ({{ratio}})",
     "search": {
       "ariaLabel": "在對話中搜尋",
       "placeholder": "在對話中搜尋...",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -96,6 +96,7 @@
     "totalDuration": "本次耗时",
     "tokenUsage": "输入 {{input}} / 输出 {{output}}",
     "tokenUsageDetail": "本轮合计 — 输入 {{input}} · 缓存写入 {{cacheWrite}} · 缓存读取 {{cacheRead}} · 输出 {{output}}",
+    "cacheHitsWithRatio": "缓存命中 {{tokens}} ({{ratio}})",
     "search": {
       "ariaLabel": "在对话中搜索",
       "placeholder": "在对话中搜索…",


### PR DESCRIPTION
## Summary

Fix the assistant message footer usage display on `feature/v0.4.7`.

This is a follow-up to `c6ab6e9`, which correctly changed the footer to read only `raw.turnUsage` instead of `raw.message.usage` / `raw.usage`. That change fixed inconsistent token semantics across Claude and Codex, but it also means the footer only works when the backend stamps a complete per-turn aggregate onto the final assistant message.

This PR keeps the `c6ab6e9` semantics and fixes the missing data path by stamping and transporting dedicated per-turn fields.

## Why

The original footer display introduced in `e683068` could read:

- `raw.message.usage`
- top-level `raw.usage`

Those fields are not reliable for the footer:

- Claude `message.usage` can represent the last API call only and may exclude cache usage.
- Codex top-level `usage` can be session-cumulative or turn-scoped depending on event arrival order.

`c6ab6e9` fixed that by making the frontend read only `raw.turnUsage`.

After that change, missing footer data is no longer a frontend fallback issue. The backend needs to stamp the whole-turn aggregate into `turnUsage` when a turn completes.

## Changes

- Keep per-message token display reading only `raw.turnUsage`.
- Stamp backend-calculated `turnCostUsd` when the model has built-in or custom pricing.
- Do not show cost when no matching price is defined.
- Normalize Codex `turn.completed` usage into Claude-style `turnUsage`.
- Support Codex `cached_input_tokens` as an alias for cache-read tokens.
- Display cache hit ratio only when `cache_read_input_tokens > 0`.
- Transport only `turnUsage` and `turnCostUsd`; do not restore `raw.usage` or `raw.message.usage` transport.
- Add i18n text for visible cache hit ratio.

## Behavior

When pricing exists:

```text
本次耗时 0:08 · 输入 41.8K / 输出 191 / $0.214