### PR TITLE
fix(tabs): stabilize new tab lifecycle and activation

### DIFF
--- a/src/main/java/com/github/claudecodegui/action/tab/CreateNewTabAction.java
+++ b/src/main/java/com/github/claudecodegui/action/tab/CreateNewTabAction.java
@@ -51,8 +51,18 @@ public class CreateNewTabAction extends AnAction {
             return;
         }
 
+        ContentManager contentManager = toolWindow.getContentManager();
+        Content selectedContent = contentManager.getSelectedContent();
+        ClaudeChatWindow sourceWindow = selectedContent == null
+                ? null
+                : ClaudeSDKToolWindow.getChatWindowForContent(selectedContent);
+        if (sourceWindow == null) {
+            sourceWindow = ClaudeSDKToolWindow.getChatWindow(project);
+        }
+
         // Create a new chat window instance with skipRegister=true (don't replace the main instance)
         ClaudeChatWindow newChatWindow = new ClaudeChatWindow(project, true);
+        newChatWindow.inheritSessionPreferencesFrom(sourceWindow);
 
         // Create a tab name in the format "AIN"
         String tabName = ClaudeSDKToolWindow.getNextTabName(toolWindow);
@@ -61,11 +71,10 @@ public class CreateNewTabAction extends AnAction {
         ContentFactory contentFactory = ContentFactory.getInstance();
         Content content = contentFactory.createContent(newChatWindow.getContent(), tabName, false);
         content.setCloseable(true);
-        newChatWindow.setParentContent(content);
         content.setDisposer(newChatWindow::dispose);
 
-        ContentManager contentManager = toolWindow.getContentManager();
         contentManager.addContent(content);
+        newChatWindow.setParentContent(content);
         contentManager.setSelectedContent(content);
 
         // Ensure the tool window is visible

--- a/src/main/java/com/github/claudecodegui/handler/TabHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/TabHandler.java
@@ -63,11 +63,20 @@ public class TabHandler extends BaseMessageHandler {
                     return;
                 }
 
+                ContentManager contentManager = toolWindow.getContentManager();
+                Content selectedContent = contentManager.getSelectedContent();
+                ClaudeChatWindow sourceWindow = selectedContent == null
+                        ? null
+                        : ClaudeSDKToolWindow.getChatWindowForContent(selectedContent);
+                if (sourceWindow == null) {
+                    sourceWindow = ClaudeSDKToolWindow.getChatWindow(project);
+                }
+
                 // Create a new chat window instance with skipRegister=true (don't replace the main instance)
                 ClaudeChatWindow newChatWindow = new ClaudeChatWindow(project, true);
+                newChatWindow.inheritSessionPreferencesFrom(sourceWindow);
 
                 // Get tab index before adding content
-                ContentManager contentManager = toolWindow.getContentManager();
                 int tabIndex = contentManager.getContentCount();
 
                 // Check if there's a saved name for this tab index
@@ -87,10 +96,10 @@ public class TabHandler extends BaseMessageHandler {
                 ContentFactory contentFactory = ContentFactory.getInstance();
                 Content content = contentFactory.createContent(newChatWindow.getContent(), tabName, false);
                 content.setCloseable(true);
-                newChatWindow.setParentContent(content);
                 content.setDisposer(newChatWindow::dispose);
 
                 contentManager.addContent(content);
+                newChatWindow.setParentContent(content);
                 contentManager.setSelectedContent(content);
 
                 // Ensure the tool window is visible

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -33,6 +33,7 @@ import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentManager;
 import com.intellij.ui.jcef.JBCefBrowser;
+import org.cef.browser.CefBrowser;
 
 import javax.swing.*;
 import java.awt.*;
@@ -337,6 +338,84 @@ public class ClaudeChatWindow {
 
     public JPanel getContent() {
         return mainPanel;
+    }
+
+    /**
+     * Restore the native JCEF surface after this content tab becomes active again.
+     * Reloading is intentionally avoided so the tab keeps its in-memory React state.
+     */
+    public void onTabActivated() {
+        Runnable repaint = () -> {
+            if (disposed || !isSelectedContent()) {
+                return;
+            }
+            webviewWatchdog.resetTimestamps();
+
+            JBCefBrowser currentBrowser = browser;
+            if (currentBrowser != null) {
+                try {
+                    refreshActivatedWebview(
+                            mainPanel,
+                            currentBrowser.getComponent(),
+                            currentBrowser.getCefBrowser(),
+                            currentBrowser.isOffScreenRendering(),
+                            () -> callJavaScript("window.onTabActivated")
+                    );
+                } catch (Exception | LinkageError e) {
+                    LOG.warn("Failed to refresh activated JCEF tab: " + e.getMessage(), e);
+                }
+            }
+        };
+
+        // selectionChanged runs before ContentManager fully remaps the heavyweight
+        // JCEF child. Waiting one EDT turn is essential for empty tabs because they
+        // have no later DOM update that would incidentally repaint the native surface.
+        ApplicationManager.getApplication().invokeLater(repaint);
+    }
+
+    private boolean isSelectedContent() {
+        Content content = parentContent;
+        ContentManager contentManager = content == null ? null : content.getManager();
+        return contentManager != null && contentManager.getSelectedContent() == content;
+    }
+
+    static void refreshActivatedWebview(
+            JPanel mainPanel,
+            JComponent browserComponent,
+            CefBrowser cefBrowser,
+            boolean offScreenRendering,
+            Runnable frontendRepaint
+    ) {
+        mainPanel.revalidate();
+        mainPanel.repaint();
+        browserComponent.revalidate();
+        browserComponent.repaint();
+
+        try {
+            if (offScreenRendering) {
+                int width = browserComponent.getWidth();
+                int height = browserComponent.getHeight();
+                if (width > 0 && height > 0) {
+                    cefBrowser.wasResized(width, height);
+                }
+            } else {
+                Component nativeComponent = cefBrowser.getUIComponent();
+                if (nativeComponent != null) {
+                    nativeComponent.setVisible(false);
+                    nativeComponent.invalidate();
+                    nativeComponent.setVisible(true);
+                    Container parent = nativeComponent.getParent();
+                    if (parent != null) {
+                        parent.validate();
+                        parent.repaint();
+                    }
+                    nativeComponent.repaint();
+                }
+            }
+            cefBrowser.notifyScreenInfoChanged();
+        } finally {
+            frontendRepaint.run();
+        }
     }
 
     public ClaudeSDKBridge getClaudeSDKBridge() {

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -13,6 +13,7 @@ import com.github.claudecodegui.provider.common.MessageCallback;
 import com.github.claudecodegui.session.ClaudeSession;
 import com.github.claudecodegui.session.SessionCallbackAdapter;
 import com.github.claudecodegui.session.SessionLifecycleManager;
+import com.github.claudecodegui.session.SessionState;
 import com.github.claudecodegui.session.StreamMessageCoalescer;
 import com.github.claudecodegui.settings.CodemossSettingsService;
 import com.github.claudecodegui.settings.TabStateService;
@@ -373,6 +374,31 @@ public class ClaudeChatWindow {
 
     public ClaudeSession getSession() {
         return session;
+    }
+
+    /**
+     * Copies provider-specific preferences into a newly-created tab without
+     * carrying over the source tab's conversation or runtime channel.
+     */
+    public void inheritSessionPreferencesFrom(ClaudeChatWindow sourceWindow) {
+        if (sourceWindow == null || sourceWindow.session == null || session == null) {
+            return;
+        }
+
+        ClaudeSession sourceSession = sourceWindow.session;
+        copySessionPreferences(sourceSession.getState(), session.getState());
+        if (handlerContext != null) {
+            handlerContext.setCurrentProvider(sourceSession.getProvider());
+            handlerContext.setCurrentModel(sourceSession.getModel());
+        }
+        persistTabSessionState();
+    }
+
+    static void copySessionPreferences(SessionState source, SessionState target) {
+        target.setProvider(source.getProvider());
+        target.setModel(source.getModel());
+        target.setPermissionMode(source.getPermissionMode());
+        target.setReasoningEffort(source.getReasoningEffort());
     }
 
     public SessionLifecycleManager getSessionLifecycleManager() {

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -451,7 +451,7 @@ public class ClaudeChatWindow {
     }
 
     public void loadRestoredHistoryIfNeeded() {
-        if (session == null) {
+        if (session == null || !frontendReady) {
             return;
         }
 
@@ -461,7 +461,7 @@ public class ClaudeChatWindow {
     }
 
     private void loadRestoredHistoryIfNeeded(TabStateService.TabSessionState savedState) {
-        if (!TabSessionRestorePolicy.shouldLoadHistory(savedState) || session == null) {
+        if (!TabSessionRestorePolicy.shouldStartHistoryLoad(savedState, frontendReady) || session == null) {
             return;
         }
         if (!restoredHistoryLoadStarted.compareAndSet(false, true)) {
@@ -502,6 +502,19 @@ public class ClaudeChatWindow {
         if (snippet != null) {
             addCodeSnippet(snippet);
         }
+    }
+
+    private void updateFrontendReadyState(boolean ready) {
+        frontendReady = ready;
+        if (!ready) {
+            return;
+        }
+        flushPendingCodeSnippet();
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (!disposed) {
+                loadRestoredHistoryIfNeeded();
+            }
+        });
     }
 
     public void updateTabStatus(ChatWindowDelegate.TabAnswerStatus status) {
@@ -1167,10 +1180,7 @@ public class ClaudeChatWindow {
 
             @Override
             public void setFrontendReady(boolean ready) {
-                frontendReady = ready;
-                if (ready) {
-                    flushPendingCodeSnippet();
-                }
+                updateFrontendReadyState(ready);
             }
         };
     }
@@ -1299,10 +1309,7 @@ public class ClaudeChatWindow {
 
             @Override
             public void setFrontendReady(boolean ready) {
-                frontendReady = ready;
-                if (ready) {
-                    flushPendingCodeSnippet();
-                }
+                updateFrontendReadyState(ready);
             }
 
             @Override

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeSDKToolWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeSDKToolWindow.java
@@ -306,8 +306,12 @@ public class ClaudeSDKToolWindow implements ToolWindowFactory, DumbAware {
 
             @Override
             public void selectionChanged(@NotNull ContentManagerEvent event) {
+                if (contentManager.getSelectedContent() != event.getContent()) {
+                    return;
+                }
                 ClaudeChatWindow window = contentToWindowMap.get(event.getContent());
                 if (window != null) {
+                    window.onTabActivated();
                     window.loadRestoredHistoryIfNeeded();
                 }
             }

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/TabSessionRestorePolicy.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/TabSessionRestorePolicy.java
@@ -15,6 +15,10 @@ final class TabSessionRestorePolicy {
         return selectedTab && shouldLoadHistory(savedState);
     }
 
+    static boolean shouldStartHistoryLoad(TabStateService.TabSessionState savedState, boolean frontendReady) {
+        return frontendReady && shouldLoadHistory(savedState);
+    }
+
     private static boolean isNonEmpty(String value) {
         return value != null && !value.trim().isEmpty();
     }

--- a/src/test/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindowSessionPreferencesTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindowSessionPreferencesTest.java
@@ -1,0 +1,51 @@
+package com.github.claudecodegui.ui.toolwindow;
+
+import com.github.claudecodegui.session.SessionState;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ClaudeChatWindowSessionPreferencesTest {
+
+    @Test
+    public void shouldCopyProviderPreferencesWithoutConversationState() {
+        SessionState source = new SessionState();
+        source.setProvider("codex");
+        source.setModel("gpt-5.6-sol");
+        source.setPermissionMode("plan");
+        source.setReasoningEffort("xhigh");
+        source.setSessionId("existing-session");
+        source.setCwd("C:/source-project");
+
+        SessionState target = new SessionState();
+        target.setSessionId("new-session");
+        target.setCwd("C:/target-project");
+
+        ClaudeChatWindow.copySessionPreferences(source, target);
+
+        assertEquals("codex", target.getProvider());
+        assertEquals("gpt-5.6-sol", target.getModel());
+        assertEquals("plan", target.getPermissionMode());
+        assertEquals("xhigh", target.getReasoningEffort());
+        assertEquals("new-session", target.getSessionId());
+        assertEquals("C:/target-project", target.getCwd());
+    }
+
+    @Test
+    public void shouldClearOptionalPreferencesWhenSourceUsesDefaults() {
+        SessionState source = new SessionState();
+        source.setProvider("codex");
+        source.setModel(null);
+        source.setReasoningEffort(null);
+
+        SessionState target = new SessionState();
+        target.setModel("stale-model");
+        target.setReasoningEffort("high");
+
+        ClaudeChatWindow.copySessionPreferences(source, target);
+
+        assertNull(target.getModel());
+        assertNull(target.getReasoningEffort());
+    }
+}

--- a/src/test/java/com/github/claudecodegui/ui/toolwindow/TabSessionRestorePolicyTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/toolwindow/TabSessionRestorePolicyTest.java
@@ -33,4 +33,13 @@ public class TabSessionRestorePolicyTest {
         assertTrue(TabSessionRestorePolicy.shouldLoadImmediately(savedState, true));
         assertFalse(TabSessionRestorePolicy.shouldLoadImmediately(savedState, false));
     }
+
+    @Test
+    public void shouldStartHistoryLoadOnlyAfterFrontendIsReady() {
+        TabStateService.TabSessionState savedState = new TabStateService.TabSessionState();
+        savedState.sessionId = "session-123";
+
+        assertFalse(TabSessionRestorePolicy.shouldStartHistoryLoad(savedState, false));
+        assertTrue(TabSessionRestorePolicy.shouldStartHistoryLoad(savedState, true));
+    }
 }

--- a/src/test/java/com/github/claudecodegui/ui/toolwindow/WebviewTabActivationTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/toolwindow/WebviewTabActivationTest.java
@@ -1,0 +1,137 @@
+package com.github.claudecodegui.ui.toolwindow;
+
+import org.cef.browser.CefBrowser;
+import org.junit.Test;
+
+import javax.swing.JPanel;
+import java.awt.Component;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class WebviewTabActivationTest {
+
+    @Test
+    public void remapsWindowedNativeSurfaceForAnEmptyTab() {
+        List<String> calls = new ArrayList<>();
+        int[][] resized = new int[1][];
+        RecordingComponent nativeComponent = new RecordingComponent();
+        new JPanel().add(nativeComponent);
+        nativeComponent.startRecording();
+        CefBrowser cefBrowser = createCefBrowser(nativeComponent, calls, resized);
+        JPanel browserComponent = new JPanel();
+        browserComponent.setSize(640, 480);
+        AtomicBoolean frontendRepainted = new AtomicBoolean(false);
+
+        ClaudeChatWindow.refreshActivatedWebview(
+                new JPanel(), browserComponent, cefBrowser, false,
+                () -> frontendRepainted.set(true));
+
+        assertTrue(nativeComponent.invalidated);
+        assertTrue(nativeComponent.repainted);
+        assertEquals(Arrays.asList(false, true), nativeComponent.visibilityChanges);
+        assertFalse(calls.contains("wasResized"));
+        assertTrue(calls.contains("notifyScreenInfoChanged"));
+        assertTrue(frontendRepainted.get());
+    }
+
+    @Test
+    public void usesResizeNotificationOnlyForOsrSurface() {
+        List<String> calls = new ArrayList<>();
+        int[][] resized = new int[1][];
+        RecordingComponent nativeComponent = new RecordingComponent();
+        nativeComponent.startRecording();
+        CefBrowser cefBrowser = createCefBrowser(nativeComponent, calls, resized);
+        JPanel browserComponent = new JPanel();
+        browserComponent.setSize(800, 600);
+        AtomicBoolean frontendRepainted = new AtomicBoolean(false);
+
+        ClaudeChatWindow.refreshActivatedWebview(
+                new JPanel(), browserComponent, cefBrowser, true,
+                () -> frontendRepainted.set(true));
+
+        assertArrayEquals(new int[]{800, 600}, resized[0]);
+        assertTrue(nativeComponent.visibilityChanges.isEmpty());
+        assertTrue(calls.contains("notifyScreenInfoChanged"));
+        assertTrue(frontendRepainted.get());
+    }
+
+    private static CefBrowser createCefBrowser(
+            Component nativeComponent,
+            List<String> calls,
+            int[][] resized
+    ) {
+        return (CefBrowser) Proxy.newProxyInstance(
+                CefBrowser.class.getClassLoader(),
+                new Class<?>[]{CefBrowser.class},
+                (proxy, method, args) -> {
+                    calls.add(method.getName());
+                    if ("getUIComponent".equals(method.getName())) {
+                        return nativeComponent;
+                    }
+                    if ("wasResized".equals(method.getName())) {
+                        resized[0] = new int[]{(int) args[0], (int) args[1]};
+                    }
+                    return defaultValue(method.getReturnType());
+                }
+        );
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        if (returnType == double.class) {
+            return 0.0d;
+        }
+        return null;
+    }
+
+    private static class RecordingComponent extends JPanel {
+        private final List<Boolean> visibilityChanges = new ArrayList<>();
+        private boolean recording;
+        private boolean invalidated;
+        private boolean repainted;
+
+        private void startRecording() {
+            recording = true;
+            visibilityChanges.clear();
+            invalidated = false;
+            repainted = false;
+        }
+
+        @Override
+        public void setVisible(boolean visible) {
+            super.setVisible(visible);
+            if (recording) {
+                visibilityChanges.add(visible);
+            }
+        }
+
+        @Override
+        public void invalidate() {
+            super.invalidate();
+            if (recording) {
+                invalidated = true;
+            }
+        }
+
+        @Override
+        public void repaint() {
+            super.repaint();
+            if (recording) {
+                repainted = true;
+            }
+        }
+    }
+}

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -7,6 +7,9 @@ interface Window {
    */
   sendToJava?: (message: string) => void;
 
+  /** Re-rasterize the JCEF surface after its IntelliJ content tab is activated. */
+  onTabActivated?: () => void;
+
   /**
    * Get clipboard file path from Java
    */

--- a/webview/src/main.tsx
+++ b/webview/src/main.tsx
@@ -15,6 +15,7 @@ import { applyLinkifyCapabilitiesPayload } from './utils/linkifyCapabilities';
 import { installRuntimeProviderDispatchers } from './utils/runtimeProviderCapabilities';
 import { sendBridgeEvent } from './utils/bridge';
 import { debugLog } from './utils/debug';
+import { forceWebviewRepaint } from './utils/forceWebviewRepaint';
 import type { UiFontConfig, CodeFontConfig } from './types/uiFontConfig';
 
 // Silence noisy console output in production (including third-party libs).
@@ -671,6 +672,9 @@ if (typeof window !== 'undefined' && !window.showPlanApprovalDialog) {
 if (typeof window !== 'undefined') {
   window.updateLinkifyCapabilities = (json: string) => {
     applyLinkifyCapabilitiesPayload(json);
+  };
+  window.onTabActivated = () => {
+    forceWebviewRepaint('tab-activated');
   };
 }
 

--- a/webview/src/utils/forceWebviewRepaint.test.ts
+++ b/webview/src/utils/forceWebviewRepaint.test.ts
@@ -3,19 +3,23 @@ import { forceWebviewRepaint } from './forceWebviewRepaint';
 
 describe('forceWebviewRepaint', () => {
   let rafQueue: FrameRequestCallback[] = [];
+  let fontScale = '1.1';
 
   beforeEach(() => {
+    vi.useFakeTimers();
     rafQueue = [];
+    fontScale = '1.1';
     vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
       rafQueue.push(cb);
       return rafQueue.length;
     });
     vi.stubGlobal('getComputedStyle', () => ({
-      getPropertyValue: () => '1.1',
+      getPropertyValue: () => fontScale,
     }) as unknown as CSSStyleDeclaration);
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -67,5 +71,46 @@ describe('forceWebviewRepaint', () => {
       flushRaf();
     }).not.toThrow();
     expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+
+  it('uses a timer fallback when JCEF does not deliver animation frames', () => {
+    const zoomWrites: string[] = [];
+    const app = {
+      style: {
+        set zoom(v: string) { zoomWrites.push(v); },
+        get zoom() { return zoomWrites[zoomWrites.length - 1] ?? ''; },
+      },
+      offsetHeight: 0,
+    } as unknown as HTMLElement;
+
+    vi.spyOn(document, 'getElementById').mockReturnValue(app);
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent').mockReturnValue(true);
+
+    forceWebviewRepaint('tab-activated');
+    vi.advanceTimersByTime(50);
+
+    expect(zoomWrites).toEqual(['1', '1.1']);
+    expect(dispatchSpy).toHaveBeenCalledWith(expect.objectContaining({ type: 'resize' }));
+  });
+
+  it('uses a distinct zoom nudge for repeated repaints at 100 percent scale', () => {
+    fontScale = '1';
+    const zoomWrites: string[] = [];
+    const app = {
+      style: {
+        set zoom(v: string) { zoomWrites.push(v); },
+        get zoom() { return zoomWrites[zoomWrites.length - 1] ?? '1'; },
+      },
+      offsetHeight: 0,
+    } as unknown as HTMLElement;
+
+    vi.spyOn(document, 'getElementById').mockReturnValue(app);
+
+    forceWebviewRepaint('first-activation');
+    flushRaf();
+    forceWebviewRepaint('second-activation');
+    flushRaf();
+
+    expect(zoomWrites).toEqual(['0.999', '1', '0.999', '1']);
   });
 });

--- a/webview/src/utils/forceWebviewRepaint.ts
+++ b/webview/src/utils/forceWebviewRepaint.ts
@@ -13,8 +13,8 @@
  *
  * The fix reuses the zoom-nudge technique already proven in main.tsx `forceReapply`
  * ("Toggle inline zoom to ensure Chromium/JCEF re-applies scaling"), but applies it
- * unconditionally. The double requestAnimationFrame waits for React to finish the
- * unmount / reflow first, so the nudge erases the post-unmount viewport.
+ * unconditionally. A timer fallback handles deprioritized/hidden JCEF surfaces where
+ * requestAnimationFrame can remain suspended during tab activation.
  *
  * @param _reason optional label for debugging; intentionally unused at runtime.
  */
@@ -28,16 +28,28 @@ export function forceWebviewRepaint(_reason?: string): void {
     .getPropertyValue('--font-scale')
     .trim();
 
-  // Wait for React to finish unmount/reflow, THEN nudge, so we erase post-unmount pixels.
+  let repainted = false;
+  const repaint = () => {
+    if (repainted) return;
+    repainted = true;
+    const restore = expectedScale || appStyle.zoom || '1';
+    const numericRestore = Number.parseFloat(restore);
+    const nudge = Number.isFinite(numericRestore) && Math.abs(numericRestore - 1) < 0.0001
+      ? '0.999'
+      : '1';
+    appStyle.zoom = nudge;
+    void app.offsetHeight;
+    appStyle.zoom = restore;
+    window.dispatchEvent(new Event('resize'));
+  };
+
+  // Keep the normal double-rAF path for post-React layout, but do not rely on it:
+  // JCEF can suspend rAF while a native-rendered content tab is hidden/black.
+  const fallbackId = window.setTimeout(repaint, 50);
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
-      const restore = expectedScale || appStyle.zoom || '1';
-      // Toggle inline zoom to force Chromium/JCEF to re-rasterize the whole viewport.
-      appStyle.zoom = '1';
-      void app.offsetHeight; // force synchronous layout
-      appStyle.zoom = restore;
-      // Let layout-dependent components recompute (mirrors main.tsx forceReapply).
-      window.dispatchEvent(new Event('resize'));
+      window.clearTimeout(fallbackId);
+      repaint();
     });
   });
 }


### PR DESCRIPTION
## Summary

- preserve the active tab's provider, model, permission mode, and reasoning effort when creating a new tab without copying conversation or runtime state
- defer restored-history loading until the Webview frontend is ready
- refresh the JCEF and React surfaces when a tab is activated to recover empty tabs that would otherwise remain black

## Problem

New tabs could lose provider-specific preferences, restored sessions could race frontend initialization, and empty windowed JCEF tabs had no later DOM update to trigger a repaint after tab switching.

## Validation

- `git diff --check upstream/feature/v0.4.8..HEAD`
- clean merge simulation against `upstream/feature/v0.4.8`
- added or updated regression tests for session preference inheritance, frontend-ready history restoration, JCEF tab activation, and Webview repaint fallback

## Test environment note

The Java suite requires the IntelliJ `ideaIC-2024.3.1` test artifact, which was not available in the local offline cache. The Webview test runner was also not installed in this worktree, so those suites are left to CI.