### PR TITLE
fix(dependency): resolve npm.exe for mise/Volta Node.js installs

### DIFF
--- a/src/main/java/com/github/claudecodegui/dependency/DependencyManager.java
+++ b/src/main/java/com/github/claudecodegui/dependency/DependencyManager.java
@@ -628,27 +628,27 @@ public class DependencyManager {
             return resolveWslNpmPath(nodePath);
         }
 
-        String npmName = PlatformUtils.isWindows() ? "npm.cmd" : "npm";
+        boolean windows = PlatformUtils.isWindows();
 
         // 1. Try to find npm in the same directory as Node.js
         if (nodePath != null && !"node".equals(nodePath)) {
             File nodeFile = new File(nodePath);
             String dir = nodeFile.getParent();
             if (dir != null) {
-                File npmFile = new File(dir, npmName);
-                if (npmFile.exists()) {
+                File npmFile = findNpmFile(new File(dir), windows);
+                if (npmFile != null) {
                     return npmFile.getAbsolutePath();
                 }
             }
         }
 
-        // 2. Windows: try to find the full path to npm.cmd from the PATH environment variable
-        if (PlatformUtils.isWindows()) {
+        // 2. Windows: try to find the full path to npm from the PATH environment variable
+        if (windows) {
             String pathEnv = System.getenv("PATH");
             if (pathEnv != null) {
                 for (String pathDir : pathEnv.split(File.pathSeparator)) {
-                    File npmFile = new File(pathDir, npmName);
-                    if (npmFile.exists()) {
+                    File npmFile = findNpmFile(new File(pathDir), windows);
+                    if (npmFile != null) {
                         LOG.info("[DependencyManager] Found npm in PATH: " + npmFile.getAbsolutePath());
                         return npmFile.getAbsolutePath();
                     }
@@ -657,7 +657,31 @@ public class DependencyManager {
         }
 
         // 3. Fall back to the bare command name (usually works on Unix)
-        return PlatformUtils.isWindows() ? npmName : "npm";
+        return windows ? "npm.cmd" : "npm";
+    }
+
+    /**
+     * 在指定目录中查找 npm 可执行文件。
+     * <p>Windows 上 npm 可能以 {@code npm.cmd}（标准 Node.js 安装）或
+     * {@code npm.exe}（mise、Volta 等版本管理器）形式存在，需按优先级依次查找；
+     * 其他平台查找 {@code npm}。
+     *
+     * @param dir     待查找的目录，为 {@code null} 时返回 {@code null}
+     * @param windows 是否在 Windows 平台查找，决定候选文件名集合
+     * @return 找到的 npm 文件，未找到返回 {@code null}
+     */
+    static File findNpmFile(File dir, boolean windows) {
+        if (dir == null) {
+            return null;
+        }
+        String[] candidates = windows ? new String[]{"npm.cmd", "npm.exe"} : new String[]{"npm"};
+        for (String name : candidates) {
+            File candidate = new File(dir, name);
+            if (candidate.exists()) {
+                return candidate;
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/test/java/com/github/claudecodegui/dependency/DependencyManagerNpmPathTest.java
+++ b/src/test/java/com/github/claudecodegui/dependency/DependencyManagerNpmPathTest.java
@@ -1,0 +1,79 @@
+package com.github.claudecodegui.dependency;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests for {@link DependencyManager#findNpmFile}, which resolves the npm
+ * executable across Node.js installers on Windows (standard npm.cmd vs
+ * mise/Volta npm.exe). Regression coverage for issue #1503.
+ */
+public class DependencyManagerNpmPathTest {
+
+    @Test
+    public void windows_prefersNpmCmdWhenBothPresent() throws IOException {
+        Path dir = newTempDir();
+        touch(dir.resolve("npm.exe"));
+        touch(dir.resolve("npm.cmd"));
+
+        File found = DependencyManager.findNpmFile(dir.toFile(), true);
+
+        assertEquals("npm.cmd must be preferred over npm.exe on Windows",
+                dir.resolve("npm.cmd").toFile(), found);
+    }
+
+    @Test
+    public void windows_fallsBackToNpmExeForMiseInstalls() throws IOException {
+        // Reproduces issue #1503: mise shims only npm.exe (no npm.cmd), so the
+        // previous hard-coded "npm.cmd" lookup failed with CreateProcess error=2.
+        Path dir = newTempDir();
+        touch(dir.resolve("npm.exe"));
+
+        File found = DependencyManager.findNpmFile(dir.toFile(), true);
+
+        assertEquals("npm.exe must be used when npm.cmd is absent (mise/Volta)",
+                dir.resolve("npm.exe").toFile(), found);
+    }
+
+    @Test
+    public void unix_returnsNpmWhenPresent() throws IOException {
+        Path dir = newTempDir();
+        touch(dir.resolve("npm"));
+
+        File found = DependencyManager.findNpmFile(dir.toFile(), false);
+
+        assertEquals(dir.resolve("npm").toFile(), found);
+    }
+
+    @Test
+    public void returnsNullWhenNoCandidateExists() throws IOException {
+        Path dir = newTempDir();
+
+        assertNull(DependencyManager.findNpmFile(dir.toFile(), true));
+        assertNull(DependencyManager.findNpmFile(dir.toFile(), false));
+    }
+
+    @Test
+    public void returnsNullForNullDirectory() {
+        assertNull(DependencyManager.findNpmFile(null, true));
+        assertNull(DependencyManager.findNpmFile(null, false));
+    }
+
+    private static Path newTempDir() throws IOException {
+        Path dir = Files.createTempDirectory("npm-resolve-test");
+        dir.toFile().deleteOnExit();
+        return dir;
+    }
+
+    private static void touch(Path file) throws IOException {
+        Files.createFile(file);
+        file.toFile().deleteOnExit();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1503.

On Windows, `DependencyManager#getNpmPath` hard-coded `npm.cmd` as the only npm candidate. Node.js installs managed by **mise** (and similar version managers like Volta) only shim `npm.exe`, so SDK installation failed with:

```
ERROR: Cannot run program "npm.cmd" ... CreateProcess error=2, 系统找不到指定的文件。
```

## Root cause

`getNpmPath` resolved `npmName = "npm.cmd"` unconditionally on Windows and only ever looked for that single filename in (1) the Node.js directory and (2) `PATH`. When neither contained `npm.cmd` it fell back to the bare string `"npm.cmd"`, which `ProcessBuilder` could not launch.

## Fix

- Extract `findNpmFile(File dir, boolean windows)`: on Windows it looks up `npm.cmd` first and falls back to `npm.exe`; elsewhere it looks up `npm`.
- `getNpmPath` now uses `findNpmFile` for both the co-located and `PATH` searches, so mise/Volta installs (npm.exe-only) resolve correctly while standard installs keep preferring `npm.cmd`.

## Testing

Added `DependencyManagerNpmPathTest` (JUnit 4) covering:
- mise scenario: only `npm.exe` present -> resolves `npm.exe` (regression for #1503)
- both present -> prefers `npm.cmd`
- Unix: `npm` present -> resolves `npm`
- empty dir / null dir -> `null`

## Notes

- Behavior is unchanged for standard Node.js installs (`npm.cmd` still preferred).
- WSL path resolution is untouched.