### PR TITLE
fix(mcp): run Codex stdio servers in the project directory

### DIFF
--- a/ai-bridge/services/claude/mcp-status/stdio-tools-getter.js
+++ b/ai-bridge/services/claude/mcp-status/stdio-tools-getter.js
@@ -87,6 +87,7 @@ export async function getStdioServerTools(serverName, serverConfig) {
       const spawnOptions = {
         env,
         stdio: ['pipe', 'pipe', 'pipe'],
+        cwd: serverConfig.cwd || undefined,
         // Hide the console window on Windows
         windowsHide: true
       };

--- a/ai-bridge/services/claude/mcp-status/stdio-tools-getter.test.js
+++ b/ai-bridge/services/claude/mcp-status/stdio-tools-getter.test.js
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { getStdioServerTools } from './stdio-tools-getter.js';
+
+test('starts the MCP server in its configured working directory', async () => {
+  const workingDirectory = await mkdtemp(path.join(os.tmpdir(), 'ccg-mcp-cwd-'));
+  const serverScript = path.join(workingDirectory, 'server.mjs');
+  await writeFile(serverScript, `
+import readline from 'node:readline';
+
+const lines = readline.createInterface({ input: process.stdin });
+lines.on('line', (line) => {
+  const request = JSON.parse(line);
+  if (request.id === 1) {
+    console.log(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        serverInfo: { name: 'cwd-test', version: '1.0.0' }
+      }
+    }));
+  } else if (request.id === 2) {
+    console.log(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      result: {
+        tools: [{
+          name: 'working-directory',
+          description: process.cwd(),
+          inputSchema: { type: 'object' }
+        }]
+      }
+    }));
+  }
+});
+`, 'utf8');
+
+  try {
+    const result = await getStdioServerTools('cwd-test', {
+      command: process.execPath,
+      args: [serverScript],
+      cwd: workingDirectory
+    });
+
+    assert.equal(result.error, null);
+    assert.equal(result.tools.length, 1);
+    assert.equal(path.resolve(result.tools[0].description), path.resolve(workingDirectory));
+  } finally {
+    await rm(workingDirectory, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 100
+    });
+  }
+});

--- a/src/main/java/com/github/claudecodegui/handler/CodexMcpServerHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/CodexMcpServerHandler.java
@@ -190,7 +190,10 @@ public class CodexMcpServerHandler extends BaseMessageHandler {
                 return;
             }
 
-            JsonObject serverConfig = targetServer.getAsJsonObject("server");
+            String sessionCwd = context.getSession() != null ? context.getSession().getCwd() : null;
+            String projectBasePath = context.getProject() != null ? context.getProject().getBasePath() : null;
+            JsonObject serverConfig = prepareServerConfig(
+                    targetServer.getAsJsonObject("server"), sessionCwd, projectBasePath);
             LOG.info("[CodexMcpServerHandler] Getting tools for Codex MCP server: " + serverId);
 
             context.getCodexSDKBridge().getMcpServerTools(serverId, serverConfig)
@@ -221,6 +224,20 @@ public class CodexMcpServerHandler extends BaseMessageHandler {
         ApplicationManager.getApplication().invokeLater(() ->
             callJavaScript("window.updateMcpServerTools", escapeJs(json))
         );
+    }
+
+    static JsonObject prepareServerConfig(
+            JsonObject originalConfig, String sessionCwd, String projectBasePath) {
+        JsonObject serverConfig = originalConfig.deepCopy();
+        if (!serverConfig.has("cwd")) {
+            String cwd = sessionCwd != null && !sessionCwd.trim().isEmpty()
+                    ? sessionCwd
+                    : projectBasePath;
+            if (cwd != null && !cwd.trim().isEmpty()) {
+                serverConfig.addProperty("cwd", cwd);
+            }
+        }
+        return serverConfig;
     }
 
     private boolean isCodexLocalConfigAuthorized() {

--- a/src/test/java/com/github/claudecodegui/handler/CodexMcpServerHandlerWorkingDirectoryTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/CodexMcpServerHandlerWorkingDirectoryTest.java
@@ -1,0 +1,41 @@
+package com.github.claudecodegui.handler;
+
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class CodexMcpServerHandlerWorkingDirectoryTest {
+
+    @Test
+    public void injectsSessionWorkingDirectoryWithoutMutatingStoredConfig() {
+        JsonObject storedConfig = new JsonObject();
+        storedConfig.addProperty("command", "node");
+
+        JsonObject effectiveConfig = CodexMcpServerHandler.prepareServerConfig(
+                storedConfig, "C:/project/session", "C:/project/base");
+
+        assertEquals("C:/project/session", effectiveConfig.get("cwd").getAsString());
+        assertFalse(storedConfig.has("cwd"));
+    }
+
+    @Test
+    public void fallsBackToProjectBasePathWhenSessionDirectoryIsBlank() {
+        JsonObject effectiveConfig = CodexMcpServerHandler.prepareServerConfig(
+                new JsonObject(), "  ", "C:/project/base");
+
+        assertEquals("C:/project/base", effectiveConfig.get("cwd").getAsString());
+    }
+
+    @Test
+    public void preservesExplicitServerWorkingDirectory() {
+        JsonObject storedConfig = new JsonObject();
+        storedConfig.addProperty("cwd", "C:/explicit/server");
+
+        JsonObject effectiveConfig = CodexMcpServerHandler.prepareServerConfig(
+                storedConfig, "C:/project/session", "C:/project/base");
+
+        assertEquals("C:/explicit/server", effectiveConfig.get("cwd").getAsString());
+    }
+}


### PR DESCRIPTION
## Summary

- inject the active session working directory into Codex MCP server configurations without mutating stored configuration
- fall back to the project base path when the session working directory is unavailable
- start stdio MCP servers with the configured working directory

## Problem

Codex stdio MCP servers were launched from the bridge process directory, so relative paths and project-local configuration could resolve against the wrong location.

## Validation

- `node --test ai-bridge/services/claude/mcp-status/stdio-tools-getter.test.js` — 1 passed
- `git diff --check upstream/feature/v0.4.8..HEAD`
- clean merge simulation against `upstream/feature/v0.4.8`
- added Java regression coverage for configuration copying, session/project fallback, and explicit `cwd` preservation

## Test environment note

The Java suite requires the IntelliJ `ideaIC-2024.3.1` test artifact, which was not available in the local offline cache, so that suite is left to CI.