### PR TITLE
fix(session): guard interrupt state races

### DIFF
--- a/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
@@ -11,8 +11,10 @@ import com.intellij.openapi.project.Project;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 /**
  * Session management for Claude conversations.
@@ -498,13 +500,18 @@ public class ClaudeSession {
      * Interrupt the current execution.
      */
     public CompletableFuture<Void> interrupt() {
-        if (state.getChannelId() == null) {
+        String provider = state.getProvider();
+        String channelId = state.getChannelId();
+        if (channelId == null) {
             return CompletableFuture.completedFuture(null);
         }
 
         return CompletableFuture.runAsync(() -> {
             try {
-                providerRouter.interruptChannel(state.getProvider(), state.getChannelId());
+                providerRouter.interruptChannel(provider, channelId);
+                if (!isCurrentChannel(provider, channelId)) {
+                    return;
+                }
                 state.setError(null);  // Clear previous error state
                 state.setBusy(false);
                 state.setLoading(false);  // Also reset loading state
@@ -517,11 +524,19 @@ public class ClaudeSession {
 
                 callbackFacade.notifyStateChange(state.isBusy(), state.isLoading(), state.getError());
             } catch (Exception e) {
-                state.setError(e.getMessage());
-                state.setLoading(false);  // Also reset loading on error
-                callbackFacade.notifyStateChange(state.isBusy(), state.isLoading(), state.getError());
+                if (isCurrentChannel(provider, channelId)) {
+                    state.setError(e.getMessage());
+                    state.setLoading(false);  // Also reset loading on error
+                    callbackFacade.notifyStateChange(state.isBusy(), state.isLoading(), state.getError());
+                }
+                throw new CompletionException(e);
             }
         });
+    }
+
+    private boolean isCurrentChannel(String provider, String channelId) {
+        return Objects.equals(provider, state.getProvider())
+                && Objects.equals(channelId, state.getChannelId());
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/session/SessionState.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionState.java
@@ -58,8 +58,8 @@ public class SessionState {
     }
 
     // Session identifiers
-    private String sessionId;
-    private String channelId;
+    private volatile String sessionId;
+    private volatile String channelId;
     private volatile String runtimeSessionEpoch = UUID.randomUUID().toString();
 
     // Session state — accessed only on EDT / single handler thread, no volatile needed.

--- a/src/test/java/com/github/claudecodegui/session/ClaudeSessionTest.java
+++ b/src/test/java/com/github/claudecodegui/session/ClaudeSessionTest.java
@@ -1,10 +1,15 @@
 package com.github.claudecodegui.session;
 
+import com.github.claudecodegui.provider.codex.CodexSDKBridge;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ClaudeSessionTest {
 
@@ -19,6 +24,38 @@ public class ClaudeSessionTest {
         assertEquals("history-session-123", session.getSessionId());
         assertEquals("history-session-123", callback.lastSessionId);
         assertEquals("/workspace/demo", session.getCwd());
+    }
+
+    @Test
+    public void interruptDoesNotResetAReplacementChannel() throws Exception {
+        BlockingCodexBridge bridge = new BlockingCodexBridge(false);
+        ClaudeSession session = new ClaudeSession(null, null, bridge);
+        session.setProvider("codex");
+        session.getState().setChannelId("old-channel");
+        session.getState().setBusy(true);
+        session.getState().setLoading(true);
+
+        java.util.concurrent.CompletableFuture<Void> interrupt = session.interrupt();
+        assertTrue(bridge.awaitInterrupt());
+        session.getState().setChannelId("new-channel");
+        session.getState().setError("new-channel-state");
+        bridge.releaseInterrupt();
+        interrupt.join();
+
+        assertEquals("new-channel", session.getChannelId());
+        assertTrue(session.isBusy());
+        assertTrue(session.isLoading());
+        assertEquals("new-channel-state", session.getError());
+    }
+
+    @Test(expected = CompletionException.class)
+    public void interruptCompletesExceptionallyWhenProviderInterruptFails() {
+        BlockingCodexBridge bridge = new BlockingCodexBridge(true);
+        ClaudeSession session = new ClaudeSession(null, null, bridge);
+        session.setProvider("codex");
+        session.getState().setChannelId("failing-channel");
+
+        session.interrupt().join();
     }
 
     private static class RecordingCallback implements ClaudeSession.SessionCallback {
@@ -55,6 +92,40 @@ public class ClaudeSessionTest {
 
         @Override
         public void onSummaryReceived(String summary) {
+        }
+    }
+
+    private static class BlockingCodexBridge extends CodexSDKBridge {
+        private final CountDownLatch interruptStarted = new CountDownLatch(1);
+        private final CountDownLatch interruptRelease = new CountDownLatch(1);
+        private final boolean fail;
+
+        private BlockingCodexBridge(boolean fail) {
+            this.fail = fail;
+        }
+
+        @Override
+        public void interruptChannel(String channelId) {
+            interruptStarted.countDown();
+            if (fail) {
+                throw new IllegalStateException("interrupt failed");
+            }
+            try {
+                if (!interruptRelease.await(5, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("interrupt test timed out");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("interrupt test interrupted", e);
+            }
+        }
+
+        private boolean awaitInterrupt() throws InterruptedException {
+            return interruptStarted.await(5, TimeUnit.SECONDS);
+        }
+
+        private void releaseInterrupt() {
+            interruptRelease.countDown();
         }
     }
 }


### PR DESCRIPTION
## Summary

- guard concurrent session interrupt and callback state transitions
- prevent stale callbacks from restoring or mutating an interrupted session
- keep the interrupt channel lifecycle deterministic during session changes

## Validation

- Relevant regression tests were added or updated on the source branch.
- `git diff --check` passed.
- No dependency changes are included.

## Test environment note

GitHub currently reports no checks for this branch. Local Java execution requires the IntelliJ IDEA 2024.3.1 test artifact, which is not available in the local Gradle cache. WebView and TypeScript suites should be run by CI before merge.