### PR TITLE
fix(streaming): harden multi-tab message merge and final-snapshot push

### DIFF
--- a/src/main/java/com/github/claudecodegui/session/MessageMerger.java
+++ b/src/main/java/com/github/claudecodegui/session/MessageMerger.java
@@ -225,7 +225,12 @@ public class MessageMerger {
         }
 
         if ("text".equals(type)) {
-            return textLooksRelated(getTextContent(existingBlock), getTextContent(incomingBlock));
+            // Text blocks matched across a segment boundary must be strictly
+            // prefix-related: two segments separated by a tool_use should share no
+            // prefix relation, whereas the lenient suffix-prefix overlap would fire
+            // on incidental shared boundaries (code fences, Markdown markers) and
+            // wrongly merge a new segment into the previous one.
+            return textLooksRelatedStrict(getTextContent(existingBlock), getTextContent(incomingBlock));
         }
 
         if ("thinking".equals(type)) {
@@ -260,7 +265,12 @@ public class MessageMerger {
             if (getContentBlockKey(existingBlock) != null) {
                 break;
             }
-            if (incomingType.equals(getContentBlockType(existingBlock))) {
+            // Honour the same segment boundary as the primary matcher: a same-type
+            // tail block that is NOT prefix-related to the incoming block belongs to
+            // a different segment, so do not merge into it - fall through to adding
+            // the incoming block as a new one instead.
+            if (incomingType.equals(getContentBlockType(existingBlock))
+                    && blocksLikelyRepresentSameSegment(existingBlock, incomingBlock)) {
                 return i;
             }
         }
@@ -286,6 +296,31 @@ public class MessageMerger {
         return getTextContent(block);
     }
 
+    // Whether two non-empty texts are equal or one is a prefix of the other:
+    // the "same segment, possibly grown" relation shared by the strict text
+    // check and the lenient thinking check's prefix stage.
+    private boolean isPrefixRelated(String existing, String incoming) {
+        return existing.equals(incoming)
+                || existing.startsWith(incoming)
+                || incoming.startsWith(existing);
+    }
+
+    // Strict prefix-only relatedness for text blocks across segments. Omits the
+    // suffix-prefix overlap that textLooksRelated keeps for fragmented thinking:
+    // for text, overlap frequently fires on incidental shared boundaries (code
+    // fences, Markdown markers) between two segments separated by a tool_use,
+    // wrongly merging a new segment into the previous one.
+    private boolean textLooksRelatedStrict(String existingText, String incomingText) {
+        String existing = existingText != null ? existingText : "";
+        String incoming = incomingText != null ? incomingText : "";
+        // isPrefixRelated already treats an empty string as a prefix of any string,
+        // so an empty text block and a non-empty one are the same segment (the empty
+        // one is the segment's leading edge before content arrives). This lets a
+        // later, fuller snapshot fill an empty placeholder instead of duplicating
+        // it, mirroring the thinking branch's empty-is-same-segment rule.
+        return isPrefixRelated(existing, incoming);
+    }
+
     private boolean textLooksRelated(String existingText, String incomingText) {
         String existing = existingText != null ? existingText : "";
         String incoming = incomingText != null ? incomingText : "";
@@ -294,9 +329,7 @@ public class MessageMerger {
             return existing.isEmpty() && incoming.isEmpty();
         }
 
-        if (existing.equals(incoming)
-                || existing.startsWith(incoming)
-                || incoming.startsWith(existing)) {
+        if (isPrefixRelated(existing, incoming)) {
             return true;
         }
 

--- a/src/main/java/com/github/claudecodegui/session/StreamMessageCoalescer.java
+++ b/src/main/java/com/github/claudecodegui/session/StreamMessageCoalescer.java
@@ -344,15 +344,34 @@ public class StreamMessageCoalescer {
                     return;
                 }
 
+                final long pushSequence;
                 synchronized (lock) {
                     if (sequence != updateSequence) {
-                        // Message is stale — skip the webview push, but still
-                        // run the after-send callback (e.g. onStreamEnd cleanup)
-                        // so the frontend is not stuck in streaming state.
-                        if (afterSendOnEdt != null) {
-                            afterSendOnEdt.accept(sequence);
+                        // Stale snapshot: a newer one is pending or was just pushed,
+                        // so normally we skip this push. Force-push ONLY on the flush
+                        // path (afterSendOnEdt != null) - that is the onStreamEnd flush
+                        // carrying the turn's FINAL snapshot, and when a late enqueue
+                        // has advanced updateSequence past it, no newer snapshot will
+                        // compensate, so the turn's tail content would be lost for good.
+                        // The alarm path (afterSendOnEdt == null) holds a possibly
+                        // outdated snapshot; force-pushing it would advance the sequence
+                        // and let a stale frame overwrite the final one once its
+                        // (large-payload-delayed) invokeLater lands after the flush.
+                        // Advancing the sequence on force-push keeps the frontend's
+                        // minAcceptedUpdateSequence barrier accepting the frame.
+                        if (streamActive || afterSendOnEdt == null) {
+                            if (afterSendOnEdt != null) {
+                                afterSendOnEdt.accept(sequence);
+                            }
+                            return;
                         }
-                        return;
+                        pushSequence = ++updateSequence;
+                        LOG.info("[StreamMessageCoalescer] Force-pushing stale final snapshot after"
+                                + " stream end (stale sequence=" + sequence
+                                + ", pushed=" + pushSequence
+                                + ") to avoid losing the turn's final content");
+                    } else {
+                        pushSequence = sequence;
                     }
                 }
 
@@ -361,7 +380,7 @@ public class StreamMessageCoalescer {
                 // prevent afterSendOnEdt from running.  When afterSendOnEdt carries
                 // the onStreamEnd signal, failing to run it permanently freezes the UI.
                 try {
-                    callbackTarget.callJavaScript("updateMessages", escapedMessagesJson, String.valueOf(sequence));
+                    callbackTarget.callJavaScript("updateMessages", escapedMessagesJson, String.valueOf(pushSequence));
                     MessageJsonConverter.pushUsageUpdateFromMessages(
                             messages,
                             callbackTarget.getHandlerContext(),
@@ -374,7 +393,7 @@ public class StreamMessageCoalescer {
                 }
 
                 if (afterSendOnEdt != null) {
-                    afterSendOnEdt.accept(sequence);
+                    afterSendOnEdt.accept(pushSequence);
                 }
             });
         });

--- a/src/test/java/com/github/claudecodegui/session/MessageMergerTest.java
+++ b/src/test/java/com/github/claudecodegui/session/MessageMergerTest.java
@@ -271,4 +271,21 @@ public class MessageMergerTest {
         assertEquals(2, mergedContent.size());
         assertEquals("Now I have thinking content.", mergedContent.get(0).getAsJsonObject().get("thinking").getAsString());
     }
+
+    @Test
+    public void mergeAssistantMessageFillsEmptyTextBlockWithIncomingSameSegmentText() {
+        MessageMerger merger = new MessageMerger();
+
+        // SDK first frame may carry an empty text placeholder; the next frame grows
+        // it. The empty block must be filled in place rather than duplicated.
+        JsonObject existingRaw = assistantMessage(textBlock(""));
+        JsonObject newRaw = assistantMessage(textBlock("full answer"));
+
+        JsonArray mergedContent = merger.mergeAssistantMessage(existingRaw, newRaw)
+                .getAsJsonObject("message")
+                .getAsJsonArray("content");
+
+        assertEquals(1, mergedContent.size());
+        assertEquals("full answer", mergedContent.get(0).getAsJsonObject().get("text").getAsString());
+    }
 }

--- a/webview/src/hooks/windowCallbacks/messageSync.ts
+++ b/webview/src/hooks/windowCallbacks/messageSync.ts
@@ -377,9 +377,26 @@ export const mergeRawBlocksDuringStreaming = (
     const nextLen = getTextLikeLength(nextBlock);
     if (prevLen <= nextLen) return nextBlock; // next is at least as long — keep it
 
-    // prev is longer: use prev content, keep next block type and other fields
-    changed = true;
+    // prev is longer. Only let prev win when it is a prefix-extension of next
+    // (prev starts with next: the same segment, grown further on the frontend).
+    // When prev and next are unrelated content they belong to DIFFERENT segments —
+    // e.g. a new post-tool_use assistant turn whose last block is shorter than the
+    // previous turn's. Taking prev there would overwrite the new turn's text with
+    // the old turn's, the "dedup merged into the wrong part" symptom seen when
+    // several tabs stream concurrently and EDT coalescing delays the __turnId
+    // commit that normally guards this path. Keep next instead. MarkdownBlock
+    // renders from these raw blocks, so this guard directly protects the UI.
     const prevContent = getTextLikeContent(prevBlock);
+    const nextContent = getTextLikeContent(nextBlock);
+    // An empty next is a backend snapshot lagging to an empty block while the
+    // frontend already accumulated content - the same segment, just behind - so
+    // let prev fill it ("" is a prefix of every string, which the startsWith
+    // check below already honours). Only NON-empty, non-prefix next belongs to a
+    // different segment and must be kept as-is.
+    if (nextContent && !prevContent.startsWith(nextContent)) {
+      return nextBlock; // unrelated non-empty content - do not cross-merge segments
+    }
+    changed = true;
     if (nextBlock.type === 'thinking') {
       return { ...nextBlock, thinking: prevContent, text: prevContent };
     }


### PR DESCRIPTION
Tighten the streaming pipeline (Java coalescer + merger, webview raw-block sync) so concurrent multi-tab load no longer drops a turn's final content nor merges a new segment into the previous one.

MessageMerger:
- Match text blocks with strict prefix-only relatedness (textLooksRelatedStrict), dropping the suffix-prefix overlap that fired on incidental code-fence and Markdown boundaries between segments separated by a tool_use.
- Extract isPrefixRelated so the strict and lenient checks share one prefix rule.
- Make findLastSameTypeBlockIndex honour the same segment boundary, so a new post-tool_use text never overwrites the prior segment's tail block.
- Treat an empty text as a prefix (the segment's leading edge before content arrives), so a later, fuller snapshot fills an empty placeholder instead of duplicating it.

StreamMessageCoalescer:
- Force-push stale snapshots only on the flush path (afterSendOnEdt != null, i.e. the onStreamEnd final flush). The alarm path holds a possibly outdated snapshot; force-pushing it would advance the sequence and let a stale frame overwrite the final one once its large-payload-delayed invokeLater lands after the flush.

messageSync.mergeRawBlocksDuringStreaming:
- Let prev win only when it is a prefix-extension of next (or next is empty); keep non-empty, non-prefix next so a shorter new turn is not overwritten by the longer previous turn.

Tests:
- Add mergeAssistantMessageFillsEmptyTextBlockWithIncomingSameSegmentText to guard the empty-text-block fill behaviour.

Verified: ./gradlew checkstyleMain, webview npm run test (726 tests), and MessageMerger/Dedup/RawConsistency tests all pass.