### PR TITLE
fix(provider): align Claude paths, mappings, and question labels

### DIFF
--- a/ai-bridge/services/claude/message-rewind.js
+++ b/ai-bridge/services/claude/message-rewind.js
@@ -5,9 +5,8 @@
 
 import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
-import { join } from 'path';
 import { setupApiKey, buildCliEnv, buildWebviewControlledSettingsOverride } from '../../config/api-config.js';
-import { getClaudeDir, getRealHomeDir, selectWorkingDirectory } from '../../utils/path-utils.js';
+import { getClaudeProjectSessionFilePath, getRealHomeDir, selectWorkingDirectory } from '../../utils/path-utils.js';
 import { ensureClaudeSdk, hasClaudeProjectSessionFile, waitForClaudeProjectSessionFile, isNoConversationFoundError } from './message-utils.js';
 import { getActiveQueryResult, getActiveSessionIds } from './message-session-registry.js';
 import { getClaudeCliPathOverride } from '../../utils/claude-cli-path.js';
@@ -253,9 +252,7 @@ async function resolveRewindCandidateMessageIds(sessionId, cwd, providedMessageI
 
 async function readClaudeProjectSessionMessages(sessionId, cwd) {
   try {
-    const projectsDir = join(getClaudeDir(), 'projects');
-    const sanitizedCwd = (cwd || process.cwd()).replace(/[^a-zA-Z0-9]/g, '-');
-    const sessionFile = join(projectsDir, sanitizedCwd, `${sessionId}.jsonl`);
+    const sessionFile = getClaudeProjectSessionFilePath(sessionId, cwd);
     if (!existsSync(sessionFile)) {
       return [];
     }

--- a/ai-bridge/services/claude/message-utils.js
+++ b/ai-bridge/services/claude/message-utils.js
@@ -5,8 +5,7 @@
 
 import { isClaudeSdkAvailable, loadAnthropicSdk, loadBedrockSdk, loadClaudeSdk } from '../../utils/sdk-loader.js';
 import { existsSync } from 'fs';
-import { join } from 'path';
-import { getClaudeDir } from '../../utils/path-utils.js';
+import { getClaudeProjectSessionFilePath as resolveClaudeProjectSessionFilePath } from '../../utils/path-utils.js';
 import { loadClaudeSettings } from '../../config/api-config.js';
 
 // SDK cache (module-internal, accessed via ensure* functions)
@@ -101,9 +100,7 @@ export function getRetryDelayMs(error) {
 }
 
 export function getClaudeProjectSessionFilePath(sessionId, cwd) {
-  const projectsDir = join(getClaudeDir(), 'projects');
-  const sanitizedCwd = String(cwd || process.cwd()).replace(/[^a-zA-Z0-9]/g, '-');
-  return join(projectsDir, sanitizedCwd, `${sessionId}.jsonl`);
+  return resolveClaudeProjectSessionFilePath(sessionId, cwd);
 }
 
 export function hasClaudeProjectSessionFile(sessionId, cwd) {

--- a/ai-bridge/services/claude/session-service.js
+++ b/ai-bridge/services/claude/session-service.js
@@ -5,10 +5,10 @@
 
 import { existsSync, createReadStream, mkdirSync, readFileSync, appendFileSync, statSync } from 'fs';
 import { readFile } from 'fs/promises';
-import { join } from 'path';
+import { dirname } from 'path';
 import { randomUUID } from 'crypto';
 import { createInterface } from 'readline';
-import { getClaudeDir } from '../../utils/path-utils.js';
+import { getClaudeProjectSessionFilePath } from '../../utils/path-utils.js';
 
 /**
  * Append a message to the JSONL history file.
@@ -16,11 +16,9 @@ import { getClaudeDir } from '../../utils/path-utils.js';
  */
 export function persistJsonlMessage(sessionId, cwd, obj) {
   try {
-    const projectsDir = join(getClaudeDir(), 'projects');
-    const sanitizedCwd = (cwd || process.cwd()).replace(/[^a-zA-Z0-9]/g, '-');
-    const projectHistoryDir = join(projectsDir, sanitizedCwd);
+    const sessionFile = getClaudeProjectSessionFilePath(sessionId, cwd);
+    const projectHistoryDir = dirname(sessionFile);
     mkdirSync(projectHistoryDir, { recursive: true });
-    const sessionFile = join(projectHistoryDir, `${sessionId}.jsonl`);
 
     // Add necessary metadata fields to ensure compatibility with ClaudeHistoryReader
     const enrichedObj = {
@@ -43,9 +41,7 @@ export function persistJsonlMessage(sessionId, cwd, obj) {
  */
 export function loadSessionHistory(sessionId, cwd) {
   try {
-    const projectsDir = join(getClaudeDir(), 'projects');
-    const sanitizedCwd = (cwd || process.cwd()).replace(/[^a-zA-Z0-9]/g, '-');
-    const sessionFile = join(projectsDir, sanitizedCwd, `${sessionId}.jsonl`);
+    const sessionFile = getClaudeProjectSessionFilePath(sessionId, cwd);
 
     if (!existsSync(sessionFile)) {
       return [];
@@ -214,8 +210,5 @@ function resolveSessionFile(sessionId, cwd = null) {
   if (!sessionId || /[\/\\]/.test(sessionId)) {
     throw new Error('Invalid session ID');
   }
-  const projectsDir = join(getClaudeDir(), 'projects');
-  const sanitizedCwd = (cwd || process.cwd()).replace(/[^a-zA-Z0-9]/g, '-');
-  const projectHistoryDir = join(projectsDir, sanitizedCwd);
-  return join(projectHistoryDir, `${sessionId}.jsonl`);
+  return getClaudeProjectSessionFilePath(sessionId, cwd);
 }

--- a/ai-bridge/services/session-title-service.js
+++ b/ai-bridge/services/session-title-service.js
@@ -5,15 +5,14 @@
  */
 
 import { appendFile, mkdir, access, open as fsOpen, stat as fsStat, readFile } from 'fs/promises';
-import { join, basename } from 'path';
+import { join } from 'path';
 import { setupApiKey, loadClaudeSettings, getCliUserAgent } from '../config/api-config.js';
 import { ensureAnthropicSdk, ensureBedrockSdk } from './claude/message-utils.js';
 import { resolveModelFromSettings } from '../utils/model-utils.js';
-import { getClaudeDir, getCodemossDir } from '../utils/path-utils.js';
+import { getClaudeProjectSessionFilePath, getCodemossDir } from '../utils/path-utils.js';
 
 const DEFAULT_HAIKU_MODEL = 'claude-haiku-4-5-20251001';
 const MAX_CONVERSATION_TEXT = 1000;
-const MAX_SANITIZED_LENGTH = 200;
 // Aligns with Java HistoryDeleteService.SESSION_ID_PATTERN — alphanumeric,
 // dot, dash, underscore. Defeats path-traversal payloads in upstream payloads.
 const SESSION_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
@@ -133,31 +132,8 @@ async function isTitleGenerationEnabled() {
   }
 }
 
-// --- Path utilities (matching CLI's sanitizePath logic) ---
-
-function djb2Hash(str) {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
-  }
-  return hash;
-}
-
-function sanitizePath(name) {
-  const sanitized = name.replace(/[^a-zA-Z0-9]/g, '-');
-  if (sanitized.length <= MAX_SANITIZED_LENGTH) {
-    return sanitized;
-  }
-  const hash = Math.abs(djb2Hash(name)).toString(36);
-  return `${sanitized.slice(0, MAX_SANITIZED_LENGTH)}-${hash}`;
-}
-
 function getSessionFilePath(sessionId, cwd) {
-  const projectsDir = join(getClaudeDir(), 'projects');
-  const sanitizedCwd = sanitizePath(cwd || process.cwd());
-  // Use basename as a defensive second layer in case validation is bypassed
-  // by future refactors — basename strips any path separators that slip through.
-  return join(projectsDir, sanitizedCwd, `${basename(sessionId)}.jsonl`);
+  return getClaudeProjectSessionFilePath(sessionId, cwd);
 }
 
 // --- API ---

--- a/ai-bridge/utils/model-utils.js
+++ b/ai-bridge/utils/model-utils.js
@@ -34,7 +34,7 @@ export function mapModelIdToSdkName(modelId) {
  * those values are written to ~/.claude/settings.json as ANTHROPIC_DEFAULT_*_MODEL env vars.
  * This function checks those settings and returns the mapped model name if configured.
  *
- * Priority: ANTHROPIC_MODEL (global override) > ANTHROPIC_DEFAULT_*_MODEL > original modelId
+ * Priority: ANTHROPIC_DEFAULT_*_MODEL for the selected family > ANTHROPIC_MODEL fallback > original modelId
  *
  * IMPORTANT: The `[1m]` suffix is controlled by the input modelId from the
  * webview, not by stale settings.env mappings.
@@ -60,30 +60,28 @@ export function resolveModelFromSettings(modelId, userEnv) {
     return requestHas1M ? `${base}[1m]` : base;
   };
 
-  // ANTHROPIC_MODEL is a global override that applies to all model types
-  if (userEnv.ANTHROPIC_MODEL && String(userEnv.ANTHROPIC_MODEL).trim()) {
-    return applySuffix(String(userEnv.ANTHROPIC_MODEL).trim());
-  }
+  const readMapped = (key) => {
+    const mapped = userEnv[key];
+    return mapped && String(mapped).trim() ? applySuffix(String(mapped).trim()) : null;
+  };
 
-  // Check model-specific env vars based on the internal model ID's type
+  // Check family-specific env vars first. A stale generic mapping must not
+  // silently route a selected Haiku/Sonnet/Opus model to another family.
   if (lowerModel.includes('opus')) {
-    const mapped = userEnv.ANTHROPIC_DEFAULT_OPUS_MODEL;
-    if (mapped && String(mapped).trim()) {
-      return applySuffix(String(mapped).trim());
-    }
+    return readMapped('ANTHROPIC_DEFAULT_OPUS_MODEL')
+      || readMapped('ANTHROPIC_MODEL')
+      || modelId;
   } else if (lowerModel.includes('haiku')) {
-    const mapped = userEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL;
-    if (mapped && String(mapped).trim()) {
-      return applySuffix(String(mapped).trim());
-    }
+    return readMapped('ANTHROPIC_DEFAULT_HAIKU_MODEL')
+      || readMapped('ANTHROPIC_MODEL')
+      || modelId;
   } else if (lowerModel.includes('sonnet')) {
     // Only apply sonnet mapping when the model ID actually contains 'sonnet'.
     // Non-Anthropic model names (e.g. 'qwen3.5-plus', 'deepseek-v3') should NOT be
     // remapped to the sonnet setting, as they are already the intended model name.
-    const mapped = userEnv.ANTHROPIC_DEFAULT_SONNET_MODEL;
-    if (mapped && String(mapped).trim()) {
-      return applySuffix(String(mapped).trim());
-    }
+    return readMapped('ANTHROPIC_DEFAULT_SONNET_MODEL')
+      || readMapped('ANTHROPIC_MODEL')
+      || modelId;
   }
   // For non-Anthropic model IDs that don't contain 'opus'/'haiku'/'sonnet',
   // skip mapping and use the original model ID as-is.

--- a/ai-bridge/utils/model-utils.test.mjs
+++ b/ai-bridge/utils/model-utils.test.mjs
@@ -39,13 +39,22 @@ test('resolveModelFromSettings applies model-specific settings mapping', () => {
   assert.equal(resolveModelFromSettings('claude-haiku-4-5', env), 'glm-4.7-flash');
 });
 
-test('resolveModelFromSettings honors global ANTHROPIC_MODEL override', () => {
+test('resolveModelFromSettings uses ANTHROPIC_MODEL as fallback when family mapping is absent', () => {
   const env = {
     ANTHROPIC_MODEL: 'override-everywhere',
-    ANTHROPIC_DEFAULT_SONNET_MODEL: 'ignored',
   };
   assert.equal(resolveModelFromSettings('claude-sonnet-4-6', env), 'override-everywhere');
   assert.equal(resolveModelFromSettings('claude-opus-4-8', env), 'override-everywhere');
+});
+
+test('resolveModelFromSettings prefers family mapping over stale ANTHROPIC_MODEL', () => {
+  const env = {
+    ANTHROPIC_MODEL: 'deepseek-v4-pro',
+    ANTHROPIC_DEFAULT_HAIKU_MODEL: 'deepseek-v4-flash',
+    ANTHROPIC_DEFAULT_SONNET_MODEL: 'deepseek-v4-flash',
+  };
+  assert.equal(resolveModelFromSettings('claude-haiku-4-5', env), 'deepseek-v4-flash');
+  assert.equal(resolveModelFromSettings('claude-sonnet-4-6', env), 'deepseek-v4-flash');
 });
 
 test('resolveModelFromSettings ignores empty / whitespace mapping values', () => {

--- a/ai-bridge/utils/path-utils.js
+++ b/ai-bridge/utils/path-utils.js
@@ -53,6 +53,37 @@ export function getClaudeDir() {
   return join(getRealHomeDir(), '.claude');
 }
 
+const CLAUDE_SESSION_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Convert a project path into the directory key used under ~/.claude/projects.
+ * Claude Code replaces every non-alphanumeric character with a hyphen and does
+ * not truncate long keys.
+ * @param {string} projectPath
+ * @returns {string}
+ */
+export function getClaudeProjectKey(projectPath) {
+  if (!projectPath || typeof projectPath !== 'string') {
+    return '';
+  }
+  return projectPath.replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+/**
+ * Resolve a validated Claude Code JSONL session file path.
+ * @param {string} sessionId
+ * @param {string|null} cwd
+ * @returns {string}
+ */
+export function getClaudeProjectSessionFilePath(sessionId, cwd = null) {
+  if (typeof sessionId !== 'string' || !CLAUDE_SESSION_ID_PATTERN.test(sessionId)) {
+    throw new Error('Invalid session ID');
+  }
+  const projectsDir = join(getClaudeDir(), 'projects');
+  const projectKey = getClaudeProjectKey(cwd || process.cwd());
+  return join(projectsDir, projectKey, `${sessionId}.jsonl`);
+}
+
 /**
  * Get the platform-specific path for Claude Code managed settings.
  * Managed settings are typically configured by enterprise IT administrators.

--- a/ai-bridge/utils/path-utils.test.js
+++ b/ai-bridge/utils/path-utils.test.js
@@ -8,6 +8,8 @@ import {
   selectWorkingDirectory,
   isBridgeDirectory,
   normalizePathForComparison,
+  getClaudeProjectKey,
+  getClaudeProjectSessionFilePath,
 } from './path-utils.js';
 
 // This test sits in <bridge>/utils/, so the bridge install dir is one level up.
@@ -101,4 +103,32 @@ test('selectWorkingDirectory skips bridge dir when it appears as process.cwd() c
     const result = selectWorkingDirectory('');
     assert.ok(!samePath(result, BRIDGE_DIR), `expected non-bridge dir, got ${result}`);
   });
+});
+
+test('getClaudeProjectKey matches the session writer for common paths', () => {
+  assert.equal(getClaudeProjectKey('D:\\Projects\\My Project'), 'D--Projects-My-Project');
+  assert.equal(getClaudeProjectKey('/Users/test/demo'), '-Users-test-demo');
+});
+
+test('getClaudeProjectKey preserves the complete key for long paths', () => {
+  const longPath = `C:\\Users\\name\\${'deep\\'.repeat(60)}project`;
+  const projectKey = getClaudeProjectKey(longPath);
+
+  assert.equal(projectKey, longPath.replace(/[^a-zA-Z0-9]/g, '-'));
+  assert.ok(projectKey.length > 200);
+});
+
+test('getClaudeProjectSessionFilePath uses the shared project key', () => {
+  const cwd = `C:\\Users\\name\\${'deep\\'.repeat(60)}project`;
+  const sessionFile = getClaudeProjectSessionFilePath('session-1', cwd);
+
+  assert.ok(sessionFile.includes(getClaudeProjectKey(cwd)));
+  assert.ok(sessionFile.endsWith('session-1.jsonl'));
+});
+
+test('getClaudeProjectSessionFilePath rejects path-like session IDs', () => {
+  assert.throws(
+    () => getClaudeProjectSessionFilePath('../outside', 'C:\\project'),
+    /Invalid session ID/,
+  );
 });

--- a/src/main/java/com/github/claudecodegui/handler/provider/ModelProviderHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/provider/ModelProviderHandler.java
@@ -316,28 +316,24 @@ public class ModelProviderHandler {
             return baseModel;
         }
 
-        String mainModel = readConfiguredEnvValue(env, "ANTHROPIC_MODEL");
-        if (mainModel != null) {
-            return mainModel;
-        }
-
         String lowerBaseModel = baseModel.toLowerCase();
         boolean isClaudeModel = lowerBaseModel.startsWith("claude-") || lowerBaseModel.startsWith("claude_");
         if (!isClaudeModel) {
             return baseModel;
         }
 
+        String mainModel = readConfiguredEnvValue(env, "ANTHROPIC_MODEL");
         if (lowerBaseModel.contains("opus")) {
             String mappedOpus = readConfiguredEnvValue(env, "ANTHROPIC_DEFAULT_OPUS_MODEL");
-            return mappedOpus != null ? mappedOpus : baseModel;
+            return mappedOpus != null ? mappedOpus : mainModel != null ? mainModel : baseModel;
         }
         if (lowerBaseModel.contains("haiku")) {
             String mappedHaiku = readConfiguredEnvValue(env, "ANTHROPIC_DEFAULT_HAIKU_MODEL");
-            return mappedHaiku != null ? mappedHaiku : baseModel;
+            return mappedHaiku != null ? mappedHaiku : mainModel != null ? mainModel : baseModel;
         }
         if (lowerBaseModel.contains("sonnet")) {
             String mappedSonnet = readConfiguredEnvValue(env, "ANTHROPIC_DEFAULT_SONNET_MODEL");
-            return mappedSonnet != null ? mappedSonnet : baseModel;
+            return mappedSonnet != null ? mappedSonnet : mainModel != null ? mainModel : baseModel;
         }
 
         return baseModel;

--- a/src/test/java/com/github/claudecodegui/handler/provider/ModelProviderHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/provider/ModelProviderHandlerTest.java
@@ -13,14 +13,27 @@ import static org.junit.Assert.assertTrue;
 public class ModelProviderHandlerTest {
 
     @Test
-    public void shouldPreferMainModelOverrideForAllClaudeModelFamilies() {
+    public void shouldUseMainModelAsFallbackWhenFamilyMappingIsMissing() {
         JsonObject env = new JsonObject();
         env.addProperty("ANTHROPIC_MODEL", "glm-4.7");
-        env.addProperty("ANTHROPIC_DEFAULT_SONNET_MODEL", "ignored-sonnet");
 
         String resolved = ModelProviderHandler.resolveConfiguredClaudeModel("claude-opus-4-6", env);
 
         assertEquals("glm-4.7", resolved);
+    }
+
+    @Test
+    public void shouldPreferFamilySpecificMappingOverMainModel() {
+        JsonObject env = new JsonObject();
+        env.addProperty("ANTHROPIC_MODEL", "deepseek-v4-pro");
+        env.addProperty("ANTHROPIC_DEFAULT_HAIKU_MODEL", "deepseek-v4-flash");
+        env.addProperty("ANTHROPIC_DEFAULT_SONNET_MODEL", "deepseek-v4-flash");
+
+        String haiku = ModelProviderHandler.resolveConfiguredClaudeModel("claude-haiku-4-5", env);
+        String sonnet = ModelProviderHandler.resolveConfiguredClaudeModel("claude-sonnet-4-6", env);
+
+        assertEquals("deepseek-v4-flash", haiku);
+        assertEquals("deepseek-v4-flash", sonnet);
     }
 
     @Test

--- a/webview/src/components/AskUserQuestionDialog.test.tsx
+++ b/webview/src/components/AskUserQuestionDialog.test.tsx
@@ -28,6 +28,21 @@ const buildRequest = (overrides: Partial<AskUserQuestionRequest> = {}): AskUserQ
   ...overrides,
 });
 
+describe('AskUserQuestionDialog provider label', () => {
+  it('identifies Codex request_user_input requests', () => {
+    render(
+      <AskUserQuestionDialog
+        isOpen
+        request={buildRequest({ toolName: 'request_user_input', provider: 'codex' })}
+        onSubmit={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('Codex 有一些问题想问你')).toBeTruthy();
+  });
+});
+
 describe('AskUserQuestionDialog countdown', () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/webview/src/components/AskUserQuestionDialog.tsx
+++ b/webview/src/components/AskUserQuestionDialog.tsx
@@ -28,6 +28,7 @@ export interface AskUserQuestionRequest {
   requestId: string;
   toolName: string;
   questions: Question[];
+  provider?: 'claude' | 'codex';
 }
 
 interface AskUserQuestionDialogProps {
@@ -87,6 +88,10 @@ const AskUserQuestionDialog = ({
   const normalizedQuestions = (Array.isArray(request?.questions) ? request!.questions : [])
     .map(normalizeQuestion)
     .filter(Boolean) as Question[];
+  const isCodexRequest = request?.provider === 'codex' || request?.toolName === 'request_user_input';
+  const dialogTitle = isCodexRequest
+    ? t('askUserQuestion.codexTitle', 'Codex 有一些问题想问你')
+    : t('askUserQuestion.title', 'Claude 有一些问题想问你');
 
   const handleCancel = useCallback(() => {
     if (request && markSubmitted()) {
@@ -139,7 +144,7 @@ const AskUserQuestionDialog = ({
       <div className="permission-dialog-overlay">
         <div className="ask-user-question-dialog">
           <h3 className="ask-user-question-dialog-title">
-            {t('askUserQuestion.title', 'Claude 有一些问题想问你')}
+            {dialogTitle}
           </h3>
           <p className="question-text">
             {t('askUserQuestion.invalidFormat', '问题数据格式不支持，请取消后重试。')}
@@ -167,7 +172,7 @@ const AskUserQuestionDialog = ({
       <div className="permission-dialog-overlay">
         <div className="ask-user-question-dialog">
           <h3 className="ask-user-question-dialog-title">
-            {t('askUserQuestion.title', 'Claude 有一些问题想问你')}
+            {dialogTitle}
           </h3>
           <p className="question-text">
             {t('askUserQuestion.loading', '正在加载问题...')}
@@ -277,7 +282,7 @@ const AskUserQuestionDialog = ({
         {/* Header area - with collapse/expand button */}
         <div className="ask-user-question-dialog-header">
           <h3 className="ask-user-question-dialog-title">
-            {t('askUserQuestion.title', 'Claude 有一些问题想问你')}
+            {dialogTitle}
           </h3>
           <button
             className="collapse-toggle-button"


### PR DESCRIPTION
## Summary

- centralize and validate Claude project session-file path resolution
- make family-specific Claude model mappings take precedence over a stale global mapping while retaining the global value as a fallback
- label Codex `request_user_input` dialogs as Codex-originated questions

## Problem

Different bridge services could resolve the same Claude session to different files, generic model overrides could route a selected Claude family to the wrong model, and Codex questions were presented with a Claude label.

## Validation

- `node --test ai-bridge/utils/model-utils.test.mjs ai-bridge/utils/path-utils.test.js` — 26 passed
- `git diff --check upstream/feature/v0.4.8..HEAD`
- clean merge simulation against `upstream/feature/v0.4.8`
- added or updated Java and Webview regression coverage for model mapping and question labeling

## Test environment note

The Java suite requires the IntelliJ `ideaIC-2024.3.1` test artifact, which was not available in the local offline cache. The Webview test runner was also not installed in this worktree, so those suites are left to CI.