### PR TITLE
fix(webview): resolve 10 verified transcript-rendering bugs from audit

### DIFF
--- a/webview/src/components/CollapsibleTextBlock.tsx
+++ b/webview/src/components/CollapsibleTextBlock.tsx
@@ -6,10 +6,24 @@ interface CollapsibleTextBlockProps {
 
 const MAX_HEIGHT = 160; // Approx 7-8 lines
 
+// Very large pasted texts (hundreds of KB) must not be fully materialized in the
+// DOM while collapsed: the node is laid out (and re-measured by the
+// ResizeObserver) even though max-height hides it visually. Above the
+// threshold only a preview slice is rendered until the user expands.
+const LARGE_CONTENT_THRESHOLD = 20000;
+const COLLAPSED_PREVIEW_CHARS = 10000;
+
 const CollapsibleTextBlock: React.FC<CollapsibleTextBlockProps> = ({ content }) => {
   const [expanded, setExpanded] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
+
+  const isLargeContent = content.length > LARGE_CONTENT_THRESHOLD;
+  const displayContent = !expanded && isLargeContent
+    ? content.slice(0, COLLAPSED_PREVIEW_CHARS)
+    : content;
+  // Large content always overflows the collapsed height — force the affordance on
+  const showOverflow = isOverflowing || isLargeContent;
 
   useEffect(() => {
     if (!contentRef.current) return;
@@ -28,7 +42,7 @@ const CollapsibleTextBlock: React.FC<CollapsibleTextBlockProps> = ({ content }) 
     observer.observe(contentRef.current);
 
     return () => observer.disconnect();
-  }, [content]);
+  }, [displayContent]);
 
   const toggleExpand = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -36,7 +50,7 @@ const CollapsibleTextBlock: React.FC<CollapsibleTextBlockProps> = ({ content }) 
   };
 
   const contentStyle: React.CSSProperties = {
-    maxHeight: (expanded || !isOverflowing) ? 'none' : `${MAX_HEIGHT}px`,
+    maxHeight: (expanded || !showOverflow) ? 'none' : `${MAX_HEIGHT}px`,
     overflow: 'hidden',
   };
   const chevronStyle: React.CSSProperties = {
@@ -51,15 +65,15 @@ const CollapsibleTextBlock: React.FC<CollapsibleTextBlockProps> = ({ content }) 
         ref={contentRef}
         style={contentStyle}
       >
-        <div className="plain-text-content">{content}</div>
+        <div className="plain-text-content">{displayContent}</div>
 
         {/* Gradient overlay when collapsed */}
-        {!expanded && isOverflowing && (
+        {!expanded && showOverflow && (
              <div className="collapse-overlay"></div>
         )}
       </div>
 
-      {isOverflowing && (
+      {showOverflow && (
         <div className="collapse-toggle" onClick={toggleExpand}>
             <span className="codicon codicon-chevron-down" style={chevronStyle}></span>
         </div>

--- a/webview/src/components/MessageItem/ContentBlockRenderer.tsx
+++ b/webview/src/components/MessageItem/ContentBlockRenderer.tsx
@@ -47,6 +47,30 @@ function getExtension(fileName?: string): string {
   return parts.length > 1 ? parts[parts.length - 1].toUpperCase() : '';
 }
 
+/** Format a token count for compact display (e.g., 524835 → "524.8K"). */
+function formatCompactTokens(count: number): string {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}K`;
+  return String(count);
+}
+
+/**
+ * Build the compaction-stats subtitle from compact_boundary metadata:
+ * "manual · 524.8K → 14.6K · 110s". Returns null when no stats are present.
+ */
+function formatCompactionStats(meta: CompactSummaryMetadata): string | null {
+  const parts: string[] = [];
+  if (meta.trigger) parts.push(meta.trigger);
+  if (typeof meta.preTokens === 'number') {
+    const tokens = typeof meta.postTokens === 'number'
+      ? `${formatCompactTokens(meta.preTokens)} → ${formatCompactTokens(meta.postTokens)}`
+      : formatCompactTokens(meta.preTokens);
+    parts.push(tokens);
+  }
+  if (typeof meta.durationMs === 'number') parts.push(`${Math.round(meta.durationMs / 1000)}s`);
+  return parts.length > 0 ? parts.join(' · ') : null;
+}
+
 interface CompactSummaryBlockProps {
   block: {
     type: 'compact_summary';
@@ -72,7 +96,9 @@ const CompactSummaryBlock = memo(function CompactSummaryBlock({ block, t }: Comp
     }
   }, []);
   const meta = block.metadata;
-  const hasMeta = meta && typeof meta.messagesSummarized === 'number';
+  const hasCountMeta = meta && typeof meta.messagesSummarized === 'number';
+  const compactionStats = meta ? formatCompactionStats(meta) : null;
+  const hasMeta = hasCountMeta || compactionStats;
   const titleText = t(block.title);
   const toggleLabel = expanded ? t('chat.compactSummary.collapse') : t('chat.compactSummary.expand');
 
@@ -93,15 +119,20 @@ const CompactSummaryBlock = memo(function CompactSummaryBlock({ block, t }: Comp
       </div>
       {hasMeta && (
         <div className="compact-summary-metadata">
-          <span className="compact-summary-meta-count">
-            {t(
-              meta.direction === 'from'
-                ? 'chat.compactSummary.messagesFrom'
-                : 'chat.compactSummary.messagesUpTo',
-              { count: meta.messagesSummarized },
-            )}
-          </span>
-          {meta.userContext && (
+          {hasCountMeta && (
+            <span className="compact-summary-meta-count">
+              {t(
+                meta.direction === 'from'
+                  ? 'chat.compactSummary.messagesFrom'
+                  : 'chat.compactSummary.messagesUpTo',
+                { count: meta.messagesSummarized },
+              )}
+            </span>
+          )}
+          {compactionStats && (
+            <span className="compact-summary-meta-count">{compactionStats}</span>
+          )}
+          {meta?.userContext && (
             <span className="compact-summary-meta-context">
               {t('chat.compactSummary.userContext', { context: meta.userContext })}
             </span>
@@ -329,12 +360,19 @@ export function ContentBlockRenderer({
 
   // Task notification block - renders as "● summary" with status color
   if (block.type === 'task_notification') {
-    // TypeScript narrows block to { type: 'task_notification'; icon: string; summary: string; status: string }
+    // TypeScript narrows block to { type: 'task_notification'; icon; summary; status; detail? }
     const statusColor = TASK_STATUS_COLORS[block.status] || 'text';
+    const detail = block.detail;
+    const truncatedDetail = detail && detail.length > 300 ? `${detail.slice(0, 300)}…` : detail;
     return (
       <div className={`task-notification-block task-notification-${statusColor}`}>
         <span className="task-notification-icon">{block.icon}</span>
-        <span className="task-notification-summary">{block.summary}</span>
+        <span className="task-notification-summary">
+          {block.summary}
+          {truncatedDetail && (
+            <span className="task-notification-detail" title={detail}>{truncatedDetail}</span>
+          )}
+        </span>
       </div>
     );
   }

--- a/webview/src/components/toolBlocks/BashToolBlock.tsx
+++ b/webview/src/components/toolBlocks/BashToolBlock.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ToolInput, ToolResultBlock } from '../../types';
 import { useIsToolDenied } from '../../hooks/useIsToolDenied';
+import { stripAnsi } from '../../utils/stripAnsi';
 
 const TASK_DETAILS_STYLE: React.CSSProperties = { padding: 0, border: 'none' };
 const TASK_CONTENT_WRAPPER_STYLE: React.CSSProperties = { paddingLeft: '40px', position: 'relative', zIndex: 1 };
@@ -43,6 +44,7 @@ const BashToolBlock = ({ input, result, toolId }: BashToolBlockProps) => {
     } else if (Array.isArray(content)) {
       output = content.map((block) => block.text ?? '').join('\n');
     }
+    output = stripAnsi(output);
   }
 
   return (

--- a/webview/src/components/toolBlocks/BashToolGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/BashToolGroupBlock.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ToolInput, ToolResultBlock } from '../../types';
+import { stripAnsi } from '../../utils/stripAnsi';
 
 interface BashItem {
   command: string;
@@ -58,6 +59,7 @@ function parseBashItem(
     } else if (Array.isArray(content)) {
       output = content.map((block) => block.text ?? '').join('\n');
     }
+    output = stripAnsi(output);
   }
 
   const isDenied = toolId ? (deniedToolIds?.has(toolId) ?? false) : false;

--- a/webview/src/components/toolBlocks/GenericToolBlock.test.tsx
+++ b/webview/src/components/toolBlocks/GenericToolBlock.test.tsx
@@ -115,4 +115,49 @@ describe('GenericToolBlock', () => {
     // still show the user where the link points before the backend resolves.
     expect(hookMocks.useResolvedFileLinkTooltip).toHaveBeenCalledWith(absolutePath, absolutePath);
   });
+
+  it('caps huge param values instead of dumping them into the DOM', () => {
+    const hugeContent = 'x'.repeat(50_000);
+    const { container } = render(
+      <GenericToolBlock
+        name="Write"
+        input={{
+          file_path: '/tmp/generated.ts',
+          content: hugeContent,
+        }}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('.task-header') as HTMLElement);
+
+    const fieldContent = container.querySelector('.task-field-content');
+    expect(fieldContent?.textContent?.length).toBeLessThan(4100);
+    expect(fieldContent?.textContent?.endsWith('… (+46000 more chars)')).toBe(true);
+  });
+
+  it('renders nested tool_result images and makes the card expandable', () => {
+    const { container } = render(
+      <GenericToolBlock
+        name="Read"
+        input={{ file_path: '/tmp/screenshot.png' }}
+        result={{
+          type: 'tool_result',
+          tool_use_id: 'toolu_img',
+          content: [
+            { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0KGgo=' } } as never,
+          ],
+        }}
+      />,
+    );
+
+    // Image-count hint in the header even though there are no other params
+    expect(container.querySelector('.codicon-file-media')).toBeTruthy();
+    expect(container.querySelector('.task-details-accordion')).toBeTruthy();
+
+    fireEvent.click(container.querySelector('.task-header') as HTMLElement);
+
+    const img = container.querySelector('.task-details-accordion img') as HTMLImageElement;
+    expect(img).toBeTruthy();
+    expect(img.src).toBe('data:image/png;base64,iVBORw0KGgo=');
+  });
 });

--- a/webview/src/components/toolBlocks/GenericToolBlock.tsx
+++ b/webview/src/components/toolBlocks/GenericToolBlock.tsx
@@ -5,6 +5,7 @@ import { useIsToolDenied } from '../../hooks/useIsToolDenied';
 import { useResolvedFileLinkTooltip } from '../../hooks/useResolvedFileLinkTooltip';
 import { openFile } from '../../utils/bridge';
 import { formatParamValue, truncate } from '../../utils/helpers';
+import { extractToolResultImages } from '../../utils/toolResultImages';
 import { getFileIcon, getFolderIcon } from '../../utils/fileIcons';
 import { isCommandToolName, parseCommandType } from '../../utils/toolCommandPath';
 import { getToolLineInfo, resolveToolTarget, summarizeToolCommand, extractPathsFromPatch } from '../../utils/toolPresentation';
@@ -37,6 +38,30 @@ const PATCH_FILE_LINK_STYLE: React.CSSProperties = {
 const LINE_INFO_STYLE: React.CSSProperties = {
   marginLeft: '8px',
   fontSize: '12px',
+};
+
+const RESULT_IMAGE_STYLE: React.CSSProperties = {
+  maxWidth: '100%',
+  maxHeight: '300px',
+  borderRadius: '4px',
+  objectFit: 'contain',
+};
+
+const IMAGE_HINT_STYLE: React.CSSProperties = {
+  marginLeft: '8px',
+  fontSize: '12px',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '2px',
+};
+
+/** Cap rendered param values so a huge Write `content` param (tens of KB) never lands in the DOM. */
+const MAX_PARAM_VALUE_CHARS = 4000;
+
+const formatParamValueCapped = (value: unknown): string => {
+  const text = formatParamValue(value);
+  if (text.length <= MAX_PARAM_VALUE_CHARS) return text;
+  return `${text.slice(0, MAX_PARAM_VALUE_CHARS)}… (+${text.length - MAX_PARAM_VALUE_CHARS} more chars)`;
 };
 
 const CODICON_MAP: Record<string, string> = {
@@ -263,7 +288,10 @@ const GenericToolBlock = ({ name, input, result, toolId }: GenericToolBlockProps
     ([key]) => !omitFields.has(key) && key !== 'pattern',
   );
 
-  const hasExpandableContent = otherParams.length > 0;
+  // Nested image blocks in the tool_result (Read of image files, screenshots)
+  const resultImages = extractToolResultImages(result);
+
+  const hasExpandableContent = otherParams.length > 0 || resultImages.length > 0;
   const isDirectoryPath = target?.isDirectory ?? false;
   const isFilePath = target?.isFile ?? false;
   const lineInfo = input && target ? getToolLineInfo(input, target) : {};
@@ -352,6 +380,12 @@ const GenericToolBlock = ({ name, input, result, toolId }: GenericToolBlockProps
                 : t('tools.lineSingle', { line: lineInfo.start })}
             </span>
           )}
+          {resultImages.length > 0 && (
+            <span className="tool-title-summary" style={IMAGE_HINT_STYLE}>
+              <span className="codicon codicon-file-media" />
+              {resultImages.length}
+            </span>
+          )}
         </div>
 
         <div className={`tool-status-indicator ${isError ? 'error' : isCompleted ? 'completed' : 'pending'}`} />
@@ -363,7 +397,13 @@ const GenericToolBlock = ({ name, input, result, toolId }: GenericToolBlockProps
               {otherParams.map(([key, value]) => (
                 <div key={key} className="task-field">
                   <div className="task-field-label">{key}</div>
-                  <div className="task-field-content">{formatParamValue(value)}</div>
+                  <div className="task-field-content">{formatParamValueCapped(value)}</div>
+                </div>
+              ))}
+              {/* Only mount the (potentially large base64) images while expanded */}
+              {expanded && resultImages.map((image, idx) => (
+                <div key={`result-image-${idx}`} className="task-field">
+                  <img src={image.src} alt={image.mediaType ?? 'image'} style={RESULT_IMAGE_STYLE} />
                 </div>
               ))}
             </div>

--- a/webview/src/components/toolBlocks/ReadToolBlock.tsx
+++ b/webview/src/components/toolBlocks/ReadToolBlock.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { ToolInput, ToolResultBlock } from '../../types';
 import { useIsToolDenied } from '../../hooks/useIsToolDenied';
 import { openFile } from '../../utils/bridge';
+import { extractToolResultImages } from '../../utils/toolResultImages';
 import { useResolvedFileLinkTooltip } from '../../hooks/useResolvedFileLinkTooltip';
 import { getFileIcon, getFolderIcon } from '../../utils/fileIcons';
 import { getToolLineInfo, resolveToolTarget } from '../../utils/toolPresentation';
@@ -64,6 +65,21 @@ const PARAM_VALUE_STYLE: React.CSSProperties = {
   flex: 1,
 };
 
+const RESULT_IMAGE_STYLE: React.CSSProperties = {
+  maxWidth: '100%',
+  maxHeight: '300px',
+  borderRadius: '4px',
+  objectFit: 'contain',
+};
+
+const IMAGE_HINT_STYLE: React.CSSProperties = {
+  marginLeft: '8px',
+  fontSize: '12px',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '2px',
+};
+
 const ReadToolBlock = ({ input, result, toolId }: ReadToolBlockProps) => {
   const [expanded, setExpanded] = useState(false);
   const { t } = useTranslation();
@@ -117,6 +133,9 @@ const ReadToolBlock = ({ input, result, toolId }: ReadToolBlockProps) => {
     key !== 'description'   // Omit Codex description field
   );
 
+  // Nested image blocks in the tool_result (Read of an image file)
+  const resultImages = extractToolResultImages(result);
+
   const headerStyle: React.CSSProperties = {
     borderBottom: expanded ? '1px solid var(--border-primary)' : undefined,
   };
@@ -154,12 +173,18 @@ const ReadToolBlock = ({ input, result, toolId }: ReadToolBlockProps) => {
                 : t('tools.lineSingle', { line: lineInfo.start })}
             </span>
           )}
+          {resultImages.length > 0 && (
+            <span className="tool-title-summary" style={IMAGE_HINT_STYLE}>
+              <span className="codicon codicon-file-media" />
+              {resultImages.length}
+            </span>
+          )}
         </div>
 
         <div className={`tool-status-indicator ${isError ? 'error' : isCompleted ? 'completed' : 'pending'}`} />
       </div>
 
-      {expanded && params.length > 0 && (
+      {expanded && (params.length > 0 || resultImages.length > 0) && (
         <div className="task-details" style={TASK_DETAILS_STYLE}>
           <div style={PARAMS_CONTAINER_STYLE}>
             {params.map(([key, value]) => (
@@ -169,6 +194,14 @@ const ReadToolBlock = ({ input, result, toolId }: ReadToolBlockProps) => {
                   {String(value)}
                 </span>
               </div>
+            ))}
+            {resultImages.map((image, idx) => (
+              <img
+                key={`result-image-${idx}`}
+                src={image.src}
+                alt={image.mediaType ?? 'image'}
+                style={RESULT_IMAGE_STYLE}
+              />
             ))}
           </div>
         </div>

--- a/webview/src/hooks/useChatComputations.ts
+++ b/webview/src/hooks/useChatComputations.ts
@@ -8,6 +8,11 @@ import type {
 import type { GetToolResultRawFn } from '../contexts/SubagentContext';
 import type { RewindableMessage } from '../components/RewindSelectDialog';
 import { formatTime } from '../utils/helpers';
+import {
+  containsAnyTag,
+  hasTaskNotificationTag,
+  INTERNAL_METADATA_TAGS,
+} from '../utils/messageUtils';
 import { extractTodosFromToolUse, extractAccumulatedTasks } from '../utils/todoToolNormalization';
 import {
   finalizeSubagentsForSettledTurn,
@@ -192,9 +197,22 @@ export function useChatComputations({
   const sessionTitle = useMemo(() => {
     if (customSessionTitle) return customSessionTitle;
     if (messages.length === 0) return t('common.newSession');
-    const firstUserMessage = messages.find((message) => message.type === 'user');
-    if (!firstUserMessage) return t('common.newSession');
-    const text = getMessageText(firstUserMessage);
+    // Pick the first REAL prompt: skip meta/caveat messages and anything whose
+    // text is raw internal XML (e.g. <local-command-caveat>) so the tag is
+    // never leaked as the session title.
+    let text = '';
+    for (const message of messages) {
+      if (message.type !== 'user') continue;
+      const raw = message.raw;
+      if (raw && typeof raw === 'object' && raw.isMeta === true) continue;
+      const candidate = getMessageText(message).trim();
+      if (!candidate) continue;
+      if (candidate.startsWith('<')) continue;
+      if (containsAnyTag(candidate, INTERNAL_METADATA_TAGS) || hasTaskNotificationTag(candidate)) continue;
+      text = candidate;
+      break;
+    }
+    if (!text) return t('common.newSession');
     return text.length > 15 ? `${text.substring(0, 15)}...` : text;
   }, [customSessionTitle, messages, t, getMessageText]);
 

--- a/webview/src/hooks/useMessageProcessing.ts
+++ b/webview/src/hooks/useMessageProcessing.ts
@@ -7,6 +7,7 @@ import {
   shouldShowMessage as shouldShowMessageUtil,
   getContentBlocks as getContentBlocksUtil,
   mergeConsecutiveAssistantMessages,
+  attachCompactBoundaryMetadata,
   isTaskNotificationOnlyMessage,
   hasNonHumanOrigin,
   isCompactRelatedMessage,
@@ -112,8 +113,10 @@ export function useMessageProcessing({ messages, currentSessionId, t }: UseMessa
   // instead of 'user' type so they render correctly (left-aligned, no bubble).
   // This includes task_notification, hook, agent, queue, channel, etc.
   const mergedMessages = useMemo(() => {
+    // Pair compact_boundary system lines with their compact-summary user line
+    // (attaches compactMetadata, drops the metadata-only boundary line).
     const merged = mergeConsecutiveAssistantMessages(
-      messages,
+      attachCompactBoundaryMetadata(messages),
       normalizeBlocks,
       mergedAssistantMessageCache.current
     );

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
@@ -23,6 +23,7 @@ import {
 } from '../messageSync';
 import { releaseSessionTransition } from '../sessionTransition';
 import { parseSequence } from '../parseSequence';
+import { reconstructTurnMetadata } from '../../../utils/turnMetadataReconstruction';
 import { collectUnresolvedToolUseIds } from './streamingCallbacks';
 
 const isTruthy = (v: unknown) => v === true || v === 'true';
@@ -164,7 +165,14 @@ export function registerMessageCallbacks(
     }
 
     try {
-      const parsed = JSON.parse(json) as ClaudeMessage[];
+      // Reconstruct per-turn footer metadata (durationMs / turnUsage) for
+      // settled turns in the snapshot — the persisted transcript carries
+      // neither field, so reloaded sessions lost the duration/token footer.
+      // The trailing turn is skipped while streaming: live stamping owns it.
+      const parsed = reconstructTurnMetadata(
+        JSON.parse(json) as ClaudeMessage[],
+        { skipTrailingTurn: isStreamingRef.current },
+      );
       if (sequence != null) {
         window.__minAcceptedUpdateSequence = Math.max(minAcceptedSequence, sequence);
       }

--- a/webview/src/styles/less/components/message.less
+++ b/webview/src/styles/less/components/message.less
@@ -1327,6 +1327,16 @@
     line-height: 1.5;
 }
 
+/* Optional <event> payload of a monitor notification - muted second line */
+.task-notification-detail {
+    display: block;
+    color: var(--text-tertiary, rgba(128, 128, 128, 0.9));
+    font-size: 12px;
+    line-height: 1.4;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
 /* Status-based colors - matching CLI behavior */
 .task-notification-success {
     .task-notification-icon {

--- a/webview/src/types/index.ts
+++ b/webview/src/types/index.ts
@@ -10,11 +10,22 @@ export interface CompactNotificationItem {
 /**
  * Metadata for compact summary messages.
  * Contains information about the compaction operation.
+ * The real transcript shape lives on a separate `type: 'system',
+ * subtype: 'compact_boundary'` line under `compactMetadata`
+ * ({ trigger, preTokens, postTokens, durationMs, … }).
  */
 export interface CompactSummaryMetadata {
   messagesSummarized?: number;
   direction?: 'up_to' | 'from';
   userContext?: string;
+  /** What initiated the compaction ('manual' | 'auto'). */
+  trigger?: string;
+  /** Context tokens before compaction. */
+  preTokens?: number;
+  /** Context tokens after compaction. */
+  postTokens?: number;
+  /** How long the compaction took, in milliseconds. */
+  durationMs?: number;
 }
 
 /**
@@ -26,6 +37,10 @@ export function isCompactSummaryMetadata(obj: unknown): obj is CompactSummaryMet
   if (m.messagesSummarized !== undefined && typeof m.messagesSummarized !== 'number') return false;
   if (m.direction !== undefined && m.direction !== 'up_to' && m.direction !== 'from') return false;
   if (m.userContext !== undefined && typeof m.userContext !== 'string') return false;
+  if (m.trigger !== undefined && typeof m.trigger !== 'string') return false;
+  if (m.preTokens !== undefined && typeof m.preTokens !== 'number') return false;
+  if (m.postTokens !== undefined && typeof m.postTokens !== 'number') return false;
+  if (m.durationMs !== undefined && typeof m.durationMs !== 'number') return false;
   return true;
 }
 
@@ -35,7 +50,7 @@ export type ClaudeContentBlock =
   | { type: 'tool_use'; id?: string; name?: string; input?: ToolInput }
   | { type: 'image'; src?: string; mediaType?: string; alt?: string }
   | { type: 'attachment'; fileName?: string; mediaType?: string }
-  | { type: 'task_notification'; icon: string; summary: string; status: string }
+  | { type: 'task_notification'; icon: string; summary: string; status: string; detail?: string }
   | { type: 'compact_notification'; headerText: string; items: CompactNotificationItem[] }
   | { type: 'compact_summary'; title: string; content: string; metadata?: CompactSummaryMetadata };
 

--- a/webview/src/utils/contentBlockNormalize.ts
+++ b/webview/src/utils/contentBlockNormalize.ts
@@ -24,17 +24,17 @@ export const ORIGIN_KINDS = {
 } as const;
 
 // ---------------------------------------------------------------------------
-// Optimized regex patterns - single pattern instead of multiple matches
-// NOTE: These regexes assume SDK outputs tags in a fixed order
-// (command-message → command-name → command-args → skill-format).
-// If SDK changes tag order, these must be updated.
+// Command tag extraction (supports multiline content).
+// NOTE: The CLI does NOT emit these tags in one fixed order — the dominant
+// real-world layout is command-name → command-message → command-args, but
+// message-first also occurs. Each tag is therefore extracted with its own
+// independent regex so intervening tags can never break the match.
 // ---------------------------------------------------------------------------
 
-// Regex to extract command-message and related tags (supports multiline content)
-const COMMAND_TAGS_REGEX = /<command-message>([\s\S]*?)<\/command-message>(?:[\s\n]*<command-name>([\s\S]*?)<\/command-name>)?(?:[\s\n]*<command-args>([\s\S]*?)<\/command-args>)?(?:[\s\n]*<skill-format>([\s\S]*?)<\/skill-format>)?/;
-
-// Regex for resubmit format - only needs command-name and command-args (no command-message required)
-const COMMAND_NAME_REGEX = /<command-name>([\s\S]*?)<\/command-name>(?:[\s\n]*<command-args>([\s\S]*?)<\/command-args>)?/;
+const COMMAND_MESSAGE_REGEX = /<command-message>([\s\S]*?)<\/command-message>/;
+const COMMAND_NAME_REGEX = /<command-name>([\s\S]*?)<\/command-name>/;
+const COMMAND_ARGS_REGEX = /<command-args>([\s\S]*?)<\/command-args>/;
+const SKILL_FORMAT_REGEX = /<skill-format>([\s\S]*?)<\/skill-format>/;
 
 // Regex to extract task-notification tags (supports multiline content)
 // Actual SDK format: <task-notification><task-id>...<status>...<summary>...<result>...<usage>...</task-notification>
@@ -42,6 +42,8 @@ const COMMAND_NAME_REGEX = /<command-name>([\s\S]*?)<\/command-name>(?:[\s\n]*<c
 // Two regexes: one for full format (with status), one for minimal format (only summary)
 const TASK_NOTIFICATION_REGEX_WITH_STATUS = /<task-notification>[\s\S]*?<status>([\s\S]*?)<\/status>[\s\S]*?<summary>([\s\S]*?)<\/summary>[\s\S]*?<\/task-notification>/;
 const TASK_NOTIFICATION_REGEX_NO_STATUS = /<task-notification>[\s\S]*?<summary>([\s\S]*?)<\/summary>[\s\S]*?<\/task-notification>/;
+// Monitor events carry the observed payload (log line, error, …) in <event>
+const TASK_NOTIFICATION_EVENT_REGEX = /<event>([\s\S]*?)<\/event>/;
 
 // ---------------------------------------------------------------------------
 // Internal XML tags that should be hidden (not rendered as user messages)
@@ -81,15 +83,15 @@ export function hasCommandMessageTag(text: string): boolean {
 export function formatCommandForDisplay(text: string): string | null {
   if (!text) return null;
 
-  // Single regex match extracts all tags at once (performance optimization)
-  const match = COMMAND_TAGS_REGEX.exec(text);
-  if (!match?.[1]) return null;
+  // Independent per-tag extraction — tolerant to any tag order
+  const messageMatch = COMMAND_MESSAGE_REGEX.exec(text);
+  if (!messageMatch?.[1]) return null;
 
-  const commandMessage = match[1].trim();
+  const commandMessage = messageMatch[1].trim();
   if (!commandMessage) return null;
 
-  const args = match[3]?.trim() ?? '';
-  const isSkillFormat = match[4]?.trim() === 'true';
+  const args = COMMAND_ARGS_REGEX.exec(text)?.[1]?.trim() ?? '';
+  const isSkillFormat = SKILL_FORMAT_REGEX.exec(text)?.[1]?.trim() === 'true';
 
   if (isSkillFormat) {
     // Skill loading message: "Skill(name)"
@@ -111,14 +113,16 @@ export function formatCommandForDisplay(text: string): string | null {
 export function formatCommandForResubmit(text: string): string | null {
   if (!text) return null;
 
-  // Use dedicated regex that matches command-name without requiring command-message
-  const match = COMMAND_NAME_REGEX.exec(text);
-  if (!match?.[1]) return null;
+  // command-name and command-args are extracted independently: the CLI puts
+  // <command-message> between them, which used to defeat a single combined regex
+  // and silently dropped the args from copy/export.
+  const nameMatch = COMMAND_NAME_REGEX.exec(text);
+  if (!nameMatch?.[1]) return null;
 
-  const commandName = match[1].trim();
+  const commandName = nameMatch[1].trim();
   if (!commandName) return null;
 
-  const args = match[2]?.trim() ?? '';
+  const args = COMMAND_ARGS_REGEX.exec(text)?.[1]?.trim() ?? '';
   return args ? `${commandName} ${args}` : commandName;
 }
 
@@ -143,14 +147,18 @@ export const TASK_STATUS_COLORS: Record<string, string> = {
 /**
  * Format task-notification for display, matching CLI's UserAgentNotificationMessage behavior.
  * Returns "● summary" with status-based color (no status text prefix).
+ * Monitor events additionally carry the observed payload in <event>, returned as `detail`
+ * so an error-carrying event stays distinguishable from a benign one.
  *
  * @param text - Raw text containing <task-notification> tags
- * @returns Object with icon, summary, and status, or null if no summary
+ * @returns Object with icon, summary, status, and optional detail, or null if no summary
  */
 export function formatTaskNotificationForDisplay(
   text: string
-): { icon: string; summary: string; status: string } | null {
+): { icon: string; summary: string; status: string; detail?: string } | null {
   if (!text) return null;
+
+  const detail = TASK_NOTIFICATION_EVENT_REGEX.exec(text)?.[1]?.trim() || undefined;
 
   // Try full format first (with status)
   const matchWithStatus = TASK_NOTIFICATION_REGEX_WITH_STATUS.exec(text);
@@ -158,7 +166,7 @@ export function formatTaskNotificationForDisplay(
     const summary = matchWithStatus[2].trim();
     if (!summary) return null;
     const status = matchWithStatus[1]?.trim() ?? 'completed';
-    return { icon: '●', summary, status };
+    return detail ? { icon: '●', summary, status, detail } : { icon: '●', summary, status };
   }
 
   // Fallback: minimal format (only summary)
@@ -166,7 +174,9 @@ export function formatTaskNotificationForDisplay(
   if (matchNoStatus?.[1]) {
     const summary = matchNoStatus[1].trim();
     if (!summary) return null;
-    return { icon: '●', summary, status: 'completed' };
+    return detail
+      ? { icon: '●', summary, status: 'completed', detail }
+      : { icon: '●', summary, status: 'completed' };
   }
 
   return null;
@@ -179,7 +189,7 @@ export function formatTaskNotificationForDisplay(
 export function createTaskNotificationBlock(text: string): ClaudeContentBlock | null {
   const n = formatTaskNotificationForDisplay(text);
   if (!n) return null;
-  return { type: 'task_notification' as const, icon: n.icon, summary: n.summary, status: n.status };
+  return { type: 'task_notification' as const, icon: n.icon, summary: n.summary, status: n.status, detail: n.detail };
 }
 
 /**

--- a/webview/src/utils/copyUtils.ts
+++ b/webview/src/utils/copyUtils.ts
@@ -100,6 +100,12 @@ export function extractMarkdownContent(message: ClaudeMessage, includeThinking =
         if (thinkingText) {
           parts.push(`<thinking>\n${thinkingText}\n</thinking>`);
         }
+      } else if (block.type === 'image') {
+        // Emit a placeholder so copied content acknowledges the image instead of
+        // silently dropping it (raster data cannot embed in a text clipboard).
+        const imageBlock = block as { mediaType?: string; source?: { media_type?: string } };
+        const mediaType = imageBlock.mediaType ?? imageBlock.source?.media_type;
+        parts.push(mediaType ? `[image: ${mediaType}]` : '[image]');
       }
       // tool_use blocks are not included in copy - they contain internal tool calls
     }

--- a/webview/src/utils/messageUtils.test.ts
+++ b/webview/src/utils/messageUtils.test.ts
@@ -7,6 +7,8 @@ import {
   formatCommandForDisplay,
   formatCommandForResubmit,
   formatTaskNotificationForDisplay,
+  createTaskNotificationBlock,
+  attachCompactBoundaryMetadata,
   hasCommandMessageTag,
   hasTaskNotificationTag,
   isTaskNotificationOnlyMessage,
@@ -1054,3 +1056,202 @@ describe('buildCompactNotification', () => {
   });
 });
 
+
+// ---------------------------------------------------------------------------
+// formatCommandForResubmit — real CLI tag order (command-name → command-message
+// → command-args). A combined regex used to require args to IMMEDIATELY follow
+// the name, silently dropping them from copy/export.
+// ---------------------------------------------------------------------------
+
+describe('formatCommandForResubmit — name → message → args tag order', () => {
+  it('extracts args when <command-message> sits between name and args', () => {
+    const text = '<command-name>/effort</command-name>\n<command-message>effort</command-message>\n<command-args>ultracode</command-args>';
+    expect(formatCommandForResubmit(text)).toBe('/effort ultracode');
+  });
+
+  it('extracts multi-word args in the real order', () => {
+    const text = '<command-name>/plugin</command-name>\n<command-message>plugin</command-message>\n<command-args>marketplace list</command-args>';
+    expect(formatCommandForResubmit(text)).toBe('/plugin marketplace list');
+  });
+
+  it('extracts multiline args bodies (e.g. /compact instructions)', () => {
+    const text = '<command-name>/compact</command-name>\n<command-message>compact</command-message>\n<command-args>keep the source paths\nand the test counts</command-args>';
+    expect(formatCommandForResubmit(text)).toBe('/compact keep the source paths\nand the test counts');
+  });
+
+  it('still supports the message-first order', () => {
+    const text = '<command-message>effort</command-message>\n<command-name>/effort</command-name>\n<command-args>ultracode</command-args>';
+    expect(formatCommandForResubmit(text)).toBe('/effort ultracode');
+  });
+});
+
+describe('formatCommandForDisplay — tag order tolerance', () => {
+  it('renders args when command-name precedes command-message (real CLI order)', () => {
+    const text = '<command-name>/effort</command-name>\n<command-message>effort</command-message>\n<command-args>ultracode</command-args>';
+    expect(formatCommandForDisplay(text)).toBe('/effort ultracode');
+  });
+
+  it('renders skill format regardless of tag position', () => {
+    const text = '<skill-format>true</skill-format>\n<command-message>opsx:ff</command-message>';
+    expect(formatCommandForDisplay(text)).toBe('Skill(opsx:ff)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatTaskNotificationForDisplay — <event> payload (monitor notifications)
+// ---------------------------------------------------------------------------
+
+describe('formatTaskNotificationForDisplay — <event> payload', () => {
+  it('returns the event body as detail for status-less monitor events', () => {
+    const text = '<task-notification>\n<task-id>bkvs4037z</task-id>\n<summary>Monitor event: "verify gate exit + result"</summary>\n<event>2026-07-13 14:14:23.887 [main] ERROR c.k.p.s.StatusClient - Failed to check branch status 123456\nEXIT=</event>\n</task-notification>';
+    const result = formatTaskNotificationForDisplay(text);
+    expect(result?.summary).toBe('Monitor event: "verify gate exit + result"');
+    expect(result?.status).toBe('completed');
+    expect(result?.detail).toBe('2026-07-13 14:14:23.887 [main] ERROR c.k.p.s.StatusClient - Failed to check branch status 123456\nEXIT=');
+  });
+
+  it('returns detail together with an explicit status', () => {
+    const text = '<task-notification><status>failed</status><summary>Build watch</summary><event>[ERROR] compilation failed</event></task-notification>';
+    const result = formatTaskNotificationForDisplay(text);
+    expect(result?.status).toBe('failed');
+    expect(result?.detail).toBe('[ERROR] compilation failed');
+  });
+
+  it('omits detail when there is no event tag', () => {
+    const text = '<task-notification><status>completed</status><summary>Review finished</summary></task-notification>';
+    const result = formatTaskNotificationForDisplay(text);
+    expect(result?.detail).toBeUndefined();
+  });
+
+  it('propagates detail into the task_notification content block', () => {
+    const text = '<task-notification><summary>Monitor event</summary><event>[INFO] BUILD SUCCESS</event></task-notification>';
+    const block = createTaskNotificationBlock(text);
+    expect(block).toMatchObject({ type: 'task_notification', summary: 'Monitor event', detail: '[INFO] BUILD SUCCESS' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attachCompactBoundaryMetadata — pairing the compact_boundary system line with
+// the compact-summary user line (real two-line transcript shape)
+// ---------------------------------------------------------------------------
+
+describe('attachCompactBoundaryMetadata', () => {
+  // Mirrors the real JSONL pair: a type:'system', subtype:'compact_boundary'
+  // line carrying compactMetadata, immediately followed by the summary line.
+  const boundaryMessage = (): ClaudeMessage => ({
+    type: 'system',
+    content: 'Conversation compacted',
+    raw: {
+      type: 'system',
+      subtype: 'compact_boundary',
+      content: 'Conversation compacted',
+      isMeta: false,
+      compactMetadata: {
+        trigger: 'manual',
+        preTokens: 524835,
+        durationMs: 109542,
+        postTokens: 14582,
+        preCompactDiscoveredTools: ['TaskCreate', 'TaskUpdate'],
+      },
+    } as ClaudeMessage['raw'],
+  });
+
+  const summaryMessage = (): ClaudeMessage => ({
+    type: 'user',
+    content: '',
+    raw: {
+      type: 'user',
+      isCompactSummary: true,
+      message: { role: 'user', content: 'This session is being continued from a previous conversation…' },
+    } as ClaudeMessage['raw'],
+  });
+
+  it('attaches compactMetadata to the following compact-summary message and drops the boundary line', () => {
+    const other = makeMsg('user', 'hello');
+    const result = attachCompactBoundaryMetadata([other, boundaryMessage(), summaryMessage()]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(other);
+    const raw = result[1].raw as Record<string, unknown>;
+    expect(raw.isCompactSummary).toBe(true);
+    expect(raw.compactMetadata).toMatchObject({
+      trigger: 'manual',
+      preTokens: 524835,
+      postTokens: 14582,
+      durationMs: 109542,
+    });
+  });
+
+  it('returns the same array reference when no boundary line is present', () => {
+    const messages = [makeMsg('user', 'hello'), makeMsg('assistant', 'hi')];
+    expect(attachCompactBoundaryMetadata(messages)).toBe(messages);
+  });
+
+  it('does not overwrite metadata the summary already carries', () => {
+    const summary = summaryMessage();
+    (summary.raw as Record<string, unknown>).compactMetadata = { trigger: 'auto', preTokens: 1 };
+    const result = attachCompactBoundaryMetadata([boundaryMessage(), summary]);
+
+    expect(result).toHaveLength(1);
+    expect((result[0].raw as Record<string, unknown>).compactMetadata).toMatchObject({ trigger: 'auto', preTokens: 1 });
+  });
+
+  it('pairs across intermediate messages between boundary and summary', () => {
+    const between = makeMsg('assistant', 'unrelated');
+    const result = attachCompactBoundaryMetadata([boundaryMessage(), between, summaryMessage()]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(between);
+    expect((result[1].raw as Record<string, unknown>).compactMetadata).toMatchObject({ trigger: 'manual' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getContentBlocks — compact summary metadata subtitle wiring
+// ---------------------------------------------------------------------------
+
+describe('getContentBlocks — compact summary compactMetadata', () => {
+  const normalizeBlocksFn = () => null;
+  const localizeMessage = (text: string) => text;
+
+  it('exposes compactMetadata as the compact_summary block metadata', () => {
+    const message: ClaudeMessage = {
+      type: 'notification',
+      content: '',
+      raw: {
+        type: 'user',
+        isCompactSummary: true,
+        compactMetadata: { trigger: 'manual', preTokens: 524835, postTokens: 14582, durationMs: 109542 },
+        message: { role: 'user', content: 'This session is being continued…' },
+      } as ClaudeMessage['raw'],
+    };
+
+    const blocks = getContentBlocks(message, normalizeBlocksFn, localizeMessage);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      type: 'compact_summary',
+      content: 'This session is being continued…',
+      metadata: { trigger: 'manual', preTokens: 524835, postTokens: 14582, durationMs: 109542 },
+    });
+  });
+
+  it('still honors the legacy summarizeMetadata shape', () => {
+    const message: ClaudeMessage = {
+      type: 'notification',
+      content: '',
+      raw: {
+        type: 'user',
+        isCompactSummary: true,
+        summarizeMetadata: { messagesSummarized: 12, direction: 'up_to' },
+        message: { role: 'user', content: 'summary' },
+      } as ClaudeMessage['raw'],
+    };
+
+    const blocks = getContentBlocks(message, normalizeBlocksFn, localizeMessage);
+    expect(blocks[0]).toMatchObject({
+      type: 'compact_summary',
+      title: 'chat.compactSummary.summarizedConversation',
+      metadata: { messagesSummarized: 12 },
+    });
+  });
+});

--- a/webview/src/utils/messageUtils.ts
+++ b/webview/src/utils/messageUtils.ts
@@ -38,6 +38,7 @@ export {
   formatCommandForResubmit,
   hasTaskNotificationTag,
   formatTaskNotificationForDisplay,
+  createTaskNotificationBlock,
   extractCommandMessageContent,
   isSyntheticToolMessageContent,
   normalizeBlocks,
@@ -165,6 +166,60 @@ export function isCompactRelatedMessage(message: ClaudeMessage): boolean {
     return true;
   }
   return false;
+}
+
+/**
+ * Check if a message is a compact-boundary system line. The CLI writes the real
+ * compaction metadata ({ trigger, preTokens, postTokens, durationMs, … }) on a
+ * separate `type: 'system', subtype: 'compact_boundary'` JSONL line, NOT on the
+ * compact-summary user line itself.
+ */
+export function isCompactBoundaryMessage(message: ClaudeMessage): boolean {
+  const raw = message.raw;
+  if (!raw || typeof raw !== 'object') return false;
+  const rawObj = raw as Record<string, unknown>;
+  const type = message.type === 'system' || rawObj.type === 'system';
+  return type && rawObj.subtype === 'compact_boundary';
+}
+
+/**
+ * Pair each compact-boundary system line with the compact-summary user line that
+ * follows it: attach its `compactMetadata` to the summary message's raw (so the
+ * CompactSummaryBlock can render the stats subtitle) and drop the boundary line
+ * itself (it is a metadata carrier, not user-visible content).
+ * Returns the input array unchanged when no boundary lines are present.
+ */
+export function attachCompactBoundaryMetadata(messages: ClaudeMessage[]): ClaudeMessage[] {
+  if (!messages.some(isCompactBoundaryMessage)) return messages;
+
+  const result: ClaudeMessage[] = [];
+  let pendingMetadata: unknown = null;
+
+  for (const message of messages) {
+    if (isCompactBoundaryMessage(message)) {
+      const rawObj = message.raw as Record<string, unknown>;
+      const meta = rawObj.compactMetadata;
+      if (meta && typeof meta === 'object') {
+        pendingMetadata = meta;
+      }
+      continue; // boundary line carries no user-visible content
+    }
+
+    if (pendingMetadata && message.raw && typeof message.raw === 'object' && message.raw.isCompactSummary) {
+      const rawObj = message.raw as Record<string, unknown>;
+      result.push(
+        rawObj.compactMetadata
+          ? message
+          : { ...message, raw: { ...(message.raw as ClaudeRawMessage), compactMetadata: pendingMetadata } },
+      );
+      pendingMetadata = null;
+      continue;
+    }
+
+    result.push(message);
+  }
+
+  return result;
 }
 
 const COMPACT_STDOUT_REGEX = /<local-command-stdout>([\s\S]*?)<\/local-command-stdout>/;
@@ -427,10 +482,14 @@ export function getContentBlocks(
   if (message.type === MESSAGE_TYPES.NOTIFICATION) {
     const rawObj = typeof message.raw === 'object' ? (message.raw as Record<string, unknown> | null) : null;
     if (rawObj && 'isCompactSummary' in rawObj && rawObj.isCompactSummary) {
-      // Use type guard for safe metadata extraction
-      const meta: CompactSummaryMetadata | undefined = isCompactSummaryMetadata(rawObj.summarizeMetadata)
-        ? rawObj.summarizeMetadata
-        : undefined;
+      // Use type guard for safe metadata extraction. Real transcripts carry the
+      // metadata as `compactMetadata` (attached from the compact_boundary system
+      // line by attachCompactBoundaryMetadata); `summarizeMetadata` is a legacy shape.
+      const meta: CompactSummaryMetadata | undefined = isCompactSummaryMetadata(rawObj.compactMetadata)
+        ? rawObj.compactMetadata
+        : isCompactSummaryMetadata(rawObj.summarizeMetadata)
+          ? rawObj.summarizeMetadata
+          : undefined;
       // Extract full summary text from raw.message.content
       const messageObj = rawObj.message as { content?: string | unknown[] } | undefined;
       let summaryText = '';

--- a/webview/src/utils/stripAnsi.test.ts
+++ b/webview/src/utils/stripAnsi.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { stripAnsi } from './stripAnsi';
+
+describe('stripAnsi', () => {
+  it('returns text without escape sequences unchanged', () => {
+    const text = 'plain output [31m looks like ansi but is not';
+    expect(stripAnsi(text)).toBe(text);
+  });
+
+  it('handles empty input', () => {
+    expect(stripAnsi('')).toBe('');
+  });
+
+  it('strips SGR color codes from vitest failure output', () => {
+    const input = '\x1b[41m\x1b[1m FAIL \x1b[22m\x1b[49m src/components/kitchen-pulse/Kitchen360Timeline.spec.tsx';
+    expect(stripAnsi(input)).toBe(' FAIL  src/components/kitchen-pulse/Kitchen360Timeline.spec.tsx');
+  });
+
+  it('strips dim/color separators used by test reporters', () => {
+    const input = '\x1b[31m\x1b[2m⎯⎯⎯⎯⎯⎯[2/5]⎯\x1b[22m\x1b[39m';
+    expect(stripAnsi(input)).toBe('⎯⎯⎯⎯⎯⎯[2/5]⎯');
+  });
+
+  it('strips multiline colorized output', () => {
+    const input = '\x1b[90m168|\x1b[39m   })\x1b[33m;\x1b[39m\n\x1b[31m × auto-loads the older range\x1b[39m';
+    expect(stripAnsi(input)).toBe('168|   });\n × auto-loads the older range');
+  });
+
+  it('strips CSI sequences with private-mode and intermediate bytes', () => {
+    expect(stripAnsi('\x1b[?25lhidden cursor\x1b[?25h')).toBe('hidden cursor');
+    expect(stripAnsi('\x1b[2Kcleared line')).toBe('cleared line');
+  });
+
+  it('strips OSC sequences terminated by BEL', () => {
+    expect(stripAnsi('\x1b]0;window title\x07visible')).toBe('visible');
+  });
+
+  it('strips OSC sequences terminated by ST (ESC backslash)', () => {
+    expect(stripAnsi('\x1b]8;;https://example.com\x1b\\link text\x1b]8;;\x1b\\')).toBe('link text');
+  });
+
+  it('removes lone ESC characters', () => {
+    expect(stripAnsi('before\x1bafter')).toBe('beforeafter');
+  });
+
+  it('preserves surrounding text exactly', () => {
+    const input = 'Test Files \x1b[1m\x1b[32m226 passed\x1b[39m\x1b[22m (226)';
+    expect(stripAnsi(input)).toBe('Test Files 226 passed (226)');
+  });
+});

--- a/webview/src/utils/stripAnsi.ts
+++ b/webview/src/utils/stripAnsi.ts
@@ -1,0 +1,25 @@
+/**
+ * Strip ANSI escape sequences from terminal output so colorized CLI output
+ * (vitest, tsc, eslint, …) renders as clean text instead of literal garbage
+ * like "[41m[1m FAIL [22m[49m".
+ *
+ * Handles:
+ * - CSI sequences: ESC [ <parameter bytes 0x30-0x3F> <intermediate bytes 0x20-0x2F> <final byte 0x40-0x7E>
+ * - OSC sequences: ESC ] ... terminated by BEL (0x07) or ST (ESC \)
+ * - Any leftover lone ESC control characters
+ */
+
+// eslint-disable-next-line no-control-regex
+const CSI_REGEX = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+// eslint-disable-next-line no-control-regex
+const OSC_REGEX = /\x1b\][\s\S]*?(?:\x07|\x1b\\)/g;
+// eslint-disable-next-line no-control-regex
+const LONE_ESC_REGEX = /\x1b/g;
+
+export function stripAnsi(text: string): string {
+  if (!text || !text.includes('\x1b')) return text;
+  return text
+    .replace(OSC_REGEX, '')
+    .replace(CSI_REGEX, '')
+    .replace(LONE_ESC_REGEX, '');
+}

--- a/webview/src/utils/toolResultImages.ts
+++ b/webview/src/utils/toolResultImages.ts
@@ -1,0 +1,37 @@
+import type { ToolResultBlock } from '../types';
+
+export interface ToolResultImage {
+  src: string;
+  mediaType?: string;
+}
+
+/**
+ * Extract nested image blocks from a tool_result's content array.
+ * Read of an image file (and screenshot-style MCP tools) return
+ * `content: [{ type: 'image', source: { type: 'base64', media_type, data } }]`
+ * which the tool cards previously dropped entirely.
+ */
+export function extractToolResultImages(result?: ToolResultBlock | null): ToolResultImage[] {
+  if (!result || !Array.isArray(result.content)) return [];
+
+  const images: ToolResultImage[] = [];
+  for (const item of result.content) {
+    if (!item || typeof item !== 'object') continue;
+    const candidate = item as Record<string, unknown>;
+    if (candidate.type !== 'image') continue;
+
+    const source = candidate.source as Record<string, unknown> | undefined;
+    if (source && typeof source === 'object') {
+      if (source.type === 'base64' && typeof source.data === 'string') {
+        const mediaType = typeof source.media_type === 'string' ? source.media_type : 'image/png';
+        images.push({ src: `data:${mediaType};base64,${source.data}`, mediaType });
+      } else if (source.type === 'url' && typeof source.url === 'string') {
+        images.push({
+          src: source.url,
+          mediaType: typeof source.media_type === 'string' ? source.media_type : undefined,
+        });
+      }
+    }
+  }
+  return images;
+}

--- a/webview/src/utils/turnMetadataReconstruction.test.ts
+++ b/webview/src/utils/turnMetadataReconstruction.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import type { ClaudeMessage } from '../types';
+import { reconstructTurnMetadata } from './turnMetadataReconstruction';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers — raw shapes mirror real transcript JSONL lines:
+// user lines carry message.content, assistant lines carry message.{id,usage},
+// both carry an ISO timestamp.
+// ---------------------------------------------------------------------------
+
+const userPrompt = (text: string, timestamp?: string): ClaudeMessage => ({
+  type: 'user',
+  content: text,
+  raw: {
+    type: 'user',
+    ...(timestamp ? { timestamp } : {}),
+    message: { role: 'user', content: [{ type: 'text', text }] },
+  } as ClaudeMessage['raw'],
+});
+
+const assistantMsg = (
+  opts: {
+    text?: string;
+    timestamp?: string;
+    id?: string;
+    usage?: Record<string, number>;
+    durationMs?: number;
+    turnUsage?: Record<string, number>;
+  } = {},
+): ClaudeMessage => ({
+  type: 'assistant',
+  content: opts.text ?? 'reply',
+  ...(opts.durationMs !== undefined ? { durationMs: opts.durationMs } : {}),
+  raw: {
+    type: 'assistant',
+    ...(opts.timestamp ? { timestamp: opts.timestamp } : {}),
+    ...(opts.turnUsage ? { turnUsage: opts.turnUsage } : {}),
+    message: {
+      role: 'assistant',
+      ...(opts.id ? { id: opts.id } : {}),
+      ...(opts.usage ? { usage: opts.usage } : {}),
+      content: [{ type: 'text', text: opts.text ?? 'reply' }],
+    },
+  } as ClaudeMessage['raw'],
+});
+
+const toolResultUser = (): ClaudeMessage => ({
+  type: 'user',
+  content: '[tool_result]',
+  raw: {
+    type: 'user',
+    message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_01', content: 'ok' }] },
+  } as ClaudeMessage['raw'],
+});
+
+const getTurnUsage = (message: ClaudeMessage): Record<string, number> | undefined =>
+  (message.raw as Record<string, unknown> | undefined)?.turnUsage as Record<string, number> | undefined;
+
+describe('reconstructTurnMetadata', () => {
+  it('stamps durationMs on the last assistant message of a settled turn', () => {
+    const messages = [
+      userPrompt('fix the bug', '2026-07-08T10:00:00.000Z'),
+      assistantMsg({ text: 'looking', timestamp: '2026-07-08T10:00:30.000Z' }),
+      toolResultUser(),
+      assistantMsg({ text: 'done', timestamp: '2026-07-08T10:02:00.000Z' }),
+      userPrompt('thanks, next task', '2026-07-08T10:05:00.000Z'),
+      assistantMsg({ text: 'sure', timestamp: '2026-07-08T10:05:20.000Z' }),
+    ];
+
+    const result = reconstructTurnMetadata(messages);
+
+    // First turn: 10:02:00 - 10:00:00 = 120000ms on the LAST assistant only
+    expect(result[1].durationMs).toBeUndefined();
+    expect(result[3].durationMs).toBe(120_000);
+    // Second (trailing, not skipped) turn: 20s
+    expect(result[5].durationMs).toBe(20_000);
+  });
+
+  it('reconstructs turnUsage by summing usage across the turn, deduping shared message ids', () => {
+    const messages = [
+      userPrompt('prompt', '2026-07-08T10:00:00.000Z'),
+      // Two transcript lines from the SAME API response (shared id + identical usage)
+      assistantMsg({
+        id: 'msg_A',
+        timestamp: '2026-07-08T10:00:10.000Z',
+        usage: { input_tokens: 10, cache_creation_input_tokens: 100, cache_read_input_tokens: 1000, output_tokens: 50 },
+      }),
+      assistantMsg({
+        id: 'msg_A',
+        timestamp: '2026-07-08T10:00:11.000Z',
+        usage: { input_tokens: 10, cache_creation_input_tokens: 100, cache_read_input_tokens: 1000, output_tokens: 50 },
+      }),
+      toolResultUser(),
+      // Second API call in the same turn
+      assistantMsg({
+        id: 'msg_B',
+        timestamp: '2026-07-08T10:00:40.000Z',
+        usage: { input_tokens: 5, cache_creation_input_tokens: 0, cache_read_input_tokens: 2000, output_tokens: 30 },
+      }),
+    ];
+
+    const result = reconstructTurnMetadata(messages);
+    const turnUsage = getTurnUsage(result[4]);
+
+    expect(turnUsage).toEqual({
+      input_tokens: 15,
+      cache_creation_input_tokens: 100,
+      cache_read_input_tokens: 3000,
+      output_tokens: 80,
+    });
+    // Intermediate assistants stay untouched
+    expect(getTurnUsage(result[1])).toBeUndefined();
+    expect(getTurnUsage(result[2])).toBeUndefined();
+  });
+
+  it('never overwrites an existing durationMs or turnUsage', () => {
+    const existingUsage = { input_tokens: 1, output_tokens: 2 };
+    const messages = [
+      userPrompt('prompt', '2026-07-08T10:00:00.000Z'),
+      assistantMsg({
+        timestamp: '2026-07-08T10:03:00.000Z',
+        durationMs: 42,
+        turnUsage: existingUsage,
+        usage: { input_tokens: 999, output_tokens: 999 },
+      }),
+    ];
+
+    const result = reconstructTurnMetadata(messages);
+
+    expect(result[1].durationMs).toBe(42);
+    expect(getTurnUsage(result[1])).toEqual(existingUsage);
+    // Nothing changed → the exact same array/object references are returned
+    expect(result).toBe(messages);
+  });
+
+  it('skips duration silently when timestamps are absent and usage when not present', () => {
+    const messages = [
+      userPrompt('prompt'),
+      assistantMsg({ text: 'reply without timestamp or usage' }),
+    ];
+
+    const result = reconstructTurnMetadata(messages);
+
+    expect(result).toBe(messages);
+    expect(result[1].durationMs).toBeUndefined();
+    expect(getTurnUsage(result[1])).toBeUndefined();
+  });
+
+  it('leaves the trailing turn untouched when skipTrailingTurn is set (live streaming)', () => {
+    const messages = [
+      userPrompt('first', '2026-07-08T10:00:00.000Z'),
+      assistantMsg({ timestamp: '2026-07-08T10:01:00.000Z' }),
+      userPrompt('second — in flight', '2026-07-08T10:02:00.000Z'),
+      assistantMsg({ timestamp: '2026-07-08T10:02:30.000Z' }),
+    ];
+
+    const result = reconstructTurnMetadata(messages, { skipTrailingTurn: true });
+
+    expect(result[1].durationMs).toBe(60_000);
+    expect(result[3].durationMs).toBeUndefined();
+  });
+
+  it('does not treat tool_result carriers, meta caveats, or task notifications as turn starts', () => {
+    const messages = [
+      userPrompt('real prompt', '2026-07-08T10:00:00.000Z'),
+      assistantMsg({ timestamp: '2026-07-08T10:00:20.000Z' }),
+      toolResultUser(),
+      {
+        type: 'user',
+        content: 'Caveat: generated by local commands',
+        raw: { type: 'user', isMeta: true, timestamp: '2026-07-08T10:00:25.000Z', message: { role: 'user', content: '<local-command-caveat>Caveat…</local-command-caveat>' } },
+      } as ClaudeMessage,
+      {
+        type: 'user',
+        content: '',
+        raw: {
+          type: 'user',
+          timestamp: '2026-07-08T10:00:28.000Z',
+          message: { role: 'user', content: [{ type: 'text', text: '<task-notification><task-id>t1</task-id><summary>done</summary></task-notification>' }] },
+        },
+      } as ClaudeMessage,
+      assistantMsg({ timestamp: '2026-07-08T10:01:00.000Z' }),
+    ];
+
+    const result = reconstructTurnMetadata(messages);
+
+    // All assistants belong to the single real turn; only the last one is stamped
+    expect(result[1].durationMs).toBeUndefined();
+    expect(result[5].durationMs).toBe(60_000);
+  });
+
+  it('handles snapshots without any real prompt', () => {
+    const messages = [toolResultUser(), assistantMsg({ timestamp: '2026-07-08T10:00:00.000Z' })];
+    expect(reconstructTurnMetadata(messages)).toBe(messages);
+  });
+
+  it('produces the exact shape extractTokenUsage expects (all four token fields)', () => {
+    const messages = [
+      userPrompt('prompt', '2026-07-08T10:00:00.000Z'),
+      assistantMsg({
+        id: 'msg_A',
+        timestamp: '2026-07-08T10:00:10.000Z',
+        usage: { input_tokens: 3, output_tokens: 7 },
+      }),
+    ];
+
+    const turnUsage = getTurnUsage(reconstructTurnMetadata(messages)[1]);
+    expect(turnUsage).toEqual({
+      input_tokens: 3,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+      output_tokens: 7,
+    });
+  });
+});

--- a/webview/src/utils/turnMetadataReconstruction.ts
+++ b/webview/src/utils/turnMetadataReconstruction.ts
@@ -1,0 +1,194 @@
+import type { ClaudeMessage, ClaudeRawMessage } from '../types';
+import { isToolResultOnlyUserMessage } from './turnScope';
+import { hasTaskNotificationTag } from './contentBlockNormalize';
+
+/**
+ * Reconstructs the per-turn footer metadata (durationMs + raw.turnUsage) that is
+ * only stamped live: durationMs is a frontend-only field written at stream end,
+ * and turnUsage is stamped by the backend from the SDK result message. Neither
+ * is persisted in transcripts, so after a session reload the "Total duration ·
+ * tokens" footer vanished for every historical turn.
+ *
+ * This pure helper post-processes a full message snapshot: it groups
+ * conversation turns (real user prompt → following assistant messages) and, for
+ * the LAST assistant message of each settled turn, stamps
+ * - durationMs: last assistant raw timestamp minus the prompt's raw timestamp
+ * - raw.turnUsage: message.usage summed across the turn's assistant messages
+ *   (deduped by message.id — one API response can span several transcript lines
+ *   that share the same id and usage), in the exact shape extractTokenUsage
+ *   (MessageItem.tsx) expects.
+ *
+ * Existing durationMs/turnUsage values are never overwritten, and missing
+ * timestamps/usage are skipped silently (the current Java transport strips raw
+ * timestamps and message.usage, so this lights up only when they are present).
+ */
+
+interface ReconstructedTurnUsage {
+  input_tokens: number;
+  cache_creation_input_tokens: number;
+  cache_read_input_tokens: number;
+  output_tokens: number;
+}
+
+export interface ReconstructTurnMetadataOptions {
+  /**
+   * Leave the trailing (possibly still in-flight) turn untouched. Pass true
+   * while streaming so the live stamping path stays the single writer for the
+   * current turn.
+   */
+  skipTrailingTurn?: boolean;
+}
+
+function asRawObject(message: ClaudeMessage): ClaudeRawMessage | null {
+  return message.raw && typeof message.raw === 'object' ? message.raw : null;
+}
+
+/** Parse the transcript timestamp off a message's raw JSONL line. */
+function getRawTimestamp(message: ClaudeMessage): number | null {
+  const raw = asRawObject(message);
+  const ts = raw?.timestamp;
+  if (typeof ts === 'number' && Number.isFinite(ts)) return ts;
+  if (typeof ts === 'string' && ts) {
+    const parsed = Date.parse(ts);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function extractRawTexts(message: ClaudeMessage): string[] {
+  const raw = asRawObject(message);
+  const texts: string[] = [];
+  const collect = (content: unknown) => {
+    if (typeof content === 'string') {
+      texts.push(content);
+    } else if (Array.isArray(content)) {
+      for (const block of content) {
+        if (block && typeof block === 'object' && (block as { type?: string }).type === 'text') {
+          const text = (block as { text?: unknown }).text;
+          if (typeof text === 'string') texts.push(text);
+        }
+      }
+    }
+  };
+  collect(raw?.content);
+  collect(raw?.message?.content);
+  if (typeof message.content === 'string') texts.push(message.content);
+  return texts;
+}
+
+/**
+ * A turn starts at a REAL user prompt: not a tool_result carrier, not a meta
+ * caveat, not a synthetic (non-human origin) message, not a task notification.
+ */
+function isRealUserPrompt(message: ClaudeMessage): boolean {
+  if (message.type !== 'user') return false;
+  if (isToolResultOnlyUserMessage(message)) return false;
+  const raw = asRawObject(message);
+  if (raw?.isMeta === true) return false;
+  if (raw?.origin && typeof raw.origin === 'object' && raw.origin.kind !== 'human') return false;
+  return !extractRawTexts(message).some(hasTaskNotificationTag);
+}
+
+function positiveNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+/**
+ * Sum message.usage across the turn's assistant messages. Transcript lines that
+ * belong to the same API response share message.id and carry identical usage,
+ * so usage is counted once per unique id.
+ */
+function sumTurnUsage(assistantMessages: ClaudeMessage[]): ReconstructedTurnUsage | null {
+  const usage: ReconstructedTurnUsage = {
+    input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+    output_tokens: 0,
+  };
+  const seenIds = new Set<string>();
+  let found = false;
+
+  for (const message of assistantMessages) {
+    const raw = asRawObject(message);
+    const rawMessage = raw?.message as Record<string, unknown> | undefined;
+    const callUsage = rawMessage?.usage as Record<string, unknown> | undefined;
+    if (!callUsage || typeof callUsage !== 'object') continue;
+
+    const id = typeof rawMessage?.id === 'string' ? rawMessage.id : null;
+    if (id) {
+      if (seenIds.has(id)) continue;
+      seenIds.add(id);
+    }
+
+    usage.input_tokens += positiveNumber(callUsage.input_tokens);
+    usage.cache_creation_input_tokens += positiveNumber(callUsage.cache_creation_input_tokens);
+    usage.cache_read_input_tokens += positiveNumber(callUsage.cache_read_input_tokens);
+    usage.output_tokens += positiveNumber(callUsage.output_tokens);
+    found = true;
+  }
+
+  if (!found) return null;
+  const total = usage.input_tokens + usage.cache_creation_input_tokens
+    + usage.cache_read_input_tokens + usage.output_tokens;
+  return total > 0 ? usage : null;
+}
+
+export function reconstructTurnMetadata(
+  messages: ClaudeMessage[],
+  options: ReconstructTurnMetadataOptions = {},
+): ClaudeMessage[] {
+  if (messages.length === 0) return messages;
+
+  const turnStarts: number[] = [];
+  for (let i = 0; i < messages.length; i += 1) {
+    if (isRealUserPrompt(messages[i])) turnStarts.push(i);
+  }
+  if (turnStarts.length === 0) return messages;
+
+  let result: ClaudeMessage[] | null = null;
+
+  for (let turn = 0; turn < turnStarts.length; turn += 1) {
+    const startIndex = turnStarts[turn];
+    const endIndex = turn + 1 < turnStarts.length ? turnStarts[turn + 1] : messages.length;
+    const isTrailingTurn = turn === turnStarts.length - 1;
+    if (isTrailingTurn && options.skipTrailingTurn) continue;
+
+    const assistantMessages: ClaudeMessage[] = [];
+    let lastAssistantIndex = -1;
+    for (let i = startIndex + 1; i < endIndex; i += 1) {
+      if (messages[i].type === 'assistant') {
+        assistantMessages.push(messages[i]);
+        lastAssistantIndex = i;
+      }
+    }
+    if (lastAssistantIndex < 0) continue;
+
+    const lastAssistant = messages[lastAssistantIndex];
+    let updated = lastAssistant;
+
+    // Duration: last assistant raw timestamp minus prompt raw timestamp.
+    if (typeof lastAssistant.durationMs !== 'number') {
+      const promptTs = getRawTimestamp(messages[startIndex]);
+      const assistantTs = getRawTimestamp(lastAssistant);
+      if (promptTs != null && assistantTs != null && assistantTs >= promptTs) {
+        updated = { ...updated, durationMs: assistantTs - promptTs };
+      }
+    }
+
+    // Token usage: only when the raw is an object without an existing turnUsage.
+    const raw = asRawObject(lastAssistant);
+    if (raw && raw.turnUsage == null) {
+      const turnUsage = sumTurnUsage(assistantMessages);
+      if (turnUsage) {
+        updated = { ...updated, raw: { ...raw, turnUsage } };
+      }
+    }
+
+    if (updated !== lastAssistant) {
+      if (!result) result = [...messages];
+      result[lastAssistantIndex] = updated;
+    }
+  }
+
+  return result ?? messages;
+}


### PR DESCRIPTION
Fixes ten rendering defects confirmed against real session transcripts:

1. Image tool_results (Read of image files, screenshot MCP tools) were never surfaced. New utils/toolResultImages.ts extracts nested image blocks; GenericToolBlock and ReadToolBlock now render them inside the expanded details (max 300px, mounted only while expanded), make the card expandable when images exist, and show an image-count hint in the header.

2. Copy/export of slash commands silently dropped the args: a combined regex required <command-args> to immediately follow <command-name>, but the CLI puts <command-message> between them. Command tags are now extracted with independent per-tag regexes in contentBlockNormalize, making both formatCommandForResubmit and formatCommandForDisplay order-tolerant.

3. The <event> payload of monitor task-notifications was discarded, so an ERROR event was indistinguishable from BUILD SUCCESS. It is now parsed as `detail`, carried on the task_notification block, and rendered as a muted second line (truncated to 300 chars, full text in the title attribute).

4. The turn duration + token-usage footer vanished after session reload because durationMs/turnUsage are only stamped live and never persisted. New pure util utils/turnMetadataReconstruction.ts groups snapshot turns and stamps durationMs (raw transcript timestamps) and raw.turnUsage (message.usage summed per turn, deduped by message.id) on the last assistant of each settled turn; wired into processUpdateMessages with the trailing turn skipped while streaming. Existing values are never overwritten. Limitation: the current Java transport (MessageJsonConverter.buildTransportRaw) strips raw timestamps and message.usage, so on today's reload payloads the util skips silently; it lights up as soon as the backend forwards those fields. Fixing the transport requires Java changes, which are out of scope for this webview-only commit.

5. Bash output rendered raw ANSI escapes as literal garbage. New utils/stripAnsi.ts removes CSI and OSC sequences plus lone ESC chars; applied to output in BashToolBlock and BashToolGroupBlock.

6. GenericToolBlock dumped untruncated param values (e.g. an 86KB Write content param) into the DOM. Rendered param values are now capped at 4000 chars with an "… (+N more chars)" marker.

7. CollapsibleTextBlock materialized entire user pastes (up to 425KB) while visually collapsed. Content above 20000 chars now renders only a 10000-char preview until expanded, with the overflow affordance forced on. Smaller texts behave exactly as before.

8. The session-title fallback rendered the raw <local-command-caveat> tag as the title. sessionTitle now skips isMeta messages and any text that starts with '<' or contains internal/task-notification tags, and picks the first real prompt.

9. Copy dropped image blocks it explicitly whitelisted. Copied content now includes an "[image: <media_type>]" placeholder per image block.

10. The compact-summary metadata subtitle never rendered: the code read `summarizeMetadata` off the summary line, but real transcripts put the data on a separate type:'system' subtype:'compact_boundary' line under `compactMetadata`. attachCompactBoundaryMetadata pairs the boundary line with the following summary message (dropping the metadata-only line), getContentBlocks accepts the compactMetadata shape, CompactSummaryMetadata gains trigger/preTokens/postTokens/ durationMs, and CompactSummaryBlock shows a "manual - 524.8K -> 14.6K - 110s" stats subtitle. Limitation: the backend currently filters system lines out of reload payloads and does not whitelist compactMetadata for transport, so the wiring activates once the backend forwards them (Java change, out of scope).

Tests: adds unit coverage for the command-tag orders, the <event>
detail, turn-metadata reconstruction (realistic JSONL-shaped fixtures), ANSI stripping, param capping, tool_result images, boundary pairing and compact metadata extraction. Suite grows from 726 to 762 tests, all passing alongside both tsc configs.