### PR TITLE
fix(webview): stop the watchdog from spinning on a dead CefServer

### DIFF
--- a/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
@@ -725,6 +725,10 @@ public class WebviewInitializer {
     }
 
     private void showJcefNotSupportedPanel(JBCefBrowserFactory.JcefSupportStatus status) {
+        // Terminal state: JCEF is unavailable, so the watchdog has no webview to
+        // monitor. Stop it to avoid spurious recovery cycles after the user
+        // enables JCEF (which requires a restart anyway).
+        host.getWebviewWatchdog().stop();
         String title;
         String solution;
         switch (status) {
@@ -769,10 +773,29 @@ public class WebviewInitializer {
     }
 
     private void showJcefRemoteModeErrorPanel() {
+        // Terminal state: the remote CefServer process is unhealthy, so every
+        // reload/recreate against it will keep throwing the same NPE. Stop the
+        // watchdog so it does not loop back into recreate every cooldown and
+        // re-flash this panel. Recovery requires an IDE restart.
+        host.getWebviewWatchdog().stop();
         JPanel panel = ErrorPanelBuilder.buildCenteredPanel(
             "⚠️",
             ClaudeCodeGuiBundle.message("toolwindow.jcefRemoteError"),
             ClaudeCodeGuiBundle.message("toolwindow.jcefRemoteSolution")
+        );
+        replaceMainContent(panel);
+    }
+
+    /**
+     * Show a generic restart-required panel when webview recovery failed
+     * for non-JCEF-specific reasons (e.g., panel removal, dispose errors).
+     */
+    private void showWebviewRecoveryFailedPanel() {
+        host.getWebviewWatchdog().stop();
+        JPanel panel = ErrorPanelBuilder.buildCenteredPanel(
+            "⚠️",
+            ClaudeCodeGuiBundle.message("toolwindow.jcefRestartRequired"),
+            ClaudeCodeGuiBundle.message("toolwindow.jcefRestartRequiredSolution")
         );
         replaceMainContent(panel);
     }
@@ -968,6 +991,14 @@ public class WebviewInitializer {
                 mainPanel.repaint();
             } catch (Exception e) {
                 LOG.warn("[WebviewWatchdog] Recreate failed: " + e.getMessage(), e);
+                // An exception reaching here escaped createUIComponents' internal
+                // handler (which already routes JCEF remote NPEs to the restart
+                // panel). mainPanel was already cleared above, so without a
+                // terminal panel the tab would be left permanently blank.
+                // Use a generic restart panel instead of JCEF-remote-specific,
+                // since the error could be from remove/dispose/revalidate rather
+                // than JCEF itself.
+                showWebviewRecoveryFailedPanel();
             }
         });
     }

--- a/src/main/java/com/github/claudecodegui/ui/WebviewWatchdog.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewWatchdog.java
@@ -219,7 +219,14 @@ public class WebviewWatchdog {
                 mainPanel.revalidate();
                 mainPanel.repaint();
             } catch (Exception e) {
-                LOG.warn("[WebviewWatchdog] Reload failed: " + e.getMessage(), e);
+                LOG.warn("[WebviewWatchdog] Reload failed, escalating to recreate: " + e.getMessage(), e);
+                // A reload that throws under an already-stalled webview almost
+                // always means the shared CefServer process is unhealthy. Waiting
+                // another full heartbeat timeout for the next checkHealth cycle
+                // only prolongs the dead screen - escalate straight to recreate,
+                // which either recovers (fresh browser on a recovering CefServer)
+                // or lands on the terminal JCEF restart panel.
+                onRecreateWebview.run();
             }
         });
     }


### PR DESCRIPTION
When JCEF becomes unavailable or the webview recovery keeps failing, the watchdog would previously keep scheduling reloads/recreates on every cooldown, leading to repeated error flashes and a dead UI.

Changes:
- Stop the watchdog in showJcefNotSupportedPanel and showJcefRemoteModeErrorPanel (terminal states requiring restart)
- Escalate from reload failure to recreate in WebviewWatchdog.reload when loadHTML throws, instead of just logging
- Add a generic showWebviewRecoveryFailedPanel for non-JCEF-specific recreate failures (e.g., dispose/remove errors), avoiding misleading "JCEF remote mode error" labeling
- Ensure recreateWebview's outer catch shows a restart panel and stops the watchdog, preventing a permanently blank tab

These changes ensure that once JCEF is confirmed dead or recovery has failed, the watchdog stops retrying and the user sees a clear restart prompt instead of a blank or cycling UI.