### PR TITLE
fix(webview): prevent ConfigSelect close while confirm dialog is open

### DIFF
--- a/webview/src/components/ChatInputBox/selectors/ConfigSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ConfigSelect.tsx
@@ -257,6 +257,11 @@ export const ConfigSelect = ({
     if (!isOpen) return;
 
     const handleClickOutside = (e: MouseEvent) => {
+      // 当确认对话框打开时跳过外部点击处理：点击确认/取消按钮会先触发 mousedown，
+      // 若此时关闭 ConfigSelect 会让确认框随之卸载，导致 onConfirm 永不执行（issue #1522）
+      if (document.querySelector('.confirm-dialog-overlay')) {
+        return;
+      }
       if (
         dropdownRef.current &&
         !dropdownRef.current.contains(e.target as Node) &&


### PR DESCRIPTION
Fixes #1522.

## Problem
Clicking the "restart" icon on a Node process opened a ConfirmDialog, but clicking either "restart" or "cancel" always behaved as cancel -- the restart never ran.

## Root cause
`handleClickOutside` in ConfigSelect listens to `mousedown`. Clicking a ConfirmDialog button fires `mousedown` before `click`; since the target is outside ConfigSelect's dropdown/button, `handleClickOutside` called `setIsOpen(false)`, unmounting the dialog before `onConfirm` could run.

## Fix
Skip the outside-click handler while a `.confirm-dialog-overlay` is present, so the dialog's button `click` resolves normally.

## Verification
- `tsc --noEmit` passes (0 errors)
- Behavior: with overlay present, mousedown no longer closes ConfigSelect; `onConfirm` fires on click