### PR TITLE
fix(claude): soft-reload same-session resume; widen status panel scope on replay

### DIFF
--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -100,6 +100,16 @@ public class ChatWindowDelegate {
         void setSlashCommandsFetched(boolean fetched);
         void setFetchedSlashCommandsCount(int count);
         void persistTabSessionState();
+
+        /**
+         * Soft-reload the currently active session's transcript without interrupting
+         * any in-flight turn.
+         * <p>Invoked when the user re-opens the session that is already active —
+         * refreshes the transcript from the server instead of tearing the session
+         * down (interrupt + recreate). Safe to call while a turn is streaming: the
+         * reload is deferred to stream end.</p>
+         */
+        void reloadActiveSessionMessages();
     }
 
     private final DelegateHost host;
@@ -305,8 +315,22 @@ public class ChatWindowDelegate {
         messageDispatcher.registerHandler(permissionHandler);
 
         HistoryHandler historyHandler = new HistoryHandler(handlerContext);
-        historyHandler.setSessionLoadCallback((sessionId, projectPath, provider) ->
-            host.getSessionLifecycleManager().loadHistorySession(sessionId, projectPath, provider));
+        historyHandler.setSessionLoadCallback((sessionId, projectPath, provider) -> {
+            ClaudeSession current = host.getSession();
+            boolean sameSession = current != null
+                    && sessionId != null
+                    && sessionId.equals(current.getSessionId())
+                    && (provider == null || provider.trim().isEmpty()
+                                || provider.equals(current.getProvider()));
+            if (sameSession) {
+                // Re-opening the very session already active: soft-reload its transcript
+                // instead of interrupting the in-flight turn.
+                LOG.info("[HistoryHandler] Same-session resume, soft-reloading transcript: " + sessionId);
+                host.reloadActiveSessionMessages();
+            } else {
+                host.getSessionLifecycleManager().loadHistorySession(sessionId, projectPath, provider);
+            }
+        });
         host.setHistoryHandler(historyHandler);
         messageDispatcher.registerHandler(historyHandler);
 

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -1194,6 +1194,39 @@ public class ClaudeChatWindow {
         };
     }
 
+    /**
+     * Soft-reload the active session's transcript from the server without
+     * interrupting any in-flight turn.
+     * <p>Used when the user re-opens the session that is already active: instead
+     * of tearing it down (interrupt + recreate), we merely refresh the transcript
+     * so the latest on-disk state is reflected. Reuses the {@code session_updated}
+     * reload path (coalescing + isSessionActive guard), and defers to stream end
+     * when a turn is live so the streaming bubble is never disturbed.</p>
+     */
+    void reloadActiveSessionMessages() {
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (disposed) {
+                return;
+            }
+            ClaudeSession current = session;
+            if (current == null) {
+                return;
+            }
+            String currentId = current.getSessionId();
+            if (currentId == null) {
+                return;
+            }
+            if (streamCoalescer != null && streamCoalescer.isStreamActive()) {
+                deferredReload.defer(currentId);
+                LOG.info("[ClaudeChatWindow] Same-session resume deferred — "
+                        + "turn streaming, will reload at stream end, sessionId=" + currentId);
+                return;
+            }
+            LOG.info("[ClaudeChatWindow] Same-session resume soft reload (no interrupt), sessionId=" + currentId);
+            requestSessionReload(currentId);
+        });
+    }
+
     private ChatWindowDelegate.DelegateHost createDelegateHost() {
         return new ChatWindowDelegate.DelegateHost() {
             @Override
@@ -1337,6 +1370,11 @@ public class ClaudeChatWindow {
             @Override
             public void persistTabSessionState() {
                 ClaudeChatWindow.this.persistTabSessionState();
+            }
+
+            @Override
+            public void reloadActiveSessionMessages() {
+                ClaudeChatWindow.this.reloadActiveSessionMessages();
             }
         };
     }

--- a/webview/src/hooks/useChatComputations.test.ts
+++ b/webview/src/hooks/useChatComputations.test.ts
@@ -82,4 +82,25 @@ describe('deriveTodosForTurn', () => {
     const latestTurn = sliceLatestConversationTurn(messages);
     expect(deriveTodosForTurn(latestTurn, getContentBlocks, true)).toEqual([]);
   });
+
+  it('keeps earlier todos when the full transcript is scoped (settled history replay)', () => {
+    // Non-streaming scope feeds the WHOLE transcript to deriveTodosForTurn, so an
+    // earlier turn's plan survives even when the last turn has no task tool —
+    // exactly what a resumed history session needs to render its task list.
+    const messages = [
+      user('previous request'),
+      assistant([toolUse('old-plan', 'update_plan', {
+        plan: [
+          { step: 'Kept step', status: 'completed' },
+          { step: 'In-flight step', status: 'in_progress' },
+        ],
+      })]),
+      user('Only answer OK'),
+    ];
+
+    expect(deriveTodosForTurn(messages, getContentBlocks, false)).toEqual([
+      { content: 'Kept step', status: 'completed' },
+      { content: 'In-flight step', status: 'completed' },
+    ]);
+  });
 });

--- a/webview/src/hooks/useChatComputations.ts
+++ b/webview/src/hooks/useChatComputations.ts
@@ -145,8 +145,14 @@ export function useChatComputations({
 
   const latestTurnMessages = useMemo(() => sliceLatestConversationTurn(messages), [messages]);
 
+  // While streaming, focus on the current turn's task progress; once settled
+  // (history replay or idle), widen the scope to the whole conversation -
+  // otherwise a multi-turn history session whose last turn has no task tool
+  // would lose its task and subagent lists entirely.
+  const statusScopeMessages = streamingActive ? latestTurnMessages : messages;
+
   const latestTurnSubagents = useSubagents({
-    messages: latestTurnMessages,
+    messages: statusScopeMessages,
     getContentBlocks,
     findToolResult,
     getToolResultRaw,
@@ -158,8 +164,8 @@ export function useChatComputations({
   );
 
   const globalTodos = useMemo(() => {
-    return deriveTodosForTurn(latestTurnMessages, getContentBlocks, streamingActive);
-  }, [latestTurnMessages, getContentBlocks, streamingActive]);
+    return deriveTodosForTurn(statusScopeMessages, getContentBlocks, streamingActive);
+  }, [statusScopeMessages, getContentBlocks, streamingActive]);
 
   const canRewindFromMessageIndex = useCallback(
     (userMessageIndex: number) => {

--- a/webview/src/hooks/useSessionManagement.ts
+++ b/webview/src/hooks/useSessionManagement.ts
@@ -223,19 +223,38 @@ export function useSessionManagement({
 
   // Load history session
   const loadHistorySession = useCallback((sessionId: string, provider?: string) => {
-    // [FIX] Send interrupt signal if AI is responding
+    const session = historyDataRef.current?.sessions?.find(s => s.sessionId === sessionId);
+    const effectiveProvider = provider || session?.provider || 'claude';
+
+    // Re-opening the very session already active: don't interrupt the in-flight
+    // turn or wipe the view - just ask the backend to soft-reload the transcript
+    // from the server. The backend sessionLoadCallback detects the same-session
+    // case and routes through reloadActiveSessionMessages (reusing the
+    // session_updated reload path, never interrupting).
+    // Claude only: codex goes through loadCodexSession, which lacks streaming
+    // defer - skipping interrupt there would clearMessages mid-stream and
+    // disturb the live reply.
+    if (sessionId === currentSessionId && effectiveProvider === 'claude') {
+      sendBridgeEvent('load_session', JSON.stringify({
+        sessionId,
+        provider: effectiveProvider,
+      }));
+      setCurrentView('chat');
+      return;
+    }
+
+    // Switching to a different session (or codex same-session): interrupt first
+    // if the AI is mid-reply, then do a full session swap.
     if (loading) {
       sendBridgeEvent('interrupt_session');
     }
-
-    const session = historyDataRef.current?.sessions?.find(s => s.sessionId === sessionId);
     beginSessionTransition(sessionId, session?.title ?? null);
     sendBridgeEvent('load_session', JSON.stringify({
       sessionId,
-      provider: provider || session?.provider || 'claude',
+      provider: effectiveProvider,
     }));
     setCurrentView('chat');
-  }, [beginSessionTransition, loading, setCurrentView]);
+  }, [beginSessionTransition, loading, setCurrentView, currentSessionId]);
 
   // Delete history session
   const deleteHistorySession = useCallback((sessionId: string) => {


### PR DESCRIPTION
Same-session resume used to tear down the active session (interrupt + recreate) even when re-opening the very session already live. It now soft-reloads the transcript via the session_updated reload path with streaming defer, so an in-flight turn is never interrupted.

The status panel's todos/subagents derived only from the latest conversation turn, so a multi-turn history session whose last turn had no task tool rendered empty task and subagent lists. When settled (history replay or idle), the scope now widens to the whole transcript.

Claude only: codex keeps its original interrupt+swap behavior since loadCodexSession lacks streaming-defer protection.