### PR TITLE
fix: stale closure in handleKeepAll causing old changes after Keep All

### DIFF
--- a/webview/src/hooks/useFileChangesManagement.ts
+++ b/webview/src/hooks/useFileChangesManagement.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type RefObject } from 'react';
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
 import type { ClaudeMessage, ToolResultBlock } from '../types';
 import { debugLog } from '../utils/debug';
 
@@ -28,6 +28,11 @@ export function useFileChangesManagement({
   const [processedFiles, setProcessedFiles] = useState<string[]>([]);
   // Base message index (for Keep All feature, only counts changes after this index)
   const [baseMessageIndex, setBaseMessageIndex] = useState(0);
+
+  // Ref to always hold the latest messages array, avoiding stale closure issues
+  // in handleKeepAll when messages.length changes between renders.
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
 
   // Callback after file undo success (triggered from StatusPanel)
   const handleUndoFile = useCallback((filePath: string) => {
@@ -96,7 +101,8 @@ export function useFileChangesManagement({
 
   // Callback for Keep All - set current changes as the new baseline
   const handleKeepAll = useCallback(() => {
-    const newBaseIndex = messages.length;
+    // Use ref to get the latest messages.length, avoiding stale closure issues
+    const newBaseIndex = messagesRef.current.length;
     setBaseMessageIndex(newBaseIndex);
     setProcessedFiles([]);
 
@@ -108,7 +114,7 @@ export function useFileChangesManagement({
         console.error('Failed to persist Keep All state:', e);
       }
     }
-  }, [messages.length, currentSessionId]);
+  }, [currentSessionId]);
 
   // Register window callbacks for editable diff operations from Java backend
   useEffect(() => {


### PR DESCRIPTION
## 问题描述

点击"保存全部"后，提示"已重置改动记录"，但后续编辑时仍会显示保存前的历史改动。

## 根因分析

`handleKeepAll` 回调通过 `useCallback` 创建，依赖项为 `[messages.length, currentSessionId]`。`messages.length` 是基本类型值，当 `messages` 数组新增消息但长度不变时，回调不会重建，导致闭包中的 `messages.length` 始终指向旧值。

## 修复方案

使用 `useRef` 始终持有最新的 `messages` 引用，通过 `messagesRef.current.length` 获取最新长度，避免闭包过期问题。

Fixes #1456