### PR TITLE
fix(streaming): keep the message list steady while tool calls ripple through

### DIFF
--- a/webview/src/components/ChatInputBox/hooks/useChatInputSelectionController.test.ts
+++ b/webview/src/components/ChatInputBox/hooks/useChatInputSelectionController.test.ts
@@ -33,6 +33,12 @@ describe('useChatInputSelectionController', () => {
     const selection = {
       removeAllRanges: vi.fn(),
       addRange: vi.fn(),
+      // A real Selection exposes these; focusInput checks isCollapsed to
+      // decide whether the user is holding a selection. Mock an empty
+      // (collapsed) selection so focus is allowed.
+      toString: () => '',
+      isCollapsed: true,
+      rangeCount: 0,
     };
     vi.spyOn(window, 'getSelection').mockReturnValue(selection as unknown as Selection);
 

--- a/webview/src/components/ChatInputBox/hooks/useChatInputSelectionController.ts
+++ b/webview/src/components/ChatInputBox/hooks/useChatInputSelectionController.ts
@@ -50,6 +50,13 @@ export function useChatInputSelectionController({
   onAutoOpenFileEnabledChange,
 }: UseChatInputSelectionControllerOptions) {
   const focusInput = useCallback(() => {
+    // Don't steal focus while the user holds a selection elsewhere (e.g.
+    // selecting a queued-message item to copy): moving focus to the editable
+    // region collapses the active selection and discards it. isCollapsed is
+    // O(1) and covers every selection shape (text, image, element), so prefer
+    // it over serializing the selection to a string on every focus call.
+    const selection = typeof window !== 'undefined' ? window.getSelection() : null;
+    if (selection && !selection.isCollapsed) return;
     editableRef.current?.focus();
   }, [editableRef]);
 

--- a/webview/src/components/MarkdownBlock.tsx
+++ b/webview/src/components/MarkdownBlock.tsx
@@ -1,8 +1,13 @@
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
-import { memo, useMemo, useState, useRef, useEffect, useCallback } from 'react';
+import { memo, useMemo, useState, useRef, useEffect, useLayoutEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { openBrowser, openClass, openFile } from '../utils/bridge';
+import {
+  captureRangeOffsets,
+  restoreRangeOffsets,
+  type TextSelectionOffsets,
+} from '../utils/selectionOffsets';
 import { useMarkdownFileLinkTooltip } from '../hooks/useMarkdownFileLinkTooltip';
 import {
   decorateExistingAnchors,
@@ -439,8 +444,15 @@ function renderStreamingProseSegment(
         return `<h${level}>${headingMatch[2]}</h${level}>`;
       }
 
-      const lines = block.split('\n').join('<br/>');
-      return `<p>${lines}</p>`;
+      // Match marked's `breaks: false` (MarkdownBlock line ~220): a single
+      // newline inside a paragraph flows as whitespace, NOT a <br>. The full
+      // pipeline collapses single newlines this way, so emitting <br> here
+      // made the streaming HTML taller than the final HTML - and since the
+      // thinking block flips between these renderers on every sub-turn (each
+      // tool call ends and restarts the stream), that height gap surfaced as
+      // a visible collapse-then-reexpand plus a scroll jump. Keeping the two
+      // renderers height-aligned lets the renderer switch happen invisibly.
+      return `<p>${block}</p>`;
     })
     .join('');
 }
@@ -786,6 +798,43 @@ const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps
     }
   }, [normalizedContent, isStreaming, i18n.language, linkifyCapabilities, t]);
 
+  // ── Streaming selection preservation ─────────────────────────────────────
+  // Every streaming delta rewrites the container's innerHTML, which destroys
+  // the text nodes underneath an active selection. We don't freeze the DOM
+  // (freezing would also stall the visible content mid-stream); instead we
+  // ferry the selection across the rebuild. Because streaming only appends,
+  // the prefix the user selected keeps its character offsets stable, so we
+  // capture them *before* React commits the new HTML — i.e. during render,
+  // while the old text nodes are still in place — then re-anchor the Range on
+  // the rebuilt text nodes in a layout effect, before paint, so there is no
+  // flicker.
+  //
+  // committedHtmlRef is read here but only mutated inside the layout effect
+  // below, so a discarded concurrent render can't poison the "last committed"
+  // comparison. rescuedSelectionRef is written during render as a deferred
+  // payload for that effect; the value is idempotent across double-invoked
+  // renders and never influences render output.
+  const committedHtmlRef = useRef(html);
+  const rescuedSelectionRef = useRef<TextSelectionOffsets | null>(null);
+
+  if (committedHtmlRef.current !== html) {
+    if (containerRef.current) {
+      rescuedSelectionRef.current = captureRangeOffsets(containerRef.current);
+    }
+  }
+
+  // After React commits the new HTML (rebuilding the text nodes), re-anchor
+  // any captured selection onto the fresh nodes. useLayoutEffect runs
+  // synchronously before paint, so the user never sees the selection drop.
+  useLayoutEffect(() => {
+    committedHtmlRef.current = html;
+    const rescued = rescuedSelectionRef.current;
+    if (rescued && containerRef.current) {
+      restoreRangeOffsets(containerRef.current, rescued);
+    }
+    rescuedSelectionRef.current = null;
+  }, [html]);
+
   // Force DOM refresh when streaming ends to fix potential layout corruption from streaming render
   useEffect(() => {
     if (prevIsStreamingRef.current && !isStreaming && containerRef.current) {
@@ -796,7 +845,14 @@ const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps
       const applyRefresh = () => {
         if (done || !containerRef.current) return;
         done = true;
+        // The forced innerHTML rewrite destroys any active selection's text
+        // nodes just like a streaming delta does. Capture the offsets on the
+        // pre-rewrite DOM, then re-anchor them on the fresh nodes.
+        const rescued = captureRangeOffsets(containerRef.current);
         containerRef.current.innerHTML = html;
+        if (rescued) {
+          restoreRangeOffsets(containerRef.current, rescued);
+        }
         renderMermaidDiagrams();
       };
 
@@ -901,6 +957,10 @@ const MarkdownBlock = ({ content = '', isStreaming = false }: MarkdownBlockProps
     }
   };
 
+  // `html` is committed directly: streaming selection is preserved by
+  // re-anchoring the Range in the layout effect above, not by freezing the
+  // output, so the visible content keeps flowing while the user holds a
+  // selection.
   return (
     <>
       <div

--- a/webview/src/components/MessageItem/ContentBlockRenderer.test.tsx
+++ b/webview/src/components/MessageItem/ContentBlockRenderer.test.tsx
@@ -1,0 +1,71 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ClaudeContentBlock } from '../../types';
+import { ContentBlockRenderer } from './ContentBlockRenderer';
+
+// Capture the props MarkdownBlock receives without rendering the real marked
+// pipeline. The block-level streaming flag is the value under test here.
+const { markdownProps } = vi.hoisted(() => ({
+  markdownProps: { isStreaming: undefined as boolean | undefined },
+}));
+
+vi.mock('../MarkdownBlock', () => ({
+  default: ({ content, isStreaming }: { content: string; isStreaming?: boolean }) => {
+    markdownProps.isStreaming = isStreaming;
+    return <div data-testid="md">{content}</div>;
+  },
+}));
+
+vi.mock('../CollapsibleTextBlock', () => ({ default: () => <div /> }));
+vi.mock('../toolBlocks', () => ({
+  BashToolBlock: () => null,
+  EditToolBlock: () => null,
+  GenericToolBlock: () => null,
+  TaskExecutionBlock: () => null,
+}));
+
+const t = ((key: string) => key) as unknown as React.ComponentProps<
+  typeof ContentBlockRenderer
+>['t'];
+
+const tableBlock = (): ClaudeContentBlock =>
+  ({ type: 'text', text: '| a |\n|---|\n| 1 |' }) as unknown as ClaudeContentBlock;
+
+function renderTextBlock({ isStreaming, isLastBlock }: { isStreaming: boolean; isLastBlock: boolean }) {
+  markdownProps.isStreaming = undefined;
+  return render(
+    <ContentBlockRenderer
+      block={tableBlock()}
+      messageIndex={0}
+      messageType="assistant"
+      isStreaming={isStreaming}
+      isThinkingExpanded={false}
+      isThinking={false}
+      isLastMessage={false}
+      isLastBlock={isLastBlock}
+      t={t}
+      onToggleThinking={() => {}}
+      findToolResult={() => null}
+    />,
+  );
+}
+
+describe('ContentBlockRenderer block-level streaming', () => {
+  it('keeps the last block streaming while the message is still streaming', () => {
+    renderTextBlock({ isStreaming: true, isLastBlock: true });
+    expect(markdownProps.isStreaming).toBe(true);
+  });
+
+  it('drops an earlier text block out of streaming once a later block arrives', () => {
+    // A tool call (or any later block) arriving makes this text block non-last.
+    // It must leave the lightweight streaming renderer for the full marked
+    // pipeline, otherwise tables/lists stay hidden until the whole turn ends.
+    renderTextBlock({ isStreaming: true, isLastBlock: false });
+    expect(markdownProps.isStreaming).toBe(false);
+  });
+
+  it('renders with the full pipeline once the message has stopped streaming', () => {
+    renderTextBlock({ isStreaming: false, isLastBlock: true });
+    expect(markdownProps.isStreaming).toBe(false);
+  });
+});

--- a/webview/src/components/MessageItem/ContentBlockRenderer.tsx
+++ b/webview/src/components/MessageItem/ContentBlockRenderer.tsx
@@ -191,13 +191,24 @@ export function ContentBlockRenderer({
   onToggleThinking,
   findToolResult,
 }: ContentBlockRendererProps): React.ReactElement | null {
+  // `isStreaming` arriving here is message-level: it stays true for the whole
+  // assistant turn, including tool round-trips and the wait for tool results.
+  // But only the LAST block of a streaming message is still receiving tokens —
+  // every earlier text/thinking block is already closed. Feeding those closed
+  // blocks the full marked pipeline (instead of the lightweight streaming
+  // renderer, which knows no tables/lists) lets block-level syntax render the
+  // moment a later block such as a tool call arrives, instead of waiting for
+  // the entire turn to end. The two renderers are height-aligned (breaks:
+  // false), so switching between them stays invisible.
+  const isActivelyStreaming = isStreaming && isLastBlock;
+
   if (block.type === 'text') {
     return messageType === 'user' ? (
       <CollapsibleTextBlock content={block.text ?? ''} />
     ) : (
       <MarkdownBlock
         content={block.text ?? ''}
-        isStreaming={isStreaming}
+        isStreaming={isActivelyStreaming}
       />
     );
   }
@@ -284,7 +295,7 @@ export function ContentBlockRenderer({
           <div className="thinking-content-inner">
             <MarkdownBlock
               content={block.thinking ?? block.text ?? t('chat.noThinkingContent')}
-              isStreaming={isStreaming}
+              isStreaming={isActivelyStreaming}
             />
           </div>
         </div>

--- a/webview/src/components/MessageItem/ContentBlockRenderer.tsx
+++ b/webview/src/components/MessageItem/ContentBlockRenderer.tsx
@@ -10,12 +10,28 @@ import {
   GenericToolBlock,
   TaskExecutionBlock,
 } from '../toolBlocks';
+import type { EditToolItem } from '../toolBlocks/EditToolBlock';
 import { EDIT_TOOL_NAMES, BASH_TOOL_NAMES, TASK_MANAGE_TOOL_NAMES, AGENT_TOOL_NAMES, isToolName, isTransientInternalToolName, normalizeToolName } from '../../utils/toolConstants';
 import { TASK_STATUS_COLORS } from '../../utils/messageUtils';
 
 const IMAGE_BLOCK_STYLE: React.CSSProperties = { cursor: 'pointer' };
-const THINKING_VISIBLE_STYLE: React.CSSProperties = { display: 'block' };
-const THINKING_HIDDEN_STYLE: React.CSSProperties = { display: 'none' };
+
+/**
+ * Stable adapter for a single edit call. Building the one-item array inline in
+ * render would hand EditToolBlock a fresh array (and wrapper object) on every
+ * parent render and defeat its memo. Routing through this memoized wrapper
+ * means EditToolBlock only re-renders when the underlying call's primitives
+ * actually change, so it stays quiet while sibling blocks drive the streaming
+ * message's frequent re-renders.
+ */
+const SingleEditToolBlock = memo(function SingleEditToolBlock({
+  name,
+  input,
+  result,
+  toolId,
+}: EditToolItem) {
+  return <EditToolBlock items={[{ name, input, result, toolId }]} />;
+});
 
 function getImageStyle(isUser: boolean): React.CSSProperties {
   return {
@@ -264,14 +280,13 @@ export function ContentBlockRenderer({
             {isThinkingExpanded ? '▼' : '▶'}
           </span>
         </div>
-        <div
-          className="thinking-content"
-          style={isThinkingExpanded ? THINKING_VISIBLE_STYLE : THINKING_HIDDEN_STYLE}
-        >
-          <MarkdownBlock
-            content={block.thinking ?? block.text ?? t('chat.noThinkingContent')}
-            isStreaming={isStreaming}
-          />
+        <div className={`thinking-content ${isThinkingExpanded ? 'expanded' : ''}`}>
+          <div className="thinking-content-inner">
+            <MarkdownBlock
+              content={block.thinking ?? block.text ?? t('chat.noThinkingContent')}
+              isStreaming={isStreaming}
+            />
+          </div>
         </div>
       </div>
     );
@@ -302,7 +317,7 @@ export function ContentBlockRenderer({
 
     if (isToolName(block.name, EDIT_TOOL_NAMES)) {
       return (
-        <EditToolBlock
+        <SingleEditToolBlock
           name={block.name}
           input={block.input}
           result={findToolResult(block.id, messageIndex)}

--- a/webview/src/components/MessageItem/MessageItem.tsx
+++ b/webview/src/components/MessageItem/MessageItem.tsx
@@ -8,7 +8,6 @@ import { ErrorDiagnosticCard } from './ErrorDiagnosticCard';
 import { matchErrorPattern } from '../../utils/errorMatcher';
 import {
   EditToolBlock,
-  EditToolGroupBlock,
   ReadToolBlock,
   ReadToolGroupBlock,
   BashToolBlock,
@@ -19,7 +18,7 @@ import {
 import { ContentBlockRenderer } from './ContentBlockRenderer';
 import { formatTime } from '../../utils/helpers';
 import { copyToClipboard } from '../../utils/copyUtils';
-import { READ_TOOL_NAMES, EDIT_TOOL_NAMES, BASH_TOOL_NAMES, SEARCH_TOOL_NAMES, AGENT_TOOL_NAMES, isToolName } from '../../utils/toolConstants';
+import { READ_TOOL_NAMES, EDIT_TOOL_NAMES, BASH_TOOL_NAMES, SEARCH_TOOL_NAMES, AGENT_TOOL_NAMES, isToolName, isNonRenderedToolUse } from '../../utils/toolConstants';
 
 export interface MessageItemProps {
   message: ClaudeMessage;
@@ -433,6 +432,19 @@ export const MessageItem = memo(function MessageItem({
 
   // Memoize blocks and grouped blocks to avoid recalculation on every render
   const blocks = useMemo(() => getContentBlocks(message), [message, getContentBlocks]);
+  // Tool calls that render nothing (TodoWrite, TaskCreate, ...) still live in
+  // `blocks`, so their arrival re-rendered the message and - worse - flipped
+  // the streaming thinking block's last-block status, which switched its
+  // MarkdownBlock between the streaming and full-pipeline renderers (they
+  // differ in height on single-newline content) and made the thinking block
+  // visibly collapse then re-expand. Filter them out of the rendered list so
+  // non-rendered tools never disturb the message list. `blocks` is kept whole
+  // for the empty-placeholder check below, since a message carrying only a
+  // non-rendered tool is not an empty streaming placeholder.
+  const renderedBlocks = useMemo(
+    () => blocks.filter((block) => !isNonRenderedToolUse(block, isMessageStreaming)),
+    [blocks, isMessageStreaming],
+  );
   const isEmptyStreamingPlaceholder =
     message.type === 'assistant' &&
     isMessageStreaming &&
@@ -455,7 +467,7 @@ export const MessageItem = memo(function MessageItem({
   useEffect(() => {
     if (!isMessageStreaming) return;
 
-    const thinkingIndices = blocks
+    const thinkingIndices = renderedBlocks
       .map((block, index) => (block.type === 'thinking' ? index : -1))
       .filter((index) => index !== -1);
 
@@ -481,9 +493,9 @@ export const MessageItem = memo(function MessageItem({
       });
       lastAutoExpandedIndexRef.current = lastThinkingIndex;
     }
-  }, [blocks, isMessageStreaming, manuallyExpandedThinking]);
+  }, [renderedBlocks, isMessageStreaming, manuallyExpandedThinking]);
 
-  const groupedBlocks = useMemo(() => groupBlocks(blocks), [blocks]);
+  const groupedBlocks = useMemo(() => groupBlocks(renderedBlocks), [renderedBlocks]);
 
   // Register user message DOM node for anchor navigation
   // Must be called before any early returns to satisfy React hooks rules
@@ -573,24 +585,17 @@ export const MessageItem = memo(function MessageItem({
             name: block.name,
             input: block.input,
             result: findToolResult(block.id, messageIndex),
+            toolId: block.id,
           };
         });
 
-        if (editItems.length === 1) {
-          return (
-            <div key={`${messageIndex}-editgroup-${grouped.startIndex}`} className="content-block">
-              <EditToolBlock
-                name={editItems[0].name}
-                input={editItems[0].input}
-                result={editItems[0].result}
-              />
-            </div>
-          );
-        }
-
+        // Always route through EditToolBlock so the instance stays stable as
+        // edits stream in (1 -> 2 -> ...). It renders the inline-diff view for
+        // a single item and delegates to the grouped list view for multiple,
+        // without unmounting on the transition.
         return (
           <div key={`${messageIndex}-editgroup-${grouped.startIndex}`} className="content-block">
-            <EditToolGroupBlock items={editItems} />
+            <EditToolBlock items={editItems} />
           </div>
         );
       }
@@ -647,7 +652,7 @@ export const MessageItem = memo(function MessageItem({
                 isThinkingExpanded={false}
                 isThinking={isThinking}
                 isLastMessage={isLast}
-                isLastBlock={grouped.startIndex === blocks.length - 1}
+                isLastBlock={grouped.startIndex === renderedBlocks.length - 1}
                 t={t}
                 onToggleThinking={() => {}}
                 findToolResult={findToolResult}
@@ -692,7 +697,7 @@ export const MessageItem = memo(function MessageItem({
             isThinkingExpanded={isThinkingExpanded(blockIndex)}
             isThinking={isThinking}
             isLastMessage={isLast}
-            isLastBlock={blockIndex === blocks.length - 1}
+            isLastBlock={blockIndex === renderedBlocks.length - 1}
             t={t}
             onToggleThinking={() => toggleThinking(blockIndex)}
             findToolResult={findToolResult}

--- a/webview/src/components/MessageList.test.tsx
+++ b/webview/src/components/MessageList.test.tsx
@@ -1,16 +1,25 @@
 import { act, fireEvent, render, screen, cleanup } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createRef } from 'react';
+import { createRef, useState } from 'react';
 import type { ClaudeMessage, ClaudeContentBlock, ToolResultBlock } from '../types';
 import { MessageList } from './MessageList';
 
 // Mock MessageItem to keep this suite focused on list-level paging behaviour.
 vi.mock('./MessageItem', () => ({
-  MessageItem: ({ messageKey, message }: { messageKey: string; message: ClaudeMessage }) => (
-    <div data-testid="message-item" data-key={messageKey} data-type={message.type}>
-      {message.content}
-    </div>
-  ),
+  MessageItem: ({ messageKey, message }: { messageKey: string; message: ClaudeMessage }) => {
+    const [localState, setLocalState] = useState('initial');
+    return (
+      <div
+        data-testid="message-item"
+        data-key={messageKey}
+        data-type={message.type}
+        data-local-state={localState}
+        onClick={() => setLocalState('preserved')}
+      >
+        {message.content}
+      </div>
+    );
+  },
 }));
 
 vi.mock('./WaitingIndicator', () => ({
@@ -314,6 +323,105 @@ describe('MessageList paged collapse', () => {
 
 describe('MessageList container behaviour', () => {
   afterEach(cleanup);
+
+  it('preserves the live assistant component when a tool snapshot adds its UUID', () => {
+    const initialMessage: ClaudeMessage = {
+      type: 'assistant',
+      content: '',
+      timestamp: '2026-07-28T09:00:00.000Z',
+      isStreaming: true,
+      __turnId: 42,
+      raw: {
+        message: {
+          content: [{ type: 'thinking', thinking: 'Working through it' }],
+        },
+      },
+    };
+    const endRef = createRef<HTMLDivElement>();
+    const renderMessageList = (messages: ClaudeMessage[]) => (
+      <MessageList
+        messages={messages}
+        streamingActive
+        isThinking
+        loading={false}
+        loadingStartTime={null}
+        t={t}
+        getMessageText={noopGetText}
+        getContentBlocks={noopGetBlocks}
+        findToolResult={noopFindToolResult}
+        extractMarkdownContent={noopExtractMd}
+        messagesEndRef={endRef}
+      />
+    );
+    const { rerender } = render(renderMessageList([initialMessage]));
+    const liveItem = screen.getByTestId('message-item');
+
+    fireEvent.click(liveItem);
+    expect(liveItem.getAttribute('data-local-state')).toBe('preserved');
+
+    const toolSnapshot: ClaudeMessage = {
+      ...initialMessage,
+      raw: {
+        uuid: 'backend-assistant-uuid',
+        message: {
+          content: [
+            { type: 'thinking', thinking: 'Working through it' },
+            { type: 'tool_use', id: 'tool-1', name: 'Read', input: { file_path: '/tmp/example' } },
+          ],
+        },
+      },
+    };
+    rerender(renderMessageList([toolSnapshot]));
+
+    expect(screen.getByTestId('message-item')).toBe(liveItem);
+    expect(liveItem.getAttribute('data-key')).toBe('turn-42');
+    expect(liveItem.getAttribute('data-local-state')).toBe('preserved');
+
+    rerender(renderMessageList([{ ...toolSnapshot, __turnId: undefined }]));
+
+    expect(screen.getByTestId('message-item')).toBe(liveItem);
+    expect(liveItem.getAttribute('data-key')).toBe('turn-42');
+    expect(liveItem.getAttribute('data-local-state')).toBe('preserved');
+  });
+
+  it('preserves a UUID-keyed replay message when a runtime turn ID is attached', () => {
+    const replayMessage: ClaudeMessage = {
+      type: 'assistant',
+      content: '',
+      timestamp: '2026-07-28T09:00:00.000Z',
+      raw: {
+        uuid: 'replay-assistant-uuid',
+        message: {
+          content: [{ type: 'thinking', thinking: 'Resuming the thought' }],
+        },
+      },
+    };
+    const endRef = createRef<HTMLDivElement>();
+    const renderMessageList = (message: ClaudeMessage) => (
+      <MessageList
+        messages={[message]}
+        streamingActive
+        isThinking
+        loading={false}
+        loadingStartTime={null}
+        t={t}
+        getMessageText={noopGetText}
+        getContentBlocks={noopGetBlocks}
+        findToolResult={noopFindToolResult}
+        extractMarkdownContent={noopExtractMd}
+        messagesEndRef={endRef}
+      />
+    );
+    const { rerender } = render(renderMessageList(replayMessage));
+    const replayItem = screen.getByTestId('message-item');
+
+    fireEvent.click(replayItem);
+    rerender(renderMessageList({ ...replayMessage, isStreaming: true, __turnId: 43 }));
+
+    expect(screen.getByTestId('message-item')).toBe(replayItem);
+    expect(replayItem.getAttribute('data-key')).toBe('replay-assistant-uuid');
+    expect(replayItem.getAttribute('data-local-state')).toBe('preserved');
+  });
 
   it('uses the latest message index for isLast even when paginated', () => {
     const messages = makeMessages(40);

--- a/webview/src/components/MessageList.tsx
+++ b/webview/src/components/MessageList.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useEffect, useRef, useMemo, useCallback, forwardRef, useImperativeHandle } from 'react';
+import { memo, useState, useEffect, useRef, useMemo, useCallback, forwardRef, useImperativeHandle, useLayoutEffect } from 'react';
 import type { TFunction } from 'i18next';
 import type { ClaudeMessage, ClaudeContentBlock, CodexHistoryPageInfo, ToolResultBlock } from '../types';
 import { getMessageKey } from '../utils/messageUtils';
@@ -45,6 +45,58 @@ function getFirstMessageBoundaryKey(message: ClaudeMessage | undefined): string 
   }
   if (message.timestamp) return `timestamp:${message.type}:${message.timestamp}`;
   return `content:${message.type}:${message.content ?? ''}`;
+}
+
+interface MessageRenderKeySnapshot {
+  keys: string[];
+  identityToKey: Map<string, string>;
+}
+
+function keepMessageRenderKeysSteady(
+  messages: ClaudeMessage[],
+  rememberedIdentities: ReadonlyMap<string, string>,
+): MessageRenderKeySnapshot {
+  const turnOccurrences = new Map<number, number>();
+  const identityToKey = new Map<string, string>();
+
+  const keys = messages.map((message, index) => {
+    const rawUuid = typeof message.raw === 'object'
+      && message.raw !== null
+      && typeof message.raw.uuid === 'string'
+      && message.raw.uuid.length > 0
+      ? message.raw.uuid
+      : undefined;
+    const uuidIdentity = rawUuid ? `uuid:${rawUuid}` : undefined;
+    let turnIdentity: string | undefined;
+    let defaultTurnKey: string | undefined;
+
+    if (typeof message.__turnId === 'number') {
+      const occurrence = turnOccurrences.get(message.__turnId) ?? 0;
+      turnOccurrences.set(message.__turnId, occurrence + 1);
+      turnIdentity = `turn:${message.__turnId}:${occurrence}`;
+      defaultTurnKey = occurrence === 0
+        ? `turn-${message.__turnId}`
+        : `turn-${message.__turnId}-${occurrence}`;
+    }
+
+    // A streaming placeholder starts without a backend UUID. When the tool-use
+    // snapshot arrives, raw.uuid is added while __turnId continues to identify
+    // the same live bubble. Keep the turn key during that identity enrichment
+    // so React preserves MessageItem's thinking expansion state. Remember both
+    // identities once they meet, which also keeps UUID-first replay messages
+    // mounted when a runtime turn ID is attached later.
+    const rememberedKey = (turnIdentity && rememberedIdentities.get(turnIdentity))
+      || (uuidIdentity && rememberedIdentities.get(uuidIdentity));
+    const renderKey = rememberedKey
+      || (rawUuid ? getMessageKey(message, index) : defaultTurnKey)
+      || getMessageKey(message, index);
+
+    if (turnIdentity) identityToKey.set(turnIdentity, renderKey);
+    if (uuidIdentity) identityToKey.set(uuidIdentity, renderKey);
+    return renderKey;
+  });
+
+  return { keys, identityToKey };
 }
 
 function extractToolResultPreview(result: ToolResultBlock | null | undefined): string {
@@ -260,6 +312,14 @@ export const MessageList = memo(forwardRef<MessageListRevealHandle, MessageListP
     () => (shouldCollapse ? messages.slice(collapsedCount) : messages),
     [messages, shouldCollapse, collapsedCount]
   );
+  const rememberedMessageKeysRef = useRef<ReadonlyMap<string, string>>(new Map());
+  const messageRenderKeySnapshot = useMemo(
+    () => keepMessageRenderKeysSteady(messages, rememberedMessageKeysRef.current),
+    [messages],
+  );
+  useLayoutEffect(() => {
+    rememberedMessageKeysRef.current = messageRenderKeySnapshot.identityToKey;
+  }, [messageRenderKeySnapshot]);
 
   return (
     <div onContextMenu={handleMessageContextMenu}>
@@ -296,7 +356,7 @@ export const MessageList = memo(forwardRef<MessageListRevealHandle, MessageListP
 
       {visibleMessages.map((message, visibleIndex) => {
         const messageIndex = shouldCollapse ? visibleIndex + collapsedCount : visibleIndex;
-        const messageKey = getMessageKey(message, messageIndex);
+        const messageKey = messageRenderKeySnapshot.keys[messageIndex];
         const toolResultSignature = getMessageToolResultSignature(message, messageIndex, getContentBlocks, findToolResult);
 
         return (

--- a/webview/src/components/toolBlocks/BashToolBlock.tsx
+++ b/webview/src/components/toolBlocks/BashToolBlock.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ToolInput, ToolResultBlock } from '../../types';
 import { useIsToolDenied } from '../../hooks/useIsToolDenied';
@@ -16,7 +16,7 @@ interface BashToolBlockProps {
   toolId?: string;
 }
 
-const BashToolBlock = ({ input, result, toolId }: BashToolBlockProps) => {
+const BashToolBlock = memo(function BashToolBlock({ input, result, toolId }: BashToolBlockProps) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
   const isDenied = useIsToolDenied(toolId);
@@ -83,6 +83,6 @@ const BashToolBlock = ({ input, result, toolId }: BashToolBlockProps) => {
       )}
     </div>
   );
-};
+});
 
 export default BashToolBlock;

--- a/webview/src/components/toolBlocks/EditToolBlock.tsx
+++ b/webview/src/components/toolBlocks/EditToolBlock.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef, useEffect } from 'react';
+import { memo, useState, useMemo, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ToolInput, ToolResultBlock } from '../../types';
 import { useIsToolDenied } from '../../hooks/useIsToolDenied';
@@ -7,14 +7,24 @@ import { openFile, showDiff, refreshFile } from '../../utils/bridge';
 import { getFileIcon } from '../../utils/fileIcons';
 import { getToolLineInfo, getToolEditCount, resolveToolTarget } from '../../utils/toolPresentation';
 import { normalizeToolInput } from '../../utils/toolInputNormalization';
+import EditToolGroupBlock from './EditToolGroupBlock';
 import GenericToolBlock from './GenericToolBlock';
 
-interface EditToolBlockProps {
+/** A single edit tool call within a (possibly batched) edit group. */
+export interface EditToolItem {
   name?: string;
   input?: ToolInput;
   result?: ToolResultBlock | null;
   /** Unique ID of the tool call, used to determine if the user denied permission */
   toolId?: string;
+}
+
+interface EditToolBlockProps {
+  /** One or more edit tool calls. A single item renders the inline-diff view;
+      multiple items delegate to EditToolGroupBlock. Routing both cases through
+      this one component keeps the instance (and its state) alive as edits
+      stream in 1 -> 2 -> ..., so the transition no longer unmounts the block. */
+  items: EditToolItem[];
 }
 
 type DiffLineType = 'unchanged' | 'deleted' | 'added';
@@ -233,7 +243,7 @@ function computeDiff(oldLines: string[], newLines: string[]): DiffResult {
   return { lines: diffLines, additions, deletions };
 }
 
-const EditToolBlock = ({ name, input, result, toolId }: EditToolBlockProps) => {
+const EditToolBlock = memo(function EditToolBlock({ items }: EditToolBlockProps) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(() => {
     try {
@@ -242,6 +252,17 @@ const EditToolBlock = ({ name, input, result, toolId }: EditToolBlockProps) => {
       return false;
     }
   });
+
+  // The inline-diff view below serves the single-item case; when there are
+  // multiple items we delegate to EditToolGroupBlock. That delegation return
+  // must sit *after* every hook, so we read items[0] up front to keep the hook
+  // order identical for any item count - React then reuses this instance (and
+  // its state) across the 1 -> N transition instead of unmounting it.
+  const firstItem = items[0];
+  const name = firstItem?.name;
+  const input = firstItem?.input;
+  const result = firstItem?.result;
+  const toolId = firstItem?.toolId;
 
   const isDenied = useIsToolDenied(toolId);
 
@@ -276,19 +297,36 @@ const EditToolBlock = ({ name, input, result, toolId }: EditToolBlockProps) => {
     '';
 
   const diff = useMemo(() => {
+    // When delegating to the grouped view (items.length > 1) the diff is never
+    // rendered, so skip the O(m*n) LCS pass for the first item - the early
+    // return below hands off to EditToolGroupBlock before this result is used.
+    if (items.length !== 1) {
+      return { lines: [], additions: 0, deletions: 0 };
+    }
     const oldLines = oldString ? oldString.split('\n') : [];
     const newLines = newString ? newString.split('\n') : [];
     return computeDiff(oldLines, newLines);
-  }, [oldString, newString]);
+  }, [items.length, oldString, newString]);
 
   // Auto-refresh file in IDEA when the tool call completes successfully
   const hasRefreshed = useRef(false);
   useEffect(() => {
+    // Only the single-item view refreshes here; the grouped view runs its own
+    // refresh effect, so skip when delegating to avoid duplicate refreshes.
+    if (items.length !== 1) return;
     if (filePath && isCompleted && !isError && !hasRefreshed.current) {
       hasRefreshed.current = true;
       refreshFile(filePath);
     }
-  }, [filePath, isCompleted, isError]);
+  }, [items.length, filePath, isCompleted, isError]);
+
+  // Multiple edits: delegate to the grouped list view. This return sits after
+  // all hooks, so the component instance (and the state above) is preserved
+  // when the item count crosses from 1 to many - React reuses this instance
+  // and only swaps the rendered subtree, instead of unmounting EditToolBlock.
+  if (items.length > 1) {
+    return <EditToolGroupBlock items={items} />;
+  }
 
   if (!normalizedInput) {
     return null;
@@ -452,6 +490,6 @@ const EditToolBlock = ({ name, input, result, toolId }: EditToolBlockProps) => {
       </div>
     </div>
   );
-};
+});
 
 export default EditToolBlock;

--- a/webview/src/components/toolBlocks/GenericToolBlock.tsx
+++ b/webview/src/components/toolBlocks/GenericToolBlock.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ToolInput, ToolResultBlock } from '../../types';
 import { useIsToolDenied } from '../../hooks/useIsToolDenied';
@@ -233,7 +233,7 @@ const PatchFileLink = ({ path }: PatchFileLinkProps) => {
   );
 };
 
-const GenericToolBlock = ({ name, input, result, toolId }: GenericToolBlockProps) => {
+const GenericToolBlock = memo(function GenericToolBlock({ name, input, result, toolId }: GenericToolBlockProps) {
   const { t } = useTranslation();
   const lowerName = (name ?? '').toLowerCase();
   const [expanded, setExpanded] = useState(false);
@@ -412,6 +412,6 @@ const GenericToolBlock = ({ name, input, result, toolId }: GenericToolBlockProps
       )}
     </div>
   );
-};
+});
 
 export default GenericToolBlock;

--- a/webview/src/components/toolBlocks/ReadToolBlock.tsx
+++ b/webview/src/components/toolBlocks/ReadToolBlock.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ToolInput, ToolResultBlock } from '../../types';
 import { useIsToolDenied } from '../../hooks/useIsToolDenied';
@@ -80,7 +80,7 @@ const IMAGE_HINT_STYLE: React.CSSProperties = {
   gap: '2px',
 };
 
-const ReadToolBlock = ({ input, result, toolId }: ReadToolBlockProps) => {
+const ReadToolBlock = memo(function ReadToolBlock({ input, result, toolId }: ReadToolBlockProps) {
   const [expanded, setExpanded] = useState(false);
   const { t } = useTranslation();
   const isDenied = useIsToolDenied(toolId);
@@ -208,6 +208,6 @@ const ReadToolBlock = ({ input, result, toolId }: ReadToolBlockProps) => {
       )}
     </div>
   );
-};
+});
 
 export default ReadToolBlock;

--- a/webview/src/styles/less/components/message.less
+++ b/webview/src/styles/less/components/message.less
@@ -931,6 +931,28 @@
     word-wrap: break-word;
     overflow-wrap: break-word;
     max-width: 100%;
+    /* Accordion: animate the collapse so auto-folding the previous thinking
+       block (when a newer one arrives mid-stream) eases shut instead of
+       snapping. grid-template-rows tracks the streaming content height, so
+       the open state stays fluid while only the collapse is animated. */
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 0.2s ease;
+}
+
+.thinking-content.expanded {
+    grid-template-rows: 1fr;
+}
+
+.thinking-content-inner {
+    overflow: hidden;
+    min-height: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .thinking-content {
+        transition: none;
+    }
 }
 
 .thinking-content .markdown-content {

--- a/webview/src/styles/less/components/tools.less
+++ b/webview/src/styles/less/components/tools.less
@@ -116,6 +116,47 @@
     to { transform: rotate(360deg); }
 }
 
+/* Streaming list-item entrance — each freshly appended tool item fades and
+   settles into place so the batch tool list grows smoothly instead of
+   snapping in. The keyframe fires once on element mount; because group items
+   keep stable keys across streaming appends, only the genuinely new item
+   animates while earlier items sit still. Scoped to items inside the group
+   list containers so unrelated file-list-items are untouched. */
+@keyframes toolItemEnter {
+    from {
+        opacity: 0;
+        transform: translateY(-4px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Let the list container breathe as it grows: the per-item maxHeight is
+   computed from the item count, so animating max-height turns a hard height
+   jump (which shoves everything below) into a gentle expand. */
+.task-details.file-list-container,
+.bash-group-timeline {
+    transition: max-height 0.2s ease;
+}
+
+.task-details.file-list-container .file-list-item,
+.bash-group-timeline .bash-timeline-item {
+    animation: toolItemEnter 0.18s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .task-details.file-list-container,
+    .bash-group-timeline {
+        transition: none;
+    }
+    .task-details.file-list-container .file-list-item,
+    .bash-group-timeline .bash-timeline-item {
+        animation: none;
+    }
+}
+
 /* Legacy keyframe retained — referenced by .waiting-indicator and other
    subtle-pulse callers; do not remove. */
 @keyframes breathing {

--- a/webview/src/utils/selectionOffsets.test.ts
+++ b/webview/src/utils/selectionOffsets.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { captureRangeOffsets, restoreRangeOffsets } from './selectionOffsets';
+
+describe('selectionOffsets', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+  });
+
+  function selectRange(startNode: Text, startOff: number, endNode: Text, endOff: number) {
+    const range = document.createRange();
+    range.setStart(startNode, startOff);
+    range.setEnd(endNode, endOff);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+  }
+
+  it('ferries a selection across an innerHTML rebuild', () => {
+    container.innerHTML = '<p>Hello world</p>';
+    const text = container.querySelector('p')!.firstChild as Text;
+    selectRange(text, 0, text, 5); // "Hello"
+
+    const offsets = captureRangeOffsets(container);
+    expect(offsets).toEqual({ start: 0, end: 5 });
+
+    // Simulate a streaming append that rebuilds the DOM with the same prefix.
+    container.innerHTML = '<p>Hello world and more</p>';
+    restoreRangeOffsets(container, offsets!);
+
+    expect(window.getSelection()?.toString()).toBe('Hello');
+  });
+
+  it('accumulates length across sibling text nodes', () => {
+    container.innerHTML = '<p>foo<b>bar</b>baz</p>';
+    const foo = container.querySelector('p')!.firstChild as Text; // "foo"
+    const bar = container.querySelector('b')!.firstChild as Text; // "bar"
+    selectRange(foo, 1, bar, 2); // "oo" + "ba"
+    const offsets = captureRangeOffsets(container);
+    expect(offsets).toEqual({ start: 1, end: 5 });
+  });
+
+  it('returns null for a collapsed selection', () => {
+    container.innerHTML = '<p>Hello</p>';
+    const text = container.querySelector('p')!.firstChild as Text;
+    const range = document.createRange();
+    range.setStart(text, 0);
+    range.collapse(true);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+    expect(captureRangeOffsets(container)).toBeNull();
+  });
+
+  it('returns null when nothing is selected', () => {
+    container.innerHTML = '<p>Hello</p>';
+    window.getSelection()?.removeAllRanges();
+    expect(captureRangeOffsets(container)).toBeNull();
+  });
+
+  it('is a no-op when the rebuilt DOM is shorter than the offsets', () => {
+    container.innerHTML = '<p>Hello world</p>';
+    const text = container.querySelector('p')!.firstChild as Text;
+    selectRange(text, 6, text, 11); // "world"
+
+    const offsets = captureRangeOffsets(container);
+    expect(offsets).toEqual({ start: 6, end: 11 });
+
+    // Rebuild loses the selected suffix — restore must not throw and must
+    // simply leave the selection empty.
+    container.innerHTML = '<p>Hi</p>';
+    expect(() => restoreRangeOffsets(container, offsets!)).not.toThrow();
+  });
+});

--- a/webview/src/utils/selectionOffsets.ts
+++ b/webview/src/utils/selectionOffsets.ts
@@ -1,0 +1,98 @@
+/**
+ * Character-span of a text selection inside a container, used to ferry a
+ * selection across an `innerHTML` rebuild.
+ */
+export interface TextSelectionOffsets {
+  start: number;
+  end: number;
+}
+
+/**
+ * Read the active selection as character offsets over `container`'s
+ * concatenated text nodes. Returns null when there is no non-collapsed
+ * selection, or when the selection is rooted outside `container`.
+ *
+ * Capture must happen *before* the container's innerHTML is rewritten: once
+ * the old text nodes are gone the selection is gone with them, so the offsets
+ * are the only thing that can survive the rebuild.
+ */
+export function captureRangeOffsets(container: HTMLElement): TextSelectionOffsets | null {
+  if (typeof window === 'undefined') return null;
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+    return null;
+  }
+  const range = selection.getRangeAt(0);
+  if (
+    !container.contains(range.startContainer) ||
+    !container.contains(range.endContainer)
+  ) {
+    return null;
+  }
+
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  let covered = 0;
+  let startOffset = -1;
+  let endOffset = -1;
+  let node = walker.nextNode() as Text | null;
+  while (node) {
+    const len = node.data.length;
+    if (startOffset === -1 && node === range.startContainer) {
+      startOffset = covered + range.startOffset;
+    }
+    if (endOffset === -1 && node === range.endContainer) {
+      endOffset = covered + range.endOffset;
+    }
+    // Both anchors resolved - no need to walk the rest of the container.
+    if (startOffset !== -1 && endOffset !== -1) break;
+    covered += len;
+    node = walker.nextNode() as Text | null;
+  }
+  if (startOffset === -1 || endOffset === -1) return null;
+  return { start: startOffset, end: endOffset };
+}
+
+/**
+ * Re-anchor a selection inside `container` from offsets previously captured by
+ * {@link captureRangeOffsets}. Best-effort: if the rebuilt DOM has no text at
+ * those offsets (the structure shifted under the selection), the call is a
+ * no-op rather than throwing.
+ */
+export function restoreRangeOffsets(
+  container: HTMLElement,
+  offsets: TextSelectionOffsets,
+): void {
+  if (typeof window === 'undefined') return;
+  const { start, end } = offsets;
+
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  let covered = 0;
+  let startNode: Text | null = null;
+  let startOff = 0;
+  let endNode: Text | null = null;
+  let endOff = 0;
+  let node = walker.nextNode() as Text | null;
+  while (node) {
+    const len = node.data.length;
+    if (!startNode && covered + len >= start) {
+      startNode = node;
+      startOff = start - covered;
+    }
+    if (!endNode && covered + len >= end) {
+      endNode = node;
+      endOff = end - covered;
+    }
+    if (startNode && endNode) break;
+    covered += len;
+    node = walker.nextNode() as Text | null;
+  }
+  if (!startNode || !endNode) return;
+
+  const selection = window.getSelection();
+  if (!selection) return;
+  const range = document.createRange();
+  range.setStart(startNode, startOff);
+  range.setEnd(endNode, endOff);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}

--- a/webview/src/utils/toolConstants.ts
+++ b/webview/src/utils/toolConstants.ts
@@ -61,3 +61,27 @@ export function isTransientInternalToolName(toolName: string | undefined): boole
   const lower = toolName.toLowerCase();
   return TRANSIENT_INTERNAL_TOOL_NAMES.has(lower) || TRANSIENT_INTERNAL_TOOL_NAMES.has(normalizeToolName(lower));
 }
+
+/**
+ * Whether a content block is a tool_use that renders nothing in the message
+ * list (TodoWrite, TaskCreate, update_plan, and transient internal tools once
+ * streaming ends). Mirrors the null-return branches in ContentBlockRenderer so
+ * callers can filter such blocks before rendering - their arrival otherwise
+ * re-renders the message and shifts the streaming thinking block's last-block
+ * status, which flickered the thinking block. Pass the message's streaming
+ * flag so the transient-internal branch matches the renderer's behavior.
+ */
+export function isNonRenderedToolUse(
+  block: { type?: string; name?: string },
+  isStreaming: boolean,
+): boolean {
+  if (block.type !== 'tool_use') return false;
+  const toolName = normalizeToolName(block.name ?? '');
+  if (toolName === 'todowrite' || toolName === 'update_plan' || TASK_MANAGE_TOOL_NAMES.has(toolName)) {
+    return true;
+  }
+  if (!isStreaming && isTransientInternalToolName(block.name)) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
A batch of coordinated changes that stop the streaming chat from twitching, collapsing, and losing state as tool_use blocks arrive and the streaming renderer hands off to the final one.

- Stabilize message render keys across identity enrichment. A live assistant bubble keeps its React key (and thus its thinking expansion state) when a backend UUID lands on a turn that already carried a runtime turn id, and vice versa for replay messages. Tracked through a remembered identity->key map, refreshed in a layout effect.

- Filter non-rendered tool calls (TodoWrite, TaskCreate, transient internal tools) out of the rendered block list. Their arrival used to flip the last-block status of the streaming thinking block, which swapped its MarkdownBlock between the streaming and full-pipeline renderers. Because those renderers differed in height on single newline content, the thinking block visibly collapsed then re-expanded.

- Align the streaming prose renderer with marked's breaks:false so a single newline flows as whitespace, matching the final pipeline and erasing the height gap that surfaced on every sub-turn handoff.

- Preserve the user's text selection across streaming innerHTML rebuilds. Capture character offsets on the pre-commit DOM and re-anchor the Range in a layout effect before paint, so holding a selection no longer drops it mid-stream (new selectionOffsets util).

- Route single and multiple edit calls through one memoized EditToolBlock so the instance (and its state) survives the 1 -> N streaming transition instead of unmounting.

- Wrap Bash/Read/Generic/Edit tool blocks in memo() and add a stable SingleEditToolBlock adapter, so sibling blocks stop re-rendering on every streaming token.

- Guard focusInput against stealing focus while the user holds a selection elsewhere (queued-message copy) via the O(1) selection.isCollapsed check.