### PR TITLE
fix(codex): isolate CLI from stale proxy environment variables

### DIFF
--- a/ai-bridge/services/codex/codex-utils.js
+++ b/ai-bridge/services/codex/codex-utils.js
@@ -38,6 +38,24 @@ export const CODEX_CLI_ENV_BLOCKLIST = new Set([
   'CODEX_SANDBOX_NETWORK_DISABLED',
   'CODEX_CI'
 ]);
+export const CODEX_PROXY_ENV_OPT_IN = 'CC_GUI_CODEX_INHERIT_PROXY';
+// Codex connects directly (including through OS-level TUN routing) unless a
+// user explicitly opts into inheriting Rider's HTTP/SOCKS proxy environment.
+export const PROXY_ENV_KEYS = new Set([
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'ALL_PROXY',
+  'NPM_CONFIG_PROXY',
+  'NPM_CONFIG_HTTPS_PROXY'
+]);
+
+function shouldInheritProxyEnvironment(baseEnv) {
+  const optInEntry = Object.entries(baseEnv).find(
+    ([key]) => key.toUpperCase() === CODEX_PROXY_ENV_OPT_IN
+  );
+  const value = optInEntry?.[1];
+  return typeof value === 'string' && /^(1|true|yes|on)$/i.test(value.trim());
+}
 
 /**
  * Reads sandbox mode override from environment variables.
@@ -83,11 +101,19 @@ export function buildCodexCliEnvironment(baseEnv) {
     return { cliEnv, removedKeys };
   }
 
+  const inheritProxyEnvironment = shouldInheritProxyEnvironment(baseEnv);
+
   for (const [key, rawValue] of Object.entries(baseEnv)) {
     if (typeof rawValue !== 'string' || rawValue.length === 0) {
       continue;
     }
     if (CODEX_CLI_ENV_BLOCKLIST.has(key)) {
+      removedKeys.push(key);
+      continue;
+    }
+    const normalizedKey = key.toUpperCase();
+    if (normalizedKey === CODEX_PROXY_ENV_OPT_IN ||
+        (!inheritProxyEnvironment && PROXY_ENV_KEYS.has(normalizedKey))) {
       removedKeys.push(key);
       continue;
     }

--- a/ai-bridge/services/codex/codex-utils.test.js
+++ b/ai-bridge/services/codex/codex-utils.test.js
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildCodexCliEnvironment } from './codex-utils.js';
+
+test('removes inherited proxy variables by default', () => {
+  const result = buildCodexCliEnvironment({
+    HTTP_PROXY: 'http://127.0.0.1:8080',
+    https_proxy: 'http://127.0.0.1:8081',
+    ALL_PROXY: 'socks5://127.0.0.1:1080',
+    NPM_CONFIG_PROXY: 'http://127.0.0.1:8082',
+    NPM_CONFIG_HTTPS_PROXY: 'http://127.0.0.1:8083',
+    PATH: 'C:\\Windows'
+  });
+
+  assert.deepEqual(result.cliEnv, { PATH: 'C:\\Windows' });
+  assert.deepEqual(result.removedKeys, [
+    'HTTP_PROXY',
+    'https_proxy',
+    'ALL_PROXY',
+    'NPM_CONFIG_PROXY',
+    'NPM_CONFIG_HTTPS_PROXY'
+  ]);
+});
+
+test('keeps proxy variables after explicit opt-in', () => {
+  const result = buildCodexCliEnvironment({
+    cc_gui_codex_inherit_proxy: 'true',
+    HTTP_PROXY: 'http://proxy.example:8080',
+    HTTPS_PROXY: 'http://proxy.example:8080'
+  });
+
+  assert.deepEqual(result.cliEnv, {
+    HTTP_PROXY: 'http://proxy.example:8080',
+    HTTPS_PROXY: 'http://proxy.example:8080'
+  });
+  assert.deepEqual(result.removedKeys, ['cc_gui_codex_inherit_proxy']);
+});
+
+test('does not enable proxy inheritance for false-like values', () => {
+  const result = buildCodexCliEnvironment({
+    CC_GUI_CODEX_INHERIT_PROXY: 'false',
+    HTTP_PROXY: 'http://proxy.example:8080'
+  });
+
+  assert.deepEqual(result.cliEnv, {});
+  assert.deepEqual(result.removedKeys, [
+    'CC_GUI_CODEX_INHERIT_PROXY',
+    'HTTP_PROXY'
+  ]);
+});


### PR DESCRIPTION
## Summary

  Prevent Codex CLI subprocesses from inheriting stale proxy environment variables from the IDE or JetBrains Toolbox by default.

  ## Problem

  On Windows, Rider may inherit outdated `HTTP_PROXY`, `HTTPS_PROXY`, or related variables from a long-running Toolbox process.

  The Codex SDK receives the complete IDE environment through `buildCodexCliEnvironment()`. As a result, Codex may bypass OS-level TUN routing and
  repeatedly report:

  ```text
  Reconnecting...
  ```
  
  The same configuration can also cause npm errors such as:

  getaddrinfo ENOTFOUND http

  Running Codex directly from a fresh terminal still works because it receives a clean environment.

  ## Solution

  - Remove inherited proxy variables from the Codex CLI environment by default:
      - HTTP_PROXY
      - HTTPS_PROXY
      - ALL_PROXY
      - NPM_CONFIG_PROXY
      - NPM_CONFIG_HTTPS_PROXY

  - Handle environment variable names case-insensitively.
  - Preserve support for users who require an explicit proxy through:

  CC_GUI_CODEX_INHERIT_PROXY=true

  - Do not pass the opt-in control variable to the Codex subprocess.

  This allows direct connections and OS-level VPN/TUN routing to work reliably while retaining an explicit fallback for corporate proxy environments.

  ## Testing

  Added unit tests covering:

  - Proxy isolation by default
  - Case-insensitive environment variable names
  - Explicit proxy inheritance opt-in
  - False-like opt-in values

  Full ai-bridge test suite:

  184 tests passed
  0 failed

  ## Environment Used for Reproduction

  - Windows
  - Rider 2024.1.3
  - CC GUI 0.4.7-fix1
  - @openai/codex-sdk 0.144.1
  - VPN client using OS-level TUN routing