### PR TITLE
fix(codex): restore file changes for custom exec patches

### DIFF
--- a/ai-bridge/services/codex/codex-event-handler.js
+++ b/ai-bridge/services/codex/codex-event-handler.js
@@ -105,6 +105,93 @@ function handleFunctionCallOutputPayload(payload, state) {
   return true;
 }
 
+function getResponseItemCallId(payload) {
+  const id = payload?.call_id ?? payload?.id;
+  return typeof id === 'string' && id.trim() ? id : '';
+}
+
+function createPatchBatchFromPayload(payload, config, fallbackCallId = '') {
+  const patchText = extractPatchFromResponseItemPayload(payload);
+  if (!patchText) return null;
+
+  const callId = getResponseItemCallId(payload) || fallbackCallId;
+  if (!callId) return null;
+
+  const operations = parseApplyPatchToOperations(patchText)
+    .map((op) => ({ ...op, filePath: resolveFilePath(op.filePath, config.cwd) }))
+    .filter((op) => op.filePath && (op.oldString !== '' || op.newString !== ''));
+  return operations.length > 0 ? { callId, operations } : null;
+}
+
+function emitSyntheticPatchToolUses(state, batch) {
+  if (!batch || !Array.isArray(batch.operations)) return 0;
+  let emittedCount = 0;
+  batch.operations.forEach((op, index) => {
+    const toolUseId = `codex_patch_${batch.callId}_${index}`;
+    const toolName = op.toolName === 'write' ? 'write' : 'edit';
+    if (state.emittedToolUseIds.has(toolUseId)) return;
+    state.emitMessage(toolUseMsg(toolUseId, toolName, {
+      file_path: op.filePath,
+      old_string: op.oldString,
+      new_string: op.newString,
+      start_line: op.startLine,
+      end_line: op.endLine,
+      replace_all: false,
+      source: 'codex_session_patch'
+    }));
+    state.emittedToolUseIds.add(toolUseId);
+    emittedCount += 1;
+  });
+  return emittedCount;
+}
+
+function emitSyntheticPatchToolResults(state, batch, isError) {
+  if (!batch || !Array.isArray(batch.operations)) return 0;
+  let emittedCount = 0;
+  batch.operations.forEach((_, index) => {
+    const toolUseId = `codex_patch_${batch.callId}_${index}`;
+    if (!state.emittedToolUseIds.has(toolUseId) || state.emittedToolResultIds.has(toolUseId)) return;
+    state.emitMessage(toolResultMsg(toolUseId, isError, isError ? 'Patch apply failed' : 'Patch applied'));
+    state.emittedToolResultIds.add(toolUseId);
+    emittedCount += 1;
+  });
+  return emittedCount;
+}
+
+function handleCustomToolCallPayload(payload, state, config) {
+  if (!payload || payload.type !== 'custom_tool_call') return false;
+
+  const batch = createPatchBatchFromPayload(payload, config);
+  if (!batch) return false;
+  if (state.processedPatchCallIds.has(batch.callId)) return true;
+
+  state.processedPatchCallIds.add(batch.callId);
+  state.pendingCustomPatchBatches.set(batch.callId, batch);
+  emitSyntheticPatchToolUses(state, batch);
+  return true;
+}
+
+function handleCustomToolCallOutputPayload(payload, state) {
+  if (!payload || payload.type !== 'custom_tool_call_output') return false;
+
+  const callId = getResponseItemCallId(payload);
+  const batch = callId ? state.pendingCustomPatchBatches.get(callId) : null;
+  if (!batch) return false;
+
+  const output = typeof payload.output === 'string' ? payload.output : JSON.stringify(payload.output ?? '');
+  const isError = payload.status === 'error' || /^(?:error:|failed to parse|permission denied|command denied)/i.test(output);
+  emitSyntheticPatchToolResults(state, batch, isError);
+  state.pendingCustomPatchBatches.delete(callId);
+  return true;
+}
+
+function flushPendingCustomPatchBatches(state, isError = false) {
+  for (const batch of state.pendingCustomPatchBatches.values()) {
+    emitSyntheticPatchToolResults(state, batch, isError);
+  }
+  state.pendingCustomPatchBatches.clear();
+}
+
 
 /** Creates the initial mutable state bag consumed by processCodexEventStream. */
 export function createInitialEventState(emitMessage) {
@@ -126,8 +213,11 @@ export function createInitialEventState(emitMessage) {
     sessionTurnBoundaryReady: false,
     sessionTurnBoundaryWarningLogged: false,
     processedPatchCallIds: new Set(),
+    pendingCustomPatchBatches: new Map(),
     processedSessionFunctionCallIds: new Set(),
     processedSessionFunctionOutputIds: new Set(),
+    processedSessionCustomToolCallIds: new Set(),
+    processedSessionCustomToolOutputIds: new Set(),
     reasoningTextCache: new Map(),
     assistantTextCache: new Map(),
     reasoningObserved: false,
@@ -315,15 +405,10 @@ async function collectPatchOperationsFromSession(state, config) {
     const callId = String(payload.call_id ?? payload.id ?? `line_${i}`);
     if (state.processedPatchCallIds.has(callId)) continue;
 
-    const patchText = extractPatchFromResponseItemPayload(payload);
-    if (!patchText) continue;
-
-    const operations = parseApplyPatchToOperations(patchText)
-      .map((op) => ({ ...op, filePath: resolveFilePath(op.filePath, config.cwd) }))
-      .filter((op) => op.filePath && (op.oldString !== '' || op.newString !== ''));
+    const batch = createPatchBatchFromPayload(payload, config, callId);
+    if (!batch) continue;
     state.processedPatchCallIds.add(callId);
-    if (operations.length === 0) continue;
-    batches.push({ callId, operations });
+    batches.push(batch);
   }
   state.sessionLineCursor = lines.length;
   return batches;
@@ -378,6 +463,26 @@ async function replayMissingFunctionCallsFromSession(state, config) {
       if (state.processedSessionFunctionOutputIds.has(callId)) continue;
       state.processedSessionFunctionOutputIds.add(callId);
       if (handleFunctionCallOutputPayload(payload, state)) {
+        toolResults += 1;
+      }
+      continue;
+    }
+
+    if (payloadType === 'custom_tool_call') {
+      const callId = getResponseItemCallId(payload) || `line_${i}`;
+      if (state.processedSessionCustomToolCallIds.has(callId)) continue;
+      state.processedSessionCustomToolCallIds.add(callId);
+      if (handleCustomToolCallPayload(payload, state, config)) {
+        toolUses += 1;
+      }
+      continue;
+    }
+
+    if (payloadType === 'custom_tool_call_output') {
+      const callId = getResponseItemCallId(payload) || `line_${i}`;
+      if (state.processedSessionCustomToolOutputIds.has(callId)) continue;
+      state.processedSessionCustomToolOutputIds.add(callId);
+      if (handleCustomToolCallOutputPayload(payload, state)) {
         toolResults += 1;
       }
     }
@@ -477,21 +582,9 @@ function emitSyntheticPatchOperations(state, patchBatches, isError, deniedCallId
   let emittedCount = 0;
   for (const batch of patchBatches) {
     if (!batch || !Array.isArray(batch.operations)) continue;
+    emitSyntheticPatchToolUses(state, batch);
     batch.operations.forEach((op, index) => {
       const toolUseId = `codex_patch_${batch.callId}_${index}`;
-      const toolName = op.toolName === 'write' ? 'write' : 'edit';
-      if (!state.emittedToolUseIds.has(toolUseId)) {
-        state.emitMessage(toolUseMsg(toolUseId, toolName, {
-          file_path: op.filePath,
-          old_string: op.oldString,
-          new_string: op.newString,
-          start_line: op.startLine,
-          end_line: op.endLine,
-          replace_all: false,
-          source: 'codex_session_patch'
-        }));
-        state.emittedToolUseIds.add(toolUseId);
-      }
       const deniedByUser = deniedCallIds instanceof Set && deniedCallIds.has(batch.callId);
       const rollbackResult = rollbackByCallId instanceof Map ? rollbackByCallId.get(batch.callId) : null;
       const rollbackSucceeded = !deniedByUser || rollbackResult?.success !== false;
@@ -501,8 +594,11 @@ function emitSyntheticPatchOperations(state, patchBatches, isError, deniedCallId
       else if (deniedByUser) {
         resultText = rollbackSucceeded ? 'Patch denied by user and rolled back' : 'Patch denied by user but rollback failed';
       }
-      state.emitMessage(toolResultMsg(toolUseId, opIsError, resultText));
-      emittedCount += 1;
+      if (!state.emittedToolResultIds.has(toolUseId)) {
+        state.emitMessage(toolResultMsg(toolUseId, opIsError, resultText));
+        state.emittedToolResultIds.add(toolUseId);
+        emittedCount += 1;
+      }
     });
   }
   return emittedCount;
@@ -819,6 +915,7 @@ export async function processCodexEventStream(events, state, config) {
         if (replayed.toolUses > 0 || replayed.toolResults > 0) {
           console.log('[DEBUG] Replayed session function calls:', JSON.stringify(replayed));
         }
+        flushPendingCustomPatchBatches(state);
         if (event.usage) {
           console.log('[DEBUG] Token usage:', event.usage);
           const claudeUsage = {
@@ -893,6 +990,18 @@ export async function processCodexEventStream(events, state, config) {
           if (handleFunctionCallOutputPayload(payload, state)) {
             if (payloadCallId) {
               state.processedSessionFunctionOutputIds.add(payloadCallId);
+            }
+            break;
+          }
+          if (handleCustomToolCallPayload(payload, state, config)) {
+            if (payloadCallId) {
+              state.processedSessionCustomToolCallIds.add(payloadCallId);
+            }
+            break;
+          }
+          if (handleCustomToolCallOutputPayload(payload, state)) {
+            if (payloadCallId) {
+              state.processedSessionCustomToolOutputIds.add(payloadCallId);
             }
             break;
           }

--- a/ai-bridge/services/codex/codex-event-handler.test.js
+++ b/ai-bridge/services/codex/codex-event-handler.test.js
@@ -46,6 +46,116 @@ function makeConfig() {
   };
 }
 
+const CUSTOM_EXEC_PATCH = [
+  '*** Begin Patch',
+  '*** Update File: hbapp/src/example.js',
+  '@@ -1 +1 @@',
+  '-const size = 30;',
+  '+const size = 32;',
+  '*** End Patch',
+].join('\n');
+
+const CUSTOM_EXEC_SOURCE = `const patch = ${JSON.stringify(CUSTOM_EXEC_PATCH)}; text(await tools.apply_patch(patch));`;
+
+test('custom_tool_call exec apply_patch emits edit and result messages without file_change', async () => {
+  const emittedMessages = [];
+  const state = createInitialEventState((message) => emittedMessages.push(message));
+
+  await captureStdout(async () => {
+    await processCodexEventStream(
+      eventsFrom([
+        {
+          type: 'response_item',
+          payload: { type: 'custom_tool_call', call_id: 'patch-1', name: 'exec', input: CUSTOM_EXEC_SOURCE },
+        },
+        {
+          type: 'response_item',
+          payload: { type: 'custom_tool_call_output', call_id: 'patch-1', output: 'Done' },
+        },
+      ]),
+      state,
+      makeConfig(),
+    );
+  });
+
+  assert.equal(emittedMessages.length, 2);
+  assert.deepEqual(emittedMessages[0].message.content[0], {
+    type: 'tool_use',
+    id: 'codex_patch_patch-1_0',
+    name: 'edit',
+    input: {
+      file_path: 'hbapp/src/example.js',
+      old_string: 'const size = 30;',
+      new_string: 'const size = 32;',
+      start_line: 1,
+      end_line: undefined,
+      replace_all: false,
+      source: 'codex_session_patch',
+    },
+  });
+  assert.deepEqual(emittedMessages[1].message.content[0], {
+    type: 'tool_result',
+    tool_use_id: 'codex_patch_patch-1_0',
+    is_error: false,
+    content: 'Patch applied',
+  });
+});
+
+test('current-turn session replay emits custom_tool_call exec patches found only in JSONL', async () => {
+  const tempDirectory = await mkdtemp(join(tmpdir(), 'codex-custom-patch-replay-'));
+  const tempSessionPath = join(tempDirectory, 'fixture-session.jsonl');
+  await writeFile(tempSessionPath, '', 'utf8');
+
+  try {
+    const emittedMessages = [];
+    const state = createInitialEventState((message) => emittedMessages.push(message));
+    state.sessionFilePath = tempSessionPath;
+    await prepareSessionReplayBoundary(state, 'fixture-thread');
+
+    await appendFile(
+      tempSessionPath,
+      [
+        { type: 'turn_context', payload: { cwd: 'C:/fixture' } },
+        {
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call',
+            call_id: 'session-patch-1',
+            name: 'exec',
+            input: CUSTOM_EXEC_SOURCE,
+          },
+        },
+        {
+          type: 'response_item',
+          payload: { type: 'custom_tool_call_output', call_id: 'session-patch-1', output: 'Done' },
+        },
+      ].map((entry) => JSON.stringify(entry)).join('\n') + '\n',
+      'utf8',
+    );
+
+    await captureStdout(async () => {
+      await processCodexEventStream(
+        eventsFrom([
+          { type: 'event_msg', payload: { type: 'patch_apply_end' } },
+          { type: 'turn.completed' },
+        ]),
+        state,
+        { ...makeConfig(), threadId: 'fixture-thread' },
+      );
+    });
+
+    const blocks = emittedMessages.flatMap((message) => message?.message?.content ?? []);
+    assert.equal(blocks.filter((block) => block.type === 'tool_use').length, 1);
+    assert.equal(blocks.filter((block) => block.type === 'tool_result').length, 1);
+    assert.equal(blocks[0].name, 'edit');
+    assert.equal(blocks[0].input.file_path, 'hbapp/src/example.js');
+    assert.equal(blocks[1].tool_use_id, 'codex_patch_session-patch-1_0');
+    assert.equal(blocks[1].is_error, false);
+  } finally {
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+});
+
 test('Codex item.updated agent_message emits incremental content deltas before completion', async () => {
   const emittedMessages = [];
   const state = createInitialEventState((message) => emittedMessages.push(message));

--- a/ai-bridge/services/codex/codex-patch-parser.js
+++ b/ai-bridge/services/codex/codex-patch-parser.js
@@ -15,7 +15,46 @@ export function extractPatchFromExecCommand(cmd) {
   if (begin < 0 || end < begin) {
     return '';
   }
-  return cmd.slice(begin, end + '*** End Patch'.length);
+  const patchText = cmd.slice(begin, end + '*** End Patch'.length);
+
+  // `custom_tool_call(exec)` carries JavaScript source rather than the raw
+  // apply_patch input. In that source the patch is commonly stored in a quoted
+  // string, so its line breaks arrive as literal `\\n` sequences. Decode one
+  // string-literal layer before handing the patch to the line-oriented parser.
+  // Raw multiline patches already contain real newlines and must stay untouched.
+  if (!patchText.includes('\n') && patchText.includes('\\n')) {
+    try {
+      return JSON.parse(`"${patchText}"`);
+    } catch {
+      return patchText
+        .replace(/\\r\\n/g, '\n')
+        .replace(/\\n/g, '\n')
+        .replace(/\\r/g, '\n')
+        .replace(/\\t/g, '\t')
+        .replace(/\\"/g, '"')
+        .replace(/\\'/g, "'")
+        .replace(/\\\\/g, '\\');
+    }
+  }
+
+  return patchText;
+}
+
+function extractPatchFromCustomToolInput(input) {
+  if (typeof input === 'string') {
+    return extractPatchFromExecCommand(input);
+  }
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return '';
+  }
+
+  const candidates = [input.patch, input.input, input.code, input.command, input.cmd];
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') continue;
+    const patch = extractPatchFromExecCommand(candidate);
+    if (patch) return patch;
+  }
+  return '';
 }
 
 /**
@@ -41,7 +80,8 @@ function parseHunkHeader(line) {
 
 /**
  * Extracts apply_patch text from a response_item payload.
- * Supports function_call(exec_command/apply_patch) and custom_tool_call(apply_patch).
+ * Supports function_call(exec_command/apply_patch) and
+ * custom_tool_call(apply_patch/exec).
  */
 export function extractPatchFromResponseItemPayload(payload) {
   if (!payload || typeof payload !== 'object') {
@@ -49,7 +89,11 @@ export function extractPatchFromResponseItemPayload(payload) {
   }
 
   const payloadType = payload.type;
-  const name = payload.name;
+  const name = typeof payload.name === 'string' ? payload.name.toLowerCase() : '';
+
+  if (payloadType === 'custom_tool_call' && name === 'exec') {
+    return extractPatchFromCustomToolInput(payload.input);
+  }
 
   if (payloadType === 'custom_tool_call' && name === 'apply_patch') {
     if (typeof payload.input === 'string') {

--- a/ai-bridge/services/codex/codex-patch-parser.test.js
+++ b/ai-bridge/services/codex/codex-patch-parser.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  extractPatchFromResponseItemPayload,
+  parseApplyPatchToOperations,
+} from './codex-patch-parser.js';
+
+const PATCH = [
+  '*** Begin Patch',
+  '*** Update File: hbapp/src/example.js',
+  '@@ -1 +1 @@',
+  '-const size = 30;',
+  '+const size = 32;',
+  '*** End Patch',
+].join('\n');
+
+test('extracts a raw patch from custom_tool_call apply_patch', () => {
+  const patch = extractPatchFromResponseItemPayload({
+    type: 'custom_tool_call',
+    name: 'apply_patch',
+    input: PATCH,
+  });
+
+  assert.equal(patch, PATCH);
+});
+
+test('extracts and decodes an escaped patch from custom_tool_call exec source', () => {
+  const source = `const patch = ${JSON.stringify(PATCH)}; text(await tools.apply_patch(patch));`;
+  const patch = extractPatchFromResponseItemPayload({
+    type: 'custom_tool_call',
+    name: 'exec',
+    input: source,
+  });
+
+  assert.equal(patch, PATCH);
+  assert.deepEqual(parseApplyPatchToOperations(patch), [{
+    filePath: 'hbapp/src/example.js',
+    kind: 'update',
+    oldString: 'const size = 30;',
+    newString: 'const size = 32;',
+    toolName: 'edit',
+    startLine: 1,
+    endLine: undefined,
+  }]);
+});
+
+test('extracts a patch from object-shaped custom_tool_call exec input', () => {
+  const patch = extractPatchFromResponseItemPayload({
+    type: 'custom_tool_call',
+    name: 'exec',
+    input: { code: `await tools.apply_patch(${JSON.stringify(PATCH)})` },
+  });
+
+  assert.equal(patch, PATCH);
+});
+
+test('does not classify unrelated custom_tool_call exec source as a patch', () => {
+  const patch = extractPatchFromResponseItemPayload({
+    type: 'custom_tool_call',
+    name: 'exec',
+    input: 'text(await tools.shell_command({ command: "git status" }));',
+  });
+
+  assert.equal(patch, '');
+});


### PR DESCRIPTION
## Summary

- recognize Codex SDK `custom_tool_call(exec)` payloads that invoke `tools.apply_patch(...)`
- decode escaped patch strings and preserve support for legacy `apply_patch` and `exec_command` payloads
- replay current-turn custom tool calls from the Codex session JSONL when the SDK stream does not expose a `file_change` item
- synthesize deduplicated `edit`/`write` tool messages so the file changes panel, IDEA diff action, and undo controls work again

## Root cause

Codex SDK 0.144.1 records patch operations as `custom_tool_call` events named `exec`, with the patch embedded in JavaScript source. The existing parser only recognized direct `custom_tool_call(apply_patch)` and `function_call(exec_command)` payloads, so no structured file-edit messages reached the webview.

Fixes #1455.

## Validation

- `node --test ai-bridge/services/codex/*.test.js` (20 tests passed)
- `git diff --check`
- `./gradlew.bat buildPlugin --console=plain`
