### PR TITLE
fix(mcp): isolate provider state and clear stale tools

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/CodexMcpServerHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/CodexMcpServerHandler.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 public class CodexMcpServerHandler extends BaseMessageHandler {
 
     private static final Logger LOG = Logger.getInstance(CodexMcpServerHandler.class);
+    static final String CODEX_MCP_TOOLS_CALLBACK = "window.updateCodexMcpServerTools";
 
     private static final String[] SUPPORTED_TYPES = {
         "get_codex_mcp_servers",
@@ -197,7 +198,7 @@ public class CodexMcpServerHandler extends BaseMessageHandler {
                 .thenAccept(result -> {
                     String resultJson = gson.toJson(result);
                     ApplicationManager.getApplication().invokeLater(() ->
-                        callJavaScript("window.updateMcpServerTools", escapeJs(resultJson))
+                        callJavaScript(CODEX_MCP_TOOLS_CALLBACK, escapeJs(resultJson))
                     );
                 })
                 .exceptionally(e -> {
@@ -219,7 +220,7 @@ public class CodexMcpServerHandler extends BaseMessageHandler {
         errorResult.add("tools", new com.google.gson.JsonArray());
         String json = gson.toJson(errorResult);
         ApplicationManager.getApplication().invokeLater(() ->
-            callJavaScript("window.updateMcpServerTools", escapeJs(json))
+            callJavaScript(CODEX_MCP_TOOLS_CALLBACK, escapeJs(json))
         );
     }
 

--- a/src/test/java/com/github/claudecodegui/handler/CodexMcpServerHandlerCallbackTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/CodexMcpServerHandlerCallbackTest.java
@@ -1,0 +1,15 @@
+package com.github.claudecodegui.handler;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CodexMcpServerHandlerCallbackTest {
+
+    @Test
+    public void codexToolsUseProviderSpecificCallbackContract() {
+        assertEquals(
+                "window.updateCodexMcpServerTools",
+                CodexMcpServerHandler.CODEX_MCP_TOOLS_CALLBACK);
+    }
+}

--- a/webview/src/components/mcp/McpSettingsSection.tsx
+++ b/webview/src/components/mcp/McpSettingsSection.tsx
@@ -28,16 +28,66 @@ import { useToolsUpdate } from './hooks/useToolsUpdate';
 
 // Sub-components
 import { ServerCard } from './ServerCard';
+import { getMcpMessagePrefix, resolveInitialMcpProvider, type McpProvider } from './providerSelection';
 
 /**
  * MCP Server Settings Component
  */
 export function McpSettingsSection({ currentProvider = 'claude' }: McpSettingsSectionProps) {
+  const [selectedProvider, setSelectedProvider] = useState<McpProvider>(() => {
+    let savedProvider: string | null = null;
+    try {
+      savedProvider = localStorage.getItem('mcp.selectedProvider');
+    } catch {
+      // Fall back to the active chat provider when storage is unavailable.
+    }
+    return resolveInitialMcpProvider(currentProvider, savedProvider);
+  });
+
+  const selectProvider = useCallback((provider: McpProvider) => {
+    setSelectedProvider(provider);
+    try {
+      localStorage.setItem('mcp.selectedProvider', provider);
+    } catch {
+      // The selection remains valid for this settings session.
+    }
+  }, []);
+
+  return (
+    <div className="mcp-settings-shell">
+      <div className="mcp-provider-tabs" role="tablist" aria-label="MCP provider">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={selectedProvider === 'claude'}
+          className={selectedProvider === 'claude' ? 'active' : ''}
+          onClick={() => selectProvider('claude')}
+        >
+          <span className="codicon codicon-hubot" aria-hidden="true" />
+          Claude
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={selectedProvider === 'codex'}
+          className={selectedProvider === 'codex' ? 'active' : ''}
+          onClick={() => selectProvider('codex')}
+        >
+          <span className="codicon codicon-terminal" aria-hidden="true" />
+          Codex
+        </button>
+      </div>
+      <McpProviderPanel key={selectedProvider} currentProvider={selectedProvider} />
+    </div>
+  );
+}
+
+function McpProviderPanel({ currentProvider }: { currentProvider: McpProvider }) {
   const { t } = useTranslation();
   const isCodexMode = currentProvider === 'codex';
 
   // Generate message type prefix based on provider
-  const messagePrefix = useMemo(() => (isCodexMode ? 'codex_' : ''), [isCodexMode]);
+  const messagePrefix = useMemo(() => getMcpMessagePrefix(currentProvider), [currentProvider]);
 
   // Get provider-specific cache keys
   const cacheKeys = useMemo(() => getCacheKeys(isCodexMode ? 'codex' : 'claude'), [isCodexMode]);

--- a/webview/src/components/mcp/McpSettingsSection.tsx
+++ b/webview/src/components/mcp/McpSettingsSection.tsx
@@ -147,6 +147,7 @@ export function McpSettingsSection({ currentProvider = 'claude' }: McpSettingsSe
 
   // Use tools list update hook
   useToolsUpdate({
+    isCodexMode,
     cacheKeys,
     setServerTools,
     onLog: addLog,

--- a/webview/src/components/mcp/ServerCard.test.ts
+++ b/webview/src/components/mcp/ServerCard.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { hasEmptyToolsWarning } from './ServerCard';
+
+describe('hasEmptyToolsWarning', () => {
+  it('warns after a connected server finishes loading with no tools', () => {
+    expect(hasEmptyToolsWarning('connected', {
+      tools: [],
+      loading: false,
+    }, true)).toBe(true);
+  });
+
+  it('does not warn while loading, after failure, or when tools exist', () => {
+    expect(hasEmptyToolsWarning('connected', {
+      tools: [],
+      loading: true,
+    }, true)).toBe(false);
+    expect(hasEmptyToolsWarning('connected', {
+      tools: [],
+      loading: false,
+      error: 'tools/list failed',
+    }, true)).toBe(false);
+    expect(hasEmptyToolsWarning('connected', {
+      tools: [{ name: 'codegraph_explore' }],
+      loading: false,
+    }, true)).toBe(false);
+  });
+
+  it('does not warn for disconnected or disabled servers', () => {
+    expect(hasEmptyToolsWarning('failed', {
+      tools: [],
+      loading: false,
+    }, true)).toBe(false);
+    expect(hasEmptyToolsWarning('connected', {
+      tools: [],
+      loading: false,
+    }, false)).toBe(false);
+  });
+});

--- a/webview/src/components/mcp/ServerCard.tsx
+++ b/webview/src/components/mcp/ServerCard.tsx
@@ -6,7 +6,7 @@
 import type { McpServer, McpServerStatusInfo } from '../../types/mcp';
 import type { ServerRefreshState, ServerToolsState, McpTool } from './types';
 import { getServerStatusInfo, getStatusIcon, getStatusColor, getStatusText, getIconColor, getServerInitial, isServerEnabled } from './utils';
-import { ServerToolsPanel } from './ServerToolsPanel';
+import { isEmptyToolsResult, ServerToolsPanel } from './ServerToolsPanel';
 
 export interface ServerCardProps {
   server: McpServer;
@@ -54,9 +54,12 @@ export function ServerCard({
       : status;
   const enabled = isServerEnabled(server, isCodexMode);
   const isConnected = effectiveStatus === 'connected';
+  const emptyToolsWarning = hasEmptyToolsWarning(effectiveStatus, toolsInfo, enabled);
 
   const iconStyle: React.CSSProperties = { background: getIconColor(server.id) };
-  const statusColorStyle: React.CSSProperties = { color: getStatusColor(server, effectiveStatus, isCodexMode) };
+  const statusColorStyle: React.CSSProperties = {
+    color: emptyToolsWarning ? 'var(--color-warning)' : getStatusColor(server, effectiveStatus, isCodexMode),
+  };
 
   return (
     <div
@@ -74,9 +77,13 @@ export function ServerCard({
           <span
             className="status-indicator"
             style={statusColorStyle}
-            title={getStatusText(server, effectiveStatus, isCodexMode, t)}
+            title={emptyToolsWarning
+              ? `${getStatusText(server, effectiveStatus, isCodexMode, t)}: ${t('mcp.noTools')}`
+              : getStatusText(server, effectiveStatus, isCodexMode, t)}
           >
-            <span className={`codicon ${getStatusIcon(server, effectiveStatus, isCodexMode)}`}></span>
+            <span className={`codicon ${emptyToolsWarning
+              ? 'codicon-warning'
+              : getStatusIcon(server, effectiveStatus, isCodexMode)}`}></span>
           </span>
         </div>
         <div className="header-right-section" onClick={(e) => e.stopPropagation()}>
@@ -219,4 +226,12 @@ export function ServerCard({
       )}
     </div>
   );
+}
+
+export function hasEmptyToolsWarning(
+  status: McpServerStatusInfo['status'] | undefined,
+  toolsInfo: ServerToolsState[string] | undefined,
+  enabled: boolean,
+): boolean {
+  return enabled && status === 'connected' && isEmptyToolsResult(toolsInfo);
 }

--- a/webview/src/components/mcp/ServerToolsPanel.test.tsx
+++ b/webview/src/components/mcp/ServerToolsPanel.test.tsx
@@ -1,0 +1,51 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ServerToolsPanel } from './ServerToolsPanel';
+
+const baseProps = {
+  isConnected: true,
+  isCodexMode: false,
+  t: (key: string) => key,
+  onLoadTools: vi.fn(),
+  onToolHover: vi.fn(),
+};
+
+describe('ServerToolsPanel empty tool state', () => {
+  it('does not show no-tools while loading or after an error', () => {
+    const view = render(<ServerToolsPanel
+      {...baseProps}
+      toolsInfo={{ tools: [], loading: true }}
+    />);
+
+    expect(view.queryByText('mcp.noTools')).toBeNull();
+
+    view.rerender(<ServerToolsPanel
+      {...baseProps}
+      toolsInfo={{ tools: [], loading: false, error: 'tools/list failed' }}
+    />);
+
+    expect(view.queryByText('mcp.noTools')).toBeNull();
+    expect(view.getByText('mcp.loadFailed')).toBeTruthy();
+  });
+
+  it('shows a warning after a connected server finishes with no tools', () => {
+    const view = render(<ServerToolsPanel
+      {...baseProps}
+      toolsInfo={{ tools: [], loading: false }}
+    />);
+
+    const emptyState = view.getByText('mcp.noTools');
+    expect(emptyState.style.color).toBe('var(--color-warning)');
+  });
+
+  it('hides stale empty-tool results after the server disconnects', () => {
+    const view = render(<ServerToolsPanel
+      {...baseProps}
+      isConnected={false}
+      toolsInfo={{ tools: [], loading: false }}
+    />);
+
+    expect(view.queryByText('mcp.noTools')).toBeNull();
+    expect(view.getByText('mcp.notConnected')).toBeTruthy();
+  });
+});

--- a/webview/src/components/mcp/ServerToolsPanel.tsx
+++ b/webview/src/components/mcp/ServerToolsPanel.tsx
@@ -27,6 +27,12 @@ export function ServerToolsPanel({
   onLoadTools,
   onToolHover,
 }: ServerToolsPanelProps) {
+  // Tool results are only meaningful while the server is connected. Keeping a
+  // stale empty result visible after a disconnect makes the panel report
+  // "no tools" instead of the actual connection state.
+  const visibleToolsInfo = isConnected ? toolsInfo : undefined;
+  const emptyToolsResult = isEmptyToolsResult(visibleToolsInfo);
+
   return (
     <div className="server-detail-panel">
       {/* Tools list */}
@@ -46,7 +52,7 @@ export function ServerToolsPanel({
                 <span className="codicon codicon-refresh"></span>
               </button>
             )}
-            {toolsInfo && !toolsInfo.loading && (
+            {visibleToolsInfo && !visibleToolsInfo.loading && (
               <button
                 className="sidebar-icon-btn"
                 onClick={(e) => {
@@ -58,7 +64,7 @@ export function ServerToolsPanel({
                 <span className="codicon codicon-sync"></span>
               </button>
             )}
-            {toolsInfo?.loading && (
+            {visibleToolsInfo?.loading && (
               <span className="sidebar-icon-btn">
                 <span className="codicon codicon-loading codicon-modifier-spin"></span>
               </span>
@@ -67,30 +73,35 @@ export function ServerToolsPanel({
         </div>
 
         <div className="sidebar-content">
-          {!isConnected && !toolsInfo && (
+          {!isConnected && !visibleToolsInfo && (
             <div className="sidebar-section-header">{t('mcp.notConnected')}</div>
           )}
 
-          {toolsInfo?.error && (
+          {visibleToolsInfo?.error && (
             <>
               <div className="sidebar-section-header" style={WARNING_HEADER_STYLE}>
                 {t('mcp.loadFailed')}
               </div>
-              <div className="mcp-load-error-detail">{toolsInfo.error}</div>
+              <div className="mcp-load-error-detail">{visibleToolsInfo.error}</div>
             </>
           )}
 
-          {toolsInfo?.tools && toolsInfo.tools.length === 0 && (
-            <div className="sidebar-section-header">{t('mcp.noTools')}</div>
+          {emptyToolsResult && (
+            <div
+              className="sidebar-section-header"
+              style={isConnected ? WARNING_HEADER_STYLE : undefined}
+            >
+              {t('mcp.noTools')}
+            </div>
           )}
 
-          {toolsInfo?.tools && toolsInfo.tools.length > 0 && (
+          {visibleToolsInfo?.tools && visibleToolsInfo.tools.length > 0 && (
             <>
               <div className="sidebar-section-header">
-                {t('mcp.tools')} ({toolsInfo.tools.length})
+                {t('mcp.tools')} ({visibleToolsInfo.tools.length})
               </div>
               <div className="sidebar-tool-list">
-                {toolsInfo.tools.map((tool, index) => (
+                {visibleToolsInfo.tools.map((tool, index) => (
                   <div
                     key={index}
                     className="sidebar-tool-item"
@@ -123,4 +134,11 @@ export function ServerToolsPanel({
       </div>
     </div>
   );
+}
+
+export function isEmptyToolsResult(toolsInfo: ServerToolsState[string] | undefined): boolean {
+  return toolsInfo != null
+    && !toolsInfo.loading
+    && !toolsInfo.error
+    && toolsInfo.tools.length === 0;
 }

--- a/webview/src/components/mcp/hooks/useServerData.test.ts
+++ b/webview/src/components/mcp/hooks/useServerData.test.ts
@@ -1,0 +1,111 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { McpServer } from '../types';
+import type { CacheKeys } from '../types';
+import { readToolsCache, writeCache, writeToolsCache } from '../utils';
+import { useServerData } from './useServerData';
+
+const sendToJavaMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../utils/bridge', () => ({
+  sendToJava: (...args: unknown[]) => sendToJavaMock(...args),
+}));
+
+const cacheKeys: CacheKeys = {
+  SERVERS: 'test.mcp.servers',
+  STATUS: 'test.mcp.status',
+  TOOLS: 'test.mcp.tools',
+  LAST_SERVER_ID: 'test.mcp.last-server',
+};
+
+const server: McpServer = {
+  id: 'server-a',
+  name: 'Primary Server',
+  server: { command: 'node' },
+};
+
+const translate = (key: string) => key;
+const onLog = vi.fn();
+
+function renderServerData() {
+  return renderHook(() => useServerData({
+    isCodexMode: false,
+    messagePrefix: '',
+    cacheKeys,
+    t: translate,
+    onLog,
+  }));
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  sendToJavaMock.mockClear();
+  onLog.mockClear();
+});
+
+afterEach(() => {
+  delete window.updateMcpServers;
+  delete window.updateMcpServerStatus;
+  delete window.updateCodexMcpServers;
+  delete window.updateCodexMcpServerStatus;
+});
+
+describe('useServerData terminal MCP status handling', () => {
+  it('clears runtime and persisted tools when a matching server fails', () => {
+    const hook = renderServerData();
+
+    act(() => {
+      window.updateMcpServers?.(JSON.stringify([server]));
+      hook.result.current.setServerTools({
+        [server.id]: { tools: [{ name: 'stale-tool' }], loading: false },
+      });
+      writeToolsCache(server.id, [{ name: 'stale-tool' }], cacheKeys);
+    });
+
+    act(() => {
+      window.updateMcpServerStatus?.(JSON.stringify([{
+        name: server.name,
+        status: 'failed',
+      }]));
+    });
+
+    expect(hook.result.current.serverTools[server.id]).toBeUndefined();
+    expect(readToolsCache(server.id, cacheKeys)).toBeNull();
+  });
+
+  it('clears cached tools when terminal status arrives before the server list', () => {
+    const hook = renderServerData();
+    writeToolsCache(server.id, [{ name: 'stale-tool' }], cacheKeys);
+
+    act(() => {
+      window.updateMcpServerStatus?.(JSON.stringify([{
+        name: server.name,
+        status: 'needs-auth',
+      }]));
+    });
+
+    expect(readToolsCache(server.id, cacheKeys)).not.toBeNull();
+
+    act(() => {
+      window.updateMcpServers?.(JSON.stringify([server]));
+    });
+
+    expect(readToolsCache(server.id, cacheKeys)).toBeNull();
+    hook.unmount();
+  });
+
+  it('does not restore tools cached for a terminal server during startup', () => {
+    writeCache(cacheKeys.SERVERS, [server]);
+    writeCache(cacheKeys.STATUS, [{
+      name: server.name,
+      status: 'disabled',
+    }]);
+    writeToolsCache(server.id, [{ name: 'stale-tool' }], cacheKeys);
+
+    const hook = renderServerData();
+
+    expect(hook.result.current.serverTools[server.id]).toBeUndefined();
+    expect(readToolsCache(server.id, cacheKeys)).toBeNull();
+    hook.unmount();
+  });
+});

--- a/webview/src/components/mcp/hooks/useServerData.ts
+++ b/webview/src/components/mcp/hooks/useServerData.ts
@@ -236,6 +236,29 @@ export function useServerData({
           statusMap.set(status.name, status);
         });
         setServerStatus(statusMap);
+        const terminalDisconnectStatuses = new Set<McpServerStatusInfo['status']>([
+          'failed',
+          'needs-auth',
+          'disabled',
+        ]);
+        const disconnectedNames = new Set(
+          statusList
+            .filter((status) => terminalDisconnectStatuses.has(status.status))
+            .map((status) => status.name.toLowerCase()),
+        );
+        if (disconnectedNames.size > 0) {
+          setServerTools((previous) => {
+            const next = { ...previous };
+            servers.forEach((server) => {
+              const serverId = server.id.toLowerCase();
+              const serverName = (server.name || '').toLowerCase();
+              if (disconnectedNames.has(serverId) || (serverName && disconnectedNames.has(serverName))) {
+                delete next[server.id];
+              }
+            });
+            return next;
+          });
+        }
         setStatusLoading(false);
         // Persist status to cache
         writeCache(cacheKeys.STATUS, statusList);
@@ -282,7 +305,7 @@ export function useServerData({
         window.updateMcpServerStatus = undefined;
       }
     };
-  }, [isCodexMode, t, onLog]);
+  }, [isCodexMode, servers, t, onLog]);
 
   return {
     // State

--- a/webview/src/components/mcp/hooks/useServerData.ts
+++ b/webview/src/components/mcp/hooks/useServerData.ts
@@ -6,7 +6,37 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import type { McpServer, McpServerStatusInfo, ServerToolsState, RefreshLog, CacheKeys } from '../types';
 import { sendToJava } from '../../../utils/bridge';
-import { readCache, readToolsCache, writeCache } from '../utils';
+import { clearToolsCache, readCache, readToolsCache, writeCache } from '../utils';
+
+const TERMINAL_DISCONNECT_STATUSES = new Set<McpServerStatusInfo['status']>([
+  'failed',
+  'needs-auth',
+  'disabled',
+]);
+
+function normalizeServerKey(value: string | undefined): string {
+  return value?.trim().toLowerCase() ?? '';
+}
+
+function getTerminalStatusNames(statusList: McpServerStatusInfo[]): Set<string> {
+  return new Set(
+    statusList
+      .filter((status) => TERMINAL_DISCONNECT_STATUSES.has(status.status))
+      .map((status) => normalizeServerKey(status.name))
+      .filter(Boolean),
+  );
+}
+
+function getTerminalServerIds(servers: McpServer[], terminalStatusNames: Set<string>): string[] {
+  if (terminalStatusNames.size === 0) {
+    return [];
+  }
+
+  return servers
+    .filter((server) => terminalStatusNames.has(normalizeServerKey(server.id))
+      || terminalStatusNames.has(normalizeServerKey(server.name)))
+    .map((server) => server.id);
+}
 
 export interface UseServerDataOptions {
   isCodexMode: boolean;
@@ -48,7 +78,7 @@ export function useServerData({
   onLog
 }: UseServerDataOptions): UseServerDataReturn {
   // State
-  const [servers, setServers] = useState<McpServer[]>([]);
+  const [servers, setServersState] = useState<McpServer[]>([]);
   const [serverStatus, setServerStatus] = useState<Map<string, McpServerStatusInfo>>(new Map());
   const [loading, setLoading] = useState(true);
   const [statusLoading, setStatusLoading] = useState(false);
@@ -57,6 +87,41 @@ export function useServerData({
 
   // Refs
   const refreshTimersRef = useRef<number[]>([]);
+  const serversRef = useRef<McpServer[]>([]);
+  const terminalStatusNamesRef = useRef<Set<string>>(new Set());
+
+  const setServers = useCallback((value: React.SetStateAction<McpServer[]>) => {
+    if (typeof value !== 'function') {
+      serversRef.current = value;
+      setServersState(value);
+      return;
+    }
+
+    setServersState((previous) => {
+      const next = value(previous);
+      serversRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const clearToolsForTerminalStatuses = useCallback((
+    currentServers: McpServer[],
+    terminalStatusNames: Set<string>,
+  ) => {
+    const terminalServerIds = getTerminalServerIds(currentServers, terminalStatusNames);
+    if (terminalServerIds.length === 0) {
+      return;
+    }
+
+    terminalServerIds.forEach((serverId) => clearToolsCache(serverId, cacheKeys));
+    setServerTools((previous) => {
+      const next = { ...previous };
+      terminalServerIds.forEach((serverId) => {
+        delete next[serverId];
+      });
+      return next;
+    });
+  }, [cacheKeys]);
 
   // Load server list
   const loadServers = useCallback(() => {
@@ -141,6 +206,7 @@ export function useServerData({
 
     // Load data from cache
     const loadFromCache = (): boolean => {
+      terminalStatusNamesRef.current = new Set();
       const cachedServers = readCache<McpServer[]>(cacheKeys.SERVERS, cacheKeys);
       const hasValidCache = !!cachedServers && cachedServers.length > 0;
 
@@ -156,6 +222,9 @@ export function useServerData({
       if (!isCodexMode) {
         const cachedStatus = readCache<McpServerStatusInfo[]>(cacheKeys.STATUS, cacheKeys);
         if (cachedStatus && cachedStatus.length > 0) {
+          const terminalStatusNames = getTerminalStatusNames(cachedStatus);
+          terminalStatusNamesRef.current = terminalStatusNames;
+          clearToolsForTerminalStatuses(cachedServers || [], terminalStatusNames);
           const statusMap = new Map<string, McpServerStatusInfo>();
           cachedStatus.forEach((status) => {
             statusMap.set(status.name, status);
@@ -209,7 +278,7 @@ export function useServerData({
     return () => {
       clearRefreshTimers();
     };
-  }, [cacheKeys, isCodexMode, loadServers, loadServerStatus, t, onLog]);
+  }, [cacheKeys, isCodexMode, loadServers, loadServerStatus, t, onLog, clearToolsForTerminalStatuses]);
 
   // Register server list update callback
   useEffect(() => {
@@ -217,6 +286,7 @@ export function useServerData({
       try {
         const serverList: McpServer[] = JSON.parse(jsonStr);
         setServers(serverList);
+        clearToolsForTerminalStatuses(serverList, terminalStatusNamesRef.current);
         setLoading(false);
         // Persist to cache so subsequent mounts can load instantly
         writeCache(cacheKeys.SERVERS, serverList);
@@ -236,29 +306,9 @@ export function useServerData({
           statusMap.set(status.name, status);
         });
         setServerStatus(statusMap);
-        const terminalDisconnectStatuses = new Set<McpServerStatusInfo['status']>([
-          'failed',
-          'needs-auth',
-          'disabled',
-        ]);
-        const disconnectedNames = new Set(
-          statusList
-            .filter((status) => terminalDisconnectStatuses.has(status.status))
-            .map((status) => status.name.toLowerCase()),
-        );
-        if (disconnectedNames.size > 0) {
-          setServerTools((previous) => {
-            const next = { ...previous };
-            servers.forEach((server) => {
-              const serverId = server.id.toLowerCase();
-              const serverName = (server.name || '').toLowerCase();
-              if (disconnectedNames.has(serverId) || (serverName && disconnectedNames.has(serverName))) {
-                delete next[server.id];
-              }
-            });
-            return next;
-          });
-        }
+        const terminalStatusNames = getTerminalStatusNames(statusList);
+        terminalStatusNamesRef.current = terminalStatusNames;
+        clearToolsForTerminalStatuses(serversRef.current, terminalStatusNames);
         setStatusLoading(false);
         // Persist status to cache
         writeCache(cacheKeys.STATUS, statusList);
@@ -305,7 +355,7 @@ export function useServerData({
         window.updateMcpServerStatus = undefined;
       }
     };
-  }, [isCodexMode, servers, t, onLog]);
+  }, [isCodexMode, t, onLog, clearToolsForTerminalStatuses, setServers]);
 
   return {
     // State

--- a/webview/src/components/mcp/hooks/useServerManagement.test.ts
+++ b/webview/src/components/mcp/hooks/useServerManagement.test.ts
@@ -1,0 +1,64 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CacheKeys, McpServer, ServerToolsState } from '../types';
+import { readToolsCache, writeToolsCache } from '../utils';
+import { useServerManagement } from './useServerManagement';
+
+const sendToJavaMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../utils/bridge', () => ({
+  sendToJava: (...args: unknown[]) => sendToJavaMock(...args),
+}));
+
+const cacheKeys: CacheKeys = {
+  SERVERS: 'test.mcp.servers',
+  STATUS: 'test.mcp.status',
+  TOOLS: 'test.mcp.tools',
+  LAST_SERVER_ID: 'test.mcp.last-server',
+};
+
+const server: McpServer = {
+  id: 'server-a',
+  name: 'Primary Server',
+  server: { command: 'node' },
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  sendToJavaMock.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useServerManagement tool cache invalidation', () => {
+  it('clears persisted tools whenever a server is toggled', () => {
+    const setServerTools = vi.fn() as unknown as React.Dispatch<React.SetStateAction<ServerToolsState>>;
+    const hook = renderHook(() => useServerManagement({
+      isCodexMode: false,
+      messagePrefix: '',
+      cacheKeys,
+      setServerTools,
+      loadServers: vi.fn(),
+      loadServerStatus: vi.fn(),
+      loadServerTools: vi.fn(),
+      onLog: vi.fn(),
+      onToast: vi.fn(),
+      t: (key) => key,
+    }));
+
+    writeToolsCache(server.id, [{ name: 'stale-tool' }], cacheKeys);
+
+    act(() => {
+      hook.result.current.handleToggleServer(server, false);
+    });
+
+    expect(readToolsCache(server.id, cacheKeys)).toBeNull();
+    expect(setServerTools).toHaveBeenCalledTimes(1);
+    expect(sendToJavaMock).toHaveBeenCalledWith('toggle_mcp_server', expect.objectContaining({
+      id: server.id,
+      enabled: false,
+    }));
+  });
+});

--- a/webview/src/components/mcp/hooks/useServerManagement.ts
+++ b/webview/src/components/mcp/hooks/useServerManagement.ts
@@ -114,6 +114,14 @@ export function useServerManagement({
 
     sendToJava(`toggle_${messagePrefix}mcp_server`, updatedServer);
 
+    // A toggle invalidates the previous tool result. This forces a fresh
+    // tools/list request after the server becomes connected again.
+    setServerTools(prev => {
+      const next = { ...prev };
+      delete next[server.id];
+      return next;
+    });
+
     // Show toast notification
     onToast(
       enabled

--- a/webview/src/components/mcp/hooks/useServerManagement.ts
+++ b/webview/src/components/mcp/hooks/useServerManagement.ts
@@ -116,6 +116,7 @@ export function useServerManagement({
 
     // A toggle invalidates the previous tool result. This forces a fresh
     // tools/list request after the server becomes connected again.
+    clearToolsCache(server.id, cacheKeys);
     setServerTools(prev => {
       const next = { ...prev };
       delete next[server.id];
@@ -132,7 +133,7 @@ export function useServerManagement({
 
     loadServers();
     loadServerStatus();
-  }, [isCodexMode, messagePrefix, onToast, t, loadServers, loadServerStatus]);
+  }, [isCodexMode, messagePrefix, cacheKeys, setServerTools, onToast, t, loadServers, loadServerStatus]);
 
   return {
     serverRefreshStates,

--- a/webview/src/components/mcp/hooks/useToolsUpdate.test.ts
+++ b/webview/src/components/mcp/hooks/useToolsUpdate.test.ts
@@ -1,0 +1,58 @@
+import { renderHook } from '@testing-library/react';
+import type { Dispatch, SetStateAction } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CacheKeys, ServerToolsState } from '../types';
+import { useToolsUpdate } from './useToolsUpdate';
+
+const cacheKeys: CacheKeys = {
+  SERVERS: 'test.servers',
+  STATUS: 'test.status',
+  TOOLS: 'test.tools',
+  LAST_SERVER_ID: 'test.lastServerId',
+};
+
+function renderToolsHook(isCodexMode: boolean) {
+  const setServerTools = vi.fn() as unknown as Dispatch<SetStateAction<ServerToolsState>>;
+  const onLog = vi.fn();
+  return renderHook(() => useToolsUpdate({
+    isCodexMode,
+    cacheKeys,
+    setServerTools,
+    onLog,
+  }));
+}
+
+afterEach(() => {
+  delete window.updateMcpServerTools;
+  delete window.updateCodexMcpServerTools;
+});
+
+describe('useToolsUpdate provider callback isolation', () => {
+  it('registers independent Claude and Codex callbacks', () => {
+    const claudeHook = renderToolsHook(false);
+    const claudeCallback = window.updateMcpServerTools;
+    const codexHook = renderToolsHook(true);
+    const codexCallback = window.updateCodexMcpServerTools;
+
+    expect(claudeCallback).toBeTypeOf('function');
+    expect(codexCallback).toBeTypeOf('function');
+    expect(codexCallback).not.toBe(claudeCallback);
+
+    claudeHook.unmount();
+    expect(window.updateMcpServerTools).toBeUndefined();
+    expect(window.updateCodexMcpServerTools).toBe(codexCallback);
+
+    codexHook.unmount();
+    expect(window.updateCodexMcpServerTools).toBeUndefined();
+  });
+
+  it('does not clear a callback replaced by a newer owner', () => {
+    const firstHook = renderToolsHook(false);
+    const replacement = vi.fn();
+    window.updateMcpServerTools = replacement;
+
+    firstHook.unmount();
+
+    expect(window.updateMcpServerTools).toBe(replacement);
+  });
+});

--- a/webview/src/components/mcp/hooks/useToolsUpdate.test.ts
+++ b/webview/src/components/mcp/hooks/useToolsUpdate.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import type { Dispatch, SetStateAction } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { CacheKeys, ServerToolsState } from '../types';
@@ -54,5 +54,35 @@ describe('useToolsUpdate provider callback isolation', () => {
     firstHook.unmount();
 
     expect(window.updateMcpServerTools).toBe(replacement);
+  });
+});
+
+describe('useToolsUpdate empty tool result', () => {
+  it('logs a connected server with no tools as a warning', () => {
+    const setServerTools = vi.fn() as unknown as Dispatch<SetStateAction<ServerToolsState>>;
+    const onLog = vi.fn();
+    const hook = renderHook(() => useToolsUpdate({
+      isCodexMode: false,
+      cacheKeys,
+      setServerTools,
+      onLog,
+    }));
+
+    act(() => {
+      window.updateMcpServerTools?.(JSON.stringify({
+        serverId: 'empty-server',
+        serverName: 'Empty server',
+        tools: [],
+        error: null,
+      }));
+    });
+
+    expect(onLog).toHaveBeenCalledWith(
+      expect.any(String),
+      'warning',
+      undefined,
+      'Empty server',
+    );
+    hook.unmount();
   });
 });

--- a/webview/src/components/mcp/hooks/useToolsUpdate.ts
+++ b/webview/src/components/mcp/hooks/useToolsUpdate.ts
@@ -90,8 +90,8 @@ export function useToolsUpdate({
         }));
 
         onLog(
-          `工具列表加载完成: 0 个工具`,
-          'success',
+          `工具列表为空，服务器已连接但没有可用工具`,
+          'warning',
           undefined,
           serverName || serverId
         );

--- a/webview/src/components/mcp/hooks/useToolsUpdate.ts
+++ b/webview/src/components/mcp/hooks/useToolsUpdate.ts
@@ -8,6 +8,7 @@ import type { ServerToolsState, McpTool, RefreshLog, CacheKeys } from '../types'
 import { writeToolsCache } from '../utils';
 
 export interface UseToolsUpdateOptions {
+  isCodexMode: boolean;
   cacheKeys: CacheKeys;
   setServerTools: React.Dispatch<React.SetStateAction<ServerToolsState>>;
   onLog: (message: string, type: RefreshLog['type'], details?: string, serverName?: string, requestInfo?: string, errorReason?: string) => void;
@@ -15,9 +16,10 @@ export interface UseToolsUpdateOptions {
 
 /**
  * Tools List Update Hook
- * Registers window.updateMcpServerTools callback
+ * Registers the provider-specific MCP tools callback.
  */
 export function useToolsUpdate({
+  isCodexMode,
   cacheKeys,
   setServerTools,
   onLog,
@@ -102,12 +104,18 @@ export function useToolsUpdate({
       }
     };
 
-    // Register on the window object
-    window.updateMcpServerTools = handleToolsUpdate;
+    if (isCodexMode) {
+      window.updateCodexMcpServerTools = handleToolsUpdate;
+    } else {
+      window.updateMcpServerTools = handleToolsUpdate;
+    }
 
-    // Cleanup
     return () => {
-      window.updateMcpServerTools = undefined;
+      if (isCodexMode && window.updateCodexMcpServerTools === handleToolsUpdate) {
+        window.updateCodexMcpServerTools = undefined;
+      } else if (!isCodexMode && window.updateMcpServerTools === handleToolsUpdate) {
+        window.updateMcpServerTools = undefined;
+      }
     };
-  }, [cacheKeys, setServerTools, onLog]);
+  }, [isCodexMode, cacheKeys, setServerTools, onLog]);
 }

--- a/webview/src/components/mcp/providerSelection.test.ts
+++ b/webview/src/components/mcp/providerSelection.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { getMcpMessagePrefix, resolveInitialMcpProvider } from './providerSelection';
+
+describe('MCP provider selection', () => {
+  it('restores an explicit MCP tab independently from the chat provider', () => {
+    expect(resolveInitialMcpProvider('claude', 'codex')).toBe('codex');
+    expect(resolveInitialMcpProvider('codex', 'claude')).toBe('claude');
+  });
+
+  it('uses the current chat provider only when no tab was saved', () => {
+    expect(resolveInitialMcpProvider('codex', null)).toBe('codex');
+    expect(resolveInitialMcpProvider('unknown', null)).toBe('claude');
+  });
+
+  it('routes each provider tab to its own backend message family', () => {
+    expect(getMcpMessagePrefix('claude')).toBe('');
+    expect(getMcpMessagePrefix('codex')).toBe('codex_');
+  });
+});

--- a/webview/src/components/mcp/providerSelection.ts
+++ b/webview/src/components/mcp/providerSelection.ts
@@ -1,0 +1,15 @@
+export type McpProvider = 'claude' | 'codex';
+
+export function resolveInitialMcpProvider(
+  currentProvider: string,
+  savedProvider: string | null,
+): McpProvider {
+  if (savedProvider === 'claude' || savedProvider === 'codex') {
+    return savedProvider;
+  }
+  return currentProvider === 'codex' ? 'codex' : 'claude';
+}
+
+export function getMcpMessagePrefix(provider: McpProvider): '' | 'codex_' {
+  return provider === 'codex' ? 'codex_' : '';
+}

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -255,6 +255,9 @@ interface Window {
    */
   updateMcpServerTools?: (json: string) => void;
 
+  /** Update Codex MCP server tools list. */
+  updateCodexMcpServerTools?: (json: string) => void;
+
   mcpServerToggled?: (json: string) => void;
 
   /**

--- a/webview/src/styles/less/components/mcp.less
+++ b/webview/src/styles/less/components/mcp.less
@@ -8,6 +8,46 @@
     height: 100%;
 }
 
+.mcp-settings-shell {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    height: 100%;
+}
+
+.mcp-provider-tabs {
+    display: flex;
+    gap: 4px;
+    padding: 3px;
+    width: fit-content;
+    border: 1px solid var(--border-primary);
+    border-radius: 8px;
+    background: var(--bg-secondary);
+}
+
+.mcp-provider-tabs button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 13px;
+}
+
+.mcp-provider-tabs button:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+}
+
+.mcp-provider-tabs button.active {
+    background: var(--accent-primary);
+    color: var(--text-white);
+}
+
 /* MCP 上下布局容器 */
 .mcp-panels-container {
     display: flex;

--- a/webview/src/types/mcp.ts
+++ b/webview/src/types/mcp.ts
@@ -131,7 +131,7 @@ export interface McpServerStatusInfo {
   /** Server name */
   name: string;
   /** Connection status */
-  status: 'connected' | 'failed' | 'needs-auth' | 'pending';
+  status: 'connected' | 'failed' | 'needs-auth' | 'pending' | 'disabled';
   /** Server info (available on successful connection) */
   serverInfo?: {
     name: string;


### PR DESCRIPTION
## Summary

- isolate Codex and Claude MCP callbacks and provider tabs
- clear stale tool results after provider disconnects
- show empty-tool warnings only for completed connected results

## Validation

- Relevant regression tests were added or updated on the source branch.
- `git diff --check` passed.
- No dependency changes are included.

## Test environment note

GitHub currently reports no checks for this branch. Local Java execution requires the IntelliJ IDEA 2024.3.1 test artifact, which is not available in the local Gradle cache. WebView and TypeScript suites should be run by CI before merge.