### PR TITLE
fix(codex): preserve config and support model aliases

### DIFF
--- a/src/main/java/com/github/claudecodegui/session/SessionSendService.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionSendService.java
@@ -2,6 +2,7 @@ package com.github.claudecodegui.session;
 
 import com.github.claudecodegui.i18n.ClaudeCodeGuiBundle;
 import com.github.claudecodegui.settings.CodemossSettingsService;
+import com.github.claudecodegui.settings.CodexSettingsManager;
 import com.github.claudecodegui.notifications.ClaudeNotifier;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
@@ -263,6 +264,7 @@ public class SessionSendService {
 
         String contextAppend = contextService.buildCodexContextAppend(openedFilesJson, fileTagPaths);
         String finalInput = (input != null ? input : "") + contextAppend;
+        String configuredModel = new CodexSettingsManager(gson).resolveModelAlias(state.getModel());
 
         return codexSDKBridge.sendMessage(
                 channelId,
@@ -271,7 +273,7 @@ public class SessionSendService {
                 state.getCwd(),
                 attachments,
                 effectivePermissionMode,
-                state.getModel(),
+                configuredModel,
                 agentPrompt,
                 requestedReasoningEffort != null ? requestedReasoningEffort : state.getReasoningEffort(),
                 effectiveCodexServiceTier,

--- a/src/main/java/com/github/claudecodegui/settings/CodexSettingsManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodexSettingsManager.java
@@ -29,6 +29,7 @@ import java.util.regex.Pattern;
 public class CodexSettingsManager {
     private static final Logger LOG = Logger.getInstance(CodexSettingsManager.class);
     private static final String MCP_SERVERS_KEY = "mcp_servers";
+    private static final String MODEL_ALIASES_KEY = "model_aliases";
 
     // Pattern to validate TOML bare keys (letters, digits, hyphens, underscores)
     private static final Pattern TOML_KEY_PATTERN = Pattern.compile("^[a-zA-Z0-9_-]+$");
@@ -403,6 +404,34 @@ public class CodexSettingsManager {
         }
 
         return result;
+    }
+
+    /** Resolve a UI model id using the optional [model_aliases] table. */
+    public String resolveModelAlias(String selectedModel) {
+        if (selectedModel == null || selectedModel.trim().isEmpty()) {
+            return selectedModel;
+        }
+        try {
+            return resolveModelAlias(selectedModel, readConfigToml());
+        } catch (IOException e) {
+            LOG.warn("[CodexSettingsManager] Failed to read model aliases: " + e.getMessage());
+            return selectedModel;
+        }
+    }
+
+    static String resolveModelAlias(String selectedModel, Map<String, Object> configToml) {
+        if (selectedModel == null || selectedModel.trim().isEmpty() || configToml == null) {
+            return selectedModel;
+        }
+        Object aliasesObject = configToml.get(MODEL_ALIASES_KEY);
+        if (!(aliasesObject instanceof Map)) {
+            return selectedModel;
+        }
+        @SuppressWarnings("unchecked")
+        Map<String, Object> aliases = (Map<String, Object>) aliasesObject;
+        Object alias = aliases.get(selectedModel.trim());
+        return alias instanceof String && !((String) alias).trim().isEmpty()
+                ? ((String) alias).trim() : selectedModel;
     }
 
     // ==================== TOML Parsing Utilities ====================

--- a/src/main/java/com/github/claudecodegui/settings/CodexSettingsManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodexSettingsManager.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
  */
 public class CodexSettingsManager {
     private static final Logger LOG = Logger.getInstance(CodexSettingsManager.class);
+    private static final String MCP_SERVERS_KEY = "mcp_servers";
 
     // Pattern to validate TOML bare keys (letters, digits, hyphens, underscores)
     private static final Pattern TOML_KEY_PATTERN = Pattern.compile("^[a-zA-Z0-9_-]+$");
@@ -148,7 +149,8 @@ public class CodexSettingsManager {
         // Check if provider has configToml (raw string format)
         if (provider.has("configToml") && provider.get("configToml").isJsonPrimitive()) {
             String configTomlContent = provider.get("configToml").getAsString();
-            writeConfigTomlRaw(configTomlContent);
+            String mergedConfigTomlContent = preserveExistingMcpServers(configTomlContent);
+            writeConfigTomlRaw(mergedConfigTomlContent);
         }
 
         // Check if provider has authJson (raw string format)
@@ -166,6 +168,39 @@ public class CodexSettingsManager {
 
         String providerId = provider.has("id") ? provider.get("id").getAsString() : "unknown";
         LOG.info("[CodexSettingsManager] Applied provider to ~/.codex: " + providerId);
+    }
+
+    private String preserveExistingMcpServers(String providerConfigToml) throws IOException {
+        Map<String, Object> existingConfig = readConfigToml();
+        if (existingConfig == null) {
+            return providerConfigToml;
+        }
+
+        Object existingMcpServersObj = existingConfig.get(MCP_SERVERS_KEY);
+        if (!(existingMcpServersObj instanceof Map)) {
+            return providerConfigToml;
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> existingMcpServers = (Map<String, Object>) existingMcpServersObj;
+        if (existingMcpServers.isEmpty()) {
+            return providerConfigToml;
+        }
+
+        Map<String, Object> providerConfig = parseToml(providerConfigToml == null ? "" : providerConfigToml);
+        Object providerMcpServersObj = providerConfig.get(MCP_SERVERS_KEY);
+        if (providerMcpServersObj instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> providerMcpServers = (Map<String, Object>) providerMcpServersObj;
+            for (Map.Entry<String, Object> entry : existingMcpServers.entrySet()) {
+                providerMcpServers.putIfAbsent(entry.getKey(), entry.getValue());
+            }
+        } else {
+            providerConfig.put(MCP_SERVERS_KEY, existingMcpServers);
+        }
+
+        LOG.info("[CodexSettingsManager] Preserved existing Codex MCP servers while applying provider");
+        return generateToml(providerConfig);
     }
 
     /**
@@ -472,6 +507,7 @@ public class CodexSettingsManager {
             int eqIndex = line.indexOf('=');
             if (eqIndex > 0) {
                 String key = line.substring(0, eqIndex).trim();
+                key = normalizeTomlKey(key);
                 String valueStr = line.substring(eqIndex + 1).trim();
                 Object value = parseTomlValue(valueStr);
                 currentSection.put(key, value);
@@ -508,9 +544,11 @@ public class CodexSettingsManager {
         }
 
         // String (quoted)
-        if ((valueStr.startsWith("\"") && valueStr.endsWith("\"")) ||
-                    (valueStr.startsWith("'") && valueStr.endsWith("'"))) {
+        if (valueStr.length() >= 2 && valueStr.startsWith("\"") && valueStr.endsWith("\"")) {
             return unescapeTomlString(valueStr.substring(1, valueStr.length() - 1));
+        }
+        if (valueStr.length() >= 2 && valueStr.startsWith("'") && valueStr.endsWith("'")) {
+            return valueStr.substring(1, valueStr.length() - 1);
         }
 
         // Number
@@ -568,15 +606,21 @@ public class CodexSettingsManager {
             if (eqIndex > 0) {
                 String key = pair.substring(0, eqIndex).trim();
                 String valueStr = pair.substring(eqIndex + 1).trim();
-                // Remove quotes from key if present
-                if ((key.startsWith("\"") && key.endsWith("\"")) ||
-                            (key.startsWith("'") && key.endsWith("'"))) {
-                    key = key.substring(1, key.length() - 1);
-                }
-                result.put(key, parseTomlValue(valueStr));
+                result.put(normalizeTomlKey(key), parseTomlValue(valueStr));
             }
         }
         return result;
+    }
+
+    private String normalizeTomlKey(String key) {
+        String trimmed = key == null ? "" : key.trim();
+        if (trimmed.length() >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
+            return unescapeTomlString(trimmed.substring(1, trimmed.length() - 1));
+        }
+        if (trimmed.length() >= 2 && trimmed.startsWith("'") && trimmed.endsWith("'")) {
+            return trimmed.substring(1, trimmed.length() - 1);
+        }
+        return trimmed;
     }
 
     /**
@@ -697,11 +741,7 @@ public class CodexSettingsManager {
         for (Map.Entry<String, Object> entry : config.entrySet()) {
             Object val = entry.getValue();
             if (!(val instanceof Map) && !isArrayOfTables(val)) {
-                if (!isValidTomlKey(entry.getKey())) {
-                    LOG.warn("[CodexSettingsManager] Skipping invalid TOML key: " + entry.getKey());
-                    continue;
-                }
-                sb.append(entry.getKey()).append(" = ").append(toTomlValue(val)).append("\n");
+                sb.append(toTomlKey(entry.getKey())).append(" = ").append(toTomlValue(val)).append("\n");
             }
         }
 
@@ -730,11 +770,8 @@ public class CodexSettingsManager {
                 for (Map<String, Object> tableEntry : tableList) {
                     sb.append("\n[[").append(entry.getKey()).append("]]\n");
                     for (Map.Entry<String, Object> kv : tableEntry.entrySet()) {
-                        if (!isValidTomlKey(kv.getKey())) {
-                            LOG.warn("[CodexSettingsManager] Skipping invalid TOML key in array entry: " + kv.getKey());
-                            continue;
-                        }
-                        sb.append(kv.getKey()).append(" = ").append(toTomlValue(kv.getValue())).append("\n");
+                        sb.append(toTomlKey(kv.getKey())).append(" = ")
+                                .append(toTomlValue(kv.getValue())).append("\n");
                     }
                 }
             }
@@ -764,11 +801,7 @@ public class CodexSettingsManager {
                             || (val instanceof List && ((List<?>) val).isEmpty())) {
                     continue;
                 }
-                if (!isValidTomlKey(entry.getKey())) {
-                    LOG.warn("[CodexSettingsManager] Skipping invalid TOML key in section: " + entry.getKey());
-                    continue;
-                }
-                sb.append(entry.getKey()).append(" = ").append(toTomlValue(val)).append("\n");
+                sb.append(toTomlKey(entry.getKey())).append(" = ").append(toTomlValue(val)).append("\n");
             }
         }
 
@@ -805,11 +838,8 @@ public class CodexSettingsManager {
                 for (Map<String, Object> tableEntry : tableList) {
                     sb.append("\n[[").append(arrayPath).append("]]\n");
                     for (Map.Entry<String, Object> kv : tableEntry.entrySet()) {
-                        if (!isValidTomlKey(kv.getKey())) {
-                            LOG.warn("[CodexSettingsManager] Skipping invalid TOML key in array entry: " + kv.getKey());
-                            continue;
-                        }
-                        sb.append(kv.getKey()).append(" = ").append(toTomlValue(kv.getValue())).append("\n");
+                        sb.append(toTomlKey(kv.getKey())).append(" = ")
+                                .append(toTomlValue(kv.getValue())).append("\n");
                     }
                 }
             }
@@ -821,6 +851,13 @@ public class CodexSettingsManager {
      */
     private boolean isValidTomlKey(String key) {
         return key != null && !key.isEmpty() && TOML_KEY_PATTERN.matcher(key).matches();
+    }
+
+    private String toTomlKey(String key) {
+        if (isValidTomlKey(key)) {
+            return key;
+        }
+        return "\"" + escapeTomlString(key == null ? "" : key) + "\"";
     }
 
     /**

--- a/src/test/java/com/github/claudecodegui/settings/CodexSettingsManagerModelAliasTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/CodexSettingsManagerModelAliasTest.java
@@ -1,0 +1,92 @@
+package com.github.claudecodegui.settings;
+
+import com.github.claudecodegui.util.PlatformUtils;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.junit.After;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CodexSettingsManagerModelAliasTest {
+    private String originalHome;
+
+    @After
+    public void restoreHome() throws Exception {
+        if (originalHome != null) {
+            setHome(originalHome);
+        }
+    }
+
+    @Test
+    public void resolvesQuotedModelAliases() throws Exception {
+        prepareHome("[model_aliases]\n\"gpt-5.5\" = \"proxy-gpt-5.5\"\n");
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+
+        assertEquals("proxy-gpt-5.5", manager.resolveModelAlias("gpt-5.5"));
+        assertEquals("gpt-5.4", manager.resolveModelAlias("gpt-5.4"));
+    }
+
+    @Test
+    public void resolvesInlineTableAliases() throws Exception {
+        prepareHome("model_aliases = { \"gpt-5.5\" = \"proxy-gpt-5.5\" }\n");
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+
+        assertEquals("proxy-gpt-5.5", manager.resolveModelAlias("gpt-5.5"));
+    }
+
+    @Test
+    public void preservesLiteralBackslashesInAliasKeysAndValues() throws Exception {
+        prepareHome("[model_aliases]\n'gpt\\\\5.6' = 'vendor\\\\gpt'\n");
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+
+        assertEquals("vendor\\\\gpt", manager.resolveModelAlias("gpt\\\\5.6"));
+    }
+
+    @Test
+    public void preservesAliasesAndExistingMcpServersWhenApplyingProvider() throws Exception {
+        Path home = prepareHome("[mcp_servers.codegraph]\ncommand = \"uvx\"\n");
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+        JsonObject provider = new JsonObject();
+        provider.addProperty("id", "proxy");
+        provider.addProperty("configToml", "model = \"gpt-5.5\"\n\n[model_aliases]\n\"gpt-5.5\" = \"proxy-gpt-5.5\"\n");
+
+        manager.applyProviderToCodexSettings(provider);
+
+        String written = Files.readString(home.resolve(".codex/config.toml"), StandardCharsets.UTF_8);
+        assertTrue(written.contains("[model_aliases]"));
+        assertTrue(written.contains("\"gpt-5.5\" = \"proxy-gpt-5.5\""));
+        assertTrue(written.contains("[mcp_servers.codegraph]"));
+        assertEquals("proxy-gpt-5.5", manager.resolveModelAlias("gpt-5.5"));
+    }
+
+    private Path prepareHome(String configToml) throws Exception {
+        Path home = Files.createTempDirectory("codex-model-alias-home");
+        if (originalHome == null) {
+            originalHome = getHome();
+        }
+        setHome(home.toString());
+        Path codexDir = home.resolve(".codex");
+        Files.createDirectories(codexDir);
+        Files.writeString(codexDir.resolve("config.toml"), configToml, StandardCharsets.UTF_8);
+        return home;
+    }
+
+    private static String getHome() throws Exception {
+        Field field = PlatformUtils.class.getDeclaredField("cachedRealHomeDir");
+        field.setAccessible(true);
+        return (String) field.get(null);
+    }
+
+    private static void setHome(String home) throws Exception {
+        Field field = PlatformUtils.class.getDeclaredField("cachedRealHomeDir");
+        field.setAccessible(true);
+        field.set(null, home);
+    }
+}

--- a/src/test/java/com/github/claudecodegui/settings/CodexSettingsManagerTomlRoundTripTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/CodexSettingsManagerTomlRoundTripTest.java
@@ -1,0 +1,128 @@
+package com.github.claudecodegui.settings;
+
+import com.github.claudecodegui.util.PlatformUtils;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.junit.After;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CodexSettingsManagerTomlRoundTripTest {
+
+    private String originalHomeDir;
+    private boolean homeOverridden;
+
+    @After
+    public void tearDown() throws Exception {
+        if (homeOverridden) {
+            setCachedHomeDirectory(originalHomeDir);
+            homeOverridden = false;
+        }
+    }
+
+    @Test
+    public void shouldPreserveQuotedKeysWhenMergingProviderAndMcpConfig() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-toml-quoted-key-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = tempHome.resolve(".codex");
+        Files.createDirectories(codexDir);
+        Files.writeString(
+                codexDir.resolve("config.toml"),
+                "[mcp_servers.codegraph]\ncommand = \"uvx\"\n",
+                StandardCharsets.UTF_8
+        );
+
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+        assertTrue(manager.readConfigToml().get("mcp_servers") instanceof Map);
+        JsonObject provider = new JsonObject();
+        provider.addProperty("id", "proxy");
+        provider.addProperty("configToml", "\"provider.name\" = \"proxy\"\n"
+                + "\n"
+                + "[model_aliases]\n"
+                + "\"gpt-5.4\" = \"vendor/gpt-5.4\"\n");
+
+        manager.applyProviderToCodexSettings(provider);
+
+        String writtenConfig = Files.readString(codexDir.resolve("config.toml"), StandardCharsets.UTF_8);
+        assertTrue(writtenConfig.contains("\"provider.name\" = \"proxy\""));
+        assertTrue(writtenConfig.contains("\"gpt-5.4\" = \"vendor/gpt-5.4\""));
+        assertTrue(writtenConfig.contains("[mcp_servers.codegraph]"));
+        assertTrue(writtenConfig.contains("command = \"uvx\""));
+    }
+
+    @Test
+    public void shouldPreserveBackslashesInTomlLiteralStrings() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-toml-literal-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = tempHome.resolve(".codex");
+        Files.createDirectories(codexDir);
+        Files.writeString(
+                codexDir.resolve("config.toml"),
+                "[literals]\nwindows_path = 'C:\\tools\\codex'\npattern = '\\d+\\s'\n",
+                StandardCharsets.UTF_8
+        );
+
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> literals = (Map<String, Object>) manager.readConfigToml().get("literals");
+
+        assertEquals("C:\\tools\\codex", literals.get("windows_path"));
+        assertEquals("\\d+\\s", literals.get("pattern"));
+    }
+
+    @Test
+    public void shouldQuoteNonBareKeysAcrossSerializedStructures() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-toml-serialization-home");
+        useTemporaryHomeDirectory(tempHome);
+
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put("top.level", "root");
+        Map<String, Object> section = new LinkedHashMap<>();
+        section.put("nested.key", "nested");
+        config.put("section", section);
+        Map<String, Object> tableEntry = new LinkedHashMap<>();
+        tableEntry.put("entry.key", "entry");
+        List<Map<String, Object>> tableEntries = new ArrayList<>();
+        tableEntries.add(tableEntry);
+        config.put("items", tableEntries);
+
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+        manager.writeConfigToml(config);
+
+        String writtenConfig = Files.readString(manager.getConfigTomlPath(), StandardCharsets.UTF_8);
+        assertTrue(writtenConfig.contains("\"top.level\" = \"root\""));
+        assertTrue(writtenConfig.contains("\"nested.key\" = \"nested\""));
+        assertTrue(writtenConfig.contains("\"entry.key\" = \"entry\""));
+    }
+
+    private void useTemporaryHomeDirectory(Path tempHome) throws Exception {
+        if (!homeOverridden) {
+            originalHomeDir = getCachedHomeDirectory();
+            homeOverridden = true;
+        }
+        setCachedHomeDirectory(tempHome.toString());
+    }
+
+    private String getCachedHomeDirectory() throws Exception {
+        Field field = PlatformUtils.class.getDeclaredField("cachedRealHomeDir");
+        field.setAccessible(true);
+        return (String) field.get(null);
+    }
+
+    private void setCachedHomeDirectory(String homeDir) throws Exception {
+        Field field = PlatformUtils.class.getDeclaredField("cachedRealHomeDir");
+        field.setAccessible(true);
+        field.set(null, homeDir);
+    }
+}


### PR DESCRIPTION
## Summary

- preserve quoted Codex TOML keys during provider updates
- support Codex model aliases when sending sessions
- keep unrelated configuration entries intact during updates

## Validation

- Relevant regression tests were added or updated on the source branch.
- `git diff --check` passed.
- No dependency changes are included.

## Test environment note

GitHub currently reports no checks for this branch. Local Java execution requires the IntelliJ IDEA 2024.3.1 test artifact, which is not available in the local Gradle cache. WebView and TypeScript suites should be run by CI before merge.