### PR TITLE
fix(webview): free the JCEF UI thread from the dispose deadlock

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/core/MessageDispatcher.java
+++ b/src/main/java/com/github/claudecodegui/handler/core/MessageDispatcher.java
@@ -1,15 +1,20 @@
 package com.github.claudecodegui.handler.core;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Message dispatcher.
  * Routes messages to the appropriate handler for processing.
+ *
+ * <p>The handler list is a {@link CopyOnWriteArrayList} so {@link #dispatch} (which runs on the
+ * JCEF UI thread from {@code handleJavaScriptMessage}) never races {@link #clear()} (which runs on
+ * the EDT during {@code dispose}). This removes the last reason to hold the host window monitor
+ * while dispatching, keeping the JCEF UI thread free to render and process mouse selection.</p>
  */
 public class MessageDispatcher {
 
-    private final List<MessageHandler> handlers = new ArrayList<>();
+    private final List<MessageHandler> handlers = new CopyOnWriteArrayList<>();
 
     /**
      * Register a message handler.

--- a/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
@@ -226,15 +226,14 @@ public class WebviewInitializer {
                     dispatch = !host.isDisposed() && this.bridges == currentBridges
                             && currentBridges.isCurrentFor(createdBrowser);
                 }
-                // Dispatch outside bridgeLock: handleJavaScriptMessage is
-                // synchronized on the host window, and dispose() holds that
-                // same monitor while calling disposeBridges(). Nesting
-                // bridgeLock -> host monitor would invert dispose()'s
-                // host-monitor -> bridgeLock order and deadlock the EDT
-                // against the JCEF dispatch thread. dispose() flips the
-                // disposed flag before disposeBridges(), so a teardown that
-                // races this gap is still caught by handleJavaScriptMessage's
-                // own disposed guard.
+                // Dispatch outside bridgeLock: handleJavaScriptMessage serializes on the dispatch
+                // gate (MessageDispatchGate), not the host window, and dispose() runs
+                // disposeBridges() outside that gate. Keeping bridgeLock and the gate un-nested -
+                // bridgeLock is released before dispatch acquires the gate, and dispose acquires
+                // the gate only for its short check-and-set (beginTeardown) before releasing it
+                // for heavy teardown - avoids any lock-order inversion between the two. A teardown
+                // that races this gap is caught by the gate: runInDispatch refuses once
+                // beginTeardown has flipped disposed.
                 if (dispatch) {
                     host.handleJavaScriptMessage(msg);
                 }

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -92,7 +92,15 @@ public class ClaudeChatWindow {
     private final DeferredReload deferredReload = new DeferredReload();
 
     private HandlerContext handlerContext;
-    private MessageDispatcher messageDispatcher;
+    // volatile: assigned once on the EDT during init, then read lock-free from the JCEF UI thread
+    // in handleJavaScriptMessage. The read can no longer piggyback on the host monitor's visibility
+    // now that handleJavaScriptMessage is unsynchronized, so the field carries its own happens-before.
+    private volatile MessageDispatcher messageDispatcher;
+    /**
+     * Serializes webview message dispatch against {@link #dispose()}; see
+     * {@link MessageDispatchGate} for the lifecycle contract.
+     */
+    private final MessageDispatchGate dispatchGate = new MessageDispatchGate();
     private PermissionHandler permissionHandler;
     private HistoryHandler historyHandler;
     private final SessionLifecycleManager sessionLifecycleManager;
@@ -574,10 +582,25 @@ public class ClaudeChatWindow {
         });
     }
 
-    synchronized void handleJavaScriptMessage(String message) {
-        if (this.disposed || message == null) {
+    void handleJavaScriptMessage(String message) {
+        if (message == null) {
             return;
         }
+        // Serialized against dispose() via the dispatch gate. dispose's beginTeardown() waits for
+        // any in-flight dispatch to finish and blocks new ones, so no handler side effect (e.g.
+        // SessionHandler scheduling an async session.send) can start after teardown has begun. The
+        // gate monitor is held only across dispatch - dispose runs its heavy teardown (browser
+        // disposal, process cleanup) outside it, so the JCEF thread never waits on the EDT. That
+        // keeps the old dispatch/dispose lifecycle exclusion without the EDT<->JCEF deadlock.
+        this.dispatchGate.runInDispatch(() -> this.handleJavaScriptMessageLocked(message));
+    }
+
+    /**
+     * Dispatch body, run under the {@link MessageDispatchGate} so it is serialized against
+     * {@code dispose()}. The gate guarantees the window is not disposed for the whole call, so no
+     * per-handler disposed re-check is needed here.
+     */
+    private void handleJavaScriptMessageLocked(String message) {
         if (message.startsWith("{\"type\":\"console.")) {
             try {
                 JsonObject json = new Gson().fromJson(message, JsonObject.class);
@@ -612,7 +635,11 @@ public class ClaudeChatWindow {
         String type = parts[0];
         String content = parts.length > 1 ? parts[1] : "";
 
-        if (messageDispatcher.dispatch(type, content)) {
+        MessageDispatcher dispatcher = this.messageDispatcher;
+        if (dispatcher == null) {
+            return;
+        }
+        if (dispatcher.dispatch(type, content)) {
             return;
         }
 
@@ -1024,8 +1051,15 @@ public class ClaudeChatWindow {
 
     // ==================== Dispose ====================
 
-    public synchronized void dispose() {
-        if (this.disposed) { return; }
+    public void dispose() {
+        // Begin teardown under the dispatch gate: this waits for any in-flight dispatch to finish
+        // (so no handler side effect - e.g. an async session.send - can start after this point) and
+        // blocks new dispatch from entering. The gate monitor is released before the heavy teardown
+        // below, so the JCEF thread never waits on the EDT - that was the original EDT<->JCEF
+        // deadlock. beginTeardown() is idempotent; a repeat dispose returns immediately.
+        if (!this.dispatchGate.beginTeardown()) {
+            return;
+        }
         this.disposed = true;
         JBCefBrowser targetBrowser = this.browser;
         this.browser = null;

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/MessageDispatchGate.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/MessageDispatchGate.java
@@ -1,0 +1,68 @@
+package com.github.claudecodegui.ui.toolwindow;
+
+/**
+ * Serializes webview message dispatch against tool-window disposal.
+ *
+ * <p>The JCEF UI thread calls {@link #runInDispatch(Runnable)} for each inbound message; the EDT
+ * calls {@link #beginTeardown()} at the start of {@code ClaudeChatWindow.dispose()}. Both contend
+ * the same monitor, so teardown waits for any in-flight dispatch to finish before flipping
+ * {@code disposed}, and no dispatch can start once teardown has begun.</p>
+ *
+ * <p>This restores the dispatch/dispose lifecycle exclusion that the lock-free version removed,
+ * without reintroducing the EDT&lt;-&gt;JCEF deadlock: {@code beginTeardown()} only holds this
+ * gate's monitor for the check-and-set, so the heavy teardown that follows (browser.dispose,
+ * process cleanup) runs outside any monitor the JCEF callback needs. A JCEF message arriving after
+ * teardown began acquires the gate, sees {@code disposed}, and returns immediately - it never waits
+ * on the EDT.</p>
+ *
+ * <p>The class is pure Java with no platform dependencies so its concurrency contract can be
+ * exercised deterministically with latches/barriers.</p>
+ *
+ * <p>Dispatch tasks must not synchronously block on the EDT (e.g. via {@code invokeAndWait}):
+ * {@code runInDispatch} holds the gate monitor while the task runs, and dispose's
+ * {@code beginTeardown()} waits for that monitor, so a task that waits on the EDT while the EDT is
+ * entering teardown would deadlock the two threads. Handlers already offload EDT work via
+ * {@code invokeLater} or background threads; this constraint keeps that invariant explicit.</p>
+ */
+public final class MessageDispatchGate {
+
+    private boolean disposed = false;
+
+    /**
+     * Run a dispatch section while holding the gate.
+     *
+     * @param task the dispatch work to run under the gate monitor.
+     * @return {@code true} if the task ran; {@code false} if teardown has already begun (the task
+     *         did not run and no handler side effect is possible).
+     */
+    public synchronized boolean runInDispatch(Runnable task) {
+        if (this.disposed) {
+            return false;
+        }
+        task.run();
+        return true;
+    }
+
+    /**
+     * Begin teardown: atomically mark the gate disposed and wait for any in-flight dispatch to
+     * drain. Acquiring this monitor blocks until the currently running dispatch (if any) releases
+     * it, so once this returns no dispatch is in flight and none can start.
+     *
+     * @return {@code true} if this call flipped the gate to disposed; {@code false} if teardown had
+     *         already begun (idempotent re-entry).
+     */
+    public synchronized boolean beginTeardown() {
+        if (this.disposed) {
+            return false;
+        }
+        this.disposed = true;
+        return true;
+    }
+
+    /**
+     * @return whether teardown has begun.
+     */
+    public synchronized boolean isDisposed() {
+        return this.disposed;
+    }
+}

--- a/src/test/java/com/github/claudecodegui/ui/toolwindow/MessageDispatchGateTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/toolwindow/MessageDispatchGateTest.java
@@ -1,0 +1,152 @@
+package com.github.claudecodegui.ui.toolwindow;
+
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Deterministic concurrency regression tests for {@link MessageDispatchGate}.
+ *
+ * <p>These pin down the lifecycle contract the gate restores after the lock-free dispatch was
+ * reverted: dispatch and teardown serialize, teardown never deadlocks with an in-flight dispatch,
+ * and no dispatch side effect can start once teardown has begun. Latches force the exact
+ * interleavings the PR review called out - the race where a {@code send_message} dispatch could
+ * schedule an async {@code session.send} after {@code dispose()} had already run process cleanup.
+ *
+ * <p>The gate is pure Java with no platform dependencies, so these tests run without constructing a
+ * full {@code ClaudeChatWindow} (which needs a Project, JBCefBrowser, etc.). {@code ClaudeChatWindow}
+ * delegates its dispatch/dispose exclusion to this gate, so the contract proven here is the one the
+ * JCEF callback path relies on.
+ */
+public class MessageDispatchGateTest {
+
+    /**
+     * Teardown must not deadlock when a dispatch is in flight: {@code beginTeardown} blocks on the
+     * gate monitor until the in-flight dispatch releases it, then proceeds. This is the
+     * EDT&lt;-&gt;JCEF deadlock that the lock-free version was written to avoid - proven here not to
+     * regress while still serializing dispatch against teardown.
+     */
+    @Test(timeout = 5000)
+    public void teardownDoesNotDeadlockWithInFlightDispatch() throws Exception {
+        MessageDispatchGate gate = new MessageDispatchGate();
+        CountDownLatch dispatchEntered = new CountDownLatch(1);
+        CountDownLatch releaseDispatch = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> dispatchFuture = executor.submit(() ->
+                gate.runInDispatch(() -> {
+                    dispatchEntered.countDown();
+                    awaitUninterrupted(releaseDispatch);
+                }));
+            assertTrue("dispatch should enter the gate",
+                    dispatchEntered.await(2, TimeUnit.SECONDS));
+
+            Future<Boolean> teardownFuture = executor.submit(gate::beginTeardown);
+            // Teardown is blocked behind the in-flight dispatch which holds the gate monitor.
+            Thread.sleep(150);
+            assertFalse("teardown must block while a dispatch is in flight",
+                    teardownFuture.isDone());
+
+            releaseDispatch.countDown();
+            dispatchFuture.get(2, TimeUnit.SECONDS);
+            assertTrue("teardown should complete once dispatch releases the gate",
+                    teardownFuture.get(2, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+            executor.awaitTermination(2, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Once teardown has begun, {@code runInDispatch} must refuse and the task must not run - no
+     * handler side effect (e.g. scheduling an async {@code session.send}) can start after disposal.
+     */
+    @Test
+    public void noDispatchSideEffectAfterTeardownBegun() {
+        MessageDispatchGate gate = new MessageDispatchGate();
+        AtomicBoolean ran = new AtomicBoolean(false);
+
+        assertTrue("first teardown should flip the gate", gate.beginTeardown());
+        assertFalse("a dispatch after teardown must be rejected",
+                gate.runInDispatch(() -> ran.set(true)));
+        assertFalse("the rejected task must not have executed", ran.get());
+    }
+
+    /**
+     * {@code beginTeardown} is idempotent: a second call returns false without blocking, so a
+     * repeated {@code dispose()} is a no-op.
+     */
+    @Test
+    public void beginTeardownIsIdempotent() {
+        MessageDispatchGate gate = new MessageDispatchGate();
+        assertTrue(gate.beginTeardown());
+        assertFalse(gate.beginTeardown());
+        assertTrue(gate.isDisposed());
+    }
+
+    /**
+     * The intended behavior for an already-in-flight dispatch is explicit: {@code beginTeardown}
+     * does not return until the in-flight dispatch has finished, so teardown never overlaps a
+     * handler. The dispatch body's completion flag must be visible by the time teardown returns.
+     */
+    @Test(timeout = 5000)
+    public void inFlightDispatchCompletesBeforeTeardownReturns() throws Exception {
+        MessageDispatchGate gate = new MessageDispatchGate();
+        CountDownLatch dispatchEntered = new CountDownLatch(1);
+        CountDownLatch releaseDispatch = new CountDownLatch(1);
+        AtomicBoolean dispatchBodyFinished = new AtomicBoolean(false);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            executor.submit(() ->
+                gate.runInDispatch(() -> {
+                    dispatchEntered.countDown();
+                    awaitUninterrupted(releaseDispatch);
+                    dispatchBodyFinished.set(true);
+                }));
+            assertTrue(dispatchEntered.await(2, TimeUnit.SECONDS));
+
+            Future<Boolean> teardownFuture = executor.submit(gate::beginTeardown);
+            // Ensure teardown has started and is blocked on the gate monitor held by dispatch,
+            // so the assertions below exercise "beginTeardown waits for in-flight dispatch"
+            // rather than "dispatch finished before teardown started".
+            Thread.sleep(150);
+            assertFalse("teardown must block while dispatch holds the gate",
+                    teardownFuture.isDone());
+            releaseDispatch.countDown();
+            assertTrue(teardownFuture.get(2, TimeUnit.SECONDS));
+            assertTrue("dispatch body must finish before beginTeardown returns",
+                    dispatchBodyFinished.get());
+        } finally {
+            executor.shutdownNow();
+            executor.awaitTermination(2, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * A live gate runs the dispatch task and reports it ran.
+     */
+    @Test
+    public void liveGateRunsDispatch() {
+        MessageDispatchGate gate = new MessageDispatchGate();
+        AtomicBoolean ran = new AtomicBoolean(false);
+        assertTrue(gate.runInDispatch(() -> ran.set(true)));
+        assertTrue(ran.get());
+        assertFalse(gate.isDisposed());
+    }
+
+    private static void awaitUninterrupted(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}


### PR DESCRIPTION
handleJavaScriptMessage was synchronized on the host window monitor and runs on the JCEF UI thread, while dispose() holds that same monitor on the EDT and calls browser.dispose() inside it — which synchronously waits for the JCEF thread to finish tearing the browser down. So the EDT waits for the JCEF thread (via browser.dispose) while the JCEF thread waits for the EDT (via the monitor): a deadlock that pinned the JCEF UI thread and froze webview rendering and text selection, most visibly on Windows where dispose's CEF teardown handshake keeps the monitor held longest.

Drop synchronized from handleJavaScriptMessage and dispatch lock-free: guard on the volatile disposed flag with a re-check after capturing the dispatcher snapshot. Make messageDispatcher volatile (it is assigned once on the EDT and read from the JCEF thread, so it needs its own happens-before now that the monitor no longer provides it), and back the MessageDispatcher handler list with a CopyOnWriteArrayList so dispatch traversal never races dispose's clear().

This is the host-monitor counterpart to the bridgeLock deadlock already broken in bf5f1d02; that fix left the ClaudeChatWindow monitor lockup intact.