### PR TITLE
fix(windows): harden npm guidance and Node service paths

### DIFF
--- a/src/main/java/com/github/claudecodegui/dependency/NpmPermissionHelper.java
+++ b/src/main/java/com/github/claudecodegui/dependency/NpmPermissionHelper.java
@@ -283,7 +283,10 @@ public class NpmPermissionHelper {
             solution.append("\n\n🔧 Detected npm permission error. Possible solutions:\n");
             solution.append("1. Run: npm cache clean --force\n");
             solution.append("2. Or manually delete: ~/.npm/_cacache\n");
-            if (!PlatformUtils.isWindows()) {
+            if (PlatformUtils.isWindows()) {
+                solution.append("3. Restart the IDE as Administrator if Node/npm was installed in a protected directory\n");
+                solution.append("4. Or move npm cache to a writable directory: npm config set cache \"%USERPROFILE%\\.npm-cache\" --global\n");
+            } else {
                 solution.append("3. Fix ownership: sudo chown -R $(whoami) ~/.npm\n");
             }
         } else if (hasCacheError(logs)) {

--- a/src/main/java/com/github/claudecodegui/handler/InputHistoryHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/InputHistoryHandler.java
@@ -13,6 +13,7 @@ import java.io.BufferedWriter;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -109,23 +110,23 @@ public class InputHistoryHandler {
         String bridgePath = context.getClaudeSDKBridge().getSdkTestDir().getAbsolutePath();
         String nodePath = context.getClaudeSDKBridge().getNodeExecutable();
 
-        String scriptBridgePath = NodeDetector.resolveScriptPath(nodePath, bridgePath);
+        String servicePath = NodeJsServiceCaller.resolveServicePath(
+                nodePath, bridgePath, "input-history-service.cjs");
         String nodeScript;
         if (param == null || param.isEmpty()) {
             // Call without parameters
             nodeScript = String.format(
-                "const { %s } = require('%s/services/input-history-service.cjs'); " +
+                "const { %s } = require(process.argv[1]); " +
                 "const result = %s(); " +
                 "console.log(JSON.stringify(result));",
                 functionName,
-                scriptBridgePath,
                 functionName
             );
-            return executeNodeScript(nodePath, nodeScript, null);
+            return executeNodeScript(nodePath, nodeScript, null, servicePath);
         } else {
             // Single parameter call (passed via stdin to avoid escaping issues)
             nodeScript = String.format(
-                "const { %s } = require('%s/services/input-history-service.cjs'); " +
+                "const { %s } = require(process.argv[1]); " +
                 "let input = ''; " +
                 "process.stdin.on('data', chunk => input += chunk); " +
                 "process.stdin.on('end', () => { " +
@@ -139,10 +140,9 @@ public class InputHistoryHandler {
                 "  } " +
                 "});",
                 functionName,
-                scriptBridgePath,
                 functionName
             );
-            return executeNodeScript(nodePath, nodeScript, param);
+            return executeNodeScript(nodePath, nodeScript, param, servicePath);
         }
     }
 
@@ -153,10 +153,11 @@ public class InputHistoryHandler {
         String bridgePath = context.getClaudeSDKBridge().getSdkTestDir().getAbsolutePath();
         String nodePath = context.getClaudeSDKBridge().getNodeExecutable();
 
-        String scriptBridgePath = NodeDetector.resolveScriptPath(nodePath, bridgePath);
+        String servicePath = NodeJsServiceCaller.resolveServicePath(
+                nodePath, bridgePath, "input-history-service.cjs");
         // Use stdin to pass JSON data, avoiding shell escaping issues with special characters
         String nodeScript = String.format(
-            "const { %s } = require('%s/services/input-history-service.cjs'); " +
+            "const { %s } = require(process.argv[1]); " +
             "let input = ''; " +
             "process.stdin.on('data', chunk => input += chunk); " +
             "process.stdin.on('end', () => { " +
@@ -170,11 +171,10 @@ public class InputHistoryHandler {
             "  } " +
             "});",
             functionName,
-            scriptBridgePath,
             functionName
         );
 
-        return executeNodeScript(nodePath, nodeScript, jsonArrayParam);
+        return executeNodeScript(nodePath, nodeScript, jsonArrayParam, servicePath);
     }
 
     /**
@@ -186,8 +186,11 @@ public class InputHistoryHandler {
      * @param stdinData  data to write to stdin, or null to skip stdin write
      * @return the last non-empty line of stdout
      */
-    private String executeNodeScript(String nodePath, String nodeScript, String stdinData) throws Exception {
-        ProcessBuilder pb = new ProcessBuilder(NodeDetector.buildNodeInlineCommand(nodePath, nodeScript));
+    private String executeNodeScript(
+            String nodePath, String nodeScript, String stdinData, String servicePath) throws Exception {
+        List<String> command = NodeDetector.buildNodeInlineCommand(nodePath, nodeScript);
+        command.add(servicePath);
+        ProcessBuilder pb = new ProcessBuilder(command);
         pb.redirectErrorStream(true);
 
         // L7 fix: register with ProcessManager so cleanupAllProcesses sees this child.

--- a/src/main/java/com/github/claudecodegui/handler/NodeJsServiceCaller.java
+++ b/src/main/java/com/github/claudecodegui/handler/NodeJsServiceCaller.java
@@ -8,6 +8,7 @@ import com.github.claudecodegui.util.PlatformUtils;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -43,18 +44,17 @@ public class NodeJsServiceCaller {
 
         String bridgePath = context.getClaudeSDKBridge().getSdkTestDir().getAbsolutePath();
         String nodePath = context.getClaudeSDKBridge().getNodeExecutable();
-        String scriptBridgePath = NodeDetector.resolveScriptPath(nodePath, bridgePath);
+        String servicePath = resolveServicePath(nodePath, bridgePath, "favorites-service.cjs");
 
         String nodeScript = String.format(
-            "const { %s } = require('%s/services/favorites-service.cjs'); " +
+            "const { %s } = require(process.argv[1]); " +
             "const result = %s(process.env.SESSION_ID); " +
             "console.log(JSON.stringify(result));",
             functionName,
-            scriptBridgePath,
             functionName
         );
 
-        ProcessBuilder pb = buildNodeProcessBuilder(nodePath, nodeScript);
+        ProcessBuilder pb = buildNodeProcessBuilder(nodePath, nodeScript, servicePath);
         pb.redirectErrorStream(true);
         pb.environment().put("SESSION_ID", sessionId);
 
@@ -69,18 +69,17 @@ public class NodeJsServiceCaller {
 
         String bridgePath = context.getClaudeSDKBridge().getSdkTestDir().getAbsolutePath();
         String nodePath = context.getClaudeSDKBridge().getNodeExecutable();
-        String scriptBridgePath = NodeDetector.resolveScriptPath(nodePath, bridgePath);
+        String servicePath = resolveServicePath(nodePath, bridgePath, "session-titles-service.cjs");
 
         String nodeScript = String.format(
-            "const { %s } = require('%s/services/session-titles-service.cjs'); " +
+            "const { %s } = require(process.argv[1]); " +
             "const result = %s(); " +
             "console.log(JSON.stringify(result));",
             functionName,
-            scriptBridgePath,
             functionName
         );
 
-        ProcessBuilder pb = buildNodeProcessBuilder(nodePath, nodeScript);
+        ProcessBuilder pb = buildNodeProcessBuilder(nodePath, nodeScript, servicePath);
         pb.redirectErrorStream(true);
 
         return executeNodeScript(pb);
@@ -94,18 +93,17 @@ public class NodeJsServiceCaller {
 
         String bridgePath = context.getClaudeSDKBridge().getSdkTestDir().getAbsolutePath();
         String nodePath = context.getClaudeSDKBridge().getNodeExecutable();
-        String scriptBridgePath = NodeDetector.resolveScriptPath(nodePath, bridgePath);
+        String servicePath = resolveServicePath(nodePath, bridgePath, "session-titles-service.cjs");
 
         String nodeScript = String.format(
-            "const { %s } = require('%s/services/session-titles-service.cjs'); " +
+            "const { %s } = require(process.argv[1]); " +
             "const result = %s(process.env.SESSION_ID, process.env.CUSTOM_TITLE); " +
             "console.log(JSON.stringify(result));",
             functionName,
-            scriptBridgePath,
             functionName
         );
 
-        ProcessBuilder pb = buildNodeProcessBuilder(nodePath, nodeScript);
+        ProcessBuilder pb = buildNodeProcessBuilder(nodePath, nodeScript, servicePath);
         pb.redirectErrorStream(true);
         pb.environment().put("SESSION_ID", sessionId);
         pb.environment().put("CUSTOM_TITLE", customTitle);
@@ -119,16 +117,14 @@ public class NodeJsServiceCaller {
     public String callNodeJsDeleteTitle(String sessionId) throws Exception {
         String bridgePath = context.getClaudeSDKBridge().getSdkTestDir().getAbsolutePath();
         String nodePath = context.getClaudeSDKBridge().getNodeExecutable();
-        String scriptBridgePath = NodeDetector.resolveScriptPath(nodePath, bridgePath);
+        String servicePath = resolveServicePath(nodePath, bridgePath, "session-titles-service.cjs");
 
-        String nodeScript = String.format(
-            "const { deleteTitle } = require('%s/services/session-titles-service.cjs'); " +
+        String nodeScript =
+            "const { deleteTitle } = require(process.argv[1]); " +
             "const result = deleteTitle(process.env.SESSION_ID); " +
-            "console.log(JSON.stringify({ success: result }));",
-            scriptBridgePath
-        );
+            "console.log(JSON.stringify({ success: result }));";
 
-        ProcessBuilder pb = buildNodeProcessBuilder(nodePath, nodeScript);
+        ProcessBuilder pb = buildNodeProcessBuilder(nodePath, nodeScript, servicePath);
         pb.redirectErrorStream(true);
         pb.environment().put("SESSION_ID", sessionId);
 
@@ -139,8 +135,15 @@ public class NodeJsServiceCaller {
      * Build a ProcessBuilder for running a Node.js inline script.
      * Delegates to {@link NodeDetector#buildNodeInlineCommand} so WSL prefixing is centralised.
      */
-    private ProcessBuilder buildNodeProcessBuilder(String nodePath, String nodeScript) {
-        return new ProcessBuilder(NodeDetector.buildNodeInlineCommand(nodePath, nodeScript));
+    private ProcessBuilder buildNodeProcessBuilder(String nodePath, String nodeScript, String servicePath) {
+        List<String> command = NodeDetector.buildNodeInlineCommand(nodePath, nodeScript);
+        command.add(servicePath);
+        return new ProcessBuilder(command);
+    }
+
+    static String resolveServicePath(String nodePath, String bridgePath, String serviceFileName) {
+        String servicePath = bridgePath + "/services/" + serviceFileName;
+        return NodeDetector.isWslPath(nodePath) ? NodeDetector.convertToWslPath(servicePath) : servicePath;
     }
 
     /**

--- a/src/test/java/com/github/claudecodegui/dependency/NpmPermissionHelperTest.java
+++ b/src/test/java/com/github/claudecodegui/dependency/NpmPermissionHelperTest.java
@@ -1,5 +1,6 @@
 package com.github.claudecodegui.dependency;
 
+import com.github.claudecodegui.util.PlatformUtils;
 import org.junit.Test;
 
 import java.nio.file.Paths;
@@ -97,5 +98,17 @@ public class NpmPermissionHelperTest {
 
         assertTrue(cmd.contains("pkg-a@1.0.0"));
         assertTrue(cmd.contains("pkg-b"));
+    }
+
+    @Test
+    public void permissionSolutionMatchesCurrentPlatform() {
+        String solution = NpmPermissionHelper.generateErrorSolution("EACCES permission denied");
+
+        if (PlatformUtils.isWindows()) {
+            assertTrue(solution.contains("npm config set cache"));
+            assertTrue(!solution.contains("sudo chown"));
+        } else {
+            assertTrue(solution.contains("sudo chown"));
+        }
     }
 }

--- a/src/test/java/com/github/claudecodegui/handler/NodeJsServiceCallerPathTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/NodeJsServiceCallerPathTest.java
@@ -1,0 +1,132 @@
+package com.github.claudecodegui.handler;
+
+import com.github.claudecodegui.bridge.NodeDetector;
+import com.github.claudecodegui.bridge.ProcessManager;
+import com.github.claudecodegui.handler.core.HandlerContext;
+import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class NodeJsServiceCallerPathTest {
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private TestClaudeSDKBridge bridge;
+    private HandlerContext context;
+
+    @Before
+    public void setUp() throws Exception {
+        Path bridgeDir = temporaryFolder.newFolder("bridge'quoted").toPath();
+        Path servicesDir = Files.createDirectories(bridgeDir.resolve("services"));
+        writeService(servicesDir.resolve("session-titles-service.cjs"),
+                "module.exports = {"
+                        + " loadTitles: () => ({}),"
+                        + " updateTitle: (sessionId, title) => ({ sessionId, title }),"
+                        + " deleteTitle: () => true"
+                        + " };\n");
+        writeService(servicesDir.resolve("favorites-service.cjs"),
+                "module.exports = {"
+                        + " loadFavorites: sessionId => ({ sessionId }),"
+                        + " toggleFavorite: sessionId => ({ sessionId })"
+                        + " };\n");
+        writeService(servicesDir.resolve("input-history-service.cjs"),
+                "module.exports = {"
+                        + " getAllHistoryData: () => ({ items: ['ok'], counts: {} })"
+                        + " };\n");
+
+        bridge = new TestClaudeSDKBridge(bridgeDir.toFile());
+        context = new HandlerContext(null, bridge, null, null, new HandlerContext.JsCallback() {
+            @Override
+            public void callJavaScript(String functionName, String... args) {
+            }
+
+            @Override
+            public String escapeJs(String str) {
+                return str;
+            }
+        });
+    }
+
+    @Test
+    public void titleServiceLoadsFromPathContainingSingleQuote() throws Exception {
+        String result = new NodeJsServiceCaller(context)
+                .callNodeJsTitlesServiceWithParams("updateTitle", "session-1", "Quoted title");
+
+        JsonObject json = JsonParser.parseString(result).getAsJsonObject();
+        assertEquals("session-1", json.get("sessionId").getAsString());
+        assertEquals("Quoted title", json.get("title").getAsString());
+        assertEquals(0, bridge.getProcessManager().getActiveProcessCount());
+    }
+
+    @Test
+    public void favoritesServiceLoadsFromPathContainingSingleQuote() throws Exception {
+        String result = new NodeJsServiceCaller(context)
+                .callNodeJsFavoritesService("loadFavorites", "session-2");
+
+        JsonObject json = JsonParser.parseString(result).getAsJsonObject();
+        assertEquals("session-2", json.get("sessionId").getAsString());
+        assertEquals(0, bridge.getProcessManager().getActiveProcessCount());
+    }
+
+    @Test
+    public void inputHistoryServiceLoadsFromPathContainingSingleQuote() throws Exception {
+        String result = new InputHistoryHandler(context)
+                .callInputHistoryService("getAllHistoryData", null);
+
+        JsonObject json = JsonParser.parseString(result).getAsJsonObject();
+        assertEquals("ok", json.getAsJsonArray("items").get(0).getAsString());
+        assertEquals(0, bridge.getProcessManager().getActiveProcessCount());
+    }
+
+    @Test
+    public void servicePathIsConvertedForWslNode() {
+        Assume.assumeTrue(NodeDetector.isWslPath("/usr/bin/node"));
+
+        assertEquals(
+                "/mnt/c/Users/g'f'd/bridge/services/session-titles-service.cjs",
+                NodeJsServiceCaller.resolveServicePath(
+                        "/usr/bin/node", "C:\\Users\\g'f'd\\bridge", "session-titles-service.cjs"));
+    }
+
+    private static void writeService(Path path, String content) throws IOException {
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+
+    private static final class TestClaudeSDKBridge extends ClaudeSDKBridge {
+        private final File sdkDir;
+        private final ProcessManager processManager = new ProcessManager();
+
+        private TestClaudeSDKBridge(File sdkDir) {
+            this.sdkDir = sdkDir;
+        }
+
+        @Override
+        public File getSdkTestDir() {
+            return sdkDir;
+        }
+
+        @Override
+        public String getNodeExecutable() {
+            return "node";
+        }
+
+        @Override
+        public ProcessManager getProcessManager() {
+            return processManager;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- provide Windows-specific npm permission recovery guidance without suggesting Unix ownership commands
- pass Node service module paths as process arguments instead of interpolating them into inline JavaScript
- convert service paths for WSL-backed Node executables while preserving native Windows paths

## Problem

Windows users could receive inapplicable npm recovery instructions, and service paths containing backslashes, quotes, or WSL/native path boundaries could break inline Node module loading.

## Validation

- `git diff --check upstream/feature/v0.4.8..HEAD`
- clean merge simulation against `upstream/feature/v0.4.8`
- added or updated Java regression tests for Windows guidance, native paths, spaces, quotes, and WSL conversion

## Test environment note

The Java suite requires the IntelliJ `ideaIC-2024.3.1` test artifact, which was not available in the local offline cache, so that suite is left to CI.