### PR TITLE
fix(ui): harden rendering and terminal actions

### DIFF
--- a/src/main/java/com/github/claudecodegui/service/GitCommitMessageService.java
+++ b/src/main/java/com/github/claudecodegui/service/GitCommitMessageService.java
@@ -186,6 +186,7 @@ Footer 包含：
                 FilePath filePath = ChangesUtil.getFilePath(change);
                 Change.Type changeType = change.getType();
 
+                int changeStart = diff.length();
                 diff.append("\n=== ").append(changeType.name()).append(": ")
                         .append(filePath.getPath()).append(" ===\n");
 
@@ -210,7 +211,12 @@ Footer 包含：
                     String after = afterRevision.getContent();
 
                     if (before != null && after != null) {
-                        diff.append(generateSimpleDiff(before, after));
+                        String simpleDiff = generateSimpleDiff(before, after);
+                        if (simpleDiff.isEmpty()) {
+                            diff.setLength(changeStart);
+                            continue;
+                        }
+                        diff.append(simpleDiff);
                     }
                 }
 
@@ -232,8 +238,14 @@ Footer 包含：
      * Generate a simple diff (showing added/removed lines).
      */
     private String generateSimpleDiff(String before, String after) {
-        String[] beforeLines = before.split("\n");
-        String[] afterLines = after.split("\n");
+        String normalizedBefore = normalizeLineEndings(before);
+        String normalizedAfter = normalizeLineEndings(after);
+        if (normalizedBefore.equals(normalizedAfter)) {
+            return "";
+        }
+
+        String[] beforeLines = normalizedBefore.split("\n");
+        String[] afterLines = normalizedAfter.split("\n");
 
         StringBuilder diff = new StringBuilder();
         int maxLines = Math.max(beforeLines.length, afterLines.length);
@@ -261,6 +273,10 @@ Footer 包含：
         }
 
         return diff.toString();
+    }
+
+    private String normalizeLineEndings(String content) {
+        return content.replace("\r\n", "\n").replace('\r', '\n');
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/terminal/SendTerminalSelectionToInputAction.java
+++ b/src/main/java/com/github/claudecodegui/terminal/SendTerminalSelectionToInputAction.java
@@ -60,7 +60,7 @@ public class SendTerminalSelectionToInputAction extends AnAction implements Dumb
 
     @Override
     public @NotNull ActionUpdateThread getActionUpdateThread() {
-        return ActionUpdateThread.EDT;
+        return ActionUpdateThread.BGT;
     }
 
     @Override

--- a/src/test/java/com/github/claudecodegui/service/GitCommitMessageServiceCommitAiConfigTest.java
+++ b/src/test/java/com/github/claudecodegui/service/GitCommitMessageServiceCommitAiConfigTest.java
@@ -3,9 +3,15 @@ package com.github.claudecodegui.service;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vcs.FilePath;
+import com.intellij.openapi.vcs.LocalFilePath;
+import com.intellij.openapi.vcs.VcsException;
 import com.intellij.openapi.vcs.changes.Change;
+import com.intellij.openapi.vcs.changes.ContentRevision;
+import com.intellij.openapi.vcs.history.VcsRevisionNumber;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
@@ -49,6 +55,64 @@ public class GitCommitMessageServiceCommitAiConfigTest {
         assertEquals("gpt-5.4", service.lastCodexModel);
         assertNull(service.lastClaudeModel);
         assertEquals("fix: use codex routing", callback.success);
+    }
+
+    @Test
+    public void shouldIgnoreLineEndingOnlyDiffs() {
+        TestableGitCommitMessageService service = new TestableGitCommitMessageService(buildConfig("claude", "claude-sonnet-4-6", "gpt-5.5"));
+
+        String diff = service.exposeGeneratedDiff(Collections.singletonList(
+                modification("README.md", "line 1\r\nline 2\r\n", "line 1\nline 2\n")
+        ));
+
+        assertEquals("", diff);
+    }
+
+    @Test
+    public void shouldKeepContentChangesWhenLineEndingsAlsoChange() {
+        TestableGitCommitMessageService service = new TestableGitCommitMessageService(buildConfig("claude", "claude-sonnet-4-6", "gpt-5.5"));
+
+        String diff = service.exposeGeneratedDiff(Collections.singletonList(
+                modification("README.md", "line 1\r\nold text\r\n", "line 1\nnew text\n")
+        ));
+
+        assertEquals("\n=== MODIFICATION: README.md ===\n- old text\n+ new text\n", diff);
+    }
+
+    @Test
+    public void shouldKeepEarlierContentChangesWhenIgnoringLaterLineEndingOnlyDiff() {
+        TestableGitCommitMessageService service = new TestableGitCommitMessageService(buildConfig("claude", "claude-sonnet-4-6", "gpt-5.5"));
+
+        String diff = service.exposeGeneratedDiff(Arrays.asList(
+                modification("content.md", "old text\n", "new text\n"),
+                modification("line-endings.md", "line 1\r\nline 2\r\n", "line 1\nline 2\n")
+        ));
+
+        assertEquals("\n=== MODIFICATION: content.md ===\n- old text\n+ new text\n", diff);
+    }
+
+    private static Change modification(String path, String before, String after) {
+        FilePath filePath = new LocalFilePath(path, false);
+        return new Change(revision(filePath, before), revision(filePath, after));
+    }
+
+    private static ContentRevision revision(FilePath filePath, String content) {
+        return new ContentRevision() {
+            @Override
+            public String getContent() throws VcsException {
+                return content;
+            }
+
+            @Override
+            public FilePath getFile() {
+                return filePath;
+            }
+
+            @Override
+            public VcsRevisionNumber getRevisionNumber() {
+                return VcsRevisionNumber.NULL;
+            }
+        };
     }
 
     private JsonObject buildConfig(String effectiveProvider, String claudeModel, String codexModel) {
@@ -118,6 +182,10 @@ public class GitCommitMessageServiceCommitAiConfigTest {
         protected void callCodexAPI(String prompt, String model, CommitMessageCallback callback) {
             this.lastCodexModel = model;
             callback.onSuccess("fix: use codex routing");
+        }
+
+        private String exposeGeneratedDiff(java.util.Collection<Change> changes) {
+            return super.generateGitDiff(changes);
         }
     }
 }

--- a/src/test/java/com/github/claudecodegui/terminal/SendTerminalSelectionToInputActionTest.java
+++ b/src/test/java/com/github/claudecodegui/terminal/SendTerminalSelectionToInputActionTest.java
@@ -1,6 +1,7 @@
 package com.github.claudecodegui.terminal;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.ActionPopupMenu;
 import com.intellij.openapi.actionSystem.ActionToolbar;
@@ -34,6 +35,13 @@ public class SendTerminalSelectionToInputActionTest {
     @After
     public void tearDown() {
         SendTerminalSelectionToInputAction.resetSelectionProvider();
+    }
+
+    @Test
+    public void updateRunsOnBackgroundThread() {
+        SendTerminalSelectionToInputAction action = new SendTerminalSelectionToInputAction();
+
+        Assert.assertEquals(ActionUpdateThread.BGT, action.getActionUpdateThread());
     }
 
     @Test

--- a/webview/src/components/MessageAnchorRail.test.ts
+++ b/webview/src/components/MessageAnchorRail.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { sampleAnchorItems } from './MessageAnchorRail';
+
+describe('sampleAnchorItems', () => {
+  it('keeps short conversations unchanged', () => {
+    const items = [
+      { id: 'first', position: 0, preview: '' },
+      { id: 'last', position: 0, preview: '' },
+    ];
+
+    expect(sampleAnchorItems(items, 30)).toEqual(items);
+  });
+
+  it('caps long conversations while retaining first and last anchors', () => {
+    const items = Array.from({ length: 1000 }, (_, index) => ({
+      id: `message-${index}`,
+      position: 0,
+      preview: '',
+    }));
+
+    const sampled = sampleAnchorItems(items, 30);
+
+    expect(sampled).toHaveLength(30);
+    expect(sampled[0].id).toBe('message-0');
+    expect(sampled.at(-1)?.id).toBe('message-999');
+    expect(new Set(sampled.map((item) => item.id)).size).toBe(30);
+  });
+});

--- a/webview/src/components/MessageAnchorRail.tsx
+++ b/webview/src/components/MessageAnchorRail.tsx
@@ -17,7 +17,18 @@ interface MessageAnchorRailProps {
 }
 
 const MAX_PREVIEW_LENGTH = 300;
+const MAX_ANCHOR_COUNT = 30;
 const TOOLTIP_DELAY_MS = 500;
+
+export function sampleAnchorItems(items: AnchorItem[], maxCount = MAX_ANCHOR_COUNT): AnchorItem[] {
+  if (items.length <= maxCount || maxCount < 2) {
+    return items;
+  }
+  return Array.from({ length: maxCount }, (_, index) => {
+    const sourceIndex = Math.round((index / (maxCount - 1)) * (items.length - 1));
+    return items[sourceIndex];
+  });
+}
 
 function getAnchorStyle(position: number): React.CSSProperties {
   return { top: `${position * 100}%` };
@@ -87,10 +98,12 @@ export const MessageAnchorRail = memo(function MessageAnchorRail({
     }
     // Guard: also prevents division by zero in the position calculation below
     if (userMessages.length <= 1) return [];
-    // Distribute positions evenly between 4% and 96%
-    return userMessages.map((item, idx) => ({
+    // Keep the rail usable for long conversations by sampling evenly across the
+    // full message range while retaining the first and last user messages.
+    const visibleMessages = sampleAnchorItems(userMessages);
+    return visibleMessages.map((item, idx) => ({
       ...item,
-      position: 0.04 + (idx / (userMessages.length - 1)) * 0.92,
+      position: 0.04 + (idx / (visibleMessages.length - 1)) * 0.92,
     }));
   }, [messages, collapsedCount]);
 

--- a/webview/src/components/toolBlocks/BashToolBlock.test.tsx
+++ b/webview/src/components/toolBlocks/BashToolBlock.test.tsx
@@ -13,6 +13,18 @@ vi.mock('../../hooks/useIsToolDenied', () => ({
 }));
 
 describe('BashToolBlock', () => {
+  it('hides empty placeholders until command details arrive', () => {
+    const { container, rerender } = render(<BashToolBlock input={{}} />);
+
+    expect(container.firstChild).toBeNull();
+
+    rerender(<BashToolBlock input={{ command: 'npm test' }} />);
+    expect(container.querySelector('.bash-tool-header')).not.toBeNull();
+
+    rerender(<BashToolBlock input={{ command: '  ', description: '\n' }} />);
+    expect(container.firstChild).toBeNull();
+  });
+
   it('renders command and stdout text in code-font-targeted nodes', () => {
     const { container } = render(
       <BashToolBlock

--- a/webview/src/components/toolBlocks/BashToolBlock.tsx
+++ b/webview/src/components/toolBlocks/BashToolBlock.tsx
@@ -19,6 +19,7 @@ interface BashToolBlockProps {
 const BashToolBlock = ({ input, result, toolId }: BashToolBlockProps) => {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
+  const isDenied = useIsToolDenied(toolId);
 
   if (!input) {
     return null;
@@ -26,8 +27,7 @@ const BashToolBlock = ({ input, result, toolId }: BashToolBlockProps) => {
 
   const command = typeof input.command === 'string' ? input.command : '';
   const description = typeof input.description === 'string' ? input.description : '';
-
-  const isDenied = useIsToolDenied(toolId);
+  if (!command.trim() && !description.trim()) return null;
 
   // Determine tool call status based on result
   // If denied, treat as completed (show error state)

--- a/webview/src/components/toolBlocks/BashToolGroupBlock.test.tsx
+++ b/webview/src/components/toolBlocks/BashToolGroupBlock.test.tsx
@@ -9,6 +9,22 @@ vi.mock('react-i18next', () => ({
 }));
 
 describe('BashToolGroupBlock', () => {
+  it('filters empty placeholders from batch counts and rows', () => {
+    const { container } = render(
+      <BashToolGroupBlock
+        items={[
+          { toolId: 'empty-object', input: {} },
+          { toolId: 'empty-strings', input: { command: '  ', description: '\n' } },
+          { toolId: 'real-command', input: { command: 'npm test' } },
+        ]}
+      />,
+    );
+
+    expect(container.querySelector('.bash-group-header')?.textContent).toContain('(1)');
+    expect(container.querySelectorAll('.bash-timeline-item')).toHaveLength(1);
+    expect(container.querySelector('.bash-timeline-description')?.textContent).toBe('npm test');
+  });
+
   it('keeps the batch header expandable without rendering a chevron icon', () => {
     const { container } = render(
       <BashToolGroupBlock

--- a/webview/src/components/toolBlocks/BashToolGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/BashToolGroupBlock.tsx
@@ -50,6 +50,7 @@ function parseBashItem(
 
   const command = typeof input.command === 'string' ? input.command : '';
   const description = typeof input.description === 'string' ? input.description : '';
+  if (!command.trim() && !description.trim()) return null;
 
   let output = '';
   if (result) {


### PR DESCRIPTION
## Summary

- run terminal action presentation updates on the background update thread
- cap long-conversation message anchors with even sampling while retaining the first and last messages
- hide empty Bash tool placeholders until command details arrive
- normalize commit-diff line endings and omit line-ending-only diff sections

## Problem

These independent rendering and action-path edge cases could trigger UI-thread warnings, overcrowded message rails, empty Bash cards, or noisy commit prompts on mixed-line-ending repositories.

## Validation

- `git diff --check upstream/feature/v0.4.8..HEAD`
- clean merge simulation against `upstream/feature/v0.4.8`
- added or updated regression tests for terminal update-thread selection, anchor sampling, empty Bash placeholders, and CRLF/LF normalization

## Test environment note

The Java suite requires the IntelliJ `ideaIC-2024.3.1` test artifact, which was not available in the local offline cache. The Webview test runner was also not installed in this worktree, so those suites are left to CI.