### PR TITLE
feat(models): add Claude Opus 5 support

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/provider/ModelProviderHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/provider/ModelProviderHandler.java
@@ -29,12 +29,14 @@ public class ModelProviderHandler {
         MODEL_CONTEXT_LIMITS.put("claude-sonnet-5", 200_000);
         MODEL_CONTEXT_LIMITS.put("claude-sonnet-4-6", 200_000);
         MODEL_CONTEXT_LIMITS.put("claude-fable-5", 200_000);
+        MODEL_CONTEXT_LIMITS.put("claude-opus-5", 200_000);
         MODEL_CONTEXT_LIMITS.put("claude-opus-4-8", 200_000);
         MODEL_CONTEXT_LIMITS.put("claude-opus-4-6", 200_000);
         // Claude models with [1m] suffix - 1M context
         MODEL_CONTEXT_LIMITS.put("claude-sonnet-5[1m]", 1_000_000);
         MODEL_CONTEXT_LIMITS.put("claude-sonnet-4-6[1m]", 1_000_000);
         MODEL_CONTEXT_LIMITS.put("claude-fable-5[1m]", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("claude-opus-5[1m]", 1_000_000);
         MODEL_CONTEXT_LIMITS.put("claude-opus-4-8[1m]", 1_000_000);
         MODEL_CONTEXT_LIMITS.put("claude-opus-4-6[1m]", 1_000_000);
         // Haiku - no 1M context available

--- a/src/main/java/com/github/claudecodegui/provider/pricing/ClaudePricingTable.java
+++ b/src/main/java/com/github/claudecodegui/provider/pricing/ClaudePricingTable.java
@@ -30,6 +30,7 @@ public final class ClaudePricingTable {
             Map.entry("claude-opus-4-6", OPUS_4_5_PRICING),
             Map.entry("claude-opus-4-7", OPUS_4_5_PRICING),
             Map.entry("claude-opus-4-8", OPUS_4_5_PRICING),
+            Map.entry("claude-opus-5", OPUS_4_5_PRICING),
             Map.entry("claude-fable-5", FABLE_5_PRICING),
             Map.entry("claude-sonnet-4", TIERED_SONNET_PRICING),
             Map.entry("claude-sonnet-4-20250514", TIERED_SONNET_PRICING),
@@ -42,6 +43,7 @@ public final class ClaudePricingTable {
     private static final List<String> MODEL_PREFIXES = List.of(
             "claude-fable-5",
             "claude-opus-4-20250514",
+            "claude-opus-5",
             "claude-opus-4-8",
             "claude-opus-4-7",
             "claude-opus-4-6",

--- a/src/test/java/com/github/claudecodegui/handler/provider/ModelProviderHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/provider/ModelProviderHandlerTest.java
@@ -78,9 +78,11 @@ public class ModelProviderHandlerTest {
         assertTrue(ModelProviderHandler.MODEL_CONTEXT_LIMITS.containsKey("claude-sonnet-5[1m]"));
         assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-sonnet-5"));
         assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-sonnet-4-6"));
+        assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-opus-5"));
         assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-8"));
         assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-6"));
         // IDs with [1m] suffix - 1M context
+        assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("claude-opus-5[1m]"));
         assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("claude-sonnet-5[1m]"));
         assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("claude-sonnet-4-6[1m]"));
         assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-8[1m]"));

--- a/src/test/java/com/github/claudecodegui/provider/pricing/PricingTableTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/pricing/PricingTableTest.java
@@ -29,6 +29,15 @@ public class PricingTableTest {
     }
 
     @Test
+    public void claudeResolvesOpus5AtOpusTierWithoutShadowingOpus4() {
+        // claude-opus-5 is $5 / $25 per MTok and must not fall through to a claude-opus-4* prefix.
+        ClaudePricing opus5 = ClaudePricingTable.resolve("claude-opus-5");
+        assertNotNull(opus5);
+        assertEquals(5.0, opus5.inputCostPer1M(), 1e-9);
+        assertEquals(25.0, opus5.outputCostPer1M(), 1e-9);
+    }
+
+    @Test
     public void claudeAppliesAbove200KTierForSonnet4() {
         ClaudePricing pricing = ClaudePricingTable.resolve("claude-sonnet-4");
         assertNotNull(pricing);

--- a/webview/src/components/ChatInputBox/ButtonArea.tsx
+++ b/webview/src/components/ChatInputBox/ButtonArea.tsx
@@ -134,6 +134,7 @@ export const ButtonArea = ({
     const modelKeyMap: Record<string, keyof typeof mapping> = {
       'claude-sonnet-5': 'sonnet',
       'claude-sonnet-4-6': 'sonnet',
+      'claude-opus-5': 'opus',
       'claude-opus-4-8': 'opus',
       'claude-haiku-4-5': 'haiku',
     };

--- a/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
@@ -45,6 +45,7 @@ const MODEL_LABEL_KEYS: Record<string, string> = {
   'claude-sonnet-5': 'models.claude.sonnet5.label',
   'claude-sonnet-4-6': 'models.claude.sonnet46.label',
   'claude-fable-5': 'models.claude.fable5.label',
+  'claude-opus-5': 'models.claude.opus5.label',
   'claude-opus-4-8': 'models.claude.opus48.label',
   'claude-opus-4-6': 'models.claude.opus46_1m.label',
   'claude-opus-4-6[1m]': 'models.claude.opus46_1m.label',
@@ -60,6 +61,7 @@ const MODEL_DESCRIPTION_KEYS: Record<string, string> = {
   'claude-sonnet-5': 'models.claude.sonnet5.description',
   'claude-sonnet-4-6': 'models.claude.sonnet46.description',
   'claude-fable-5': 'models.claude.fable5.description',
+  'claude-opus-5': 'models.claude.opus5.description',
   'claude-opus-4-8': 'models.claude.opus48.description',
   'claude-opus-4-6': 'models.claude.opus46_1m.description',
   'claude-opus-4-6[1m]': 'models.claude.opus46_1m.description',
@@ -79,6 +81,7 @@ const MODEL_DESCRIPTION_KEYS: Record<string, string> = {
 const MODEL_ID_TO_MAPPING_KEY: Record<string, string> = {
   'claude-sonnet-5': 'sonnet',
   'claude-sonnet-4-6': 'sonnet',
+  'claude-opus-5': 'opus',
   'claude-opus-4-8': 'opus',
   'claude-opus-4-6': 'opus',
   'claude-opus-4-6[1m]': 'opus',

--- a/webview/src/components/ChatInputBox/types.ts
+++ b/webview/src/components/ChatInputBox/types.ts
@@ -314,9 +314,14 @@ export function normalizeClaudeModelId(modelId: string | undefined | null): stri
  */
 export const CLAUDE_MODELS: ModelInfo[] = [
   {
+    id: 'claude-opus-5',
+    label: 'Opus 5',
+    description: 'Opus 5 · Latest and most capable',
+  },
+  {
     id: 'claude-opus-4-8',
     label: 'Opus 4.8',
-    description: 'Opus 4.8 · Latest and most capable',
+    description: 'Opus 4.8 · Previous flagship',
   },
   {
     id: 'claude-sonnet-5',
@@ -402,6 +407,7 @@ export const AVAILABLE_PROVIDERS: ProviderInfo[] = [
  */
 export const EFFORT_SUPPORTED_CLAUDE_MODELS = new Set([
   'claude-fable-5',
+  'claude-opus-5',
   'claude-opus-4-8',
   'claude-opus-4-6',
   'claude-opus-4-6[1m]',
@@ -414,6 +420,7 @@ export const EFFORT_SUPPORTED_CLAUDE_MODELS = new Set([
  */
 export const XHIGH_EFFORT_CLAUDE_MODELS = new Set([
   'claude-fable-5',
+  'claude-opus-5',
   'claude-opus-4-8',
 ]);
 
@@ -422,6 +429,7 @@ export const XHIGH_EFFORT_CLAUDE_MODELS = new Set([
  */
 export const MAX_EFFORT_CLAUDE_MODELS = new Set([
   'claude-fable-5',
+  'claude-opus-5',
   'claude-opus-4-8',
   'claude-opus-4-6',
   'claude-opus-4-6[1m]',

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -1664,9 +1664,13 @@
         "label": "Haiku 4.5",
         "description": "Haiku 4.5 · Fastest for quick answers"
       },
+      "opus5": {
+        "label": "Opus 5",
+        "description": "Opus 5 · Latest and most capable"
+      },
       "opus48": {
         "label": "Opus 4.8",
-        "description": "Opus 4.8 · Latest and most capable"
+        "description": "Opus 4.8 · Previous flagship"
       },
       "fable5": {
         "label": "Fable 5",

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -1420,9 +1420,13 @@
         "label": "Haiku 4.5",
         "description": "Haiku 4.5 · El más rápido para respuestas rápidas"
       },
+      "opus5": {
+        "label": "Opus 5",
+        "description": "Opus 5 · El más reciente y capaz"
+      },
       "opus48": {
         "label": "Opus 4.8",
-        "description": "Opus 4.8 · El más reciente y capaz"
+        "description": "Opus 4.8 · Buque insignia anterior"
       },
       "fable5": {
         "label": "Fable 5",

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -1420,9 +1420,13 @@
         "label": "Haiku 4.5",
         "description": "Haiku 4.5 · Le plus rapide pour des réponses rapides"
       },
+      "opus5": {
+        "label": "Opus 5",
+        "description": "Opus 5 · Le plus récent et le plus performant"
+      },
       "opus48": {
         "label": "Opus 4.8",
-        "description": "Opus 4.8 · Le plus récent et le plus performant"
+        "description": "Opus 4.8 · Modèle phare précédent"
       },
       "fable5": {
         "label": "Fable 5",

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -1419,9 +1419,13 @@
         "label": "Haiku 4.5",
         "description": "Haiku 4.5 · सबसे तेज़, त्वरित उत्तरों के लिए उपयुक्त"
       },
+      "opus5": {
+        "label": "Opus 5",
+        "description": "Opus 5 · नवीनतम और सबसे सक्षम"
+      },
       "opus48": {
         "label": "Opus 4.8",
-        "description": "Opus 4.8 · नवीनतम और सबसे सक्षम"
+        "description": "Opus 4.8 · पिछला फ्लैगशिप"
       },
       "fable5": {
         "label": "Fable 5",

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -1431,9 +1431,13 @@
         "label": "Haiku 4.5",
         "description": "Haiku 4.5 · 迅速な回答に最速"
       },
+      "opus5": {
+        "label": "Opus 5",
+        "description": "Opus 5 · 最新かつ最も優れたモデル"
+      },
       "opus48": {
         "label": "Opus 4.8",
-        "description": "Opus 4.8 · 最新かつ最も優れたモデル"
+        "description": "Opus 4.8 · 前世代のフラッグシップ"
       },
       "fable5": {
         "label": "Fable 5",

--- a/webview/src/i18n/locales/ko.json
+++ b/webview/src/i18n/locales/ko.json
@@ -1537,9 +1537,13 @@
         "label": "Haiku 4.5",
         "description": "Haiku 4.5 · 빠른 응답에 최적"
       },
+      "opus5": {
+        "label": "Opus 5",
+        "description": "Opus 5 · 최신 및 가장 강력한 모델"
+      },
       "opus48": {
         "label": "Opus 4.8",
-        "description": "Opus 4.8 · 최신 및 가장 강력한 모델"
+        "description": "Opus 4.8 · 이전 세대 플래그쉽"
       },
       "fable5": {
         "label": "Fable 5",

--- a/webview/src/i18n/locales/pt-BR.json
+++ b/webview/src/i18n/locales/pt-BR.json
@@ -1592,9 +1592,13 @@
         "label": "Haiku 4.5",
         "description": "Haiku 4.5 · Mais rápido para respostas rápidas"
       },
+      "opus5": {
+        "label": "Opus 5",
+        "description": "Opus 5 · O mais recente e capaz"
+      },
       "opus48": {
         "label": "Opus 4.8",
-        "description": "Opus 4.8 · O mais recente e capaz"
+        "description": "Opus 4.8 · Carro-chefe anterior"
       },
       "fable5": {
         "label": "Fable 5",

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -1446,9 +1446,13 @@
         "label": "Haiku 4.5",
         "description": "Haiku 4.5 · Самая быстрая для быстрых ответов"
       },
+      "opus5": {
+        "label": "Opus 5",
+        "description": "Opus 5 · Новейшая и самая мощная"
+      },
       "opus48": {
         "label": "Opus 4.8",
-        "description": "Opus 4.8 · Новейшая и самая мощная"
+        "description": "Opus 4.8 · Флагман предыдущего поколения"
       },
       "fable5": {
         "label": "Fable 5",

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -1425,9 +1425,13 @@
         "label": "Haiku 4.5",
         "description": "Haiku 4.5 · 速度最快，適合快速回覆"
       },
+      "opus5": {
+        "label": "Opus 5",
+        "description": "Opus 5 · 最新最強大的模型"
+      },
       "opus48": {
         "label": "Opus 4.8",
-        "description": "Opus 4.8 · 最新最強大的模型"
+        "description": "Opus 4.8 · 上一代旗艦"
       },
       "fable5": {
         "label": "Fable 5",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -1669,9 +1669,13 @@
         "label": "Haiku 4.5",
         "description": "Haiku 速度最快，适合快速答复"
       },
+      "opus5": {
+        "label": "Opus 5",
+        "description": "Opus 5 · 最新最强大的模型"
+      },
       "opus48": {
         "label": "Opus 4.8",
-        "description": "Opus 4.8 · 最新最强大的模型"
+        "description": "Opus 4.8 · 上一代旗舰"
       },
       "fable5": {
         "label": "Fable 5",


### PR DESCRIPTION
Register claude-opus-5 as a built-in Claude model across every place the plugin resolves model metadata:

- Model picker entry (listed first) and the opus mapping bucket in both ModelSelect and ButtonArea
- Reasoning effort: low/medium/high/xhigh/max, per the Anthropic effort documentation
- Localized label and description in all 10 locales
- Pricing: 5.00 USD input / 25.00 USD output per MTok, plus a MODEL_PREFIXES entry so the ID does not fall through to a shorter claude-opus-4* prefix
- Context limits: 200K for the base ID, 1M for claude-opus-5[1m]

Opus 4.8 is demoted from "Latest and most capable" to "Previous flagship" in all locales so only one model claims the flagship position.

Existing models are left in place; they stay selectable and past sessions still need their pricing for the usage footer.