### PR TITLE
fix(provider): restore Codex quota popup visibility

### DIFF
--- a/webview/src/components/ChatInputBox/selectors/ProviderSelect.codexQuota.test.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ProviderSelect.codexQuota.test.tsx
@@ -37,6 +37,10 @@ describe('ProviderSelect Codex quota submenu', () => {
     render(<ProviderSelect value="claude" />);
 
     fireEvent.click(screen.getByRole('button'));
+    const providerDropdown = document.querySelector('.selector-dropdown') as HTMLElement;
+    // The quota panel is positioned above this dropdown. Setting overflow-x to
+    // hidden also clips vertical overflow, so the panel becomes invisible.
+    expect(providerDropdown.style.overflowX).toBe('');
     const codexRow = screen.getByText('Codex').closest('.selector-option')!;
     expect(codexRow.querySelector('.codicon-chevron-right')).toBeTruthy();
 

--- a/webview/src/components/ChatInputBox/selectors/ProviderSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ProviderSelect.tsx
@@ -18,7 +18,6 @@ const DROPDOWN_STYLE: React.CSSProperties = {
   marginBottom: '4px',
   zIndex: 10000,
   maxWidth: 'calc(100vw - 16px)',
-  overflowX: 'hidden',
 };
 const TOAST_STYLE: React.CSSProperties = { zIndex: 20000 };
 /** Gap (px) between the floating quota panel and the top of the provider dropdown. */


### PR DESCRIPTION
## Summary

- Restore visibility of the Codex subscription quota popup in the provider selector.
- Add a regression assertion ensuring the parent dropdown does not clip the floating quota panel.

## Root cause

The provider dropdown gained `overflowX: 'hidden'` in v0.4.6 to keep selector menus inside the viewport. The Codex quota panel is rendered as an absolutely positioned child above that dropdown. CSS overflow normalization makes the dropdown clip the panel vertically as well, so the quota UI is rendered but remains invisible.

This change removes the overflow clipping only from `ProviderSelect`; the viewport-aware width and positioning logic remain unchanged.

## Validation

- `npm exec vitest run src/components/ChatInputBox/selectors/ProviderSelect.codexQuota.test.tsx` — 3 tests passed
- `npm run build` — passed
- `./gradlew buildPlugin` — passed
- Manually verified in IntelliJ IDEA using a packaged v0.4.7-fix1 build
