### PR TITLE
fix(webview): recover startup before frontend readiness

### DIFF
--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -487,6 +487,7 @@ public class ChatWindowDelegate {
     public void handleFrontendReady() {
         LOG.info("Received frontend_ready signal, frontend is now ready to receive data");
         host.setFrontendReady(true);
+        host.getWebviewWatchdog().markFrontendReady();
 
         host.callJavaScript(
             "window.updateLinkifyCapabilities",

--- a/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
@@ -292,19 +292,7 @@ public class WebviewInitializer {
                 return new JBCefJSQuery.Response("ok");
             });
 
-            HtmlLoader htmlLoader = host.getHtmlLoader();
-            String htmlContent = htmlLoader.loadChatHtml();
-
-            // Per-tab provider/model injection: each tab's WebView reads the
-            // same global localStorage snapshot, so without this every tab on
-            // IDE startup overrides the per-tab provider that
-            // ClaudeChatWindow.restorePersistedTabSessionState already wrote to
-            // the session — see issue #1353.
-            ClaudeSession session =
-                    host.getHandlerContext() != null ? host.getHandlerContext().getSession() : null;
-            String tabProvider = session != null ? session.getProvider() : null;
-            String tabModel = session != null ? session.getModel() : null;
-            htmlContent = htmlLoader.injectInitialTabState(htmlContent, tabProvider, tabModel);
+            String htmlContent = loadChatHtmlWithInitialTabState();
 
             // LoadHandler must be registered before loadHTML, otherwise the
             // first frame's onLoadEnd is missed and the JS bridge injection
@@ -917,7 +905,8 @@ public class WebviewInitializer {
             }
             host.setFrontendReady(false);
             try {
-                browser.loadHTML(host.getHtmlLoader().loadChatHtml());
+                LOG.info("[WebviewWatchdog] Reloading webview (" + reason + ")");
+                browser.loadHTML(loadChatHtmlWithInitialTabState());
                 BrowserBridges currentBridges;
                 synchronized (this.bridgeLock) {
                     currentBridges = this.bridges;
@@ -925,12 +914,26 @@ public class WebviewInitializer {
                 if (currentBridges != null && currentBridges.belongsTo(browser)) {
                     scheduleBridgeInjectionRetries(browser, currentBridges);
                 }
+                host.getWebviewWatchdog().resetTimestamps();
                 host.getMainPanel().revalidate();
                 host.getMainPanel().repaint();
             } catch (Exception e) {
                 LOG.warn("[WebviewWatchdog] Reload failed: " + e.getMessage(), e);
             }
         });
+    }
+
+    private String loadChatHtmlWithInitialTabState() {
+        HtmlLoader htmlLoader = host.getHtmlLoader();
+        String htmlContent = htmlLoader.loadChatHtml();
+
+        // Each tab reads the same localStorage snapshot. Preserve the session's
+        // provider and model on both initial load and watchdog recovery.
+        ClaudeSession session = host.getHandlerContext() != null
+                ? host.getHandlerContext().getSession() : null;
+        String tabProvider = session != null ? session.getProvider() : null;
+        String tabModel = session != null ? session.getModel() : null;
+        return htmlLoader.injectInitialTabState(htmlContent, tabProvider, tabModel);
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/ui/WebviewWatchdog.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewWatchdog.java
@@ -24,6 +24,8 @@ public class WebviewWatchdog {
     private static final long HEARTBEAT_TIMEOUT_MS = 45_000L;
     private static final long WATCHDOG_INTERVAL_MS = 10_000L;
     private static final long RECOVERY_COOLDOWN_MS = 60_000L;
+    private static final long STARTUP_READY_TIMEOUT_MS = 15_000L;
+    private static final long STARTUP_RECOVERY_COOLDOWN_MS = 15_000L;
 
     private volatile long lastHeartbeatAtMs = System.currentTimeMillis();
     private volatile long lastRafAtMs = System.currentTimeMillis();
@@ -36,6 +38,7 @@ public class WebviewWatchdog {
     private final JPanel mainPanel;
     private final BrowserProvider browserProvider;
     private final HtmlLoader htmlLoader;
+    private final Runnable onReloadWebview;
     private final Runnable onRecreateWebview;
     private final DisposedCheck disposedCheck;
 
@@ -62,27 +65,36 @@ public class WebviewWatchdog {
         boolean isStreamActive();
     }
 
+    public interface ReadyCheck {
+        boolean isFrontendReady();
+    }
+
     // Extended timeout during active streaming — IPC saturation is expected
     // when pushing large message payloads.  Reloading would destroy React state
     // and the backend would continue pushing to a blank page.
     private static final long STREAMING_HEARTBEAT_TIMEOUT_MS = 180_000L; // 3 minutes
 
     private final StreamActiveCheck streamActiveCheck;
+    private final ReadyCheck readyCheck;
 
     public WebviewWatchdog(
             JPanel mainPanel,
             BrowserProvider browserProvider,
             HtmlLoader htmlLoader,
+            Runnable onReloadWebview,
             Runnable onRecreateWebview,
             DisposedCheck disposedCheck,
-            StreamActiveCheck streamActiveCheck
+            StreamActiveCheck streamActiveCheck,
+            ReadyCheck readyCheck
     ) {
         this.mainPanel = mainPanel;
         this.browserProvider = browserProvider;
         this.htmlLoader = htmlLoader;
+        this.onReloadWebview = onReloadWebview;
         this.onRecreateWebview = onRecreateWebview;
         this.disposedCheck = disposedCheck;
         this.streamActiveCheck = streamActiveCheck;
+        this.readyCheck = readyCheck;
     }
 
     /**
@@ -154,11 +166,24 @@ public class WebviewWatchdog {
         long now = System.currentTimeMillis();
         lastHeartbeatAtMs = now;
         lastRafAtMs = now;
+        lastVisibility = null;
+        lastHasFocus = null;
+    }
+
+    public void markFrontendReady() {
+        resetTimestamps();
+        stallCount = 0;
+        lastRecoveryAtMs = 0L;
+    }
+
+    /** Give an activated tab one heartbeat window before evaluating stale metadata. */
+    public void markTabActivated() {
+        resetTimestamps();
     }
 
     private void checkHealth() {
         if (disposedCheck.isDisposed()) { return; }
-        if (!mainPanel.isShowing()) { return; }
+        boolean frontendReady = readyCheck.isFrontendReady();
 
         long now = System.currentTimeMillis();
         long heartbeatAgeMs = now - lastHeartbeatAtMs;
@@ -166,11 +191,12 @@ public class WebviewWatchdog {
 
         boolean visible = lastVisibility == null || "visible".equals(lastVisibility);
         boolean focused = lastHasFocus == null || lastHasFocus;
-        if (!visible || !focused) {
+        if (!shouldMonitor(frontendReady, mainPanel.isShowing(), visible, focused)) {
             return;
         }
 
-        if (now - lastRecoveryAtMs < RECOVERY_COOLDOWN_MS) {
+        long recoveryCooldownMs = recoveryCooldownMs(frontendReady);
+        if (now - lastRecoveryAtMs < recoveryCooldownMs) {
             return;
         }
 
@@ -179,7 +205,7 @@ public class WebviewWatchdog {
         // Reloading during streaming causes "fake death": backend continues working
         // but the webview shows empty content because streaming state is lost.
         boolean streaming = streamActiveCheck.isStreamActive();
-        long effectiveTimeoutMs = streaming ? STREAMING_HEARTBEAT_TIMEOUT_MS : HEARTBEAT_TIMEOUT_MS;
+        long effectiveTimeoutMs = heartbeatTimeoutMs(frontendReady, streaming);
 
         boolean stalled = heartbeatAgeMs > effectiveTimeoutMs || rafAgeMs > effectiveTimeoutMs;
         if (!stalled) {
@@ -190,7 +216,8 @@ public class WebviewWatchdog {
         if (disposedCheck.isDisposed()) { return; }
 
         stallCount += 1;
-        String reason = "heartbeatAgeMs=" + heartbeatAgeMs + ", rafAgeMs=" + rafAgeMs;
+        String reason = "frontendReady=" + frontendReady
+                + ", heartbeatAgeMs=" + heartbeatAgeMs + ", rafAgeMs=" + rafAgeMs;
         LOG.warn("[WebviewWatchdog] Webview appears stalled (" + stallCount + "), attempting recovery. " + reason);
 
         lastRecoveryAtMs = now;
@@ -206,6 +233,28 @@ public class WebviewWatchdog {
         }
     }
 
+    static long heartbeatTimeoutMs(boolean frontendReady, boolean streaming) {
+        if (!frontendReady) {
+            return STARTUP_READY_TIMEOUT_MS;
+        }
+        return streaming ? STREAMING_HEARTBEAT_TIMEOUT_MS : HEARTBEAT_TIMEOUT_MS;
+    }
+
+    static long recoveryCooldownMs(boolean frontendReady) {
+        return frontendReady ? RECOVERY_COOLDOWN_MS : STARTUP_RECOVERY_COOLDOWN_MS;
+    }
+
+    static boolean shouldMonitor(boolean frontendReady,
+                                 boolean panelShowing,
+                                 boolean pageVisible,
+                                 boolean pageFocused) {
+        if (!frontendReady) {
+            return true;
+        }
+        // Editor focus is independent from webview render health.
+        return panelShowing && pageVisible;
+    }
+
     private void reload(String reason) {
         ApplicationManager.getApplication().invokeLater(() -> {
             if (disposedCheck.isDisposed()) { return; }
@@ -214,13 +263,7 @@ public class WebviewWatchdog {
                 onRecreateWebview.run();
                 return;
             }
-            try {
-                browser.loadHTML(htmlLoader.loadChatHtml());
-                mainPanel.revalidate();
-                mainPanel.repaint();
-            } catch (Exception e) {
-                LOG.warn("[WebviewWatchdog] Reload failed: " + e.getMessage(), e);
-            }
+            onReloadWebview.run();
         });
     }
 }

--- a/src/main/java/com/github/claudecodegui/ui/WebviewWatchdog.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewWatchdog.java
@@ -1,6 +1,5 @@
 package com.github.claudecodegui.ui;
 
-import com.github.claudecodegui.util.HtmlLoader;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.application.ApplicationManager;
@@ -11,6 +10,7 @@ import com.intellij.util.concurrency.AppExecutorUtil;
 import javax.swing.*;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Webview render watchdog for JCEF stall/black-screen recovery.
@@ -26,6 +26,7 @@ public class WebviewWatchdog {
     private static final long RECOVERY_COOLDOWN_MS = 60_000L;
     private static final long STARTUP_READY_TIMEOUT_MS = 15_000L;
     private static final long STARTUP_RECOVERY_COOLDOWN_MS = 15_000L;
+    private static final int MAX_STARTUP_RECOVERY_ATTEMPTS = 2;
 
     private volatile long lastHeartbeatAtMs = System.currentTimeMillis();
     private volatile long lastRafAtMs = System.currentTimeMillis();
@@ -34,10 +35,10 @@ public class WebviewWatchdog {
     private volatile int stallCount = 0;
     private volatile long lastRecoveryAtMs = 0L;
     private volatile ScheduledFuture<?> watchdogFuture = null;
+    private final AtomicInteger startupRecoveryAttempts = new AtomicInteger();
 
     private final JPanel mainPanel;
     private final BrowserProvider browserProvider;
-    private final HtmlLoader htmlLoader;
     private final Runnable onReloadWebview;
     private final Runnable onRecreateWebview;
     private final DisposedCheck disposedCheck;
@@ -80,7 +81,6 @@ public class WebviewWatchdog {
     public WebviewWatchdog(
             JPanel mainPanel,
             BrowserProvider browserProvider,
-            HtmlLoader htmlLoader,
             Runnable onReloadWebview,
             Runnable onRecreateWebview,
             DisposedCheck disposedCheck,
@@ -89,7 +89,6 @@ public class WebviewWatchdog {
     ) {
         this.mainPanel = mainPanel;
         this.browserProvider = browserProvider;
-        this.htmlLoader = htmlLoader;
         this.onReloadWebview = onReloadWebview;
         this.onRecreateWebview = onRecreateWebview;
         this.disposedCheck = disposedCheck;
@@ -172,13 +171,13 @@ public class WebviewWatchdog {
 
     public void markFrontendReady() {
         resetTimestamps();
-        stallCount = 0;
-        lastRecoveryAtMs = 0L;
+        resetRecoveryState();
     }
 
     /** Give an activated tab one heartbeat window before evaluating stale metadata. */
     public void markTabActivated() {
         resetTimestamps();
+        resetRecoveryState();
     }
 
     private void checkHealth() {
@@ -214,6 +213,7 @@ public class WebviewWatchdog {
         }
 
         if (disposedCheck.isDisposed()) { return; }
+        if (!tryAcquireRecoveryPermit(frontendReady)) { return; }
 
         stallCount += 1;
         String reason = "frontendReady=" + frontendReady
@@ -231,6 +231,33 @@ public class WebviewWatchdog {
             onRecreateWebview.run();
             stallCount = 0;
         }
+
+        if (!frontendReady && startupRecoveryAttempts.get() == MAX_STARTUP_RECOVERY_ATTEMPTS) {
+            LOG.warn("[WebviewWatchdog] Startup recovery limit reached; "
+                    + "waiting for frontend readiness or tab activation before retrying");
+        }
+    }
+
+    boolean tryAcquireRecoveryPermit(boolean frontendReady) {
+        if (frontendReady) {
+            return true;
+        }
+
+        while (true) {
+            int attempts = startupRecoveryAttempts.get();
+            if (attempts >= MAX_STARTUP_RECOVERY_ATTEMPTS) {
+                return false;
+            }
+            if (startupRecoveryAttempts.compareAndSet(attempts, attempts + 1)) {
+                return true;
+            }
+        }
+    }
+
+    private void resetRecoveryState() {
+        stallCount = 0;
+        lastRecoveryAtMs = 0L;
+        startupRecoveryAttempts.set(0);
     }
 
     static long heartbeatTimeoutMs(boolean frontendReady, boolean streaming) {

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -156,7 +156,6 @@ public class ClaudeChatWindow {
         this.webviewWatchdog = new WebviewWatchdog(
                 mainPanel,
                 () -> browser,
-                htmlLoader,
                 () -> webviewInitializer.reloadWebview("watchdog_reload"),
                 () -> webviewInitializer.recreateWebview("watchdog_recreate"),
                 () -> disposed,
@@ -359,7 +358,7 @@ public class ClaudeChatWindow {
             if (disposed || !isSelectedContent()) {
                 return;
             }
-            webviewWatchdog.resetTimestamps();
+            webviewWatchdog.markTabActivated();
 
             JBCefBrowser currentBrowser = browser;
             if (currentBrowser != null) {

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -157,9 +157,11 @@ public class ClaudeChatWindow {
                 mainPanel,
                 () -> browser,
                 htmlLoader,
+                () -> webviewInitializer.reloadWebview("watchdog_reload"),
                 () -> webviewInitializer.recreateWebview("watchdog_recreate"),
                 () -> disposed,
-                () -> streamCoalescer.isStreamActive()
+                () -> streamCoalescer.isStreamActive(),
+                () -> frontendReady
         );
 
         this.session = new ClaudeSession(project, claudeSDKBridge, codexSDKBridge);

--- a/src/test/java/com/github/claudecodegui/ui/WebviewWatchdogTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/WebviewWatchdogTest.java
@@ -1,0 +1,43 @@
+package com.github.claudecodegui.ui;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class WebviewWatchdogTest {
+
+    @Test
+    public void usesShortTimeoutBeforeFrontendReady() {
+        long startupTimeout = WebviewWatchdog.heartbeatTimeoutMs(false, false);
+
+        assertEquals(startupTimeout, WebviewWatchdog.heartbeatTimeoutMs(false, true));
+        assertTrue(startupTimeout < WebviewWatchdog.heartbeatTimeoutMs(true, false));
+    }
+
+    @Test
+    public void extendsHeartbeatTimeoutOnlyForReadyStreamingWebview() {
+        assertTrue(WebviewWatchdog.heartbeatTimeoutMs(true, true)
+                > WebviewWatchdog.heartbeatTimeoutMs(true, false));
+    }
+
+    @Test
+    public void retriesStartupRecoverySoonerThanRuntimeRecovery() {
+        assertTrue(WebviewWatchdog.recoveryCooldownMs(false)
+                < WebviewWatchdog.recoveryCooldownMs(true));
+    }
+
+    @Test
+    public void monitorsStartupEvenWhenPanelIsHiddenOrUnfocused() {
+        assertTrue(WebviewWatchdog.shouldMonitor(false, false, false, false));
+    }
+
+    @Test
+    public void pausesRuntimeMonitoringWhenWebviewCannotRenderVisibly() {
+        assertTrue(WebviewWatchdog.shouldMonitor(true, true, true, true));
+        assertFalse(WebviewWatchdog.shouldMonitor(true, false, true, true));
+        assertFalse(WebviewWatchdog.shouldMonitor(true, true, false, true));
+        assertFalse(WebviewWatchdog.shouldMonitor(true, true, true, false));
+    }
+}

--- a/src/test/java/com/github/claudecodegui/ui/WebviewWatchdogTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/WebviewWatchdogTest.java
@@ -38,6 +38,7 @@ public class WebviewWatchdogTest {
         assertTrue(WebviewWatchdog.shouldMonitor(true, true, true, true));
         assertFalse(WebviewWatchdog.shouldMonitor(true, false, true, true));
         assertFalse(WebviewWatchdog.shouldMonitor(true, true, false, true));
-        assertFalse(WebviewWatchdog.shouldMonitor(true, true, true, false));
+        // Editor focus is independent from Webview render health.
+        assertTrue(WebviewWatchdog.shouldMonitor(true, true, true, false));
     }
 }

--- a/src/test/java/com/github/claudecodegui/ui/WebviewWatchdogTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/WebviewWatchdogTest.java
@@ -41,4 +41,64 @@ public class WebviewWatchdogTest {
         // Editor focus is independent from Webview render health.
         assertTrue(WebviewWatchdog.shouldMonitor(true, true, true, false));
     }
+
+    @Test
+    public void capsBackgroundStartupRecovery() {
+        WebviewWatchdog watchdog = createWatchdog();
+
+        assertTrue(watchdog.tryAcquireRecoveryPermit(false));
+        assertTrue(watchdog.tryAcquireRecoveryPermit(false));
+        assertFalse(watchdog.tryAcquireRecoveryPermit(false));
+    }
+
+    @Test
+    public void frontendReadinessRestoresStartupRecoveryBudget() {
+        WebviewWatchdog watchdog = exhaustedWatchdog();
+
+        watchdog.markFrontendReady();
+
+        assertTrue(watchdog.tryAcquireRecoveryPermit(false));
+        assertTrue(watchdog.tryAcquireRecoveryPermit(false));
+        assertFalse(watchdog.tryAcquireRecoveryPermit(false));
+    }
+
+    @Test
+    public void tabActivationRestoresStartupRecoveryBudget() {
+        WebviewWatchdog watchdog = exhaustedWatchdog();
+
+        watchdog.markTabActivated();
+
+        assertTrue(watchdog.tryAcquireRecoveryPermit(false));
+        assertTrue(watchdog.tryAcquireRecoveryPermit(false));
+        assertFalse(watchdog.tryAcquireRecoveryPermit(false));
+    }
+
+    @Test
+    public void runtimeRecoveryIsNotCappedByStartupBudget() {
+        WebviewWatchdog watchdog = createWatchdog();
+
+        for (int attempt = 0; attempt < 10; attempt++) {
+            assertTrue(watchdog.tryAcquireRecoveryPermit(true));
+        }
+    }
+
+    private static WebviewWatchdog exhaustedWatchdog() {
+        WebviewWatchdog watchdog = createWatchdog();
+        assertTrue(watchdog.tryAcquireRecoveryPermit(false));
+        assertTrue(watchdog.tryAcquireRecoveryPermit(false));
+        assertFalse(watchdog.tryAcquireRecoveryPermit(false));
+        return watchdog;
+    }
+
+    private static WebviewWatchdog createWatchdog() {
+        return new WebviewWatchdog(
+                new javax.swing.JPanel(),
+                () -> null,
+                () -> { },
+                () -> { },
+                () -> false,
+                () -> false,
+                () -> false
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- recover the WebView during startup when frontend readiness is not reached
- strengthen watchdog recovery behavior for stalled or hidden surfaces
- avoid treating an unready frontend as a permanently failed session

## Validation

- Relevant regression tests were added or updated on the source branch.
- `git diff --check` passed.
- No dependency changes are included.

## Test environment note

GitHub currently reports no checks for this branch. Local Java execution requires the IntelliJ IDEA 2024.3.1 test artifact, which is not available in the local Gradle cache. WebView and TypeScript suites should be run by CI before merge.