### PR TITLE
fix(codex): support weekly-only quota responses

### DIFF
--- a/src/main/java/com/github/claudecodegui/service/CodexSubscriptionQuotaService.java
+++ b/src/main/java/com/github/claudecodegui/service/CodexSubscriptionQuotaService.java
@@ -44,6 +44,8 @@ public final class CodexSubscriptionQuotaService {
     private static final Gson GSON = new Gson();
     private static final String WHAM_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
     private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(12);
+    private static final int FIVE_HOUR_WINDOW_MINUTES = 5 * 60;
+    private static final int WEEKLY_WINDOW_MINUTES = 7 * 24 * 60;
     static final Duration SESSION_UPDATE_TIMEOUT = Duration.ofSeconds(5);
     static final Duration SESSION_FALLBACK_TIMEOUT = Duration.ofSeconds(60);
     static final Duration API_UPDATE_TIMEOUT = Duration.ofSeconds(60);
@@ -127,21 +129,55 @@ public final class CodexSubscriptionQuotaService {
         payload.addProperty("fetchedAt", now);
         payload.addProperty("source", source);
 
+        JsonObject primaryWindow = pickFirstObject(rateLimit, "primary_window", "primary");
+        JsonObject secondaryWindow = pickFirstObject(rateLimit, "secondary_window", "secondary");
+        JsonObject fiveHourWindow = findWindowByDuration(primaryWindow, secondaryWindow, FIVE_HOUR_WINDOW_MINUTES);
+        JsonObject weeklyWindow = findWindowByDuration(primaryWindow, secondaryWindow, WEEKLY_WINDOW_MINUTES);
+
+        // Older payloads may omit duration metadata. Preserve the original positional
+        // mapping for those responses, without misclassifying a duration-identified
+        // weekly primary window as the five-hour window.
+        if (fiveHourWindow == null && primaryWindow != weeklyWindow) {
+            fiveHourWindow = primaryWindow;
+        }
+        if (weeklyWindow == null && secondaryWindow != fiveHourWindow) {
+            weeklyWindow = secondaryWindow;
+        }
+
         JsonObject windows = new JsonObject();
-        windows.add("fiveHour", toWindow("5h", 5, pickFirstObject(rateLimit, "primary_window", "primary"), source, now));
-        windows.add("weekly", toWindow("weekly", 7 * 24, pickFirstObject(rateLimit, "secondary_window", "secondary"), source, now));
+        windows.add("fiveHour", toWindow("5h", 5, fiveHourWindow, source, now));
+        windows.add("weekly", toWindow("weekly", 7 * 24, weeklyWindow, source, now));
         payload.add("windows", windows);
         return payload;
+    }
+
+    private static JsonObject findWindowByDuration(
+            JsonObject first,
+            JsonObject second,
+            int expectedMinutes
+    ) {
+        if (readWindowDurationMinutes(first) == expectedMinutes) {
+            return first;
+        }
+        if (readWindowDurationMinutes(second) == expectedMinutes) {
+            return second;
+        }
+        return null;
+    }
+
+    private static int readWindowDurationMinutes(JsonObject source) {
+        int durationMinutes = readInt(source, "window_duration_mins", "window_minutes");
+        if (durationMinutes > 0) {
+            return durationMinutes;
+        }
+        int durationSeconds = readInt(source, "limit_window_seconds");
+        return durationSeconds > 0 ? Math.max(1, durationSeconds / 60) : 0;
     }
 
     private static JsonObject toWindow(String label, int defaultHours, JsonObject source, String payloadSource, long now) {
         JsonObject window = new JsonObject();
         window.addProperty("windowLabel", label);
-        int durationMinutes = readInt(source, "window_duration_mins", "window_minutes");
-        if (durationMinutes <= 0) {
-            int durationSeconds = readInt(source, "limit_window_seconds");
-            durationMinutes = durationSeconds > 0 ? Math.max(1, durationSeconds / 60) : 0;
-        }
+        int durationMinutes = readWindowDurationMinutes(source);
         window.addProperty("windowHours", durationMinutes > 0 ? Math.max(1, durationMinutes / 60) : defaultHours);
 
         Double usedPercent = readDoubleNullable(source, "used_percent");

--- a/src/test/java/com/github/claudecodegui/service/CodexSubscriptionQuotaServiceTest.java
+++ b/src/test/java/com/github/claudecodegui/service/CodexSubscriptionQuotaServiceTest.java
@@ -98,6 +98,73 @@ public class CodexSubscriptionQuotaServiceTest {
     }
 
     @Test
+    public void mapsWeeklyOnlyPrimaryWindowToWeeklySlot() {
+        JsonObject usage = JsonParser.parseString("""
+                {
+                  "rate_limit": {
+                    "primary_window": {
+                      "used_percent": 2,
+                      "limit_window_seconds": 604800,
+                      "reset_at": 1784511152
+                    }
+                  }
+                }
+                """).getAsJsonObject();
+
+        JsonObject payload = CodexSubscriptionQuotaService.buildPayloadFromUsage(usage, 1710000000000L);
+        JsonObject windows = payload.getAsJsonObject("windows");
+        JsonObject fiveHour = windows.getAsJsonObject("fiveHour");
+        JsonObject weekly = windows.getAsJsonObject("weekly");
+
+        assertTrue(fiveHour.get("usedPercent").isJsonNull());
+        assertEquals(2.0, weekly.get("usedPercent").getAsDouble(), 0.001);
+        assertEquals(98.0, weekly.get("remainingPercent").getAsDouble(), 0.001);
+        assertEquals(168, weekly.get("windowHours").getAsInt());
+        assertEquals(1784511152000L, weekly.get("resetsAt").getAsLong());
+    }
+
+    @Test
+    public void mapsWeeklyOnlySessionPrimaryToWeeklySlot() {
+        JsonObject rateLimits = JsonParser.parseString("""
+                {
+                  "primary": {
+                    "used_percent": 2,
+                    "window_minutes": 10080,
+                    "resets_at": 1784511152
+                  }
+                }
+                """).getAsJsonObject();
+
+        JsonObject payload = CodexSubscriptionQuotaService.buildPayloadFromSessionRateLimits(
+                rateLimits,
+                1710000000000L
+        );
+        JsonObject windows = payload.getAsJsonObject("windows");
+
+        assertTrue(windows.getAsJsonObject("fiveHour").get("usedPercent").isJsonNull());
+        assertEquals(2.0, windows.getAsJsonObject("weekly").get("usedPercent").getAsDouble(), 0.001);
+        assertEquals(168, windows.getAsJsonObject("weekly").get("windowHours").getAsInt());
+    }
+
+    @Test
+    public void keepsLegacyPositionalMappingWhenDurationsAreMissing() {
+        JsonObject usage = JsonParser.parseString("""
+                {
+                  "rate_limit": {
+                    "primary_window": { "used_percent": 30 },
+                    "secondary_window": { "used_percent": 40 }
+                  }
+                }
+                """).getAsJsonObject();
+
+        JsonObject payload = CodexSubscriptionQuotaService.buildPayloadFromUsage(usage, 1710000000000L);
+        JsonObject windows = payload.getAsJsonObject("windows");
+
+        assertEquals(30.0, windows.getAsJsonObject("fiveHour").get("usedPercent").getAsDouble(), 0.001);
+        assertEquals(40.0, windows.getAsJsonObject("weekly").get("usedPercent").getAsDouble(), 0.001);
+    }
+
+    @Test
     public void returnsFreshSessionSnapshotWithoutFetching() {
         AtomicLong now = new AtomicLong(BASE_NOW);
         AtomicInteger fetchCount = new AtomicInteger();


### PR DESCRIPTION
## What changed
- Detect Codex quota windows by their reported duration instead of assuming the primary window is always the 5-hour limit.
- Return the weekly quota when the current API supplies only a weekly window, while retaining the legacy primary/secondary fallback for older responses.
- Add regression coverage for weekly-only HTTP/session payloads and legacy durationless payloads.

## Why
The current Codex quota response can expose only the weekly window as its primary window. The previous positional mapping displayed that weekly usage in the 5-hour row and left the weekly row unavailable.

## User impact
When a weekly-only response is received, CC GUI shows the 5-hour quota as unavailable and shows the real weekly quota in the weekly row. Older response formats continue to work.

## Validation
- `./gradlew.bat test --tests "com.github.claudecodegui.service.CodexSubscriptionQuotaServiceTest"`
- `./gradlew.bat checkstyleMain`