### PR TITLE
fix(session): plug check-then-act race that resurrected the cleared list on new session

### DIFF
--- a/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
@@ -38,6 +38,8 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
     private final StreamDeltaThrottler thinkingDeltaThrottler;
     private final Alarm streamEndFallbackAlarm;
     private volatile boolean active = true;
+    /** Lock making deactivate() atomic with onMessageUpdate()'s active-check-then-enqueue. */
+    private final Object lifecycleLock = new Object();
     /** Guards against duplicate onStreamEnd delivery from dual-path dispatch. */
     private volatile boolean streamEndSignalSent = false;
 
@@ -73,7 +75,9 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
     }
 
     public void deactivate() {
-        active = false;
+        synchronized (lifecycleLock) {
+            active = false;
+        }
         contentDeltaThrottler.dispose();
         thinkingDeltaThrottler.dispose();
         streamEndFallbackAlarm.cancelAllRequests();
@@ -85,10 +89,14 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
 
     @Override
     public void onMessageUpdate(List<ClaudeSession.Message> messages) {
-        if (isInactive()) {
-            return;
+        // Atomic vs deactivate(): a stale-session reload landing mid-transition
+        // must not enqueue with a post-barrier sequence and resurrect the cleared list.
+        synchronized (lifecycleLock) {
+            if (!active) {
+                return;
+            }
+            streamCoalescer.enqueue(messages);
         }
-        streamCoalescer.enqueue(messages);
     }
 
     @Override


### PR DESCRIPTION
SessionCallbackAdapter.onMessageUpdate read the volatile `active` flag and then called streamCoalescer.enqueue() in two separate steps. A background loadFromServer() continuation - triggered by a same-session soft-reload or a session_updated reload still in flight when the user started a new session - could observe active=true, get preempted while the EDT ran deactivate() + resetStreamState(), then resume and enqueue the stale session's messages. That enqueue landed after resetStreamState had bumped the sequence barrier, so it carried a post-barrier sequence and sailed past the frontend's __minAcceptedUpdateSequence guard once the transition guard released, repopulating the message list the user had just cleared.

Guard the active check and the enqueue with lifecycleLock, the same lock deactivate() takes. The two are now mutually exclusive: a stale reload either enqueues before deactivate (and is wiped by the subsequent resetStreamState), or returns after deactivate - it can never enqueue a post-barrier snapshot.