### PR TITLE
fix(codex): scope session replay to current turn

### DIFF
--- a/ai-bridge/services/codex/codex-event-handler.js
+++ b/ai-bridge/services/codex/codex-event-handler.js
@@ -8,6 +8,7 @@
  *
  * Exports:
  *   - createInitialEventState(emitMessage) — factory for the mutable state bag
+ *   - prepareSessionReplayBoundary(state, threadId) — captures the pre-turn JSONL baseline
  *   - processCodexEventStream(events, state, config) — the main event loop
  */
 
@@ -118,8 +119,12 @@ export function createInitialEventState(emitMessage) {
     emittedDeniedCommandToolResultIds: new Set(),
     sessionFilePath: null,
     sessionLineCursor: 0,
-    sessionFunctionCursor: 0,
-    sessionTurnStartCursor: 0,
+    sessionReplayBaselineCursor: null,
+    sessionReplayBaselinePrepared: false,
+    sessionFunctionCursor: null,
+    sessionTurnStartCursor: null,
+    sessionTurnBoundaryReady: false,
+    sessionTurnBoundaryWarningLogged: false,
     processedPatchCallIds: new Set(),
     processedSessionFunctionCallIds: new Set(),
     processedSessionFunctionOutputIds: new Set(),
@@ -181,6 +186,85 @@ function countSessionJsonlLines(content) {
   return splitSessionJsonlEntries(content).length;
 }
 
+/**
+ * Captures the end of the existing session before the current Codex turn starts.
+ * A later replay boundary is only accepted when a new turn_context appears at or
+ * after this cursor, so historical function calls can never become replay candidates.
+ */
+export async function prepareSessionReplayBoundary(state, threadId) {
+  state.sessionReplayBaselinePrepared = true;
+  state.sessionReplayBaselineCursor = threadId ? null : 0;
+  state.sessionFunctionCursor = null;
+  state.sessionTurnStartCursor = null;
+  state.sessionTurnBoundaryReady = false;
+  state.sessionTurnBoundaryWarningLogged = false;
+
+  if (!threadId) {
+    state.sessionLineCursor = 0;
+    return;
+  }
+
+  const sessionPath = ensureSessionFilePath(state, threadId);
+  if (!sessionPath) {
+    logWarn('SESSION_REPLAY', `Unable to locate resumed session ${threadId}; JSONL function replay is disabled for this turn.`);
+    return;
+  }
+
+  try {
+    const content = await readFile(sessionPath, 'utf8');
+    const baseline = countSessionJsonlLines(content);
+    state.sessionReplayBaselineCursor = baseline;
+    state.sessionLineCursor = baseline;
+  } catch (error) {
+    logWarn('SESSION_REPLAY', 'Unable to capture the pre-turn session boundary; JSONL function replay is disabled for this turn:', error?.message || error);
+  }
+}
+
+function getSessionThreadId(state, config) {
+  return config.threadId || state.currentThreadId || null;
+}
+
+async function ensureSessionTurnBoundary(state, config) {
+  if (state.sessionTurnBoundaryReady) return true;
+  if (!state.sessionReplayBaselinePrepared || !Number.isInteger(state.sessionReplayBaselineCursor)) {
+    return false;
+  }
+
+  const sessionPath = ensureSessionFilePath(state, getSessionThreadId(state, config));
+  if (!sessionPath) return false;
+
+  let content = '';
+  try {
+    content = await readFile(sessionPath, 'utf8');
+  } catch (error) {
+    logDebug('SESSION_REPLAY', 'Failed to read session file while locating the current turn boundary:', error?.message || error);
+    return false;
+  }
+
+  const lines = splitSessionJsonlEntries(content);
+  const baseline = state.sessionReplayBaselineCursor;
+  for (let i = baseline; i < lines.length; i++) {
+    let parsed;
+    try { parsed = JSON.parse(lines[i]); } catch { continue; }
+    if (parsed?.type !== 'turn_context') continue;
+
+    const boundaryCursor = i + 1;
+    state.sessionTurnStartCursor = boundaryCursor;
+    state.sessionFunctionCursor = boundaryCursor;
+    state.sessionTurnBoundaryReady = true;
+    logDebug('SESSION_REPLAY', `Established current turn boundary at session line ${boundaryCursor}.`);
+    return true;
+  }
+
+  return false;
+}
+
+function warnSessionTurnBoundaryNotReady(state) {
+  if (state.sessionTurnBoundaryWarningLogged) return;
+  state.sessionTurnBoundaryWarningLogged = true;
+  logWarn('SESSION_REPLAY', 'Skipping JSONL function replay until a verified current-turn turn_context is available.');
+}
+
 async function readLatestTurnContextFromSession(state, threadId) {
   const sessionPath = ensureSessionFilePath(state, threadId);
   if (!sessionPath) return null;
@@ -205,7 +289,7 @@ async function readLatestTurnContextFromSession(state, threadId) {
 }
 
 async function collectPatchOperationsFromSession(state, config) {
-  const sessionPath = ensureSessionFilePath(state, config.threadId);
+  const sessionPath = ensureSessionFilePath(state, getSessionThreadId(state, config));
   if (!sessionPath) return [];
   let content = '';
   try { content = await readFile(sessionPath, 'utf8'); } catch (error) {
@@ -246,7 +330,11 @@ async function collectPatchOperationsFromSession(state, config) {
 }
 
 async function replayMissingFunctionCallsFromSession(state, config) {
-  const sessionPath = ensureSessionFilePath(state, config.threadId);
+  if (!state.sessionTurnBoundaryReady || !Number.isInteger(state.sessionTurnStartCursor)) {
+    return { toolUses: 0, toolResults: 0 };
+  }
+
+  const sessionPath = ensureSessionFilePath(state, getSessionThreadId(state, config));
   if (!sessionPath) return { toolUses: 0, toolResults: 0 };
 
   let content = '';
@@ -257,14 +345,10 @@ async function replayMissingFunctionCallsFromSession(state, config) {
   if (!content.trim()) return { toolUses: 0, toolResults: 0 };
 
   const lines = splitSessionJsonlEntries(content);
-  const candidateStartIndexes = [
-    state.sessionFunctionCursor > 0 ? state.sessionFunctionCursor : null,
-    state.sessionTurnStartCursor > 0 ? state.sessionTurnStartCursor : null,
-    Math.max(0, lines.length - SESSION_PATCH_SCAN_MAX_LINES),
-  ].filter((value) => Number.isInteger(value) && value >= 0);
-  const startIndex = candidateStartIndexes.length > 0
-    ? Math.max(...candidateStartIndexes)
-    : Math.max(0, lines.length - SESSION_PATCH_SCAN_MAX_LINES);
+  const startIndex = Math.max(
+    state.sessionTurnStartCursor,
+    Number.isInteger(state.sessionFunctionCursor) ? state.sessionFunctionCursor : state.sessionTurnStartCursor,
+  );
 
   let toolUses = 0;
   let toolResults = 0;
@@ -304,7 +388,11 @@ async function replayMissingFunctionCallsFromSession(state, config) {
 }
 
 async function replayMissingFunctionCallsDuringStream(state, config) {
-  await replayMissingFunctionCallsFromSession(state, config);
+  if (!await ensureSessionTurnBoundary(state, config)) {
+    warnSessionTurnBoundaryNotReady(state);
+    return { toolUses: 0, toolResults: 0 };
+  }
+  return replayMissingFunctionCallsFromSession(state, config);
 }
 
 function buildPermissionInputForPatchOperation(operation) {
@@ -660,30 +748,13 @@ export async function processCodexEventStream(events, state, config) {
       switch (event.type) {
       case 'thread.started': {
         state.currentThreadId = event.thread_id;
-        state.sessionFilePath = null;
-        state.sessionLineCursor = 0;
-        state.sessionFunctionCursor = 0;
-        state.sessionTurnStartCursor = 0;
-        state.processedPatchCallIds.clear();
-        state.processedSessionFunctionCallIds.clear();
-        state.processedSessionFunctionOutputIds.clear();
         console.log('[THREAD_ID]', state.currentThreadId);
         break;
       }
 
       case 'turn.started': {
         state.turnCompleted = false;
-        const sessionPath = ensureSessionFilePath(state, config.threadId);
-        if (sessionPath && existsSync(sessionPath)) {
-          try {
-            const content = await readFile(sessionPath, 'utf8');
-            state.sessionTurnStartCursor = countSessionJsonlLines(content);
-          } catch {
-            state.sessionTurnStartCursor = state.sessionFunctionCursor;
-          }
-        } else {
-          state.sessionTurnStartCursor = state.sessionFunctionCursor;
-        }
+        await ensureSessionTurnBoundary(state, config);
         console.log('[DEBUG] Turn started');
         break;
       }
@@ -744,7 +815,7 @@ export async function processCodexEventStream(events, state, config) {
       case 'turn.completed': {
         state.turnCompleted = true;
         console.log('[DEBUG] Turn completed');
-        const replayed = await replayMissingFunctionCallsFromSession(state, config);
+        const replayed = await replayMissingFunctionCallsDuringStream(state, config);
         if (replayed.toolUses > 0 || replayed.toolResults > 0) {
           console.log('[DEBUG] Replayed session function calls:', JSON.stringify(replayed));
         }

--- a/ai-bridge/services/codex/codex-event-handler.test.js
+++ b/ai-bridge/services/codex/codex-event-handler.test.js
@@ -1,8 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { appendFile, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   createInitialEventState,
   isWindowsTaskkillParseNoise,
+  prepareSessionReplayBoundary,
   processCodexEventStream,
 } from './codex-event-handler.js';
 
@@ -81,6 +85,266 @@ test('Codex item.updated agent_message emits incremental content deltas before c
       content: [{ type: 'text', text: 'Hello' }],
     },
   });
+});
+
+test('Codex session replay does not emit historical function calls before turn.started', async () => {
+  const tempDirectory = await mkdtemp(join(tmpdir(), 'codex-history-replay-'));
+  const tempSessionPath = join(tempDirectory, 'fixture-session.jsonl');
+  const historicalEntries = [
+    {
+      type: 'response_item',
+      payload: {
+        type: 'function_call',
+        name: 'shell_command',
+        call_id: 'old-call-1',
+        arguments: JSON.stringify({ command: 'echo OLD_COMMAND' }),
+      },
+    },
+    {
+      type: 'response_item',
+      payload: {
+        type: 'function_call_output',
+        call_id: 'old-call-1',
+        output: 'OLD_OUTPUT',
+      },
+    },
+  ];
+
+  await writeFile(
+    tempSessionPath,
+    `${historicalEntries.map((entry) => JSON.stringify(entry)).join('\n')}\n`,
+    'utf8',
+  );
+
+  try {
+    const emittedMessages = [];
+    const state = createInitialEventState((message) => emittedMessages.push(message));
+    state.sessionFilePath = tempSessionPath;
+    await prepareSessionReplayBoundary(state, 'fixture-thread');
+
+    await captureStdout(async () => {
+      await processCodexEventStream(
+        eventsFrom([
+          { type: 'event_msg', payload: { type: 'status' } },
+          { type: 'turn.started' },
+          { type: 'turn.completed' },
+        ]),
+        state,
+        { ...makeConfig(), threadId: 'fixture-thread' },
+      );
+    });
+
+    const historicalToolUses = emittedMessages.filter((message) =>
+      message?.message?.content?.some((block) =>
+        block.type === 'tool_use' && block.input?.command === 'echo OLD_COMMAND'
+      )
+    );
+
+    assert.equal(
+      historicalToolUses.length,
+      0,
+      'event_msg before turn.started replayed the historical OLD_COMMAND tool call',
+    );
+  } finally {
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+});
+
+test('Codex session replay emits only current-turn function calls after a delayed turn_context', async () => {
+  const tempDirectory = await mkdtemp(join(tmpdir(), 'codex-current-turn-replay-'));
+  const tempSessionPath = join(tempDirectory, 'fixture-session.jsonl');
+  const historicalEntry = {
+    type: 'response_item',
+    payload: {
+      type: 'function_call',
+      name: 'shell_command',
+      call_id: 'old-call-1',
+      arguments: JSON.stringify({ command: 'echo OLD_COMMAND' }),
+    },
+  };
+  await writeFile(tempSessionPath, `${JSON.stringify(historicalEntry)}\n`, 'utf8');
+
+  try {
+    const emittedMessages = [];
+    const state = createInitialEventState((message) => emittedMessages.push(message));
+    state.sessionFilePath = tempSessionPath;
+    await prepareSessionReplayBoundary(state, 'fixture-thread');
+
+    async function* delayedCurrentTurnEvents() {
+      yield { type: 'turn.started' };
+      await appendFile(
+        tempSessionPath,
+        [
+          { type: 'turn_context', payload: { cwd: 'C:/fixture' } },
+          {
+            type: 'response_item',
+            payload: {
+              type: 'function_call',
+              name: 'shell_command',
+              call_id: 'current-call-1',
+              arguments: JSON.stringify({ command: 'echo CURRENT_COMMAND' }),
+            },
+          },
+          {
+            type: 'response_item',
+            payload: {
+              type: 'function_call_output',
+              call_id: 'current-call-1',
+              output: 'CURRENT_OUTPUT',
+            },
+          },
+        ].map((entry) => JSON.stringify(entry)).join('\n') + '\n',
+        'utf8',
+      );
+      yield { type: 'event_msg', payload: { type: 'status' } };
+      yield { type: 'event_msg', payload: { type: 'status' } };
+      yield { type: 'turn.completed' };
+    }
+
+    await captureStdout(async () => {
+      await processCodexEventStream(
+        delayedCurrentTurnEvents(),
+        state,
+        { ...makeConfig(), threadId: 'fixture-thread' },
+      );
+    });
+
+    const toolUseCommands = emittedMessages.flatMap((message) =>
+      message?.message?.content
+        ?.filter((block) => block.type === 'tool_use')
+        .map((block) => block.input?.command) ?? []
+    );
+    const currentResults = emittedMessages.flatMap((message) =>
+      message?.message?.content
+        ?.filter((block) => block.type === 'tool_result' && block.tool_use_id === 'current-call-1') ?? []
+    );
+
+    assert.deepEqual(toolUseCommands, ['echo CURRENT_COMMAND']);
+    assert.equal(currentResults.length, 1);
+    assert.equal(currentResults[0].content, 'CURRENT_OUTPUT');
+  } finally {
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+});
+
+test('Codex session replay accepts a verified current turn before turn.started is observed', async () => {
+  const tempDirectory = await mkdtemp(join(tmpdir(), 'codex-early-current-turn-'));
+  const tempSessionPath = join(tempDirectory, 'fixture-session.jsonl');
+  await writeFile(
+    tempSessionPath,
+    `${JSON.stringify({
+      type: 'response_item',
+      payload: {
+        type: 'function_call',
+        name: 'shell_command',
+        call_id: 'old-call-1',
+        arguments: JSON.stringify({ command: 'echo OLD_COMMAND' }),
+      },
+    })}\n`,
+    'utf8',
+  );
+
+  try {
+    const emittedMessages = [];
+    const state = createInitialEventState((message) => emittedMessages.push(message));
+    state.sessionFilePath = tempSessionPath;
+    await prepareSessionReplayBoundary(state, 'fixture-thread');
+
+    await appendFile(
+      tempSessionPath,
+      [
+        { type: 'turn_context', payload: { cwd: 'C:/fixture' } },
+        {
+          type: 'response_item',
+          payload: {
+            type: 'function_call',
+            name: 'shell_command',
+            call_id: 'current-call-early',
+            arguments: JSON.stringify({ command: 'echo EARLY_CURRENT_COMMAND' }),
+          },
+        },
+      ].map((entry) => JSON.stringify(entry)).join('\n') + '\n',
+      'utf8',
+    );
+
+    await captureStdout(async () => {
+      await processCodexEventStream(
+        eventsFrom([
+          { type: 'event_msg', payload: { type: 'status' } },
+          { type: 'turn.started' },
+          { type: 'turn.completed' },
+        ]),
+        state,
+        { ...makeConfig(), threadId: 'fixture-thread' },
+      );
+    });
+
+    const commands = emittedMessages.flatMap((message) =>
+      message?.message?.content
+        ?.filter((block) => block.type === 'tool_use')
+        .map((block) => block.input?.command) ?? []
+    );
+    assert.deepEqual(commands, ['echo EARLY_CURRENT_COMMAND']);
+  } finally {
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+});
+
+test('Codex direct response items and JSONL replay emit the same call_id only once', async () => {
+  const tempDirectory = await mkdtemp(join(tmpdir(), 'codex-replay-dedup-'));
+  const tempSessionPath = join(tempDirectory, 'fixture-session.jsonl');
+  await writeFile(tempSessionPath, '', 'utf8');
+
+  try {
+    const emittedMessages = [];
+    const state = createInitialEventState((message) => emittedMessages.push(message));
+    state.sessionFilePath = tempSessionPath;
+    await prepareSessionReplayBoundary(state, 'fixture-thread');
+
+    const functionCall = {
+      type: 'function_call',
+      name: 'shell_command',
+      call_id: 'dedup-call-1',
+      arguments: JSON.stringify({ command: 'echo DEDUP_COMMAND' }),
+    };
+    const functionOutput = {
+      type: 'function_call_output',
+      call_id: 'dedup-call-1',
+      output: 'DEDUP_OUTPUT',
+    };
+    await appendFile(
+      tempSessionPath,
+      [
+        { type: 'turn_context', payload: { cwd: 'C:/fixture' } },
+        { type: 'response_item', payload: functionCall },
+        { type: 'response_item', payload: functionOutput },
+      ].map((entry) => JSON.stringify(entry)).join('\n') + '\n',
+      'utf8',
+    );
+
+    await captureStdout(async () => {
+      await processCodexEventStream(
+        eventsFrom([
+          { type: 'response_item', payload: functionCall },
+          { type: 'response_item', payload: functionOutput },
+          { type: 'event_msg', payload: { type: 'status' } },
+          { type: 'turn.completed' },
+        ]),
+        state,
+        { ...makeConfig(), threadId: 'fixture-thread' },
+      );
+    });
+
+    const matchingBlocks = emittedMessages.flatMap((message) =>
+      message?.message?.content?.filter((block) =>
+        block.id === 'dedup-call-1' || block.tool_use_id === 'dedup-call-1'
+      ) ?? []
+    );
+    assert.equal(matchingBlocks.filter((block) => block.type === 'tool_use').length, 1);
+    assert.equal(matchingBlocks.filter((block) => block.type === 'tool_result').length, 1);
+  } finally {
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
 });
 
 test('isWindowsTaskkillParseNoise: matches English SUCCESS taskkill output', () => {

--- a/ai-bridge/services/codex/message-service.js
+++ b/ai-bridge/services/codex/message-service.js
@@ -29,7 +29,11 @@ import {
   buildErrorPayload
 } from './codex-utils.js';
 import { collectAgentsInstructions } from './codex-agents-loader.js';
-import { createInitialEventState, processCodexEventStream } from './codex-event-handler.js';
+import {
+  createInitialEventState,
+  prepareSessionReplayBoundary,
+  processCodexEventStream,
+} from './codex-event-handler.js';
 
 // ---------------------------------------------------------------------------
 // sendMessage
@@ -249,6 +253,13 @@ export async function sendMessage(
       console.log('[DEBUG] Using string input format');
     }
 
+    const workingDirectory = cwd && cwd.trim() !== '' ? cwd : undefined;
+    const emitMessage = (msg) => {
+      console.log('[MESSAGE]', JSON.stringify(msg));
+    };
+    const state = createInitialEventState(emitMessage);
+    await prepareSessionReplayBoundary(state, threadId);
+
     const turnAbortController = new AbortController();
     const { events } = await thread.runStreamed(runInput, {
       signal: turnAbortController.signal
@@ -259,14 +270,6 @@ export async function sendMessage(
     // ============================================================
     // 7. Delegate Event Processing to codex-event-handler
     // ============================================================
-
-    const workingDirectory = cwd && cwd.trim() !== '' ? cwd : undefined;
-
-    const emitMessage = (msg) => {
-      console.log('[MESSAGE]', JSON.stringify(msg));
-    };
-
-    const state = createInitialEventState(emitMessage);
 
     const config = {
       cwd: workingDirectory,

--- a/webview/src/hooks/useChatComputations.test.ts
+++ b/webview/src/hooks/useChatComputations.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { ClaudeContentBlock, ClaudeMessage } from '../types';
+import { sliceLatestConversationTurn } from '../utils/turnScope';
+import { deriveTodosForTurn } from './useChatComputations';
+
+interface TestMessage extends ClaudeMessage {
+  __blocks?: ClaudeContentBlock[];
+}
+
+const getContentBlocks = (message: ClaudeMessage): ClaudeContentBlock[] =>
+  (message as TestMessage).__blocks ?? [];
+
+const user = (content: string): ClaudeMessage => ({ type: 'user', content });
+
+const assistant = (blocks: ClaudeContentBlock[]): ClaudeMessage =>
+  ({ type: 'assistant', __blocks: blocks }) as TestMessage;
+
+const toolUse = (id: string, name: string, input: Record<string, unknown>): ClaudeContentBlock =>
+  ({ type: 'tool_use', id, name, input });
+
+describe('deriveTodosForTurn', () => {
+  it('does not carry a completed plan into a new user turn', () => {
+    const messages = [
+      user('previous request'),
+      assistant([
+        toolUse('plan-1', 'update_plan', {
+          plan: Array.from({ length: 5 }, (_, index) => ({
+            step: `Previous step ${index + 1}`,
+            status: 'completed',
+          })),
+        }),
+      ]),
+      user('Only answer OK'),
+    ];
+
+    const latestTurn = sliceLatestConversationTurn(messages);
+    expect(deriveTodosForTurn(latestTurn, getContentBlocks, true)).toEqual([]);
+  });
+
+  it('shows the latest plan created in the current turn', () => {
+    const messages = [
+      user('previous request'),
+      assistant([toolUse('old-plan', 'update_plan', {
+        plan: [{ step: 'Old step', status: 'completed' }],
+      })]),
+      user('new request'),
+      assistant([toolUse('new-plan', 'update_plan', {
+        plan: [
+          { step: 'First', status: 'in_progress' },
+          { step: 'Second', status: 'pending' },
+          { step: 'Third', status: 'pending' },
+        ],
+      })]),
+    ];
+
+    const latestTurn = sliceLatestConversationTurn(messages);
+    expect(deriveTodosForTurn(latestTurn, getContentBlocks, true)).toEqual([
+      { content: 'First', status: 'in_progress' },
+      { content: 'Second', status: 'pending' },
+      { content: 'Third', status: 'pending' },
+    ]);
+  });
+
+  it('does not carry completed structured tasks into a new user turn', () => {
+    const messages = [
+      user('previous request'),
+      assistant([toolUse('task-create-1', 'TaskCreate', { subject: 'Previous task' })]),
+      {
+        type: 'user',
+        raw: {
+          content: [{
+            type: 'tool_result',
+            tool_use_id: 'task-create-1',
+            content: 'Task #1 created successfully',
+          }],
+        },
+      } as ClaudeMessage,
+      assistant([toolUse('task-update-1', 'TaskUpdate', { taskId: '1', status: 'completed' })]),
+      user('Only answer OK'),
+    ];
+
+    const latestTurn = sliceLatestConversationTurn(messages);
+    expect(deriveTodosForTurn(latestTurn, getContentBlocks, true)).toEqual([]);
+  });
+});

--- a/webview/src/hooks/useChatComputations.ts
+++ b/webview/src/hooks/useChatComputations.ts
@@ -1,8 +1,10 @@
 import { type RefObject, useCallback, useMemo, useRef } from 'react';
 import type { TFunction } from 'i18next';
 import type {
+  ClaudeContentBlock,
   ClaudeMessage,
   ClaudeRawMessage,
+  TodoItem,
   ToolResultBlock,
 } from '../types';
 import type { GetToolResultRawFn } from '../contexts/SubagentContext';
@@ -31,6 +33,33 @@ interface UseChatComputationsParams {
   currentSessionIdRef: RefObject<string | null>;
   getMessageText: ReturnType<typeof useMessageProcessing>['getMessageText'];
   getContentBlocks: ReturnType<typeof useMessageProcessing>['getContentBlocks'];
+}
+
+export function deriveTodosForTurn(
+  turnMessages: ClaudeMessage[],
+  getContentBlocks: (message: ClaudeMessage) => ClaudeContentBlock[],
+  streamingActive: boolean,
+): TodoItem[] {
+  let latestTodos: ReturnType<typeof extractTodosFromToolUse> = null;
+  for (let i = turnMessages.length - 1; i >= 0; i--) {
+    const msg = turnMessages[i];
+    if (msg.type !== 'assistant') continue;
+    const blocks = getContentBlocks(msg);
+    for (let j = blocks.length - 1; j >= 0; j--) {
+      const todos = extractTodosFromToolUse(blocks[j]);
+      if (todos && todos.length > 0) {
+        latestTodos = todos;
+        break;
+      }
+    }
+    if (latestTodos) break;
+  }
+
+  if (latestTodos) {
+    return finalizeTodosForSettledTurn(latestTodos, streamingActive);
+  }
+
+  return extractAccumulatedTasks(turnMessages, getContentBlocks);
 }
 
 /**
@@ -124,29 +153,8 @@ export function useChatComputations({
   );
 
   const globalTodos = useMemo(() => {
-    let latestTodos: ReturnType<typeof extractTodosFromToolUse> = null;
-    for (let i = latestTurnMessages.length - 1; i >= 0; i--) {
-      const msg = latestTurnMessages[i];
-      if (msg.type !== 'assistant') continue;
-      const blocks = getContentBlocks(msg);
-      for (let j = blocks.length - 1; j >= 0; j--) {
-        const todos = extractTodosFromToolUse(blocks[j]);
-        if (todos && todos.length > 0) {
-          latestTodos = todos;
-          break;
-        }
-      }
-      if (latestTodos) break;
-    }
-    if (latestTodos) {
-      return finalizeTodosForSettledTurn(latestTodos, streamingActive);
-    }
-    const accumulated = extractAccumulatedTasks(messages, getContentBlocks);
-    if (accumulated.length > 0) {
-      return accumulated;
-    }
-    return [];
-  }, [latestTurnMessages, messages, getContentBlocks, streamingActive]);
+    return deriveTodosForTurn(latestTurnMessages, getContentBlocks, streamingActive);
+  }, [latestTurnMessages, getContentBlocks, streamingActive]);
 
   const canRewindFromMessageIndex = useCallback(
     (userMessageIndex: number) => {


### PR DESCRIPTION
## Summary

- capture the session JSONL baseline before starting a Codex turn
- replay function calls only after a verified current-turn `turn_context`
- preserve current-turn replay and call-id deduplication
- prevent completed tasks from a previous turn appearing in a new turn

## Tests

- `node --test services/codex/codex-event-handler.test.js`
- `npm test`
- `npm run build`
- `./gradlew test`