### PR TITLE
fix(provider): isolate prompts and protect bridge stdout

### DIFF
--- a/ai-bridge/channel-manager.js
+++ b/ai-bridge/channel-manager.js
@@ -40,11 +40,11 @@ injectStartupEnvVars();
 configureCliIdentity();
 
 // Diagnostic logging: startup info
-console.log('[DIAG-ENTRY] ========== CHANNEL-MANAGER STARTUP ==========');
-console.log('[DIAG-ENTRY] Node.js version:', process.version);
-console.log('[DIAG-ENTRY] Platform:', process.platform);
-console.log('[DIAG-ENTRY] CWD:', process.cwd());
-console.log('[DIAG-ENTRY] argv:', process.argv);
+console.error('[DIAG-ENTRY] ========== CHANNEL-MANAGER STARTUP ==========');
+console.error('[DIAG-ENTRY] Node.js version:', process.version);
+console.error('[DIAG-ENTRY] Platform:', process.platform);
+console.error('[DIAG-ENTRY] CWD:', process.cwd());
+console.error('[DIAG-ENTRY] argv:', process.argv);
 
 // Parse command-line arguments
 const provider = process.argv[2];
@@ -52,9 +52,9 @@ const command = process.argv[3];
 const args = process.argv.slice(4);
 
 // Diagnostic logging: argument info
-console.log('[DIAG-ENTRY] Provider:', provider);
-console.log('[DIAG-ENTRY] Command:', command);
-console.log('[DIAG-ENTRY] Args:', args);
+console.error('[DIAG-ENTRY] Provider:', provider);
+console.error('[DIAG-ENTRY] Command:', command);
+console.error('[DIAG-ENTRY] Args:', args);
 
 // Error handling
 process.on('uncaughtException', (error) => {
@@ -122,10 +122,10 @@ const providerHandlers = {
 
 // Execute command
 (async () => {
-  console.log('[DIAG-EXEC] ========== STARTING EXECUTION ==========');
+  console.error('[DIAG-EXEC] ========== STARTING EXECUTION ==========');
   try {
     // Validate provider
-    console.log('[DIAG-EXEC] Validating provider...');
+    console.error('[DIAG-EXEC] Validating provider...');
     if (!provider || !providerHandlers[provider]) {
       console.error('Invalid provider. Use "claude", "codex", or "system"');
       console.log(JSON.stringify({
@@ -146,15 +146,15 @@ const providerHandlers = {
     }
 
     // Read stdin data
-    console.log('[DIAG-EXEC] Reading stdin data...');
+    console.error('[DIAG-EXEC] Reading stdin data...');
     const stdinData = await readStdinData(provider);
-    console.log('[DIAG-EXEC] Stdin data received, keys:', stdinData ? Object.keys(stdinData) : 'null');
+    console.error('[DIAG-EXEC] Stdin data received, keys:', stdinData ? Object.keys(stdinData) : 'null');
 
     // Dispatch to the appropriate provider handler
-    console.log('[DIAG-EXEC] Dispatching to handler:', provider);
+    console.error('[DIAG-EXEC] Dispatching to handler:', provider);
     const handler = providerHandlers[provider];
     await handler(command, args, stdinData);
-    console.log('[DIAG-EXEC] Handler completed successfully');
+    console.error('[DIAG-EXEC] Handler completed successfully');
 
     // IMPORTANT: Do not use process.exit(0) here -- it terminates the process
     // before the stdout buffer is fully flushed, which can truncate large JSON

--- a/ai-bridge/channel-manager.protocol.test.mjs
+++ b/ai-bridge/channel-manager.protocol.test.mjs
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const bridgeDir = dirname(fileURLToPath(import.meta.url));
+const channelManager = join(bridgeDir, 'channel-manager.js');
+
+test('system command keeps stdout reserved for its JSON response', () => {
+  const result = spawnSync(process.execPath, [channelManager, 'system', 'checkCodexSdk'], {
+    cwd: bridgeDir,
+    input: '',
+    encoding: 'utf8',
+    timeout: 10_000,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stdout, /\[DIAG-|\[sdk-loader\]/);
+  const response = JSON.parse(result.stdout.trim());
+  assert.equal(typeof response.success, 'boolean');
+  assert.equal(typeof response.available, 'boolean');
+});

--- a/ai-bridge/config/api-config.js
+++ b/ai-bridge/config/api-config.js
@@ -11,7 +11,7 @@ import { getClaudeDir, getCodemossDir, getManagedSettingsPath } from '../utils/p
 const DEBUG = process.env.CLAUDE_DEBUG === '1' || process.env.CLAUDE_DEBUG === 'true';
 function debugLog(...args) {
   if (DEBUG) {
-    console.log(...args);
+    console.error(...args);
   }
 }
 

--- a/ai-bridge/permission-ipc.js
+++ b/ai-bridge/permission-ipc.js
@@ -11,7 +11,7 @@ import { randomUUID } from 'crypto';
 export function debugLog(tag, message, data = null) {
   const timestamp = new Date().toISOString();
   const dataStr = data ? ` | Data: ${JSON.stringify(data)}` : '';
-  console.log(`[${timestamp}][PERM_DEBUG][${tag}] ${message}${dataStr}`);
+  console.error(`[${timestamp}][PERM_DEBUG][${tag}] ${message}${dataStr}`);
 }
 
 export function errorClass(error) {

--- a/ai-bridge/permission-safety.js
+++ b/ai-bridge/permission-safety.js
@@ -44,7 +44,7 @@ export function rewriteToolInputPaths(toolName, input) {
     // Verify the resolved path is still within the project root
     const resolvedRoot = resolve(projectRoot);
     if (!sanitized.startsWith(resolvedRoot + sep) && sanitized !== resolvedRoot) {
-      console.log(`[PERMISSION][PATH_REWRITE_BLOCKED] Rewritten path escaped project root: ${pathValue} → ${sanitized} (root: ${resolvedRoot})`);
+      console.error(`[PERMISSION][PATH_REWRITE_BLOCKED] Rewritten path escaped project root: ${pathValue} → ${sanitized} (root: ${resolvedRoot})`);
       return pathValue;
     }
 
@@ -74,7 +74,7 @@ export function rewriteToolInputPaths(toolName, input) {
   traverse(input);
 
   if (rewrites.length > 0) {
-    console.log(`[PERMISSION] Rewrote paths for ${toolName}:`, JSON.stringify(rewrites));
+    console.error(`[PERMISSION] Rewrote paths for ${toolName}:`, JSON.stringify(rewrites));
   }
 
   return { changed: rewrites.length > 0 };

--- a/ai-bridge/services/codex/codex-utils.js
+++ b/ai-bridge/services/codex/codex-utils.js
@@ -21,7 +21,7 @@ export const DEBUG_LEVEL = process.env.CODEX_DEBUG_LEVEL ? parseInt(process.env.
  */
 export function debugLog(level, tag, ...args) {
   if (DEBUG_LEVEL >= level) {
-    console.log(`[${tag}]`, ...args);
+    console.error(`[${tag}]`, ...args);
   }
 }
 

--- a/ai-bridge/utils/sdk-loader.js
+++ b/ai-bridge/utils/sdk-loader.js
@@ -111,7 +111,7 @@ export function isClaudeSdkAvailable() {
     const npmPackage = '@anthropic-ai/claude-agent-sdk';
     const sdkPath = getPackageDirFromRoot(getSdkRootDir(sdkId), npmPackage);
     const exists = existsSync(sdkPath);
-    console.log('[sdk-loader] isClaudeSdkAvailable:', {
+    console.error('[sdk-loader] isClaudeSdkAvailable:', {
         path: sdkPath,
         exists: exists,
         depsBase: DEPS_BASE
@@ -128,7 +128,7 @@ export function isCodexSdkAvailable() {
     const npmPackage = '@openai/codex-sdk';
     const sdkPath = getPackageDirFromRoot(getSdkRootDir(sdkId), npmPackage);
     const exists = existsSync(sdkPath);
-    console.log('[sdk-loader] isCodexSdkAvailable:', {
+    console.error('[sdk-loader] isCodexSdkAvailable:', {
         path: sdkPath,
         exists: exists
     });
@@ -141,47 +141,47 @@ export function isCodexSdkAvailable() {
  * @throws {Error} If the SDK is not installed
  */
 export async function loadClaudeSdk() {
-    console.log('[DIAG-SDK] loadClaudeSdk() called');
+    console.error('[DIAG-SDK] loadClaudeSdk() called');
 
     // Return the cached SDK if available
     if (sdkCache.has('claude')) {
-        console.log('[DIAG-SDK] Returning cached SDK');
+        console.error('[DIAG-SDK] Returning cached SDK');
         return sdkCache.get('claude');
     }
 
     // If a load is already in progress, return the same promise to prevent duplicate loading
     if (loadingPromises.has('claude')) {
-        console.log('[DIAG-SDK] SDK loading in progress, returning existing promise');
+        console.error('[DIAG-SDK] SDK loading in progress, returning existing promise');
         return loadingPromises.get('claude');
     }
 
     const sdkRootDir = getSdkRootDir('claude-sdk');
     const sdkPath = getPackageDirFromRoot(sdkRootDir, '@anthropic-ai/claude-agent-sdk');
-    console.log('[DIAG-SDK] SDK path:', sdkPath);
-    console.log('[DIAG-SDK] SDK path exists:', existsSync(sdkPath));
+        console.error('[DIAG-SDK] SDK path:', sdkPath);
+        console.error('[DIAG-SDK] SDK path exists:', existsSync(sdkPath));
 
     if (!existsSync(sdkPath)) {
-        console.log('[DIAG-SDK] SDK not installed at path');
+            console.error('[DIAG-SDK] SDK not installed at path');
         throw new Error('SDK_NOT_INSTALLED:claude');
     }
 
     // Create and cache the loading promise
     const loadPromise = (async () => {
         try {
-            console.log('[DIAG-SDK] SDK root dir:', sdkRootDir);
+            console.error('[DIAG-SDK] SDK root dir:', sdkRootDir);
 
             // Node ESM does not support import(directory); must resolve to a concrete file (e.g. sdk.mjs)
             const resolvedUrl = resolveExternalPackageUrl('@anthropic-ai/claude-agent-sdk', sdkRootDir);
-            console.log('[DIAG-SDK] Resolved URL:', resolvedUrl);
+            console.error('[DIAG-SDK] Resolved URL:', resolvedUrl);
 
-            console.log('[DIAG-SDK] Starting dynamic import...');
+            console.error('[DIAG-SDK] Starting dynamic import...');
             const sdk = await import(resolvedUrl);
-            console.log('[DIAG-SDK] SDK imported successfully, exports:', Object.keys(sdk));
+            console.error('[DIAG-SDK] SDK imported successfully, exports:', Object.keys(sdk));
 
             sdkCache.set('claude', sdk);
             return sdk;
         } catch (error) {
-            console.log('[DIAG-SDK] SDK import failed:', error.message);
+            console.error('[DIAG-SDK] SDK import failed:', error.message);
             const pkgDir = getPackageDirFromRoot(sdkRootDir, '@anthropic-ai/claude-agent-sdk');
             const hintFile = join(pkgDir, 'sdk.mjs');
             const hint = existsSync(hintFile) ? ` Did you mean to import ${hintFile}?` : '';

--- a/ai-bridge/utils/sdk-loader.js
+++ b/ai-bridge/utils/sdk-loader.js
@@ -157,11 +157,11 @@ export async function loadClaudeSdk() {
 
     const sdkRootDir = getSdkRootDir('claude-sdk');
     const sdkPath = getPackageDirFromRoot(sdkRootDir, '@anthropic-ai/claude-agent-sdk');
-        console.error('[DIAG-SDK] SDK path:', sdkPath);
-        console.error('[DIAG-SDK] SDK path exists:', existsSync(sdkPath));
+    console.error('[DIAG-SDK] SDK path:', sdkPath);
+    console.error('[DIAG-SDK] SDK path exists:', existsSync(sdkPath));
 
     if (!existsSync(sdkPath)) {
-            console.error('[DIAG-SDK] SDK not installed at path');
+        console.error('[DIAG-SDK] SDK not installed at path');
         throw new Error('SDK_NOT_INSTALLED:claude');
     }
 

--- a/src/main/java/com/github/claudecodegui/handler/PromptHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/PromptHandler.java
@@ -90,7 +90,6 @@ public class PromptHandler extends BaseMessageHandler {
      * Cleanup method called when the handler is disposed.
      * Stops the file watcher to prevent memory leaks.
      */
-    @Override
     public void dispose() {
         if (fileWatcher != null) {
             fileWatcher.stopWatching();

--- a/src/main/java/com/github/claudecodegui/handler/PromptHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/PromptHandler.java
@@ -66,17 +66,19 @@ public class PromptHandler extends BaseMessageHandler {
         this.fileWatcher = new PromptFileWatcher(
             context.getProject(),
             settingsService,
-            (scope, promptsJson) -> {
+            (scope, provider, promptsJson) -> {
                 // When file changes, notify frontend to update cache
                 final String callbackName = scope == PromptScope.GLOBAL
                     ? "window.updateGlobalPrompts"
                     : "window.updateProjectPrompts";
+                final String payloadJson = promptListPayloadJson(provider, promptsJson);
 
                 ApplicationManager.getApplication().invokeLater(() -> {
-                    callJavaScript(callbackName, escapeJs(promptsJson));
+                    callJavaScript(callbackName, escapeJs(payloadJson));
                 });
 
-                LOG.info("[PromptHandler] File watcher triggered update for scope=" + scope.getValue());
+                LOG.info("[PromptHandler] File watcher triggered update for scope="
+                        + scope.getValue() + ", provider=" + provider);
             }
         );
 
@@ -88,6 +90,7 @@ public class PromptHandler extends BaseMessageHandler {
      * Cleanup method called when the handler is disposed.
      * Stops the file watcher to prevent memory leaks.
      */
+    @Override
     public void dispose() {
         if (fileWatcher != null) {
             fileWatcher.stopWatching();
@@ -157,6 +160,36 @@ public class PromptHandler extends BaseMessageHandler {
         }
     }
 
+    private String parseProviderFromData(String data) {
+        if (data == null || data.trim().isEmpty()) {
+            return "claude";
+        }
+        try {
+            JsonObject json = gson.fromJson(data, JsonObject.class);
+            if (json == null || !json.has("provider")) {
+                return "claude";
+            }
+            return CodemossSettingsService.normalizePromptProvider(json.get("provider").getAsString());
+        } catch (Exception e) {
+            LOG.warn("[PromptHandler] Failed to parse provider, defaulting to Claude: " + e.getMessage());
+            return "claude";
+        }
+    }
+
+    private String promptRefreshJson(PromptScope scope, String provider) {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("scope", scope.getValue());
+        payload.addProperty("provider", CodemossSettingsService.normalizePromptProvider(provider));
+        return gson.toJson(payload);
+    }
+
+    private String promptListPayloadJson(String provider, String promptsJson) {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("provider", CodemossSettingsService.normalizePromptProvider(provider));
+        payload.add("prompts", JsonParser.parseString(promptsJson));
+        return gson.toJson(payload);
+    }
+
     /**
      * Get all prompts.
      * Supports scope parameter for filtering by GLOBAL or PROJECT scope.
@@ -166,12 +199,14 @@ public class PromptHandler extends BaseMessageHandler {
     private void handleGetPrompts(String content) {
         try {
             PromptScope scope = parseScopeFromData(content);
-            LOG.debug("[PromptHandler] Getting prompts for scope: " + scope.getValue());
+            String provider = parseProviderFromData(content);
+            LOG.debug("[PromptHandler] Getting prompts for scope=" + scope.getValue() + ", provider=" + provider);
 
-            List<JsonObject> prompts = settingsService.getPrompts(scope, context.getProject());
-            LOG.debug("[PromptHandler] Retrieved " + prompts.size() + " prompts for scope: " + scope.getValue());
+            List<JsonObject> prompts = settingsService.getPrompts(scope, context.getProject(), provider);
+            LOG.debug("[PromptHandler] Retrieved " + prompts.size()
+                    + " prompts for scope=" + scope.getValue() + ", provider=" + provider);
 
-            String promptsJson = gson.toJson(prompts);
+            String promptsJson = promptListPayloadJson(provider, gson.toJson(prompts));
 
             // Call different window callbacks based on scope
             final String callbackName = scope == PromptScope.GLOBAL
@@ -199,7 +234,8 @@ public class PromptHandler extends BaseMessageHandler {
 
             ApplicationManager.getApplication().invokeLater(() -> {
                 LOG.error("[PromptHandler] Sending empty prompts list due to error: " + e.getMessage());
-                callJavaScript(callbackName, escapeJs("[]"));
+                String provider = parseProviderFromData(content);
+                callJavaScript(callbackName, escapeJs(promptListPayloadJson(provider, "[]")));
             });
         } catch (Exception e) {
             LOG.error("[PromptHandler] Failed to get prompts: " + e.getMessage(), e);
@@ -212,7 +248,8 @@ public class PromptHandler extends BaseMessageHandler {
 
             ApplicationManager.getApplication().invokeLater(() -> {
                 LOG.error("[PromptHandler] Sending empty prompts list due to error");
-                callJavaScript(callbackName, escapeJs("[]"));
+                String provider = parseProviderFromData(content);
+                callJavaScript(callbackName, escapeJs(promptListPayloadJson(provider, "[]")));
             });
         }
     }
@@ -274,6 +311,7 @@ public class PromptHandler extends BaseMessageHandler {
             if (data.has("scope")) {
                 scope = PromptScope.fromString(data.get("scope").getAsString());
             }
+            String provider = parseProviderFromData(content);
 
             // Extract prompt object (support both new and legacy formats)
             JsonObject prompt;
@@ -284,14 +322,14 @@ public class PromptHandler extends BaseMessageHandler {
                 prompt = data;
             }
 
-            settingsService.addPrompt(prompt, scope, context.getProject());
+            settingsService.addPrompt(prompt, scope, context.getProject(), provider);
 
             // Refresh the list
             final PromptScope finalScope = scope;
+            final String finalProvider = provider;
             ApplicationManager.getApplication().invokeLater(() -> {
                 // Refresh with the same scope
-                String scopeJson = "{\"scope\":\"" + finalScope.getValue() + "\"}";
-                handleGetPrompts(scopeJson);
+                handleGetPrompts(promptRefreshJson(finalScope, finalProvider));
                 callJavaScript("window.promptOperationResult", escapeJs("{\"success\":true,\"operation\":\"add\"}"));
             });
         } catch (Exception e) {
@@ -327,18 +365,19 @@ public class PromptHandler extends BaseMessageHandler {
             if (data.has("scope")) {
                 scope = PromptScope.fromString(data.get("scope").getAsString());
             }
+            String provider = parseProviderFromData(content);
 
             String id = data.get("id").getAsString();
             JsonObject updates = data.getAsJsonObject("updates");
 
-            settingsService.updatePrompt(id, updates, scope, context.getProject());
+            settingsService.updatePrompt(id, updates, scope, context.getProject(), provider);
 
             // Refresh the list
             final PromptScope finalScope = scope;
+            final String finalProvider = provider;
             ApplicationManager.getApplication().invokeLater(() -> {
                 // Refresh with the same scope
-                String scopeJson = "{\"scope\":\"" + finalScope.getValue() + "\"}";
-                handleGetPrompts(scopeJson);
+                handleGetPrompts(promptRefreshJson(finalScope, finalProvider));
                 callJavaScript("window.promptOperationResult", escapeJs("{\"success\":true,\"operation\":\"update\"}"));
             });
         } catch (Exception e) {
@@ -369,18 +408,19 @@ public class PromptHandler extends BaseMessageHandler {
             if (data.has("scope")) {
                 scope = PromptScope.fromString(data.get("scope").getAsString());
             }
+            String provider = parseProviderFromData(content);
 
             String id = data.get("id").getAsString();
 
-            boolean deleted = settingsService.deletePrompt(id, scope, context.getProject());
+            boolean deleted = settingsService.deletePrompt(id, scope, context.getProject(), provider);
 
             if (deleted) {
                 // Refresh the list
                 final PromptScope finalScope = scope;
+                final String finalProvider = provider;
                 ApplicationManager.getApplication().invokeLater(() -> {
                     // Refresh with the same scope
-                    String scopeJson = "{\"scope\":\"" + finalScope.getValue() + "\"}";
-                    handleGetPrompts(scopeJson);
+                    handleGetPrompts(promptRefreshJson(finalScope, finalProvider));
                     callJavaScript("window.promptOperationResult", escapeJs("{\"success\":true,\"operation\":\"delete\"}"));
                 });
             } else {
@@ -423,7 +463,8 @@ public class PromptHandler extends BaseMessageHandler {
             try {
                 // Parse scope (default to GLOBAL)
                 PromptScope scope = parseScopeFromData(content);
-                List<JsonObject> prompts = settingsService.getPrompts(scope, context.getProject());
+                String provider = parseProviderFromData(content);
+                List<JsonObject> prompts = settingsService.getPrompts(scope, context.getProject(), provider);
 
                 // Filter prompts by selected IDs if provided
                 if (content != null && !content.isEmpty()) {
@@ -466,6 +507,7 @@ public class PromptHandler extends BaseMessageHandler {
                 exportData.addProperty("format", "claude-code-prompts-export-v1");
                 exportData.addProperty("exportTime", exportTime);
                 exportData.addProperty("promptCount", prompts.size());
+                exportData.addProperty("provider", provider);
 
                 JsonArray promptsArray = new JsonArray();
                 for (JsonObject prompt : prompts) {
@@ -537,6 +579,7 @@ public class PromptHandler extends BaseMessageHandler {
             try {
                 // Parse scope (default to GLOBAL)
                 PromptScope scope = parseScopeFromData(content);
+                String provider = parseProviderFromData(content);
                 // Create file chooser descriptor for JSON files
                 FileChooserDescriptor descriptor = new FileChooserDescriptor(
                     true,  // chooseFiles
@@ -610,12 +653,15 @@ public class PromptHandler extends BaseMessageHandler {
                 List<JsonObject> promptsToImport = new ArrayList<>();
 
                 for (int i = 0; i < promptsArray.size(); i++) {
-                    promptsToImport.add(promptsArray.get(i).getAsJsonObject());
+                    JsonObject prompt = promptsArray.get(i).getAsJsonObject().deepCopy();
+                    prompt.addProperty("provider", provider);
+                    promptsToImport.add(prompt);
                 }
 
                 // Validate and detect conflicts
                 AbstractPromptManager promptManager = settingsService.getPromptManager(scope, context.getProject());
-                Set<String> conflicts = promptManager.detectConflicts(promptsToImport);
+                Set<String> conflicts = settingsService.detectPromptConflicts(
+                        promptsToImport, scope, context.getProject(), provider);
 
                 // Prepare preview data
                 JsonObject previewData = new JsonObject();
@@ -687,6 +733,7 @@ public class PromptHandler extends BaseMessageHandler {
             if (data.has("scope")) {
                 scope = PromptScope.fromString(data.get("scope").getAsString());
             }
+            String provider = parseProviderFromData(content);
 
             JsonArray selectedPromptsArray = data.getAsJsonArray("prompts");
             String strategyStr = data.get("strategy").getAsString();
@@ -694,24 +741,27 @@ public class PromptHandler extends BaseMessageHandler {
 
             List<JsonObject> promptsToImport = new ArrayList<>();
             for (int i = 0; i < selectedPromptsArray.size(); i++) {
-                promptsToImport.add(selectedPromptsArray.get(i).getAsJsonObject());
+                JsonObject prompt = selectedPromptsArray.get(i).getAsJsonObject().deepCopy();
+                prompt.addProperty("provider", provider);
+                promptsToImport.add(prompt);
             }
 
-            AbstractPromptManager promptManager = settingsService.getPromptManager(scope, context.getProject());
-            Map<String, Object> result = promptManager.batchImportPrompts(promptsToImport, strategy);
+            Map<String, Object> result = settingsService.batchImportPrompts(
+                    promptsToImport, strategy, scope, context.getProject(), provider);
 
             // Add scope to result for frontend to know which list to refresh
             result.put("scope", scope.getValue());
+            result.put("provider", provider);
 
             // Send result to frontend
             final PromptScope finalScope = scope;
+            final String finalProvider = provider;
             ApplicationManager.getApplication().invokeLater(() -> {
                 String resultJson = gson.toJson(result);
                 callJavaScript("window.promptImportResult", escapeJs(resultJson));
 
                 // Refresh the list with the same scope
-                String scopeJson = "{\"scope\":\"" + finalScope.getValue() + "\"}";
-                handleGetPrompts(scopeJson);
+                handleGetPrompts(promptRefreshJson(finalScope, finalProvider));
 
                 // Show notification
                 boolean success = Boolean.TRUE.equals(result.get("success"));

--- a/src/main/java/com/github/claudecodegui/settings/CodemossSettingsService.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodemossSettingsService.java
@@ -24,6 +24,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1038,7 +1041,20 @@ public class CodemossSettingsService {
      * @throws IOException if reading fails
      */
     public List<JsonObject> getPrompts(PromptScope scope, Project project) throws IOException {
-        return getPromptManager(scope, project).getPrompts();
+        return getPrompts(scope, project, "claude");
+    }
+
+    public List<JsonObject> getPrompts(PromptScope scope, Project project, String provider) throws IOException {
+        String normalizedProvider = normalizePromptProvider(provider);
+        List<JsonObject> result = new ArrayList<>();
+        for (JsonObject prompt : getPromptManager(scope, project).getPrompts()) {
+            if (promptBelongsToProvider(prompt, normalizedProvider)) {
+                JsonObject copy = prompt.deepCopy();
+                copy.addProperty("provider", normalizedProvider);
+                result.add(copy);
+            }
+        }
+        return result;
     }
 
     /**
@@ -1050,7 +1066,23 @@ public class CodemossSettingsService {
      * @throws IOException if writing fails
      */
     public void addPrompt(JsonObject prompt, PromptScope scope, Project project) throws IOException {
-        getPromptManager(scope, project).addPrompt(prompt);
+        addPrompt(prompt, scope, project, "claude");
+    }
+
+    public void addPrompt(JsonObject prompt, PromptScope scope, Project project, String provider) throws IOException {
+        AbstractPromptManager manager = getPromptManager(scope, project);
+        JsonObject copy = prompt.deepCopy();
+        String normalizedProvider = normalizePromptProvider(provider);
+        copy.addProperty("provider", normalizedProvider);
+        if (copy.has("id") && copy.get("id").isJsonPrimitive()) {
+            String id = copy.get("id").getAsString();
+            JsonObject existing = manager.getPrompt(id);
+            if (existing != null && !promptBelongsToProvider(existing, normalizedProvider)) {
+                JsonObject config = manager.readPromptConfig();
+                copy.addProperty("id", manager.generateUniqueId(id, config.getAsJsonObject("prompts")));
+            }
+        }
+        manager.addPrompt(copy);
     }
 
     /**
@@ -1063,7 +1095,19 @@ public class CodemossSettingsService {
      * @throws IOException if writing fails
      */
     public void updatePrompt(String id, JsonObject updates, PromptScope scope, Project project) throws IOException {
-        getPromptManager(scope, project).updatePrompt(id, updates);
+        updatePrompt(id, updates, scope, project, "claude");
+    }
+
+    public void updatePrompt(String id, JsonObject updates, PromptScope scope, Project project, String provider) throws IOException {
+        AbstractPromptManager manager = getPromptManager(scope, project);
+        String normalizedProvider = normalizePromptProvider(provider);
+        JsonObject existing = manager.getPrompt(id);
+        if (!promptBelongsToProvider(existing, normalizedProvider)) {
+            throw new IllegalArgumentException("Prompt with id '" + id + "' not found for provider " + normalizedProvider);
+        }
+        JsonObject copy = updates.deepCopy();
+        copy.addProperty("provider", normalizedProvider);
+        manager.updatePrompt(id, copy);
     }
 
     /**
@@ -1076,7 +1120,17 @@ public class CodemossSettingsService {
      * @throws IOException if writing fails
      */
     public boolean deletePrompt(String id, PromptScope scope, Project project) throws IOException {
-        return getPromptManager(scope, project).deletePrompt(id);
+        return deletePrompt(id, scope, project, "claude");
+    }
+
+    public boolean deletePrompt(String id, PromptScope scope, Project project, String provider) throws IOException {
+        AbstractPromptManager manager = getPromptManager(scope, project);
+        String normalizedProvider = normalizePromptProvider(provider);
+        JsonObject existing = manager.getPrompt(id);
+        if (!promptBelongsToProvider(existing, normalizedProvider)) {
+            return false;
+        }
+        return manager.deletePrompt(id);
     }
 
     /**
@@ -1089,7 +1143,18 @@ public class CodemossSettingsService {
      * @throws IOException if reading fails
      */
     public JsonObject getPrompt(String id, PromptScope scope, Project project) throws IOException {
-        return getPromptManager(scope, project).getPrompt(id);
+        return getPrompt(id, scope, project, "claude");
+    }
+
+    public JsonObject getPrompt(String id, PromptScope scope, Project project, String provider) throws IOException {
+        String normalizedProvider = normalizePromptProvider(provider);
+        JsonObject prompt = getPromptManager(scope, project).getPrompt(id);
+        if (!promptBelongsToProvider(prompt, normalizedProvider)) {
+            return null;
+        }
+        JsonObject copy = prompt.deepCopy();
+        copy.addProperty("provider", normalizedProvider);
+        return copy;
     }
 
     /**
@@ -1103,7 +1168,144 @@ public class CodemossSettingsService {
      * @throws IOException if writing fails
      */
     public Map<String, Object> batchImportPrompts(List<JsonObject> promptsToImport, ConflictStrategy strategy, PromptScope scope, Project project) throws IOException {
-        return getPromptManager(scope, project).batchImportPrompts(promptsToImport, strategy);
+        return batchImportPrompts(promptsToImport, strategy, scope, project, "claude");
+    }
+
+    public Map<String, Object> batchImportPrompts(List<JsonObject> promptsToImport, ConflictStrategy strategy,
+                                                  PromptScope scope, Project project, String provider) throws IOException {
+        AbstractPromptManager manager = getPromptManager(scope, project);
+        String normalizedProvider = normalizePromptProvider(provider);
+        List<JsonObject> scopedPrompts = new ArrayList<>();
+        for (JsonObject prompt : promptsToImport) {
+            JsonObject copy = prompt.deepCopy();
+            copy.addProperty("provider", normalizedProvider);
+            scopedPrompts.add(copy);
+        }
+        return batchImportProviderPrompts(manager, scopedPrompts, strategy, normalizedProvider);
+    }
+
+    public Set<String> detectPromptConflicts(List<JsonObject> promptsToImport, PromptScope scope,
+                                             Project project, String provider) throws IOException {
+        AbstractPromptManager manager = getPromptManager(scope, project);
+        String normalizedProvider = normalizePromptProvider(provider);
+        Set<String> conflicts = new HashSet<>();
+        JsonObject existingPrompts = manager.readPromptConfig().getAsJsonObject("prompts");
+        for (JsonObject prompt : promptsToImport) {
+            if (!prompt.has("id") || !prompt.get("id").isJsonPrimitive()) {
+                continue;
+            }
+            String id = prompt.get("id").getAsString();
+            if (existingPrompts.has(id)
+                    && promptBelongsToProvider(existingPrompts.getAsJsonObject(id), normalizedProvider)) {
+                conflicts.add(id);
+            }
+        }
+        return conflicts;
+    }
+
+    private Map<String, Object> batchImportProviderPrompts(AbstractPromptManager manager,
+                                                           List<JsonObject> promptsToImport,
+                                                           ConflictStrategy strategy,
+                                                           String provider) throws IOException {
+        Map<String, Object> result = new HashMap<>();
+        int imported = 0;
+        int skipped = 0;
+        int updated = 0;
+        List<String> errors = new ArrayList<>();
+
+        JsonObject config = manager.readPromptConfig();
+        JsonObject prompts = config.getAsJsonObject("prompts");
+        Set<String> conflicts = new HashSet<>();
+        for (JsonObject prompt : promptsToImport) {
+            if (!prompt.has("id") || !prompt.get("id").isJsonPrimitive()) {
+                continue;
+            }
+            String id = prompt.get("id").getAsString();
+            if (prompts.has(id) && promptBelongsToProvider(prompts.getAsJsonObject(id), provider)) {
+                conflicts.add(id);
+            }
+        }
+
+        for (JsonObject prompt : promptsToImport) {
+            try {
+                String validationError = manager.validatePrompt(prompt);
+                if (validationError != null) {
+                    errors.add("Validation failed: " + validationError);
+                    skipped++;
+                    continue;
+                }
+
+                String id = prompt.get("id").getAsString();
+                boolean hasSameProviderConflict = conflicts.contains(id);
+
+                if (hasSameProviderConflict) {
+                    switch (strategy) {
+                        case SKIP:
+                            skipped++;
+                            continue;
+                        case OVERWRITE:
+                            JsonObject overwritePrompt = prompt.deepCopy();
+                            overwritePrompt.addProperty("provider", provider);
+                            overwritePrompt.addProperty("updatedAt", System.currentTimeMillis());
+                            prompts.add(id, overwritePrompt);
+                            updated++;
+                            break;
+                        case DUPLICATE:
+                            String duplicateId = manager.generateUniqueId(id, prompts);
+                            JsonObject duplicatePrompt = prompt.deepCopy();
+                            duplicatePrompt.addProperty("id", duplicateId);
+                            duplicatePrompt.addProperty("provider", provider);
+                            if (!duplicatePrompt.has("createdAt")) {
+                                duplicatePrompt.addProperty("createdAt", System.currentTimeMillis());
+                            }
+                            duplicatePrompt.addProperty("updatedAt", System.currentTimeMillis());
+                            prompts.add(duplicateId, duplicatePrompt);
+                            imported++;
+                            break;
+                    }
+                } else {
+                    String targetId = prompts.has(id) ? manager.generateUniqueId(id, prompts) : id;
+                    JsonObject newPrompt = prompt.deepCopy();
+                    newPrompt.addProperty("id", targetId);
+                    newPrompt.addProperty("provider", provider);
+                    if (!newPrompt.has("createdAt")) {
+                        newPrompt.addProperty("createdAt", System.currentTimeMillis());
+                    }
+                    if (!newPrompt.has("updatedAt")) {
+                        newPrompt.addProperty("updatedAt", System.currentTimeMillis());
+                    }
+                    prompts.add(targetId, newPrompt);
+                    imported++;
+                }
+            } catch (Exception e) {
+                errors.add("Failed to import prompt: " + e.getMessage());
+                skipped++;
+            }
+        }
+
+        manager.writePromptConfig(config);
+        result.put("imported", imported);
+        result.put("updated", updated);
+        result.put("skipped", skipped);
+        result.put("errors", errors);
+        result.put("success", errors.isEmpty());
+        return result;
+    }
+
+    public static String normalizePromptProvider(String provider) {
+        return "codex".equalsIgnoreCase(provider) ? "codex" : "claude";
+    }
+
+    private static boolean promptBelongsToProvider(JsonObject prompt, String provider) {
+        if (prompt == null) {
+            return false;
+        }
+        String promptProvider = prompt.has("provider")
+                && prompt.get("provider").isJsonPrimitive()
+                && prompt.get("provider").getAsJsonPrimitive().isString()
+                ? prompt.get("provider").getAsString()
+                : "claude";
+        return normalizePromptProvider(promptProvider).equals(provider);
     }
 
     // ==================== Deprecated Backward-Compatible Methods ====================

--- a/src/main/java/com/github/claudecodegui/watcher/PromptFileWatcher.java
+++ b/src/main/java/com/github/claudecodegui/watcher/PromptFileWatcher.java
@@ -16,7 +16,6 @@ import com.intellij.util.messages.MessageBusConnection;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
-import java.util.function.BiConsumer;
 
 /**
  * Watches for changes to .codemoss/prompt.json files and notifies listeners.
@@ -28,7 +27,7 @@ public class PromptFileWatcher implements BulkFileListener {
     private final Project project;
     private final CodemossSettingsService settingsService;
     private final Gson gson;
-    private final BiConsumer<PromptScope, String> onPromptsChanged;
+    private final PromptChangeListener onPromptsChanged;
     private MessageBusConnection connection;
 
     /**
@@ -36,12 +35,12 @@ public class PromptFileWatcher implements BulkFileListener {
      *
      * @param project IntelliJ Project instance
      * @param settingsService Settings service for loading prompts
-     * @param onPromptsChanged Callback when prompts change: (scope, promptsJson) -> void
+     * @param onPromptsChanged Callback when prompts change: (scope, provider, promptsJson) -> void
      */
     public PromptFileWatcher(
         Project project,
         CodemossSettingsService settingsService,
-        BiConsumer<PromptScope, String> onPromptsChanged
+        PromptChangeListener onPromptsChanged
     ) {
         this.project = project;
         this.settingsService = settingsService;
@@ -110,19 +109,21 @@ public class PromptFileWatcher implements BulkFileListener {
      */
     private void reloadAndNotify(PromptScope scope) {
         try {
-            // Reload prompts from file
-            List<JsonObject> prompts = settingsService.getPrompts(scope, project);
-            String promptsJson = gson.toJson(prompts);
-
-            // Notify listeners (will update frontend cache)
-            if (onPromptsChanged != null) {
-                onPromptsChanged.accept(scope, promptsJson);
-            }
-
-            LOG.info("[PromptFileWatcher] Reloaded " + prompts.size() + " prompts for scope=" + scope.getValue());
+            notifyProvider(scope, "claude");
+            notifyProvider(scope, "codex");
         } catch (Exception e) {
             LOG.error("[PromptFileWatcher] Failed to reload prompts for scope=" + scope.getValue(), e);
         }
+    }
+
+    private void notifyProvider(PromptScope scope, String provider) throws Exception {
+        List<JsonObject> prompts = settingsService.getPrompts(scope, project, provider);
+        String promptsJson = gson.toJson(prompts);
+        if (onPromptsChanged != null) {
+            onPromptsChanged.accept(scope, provider, promptsJson);
+        }
+        LOG.info("[PromptFileWatcher] Reloaded " + prompts.size()
+                + " prompts for scope=" + scope.getValue() + ", provider=" + provider);
     }
 
     /**
@@ -153,5 +154,10 @@ public class PromptFileWatcher implements BulkFileListener {
             connection = null;
             LOG.info("[PromptFileWatcher] Stopped watching prompt files");
         }
+    }
+
+    @FunctionalInterface
+    public interface PromptChangeListener {
+        void accept(PromptScope scope, String provider, String promptsJson);
     }
 }

--- a/src/test/java/com/github/claudecodegui/settings/CodemossSettingsServicePromptProviderTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/CodemossSettingsServicePromptProviderTest.java
@@ -1,0 +1,73 @@
+package com.github.claudecodegui.settings;
+
+import com.github.claudecodegui.model.PromptScope;
+import com.github.claudecodegui.util.PlatformUtils;
+import com.google.gson.JsonObject;
+import org.junit.After;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class CodemossSettingsServicePromptProviderTest {
+    private String originalHome;
+
+    @After
+    public void restoreHome() throws Exception {
+        if (originalHome != null) {
+            setHome(originalHome);
+        }
+    }
+
+    @Test
+    public void isolatesProviderReadsAndProtectsCrossProviderDeletes() throws Exception {
+        Path home = Files.createTempDirectory("prompt-provider-home");
+        originalHome = getHome();
+        setHome(home.toString());
+        Files.createDirectories(home.resolve(".codemoss"));
+
+        JsonObject config = new JsonObject();
+        JsonObject prompts = new JsonObject();
+        prompts.add("same-id", prompt("Claude", "claude"));
+        prompts.add("codex-id", prompt("Codex", "codex"));
+        config.add("prompts", prompts);
+        Files.writeString(home.resolve(".codemoss/prompt.json"), config.toString());
+
+        CodemossSettingsService service = new CodemossSettingsService();
+        List<JsonObject> codexPrompts = service.getPrompts(PromptScope.GLOBAL, null, "codex");
+        assertEquals(1, codexPrompts.size());
+        assertEquals("codex-id", codexPrompts.get(0).get("id").getAsString());
+
+        assertFalse(service.deletePrompt("same-id", PromptScope.GLOBAL, null, "codex"));
+        assertEquals(2, service.getPromptManager(PromptScope.GLOBAL, null).getPrompts().size());
+    }
+
+    private static JsonObject prompt(String name, String provider) {
+        JsonObject prompt = new JsonObject();
+        prompt.addProperty("id", provider + "-id");
+        if ("claude".equals(provider)) {
+            prompt.addProperty("id", "same-id");
+        }
+        prompt.addProperty("name", name);
+        prompt.addProperty("content", provider);
+        prompt.addProperty("provider", provider);
+        return prompt;
+    }
+
+    private static String getHome() throws Exception {
+        Field field = PlatformUtils.class.getDeclaredField("cachedRealHomeDir");
+        field.setAccessible(true);
+        return (String) field.get(null);
+    }
+
+    private static void setHome(String home) throws Exception {
+        Field field = PlatformUtils.class.getDeclaredField("cachedRealHomeDir");
+        field.setAccessible(true);
+        field.set(null, home);
+    }
+}

--- a/webview/src/components/ChatInputBox/hooks/useChatInputCompletionsCoordinator.ts
+++ b/webview/src/components/ChatInputBox/hooks/useChatInputCompletionsCoordinator.ts
@@ -140,9 +140,14 @@ export function useChatInputCompletionsCoordinator({
     },
   });
 
+  const promptDataProvider = useCallback(
+    (query: string, signal: AbortSignal) => promptProvider(query, signal, currentProvider),
+    [currentProvider],
+  );
+
   const promptCompletion = useCompletionDropdown<PromptItem>({
     trigger: '!',
-    provider: promptProvider,
+    provider: promptDataProvider,
     toDropdownItem: promptToDropdownItem,
     onSelect: (prompt, query) => {
       if (

--- a/webview/src/components/ChatInputBox/providers/promptProvider.test.ts
+++ b/webview/src/components/ChatInputBox/providers/promptProvider.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  promptProvider,
+  resetPromptsState,
+  setupPromptsCallback,
+} from './promptProvider';
+
+describe('promptProvider provider isolation', () => {
+  beforeEach(() => {
+    resetPromptsState();
+    window.sendToJava = vi.fn();
+    setupPromptsCallback();
+  });
+
+  it('loads only prompts owned by the requested provider', async () => {
+    const loading = promptProvider('', new AbortController().signal, 'codex');
+    window.updateGlobalPrompts?.(JSON.stringify({
+      provider: 'codex',
+      prompts: [
+        { id: 'codex-1', name: 'Codex prompt', content: 'codex', provider: 'codex' },
+        { id: 'claude-1', name: 'Claude prompt', content: 'claude', provider: 'claude' },
+      ],
+    }));
+    window.updateProjectPrompts?.(JSON.stringify({ provider: 'codex', prompts: [] }));
+
+    const items = await loading;
+
+    expect(items.map(item => item.id)).toContain('codex-1');
+    expect(items.map(item => item.id)).not.toContain('claude-1');
+  });
+
+  it('ignores callbacks for a provider that is no longer active', async () => {
+    window.updateGlobalPrompts?.(JSON.stringify({ provider: 'codex', prompts: [
+      { id: 'codex-1', name: 'Codex prompt', content: 'codex', provider: 'codex' },
+    ] }));
+    await promptProvider('', new AbortController().signal, 'codex');
+
+    await promptProvider('', new AbortController().signal, 'claude');
+    window.updateGlobalPrompts?.(JSON.stringify({ provider: 'codex', prompts: [
+      { id: 'codex-2', name: 'Stale Codex prompt', content: 'codex', provider: 'codex' },
+    ] }));
+    window.updateGlobalPrompts?.(JSON.stringify({ provider: 'claude', prompts: [
+      { id: 'claude-1', name: 'Claude prompt', content: 'claude' },
+    ] }));
+    window.updateProjectPrompts?.(JSON.stringify({ provider: 'claude', prompts: [] }));
+
+    const items = await promptProvider('', new AbortController().signal, 'claude');
+
+    expect(items.map(item => item.id)).toContain('claude-1');
+    expect(items.map(item => item.id)).not.toContain('codex-2');
+  });
+});

--- a/webview/src/components/ChatInputBox/providers/promptProvider.ts
+++ b/webview/src/components/ChatInputBox/providers/promptProvider.ts
@@ -1,5 +1,5 @@
 import type { DropdownItemData } from '../types';
-import type { PromptConfig, PromptScope, GetPromptsMessage } from '../../../types/prompt';
+import type { PromptConfig, PromptProvider, PromptScope, GetPromptsMessage } from '../../../types/prompt';
 import { sendBridgeEvent } from '../../../utils/bridge';
 import i18n from '../../../i18n/config';
 import { debugError, debugLog, debugWarn } from '../../../utils/debug.js';
@@ -13,6 +13,7 @@ export interface PromptItem {
   name: string;
   content: string;
   scope?: PromptScope; // Add scope to track source
+  provider?: PromptProvider;
 }
 
 // ============================================================================
@@ -20,11 +21,13 @@ export interface PromptItem {
 // ============================================================================
 
 type LoadingState = 'idle' | 'loading' | 'success' | 'failed';
+type PromptCallbackPayload = { provider: PromptProvider; prompts: PromptConfig[] };
 
 let cachedGlobalPrompts: PromptItem[] = [];
 let cachedProjectPrompts: PromptItem[] = [];
 let globalLoadingState: LoadingState = 'idle';
 let projectLoadingState: LoadingState = 'idle';
+let activePromptProvider: PromptProvider = 'claude';
 let lastRefreshTime = 0;
 let callbackRegistered = false;
 let retryCount = 0;
@@ -38,6 +41,47 @@ const MAX_PENDING_WAITERS = 10; // Maximum concurrent waiters
 // ============================================================================
 // Core Functions
 // ============================================================================
+
+function normalizePromptProvider(provider?: string | null): PromptProvider {
+  return provider === 'codex' ? 'codex' : 'claude';
+}
+
+function promptOwner(prompt: PromptConfig): PromptProvider {
+  return normalizePromptProvider(prompt.provider);
+}
+
+function setActivePromptProvider(provider?: string | null): PromptProvider {
+  const nextProvider = normalizePromptProvider(provider);
+  if (nextProvider === activePromptProvider) return activePromptProvider;
+  cachedGlobalPrompts = [];
+  cachedProjectPrompts = [];
+  globalLoadingState = 'idle';
+  projectLoadingState = 'idle';
+  lastRefreshTime = 0;
+  retryCount = 0;
+  pendingWaiters.forEach(w => w.reject(new Error('Prompt provider changed')));
+  pendingWaiters = [];
+  activePromptProvider = nextProvider;
+  return activePromptProvider;
+}
+
+function promptToItem(prompt: PromptConfig, scope: PromptScope, provider: PromptProvider): PromptItem {
+  return { id: prompt.id, name: prompt.name, content: prompt.content, scope, provider };
+}
+
+function parsePromptCallbackPayload(json: string): PromptCallbackPayload | null {
+  const parsed: unknown = JSON.parse(json);
+  // Legacy array payloads come from the pre-provider backend and therefore
+  // represent the existing Claude prompt library.
+  if (Array.isArray(parsed)) return { provider: 'claude', prompts: parsed as PromptConfig[] };
+  if (!parsed || typeof parsed !== 'object') return null;
+  const value = parsed as { provider?: unknown; prompts?: unknown };
+  if (!Array.isArray(value.prompts)) return null;
+  return {
+    provider: normalizePromptProvider(typeof value.provider === 'string' ? value.provider : activePromptProvider),
+    prompts: value.prompts as PromptConfig[],
+  };
+}
 
 export function resetPromptsState() {
   cachedGlobalPrompts = [];
@@ -59,17 +103,11 @@ export function setupPromptsCallback() {
     debugLog('[PromptProvider] Received global prompts from backend, length=' + json.length);
 
     try {
-      const parsed = JSON.parse(json);
-      let prompts: PromptItem[] = [];
-
-      if (Array.isArray(parsed)) {
-        prompts = parsed.map((prompt: PromptConfig) => ({
-          id: prompt.id,
-          name: prompt.name,
-          content: prompt.content,
-          scope: 'global' as PromptScope,
-        }));
-      }
+      const payload = parsePromptCallbackPayload(json);
+      if (!payload || payload.provider !== activePromptProvider) return;
+      const prompts = payload.prompts
+        .filter(prompt => promptOwner(prompt) === activePromptProvider)
+        .map(prompt => promptToItem(prompt, 'global', activePromptProvider));
 
       cachedGlobalPrompts = prompts;
       globalLoadingState = 'success';
@@ -89,17 +127,11 @@ export function setupPromptsCallback() {
     debugLog('[PromptProvider] Received project prompts from backend, length=' + json.length);
 
     try {
-      const parsed = JSON.parse(json);
-      let prompts: PromptItem[] = [];
-
-      if (Array.isArray(parsed)) {
-        prompts = parsed.map((prompt: PromptConfig) => ({
-          id: prompt.id,
-          name: prompt.name,
-          content: prompt.content,
-          scope: 'project' as PromptScope,
-        }));
-      }
+      const payload = parsePromptCallbackPayload(json);
+      if (!payload || payload.provider !== activePromptProvider) return;
+      const prompts = payload.prompts
+        .filter(prompt => promptOwner(prompt) === activePromptProvider)
+        .map(prompt => promptToItem(prompt, 'project', activePromptProvider));
 
       cachedProjectPrompts = prompts;
       projectLoadingState = 'success';
@@ -191,7 +223,8 @@ function waitForPrompts(signal: AbortSignal, timeoutMs: number): Promise<void> {
   });
 }
 
-function requestRefresh(force = false): boolean {
+function requestRefresh(force = false, provider?: string): boolean {
+  const requestProvider = setActivePromptProvider(provider ?? activePromptProvider);
   const now = Date.now();
 
   if (!force && now - lastRefreshTime < MIN_REFRESH_INTERVAL) {
@@ -209,8 +242,8 @@ function requestRefresh(force = false): boolean {
   const attempt = force ? 0 : retryCount + 1;
 
   // Request both global and project prompts
-  const globalMessage: GetPromptsMessage = { scope: 'global' };
-  const projectMessage: GetPromptsMessage = { scope: 'project' };
+  const globalMessage: GetPromptsMessage = { scope: 'global', provider: requestProvider };
+  const projectMessage: GetPromptsMessage = { scope: 'project', provider: requestProvider };
 
   const globalSent = sendBridgeEvent('get_prompts', JSON.stringify(globalMessage));
   const projectSent = sendBridgeEvent('get_prompts', JSON.stringify(projectMessage));
@@ -244,13 +277,15 @@ export const EMPTY_STATE_ID = '__empty_state__';
 
 export async function promptProvider(
   query: string,
-  signal: AbortSignal
+  signal: AbortSignal,
+  provider?: string,
 ): Promise<PromptItem[]> {
   if (signal.aborted) {
     throw new DOMException('Aborted', 'AbortError');
   }
 
   setupPromptsCallback();
+  const requestProvider = setActivePromptProvider(provider ?? activePromptProvider);
 
   const now = Date.now();
 
@@ -280,7 +315,7 @@ export async function promptProvider(
   // Attempt to refresh data (non-blocking)
   if ((globalLoadingState === 'idle' || globalLoadingState === 'failed') ||
       (projectLoadingState === 'idle' || projectLoadingState === 'failed')) {
-    requestRefresh();
+    requestRefresh(false, requestProvider);
   } else if (now - lastRefreshTime > LOADING_TIMEOUT) {
     // Handle timeout for each scope separately
     if (globalLoadingState === 'loading') {
@@ -365,7 +400,8 @@ export function promptToDropdownItem(prompt: PromptItem): DropdownItemData {
  * Directly update global prompts cache (called by PromptSection)
  * This ensures cache is always in sync with settings page
  */
-export function updateGlobalPromptsCache(prompts: PromptItem[]) {
+export function updateGlobalPromptsCache(prompts: PromptItem[], provider?: string) {
+  setActivePromptProvider(provider ?? activePromptProvider);
   cachedGlobalPrompts = prompts;
   globalLoadingState = 'success';
   lastRefreshTime = Date.now();
@@ -376,7 +412,8 @@ export function updateGlobalPromptsCache(prompts: PromptItem[]) {
  * Directly update project prompts cache (called by PromptSection)
  * This ensures cache is always in sync with settings page
  */
-export function updateProjectPromptsCache(prompts: PromptItem[]) {
+export function updateProjectPromptsCache(prompts: PromptItem[], provider?: string) {
+  setActivePromptProvider(provider ?? activePromptProvider);
   cachedProjectPrompts = prompts;
   projectLoadingState = 'success';
   lastRefreshTime = Date.now();
@@ -392,7 +429,8 @@ export function updateProjectPromptsCache(prompts: PromptItem[]) {
  * - requestRefresh() has MIN_REFRESH_INTERVAL deduplication protection
  * - Shares state with promptProvider, subsequent calls hit cache directly
  */
-export function preloadPrompts(): void {
+export function preloadPrompts(provider?: string): void {
+  const requestProvider = setActivePromptProvider(provider ?? activePromptProvider);
   // Only preload in idle state, don't interfere with in-progress or completed loads
   if (globalLoadingState !== 'idle' && projectLoadingState !== 'idle') {
     debugLog('[PromptProvider] Preload skipped (globalState=' + globalLoadingState + ', projectState=' + projectLoadingState + ')');
@@ -405,7 +443,7 @@ export function preloadPrompts(): void {
   setupPromptsCallback();
 
   // Request refresh -- built-in deduplication protection
-  requestRefresh();
+  requestRefresh(false, requestProvider);
 }
 
 /**
@@ -413,7 +451,8 @@ export function preloadPrompts(): void {
  * Used when switching to chat view to ensure project prompts are loaded
  * Ignores time interval and retry count limits
  */
-export function forceRefreshPrompts(): void {
+export function forceRefreshPrompts(provider?: string): void {
+  const requestProvider = setActivePromptProvider(provider ?? activePromptProvider);
   debugLog('[PromptProvider] Force refreshing prompts');
 
   // Ensure callback is registered before requesting refresh
@@ -421,7 +460,7 @@ export function forceRefreshPrompts(): void {
 
   // Reset retry count and force refresh
   retryCount = 0;
-  requestRefresh(true);
+  requestRefresh(true, requestProvider);
 }
 
 export default promptProvider;

--- a/webview/src/components/settings/PromptSection/index.tsx
+++ b/webview/src/components/settings/PromptSection/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { PromptScope } from '../../../types/prompt';
+import type { PromptConfig, PromptProvider, PromptScope } from '../../../types/prompt';
 import { usePromptManagement } from '../hooks/usePromptManagement';
 import { updateGlobalPromptsCache, updateProjectPromptsCache } from '../../ChatInputBox/providers';
 import PromptScopeSection from './PromptScopeSection';
@@ -10,14 +10,36 @@ import PromptExportDialog from './PromptExportDialog';
 import PromptImportConfirmDialog from './PromptImportConfirmDialog';
 import styles from './style.module.less';
 
+type PromptCallbackPayload = { provider: PromptProvider; prompts: PromptConfig[] };
+
 interface PromptSectionProps {
   onSuccess?: (message: string) => void;
+  currentProvider?: 'claude' | 'codex' | string;
+}
+
+function normalizePromptProvider(provider?: string | null): PromptProvider {
+  return provider === 'codex' ? 'codex' : 'claude';
+}
+
+function parsePromptCallbackPayload(json: string, fallbackProvider: PromptProvider): PromptCallbackPayload | null {
+  const parsed: unknown = JSON.parse(json);
+  // Legacy payloads predate provider routing and belong to Claude by default.
+  if (Array.isArray(parsed)) return { provider: 'claude', prompts: parsed as PromptConfig[] };
+  if (!parsed || typeof parsed !== 'object') return null;
+  const value = parsed as { provider?: unknown; prompts?: unknown };
+  if (!Array.isArray(value.prompts)) return null;
+  return {
+    provider: normalizePromptProvider(typeof value.provider === 'string' ? value.provider : fallbackProvider),
+    prompts: value.prompts as PromptConfig[],
+  };
 }
 
 export default function PromptSection({
   onSuccess,
+  currentProvider = 'claude',
 }: PromptSectionProps) {
   const { t } = useTranslation();
+  const promptProvider: PromptProvider = normalizePromptProvider(currentProvider);
 
   // Use prompt management hook
   const {
@@ -50,7 +72,7 @@ export default function PromptSection({
     handleSaveImportedPrompts,
     handlePromptImportResult,
     cleanupPromptsTimeout,
-  } = usePromptManagement({ onSuccess });
+  } = usePromptManagement({ onSuccess, provider: promptProvider });
 
   // Load project info and prompts on mount
   useEffect(() => {
@@ -61,7 +83,7 @@ export default function PromptSection({
     // Then load prompts
     loadAllPrompts();
     return () => cleanupPromptsTimeout();
-  }, [loadAllPrompts, cleanupPromptsTimeout]);
+  }, [loadAllPrompts, cleanupPromptsTimeout, promptProvider]);
 
   // Setup window callbacks
   useEffect(() => {
@@ -76,17 +98,23 @@ export default function PromptSection({
     // Chain our handlers with existing ones
     window.updateGlobalPrompts = (json: string) => {
       try {
-        const promptsList = JSON.parse(json);
+        const payload = parsePromptCallbackPayload(json, promptProvider);
+        if (!payload || payload.provider !== promptProvider) {
+          originalUpdateGlobalPrompts?.(json);
+          return;
+        }
+        const promptsList = payload.prompts;
         updateGlobalPrompts(promptsList);
 
         // ✅ Sync update promptProvider cache
-        const promptItems = promptsList.map((prompt: any) => ({
+        const promptItems = promptsList.map((prompt) => ({
           id: prompt.id,
           name: prompt.name,
           content: prompt.content,
           scope: 'global' as PromptScope,
+          provider: promptProvider,
         }));
-        updateGlobalPromptsCache(promptItems);
+        updateGlobalPromptsCache(promptItems, promptProvider);
       } catch (error) {
         console.error('[PromptSection] Failed to parse global prompts:', error);
       }
@@ -96,17 +124,23 @@ export default function PromptSection({
 
     window.updateProjectPrompts = (json: string) => {
       try {
-        const promptsList = JSON.parse(json);
+        const payload = parsePromptCallbackPayload(json, promptProvider);
+        if (!payload || payload.provider !== promptProvider) {
+          originalUpdateProjectPrompts?.(json);
+          return;
+        }
+        const promptsList = payload.prompts;
         updateProjectPrompts(promptsList);
 
         // ✅ Sync update promptProvider cache
-        const promptItems = promptsList.map((prompt: any) => ({
+        const promptItems = promptsList.map((prompt) => ({
           id: prompt.id,
           name: prompt.name,
           content: prompt.content,
           scope: 'project' as PromptScope,
+          provider: promptProvider,
         }));
-        updateProjectPromptsCache(promptItems);
+        updateProjectPromptsCache(promptItems, promptProvider);
       } catch (error) {
         console.error('[PromptSection] Failed to parse project prompts:', error);
       }
@@ -175,6 +209,7 @@ export default function PromptSection({
     handlePromptOperationResult,
     handlePromptImportPreviewResult,
     handlePromptImportResult,
+    promptProvider,
   ]);
 
   // Get all prompts for export dialog (combining global and project based on export scope)

--- a/webview/src/components/settings/hooks/usePromptManagement.ts
+++ b/webview/src/components/settings/hooks/usePromptManagement.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import type {
   PromptConfig,
+  PromptProvider,
   PromptScope,
   GetPromptsMessage,
   AddPromptMessage,
@@ -47,10 +48,11 @@ export interface ExportDialogState {
 export interface UsePromptManagementOptions {
   onError?: (message: string) => void;
   onSuccess?: (message: string) => void;
+  provider?: PromptProvider;
 }
 
 export function usePromptManagement(options: UsePromptManagementOptions = {}) {
-  const { onSuccess, onError } = options;
+  const { onSuccess, onError, provider = 'claude' } = options;
   const { t } = useTranslation();
 
   // Timeout timer reference (using useRef to avoid global variable pollution)
@@ -97,7 +99,7 @@ export function usePromptManagement(options: UsePromptManagementOptions = {}) {
     const TIMEOUT = 2000; // 2-second timeout
 
     setPromptsLoading(true);
-    const message: GetPromptsMessage = { scope };
+    const message: GetPromptsMessage = { scope, provider };
     sendToJava(`get_prompts:${JSON.stringify(message)}`);
 
     // Set up timeout timer - show empty list after timeout
@@ -109,7 +111,7 @@ export function usePromptManagement(options: UsePromptManagementOptions = {}) {
 
     // Store timeout ID in ref
     promptsLoadingTimeoutRef.current = timeoutId;
-  }, []);
+  }, [provider]);
 
   // Convenience functions for loading prompts
   const loadGlobalPrompts = useCallback(() => loadPrompts('global'), [loadPrompts]);
@@ -186,10 +188,12 @@ export function usePromptManagement(options: UsePromptManagementOptions = {}) {
         // Add new prompt
         const message: AddPromptMessage = {
           scope,
+          provider,
           prompt: {
             id: crypto.randomUUID ? crypto.randomUUID() : Date.now().toString(),
             name: data.name,
             content: data.content,
+            provider,
             createdAt: Date.now(),
           },
         };
@@ -198,10 +202,12 @@ export function usePromptManagement(options: UsePromptManagementOptions = {}) {
         // Update existing prompt
         const message: UpdatePromptMessage = {
           scope,
+          provider,
           id: promptDialog.prompt.id,
           updates: {
             name: data.name,
             content: data.content,
+            provider,
             updatedAt: Date.now(),
           },
         };
@@ -212,7 +218,7 @@ export function usePromptManagement(options: UsePromptManagementOptions = {}) {
       // Reload list after prompt operation (with timeout protection)
       loadPrompts(scope);
     },
-    [promptDialog, loadPrompts]
+    [promptDialog, loadPrompts, provider]
   );
 
   // Confirm prompt deletion
@@ -223,13 +229,14 @@ export function usePromptManagement(options: UsePromptManagementOptions = {}) {
 
     const message: DeletePromptMessage = {
       scope,
+      provider,
       id: prompt.id,
     };
     sendToJava(`delete_prompt:${JSON.stringify(message)}`);
     setDeletePromptConfirm({ isOpen: false, prompt: null, scope: 'global' });
     // Reload list after deletion (with timeout protection)
     loadPrompts(scope);
-  }, [deletePromptConfirm, loadPrompts]);
+  }, [deletePromptConfirm, loadPrompts, provider]);
 
   // Cancel prompt deletion
   const cancelDeletePrompt = useCallback(() => {
@@ -268,18 +275,19 @@ export function usePromptManagement(options: UsePromptManagementOptions = {}) {
     const scope = exportDialog.scope;
     const message: ExportPromptsMessage = {
       scope,
+      provider,
       promptIds: selectedIds,
     };
     sendToJava(`export_prompts:${JSON.stringify(message)}`);
     setExportDialog({ isOpen: false, scope: 'global' });
-  }, [exportDialog.scope]);
+  }, [exportDialog.scope, provider]);
 
   // Import prompts from file
   const handleImportPromptsFile = useCallback((scope: PromptScope) => {
     currentImportScopeRef.current = scope;
-    const message: ImportPromptsFileMessage = { scope };
+    const message: ImportPromptsFileMessage = { scope, provider };
     sendToJava(`import_prompts_file:${JSON.stringify(message)}`);
-  }, []);
+  }, [provider]);
 
   // Handle import preview result (used by window callback)
   const handlePromptImportPreviewResult = useCallback(
@@ -313,6 +321,7 @@ export function usePromptManagement(options: UsePromptManagementOptions = {}) {
 
       const message: SaveImportedPromptsMessage = {
         scope,
+        provider,
         prompts: selectedPrompts,
         strategy,
       };
@@ -320,7 +329,7 @@ export function usePromptManagement(options: UsePromptManagementOptions = {}) {
       sendToJava(`save_imported_prompts:${JSON.stringify(message)}`);
       setImportPreviewDialog({ isOpen: false, previewData: null, scope: 'global' });
     },
-    [importPreviewDialog.previewData]
+    [importPreviewDialog.previewData, provider]
   );
 
   // Handle import result (used by window callback)

--- a/webview/src/components/settings/index.tsx
+++ b/webview/src/components/settings/index.tsx
@@ -637,6 +637,7 @@ const SettingsView = ({
           {/* Prompts */}
           <div style={currentTab === 'prompts' ? BLOCK_STYLE : NONE_STYLE}>
             <PromptSection
+              currentProvider={currentProvider}
               onSuccess={(msg) => addToast(msg, 'success')}
             />
           </div>

--- a/webview/src/types/prompt.ts
+++ b/webview/src/types/prompt.ts
@@ -4,6 +4,7 @@ import type { ConflictStrategy } from './import';
  * Prompt scope type - determines where prompts are stored
  */
 export type PromptScope = 'global' | 'project';
+export type PromptProvider = 'claude' | 'codex';
 
 /**
  * Prompt library configuration
@@ -21,6 +22,7 @@ export interface PromptConfig {
   updatedAt?: number;
   /** Scope of the prompt (for display purposes) */
   scope?: PromptScope;
+  provider?: PromptProvider;
 }
 
 /**
@@ -41,6 +43,7 @@ export interface PromptOperationResult {
  */
 export interface GetPromptsMessage {
   scope: PromptScope;
+  provider?: PromptProvider;
 }
 
 /**
@@ -48,6 +51,7 @@ export interface GetPromptsMessage {
  */
 export interface AddPromptMessage {
   scope: PromptScope;
+  provider?: PromptProvider;
   prompt: Omit<PromptConfig, 'scope'>;
 }
 
@@ -56,6 +60,7 @@ export interface AddPromptMessage {
  */
 export interface UpdatePromptMessage {
   scope: PromptScope;
+  provider?: PromptProvider;
   id: string;
   updates: Partial<Omit<PromptConfig, 'id' | 'scope'>>;
 }
@@ -65,6 +70,7 @@ export interface UpdatePromptMessage {
  */
 export interface DeletePromptMessage {
   scope: PromptScope;
+  provider?: PromptProvider;
   id: string;
 }
 
@@ -73,6 +79,7 @@ export interface DeletePromptMessage {
  */
 export interface ExportPromptsMessage {
   scope: PromptScope;
+  provider?: PromptProvider;
   promptIds: string[];
 }
 
@@ -81,6 +88,7 @@ export interface ExportPromptsMessage {
  */
 export interface ImportPromptsFileMessage {
   scope: PromptScope;
+  provider?: PromptProvider;
 }
 
 /**
@@ -88,6 +96,7 @@ export interface ImportPromptsFileMessage {
  */
 export interface SaveImportedPromptsMessage {
   scope: PromptScope;
+  provider?: PromptProvider;
   prompts: PromptConfig[];
   strategy: ConflictStrategy;
 }


### PR DESCRIPTION
## Summary

- isolate prompt-library reads, writes, imports, exports, watchers, settings, and completion caches by Claude/Codex provider
- preserve backward compatibility by treating legacy prompts without provider metadata as Claude prompts
- route bridge diagnostics to stderr so stdout remains a machine-readable JSON channel

## Problem

Prompt data could leak across provider switches, stale callbacks could repopulate the wrong completion cache, and diagnostic output on stdout could corrupt bridge protocol responses.

## Validation

- `node --test ai-bridge/channel-manager.protocol.test.mjs` — 1 passed
- `git diff --check upstream/feature/v0.4.8..HEAD`
- clean merge simulation against `upstream/feature/v0.4.8`
- added Java and Webview regression coverage for provider-scoped prompt access and stale callback isolation

## Test environment note

The Java suite requires the IntelliJ `ideaIC-2024.3.1` test artifact, which was not available in the local offline cache. The Webview test runner was also not installed in this worktree, so those suites are left to CI.