### PR TITLE
feat: teach the frontend to track async subagents so they don't wander off into the void

### DIFF
--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -157,6 +157,18 @@ function processStreamMessage(msg, state, logPrefix) {
     state.streamStarted = true;
   }
 
+  // Subagent (sidechain) messages carry a non-null parent_tool_use_id pointing
+  // at the main turn's Agent/Task tool_use. Their detailed thinking and tool
+  // calls belong to the sidechain transcript, which the frontend loads
+  // separately via onSubagentHistoryLoaded - so never emit them into the main
+  // session stream, otherwise the subagent's internals pollute the main chat.
+  // Mirrors the parent_tool_use_id gate in persistent-query-service.js, which is
+  // the active path in daemon mode; this branch covers the non-daemon CLI path
+  // (channel-manager.js) and tests, keeping both stream routes consistent.
+  if (msg?.parent_tool_use_id) {
+    return;
+  }
+
   // Handle stream_event type (streaming deltas from SDK)
   if (state.streamingEnabled && msg.type === 'stream_event') {
     state.hasStreamEvents = true;

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -249,7 +249,7 @@ const _sessionCleanupTimer = setInterval(async () => {
 // unref() so the timer does not prevent natural process exit
 _sessionCleanupTimer.unref();
 
-async function executeTurn(runtime, requestContext, turnMeta) {
+  async function executeTurn(runtime, requestContext, turnMeta) {
   if (!runtime || runtime.closed) {
     const err = new Error('Runtime is closed');
     err.runtimeTerminated = true;
@@ -301,6 +301,16 @@ async function executeTurn(runtime, requestContext, turnMeta) {
         turnState.streamStarted = true;
       }
 
+      // Subagent (sidechain) messages carry a non-null parent_tool_use_id pointing
+      // at the main turn's Agent/Task tool_use. Their detailed thinking and tool
+      // calls belong to the sidechain transcript, which the frontend loads
+      // separately via onSubagentHistoryLoaded - so never emit them into the main
+      // session stream, otherwise the subagent's internals pollute the main chat.
+      // task_notification (type:'system') has no parent_tool_use_id and is preserved.
+      if (msg?.parent_tool_use_id) {
+        continue;
+      }
+
       if (msg?.type === 'stream_event' && turnState.streamingEnabled) {
         turnState.hasStreamEvents = true;
         processStreamEvent(msg, turnState);
@@ -331,6 +341,16 @@ async function executeTurn(runtime, requestContext, turnMeta) {
         if (msg.is_error) {
           throw new Error(msg.result || msg.message || 'API request failed');
         }
+        // A task_notification for a background (run_in_background) Agent that
+        // settles AFTER this result cannot ride the in-turn [MESSAGE] stream:
+        // executeTurn breaks here and clears turnSink in the finally below
+        // (synchronously, before the perpetual reader's next query.next()
+        // resolves), so the perpetual reader routes that late event to the
+        // inter-turn daemon path (emitTaskEvent -> DaemonBridge "task_event"
+        // -> window.onTaskEvent). task_notification that settles BEFORE the
+        // result is still processed above in the in-turn [MESSAGE] stream.
+        // Both paths converge on window.onTaskEvent, which dedups by
+        // tool_use_id + observable fields - see DaemonBridge.handleDaemonEvent.
         break;
       }
     }

--- a/ai-bridge/services/claude/runtime-lifecycle.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.js
@@ -250,7 +250,7 @@ async function createRuntime(requestContext, callbacks) {
  */
 export function startPerpetualReader(runtime, callbacks) {
   /**
-   * Emit an inter-turn event using daemon.js's writeRawLine mechanism.
+   * Emit an inter-turn daemon event using daemon.js's writeRawLine mechanism.
    *
    * IMPORTANT: Must bypass activeRequestId interception to avoid misrouting.
    *
@@ -258,33 +258,49 @@ export function startPerpetualReader(runtime, callbacks) {
    * - daemon.js intercepts process.stdout.write and wraps output with activeRequestId
    * - If we used console.log() here, the event would be tagged with whatever request
    *   is currently active (possibly from a different session)
-   * - This would cause the session_updated event to be delivered to the wrong session
+   * - This would cause the event to be delivered to the wrong session
    * - writeRawLine (_originalStdoutWrite) bypasses the interception layer and outputs
    *   directly to stdout, ensuring the event is process-level and not request-scoped
    *
-   * The event format {type: 'daemon', event: 'session_updated', sessionId} is recognized
+   * The event format {type: 'daemon', event, sessionId, ...payload} is recognized
    * by Java's DaemonBridge.handleDaemonEvent() which routes it to registered listeners.
    */
-  const emitInterTurnEvent = (sessionId) => {
+  const emitDaemonEvent = (event, sessionId, payload = {}) => {
     try {
-      // Access the global writeRawLine from daemon.js
-      // daemon.js stores the original stdout.write as _originalStdoutWrite
-      // We must use _originalStdoutWrite to bypass activeRequestId wrapping
+      // daemon.js stores the original stdout.write as _originalStdoutWrite.
+      // We must use _originalStdoutWrite to bypass activeRequestId wrapping.
       const originalWrite = process.stdout._originalStdoutWrite;
       if (!originalWrite) {
-        console.error('[PERPETUAL_READER] _originalStdoutWrite not available (daemon.js not initialized?), cannot emit session_updated event');
+        console.error(`[PERPETUAL_READER] _originalStdoutWrite not available (daemon.js not initialized?), cannot emit ${event} event`);
         return;
       }
-      const eventPayload = {
-        type: 'daemon',
-        event: 'session_updated',
-        sessionId: sessionId
-      };
+      const eventPayload = { type: 'daemon', event, sessionId, ...payload };
       originalWrite.call(process.stdout, JSON.stringify(eventPayload) + '\n', 'utf8');
     } catch (err) {
-      console.error('[PERPETUAL_READER] Failed to emit session_updated event:', err);
+      console.error(`[PERPETUAL_READER] Failed to emit ${event} event:`, err);
     }
   };
+
+  const emitInterTurnEvent = (sessionId) => emitDaemonEvent('session_updated', sessionId);
+
+  // Forward a task_* SDK system event (async subagent lifecycle) to Java as a
+  // daemon event. This is the inter-turn delivery path for a task_notification
+  // that settles AFTER the turn's result: executeTurn breaks on the result and
+  // clears turnSink (in its finally) before the perpetual reader's next
+  // query.next() resolves, so the late event arrives with turnSink already
+  // null and the in-turn [MESSAGE] stream cannot carry it. Without this
+  // forward, that late event is silently dropped and the frontend subagent
+  // list stays stuck on "running" until a manual reload.
+  //
+  // A task_notification that settles BEFORE the turn's result is still pushed
+  // to turnSink while it is live, so executeTurn processes it via the in-turn
+  // [MESSAGE] stream (ClaudeMessageHandler.handleSystemMessage ->
+  // notifyTaskEvent). Both paths converge on window.onTaskEvent, which dedups
+  // by tool_use_id + observable fields - see DaemonBridge.handleDaemonEvent
+  // for the defense-in-depth rationale. Do NOT delete either path without
+  // confirming at runtime which one a given task_notification takes.
+  const emitTaskEvent = (sessionId, taskMsg) =>
+    emitDaemonEvent('task_event', sessionId, { taskEvent: taskMsg });
 
   // Start the perpetual reader loop; return the promise so callers (and tests)
   // can await its completion.
@@ -342,6 +358,29 @@ export function startPerpetualReader(runtime, callbacks) {
             } else {
               // Anonymous runtime - silently consume
               console.log('[PERPETUAL_READER] Inter-turn result for anonymous runtime, consuming silently');
+            }
+          }
+          // task_* SDK system events (async subagent lifecycle) that reach
+          // this inter-turn branch are the late ones - they settle AFTER the
+          // turn's result, by which point executeTurn has already exited and
+          // cleared turnSink, so they could not ride the in-turn [MESSAGE]
+          // stream. A task_notification that settles BEFORE the result is
+          // pushed to turnSink while it is still live, so executeTurn emits
+          // it in-turn and it never reaches this branch. Forward the late
+          // ones to Java so the frontend subagent list can mark the agent
+          // done instead of staying stuck on "running" until a manual reload.
+          // Other inter-turn message types are still silently consumed
+          // (already persisted to JSONL by the CLI).
+          if (msg?.type === 'system' && typeof msg.subtype === 'string' && msg.subtype.startsWith('task_')) {
+            // Mirror emitInterTurnEvent's sessionId guard: anonymous runtimes
+            // (no session_id yet) have no Java listener to claim the event, so
+            // emitting {sessionId: null} only wastes a cross-process hop and
+            // risks JsonNull handling on the Java side. Silently consume instead.
+            if (runtime.sessionId) {
+              console.log('[PERPETUAL_READER] Inter-turn task_* event for sessionId=' + runtime.sessionId + ', subtype=' + msg.subtype);
+              emitTaskEvent(runtime.sessionId, msg);
+            } else {
+              console.log('[PERPETUAL_READER] Inter-turn task_* event for anonymous runtime, consuming silently (subtype=' + msg.subtype + ')');
             }
           }
           // For other message types during inter-turn, we silently consume

--- a/src/main/java/com/github/claudecodegui/handler/history/SubagentHistoryService.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/SubagentHistoryService.java
@@ -66,6 +66,7 @@ class SubagentHistoryService {
 
             JsonArray messages = readJsonl(file);
             response.addProperty("success", true);
+            response.addProperty("completed", hasCompleted(messages));
             response.add("messages", messages);
         } catch (Exception e) {
             LOG.warn("[SubagentHistory] Failed to load subagent log: " + e.getMessage());
@@ -180,6 +181,31 @@ class SubagentHistoryService {
                     });
         }
         return messages;
+    }
+
+    static boolean hasCompleted(JsonArray messages) {
+        for (int i = messages.size() - 1; i >= 0; i--) {
+            if (!messages.get(i).isJsonObject()) {
+                continue;
+            }
+            JsonObject record = messages.get(i).getAsJsonObject();
+            if (!"assistant".equals(getString(record, "type"))
+                    || !record.has("message") || !record.get("message").isJsonObject()) {
+                continue;
+            }
+            JsonObject message = record.getAsJsonObject("message");
+            String stopReason = getString(message, "stop_reason");
+            // The sidechain's last assistant stop_reason is the only persisted
+            // completion signal (task_notification is a live event, not stored).
+            // tool_use means the agent is still mid-turn (waiting on a tool
+            // result); a null/missing value means streaming/incomplete. Any
+            // other value (end_turn, stop_sequence, max_tokens, pause_turn,
+            // refusal) means the agent's turn ended - treat it as terminal so
+            // the UI does not stay stuck on "running" after a max_tokens or
+            // refusal termination, which would reproduce the bug this fixes.
+            return stopReason != null && !"tool_use".equals(stopReason);
+        }
+        return false;
     }
 
     private void sendResponse(JsonObject response) {

--- a/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
@@ -644,6 +644,37 @@ public class DaemonBridge {
                 break;
             }
 
+            case "task_event": {
+                // Async subagent lifecycle event (task_notification for a
+                // background Agent invoked with run_in_background:true). Emitted
+                // by the ai-bridge perpetual reader's inter-turn branch; dispatch
+                // to listeners exactly like session_updated so ClaudeChatWindow
+                // can forward it to the frontend.
+                //
+                // Dual delivery path (intentional defense-in-depth): task_* may
+                // ALSO reach the frontend in-turn via the [MESSAGE] stream
+                // (ClaudeMessageHandler.handleSystemMessage -> notifyTaskEvent),
+                // depending on whether the SDK drains task_notification before or
+                // after the turn's result. Both paths converge on
+                // SessionCallbackAdapter.onTaskEvent -> window.onTaskEvent, where
+                // registerCallbacks.ts dedups by tool_use_id + observable fields,
+                // so a duplicate delivery is a no-op rather than a double update.
+                // Do NOT delete either path without first confirming at runtime
+                // which is active (enable LOG.debug below + ai-bridge's
+                // [PERPETUAL_READER] Inter-turn log to verify).
+                String taskSessionId = obj.has("sessionId") && obj.get("sessionId").isJsonPrimitive()
+                        ? obj.get("sessionId").getAsString() : "?";
+                LOG.debug("[DaemonBridge] task_event received: sessionId=" + taskSessionId);
+                for (DaemonEventListener listener : eventListeners) {
+                    try {
+                        listener.onDaemonEvent(event, obj);
+                    } catch (Exception ex) {
+                        LOG.warn("[DaemonBridge] Listener threw while handling " + event, ex);
+                    }
+                }
+                break;
+            }
+
             default:
                 LOG.debug("[DaemonBridge] Unhandled daemon event: " + event);
         }

--- a/src/main/java/com/github/claudecodegui/session/CallbackHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/CallbackHandler.java
@@ -157,4 +157,14 @@ public class CallbackHandler {
             callback.onUserMessageUuidPatched(content, uuid);
         }
     }
+
+    /**
+     * Notify of a Claude Code task_* SDK system event (task_started /
+     * task_progress / task_notification).
+     */
+    public void notifyTaskEvent(String eventJson) {
+        if (callback != null) {
+            callback.onTaskEvent(eventJson);
+        }
+    }
 }

--- a/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
@@ -663,11 +663,39 @@ public class ClaudeMessageHandler implements MessageCallback {
      * Handle a system-level message (not from AI, but from the system).
      */
     private void handleSystemMessage(String content) {
-        LOG.debug("System message: " + content);
+        // Truncate to avoid dumping full system messages (which may carry
+        // slash_commands or task_notification payloads) into the IDE log.
+        LOG.debug("System message: " + (content.length() > 200 ? content.substring(0, 200) + "..." : content));
 
         // Parse slash_commands field from the system message
         try {
             JsonObject systemObj = gson.fromJson(content, JsonObject.class);
+            // gson.fromJson returns null for a JSON "null" literal; guard the
+            // has()/get() calls below against NPE. In practice [MESSAGE]
+            // payloads are always JSON objects, but keep the parse defensive.
+            if (systemObj == null) {
+                return;
+            }
+
+            // Forward task_* SDK system events (async subagent lifecycle) to the
+            // frontend. Async agents run in a background sidechain whose detailed
+            // messages never enter the main stream; the only mainstream signal of
+            // their existence is these lightweight events (task_started /
+            // task_progress / task_notification). Without forwarding, the subagent
+            // list cannot tell launch from completion, and async results vanish.
+            //
+            // This is the in-turn [MESSAGE] delivery path. task_notification may
+            // also arrive inter-turn via the daemon channel (DaemonBridge
+            // "task_event" -> ClaudeChatWindow -> onTaskEvent); both paths are
+            // intentional defense-in-depth - see DaemonBridge.handleDaemonEvent.
+            String subtype = systemObj.has("subtype") && !systemObj.get("subtype").isJsonNull()
+                    ? systemObj.get("subtype").getAsString() : null;
+            if (subtype != null && subtype.startsWith("task_")) {
+                callbackHandler.notifyTaskEvent(content);
+                // task_* events carry no slash_commands; skip the rest.
+                return;
+            }
+
             if (systemObj.has("slash_commands") && systemObj.get("slash_commands").isJsonArray()) {
                 JsonArray commandsArray = systemObj.getAsJsonArray("slash_commands");
                 List<String> commands = new ArrayList<>();
@@ -679,7 +707,7 @@ public class ClaudeMessageHandler implements MessageCallback {
                 callbackHandler.notifySlashCommandsReceived(commands);
             }
         } catch (Exception e) {
-            LOG.warn("Failed to extract slash commands from system message: " + e.getMessage());
+            LOG.warn("Failed to parse system message: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
@@ -131,6 +131,21 @@ public class ClaudeSession {
 
         default void onUserMessageUuidPatched(String content, String uuid) {
         }
+
+        /**
+         * Called when a Claude Code task_* SDK system event is received
+         * (task_started / task_progress / task_notification).
+         *
+         * <p>Async subagents (Agent/Task tool invoked with run_in_background:true) run
+         * in a background sidechain whose detailed
+         * messages never enter the main SDK stream. The main stream only carries these
+         * lightweight system events, which carry the agent's lifecycle signals: launch,
+         * per-tool progress, and terminal completion (with result + usage). Forwarding
+         * them to the frontend lets the subagent list reflect real running/completed
+         * state instead of being stuck on the launch summary.</p>
+         */
+        default void onTaskEvent(String eventJson) {
+        }
     }
 
     public ClaudeSession(Project project, ClaudeSDKBridge claudeSDKBridge, CodexSDKBridge codexSDKBridge) {

--- a/src/main/java/com/github/claudecodegui/session/MessageParser.java
+++ b/src/main/java/com/github/claudecodegui/session/MessageParser.java
@@ -24,6 +24,19 @@ public class MessageParser {
             return null;
         }
 
+        // Filter out sidechain messages (subagent transcripts) so they never
+        // enter the main session list. This mirrors the isSidechain filter
+        // ClaudeSessionLiteReader applies on history reload, keeping reloaded
+        // history consistent with the live stream (whose subagent messages are
+        // already filtered upstream by ai-bridge's parent_tool_use_id check).
+        // parseServerMessage runs on the history-reload path, so this is a
+        // defense-in-depth guard against any isSidechain-tagged entry slipping
+        // through into the rendered chat.
+        if (msg.has("isSidechain") && !msg.get("isSidechain").isJsonNull()
+                && msg.get("isSidechain").getAsBoolean()) {
+            return null;
+        }
+
         // Filter out command messages - only for user messages
         // Assistant messages may contain these tags in code examples.
         // Use rawMessage (not msg) so a normalized history envelope, whose "message"

--- a/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
@@ -380,6 +380,19 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         jsTarget.callJavaScript("patchMessageUuid", JsUtils.escapeJs(content), JsUtils.escapeJs(uuid));
     }
 
+    @Override
+    public void onTaskEvent(String eventJson) {
+        if (isInactive() || eventJson == null || eventJson.trim().isEmpty()) {
+            return;
+        }
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (isInactive()) {
+                return;
+            }
+            jsTarget.callJavaScript("onTaskEvent", JsUtils.escapeJs(eventJson));
+        });
+    }
+
     /**
      * Dispose internal resources. Call when the parent window is disposed.
      */

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -110,7 +110,13 @@ public class ClaudeChatWindow {
     private WebviewInitializer webviewInitializer;
     private final EditorContextTracker editorContextTracker;
     private final ChatWindowDelegate chatWindowDelegate;
-    private SessionCallbackAdapter sessionCallbackAdapter;
+    // volatile: read from the daemon reader thread by the task_event listener
+    // (titleEventListener), while reassigned on the EDT in setupSessionCallbacks.
+    // Without volatile a session switch could publish a new adapter on the EDT
+    // that the daemon thread never observes, so a late task_notification would
+    // route to the deactivated adapter and be dropped - leaving the subagent
+    // stuck on "running".
+    private volatile SessionCallbackAdapter sessionCallbackAdapter;
 
     public ClaudeChatWindow(Project project) {
         this(project, false);
@@ -850,6 +856,36 @@ public class ClaudeChatWindow {
                     // loadFromServer() returns, so a reload never lands on a session
                     // that the user has navigated away from.
                     requestSessionReload(updatedSessionId);
+                } else if ("task_event".equals(event)) {
+                    // Async subagent (Agent/Task tool with run_in_background:true)
+                    // lifecycle event forwarded by the
+                    // ai-bridge perpetual reader. task_notification arrives inter-turn
+                    // (after the turn's result), so it cannot ride the normal [MESSAGE]
+                    // stream -- route it to the frontend via onTaskEvent so the subagent
+                    // list reflects completion/usage instead of staying on "running".
+                    String taskSessionId = data.has("sessionId") && data.get("sessionId").isJsonPrimitive()
+                            ? data.get("sessionId").getAsString() : null;
+                    if (taskSessionId == null) {
+                        LOG.warn("[ClaudeChatWindow] task_event event missing sessionId");
+                        return;
+                    }
+                    // Mirror session_updated's guard: drop events that do not match the
+                    // active session so a stale background-agent completion cannot leak
+                    // into a session the user has since navigated to. Capture the
+                    // adapter into a local before the session check: session and
+                    // sessionCallbackAdapter are both volatile and reassigned on the EDT,
+                    // so reading them separately could route an old-session event to a
+                    // newly activated adapter. The captured adapter's onTaskEvent
+                    // re-checks isInactive(), so if the session switched after the
+                    // snapshot the delivery is skipped.
+                    var adapter = sessionCallbackAdapter;
+                    String currentSessionId = session != null ? session.getSessionId() : null;
+                    if (currentSessionId == null || !currentSessionId.equals(taskSessionId)) {
+                        return;
+                    }
+                    if (adapter != null && data.has("taskEvent") && !data.get("taskEvent").isJsonNull()) {
+                        adapter.onTaskEvent(data.get("taskEvent").toString());
+                    }
                 }
             };
             this.claudeSDKBridge.addDaemonEventListener(this.titleEventListener);

--- a/src/main/java/com/github/claudecodegui/util/MessageJsonConverter.java
+++ b/src/main/java/com/github/claudecodegui/util/MessageJsonConverter.java
@@ -7,10 +7,12 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.ui.jcef.JBCefBrowser;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -163,12 +165,7 @@ public class MessageJsonConverter {
                 if (c.isJsonPrimitive() && c.getAsJsonPrimitive().isString()) {
                     String s = c.getAsString();
                     if (s.length() > MAX_TOOL_RESULT_CHARS) {
-                        int head = (int) Math.floor(MAX_TOOL_RESULT_CHARS * 0.65);
-                        int tail = MAX_TOOL_RESULT_CHARS - head;
-                        String prefix = s.substring(0, Math.min(head, s.length()));
-                        String suffix = tail > 0 ? s.substring(Math.max(0, s.length() - tail)) : "";
-                        String truncated = prefix + "\n...\n(truncated, original length: " + s.length() + " chars)\n...\n" + suffix;
-                        block.addProperty("content", truncated);
+                        block.addProperty("content", truncateString(s));
                     }
                 }
             }
@@ -208,6 +205,11 @@ public class MessageJsonConverter {
         // would be misleading if rendered per message.
         copyFieldIfPresent(raw, transport, "turnUsage");
         copyFieldIfPresent(raw, transport, "turnCostUsd");
+        // Agent/Task tool metadata (agentId, totalDurationMs, totalTokens,
+        // toolStats, ...) stamped by the SDK on tool_result messages. The
+        // frontend's SubagentList / AgentGroupBlock read this to render
+        // subagent usage and status; without it sync subagents show no metadata.
+        copyToolUseResultIfPresent(raw, transport);
 
         if (raw.has("content")) {
             transport.add("content", raw.get("content").deepCopy());
@@ -248,6 +250,74 @@ public class MessageJsonConverter {
         if (source.has(fieldName)) {
             target.add(fieldName, source.get(fieldName).deepCopy());
         }
+    }
+
+    /**
+     * Copy the toolUseResult metadata field, truncating any oversized string
+     * values so a chatty subagent result cannot blow up the transport payload.
+     * The SDK may stamp toolUseResult as a raw error string, a usage object, or
+     * an object holding nested arrays of content blocks, so truncation must
+     * walk every shape rather than only the top-level object.
+     */
+    private static void copyToolUseResultIfPresent(JsonObject source, JsonObject target) {
+        if (!source.has("toolUseResult") || source.get("toolUseResult").isJsonNull()) {
+            return;
+        }
+        JsonElement toolUseResult = source.get("toolUseResult").deepCopy();
+        target.add("toolUseResult", truncateStringFields(toolUseResult));
+    }
+
+    /**
+     * Recursively truncate oversized strings inside any JSON shape (primitive,
+     * object, or array) so no single field can exceed the transport budget.
+     */
+    private static JsonElement truncateStringFields(JsonElement el) {
+        if (el == null || el.isJsonNull()) {
+            return el;
+        }
+        if (el.isJsonPrimitive()) {
+            JsonPrimitive primitive = el.getAsJsonPrimitive();
+            if (primitive.isString()) {
+                String s = primitive.getAsString();
+                return s.length() > MAX_TOOL_RESULT_CHARS
+                        ? new JsonPrimitive(truncateString(s)) : el;
+            }
+            // Non-string primitives (number, boolean) pass through unchanged.
+            return el;
+        }
+        if (el.isJsonObject()) {
+            JsonObject obj = el.getAsJsonObject();
+            for (String key : new ArrayList<>(obj.keySet())) {
+                obj.add(key, truncateStringFields(obj.get(key)));
+            }
+            return obj;
+        }
+        if (el.isJsonArray()) {
+            JsonArray arr = el.getAsJsonArray();
+            for (int i = 0; i < arr.size(); i++) {
+                arr.set(i, truncateStringFields(arr.get(i)));
+            }
+            return arr;
+        }
+        return el;
+    }
+
+    /**
+     * Truncate a string to fit within {@link #MAX_TOOL_RESULT_CHARS}, preserving
+     * both the head and the tail and inserting a marker that records the original
+     * length. The marker's overhead is reserved up front so the returned string
+     * never exceeds the budget (naive head/tail split ignores the marker and can
+     * overshoot by the marker length).
+     */
+    private static String truncateString(String s) {
+        if (s.length() <= MAX_TOOL_RESULT_CHARS) {
+            return s;
+        }
+        String marker = "\n...\n(truncated, original length: " + s.length() + " chars)\n...\n";
+        int available = Math.max(0, MAX_TOOL_RESULT_CHARS - marker.length());
+        int head = available * 2 / 3;
+        int tail = available - head;
+        return s.substring(0, head) + marker + s.substring(s.length() - tail);
     }
 
     /**

--- a/src/test/java/com/github/claudecodegui/handler/history/SubagentHistoryServiceCompletionTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/history/SubagentHistoryServiceCompletionTest.java
@@ -1,0 +1,92 @@
+package com.github.claudecodegui.handler.history;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParser;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SubagentHistoryServiceCompletionTest {
+
+    private static JsonArray messages(String... records) {
+        JsonArray result = new JsonArray();
+        for (String record : records) {
+            result.add(JsonParser.parseString(record));
+        }
+        return result;
+    }
+
+    @Test
+    public void completedWhenLastAssistantStopsAtEndTurn() {
+        JsonArray history = messages(
+                "{\"type\":\"assistant\",\"message\":{\"stop_reason\":\"tool_use\"}}",
+                "{\"type\":\"user\",\"message\":{\"content\":[]}}",
+                "{\"type\":\"assistant\",\"message\":{\"stop_reason\":\"end_turn\"}}"
+        );
+
+        assertTrue(SubagentHistoryService.hasCompleted(history));
+    }
+
+    @Test
+    public void unfinishedWhenLastAssistantIsStillUsingTools() {
+        JsonArray history = messages(
+                "{\"type\":\"assistant\",\"message\":{\"stop_reason\":\"tool_use\"}}",
+                "{\"type\":\"user\",\"message\":{\"content\":[]}}"
+        );
+
+        assertFalse(SubagentHistoryService.hasCompleted(history));
+    }
+
+    @Test
+    public void unfinishedWhenLastAssistantIsPartialThinking() {
+        JsonArray history = messages(
+                "{\"type\":\"assistant\",\"message\":{\"stop_reason\":\"tool_use\"}}",
+                "{\"type\":\"assistant\",\"message\":{\"stop_reason\":null}}"
+        );
+
+        assertFalse(SubagentHistoryService.hasCompleted(history));
+    }
+
+    @Test
+    public void ignoresNonAssistantRecordsAfterTerminalAssistant() {
+        JsonArray history = messages(
+                "{\"type\":\"assistant\",\"message\":{\"stop_reason\":\"end_turn\"}}",
+                "{\"type\":\"progress\"}"
+        );
+
+        assertTrue(SubagentHistoryService.hasCompleted(history));
+    }
+
+    @Test
+    public void completedWhenLastAssistantStopsAtMaxTokens() {
+        // A background agent that hits the token limit has still terminated;
+        // treating max_tokens as not-completed would leave the UI stuck on
+        // "running", reproducing the bug this class exists to fix.
+        JsonArray history = messages(
+                "{\"type\":\"assistant\",\"message\":{\"stop_reason\":\"tool_use\"}}",
+                "{\"type\":\"user\",\"message\":{\"content\":[]}}",
+                "{\"type\":\"assistant\",\"message\":{\"stop_reason\":\"max_tokens\"}}"
+        );
+
+        assertTrue(SubagentHistoryService.hasCompleted(history));
+    }
+
+    @Test
+    public void completedWhenLastAssistantStopsAtRefusal() {
+        JsonArray history = messages(
+                "{\"type\":\"assistant\",\"message\":{\"stop_reason\":\"refusal\"}}"
+        );
+
+        assertTrue(SubagentHistoryService.hasCompleted(history));
+    }
+
+    @Test
+    public void completedWhenLastAssistantStopsAtPauseTurn() {
+        JsonArray history = messages(
+                "{\"type\":\"assistant\",\"message\":{\"stop_reason\":\"pause_turn\"}}"
+        );
+
+        assertTrue(SubagentHistoryService.hasCompleted(history));
+    }
+}

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -31,7 +31,7 @@ import { ToastContainer } from './components/Toast';
 import { ChatHeader } from './components/ChatHeader';
 import { ChatScreen } from './components/ChatScreen';
 import type { MessageListRevealHandle } from './components/ConversationSearch/types';
-import { useSubagentContextValues } from './contexts/SubagentContext';
+import { useSubagentContextValues, useSetTaskEvents } from './contexts/SubagentContext';
 import { useMessages } from './contexts/MessagesContext';
 import { useSession } from './contexts/SessionContext';
 import { useUIState } from './contexts/UIStateContext';
@@ -70,6 +70,10 @@ const App = () => {
     setIsThinking,
     streamingActive, setStreamingActive,
   } = useMessages();
+
+  // task_events live in TaskEventProvider (SubagentContext) so their updates do
+  // not re-render every MessagesContext consumer.
+  const setTaskEvents = useSetTaskEvents();
 
   // ── Session state (extracted to SessionContext, stage 2 of TASK-P1-01) ──
   const {
@@ -263,6 +267,8 @@ const App = () => {
     setHistoryData, setMessages, setCurrentView, setCurrentSessionId,
     setCustomSessionTitle, setUsagePercentage, setUsageUsedTokens, setUsageMaxTokens,
     setStatus, setLoading, setIsThinking, setStreamingActive,
+    setTaskEvents,
+    setSubagentHistories,
     clearToasts, addToast, t,
   });
 
@@ -283,6 +289,7 @@ const App = () => {
     setIsRewinding, setRewindDialogOpen, setCurrentRewindRequest,
     setContextInfo, setSelectedAgent,
     setSubagentHistories,
+    setTaskEvents,
     currentProviderRef, messagesContainerRef, isUserAtBottomRef, userPausedRef,
     suppressNextStatusToastRef,
     streamingContentRef, streamingThinkingRef, isStreamingRef, useBackendStreamingRenderRef,
@@ -387,7 +394,7 @@ const App = () => {
     fileChangeMgmt,
     filteredFileChanges, subagents, globalTodos, rewindableMessages, sessionTitle,
   } = useChatComputations({
-    t, messages, mergedMessages, customSessionTitle, streamingActive, currentProvider,
+    t, messages, mergedMessages, subagentHistories, customSessionTitle, streamingActive, currentProvider,
     currentSessionId, currentSessionIdRef,
     getMessageText, getContentBlocks,
   });

--- a/webview/src/components/ChatScreen.tsx
+++ b/webview/src/components/ChatScreen.tsx
@@ -25,7 +25,7 @@ import type { ClaudeMessage, TodoItem, ToolResultBlock } from '../types';
 import type { useMessageProcessing, useFileChanges, useSubagents, useFileChangesManagement, useModelProviderState, useMessageQueue } from '../hooks';
 import type { GetToolResultRawFn } from '../contexts/SubagentContext';
 
-type SubagentHistoryGetter = (key: string) => ReturnType<typeof useMessages>['subagentHistories'][string] | undefined;
+type SubagentHistoryMap = ReturnType<typeof useMessages>['subagentHistories'];
 type ProviderState = ReturnType<typeof useModelProviderState>;
 type MessageQueueValue = ReturnType<typeof useMessageQueue>['queue'];
 type SubagentList = ReturnType<typeof useSubagents>;
@@ -44,7 +44,7 @@ export interface ChatScreenProps {
   subagents: SubagentList;
   globalTodos: TodoItem[];
   filteredFileChanges: FileChangeList;
-  subagentHistoryCtxValue: SubagentHistoryGetter;
+  subagentHistoryCtxValue: SubagentHistoryMap;
   sessionIdCtxValue: { currentSessionId: string | null };
 
   // Refs

--- a/webview/src/components/StatusPanel/SubagentList.tsx
+++ b/webview/src/components/StatusPanel/SubagentList.tsx
@@ -64,7 +64,7 @@ const SubagentRow = memo(({ subagent, isExpanded, history, canLoad, onToggle, t 
 
 SubagentRow.displayName = 'SubagentRow';
 
-const SubagentList = memo(({ subagents, histories = {}, currentSessionId, isStreaming = false }: SubagentListProps) => {
+const SubagentList = memo(({ subagents, histories = {}, currentSessionId }: SubagentListProps) => {
   const { t } = useTranslation();
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
@@ -85,6 +85,11 @@ const SubagentList = memo(({ subagents, histories = {}, currentSessionId, isStre
     }));
   }, [currentSessionId]);
 
+  // Track the expanded row's status so the polling effect re-runs (and clears
+  // its interval) when it transitions out of "running", instead of leaving a
+  // no-op interval firing every 2 s until the row is collapsed.
+  const expandedStatus = subagents.find((item) => item.id === expandedId)?.status;
+
   useEffect(() => {
     if (!expandedId) return;
     const subagent = subagentsRef.current.find((item) => item.id === expandedId);
@@ -92,14 +97,14 @@ const SubagentList = memo(({ subagents, histories = {}, currentSessionId, isStre
     if (!historiesRef.current[expandedId]) {
       requestHistory(subagent);
     }
-    if (!isStreaming || subagent.status !== 'running') return;
+    if (!currentSessionId || subagent.status !== 'running') return;
     const timer = window.setInterval(() => {
       const current = subagentsRef.current.find((item) => item.id === expandedId);
       if (!current || current.status !== 'running') return;
       requestHistory(current);
     }, 2_000);
     return () => window.clearInterval(timer);
-  }, [currentSessionId, expandedId, isStreaming, requestHistory]);
+  }, [currentSessionId, expandedId, requestHistory, expandedStatus]);
 
   const historyById = useMemo(() => histories, [histories]);
 

--- a/webview/src/components/toolBlocks/AgentGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/AgentGroupBlock.tsx
@@ -4,7 +4,8 @@ import type { ClaudeContentBlock, ToolResultBlock } from '../../types';
 import { normalizeToolName } from '../../utils/toolConstants';
 import { sendBridgeEvent } from '../../utils/bridge';
 import { getPersistedExpanded, setPersistedExpanded } from '../../utils/expandedState';
-import { useSubagentHistoryGetter, useSessionId, useGetToolResultRaw, type GetToolResultRawFn } from '../../contexts/SubagentContext';
+import { extractResultText, isAsyncAgentInput, parseAgentToolMeta } from '../../utils/subagentResult';
+import { useSubagentHistories, useSessionId, useGetToolResultRaw, useTaskEvent } from '../../contexts/SubagentContext';
 import SubagentProcessDetails from '../StatusPanel/SubagentProcessDetails';
 import { ContentBlockRenderer } from '../MessageItem/ContentBlockRenderer';
 
@@ -38,37 +39,6 @@ function getAgentType(block: ClaudeContentBlock): string {
   return typeof t === 'string' ? t : '';
 }
 
-function extractResultText(result?: ToolResultBlock | null): string | undefined {
-  if (!result) return undefined;
-  if (typeof result.content === 'string') return result.content;
-  if (Array.isArray(result.content)) {
-    return result.content
-      .filter((item): item is { type: string; text: string } => item?.type === 'text' && typeof item.text === 'string')
-      .map((item) => item.text)
-      .join('\n') || undefined;
-  }
-  return undefined;
-}
-
-function parseAgentToolMeta(
-  getToolResultRaw: GetToolResultRawFn,
-  toolUseId?: string,
-): { agentId?: string; totalDurationMs?: number; totalTokens?: number; totalToolUseCount?: number } {
-  if (!toolUseId) return {};
-  const rawMessage = getToolResultRaw(toolUseId);
-  const metadata = rawMessage?.toolUseResult;
-  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return {};
-  const record = metadata as Record<string, unknown>;
-  const getString = (value: unknown) => (typeof value === 'string' && value.trim() ? value.trim() : undefined);
-  const getNumber = (value: unknown) => (typeof value === 'number' && Number.isFinite(value) ? value : undefined);
-  return {
-    agentId: getString(record.agentId),
-    totalDurationMs: getNumber(record.totalDurationMs),
-    totalTokens: getNumber(record.totalTokens),
-    totalToolUseCount: getNumber(record.totalToolUseCount),
-  };
-}
-
 const AgentGroupBlock = memo(function AgentGroupBlock({
   agentBlock,
   followingBlocks,
@@ -79,7 +49,7 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
   findToolResult,
 }: AgentGroupBlockProps) {
   const { t } = useTranslation();
-  const getSubagentHistory = useSubagentHistoryGetter();
+  const histories = useSubagentHistories();
   const currentSessionId = useSessionId();
   const getToolResultRaw = useGetToolResultRaw();
 
@@ -96,8 +66,16 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
 
   const input = agentBlock.type === 'tool_use' ? (agentBlock.input as Record<string, unknown> | undefined) : undefined;
   const result = findToolResult(toolId, messageIndex);
-  const isCompleted = result !== undefined && result !== null;
-  const isError = isCompleted && result?.is_error === true;
+  const hasTerminalResult = result !== undefined && result !== null;
+
+  // A background (run_in_background) Agent only gets a launch acknowledgment
+  // tool_result; its real terminal status arrives later via task_notification,
+  // so stay "running" until that event lands. Sync agents complete inline.
+  // isAsyncAgentInput centralizes the strict === true check (and the snake/camel
+  // guard) shared with useSubagents and TaskExecutionBlock.
+  const isAsync = isAsyncAgentInput(input);
+  const taskEvent = useTaskEvent(toolId);
+  const taskFailed = taskEvent?.status === 'failed' || taskEvent?.status === 'stopped';
 
   const agentType = getAgentType(agentBlock);
   const summary = getAgentSummary(agentBlock);
@@ -105,7 +83,18 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
 
   const agentToolMeta = parseAgentToolMeta(getToolResultRaw, toolId);
   const agentId = agentToolMeta.agentId ?? (input?.agent_id as string | undefined) ?? (input?.agentId as string | undefined);
-  const history = (toolId ? getSubagentHistory(toolId) : undefined) ?? (agentId ? getSubagentHistory(agentId) : undefined);
+  const history = (toolId ? histories[toolId] : undefined) ?? (agentId ? histories[agentId] : undefined);
+  // A settled main turn is only the launch boundary for a background Agent. Use
+  // the live task_notification or a terminal sidechain end_turn as completion.
+  // A failed launch (validation error before the task was registered) returns an
+  // is_error tool_result and never emits a task_notification, so treat that as
+  // an error instead of staying stuck on "running".
+  const isCompleted = isAsync
+    ? (taskEvent ? !taskFailed : history?.completed === true)
+    : hasTerminalResult;
+  const isError = isAsync
+    ? (taskEvent ? taskFailed : result?.is_error === true)
+    : hasTerminalResult && result?.is_error === true;
 
   const noopToggleThinking = useCallback(() => {}, []);
 
@@ -124,7 +113,7 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
 
   useEffect(() => {
     // Clear existing timer when dependencies change or conditions no longer met
-    if (!expanded || !currentSessionId || !toolId || !isStreaming || isCompleted || history) {
+    if (!expanded || !currentSessionId || !toolId || isCompleted || isError) {
       if (pollingTimerRef.current !== null) {
         window.clearInterval(pollingTimerRef.current);
         pollingTimerRef.current = null;
@@ -150,7 +139,7 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
         pollingTimerRef.current = null;
       }
     };
-  }, [agentId, currentSessionId, summary, expanded, history, isStreaming, isCompleted, toolId]);
+  }, [agentId, currentSessionId, summary, expanded, isCompleted, isError, toolId]);
 
   return (
     <div className="task-container agent-group-container">
@@ -192,11 +181,11 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
       {expanded && (
         <div className="task-details agent-group-content">
           <SubagentProcessDetails
-            agentId={agentId}
-            totalDurationMs={agentToolMeta.totalDurationMs}
-            totalTokens={agentToolMeta.totalTokens}
-            totalToolUseCount={agentToolMeta.totalToolUseCount}
-            resultText={extractResultText(result)}
+            agentId={(isAsync ? taskEvent?.agentId : undefined) ?? agentId}
+            totalDurationMs={(isAsync ? taskEvent?.totalDurationMs : undefined) ?? agentToolMeta.totalDurationMs}
+            totalTokens={(isAsync ? taskEvent?.totalTokens : undefined) ?? agentToolMeta.totalTokens}
+            totalToolUseCount={(isAsync ? taskEvent?.totalToolUseCount : undefined) ?? agentToolMeta.totalToolUseCount}
+            resultText={(isAsync ? taskEvent?.summary : undefined) ?? extractResultText(result)}
             history={history}
             canLoad={Boolean(currentSessionId)}
           />

--- a/webview/src/components/toolBlocks/TaskExecutionBlock.test.tsx
+++ b/webview/src/components/toolBlocks/TaskExecutionBlock.test.tsx
@@ -2,9 +2,10 @@ import { act, fireEvent, render } from '@testing-library/react';
 import TaskExecutionBlock from './TaskExecutionBlock';
 
 const mockSendBridgeEvent = vi.fn();
-const mockGetSubagentHistory = vi.fn<(key: string) => unknown>();
+let mockHistories: Record<string, unknown> = {};
 const mockUseSessionId = vi.fn<() => string | null>();
 const mockGetToolResultRaw = vi.fn<(toolUseId: string) => Record<string, unknown> | null>();
+const mockUseTaskEvent = vi.fn<(toolUseId: string | undefined) => unknown>();
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -17,49 +18,52 @@ vi.mock('../../utils/bridge', () => ({
 }));
 
 vi.mock('../../contexts/SubagentContext', () => ({
-  useSubagentHistoryGetter: () => mockGetSubagentHistory,
+  useSubagentHistories: () => mockHistories,
   useSessionId: () => mockUseSessionId(),
   useGetToolResultRaw: () => mockGetToolResultRaw,
+  useTaskEvent: (toolUseId: string | undefined) => mockUseTaskEvent(toolUseId),
 }));
 
 describe('TaskExecutionBlock polling', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     mockSendBridgeEvent.mockReset();
-    mockGetSubagentHistory.mockReset();
     mockGetToolResultRaw.mockReset();
     mockUseSessionId.mockReset();
+    mockUseTaskEvent.mockReset();
 
-    mockGetSubagentHistory.mockReturnValue(undefined);
+    mockHistories = {};
     mockGetToolResultRaw.mockReturnValue(null);
     mockUseSessionId.mockReturnValue('session-1');
+    mockUseTaskEvent.mockReturnValue(undefined);
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it('does not start polling when the agent tool is no longer streaming', () => {
+  it('continues polling an unresolved agent after the main turn settles', () => {
     const setIntervalSpy = vi.spyOn(window, 'setInterval');
 
     const { container } = render(
       <TaskExecutionBlock
-        name="Task"
+        name="Agent"
         toolId="task-1"
         isStreaming={false}
         input={{
           description: 'Inspect render path',
           subagent_type: 'Explore',
+          run_in_background: true,
         }}
       />,
     );
 
     fireEvent.click(container.querySelector('.task-header') as HTMLElement);
 
-    expect(setIntervalSpy).not.toHaveBeenCalled();
+    expect(setIntervalSpy).toHaveBeenCalled();
   });
 
-  it('keeps the task header expandable without rendering a chevron icon', () => {
+  it('expands the task details when the header is clicked', () => {
     const { container } = render(
       <TaskExecutionBlock
         name="Task"
@@ -71,7 +75,7 @@ describe('TaskExecutionBlock polling', () => {
       />,
     );
 
-    expect(container.querySelector('.task-chevron')).toBeNull();
+    expect(container.querySelector('.task-details')).toBeNull();
 
     fireEvent.click(container.querySelector('.task-header') as HTMLElement);
 
@@ -125,5 +129,260 @@ describe('TaskExecutionBlock polling', () => {
     });
 
     expect(mockSendBridgeEvent).not.toHaveBeenCalled();
+  });
+
+  it('keeps an async agent pending until its task_notification lands', () => {
+    mockUseTaskEvent.mockReturnValue(undefined);
+
+    const { container } = render(
+      <TaskExecutionBlock
+        name="Agent"
+        toolId="agent-async"
+        isStreaming={true}
+        input={{
+          description: 'background research',
+          subagent_type: 'research',
+          run_in_background: true,
+        } as any}
+      />,
+    );
+
+    // Launch ack tool_result is present, but async agents must NOT flip to
+    // completed on it alone.
+    const indicator = container.querySelector('.tool-status-indicator');
+    expect(indicator?.className).toContain('pending');
+    expect(indicator?.className).not.toContain('completed');
+  });
+
+  it('keeps an unfinished async agent pending after history reload', () => {
+    mockUseTaskEvent.mockReturnValue(undefined);
+    mockHistories = { 'agent-async': { success: true, completed: false, messages: [] } };
+
+    const { container } = render(
+      <TaskExecutionBlock
+        name="Agent"
+        toolId="agent-async"
+        isStreaming={false}
+        input={{
+          description: 'background research',
+          subagent_type: 'research',
+          run_in_background: true,
+        } as any}
+      />,
+    );
+
+    const indicator = container.querySelector('.tool-status-indicator');
+    expect(indicator?.className).toContain('pending');
+    expect(indicator?.className).not.toContain('completed');
+  });
+
+  it('marks an async agent completed when sidechain history ends normally', () => {
+    mockUseTaskEvent.mockReturnValue(undefined);
+    mockHistories = { 'agent-async': { success: true, completed: true, messages: [] } };
+
+    const { container } = render(
+      <TaskExecutionBlock
+        name="Agent"
+        toolId="agent-async"
+        isStreaming={false}
+        input={{
+          description: 'background research',
+          subagent_type: 'research',
+          run_in_background: true,
+        } as any}
+      />,
+    );
+
+    const indicator = container.querySelector('.tool-status-indicator');
+    expect(indicator?.className).toContain('completed');
+    expect(indicator?.className).not.toContain('pending');
+  });
+
+  it('flips an async agent to completed when a task_notification arrives', () => {
+    mockUseTaskEvent.mockReturnValue({
+      toolUseId: 'agent-async',
+      status: 'completed',
+    } as any);
+
+    const { container } = render(
+      <TaskExecutionBlock
+        name="Agent"
+        toolId="agent-async"
+        isStreaming={true}
+        input={{
+          description: 'background research',
+          subagent_type: 'research',
+          run_in_background: true,
+        } as any}
+      />,
+    );
+
+    const indicator = container.querySelector('.tool-status-indicator');
+    expect(indicator?.className).toContain('completed');
+  });
+
+  it('shows the error indicator when a task_notification reports failure', () => {
+    mockUseTaskEvent.mockReturnValue({
+      toolUseId: 'agent-fail',
+      status: 'failed',
+    } as any);
+
+    const { container } = render(
+      <TaskExecutionBlock
+        name="Agent"
+        toolId="agent-fail"
+        isStreaming={true}
+        input={{
+          description: 'background research',
+          subagent_type: 'research',
+          run_in_background: true,
+        } as any}
+      />,
+    );
+
+    const indicator = container.querySelector('.tool-status-indicator');
+    expect(indicator?.className).toContain('error');
+  });
+
+  it('marks an async agent as errored when the launch tool_result reports is_error', () => {
+    // A failed launch (validation error before the background task was
+    // registered) returns an is_error tool_result and never emits a
+    // task_notification - the card must show error, not stay "pending".
+    mockUseTaskEvent.mockReturnValue(undefined);
+
+    const { container } = render(
+      <TaskExecutionBlock
+        name="Agent"
+        toolId="agent-launch-fail"
+        isStreaming={true}
+        result={{ type: 'tool_result', tool_use_id: 'agent-launch-fail', content: 'Agent Teams is not available', is_error: true } as any}
+        input={{
+          description: 'background research',
+          subagent_type: 'research',
+          run_in_background: true,
+        } as any}
+      />,
+    );
+
+    const indicator = container.querySelector('.tool-status-indicator');
+    expect(indicator?.className).toContain('error');
+    expect(indicator?.className).not.toContain('pending');
+  });
+
+  it('stops polling when an async agent fails', () => {
+    const clearIntervalSpy = vi.spyOn(window, 'clearInterval');
+
+    // Start with no task_event: the card is pending and begins polling.
+    mockUseTaskEvent.mockReturnValue(undefined);
+
+    const { container, rerender } = render(
+      <TaskExecutionBlock
+        name="Agent"
+        toolId="agent-poll-fail"
+        isStreaming={true}
+        input={{
+          description: 'background research',
+          subagent_type: 'research',
+          run_in_background: true,
+        } as any}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('.task-header') as HTMLElement);
+
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+
+    expect(mockSendBridgeEvent).toHaveBeenCalledWith(
+      'load_subagent_session',
+      expect.stringContaining('"toolUseId":"agent-poll-fail"'),
+    );
+
+    // A failure notification arrives - the card must stop polling.
+    mockUseTaskEvent.mockReturnValue({
+      toolUseId: 'agent-poll-fail',
+      status: 'failed',
+    } as any);
+
+    rerender(
+      <TaskExecutionBlock
+        name="Agent"
+        toolId="agent-poll-fail"
+        isStreaming={true}
+        input={{
+          description: 'background research',
+          subagent_type: 'research',
+          run_in_background: true,
+        } as any}
+      />,
+    );
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+
+    mockSendBridgeEvent.mockClear();
+    act(() => {
+      vi.advanceTimersByTime(4_000);
+    });
+
+    expect(mockSendBridgeEvent).not.toHaveBeenCalled();
+  });
+
+  it('renders task_event usage in SubagentProcessDetails for a completed async agent', () => {
+    mockUseTaskEvent.mockReturnValue({
+      toolUseId: 'agent-usage',
+      status: 'completed',
+      totalTokens: 4200,
+      totalToolUseCount: 7,
+      totalDurationMs: 18000,
+      summary: '调研完成',
+    } as any);
+
+    const { container } = render(
+      <TaskExecutionBlock
+        name="Agent"
+        toolId="agent-usage"
+        isStreaming={false}
+        input={{
+          description: 'background research',
+          subagent_type: 'research',
+          run_in_background: true,
+        } as any}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('.task-header') as HTMLElement);
+
+    const stats = container.querySelector('.subagent-process-stats');
+    expect(stats).toBeTruthy();
+    expect(stats?.textContent).toContain('7');
+    expect(stats?.textContent).toContain('4,200');
+    expect(container.querySelector('.subagent-result-card')?.textContent).toContain('调研完成');
+  });
+
+  it('parses spawn_agent meta (nickname, model, reasoning effort) from result text', () => {
+    mockUseTaskEvent.mockReturnValue(undefined);
+    mockGetToolResultRaw.mockReturnValue(null);
+
+    const result = {
+      type: 'tool_result',
+      tool_use_id: 'spawn-1',
+      content: '{"agent_id":"af5a83aa","nickname":"researcher","model":"claude-sonnet-4-6","reasoning_effort":"high"}',
+    } as any;
+
+    const { container } = render(
+      <TaskExecutionBlock
+        name="spawn_agent"
+        toolId="spawn-1"
+        result={result}
+        input={{ prompt: 'do research' } as any}
+      />,
+    );
+
+    const summaries = container.querySelectorAll('.tool-title-summary');
+    const text = Array.from(summaries).map((el) => el.textContent).join(' ');
+    expect(text).toContain('researcher');
+    expect(text).toContain('claude-sonnet-4-6');
+    expect(text).toContain('high');
   });
 });

--- a/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
+++ b/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from 'react-i18next';
 import type { ToolInput, ToolResultBlock } from '../../types';
 import { normalizeToolName } from '../../utils/toolConstants';
 import { sendBridgeEvent } from '../../utils/bridge';
-import { useSubagentHistoryGetter, useSessionId, useGetToolResultRaw, type GetToolResultRawFn } from '../../contexts/SubagentContext';
+import { extractResultText, isAsyncAgentInput, parseAgentToolMeta } from '../../utils/subagentResult';
+import { useSubagentHistories, useSessionId, useGetToolResultRaw, useTaskEvent } from '../../contexts/SubagentContext';
 import SubagentProcessDetails from '../StatusPanel/SubagentProcessDetails';
 
 const MONO_FONT_STYLE: React.CSSProperties = {
@@ -25,21 +26,6 @@ type SpawnAgentMeta = {
   model?: string;
   reasoningEffort?: string;
 };
-
-function extractResultText(result?: ToolResultBlock | null): string | undefined {
-  if (!result) return undefined;
-  if (typeof result.content === 'string') {
-    return result.content;
-  }
-  if (Array.isArray(result.content)) {
-    const text = result.content
-      .map((item) => (item && typeof item.text === 'string' ? item.text : ''))
-      .filter(Boolean)
-      .join('\n');
-    return text || undefined;
-  }
-  return undefined;
-}
 
 function parseSpawnAgentMeta(input: ToolInput, result?: ToolResultBlock | null): SpawnAgentMeta {
   const text = extractResultText(result)?.trim();
@@ -65,12 +51,15 @@ function parseSpawnAgentMeta(input: ToolInput, result?: ToolResultBlock | null):
     return undefined;
   };
 
+  // Reuse a single regex match for both model and reasoningEffort instead of
+  // running the same pattern twice over the text.
+  const modelMatch = text?.match(/\(([A-Za-z0-9._:-]+)(?:\s+(low|medium|high|xhigh))?\)/i);
   const agentId = getString(
     parsed?.agent_id,
     parsed?.agentId,
     parsed?.agent_path,
     parsed?.agentPath,
-  ) ?? (text?.match(/\b([0-9a-f]{8}-[0-9a-f-]{27})\b/i)?.[1]);
+  ) ?? text?.match(/\b([0-9a-f]{8}-[0-9a-f-]{27})\b/i)?.[1];
 
   const nickname = getString(
     parsed?.nickname,
@@ -80,40 +69,16 @@ function parseSpawnAgentMeta(input: ToolInput, result?: ToolResultBlock | null):
   const model = getString(
     parsed?.model,
     input.model,
-  ) ?? (text?.match(/\(([A-Za-z0-9._:-]+)(?:\s+(low|medium|high|xhigh))?\)/i)?.[1]);
+  ) ?? modelMatch?.[1];
 
   const reasoningEffort = getString(
     parsed?.reasoning_effort,
     parsed?.reasoningEffort,
     input.reasoning_effort,
     input.reasoningEffort,
-  ) ?? (text?.match(/\(([A-Za-z0-9._:-]+)(?:\s+(low|medium|high|xhigh))?\)/i)?.[2]);
+  ) ?? modelMatch?.[2];
 
   return { agentId, nickname, model, reasoningEffort };
-}
-
-function parseAgentToolMeta(
-  getToolResultRaw: GetToolResultRawFn,
-  toolUseId?: string,
-): {
-  agentId?: string;
-  totalDurationMs?: number;
-  totalTokens?: number;
-  totalToolUseCount?: number;
-} {
-  if (!toolUseId) return {};
-  const rawMessage = getToolResultRaw(toolUseId);
-  const metadata = rawMessage?.toolUseResult;
-  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return {};
-  const record = metadata as Record<string, unknown>;
-  const getString = (value: unknown) => (typeof value === 'string' && value.trim() ? value.trim() : undefined);
-  const getNumber = (value: unknown) => (typeof value === 'number' && Number.isFinite(value) ? value : undefined);
-  return {
-    agentId: getString(record.agentId),
-    totalDurationMs: getNumber(record.totalDurationMs),
-    totalTokens: getNumber(record.totalTokens),
-    totalToolUseCount: getNumber(record.totalToolUseCount),
-  };
 }
 
 function shortenAgentId(agentId?: string): string | undefined {
@@ -121,18 +86,18 @@ function shortenAgentId(agentId?: string): string | undefined {
   return agentId.length > 8 ? `${agentId.slice(0, 8)}…` : agentId;
 }
 
-const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, result, toolId, isStreaming = false }: TaskExecutionBlockProps) {
+const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, result, toolId }: TaskExecutionBlockProps) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
-  const getSubagentHistory = useSubagentHistoryGetter();
+  const histories = useSubagentHistories();
   const currentSessionId = useSessionId();
   const getToolResultRaw = useGetToolResultRaw();
+  const taskEvent = useTaskEvent(toolId);
 
-  if (!input) {
-    return null;
-  }
-
-  const normalizedName = normalizeToolName(name ?? '');
+  // Compute derived values up front, guarding input, so both useEffects below
+  // run before the !input early return (React rules-of-hooks). input is always
+  // defined for tool_use blocks in practice; the guard keeps hook order stable.
+  const normalizedName = input ? normalizeToolName(name ?? '') : '';
   const isSpawnAgent = normalizedName === 'spawn_agent';
   const isAgentTool = normalizedName === 'agent' || normalizedName === 'task' || normalizedName === 'spawn_agent';
   const {
@@ -149,41 +114,71 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
     agent_path: _agentPath,
     agentPath: _agentPathCamel,
     ...rest
-  } = input;
-  const spawnMeta = isSpawnAgent ? parseSpawnAgentMeta(input, result) : {};
-  const agentToolMeta = !isSpawnAgent ? parseAgentToolMeta(getToolResultRaw, toolId) : {};
+  } = input ?? ({} as ToolInput);
+  const spawnMeta = isSpawnAgent && input ? parseSpawnAgentMeta(input, result) : {};
+  const agentToolMeta = !isSpawnAgent && input ? parseAgentToolMeta(getToolResultRaw, toolId) : {};
   const agentId = spawnMeta.agentId ?? agentToolMeta.agentId;
   const identityLabel = spawnMeta.nickname || (typeof subagentType === 'string' && subagentType ? subagentType : undefined);
   const modelSummary = [spawnMeta.model, spawnMeta.reasoningEffort].filter(Boolean).join(' ');
   const shortAgentId = shortenAgentId(agentId);
 
-  // Determine status based on result
-  const isCompleted = result !== undefined && result !== null;
-  const isError = isCompleted && result?.is_error === true;
-  const history = (toolId ? getSubagentHistory(toolId) : undefined) ?? (agentId ? getSubagentHistory(agentId) : undefined);
+  // A background (run_in_background) Agent only gets a launch acknowledgment
+  // tool_result; its real terminal status arrives later via a task_notification
+  // event, so the card must stay "running" until that event lands and must not
+  // flip to completed on the launch ack alone. Sync agents run inline, so a
+  // tool_result means done. A failed launch (validation error before the task
+  // was registered) returns an is_error tool_result and never emits a
+  // task_notification, so treat that as an error instead of staying stuck.
+  // isAsyncAgentInput centralizes the strict === true check shared with
+  // useSubagents and AgentGroupBlock.
+  const isAsync = input ? isAsyncAgentInput(input) : false;
+  const hasTerminalResult = result !== undefined && result !== null;
+  const taskFailed = taskEvent?.status === 'failed' || taskEvent?.status === 'stopped';
+  // Async completion has two authoritative sources: the live task_notification,
+  // and (after reload/polling) a sidechain transcript that ends in
+  // assistant/end_turn. A settled main turn alone proves only that the launch
+  // turn ended; the background sidechain may still be running.
+  const history = (toolId ? histories[toolId] : undefined) ?? (agentId ? histories[agentId] : undefined);
+  const isCompleted = isAsync
+    ? (taskEvent ? !taskFailed : history?.completed === true)
+    : hasTerminalResult;
+  const isError = isAsync
+    ? (taskEvent ? taskFailed : result?.is_error === true)
+    : hasTerminalResult && result?.is_error === true;
+
+  // For background agents the task_notification carries the authoritative usage
+  // and summary (the launch ack has none); prefer it over toolUseResult. Sync
+  // agents keep reading toolUseResult as before.
+  const detailAgentId = (isAsync ? taskEvent?.agentId : undefined) ?? agentId;
+  const detailDurationMs = (isAsync ? taskEvent?.totalDurationMs : undefined) ?? agentToolMeta.totalDurationMs;
+  const detailTokens = (isAsync ? taskEvent?.totalTokens : undefined) ?? agentToolMeta.totalTokens;
+  const detailToolUseCount = (isAsync ? taskEvent?.totalToolUseCount : undefined) ?? agentToolMeta.totalToolUseCount;
+  const detailResultText = (isAsync ? taskEvent?.summary : undefined) ?? extractResultText(result);
 
   useEffect(() => {
-    if (!expanded || !isAgentTool || !currentSessionId || !toolId || history) return;
+    if (!input || !expanded || !isAgentTool || !currentSessionId || !toolId || history) return;
     sendBridgeEvent('load_subagent_session', JSON.stringify({
       sessionId: currentSessionId,
       agentId,
       description: typeof description === 'string' ? description : undefined,
       toolUseId: toolId,
     }));
-  }, [agentId, currentSessionId, description, expanded, history, isAgentTool, toolId]);
+  }, [input, agentId, currentSessionId, description, expanded, history, isAgentTool, toolId]);
 
+  // Poll while an expanded async Agent is unresolved, including after a main
+  // turn settles. This lets a reloaded session observe the sidechain's terminal
+  // end_turn without relying on the live-only task_notification event. Stop once
+  // the agent reaches a terminal state (completed or error) so a failed
+  // background agent does not leak an interval forever.
   const shouldPollHistory = expanded
     && isAgentTool
     && Boolean(currentSessionId)
     && Boolean(toolId)
-    && isStreaming
     && !isCompleted
-    && !history;
+    && !isError;
 
-  // Poll subagent history only while the tool is still actively streaming and
-  // we have not received history yet. Avoid keeping idle intervals alive.
   useEffect(() => {
-    if (!shouldPollHistory || !currentSessionId || !toolId) return;
+    if (!input || !shouldPollHistory || !currentSessionId || !toolId) return;
     const timer = window.setInterval(() => {
       sendBridgeEvent('load_subagent_session', JSON.stringify({
         sessionId: currentSessionId,
@@ -193,7 +188,11 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
       }));
     }, 2_000);
     return () => window.clearInterval(timer);
-  }, [agentId, currentSessionId, description, shouldPollHistory, toolId]);
+  }, [input, agentId, currentSessionId, description, shouldPollHistory, toolId]);
+
+  if (!input) {
+    return null;
+  }
 
   return (
     <div className="task-container">
@@ -264,11 +263,11 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
 
             {isAgentTool && (
               <SubagentProcessDetails
-                agentId={agentId}
-                totalDurationMs={agentToolMeta.totalDurationMs}
-                totalTokens={agentToolMeta.totalTokens}
-                totalToolUseCount={agentToolMeta.totalToolUseCount}
-                resultText={extractResultText(result)}
+                agentId={detailAgentId}
+                totalDurationMs={detailDurationMs}
+                totalTokens={detailTokens}
+                totalToolUseCount={detailToolUseCount}
+                resultText={detailResultText}
                 history={history}
                 canLoad={Boolean(currentSessionId)}
               />

--- a/webview/src/contexts/MessagesContext.tsx
+++ b/webview/src/contexts/MessagesContext.tsx
@@ -26,6 +26,10 @@ const MessagesContext = createContext<MessagesContextValue | null>(null);
  * Provides messages flow state (messages, subagent histories, loading, streaming).
  * Stage 1 of TASK-P1-01 (App.tsx God Component decomposition).
  *
+ * task_events live in SubagentContext's TaskEventProvider, NOT here, so that
+ * task_event updates do not invalidate this context's value and re-render
+ * every consumer of it.
+ *
  * Currently only App.tsx consumes this context. As subsequent stages migrate
  * downstream hooks (useWindowCallbacks, useMessageSender, useSessionManagement)
  * to read setters via useMessages() directly, prop drilling will collapse.

--- a/webview/src/contexts/SubagentContext.tsx
+++ b/webview/src/contexts/SubagentContext.tsx
@@ -1,13 +1,15 @@
-import { createContext, useCallback, useContext, useMemo, useRef } from 'react';
-import type { ClaudeRawMessage, SubagentHistoryResponse } from '../types';
+import { createContext, useContext, useMemo, useState, type ReactNode } from 'react';
+import type { ClaudeRawMessage, SubagentHistoryResponse, TaskEvent, TaskEventMap } from '../types';
 
-// SubagentHistoryContext holds a getter function instead of the full Record.
-// This keeps the context value reference stable even when individual entries
-// are updated, preventing unnecessary re-renders of TaskExecutionBlock instances
-// that don't care about the changed key.
-type GetSubagentHistoryFn = (key: string) => SubagentHistoryResponse | undefined;
-
-const SubagentHistoryContext = createContext<GetSubagentHistoryFn>(() => undefined);
+// SubagentHistoryContext holds the full history map so consumers
+// (AgentGroupBlock / TaskExecutionBlock) re-render when an entry arrives.
+// Reactivity is required: an inline Agent card expands, polls the sidechain
+// transcript, and must flip from "pending" to "completed" once the response
+// lands - a stable getter would never trigger that re-render. The map is small
+// (one entry per polled subagent) and updates are low-frequency (2 s polling,
+// only for expanded cards), so re-rendering all inline cards on a change is
+// bounded and matches the TaskEventContext pattern below.
+const SubagentHistoryContext = createContext<Record<string, SubagentHistoryResponse>>({});
 
 interface SessionIdContextValue {
   currentSessionId: string | null;
@@ -21,12 +23,67 @@ export type GetToolResultRawFn = (toolUseId: string) => ClaudeRawMessage | null;
 
 const ToolResultRawContext = createContext<GetToolResultRawFn>(() => null);
 
+// TaskEventContext holds the full task-events map (keyed by tool_use_id) so that
+// inline Agent tool cards (TaskExecutionBlock / AgentGroupBlock) can subscribe to
+// a background agent's terminal status. Unlike SubagentHistoryContext, this
+// deliberately re-renders consumers on change: a background agent's
+// task_notification arrives after the launch tool_result, and the card must flip
+// from "running" to "completed" without a manual reload. The map is small (one
+// entry per background agent) and updates are low-frequency, so the re-render
+// cost is bounded.
+//
+// Split into its own provider (TaskEventProvider) rather than living in
+// MessagesContext so that task_event updates do not invalidate the
+// MessagesContext value and re-render every consumer of it.
+const TaskEventContext = createContext<TaskEventMap>({});
+
+// SetTaskEventContext is separated from TaskEventContext so that components
+// which only need the setter (App.tsx, useSessionManagement, useWindowCallbacks)
+// do not re-render when the map changes.
+const SetTaskEventContext = createContext<React.Dispatch<React.SetStateAction<TaskEventMap>> | null>(null);
+
 /**
- * Hook for looking up a specific subagent's history by key (toolUseId or agentId).
- * Returns a stable getter function — the reference never changes, so consumers
- * won't re-render when *other* subagent histories are updated.
+ * Provider that owns the task-events map state. Mount once above the App so
+ * both the setter (consumed by App/session-management/window-callbacks) and the
+ * map (consumed by inline Agent cards and useSubagents) share a single source.
  */
-export function useSubagentHistoryGetter(): GetSubagentHistoryFn {
+export function TaskEventProvider({ children }: { children: ReactNode }) {
+  const [taskEvents, setTaskEvents] = useState<TaskEventMap>({});
+  return (
+    <SetTaskEventContext.Provider value={setTaskEvents}>
+      <TaskEventContext.Provider value={taskEvents}>
+        {children}
+      </TaskEventContext.Provider>
+    </SetTaskEventContext.Provider>
+  );
+}
+
+/**
+ * Read the task-events map. Re-renders the caller when any entry changes.
+ */
+export function useTaskEvents(): TaskEventMap {
+  return useContext(TaskEventContext);
+}
+
+/**
+ * Read the setter for the task-events map. Stable identity; does NOT re-render
+ * the caller when the map changes. Throws if used outside TaskEventProvider.
+ */
+export function useSetTaskEvents(): React.Dispatch<React.SetStateAction<TaskEventMap>> {
+  const setTaskEvents = useContext(SetTaskEventContext);
+  if (!setTaskEvents) {
+    throw new Error('useSetTaskEvents must be used within a TaskEventProvider');
+  }
+  return setTaskEvents;
+}
+
+/**
+ * Read the full subagent-history map. Re-renders the caller whenever any entry
+ * changes, so an expanded inline Agent card reflects a freshly loaded sidechain
+ * transcript without a manual reload. Callers narrow to the key they care about
+ * (toolUseId, falling back to agentId).
+ */
+export function useSubagentHistories(): Record<string, SubagentHistoryResponse> {
   return useContext(SubagentHistoryContext);
 }
 
@@ -45,24 +102,27 @@ export function useGetToolResultRaw(): GetToolResultRawFn {
 }
 
 /**
+ * Hook returning the latest task_* event for a background (run_in_background)
+ * Agent tool call, keyed by its tool_use_id. Re-renders the caller when the
+ * event map changes so inline Agent cards reflect completion in real time.
+ */
+export function useTaskEvent(toolUseId: string | undefined): TaskEvent | undefined {
+  const taskEvents = useContext(TaskEventContext);
+  if (!toolUseId) return undefined;
+  return taskEvents[toolUseId];
+}
+
+/**
  * Creates the context value objects used by App.tsx's Providers.
- * Returns stable references that survive re-renders.
+ * `subagentHistoryCtxValue` is the raw map so Provider consumers re-render when
+ * an entry arrives (see useSubagentHistories); its identity changes only when
+ * `subagentHistories` changes. `sessionIdCtxValue` is memoized on
+ * `currentSessionId` so SessionIdContext consumers don't re-render on every
+ * history update.
  */
 export function useSubagentContextValues(subagentHistories: Record<string, SubagentHistoryResponse>, currentSessionId: string | null) {
-  const historiesRef = useRef(subagentHistories);
-  historiesRef.current = subagentHistories;
-
-  const getHistory = useCallback<GetSubagentHistoryFn>(
-    (key: string) => historiesRef.current[key],
-    [],
-  );
-
-  // getHistory has empty deps so its identity never changes — use it directly
-  // as the context value without an unnecessary useMemo wrapper.
-  const subagentHistoryCtxValue = getHistory;
   const sessionIdCtxValue = useMemo(() => ({ currentSessionId }), [currentSessionId]);
-
-  return { subagentHistoryCtxValue, sessionIdCtxValue };
+  return { subagentHistoryCtxValue: subagentHistories, sessionIdCtxValue };
 }
 
 export { SubagentHistoryContext, SessionIdContext, ToolResultRawContext };

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -127,6 +127,15 @@ interface Window {
   onSubagentHistoryLoaded?: (json: string) => void;
 
   /**
+   * task_* SDK system event callback (async subagent lifecycle).
+   * Payload: { subtype: 'task_started'|'task_progress'|'task_notification',
+   *   task_id, tool_use_id, status?, summary?, usage?, output_file? }.
+   * task_notification carries the terminal status and result summary that the
+   * StatusPanel uses to mark a background (run_in_background) Agent subagent as completed.
+   */
+  onTaskEvent?: (eventJson: string) => void;
+
+  /**
    * SDK-to-CLI session conversion result callback.
    * Called by the Java backend after attempting to convert entrypoint from "sdk-cli" to "cli".
    * Payload: { success: boolean, infoCode?: string, errorCode?: string }.

--- a/webview/src/hooks/useChatComputations.ts
+++ b/webview/src/hooks/useChatComputations.ts
@@ -4,6 +4,7 @@ import type {
   ClaudeContentBlock,
   ClaudeMessage,
   ClaudeRawMessage,
+  SubagentHistoryResponse,
   TodoItem,
   ToolResultBlock,
 } from '../types';
@@ -31,6 +32,7 @@ interface UseChatComputationsParams {
   t: TFunction;
   messages: ClaudeMessage[];
   mergedMessages: ClaudeMessage[];
+  subagentHistories: Record<string, SubagentHistoryResponse>;
   customSessionTitle: string | null;
   streamingActive: boolean;
   currentProvider: string;
@@ -38,6 +40,26 @@ interface UseChatComputationsParams {
   currentSessionIdRef: RefObject<string | null>;
   getMessageText: ReturnType<typeof useMessageProcessing>['getMessageText'];
   getContentBlocks: ReturnType<typeof useMessageProcessing>['getContentBlocks'];
+}
+
+/**
+ * Whether a message slice contains any assistant tool_use block. Used to decide
+ * whether the latest-turn scope is carrying active tool work worth focusing on,
+ * or is empty of tools (a reload snapshot / text-only turn) and should widen to
+ * the full conversation so StatusPanel lists do not disappear.
+ */
+function sliceHasToolUse(
+  messages: ClaudeMessage[],
+  getContentBlocks: (message: ClaudeMessage) => ClaudeContentBlock[],
+): boolean {
+  for (const message of messages) {
+    if (message.type !== 'assistant') continue;
+    const blocks = getContentBlocks(message);
+    for (const block of blocks) {
+      if (block.type === 'tool_use') return true;
+    }
+  }
+  return false;
 }
 
 export function deriveTodosForTurn(
@@ -78,6 +100,7 @@ export function useChatComputations({
   t,
   messages,
   mergedMessages,
+  subagentHistories,
   customSessionTitle,
   streamingActive,
   currentProvider,
@@ -149,13 +172,27 @@ export function useChatComputations({
   // (history replay or idle), widen the scope to the whole conversation -
   // otherwise a multi-turn history session whose last turn has no task tool
   // would lose its task and subagent lists entirely.
-  const statusScopeMessages = streamingActive ? latestTurnMessages : messages;
+  //
+  // Exception: if the latest-turn slice carries no tool_use at all (e.g. a
+  // same-session reload snapshot whose latest turn predates the active work, or
+  // a text-only turn), widen to the full conversation. Without this, the
+  // StatusPanel subagent/todo lists can briefly disappear when a deferred
+  // reload's message refresh lands at the frontend a moment before the
+  // stream-end signal flips streamingActive back to false. Widening only adds
+  // content (earlier turns' settled items) - it never drops the current turn's.
+  const statusScopeMessages = useMemo(() => {
+    if (!streamingActive) return messages;
+    return latestTurnMessages.length > 0 && sliceHasToolUse(latestTurnMessages, getContentBlocks)
+      ? latestTurnMessages
+      : messages;
+  }, [streamingActive, latestTurnMessages, messages, getContentBlocks]);
 
   const latestTurnSubagents = useSubagents({
     messages: statusScopeMessages,
     getContentBlocks,
     findToolResult,
     getToolResultRaw,
+    subagentHistories,
   });
 
   const subagents = useMemo(

--- a/webview/src/hooks/useSessionManagement.ts
+++ b/webview/src/hooks/useSessionManagement.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 import type { TFunction } from 'i18next';
-import type { ClaudeMessage, HistoryData } from '../types';
+import type { ClaudeMessage, HistoryData, SubagentHistoryResponse, TaskEventMap } from '../types';
 import { sendBridgeEvent } from '../utils/bridge';
 import { getSkipNewSessionConfirm } from '../utils/skipNewSessionConfirm';
 import { clearAllPersistedExpanded } from '../utils/expandedState';
@@ -30,6 +30,10 @@ interface UseSessionManagementOptions {
   setLoading: (loading: boolean) => void;
   setIsThinking: (thinking: boolean) => void;
   setStreamingActive: (active: boolean) => void;
+  /** Clears async subagent task events so stale completions cannot leak across sessions. */
+  setTaskEvents?: React.Dispatch<React.SetStateAction<TaskEventMap>>;
+  /** Clears polled sidechain histories so stale transcripts cannot leak across sessions. */
+  setSubagentHistories?: React.Dispatch<React.SetStateAction<Record<string, SubagentHistoryResponse>>>;
   clearToasts: () => void;
   addToast: (message: string, type?: ToastType) => void;
   t: TFunction;
@@ -77,6 +81,8 @@ export function useSessionManagement({
   setLoading: setLoadingState,
   setIsThinking,
   setStreamingActive,
+  setTaskEvents,
+  setSubagentHistories,
   clearToasts,
   addToast,
   t,
@@ -115,6 +121,18 @@ export function useSessionManagement({
       setStreamingActive(false);
     }
     setMessages([]);
+    // Drop async subagent events from the prior session: tool_use_ids are
+    // globally unique so stale entries cannot mislabel the new session's
+    // agents, but leaving them would grow the map without bound.
+    if (setTaskEvents) {
+      setTaskEvents({});
+    }
+    // Sidechain histories carry full transcript arrays (potentially large).
+    // Clear them on session switch for the same unbounded-growth reason; an
+    // expanded card will re-fetch the sidechain it actually needs via polling.
+    if (setSubagentHistories) {
+      setSubagentHistories({});
+    }
     if (currentSessionIdRef) {
       currentSessionIdRef.current = nextSessionId;
     }
@@ -142,7 +160,7 @@ export function useSessionManagement({
         window.__sessionTransitionToken = null;
       }
     }, 15_000); // 15 seconds — generous enough for slow history loads
-  }, [clearToasts, currentSessionIdRef, setStatus, setLoadingState, setIsThinking, setStreamingActive, setMessages, setCurrentSessionId, setCustomSessionTitle, setUsagePercentage, setUsageUsedTokens, setUsageMaxTokens]);
+  }, [clearToasts, currentSessionIdRef, setStatus, setLoadingState, setIsThinking, setStreamingActive, setMessages, setCurrentSessionId, setCustomSessionTitle, setUsagePercentage, setUsageUsedTokens, setUsageMaxTokens, setTaskEvents, setSubagentHistories]);
 
   // Create new session
   const createNewSession = useCallback(() => {

--- a/webview/src/hooks/useSubagents.test.ts
+++ b/webview/src/hooks/useSubagents.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ClaudeContentBlock, ClaudeMessage, ToolResultBlock } from '../types';
-import { extractSubagentsFromMessages } from './useSubagents';
+import { applySubagentHistoryCompletion, extractSubagentsFromMessages } from './useSubagents';
 
 const assistantWithAgent = (toolUseId: string): ClaudeMessage => ({
   type: 'assistant',
@@ -97,5 +97,157 @@ describe('extractSubagentsFromMessages', () => {
       totalToolUseCount: 4,
     });
     expect(subagents[0].toolStats).toMatchObject({ readCount: 4 });
+  });
+
+  const assistantWithAsyncAgent = (toolUseId: string): ClaudeMessage => ({
+    type: 'assistant',
+    content: '',
+    raw: {
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: toolUseId,
+            name: 'Agent',
+            input: {
+              subagent_type: 'research',
+              description: '后台调研 subagent',
+              prompt: '调研索引服务设计模式',
+              run_in_background: true,
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  // Async agent (Agent tool with run_in_background:true) only gets a launch
+  // acknowledgment tool_result; the terminal status arrives later via a
+  // task_notification event.
+  const launchAckResult = (toolUseId: string): ClaudeMessage => ({
+    type: 'user',
+    content: '',
+    raw: {
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: toolUseId,
+          content: 'Async agent launched successfully.',
+        },
+      ],
+    } as any,
+  });
+
+  it('keeps async agent running while only the launch ack has landed', () => {
+    const messages = [assistantWithAsyncAgent('tu_spawn'), launchAckResult('tu_spawn')];
+
+    const subagents = extractSubagentsFromMessages(
+      messages, getContentBlocks, findToolResult(messages), getToolResultRaw(messages), {},
+    );
+
+    expect(subagents).toHaveLength(1);
+    expect(subagents[0].status).toBe('running');
+  });
+
+  it('completes async agent from its task_notification with event-derived metadata', () => {
+    const messages = [assistantWithAsyncAgent('tu_spawn'), launchAckResult('tu_spawn')];
+    const taskEvents = {
+      tu_spawn: {
+        toolUseId: 'tu_spawn',
+        status: 'completed' as const,
+        summary: '后台调研完成,发现 3 处索引模式',
+        totalTokens: 4200,
+        totalToolUseCount: 7,
+        totalDurationMs: 18000,
+      },
+    };
+
+    const subagents = extractSubagentsFromMessages(
+      messages, getContentBlocks, findToolResult(messages), getToolResultRaw(messages), taskEvents,
+    );
+
+    expect(subagents).toHaveLength(1);
+    expect(subagents[0]).toMatchObject({
+      id: 'tu_spawn',
+      status: 'completed',
+      resultText: '后台调研完成,发现 3 处索引模式',
+      totalTokens: 4200,
+      totalToolUseCount: 7,
+      totalDurationMs: 18000,
+    });
+  });
+
+  it('marks async agent as error when task_notification reports failure', () => {
+    const messages = [assistantWithAsyncAgent('tu_spawn')];
+    const taskEvents = {
+      tu_spawn: { toolUseId: 'tu_spawn', status: 'failed' as const },
+    };
+
+    const subagents = extractSubagentsFromMessages(
+      messages, getContentBlocks, findToolResult(messages), getToolResultRaw(messages), taskEvents,
+    );
+
+    expect(subagents).toHaveLength(1);
+    expect(subagents[0].status).toBe('error');
+  });
+
+  it('marks a failed async launch as error when the ack tool_result is is_error', () => {
+    // A validation failure (e.g. "In-process teammates cannot spawn background
+    // agents") returns an is_error tool_result before the background task is
+    // registered, so no task_notification ever follows - the agent must surface
+    // as error, not stay stuck on "running".
+    const messages: ClaudeMessage[] = [
+      assistantWithAsyncAgent('tu_launch_fail'),
+      {
+        type: 'user',
+        content: '',
+        raw: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tu_launch_fail',
+              content: 'In-process teammates cannot spawn background agents',
+              is_error: true,
+            },
+          ],
+        } as any,
+      },
+    ];
+
+    const subagents = extractSubagentsFromMessages(
+      messages, getContentBlocks, findToolResult(messages), getToolResultRaw(messages), {},
+    );
+
+    expect(subagents).toHaveLength(1);
+    expect(subagents[0].status).toBe('error');
+  });
+
+  it('finalizes only async agents whose sidechain history ends in end_turn', () => {
+    const messages = [assistantWithAsyncAgent('tu_spawn'), launchAckResult('tu_spawn')];
+    const extracted = extractSubagentsFromMessages(
+      messages, getContentBlocks, findToolResult(messages), getToolResultRaw(messages), {},
+    );
+
+    expect(applySubagentHistoryCompletion(extracted, {
+      tu_spawn: { success: true, completed: false, messages: [] },
+    })[0].status).toBe('running');
+
+    expect(applySubagentHistoryCompletion(extracted, {
+      tu_spawn: { success: true, completed: true, messages: [] },
+    })[0].status).toBe('completed');
+  });
+
+  it('does not overwrite a task_notification error with sidechain completion', () => {
+    const messages = [assistantWithAsyncAgent('tu_spawn')];
+    const taskEvents = {
+      tu_spawn: { toolUseId: 'tu_spawn', status: 'failed' as const },
+    };
+    const extracted = extractSubagentsFromMessages(
+      messages, getContentBlocks, findToolResult(messages), getToolResultRaw(messages), taskEvents,
+    );
+
+    expect(applySubagentHistoryCompletion(extracted, {
+      tu_spawn: { success: true, completed: true, messages: [] },
+    })[0].status).toBe('error');
   });
 });

--- a/webview/src/hooks/useSubagents.ts
+++ b/webview/src/hooks/useSubagents.ts
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
-import type { ClaudeMessage, ClaudeRawMessage, ClaudeContentBlock, ToolResultBlock, SubagentInfo, SubagentStatus } from '../types';
+import type { ClaudeMessage, ClaudeRawMessage, ClaudeContentBlock, ToolResultBlock, SubagentHistoryResponse, SubagentInfo, SubagentStatus, TaskEvent, TaskEventMap } from '../types';
 import { normalizeToolInput } from '../utils/toolInputNormalization';
 import { normalizeToolName } from '../utils/toolConstants';
+import { extractResultText, isAsyncAgentInput } from '../utils/subagentResult';
+import { useTaskEvents } from '../contexts/SubagentContext';
 
 type GetToolResultRawFn = (toolUseId: string) => ClaudeRawMessage | null;
 
@@ -10,12 +12,38 @@ interface UseSubagentsParams {
   getContentBlocks: (message: ClaudeMessage) => ClaudeContentBlock[];
   findToolResult: (toolUseId?: string, messageIndex?: number) => ToolResultBlock | null;
   getToolResultRaw: GetToolResultRawFn;
+  subagentHistories?: Record<string, SubagentHistoryResponse>;
 }
 
 /**
- * Determine subagent status based on tool result
+ * Determine subagent status.
+ *
+ * Async agents (Agent/Task tool invoked with run_in_background:true) only
+ * receive a launch acknowledgment tool_result, not a completion signal. The
+ * terminal status arrives later via a task_notification event, so while no
+ * event has landed the agent is still running.
+ *
+ * Sync agents (task/agent without run_in_background) run inline: a tool_result
+ * means the agent is done.
  */
-function determineStatus(result: ToolResultBlock | null): SubagentStatus {
+function determineStatus(
+  result: ToolResultBlock | null,
+  isAsync: boolean,
+  taskEvent: TaskEvent | undefined,
+): SubagentStatus {
+  if (isAsync) {
+    if (taskEvent) {
+      return taskEvent.status === 'failed' || taskEvent.status === 'stopped' ? 'error' : 'completed';
+    }
+    // A failed launch (validation error before the background task was
+    // registered) returns an is_error tool_result and never emits a
+    // task_notification - surface it as an error instead of staying stuck on
+    // "running" forever.
+    if (result?.is_error) {
+      return 'error';
+    }
+    return 'running';
+  }
   if (!result) {
     return 'running';
   }
@@ -25,45 +53,36 @@ function determineStatus(result: ToolResultBlock | null): SubagentStatus {
   return 'completed';
 }
 
-function extractResultText(result: ToolResultBlock | null): string | undefined {
-  if (!result) return undefined;
-  if (typeof result.content === 'string') return result.content;
-  if (!Array.isArray(result.content)) return undefined;
-  const text = result.content
-    .map((item) => (item && typeof item.text === 'string' ? item.text : ''))
-    .filter(Boolean)
-    .join('\n');
-  return text || undefined;
-}
-
 function extractResultMetadata(
   result: ToolResultBlock | null,
   getToolResultRaw: GetToolResultRawFn,
   toolUseId: string,
+  taskEvent: TaskEvent | undefined,
 ): Partial<SubagentInfo> {
   const rawMessage = getToolResultRaw(toolUseId);
   const metadata = rawMessage?.toolUseResult;
-  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
-    return { resultText: extractResultText(result) };
-  }
+  const record = metadata && typeof metadata === 'object' && !Array.isArray(metadata)
+    ? (metadata as Record<string, unknown>)
+    : null;
 
-  const record = metadata as Record<string, unknown>;
   const getString = (value: unknown) => (typeof value === 'string' && value.trim() ? value.trim() : undefined);
   const getNumber = (value: unknown) => (typeof value === 'number' && Number.isFinite(value) ? value : undefined);
-  const toolStats = record.toolStats && typeof record.toolStats === 'object' && !Array.isArray(record.toolStats)
+  const toolStats = record?.toolStats && typeof record.toolStats === 'object' && !Array.isArray(record.toolStats)
     ? Object.fromEntries(
       Object.entries(record.toolStats as Record<string, unknown>)
         .filter((entry): entry is [string, number] => typeof entry[1] === 'number' && Number.isFinite(entry[1])),
     )
     : undefined;
 
+  // task_notification wins over toolUseResult: for async agents the launch
+  // tool_result carries no usage, so the event is the only source of truth.
   return {
-    agentId: getString(record.agentId),
-    totalDurationMs: getNumber(record.totalDurationMs),
-    totalTokens: getNumber(record.totalTokens),
-    totalToolUseCount: getNumber(record.totalToolUseCount),
+    agentId: taskEvent?.agentId ?? getString(record?.agentId),
+    totalDurationMs: taskEvent?.totalDurationMs ?? getNumber(record?.totalDurationMs),
+    totalTokens: taskEvent?.totalTokens ?? getNumber(record?.totalTokens),
+    totalToolUseCount: taskEvent?.totalToolUseCount ?? getNumber(record?.totalToolUseCount),
     toolStats,
-    resultText: extractResultText(result),
+    resultText: taskEvent?.summary ?? extractResultText(result),
   };
 }
 
@@ -72,6 +91,7 @@ export function extractSubagentsFromMessages(
   getContentBlocks: (message: ClaudeMessage) => ClaudeContentBlock[],
   findToolResult: (toolUseId?: string, messageIndex?: number) => ToolResultBlock | null,
   getToolResultRaw: GetToolResultRawFn,
+  taskEvents: TaskEventMap = {},
 ): SubagentInfo[] {
   const subagents: SubagentInfo[] = [];
 
@@ -101,8 +121,12 @@ export function extractSubagentsFromMessages(
       // Check tool result to determine status
       const toolUseId = block.id ?? '';
       const result = findToolResult(toolUseId, messageIndex);
-      const status = determineStatus(result);
-      const resultMetadata = extractResultMetadata(result, getToolResultRaw, toolUseId);
+      const taskEvent = taskEvents[toolUseId];
+      // isAsync is read via the shared isAsyncAgentInput helper so the
+      // StatusPanel list and the inline Agent cards stay in lockstep.
+      const isAsync = isAsyncAgentInput(input);
+      const status = determineStatus(result, isAsync, taskEvent);
+      const resultMetadata = extractResultMetadata(result, getToolResultRaw, toolUseId, taskEvent);
 
       subagents.push({
         id,
@@ -110,6 +134,7 @@ export function extractSubagentsFromMessages(
         description,
         prompt,
         status,
+        isAsync,
         messageIndex,
         ...resultMetadata,
       });
@@ -119,17 +144,37 @@ export function extractSubagentsFromMessages(
   return subagents;
 }
 
+export function applySubagentHistoryCompletion(
+  subagents: SubagentInfo[],
+  subagentHistories: Record<string, SubagentHistoryResponse>,
+): SubagentInfo[] {
+  return subagents.map((subagent) => {
+    if (!subagent.isAsync || subagent.status !== 'running') return subagent;
+    const history = subagentHistories[subagent.id]
+      ?? (subagent.agentId ? subagentHistories[subagent.agentId] : undefined);
+    return history?.completed ? { ...subagent, status: 'completed' as const } : subagent;
+  });
+}
+
 /**
- * Hook to extract subagent information from Task tool calls
+ * Hook to extract subagent information from Task tool calls.
  */
 export function useSubagents({
   messages,
   getContentBlocks,
   findToolResult,
   getToolResultRaw,
+  subagentHistories = {},
 }: UseSubagentsParams): SubagentInfo[] {
-  return useMemo(
-    () => extractSubagentsFromMessages(messages, getContentBlocks, findToolResult, getToolResultRaw),
-    [messages, getContentBlocks, findToolResult, getToolResultRaw],
-  );
+  const taskEvents = useTaskEvents();
+  return useMemo(() => {
+    const extracted = extractSubagentsFromMessages(
+      messages,
+      getContentBlocks,
+      findToolResult,
+      getToolResultRaw,
+      taskEvents,
+    );
+    return applySubagentHistoryCompletion(extracted, subagentHistories);
+  }, [messages, getContentBlocks, findToolResult, getToolResultRaw, taskEvents, subagentHistories]);
 }

--- a/webview/src/hooks/useWindowCallbacks.ts
+++ b/webview/src/hooks/useWindowCallbacks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import type { TFunction } from 'i18next';
 import type { MutableRefObject, RefObject } from 'react';
-import type { ClaudeMessage, ClaudeRawMessage, HistoryData, SubagentHistoryResponse } from '../types';
+import type { ClaudeMessage, ClaudeRawMessage, HistoryData, SubagentHistoryResponse, TaskEventMap } from '../types';
 import type { PermissionMode, SelectedAgent } from '../components/ChatInputBox/types';
 import type { ProviderConfig } from '../types/provider';
 import type { PermissionRequest } from '../components/PermissionDialog';
@@ -58,6 +58,7 @@ export interface UseWindowCallbacksOptions {
   setContextInfo: React.Dispatch<React.SetStateAction<ContextInfo | null>>;
   setSelectedAgent: React.Dispatch<React.SetStateAction<SelectedAgent | null>>;
   setSubagentHistories?: React.Dispatch<React.SetStateAction<Record<string, SubagentHistoryResponse>>>;
+  setTaskEvents?: React.Dispatch<React.SetStateAction<TaskEventMap>>;
 
   // Refs
   currentProviderRef: MutableRefObject<string>;

--- a/webview/src/hooks/windowCallbacks/registerCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks.ts
@@ -12,6 +12,8 @@
 
 import type { MutableRefObject } from 'react';
 import type { UseWindowCallbacksOptions } from '../useWindowCallbacks';
+import { parseTaskNotification } from '../../utils/taskEventParser';
+import { deepEqual } from '../../utils/deepEqual';
 import {
   setupSlashCommandsCallback,
   resetSlashCommandsState,
@@ -32,21 +34,9 @@ import { registerUsageModeCallbacks } from './registerCallbacks/usageModeCallbac
 import { registerPermissionCallbacks } from './registerCallbacks/permissionCallbacks';
 import { registerAgentAndSelectionCallbacks } from './registerCallbacks/agentCallbacks';
 
-function areSubagentMessagesEquivalent(previousMessages?: unknown[], nextMessages?: unknown[]): boolean {
+function areSubagentMessagesEquivalent(previousMessages: unknown[] | undefined, nextMessages: unknown[] | undefined): boolean {
   if (previousMessages === nextMessages) return true;
-  if (!Array.isArray(previousMessages) || !Array.isArray(nextMessages)) {
-    return previousMessages === nextMessages;
-  }
-  if (previousMessages.length !== nextMessages.length) return false;
-
-  // NOTE: Uses JSON.stringify for shallow deep-equality check.
-  // Acceptable for cache invalidation; key order divergence between code paths
-  // produces false negatives that just trigger re-render (safe degradation).
-  try {
-    return JSON.stringify(previousMessages) === JSON.stringify(nextMessages);
-  } catch {
-    return false;
-  }
+  return deepEqual(previousMessages, nextMessages);
 }
 
 export function registerWindowCallbacks(
@@ -114,6 +104,53 @@ export function registerWindowCallbacks(
       });
     } catch {
       // Ignore malformed callback payloads; the request can be retried by reopening the Agent row.
+    }
+  };
+
+  // task_* SDK system events signal the lifecycle of a background Agent
+  // (Agent/Task tool invoked with run_in_background:true). Only
+  // task_notification carries a terminal status; task_started / task_progress
+  // merely announce progress and must not flip the running state. Without
+  // this, the StatusPanel cannot tell a launched async agent from a finished
+  // one, and the completion summary never surfaces.
+  //
+  // Cross-session safety is enforced by three layers, so this handler does
+  // not re-check sessionId (which is not part of the taskEvent payload):
+  //   1. Java ClaudeChatWindow.titleEventListener drops events whose sessionId
+  //      does not match the active session.
+  //   2. beginSessionTransition (useSessionManagement) clears taskEvents on
+  //      session switch, so stale entries from the prior session cannot linger.
+  //   3. tool_use_ids are globally unique, so even a delayed event can only
+  //      update the agent it was emitted for, never mislabel another.
+  window.onTaskEvent = (eventJson: string) => {
+    try {
+      if (!options.setTaskEvents) return;
+      const taskEvent = parseTaskNotification(JSON.parse(eventJson));
+      if (!taskEvent) return;
+      const { toolUseId } = taskEvent;
+      options.setTaskEvents((prev) => {
+        const existing = prev[toolUseId];
+        // Dedup: skip the state update when no observable field changed. Include
+        // agentId/outputFilePath so a follow-up event that adds the sidechain
+        // transcript path still lands (task_notification is terminal, but a
+        // late output_file attachment would otherwise be swallowed).
+        if (existing
+          && existing.status === taskEvent.status
+          && existing.summary === taskEvent.summary
+          && existing.totalTokens === taskEvent.totalTokens
+          && existing.totalToolUseCount === taskEvent.totalToolUseCount
+          && existing.totalDurationMs === taskEvent.totalDurationMs
+          && existing.agentId === taskEvent.agentId
+          && existing.outputFilePath === taskEvent.outputFilePath) {
+          return prev;
+        }
+        return { ...prev, [toolUseId]: taskEvent };
+      });
+    } catch {
+      // Ignore malformed task event payloads. A task_notification is terminal,
+      // so a dropped event is not retried - but a later task_progress /
+      // task_notification for the same tool_use_id will still land and update
+      // the entry, so the subagent list is not permanently stuck.
     }
   };
 

--- a/webview/src/main.tsx
+++ b/webview/src/main.tsx
@@ -5,6 +5,7 @@ import { MessagesProvider } from './contexts/MessagesContext';
 import { SessionProvider } from './contexts/SessionContext';
 import { UIStateProvider } from './contexts/UIStateContext';
 import { DialogProvider } from './contexts/DialogContext';
+import { TaskEventProvider } from './contexts/SubagentContext';
 import './codicon.css';
 import './styles/app.less';
 import './i18n/config';
@@ -684,9 +685,11 @@ ReactDOM.createRoot(document.getElementById('app') as HTMLElement).render(
     <UIStateProvider>
       <SessionProvider>
         <MessagesProvider>
-          <DialogProvider>
-            <App />
-          </DialogProvider>
+          <TaskEventProvider>
+            <DialogProvider>
+              <App />
+            </DialogProvider>
+          </TaskEventProvider>
         </MessagesProvider>
       </SessionProvider>
     </UIStateProvider>

--- a/webview/src/types/index.ts
+++ b/webview/src/types/index.ts
@@ -138,4 +138,4 @@ export interface HistoryData {
 export type { FileChangeStatus, EditOperation, FileChangeSummary } from './fileChanges';
 
 // Subagent types
-export type { SubagentStatus, SubagentInfo, SubagentHistoryResponse } from './subagent';
+export type { SubagentStatus, SubagentInfo, SubagentHistoryResponse, TaskEvent, TaskEventMap, TaskEventStatus } from './subagent';

--- a/webview/src/types/subagent.ts
+++ b/webview/src/types/subagent.ts
@@ -3,8 +3,45 @@
  */
 export type SubagentStatus = 'running' | 'completed' | 'error';
 
+/**
+ * Terminal status carried by a Claude Code task_notification SDK event.
+ * Maps onto SubagentStatus: failed/stopped -> error, completed -> completed.
+ */
+export type TaskEventStatus = 'completed' | 'failed' | 'stopped';
+
+/**
+ * A task_* SDK system event for a background (async Agent) subagent — one
+ * invoked via the Agent/Task tool with run_in_background:true. The mainstream
+ * only carries these lightweight events; the agent's detailed messages live in
+ * a background sidechain. task_notification arrives once the agent finishes and
+ * carries the result summary plus usage.
+ */
+export interface TaskEvent {
+  /** tool_use_id of the background Agent call; matches SubagentInfo.id */
+  toolUseId: string;
+  /** Runtime agent id (SDK task_id); locates the sidechain transcript */
+  agentId?: string;
+  /** Terminal status reported by task_notification */
+  status: TaskEventStatus;
+  /** Human-readable result summary */
+  summary?: string;
+  /** Token usage reported at completion */
+  totalTokens?: number;
+  /** Tool invocation count reported at completion */
+  totalToolUseCount?: number;
+  /** Total runtime in milliseconds, when reported */
+  totalDurationMs?: number;
+  /** Path to the sidechain JSONL transcript */
+  outputFilePath?: string;
+}
+
+/** Map of tool_use_id -> latest task_* event for async subagents. */
+export type TaskEventMap = Record<string, TaskEvent>;
+
 export interface SubagentHistoryResponse {
   success: boolean;
+  /** True only when the sidechain transcript ends with an assistant end_turn. */
+  completed?: boolean;
   toolUseId?: string;
   agentId?: string;
   sessionId?: string;
@@ -26,6 +63,12 @@ export interface SubagentInfo {
   prompt?: string;
   /** Execution status */
   status: SubagentStatus;
+  /**
+   * True for async agents (Agent/Task tool with run_in_background:true).
+   * Their terminal status arrives live via task_notification; after history
+   * reload it is recovered from the sidechain transcript's terminal end_turn.
+   */
+  isAsync?: boolean;
   /** Message index where this subagent was invoked */
   messageIndex: number;
   /** Stable runtime agent id returned by Claude Code, used to locate sidechain logs */

--- a/webview/src/utils/deepEqual.test.ts
+++ b/webview/src/utils/deepEqual.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { deepEqual } from './deepEqual';
+
+describe('deepEqual', () => {
+  it('returns true for primitives that are strictly equal', () => {
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual('a', 'a')).toBe(true);
+    expect(deepEqual(true, true)).toBe(true);
+  });
+
+  it('returns false for primitives that differ', () => {
+    expect(deepEqual(1, 2)).toBe(false);
+    expect(deepEqual('a', 'b')).toBe(false);
+    // No coercion: 1 and '1' are not equal.
+    expect(deepEqual(1, '1')).toBe(false);
+  });
+
+  it('handles null symmetrically', () => {
+    expect(deepEqual(null, null)).toBe(true);
+    expect(deepEqual(null, {})).toBe(false);
+    expect(deepEqual({}, null)).toBe(false);
+  });
+
+  it('treats NaN as not equal (no special-case)', () => {
+    expect(deepEqual(NaN, NaN)).toBe(false);
+  });
+
+  it('compares arrays element-wise', () => {
+    expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(deepEqual([1, 2, 3], [1, 2])).toBe(false);
+    expect(deepEqual([1, [2]], [1, [2]])).toBe(true);
+    expect(deepEqual([1, 2], [2, 1])).toBe(false);
+  });
+
+  it('returns false when one side is an array and the other is an object', () => {
+    expect(deepEqual([], {})).toBe(false);
+    expect(deepEqual([1], { 0: 1 })).toBe(false);
+  });
+
+  it('compares objects regardless of key order', () => {
+    // The key behavior a JSON.stringify comparison got wrong (false negative):
+    // semantically identical payloads with different insertion order must be
+    // equal so onTaskEvent dedup does not double-update.
+    expect(deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+  });
+
+  it('returns false when the key set differs', () => {
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(deepEqual({ a: 1, b: 2 }, { a: 1, c: 2 })).toBe(false);
+  });
+
+  it('compares nested structures', () => {
+    expect(deepEqual({ a: { b: [1, 2] } }, { a: { b: [1, 2] } })).toBe(true);
+    expect(deepEqual({ a: { b: [1, 2] } }, { a: { b: [1, 3] } })).toBe(false);
+  });
+
+  it('treats {a:1, b:undefined} as not equal to {a:1}', () => {
+    // Documented behavior difference from JSON.stringify (which would call
+    // them equal). deepEqual counts the key, so these differ. This is the
+    // safe-degradation direction (more re-renders, never a stale skip).
+    expect(deepEqual({ a: 1, b: undefined }, { a: 1 })).toBe(false);
+  });
+});

--- a/webview/src/utils/deepEqual.ts
+++ b/webview/src/utils/deepEqual.ts
@@ -1,0 +1,38 @@
+/**
+ * Structural deep-equality check for JSON-like values.
+ *
+ * Unlike JSON.stringify comparison, key order in objects does not affect the
+ * result, so semantically identical payloads with different insertion order
+ * are correctly reported as equal (no false negatives).
+ *
+ * Intended for small, bounded payloads (e.g. subagent history messages) where
+ * a recursive walk is cheaper than re-rendering downstream consumers.
+ *
+ * Assumes acyclic input (no visited-pair guard): callers feed JSON-derived
+ * data (JSON.parse cannot produce cycles), so a WeakSet guard would be pure
+ * overhead. Do not pass values that may contain circular references.
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') {
+    return false;
+  }
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  const objA = a as Record<string, unknown>;
+  const objB = b as Record<string, unknown>;
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+  if (keysA.length !== keysB.length) return false;
+  for (const key of keysA) {
+    if (!Object.prototype.hasOwnProperty.call(objB, key)) return false;
+    if (!deepEqual(objA[key], objB[key])) return false;
+  }
+  return true;
+}

--- a/webview/src/utils/subagentResult.test.ts
+++ b/webview/src/utils/subagentResult.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { isAsyncAgentInput, extractResultText, parseAgentToolMeta } from './subagentResult';
+
+describe('isAsyncAgentInput', () => {
+  it('returns true for run_in_background: true (snake_case)', () => {
+    expect(isAsyncAgentInput({ run_in_background: true })).toBe(true);
+  });
+
+  it('returns true for runInBackground: true (camelCase guard)', () => {
+    expect(isAsyncAgentInput({ runInBackground: true })).toBe(true);
+  });
+
+  it('returns false for run_in_background: false', () => {
+    expect(isAsyncAgentInput({ run_in_background: false })).toBe(false);
+  });
+
+  it('returns false for truthy non-boolean values (strict === true)', () => {
+    // A string like "false" must not flip the flag - this is the regression
+    // the strict === true check exists to prevent.
+    expect(isAsyncAgentInput({ run_in_background: 'false' })).toBe(false);
+    expect(isAsyncAgentInput({ run_in_background: 'true' })).toBe(false);
+    expect(isAsyncAgentInput({ run_in_background: 1 })).toBe(false);
+  });
+
+  it('returns false when the field is absent', () => {
+    expect(isAsyncAgentInput({ prompt: 'do stuff' })).toBe(false);
+  });
+
+  it('returns false for non-object / nullish input', () => {
+    expect(isAsyncAgentInput(null)).toBe(false);
+    expect(isAsyncAgentInput(undefined)).toBe(false);
+    expect(isAsyncAgentInput('not-an-object')).toBe(false);
+    expect(isAsyncAgentInput(42)).toBe(false);
+  });
+});
+
+describe('extractResultText', () => {
+  it('returns undefined for no result', () => {
+    expect(extractResultText(undefined)).toBeUndefined();
+    expect(extractResultText(null)).toBeUndefined();
+  });
+
+  it('returns string content directly', () => {
+    expect(extractResultText({ type: 'tool_result', content: 'done' })).toBe('done');
+  });
+
+  it('joins text blocks from array content', () => {
+    expect(
+      extractResultText({
+        type: 'tool_result',
+        content: [{ type: 'text', text: 'a' }, { type: 'text', text: 'b' }],
+      }),
+    ).toBe('a\nb');
+  });
+
+  it('returns undefined for empty/whitespace-only text', () => {
+    expect(
+      extractResultText({ type: 'tool_result', content: [{ type: 'text', text: '' }] }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when content has no text blocks', () => {
+    expect(extractResultText({ type: 'tool_result', content: [{ type: 'image' }] })).toBeUndefined();
+  });
+});
+
+describe('parseAgentToolMeta', () => {
+  it('returns empty object when toolUseId is missing', () => {
+    expect(parseAgentToolMeta(() => null)).toEqual({});
+  });
+
+  it('returns empty object when raw has no toolUseResult', () => {
+    const getter = () => ({ content: 'x' });
+    expect(parseAgentToolMeta(getter, 'tu_1')).toEqual({});
+  });
+
+  it('extracts agentId/usage metadata from toolUseResult', () => {
+    const getter = () => ({
+      toolUseResult: {
+        agentId: 'af5a83aa',
+        totalDurationMs: 18000,
+        totalTokens: 4200,
+        totalToolUseCount: 7,
+      },
+    });
+    expect(parseAgentToolMeta(getter, 'tu_1')).toEqual({
+      agentId: 'af5a83aa',
+      totalDurationMs: 18000,
+      totalTokens: 4200,
+      totalToolUseCount: 7,
+    });
+  });
+
+  it('ignores non-object toolUseResult (e.g. raw error string)', () => {
+    // The SDK may overwrite toolUseResult with a raw error string; the helper
+    // must fall back to {} rather than reading properties off a string.
+    const getter = () => ({ toolUseResult: 'some error string' });
+    expect(parseAgentToolMeta(getter, 'tu_1')).toEqual({});
+  });
+
+  it('ignores non-finite / wrong-typed numeric fields', () => {
+    const getter = () => ({
+      toolUseResult: { totalTokens: NaN, totalDurationMs: Infinity, totalToolUseCount: '7' },
+    });
+    expect(parseAgentToolMeta(getter, 'tu_1')).toEqual({});
+  });
+});

--- a/webview/src/utils/subagentResult.ts
+++ b/webview/src/utils/subagentResult.ts
@@ -1,0 +1,66 @@
+import type { ToolResultBlock } from '../types';
+import type { GetToolResultRawFn } from '../contexts/SubagentContext';
+
+/**
+ * Extract concatenated text content from a tool_result block.
+ *
+ * Shared by useSubagents, AgentGroupBlock, and TaskExecutionBlock so the
+ * extraction logic (string vs array content, text-block filtering) stays in
+ * one place. Returns undefined when there is no text to show.
+ */
+export function extractResultText(result?: ToolResultBlock | null): string | undefined {
+  if (!result) return undefined;
+  if (typeof result.content === 'string') return result.content;
+  if (Array.isArray(result.content)) {
+    const text = result.content
+      .map((item) => (item && typeof item.text === 'string' ? item.text : ''))
+      .filter(Boolean)
+      .join('\n');
+    return text || undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Whether an Agent/Task tool input launches a background (async) subagent.
+ *
+ * Claude Code triggers async via the `run_in_background: true` input parameter
+ * (AgentTool schema), NOT via the tool name. normalizeToolInput preserves the
+ * snake_case field via spread for the Agent/Task tools, so both the StatusPanel
+ * list (useSubagents, normalized input) and the inline Agent cards
+ * (AgentGroupBlock/TaskExecutionBlock, raw block.input) read the same field.
+ *
+ * Strict === true avoids truthy strings (e.g. "false") flipping the flag. The
+ * camelCase `runInBackground` form is also checked as a guard against future
+ * normalization changes. Shared by all three call sites so they cannot drift.
+ */
+export function isAsyncAgentInput(input: unknown): boolean {
+  if (!input || typeof input !== 'object') return false;
+  const record = input as Record<string, unknown>;
+  return record.run_in_background === true || record.runInBackground === true;
+}
+
+/**
+ * Per-agent usage metadata the SDK stamps on the tool_result's toolUseResult
+ * field (agentId, totalDurationMs, totalTokens, totalToolUseCount). Shared by
+ * AgentGroupBlock and TaskExecutionBlock so the field extraction stays single-
+ * sourced. Returns an empty object when there is no usable metadata.
+ */
+export function parseAgentToolMeta(
+  getToolResultRaw: GetToolResultRawFn,
+  toolUseId?: string,
+): { agentId?: string; totalDurationMs?: number; totalTokens?: number; totalToolUseCount?: number } {
+  if (!toolUseId) return {};
+  const rawMessage = getToolResultRaw(toolUseId);
+  const metadata = rawMessage?.toolUseResult;
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return {};
+  const record = metadata as Record<string, unknown>;
+  const getString = (value: unknown) => (typeof value === 'string' && value.trim() ? value.trim() : undefined);
+  const getNumber = (value: unknown) => (typeof value === 'number' && Number.isFinite(value) ? value : undefined);
+  return {
+    agentId: getString(record.agentId),
+    totalDurationMs: getNumber(record.totalDurationMs),
+    totalTokens: getNumber(record.totalTokens),
+    totalToolUseCount: getNumber(record.totalToolUseCount),
+  };
+}

--- a/webview/src/utils/taskEventParser.test.ts
+++ b/webview/src/utils/taskEventParser.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { parseTaskNotification } from './taskEventParser';
+
+describe('parseTaskNotification', () => {
+  it('parses a complete task_notification with usage', () => {
+    const ev = parseTaskNotification({
+      type: 'system',
+      subtype: 'task_notification',
+      task_id: 'af5a83aa',
+      tool_use_id: 'tu_1',
+      status: 'completed',
+      summary: '调研完成',
+      output_file: '/tmp/agent.jsonl',
+      usage: { total_tokens: 4200, tool_uses: 7, duration_ms: 18000 },
+    });
+
+    expect(ev).toEqual({
+      toolUseId: 'tu_1',
+      agentId: 'af5a83aa',
+      status: 'completed',
+      summary: '调研完成',
+      totalTokens: 4200,
+      totalToolUseCount: 7,
+      totalDurationMs: 18000,
+      outputFilePath: '/tmp/agent.jsonl',
+    });
+  });
+
+  it('ignores input_tokens/output_tokens (not part of the task_notification schema)', () => {
+    // Claude Code's task_notification usage only carries total_tokens /
+    // tool_uses / duration_ms (sdkEventQueue.ts TaskNotificationSdkEvent and
+    // print.ts's XML parser are the only emit sites). input_tokens /
+    // output_tokens are never present, so the parser must not synthesize
+    // totalTokens from them - it should read total_tokens alone.
+    const ev = parseTaskNotification({
+      subtype: 'task_notification',
+      tool_use_id: 'tu_2',
+      status: 'completed',
+      usage: { total_tokens: 1500, tool_uses: 2, duration_ms: 9000 },
+    });
+
+    expect(ev?.totalTokens).toBe(1500);
+    expect(ev?.totalToolUseCount).toBe(2);
+    expect(ev?.totalDurationMs).toBe(9000);
+  });
+
+  it('leaves usage fields undefined when usage is missing', () => {
+    const ev = parseTaskNotification({
+      subtype: 'task_notification',
+      tool_use_id: 'tu_3',
+      status: 'failed',
+    });
+
+    expect(ev?.status).toBe('failed');
+    expect(ev?.totalTokens).toBeUndefined();
+    expect(ev?.totalToolUseCount).toBeUndefined();
+    expect(ev?.totalDurationMs).toBeUndefined();
+    expect(ev?.summary).toBeUndefined();
+    expect(ev?.agentId).toBeUndefined();
+    expect(ev?.outputFilePath).toBeUndefined();
+  });
+
+  it('returns null for non-task_notification subtypes', () => {
+    expect(parseTaskNotification({ subtype: 'task_started', tool_use_id: 'tu', status: 'completed' })).toBeNull();
+    expect(parseTaskNotification({ subtype: 'task_progress', tool_use_id: 'tu', status: 'completed' })).toBeNull();
+  });
+
+  it('returns null when tool_use_id or status is missing', () => {
+    expect(parseTaskNotification({ subtype: 'task_notification', status: 'completed' })).toBeNull();
+    expect(parseTaskNotification({ subtype: 'task_notification', tool_use_id: 'tu' })).toBeNull();
+    expect(parseTaskNotification({ subtype: 'task_notification', tool_use_id: '', status: 'completed' })).toBeNull();
+  });
+
+  it('returns null for malformed payloads', () => {
+    expect(parseTaskNotification(null)).toBeNull();
+    expect(parseTaskNotification(undefined)).toBeNull();
+    expect(parseTaskNotification('not-an-object')).toBeNull();
+    expect(parseTaskNotification({})).toBeNull();
+  });
+
+  it('passes stopped status through for the caller to map', () => {
+    // parseTaskNotification does not interpret status; determineStatus maps
+    // stopped/failed -> error. Verify the raw status survives so that mapping
+    // can fire.
+    const ev = parseTaskNotification({
+      subtype: 'task_notification',
+      tool_use_id: 'tu_4',
+      status: 'stopped',
+    });
+    expect(ev?.status).toBe('stopped');
+  });
+
+  it('rejects status values outside the SDK enum', () => {
+    // SDK only emits 'completed' | 'failed' | 'stopped' (sdkEventQueue.ts
+    // emitTaskTerminatedSdk; print.ts maps XML 'killed' -> 'stopped'). An
+    // unexpected value must not slip through the type system and masquerade
+    // as a known terminal status downstream.
+    expect(parseTaskNotification({ subtype: 'task_notification', tool_use_id: 'tu', status: 'running' })).toBeNull();
+    expect(parseTaskNotification({ subtype: 'task_notification', tool_use_id: 'tu', status: 'killed' })).toBeNull();
+    expect(parseTaskNotification({ subtype: 'task_notification', tool_use_id: 'tu', status: 'pending' })).toBeNull();
+    expect(parseTaskNotification({ subtype: 'task_notification', tool_use_id: 'tu', status: 42 })).toBeNull();
+    expect(parseTaskNotification({ subtype: 'task_notification', tool_use_id: 'tu', status: null })).toBeNull();
+  });
+
+  it('treats an empty output_file as no path', () => {
+    // The SDK defaults output_file to '' when no sidechain transcript was
+    // produced (sdkEventQueue.ts emitTaskTerminatedSdk). '' is not a usable
+    // path and would diverge from undefined across the dual delivery paths'
+    // dedup, so the parser coalesces it to undefined.
+    const ev = parseTaskNotification({
+      subtype: 'task_notification',
+      tool_use_id: 'tu',
+      status: 'completed',
+      output_file: '',
+    });
+    expect(ev?.outputFilePath).toBeUndefined();
+  });
+});

--- a/webview/src/utils/taskEventParser.ts
+++ b/webview/src/utils/taskEventParser.ts
@@ -1,0 +1,62 @@
+import type { TaskEvent } from '../types';
+
+/**
+ * Parse a raw SDK task_notification payload into a {@link TaskEvent}, or return
+ * null when the payload is not a task_notification or lacks the required
+ * tool_use_id/status.
+ *
+ * Extracted as a pure function so the JSON -> TaskEvent mapping (subtype guard,
+ * usage extraction, field extraction) is unit-testable independent of the React
+ * state setter in registerCallbacks.
+ *
+ * SDK field names are snake_case and mirror Claude Code's
+ * SDKTaskNotificationMessageSchema (subtype / tool_use_id / status / task_id /
+ * summary / output_file / usage). The usage object is optional; when present it
+ * carries only {total_tokens, tool_uses, duration_ms} - see
+ * sdkEventQueue.ts TaskNotificationSdkEvent and print.ts's XML task_notification
+ * parser, which are the only two emit sites. There is no input_tokens /
+ * output_tokens field on a task_notification.
+ */
+
+// The SDK only ever emits these three terminal statuses (sdkEventQueue.ts
+// emitTaskTerminatedSdk; print.ts maps XML 'killed' -> 'stopped'). Validating
+// at runtime keeps an unexpected value from sneaking through the type system
+// and masquerading as a known terminal status downstream.
+const TASK_EVENT_STATUSES: readonly TaskEvent['status'][] = ['completed', 'failed', 'stopped'];
+function isTaskEventStatus(value: unknown): value is TaskEvent['status'] {
+  return typeof value === 'string' && (TASK_EVENT_STATUSES as readonly string[]).includes(value);
+}
+
+export function parseTaskNotification(raw: unknown): TaskEvent | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const ev = raw as Record<string, unknown>;
+  if (ev.subtype !== 'task_notification') return null;
+
+  const toolUseId = typeof ev.tool_use_id === 'string' ? ev.tool_use_id : undefined;
+  const status = ev.status;
+  if (!toolUseId || !isTaskEventStatus(status)) return null;
+
+  const usage = ev.usage && typeof ev.usage === 'object'
+    ? ev.usage as Record<string, unknown>
+    : {};
+
+  const totalTokens = typeof usage.total_tokens === 'number' ? usage.total_tokens : undefined;
+  const totalToolUseCount = typeof usage.tool_uses === 'number' ? usage.tool_uses : undefined;
+  const totalDurationMs = typeof usage.duration_ms === 'number' ? usage.duration_ms : undefined;
+  const summary = typeof ev.summary === 'string' ? ev.summary : undefined;
+
+  return {
+    toolUseId,
+    agentId: typeof ev.task_id === 'string' ? ev.task_id : undefined,
+    status,
+    summary,
+    totalTokens,
+    totalToolUseCount,
+    totalDurationMs,
+    // Treat an empty output_file the same as a missing one: the SDK defaults
+    // output_file to '' when no sidechain transcript was produced, and '' is
+    // not a usable path. Coalescing to undefined keeps dedup stable across the
+    // dual delivery paths ('' would otherwise differ from undefined).
+    outputFilePath: typeof ev.output_file === 'string' && ev.output_file ? ev.output_file : undefined,
+  };
+}

--- a/webview/src/utils/turnScope.test.ts
+++ b/webview/src/utils/turnScope.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { finalizeSubagentsForSettledTurn } from './turnScope';
+import type { SubagentInfo } from '../types';
+
+const subagent = (overrides: Partial<SubagentInfo>): SubagentInfo => ({
+  id: 'tu_1',
+  type: 'research',
+  description: 'task',
+  status: 'running',
+  messageIndex: 0,
+  ...overrides,
+});
+
+describe('finalizeSubagentsForSettledTurn', () => {
+  it('does not infer async completion from a settled main turn', () => {
+    const result = finalizeSubagentsForSettledTurn([subagent({ isAsync: true })], false);
+    expect(result[0].status).toBe('running');
+  });
+
+  it('preserves terminal status supplied by task_notification or sidechain history', () => {
+    const result = finalizeSubagentsForSettledTurn(
+      [
+        subagent({ isAsync: true, status: 'completed' }),
+        subagent({ isAsync: true, status: 'error' }),
+      ],
+      false,
+    );
+    expect(result.map((item) => item.status)).toEqual(['completed', 'error']);
+  });
+
+  it('does not mutate sync extraction results', () => {
+    const running = subagent({ isAsync: false });
+    const completed = subagent({ isAsync: false, status: 'completed' });
+    const result = finalizeSubagentsForSettledTurn([running, completed], false);
+    expect(result).toEqual([running, completed]);
+  });
+
+  it('returns the same states while streaming', () => {
+    const result = finalizeSubagentsForSettledTurn(
+      [subagent({ isAsync: false }), subagent({ isAsync: true })],
+      true,
+    );
+    expect(result[0].status).toBe('running');
+    expect(result[1].status).toBe('running');
+  });
+});

--- a/webview/src/utils/turnScope.ts
+++ b/webview/src/utils/turnScope.ts
@@ -39,11 +39,11 @@ export function finalizeTodosForSettledTurn(todos: TodoItem[], isStreaming: bool
   ));
 }
 
-export function finalizeSubagentsForSettledTurn(subagents: SubagentInfo[], isStreaming: boolean): SubagentInfo[] {
-  if (isStreaming) return subagents;
-  return subagents.map((subagent) => (
-    subagent.status === 'running'
-      ? { ...subagent, status: 'completed' }
-      : subagent
-  ));
+export function finalizeSubagentsForSettledTurn(subagents: SubagentInfo[], _isStreaming: boolean): SubagentInfo[] {
+  // A settled main turn is not evidence that a run_in_background agent ended:
+  // the launch turn completes while the sidechain may still be running. Async
+  // agents are finalized only by task_notification or by a sidechain transcript
+  // ending in assistant/end_turn (resolved in useSubagents). Sync agents already
+  // derive their terminal state from the Agent tool_result.
+  return subagents;
 }


### PR DESCRIPTION
This change fixes the async subagent lifecycle notification issue where background Agents (invoked with run_in_background:true) would complete but the UI would stay stuck on "running" until manual reload.

The fix implements a dual delivery path (defense-in-depth):
- In-turn path: task_* events flow through the main [MESSAGE] stream
- Inter-turn path: events caught by the perpetual reader and forwarded via daemon channel after the turn completes

Key changes:
- Filter out sidechain messages with parent_tool_use_id to keep subagent internals from polluting the main chat stream
- Add task_event handling in DaemonBridge and ClaudeChatWindow to forward inter-turn notifications to the frontend
- Add TaskEvent type definitions and parsing utilities
- Update AgentGroupBlock and TaskExecutionBlock to display subagent metadata (duration, tokens, usage)
- Add comprehensive tests for task event handling and subagent grouping