### PR TITLE
fix(codex): harden history, skills, and usage handling

### DIFF
--- a/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
@@ -364,12 +364,34 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
             if (isInactive()) {
                 return;
             }
-            double percentage = maxTokens > 0 ? (usedTokens * 100.0 / maxTokens) : 0.0;
+            int safeUsedTokens = normalizeUsageValue(usedTokens);
+            int safeMaxTokens = normalizeUsageValue(maxTokens);
+            double percentage = calculateUsagePercentage(safeUsedTokens, safeMaxTokens);
             String json = String.format("{\"percentage\":%.2f,\"usedTokens\":%d,\"maxTokens\":%d}",
-                    percentage, usedTokens, maxTokens);
+                    percentage, safeUsedTokens, safeMaxTokens);
             jsTarget.callJavaScript("onUsageUpdate", JsUtils.escapeJs(json));
-            LOG.debug("Usage update sent to frontend: " + usedTokens + "/" + maxTokens);
+            LOG.debug("Usage update sent to frontend: " + safeUsedTokens + "/" + safeMaxTokens);
         });
+    }
+
+    /**
+     * Keep usage counters non-negative before they cross the JavaScript bridge.
+     * Malformed or incomplete SDK usage payloads must not produce negative values
+     * in the context tooltip.
+     */
+    static int normalizeUsageValue(int value) {
+        return Math.max(0, value);
+    }
+
+    /**
+     * Calculate a bounded usage percentage for the context indicator.
+     */
+    static double calculateUsagePercentage(int usedTokens, int maxTokens) {
+        if (maxTokens <= 0) {
+            return 0.0;
+        }
+        double percentage = usedTokens * 100.0 / maxTokens;
+        return Math.max(0.0, Math.min(100.0, percentage));
     }
 
     @Override

--- a/src/main/java/com/github/claudecodegui/skill/CodexSkillService.java
+++ b/src/main/java/com/github/claudecodegui/skill/CodexSkillService.java
@@ -180,21 +180,48 @@ public class CodexSkillService {
      */
     public static JsonObject scanSkillsDirectory(String dirPath, String scope) {
         JsonObject skills = new JsonObject();
-        File dir = new File(dirPath);
+        Path rootDir = Paths.get(dirPath).toAbsolutePath().normalize();
+        File dir = rootDir.toFile();
 
         if (!dir.exists() || !dir.isDirectory()) {
             return skills;
         }
 
-        File[] entries = dir.listFiles();
-        if (entries == null) {
+        List<File> entries = new ArrayList<>();
+        try {
+            Files.walkFileTree(rootDir, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path currentDir, BasicFileAttributes attrs) {
+                    if (!currentDir.equals(rootDir) && containsHiddenPathSegment(rootDir, currentDir)) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (attrs.isRegularFile() && isSkillDefinitionFile(file)) {
+                        Path skillDir = file.getParent();
+                        if (skillDir != null && !skillDir.equals(rootDir)) {
+                            entries.add(skillDir.toFile());
+                        }
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException e) {
+                    LOG.warn("[CodexSkills] Skipping unreadable path: " + file, e);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+            entries = entries.stream().distinct().sorted().toList();
+        } catch (IOException e) {
+            LOG.warn("[CodexSkills] Failed to scan skills directory: " + dirPath, e);
             return skills;
         }
 
         for (File entry : entries) {
-            if (!entry.isDirectory() || entry.getName().startsWith(".")) {
-                continue;
-            }
             // Use normalized path in id to prevent collisions when same-named skills
             // exist in different scan directories (child vs parent)
             String normalizedEntryPath = normalizePath(entry.getAbsolutePath());
@@ -241,6 +268,29 @@ public class CodexSkillService {
 
         LOG.info("[CodexSkills] Scanned " + skills.size() + " skills from " + scope + ": " + dirPath);
         return skills;
+    }
+
+    private static boolean isSkillDefinitionFile(Path path) {
+        Path fileNamePath = path.getFileName();
+        if (fileNamePath == null) {
+            return false;
+        }
+        String fileName = fileNamePath.toString();
+        return "SKILL.md".equals(fileName) || "skill.md".equals(fileName);
+    }
+
+    private static boolean containsHiddenPathSegment(Path rootDir, Path skillDir) {
+        Path normalizedSkillDir = skillDir.toAbsolutePath().normalize();
+        if (!normalizedSkillDir.startsWith(rootDir)) {
+            return true;
+        }
+        Path relative = rootDir.relativize(normalizedSkillDir);
+        for (Path segment : relative) {
+            if (segment.toString().startsWith(".")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // ==================== Config.toml Integration ====================

--- a/src/main/java/com/github/claudecodegui/skill/CodexSkillService.java
+++ b/src/main/java/com/github/claudecodegui/skill/CodexSkillService.java
@@ -215,13 +215,12 @@ public class CodexSkillService {
                     return FileVisitResult.CONTINUE;
                 }
             });
-            entries = entries.stream().distinct().sorted().toList();
         } catch (IOException e) {
             LOG.warn("[CodexSkills] Failed to scan skills directory: " + dirPath, e);
             return skills;
         }
 
-        for (File entry : entries) {
+        for (File entry : entries.stream().distinct().sorted().toList()) {
             // Use normalized path in id to prevent collisions when same-named skills
             // exist in different scan directories (child vs parent)
             String normalizedEntryPath = normalizePath(entry.getAbsolutePath());

--- a/src/main/java/com/github/claudecodegui/skill/CodexSkillService.java
+++ b/src/main/java/com/github/claudecodegui/skill/CodexSkillService.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
@@ -186,6 +187,10 @@ public class CodexSkillService {
      * Scans a directory for skill subdirectories and returns skill metadata as JsonObject.
      */
     public static JsonObject scanSkillsDirectory(String dirPath, String scope) {
+        return scanSkillsDirectory(dirPath, scope, MAX_SKILL_SCAN_NODES);
+    }
+
+    static JsonObject scanSkillsDirectory(String dirPath, String scope, int maxScanNodes) {
         JsonObject skills = new JsonObject();
         Path rootDir = Paths.get(dirPath).toAbsolutePath().normalize();
         File dir = rootDir.toFile();
@@ -206,28 +211,26 @@ public class CodexSkillService {
                             || isSkippedSkillScanDirectory(currentDir))) {
                         return FileVisitResult.SKIP_SUBTREE;
                     }
-                    if (++visitedNodes[0] > MAX_SKILL_SCAN_NODES) {
+                    if (++visitedNodes[0] > maxScanNodes) {
                         limitReached[0] = true;
                         return FileVisitResult.TERMINATE;
+                    }
+                    if (!currentDir.equals(rootDir) && locateSkillDefinition(currentDir) != null) {
+                        if (entries.size() >= MAX_DISCOVERED_SKILLS) {
+                            limitReached[0] = true;
+                            return FileVisitResult.TERMINATE;
+                        }
+                        entries.add(currentDir.toFile());
+                        return FileVisitResult.SKIP_SUBTREE;
                     }
                     return FileVisitResult.CONTINUE;
                 }
 
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                    if (++visitedNodes[0] > MAX_SKILL_SCAN_NODES) {
+                    if (++visitedNodes[0] > maxScanNodes) {
                         limitReached[0] = true;
                         return FileVisitResult.TERMINATE;
-                    }
-                    if (attrs.isRegularFile() && isSkillDefinitionFile(file)) {
-                        Path skillDir = file.getParent();
-                        if (skillDir != null && !skillDir.equals(rootDir)) {
-                            if (entries.size() >= MAX_DISCOVERED_SKILLS) {
-                                limitReached[0] = true;
-                                return FileVisitResult.TERMINATE;
-                            }
-                            entries.add(skillDir.toFile());
-                        }
                     }
                     return FileVisitResult.CONTINUE;
                 }
@@ -271,11 +274,8 @@ public class CodexSkillService {
             }
 
             // Store skillPath (SKILL.md path) for config.toml operations
-            Path skillMd = entry.toPath().resolve("SKILL.md");
-            if (!Files.exists(skillMd)) {
-                skillMd = entry.toPath().resolve("skill.md");
-            }
-            if (Files.exists(skillMd)) {
+            Path skillMd = locateSkillDefinition(entry.toPath());
+            if (skillMd != null) {
                 skill.addProperty("skillPath", skillMd.toString());
             }
 
@@ -302,13 +302,13 @@ public class CodexSkillService {
         );
     }
 
-    private static boolean isSkillDefinitionFile(Path path) {
-        Path fileNamePath = path.getFileName();
-        if (fileNamePath == null) {
-            return false;
+    private static Path locateSkillDefinition(Path skillDir) {
+        Path upper = skillDir.resolve("SKILL.md");
+        if (Files.isRegularFile(upper, LinkOption.NOFOLLOW_LINKS)) {
+            return upper;
         }
-        String fileName = fileNamePath.toString();
-        return "SKILL.md".equals(fileName) || "skill.md".equals(fileName);
+        Path lower = skillDir.resolve("skill.md");
+        return Files.isRegularFile(lower, LinkOption.NOFOLLOW_LINKS) ? lower : null;
     }
 
     private static boolean containsHiddenPathSegment(Path rootDir, Path skillDir) {

--- a/src/main/java/com/github/claudecodegui/skill/CodexSkillService.java
+++ b/src/main/java/com/github/claudecodegui/skill/CodexSkillService.java
@@ -23,6 +23,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -42,6 +43,12 @@ public class CodexSkillService {
     private static final Logger LOG = Logger.getInstance(CodexSkillService.class);
     private static final Gson gson = new Gson();
     private static final int MAX_SCAN_LEVELS = 3;
+    private static final int MAX_SKILL_SCAN_DEPTH = 8;
+    private static final int MAX_SKILL_SCAN_NODES = 10_000;
+    private static final int MAX_DISCOVERED_SKILLS = 1_000;
+    private static final Set<String> SKIPPED_SKILL_SCAN_DIRECTORIES = Set.of(
+            "node_modules", "build", "target", "dist", "out", "coverage"
+    );
 
     // Shared instance to avoid repeated instantiation (I1)
     private static final CodexSettingsManager codexSettingsManager = new CodexSettingsManager(gson);
@@ -188,21 +195,37 @@ public class CodexSkillService {
         }
 
         List<File> entries = new ArrayList<>();
+        int[] visitedNodes = {0};
+        boolean[] limitReached = {false};
         try {
-            Files.walkFileTree(rootDir, new SimpleFileVisitor<>() {
+            Files.walkFileTree(rootDir, EnumSet.noneOf(FileVisitOption.class), MAX_SKILL_SCAN_DEPTH,
+                    new SimpleFileVisitor<>() {
                 @Override
                 public FileVisitResult preVisitDirectory(Path currentDir, BasicFileAttributes attrs) {
-                    if (!currentDir.equals(rootDir) && containsHiddenPathSegment(rootDir, currentDir)) {
+                    if (!currentDir.equals(rootDir) && (containsHiddenPathSegment(rootDir, currentDir)
+                            || isSkippedSkillScanDirectory(currentDir))) {
                         return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    if (++visitedNodes[0] > MAX_SKILL_SCAN_NODES) {
+                        limitReached[0] = true;
+                        return FileVisitResult.TERMINATE;
                     }
                     return FileVisitResult.CONTINUE;
                 }
 
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (++visitedNodes[0] > MAX_SKILL_SCAN_NODES) {
+                        limitReached[0] = true;
+                        return FileVisitResult.TERMINATE;
+                    }
                     if (attrs.isRegularFile() && isSkillDefinitionFile(file)) {
                         Path skillDir = file.getParent();
                         if (skillDir != null && !skillDir.equals(rootDir)) {
+                            if (entries.size() >= MAX_DISCOVERED_SKILLS) {
+                                limitReached[0] = true;
+                                return FileVisitResult.TERMINATE;
+                            }
                             entries.add(skillDir.toFile());
                         }
                     }
@@ -218,6 +241,9 @@ public class CodexSkillService {
         } catch (IOException e) {
             LOG.warn("[CodexSkills] Failed to scan skills directory: " + dirPath, e);
             return skills;
+        }
+        if (limitReached[0]) {
+            LOG.warn("[CodexSkills] Skill scan limit reached: " + dirPath);
         }
 
         for (File entry : entries.stream().distinct().sorted().toList()) {
@@ -267,6 +293,13 @@ public class CodexSkillService {
 
         LOG.info("[CodexSkills] Scanned " + skills.size() + " skills from " + scope + ": " + dirPath);
         return skills;
+    }
+
+    private static boolean isSkippedSkillScanDirectory(Path directory) {
+        Path fileName = directory.getFileName();
+        return fileName != null && SKIPPED_SKILL_SCAN_DIRECTORIES.contains(
+                fileName.toString().toLowerCase(Locale.ROOT)
+        );
     }
 
     private static boolean isSkillDefinitionFile(Path path) {

--- a/src/test/java/com/github/claudecodegui/session/SessionCallbackAdapterUsageTest.java
+++ b/src/test/java/com/github/claudecodegui/session/SessionCallbackAdapterUsageTest.java
@@ -1,0 +1,30 @@
+package com.github.claudecodegui.session;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Verifies usage values crossing the session callback JavaScript bridge are safe.
+ */
+public class SessionCallbackAdapterUsageTest {
+
+    @Test
+    public void normalizeUsageValueRejectsNegativeValues() {
+        assertEquals(0, SessionCallbackAdapter.normalizeUsageValue(-1));
+        assertEquals(42, SessionCallbackAdapter.normalizeUsageValue(42));
+    }
+
+    @Test
+    public void calculateUsagePercentageHandlesInvalidCapacity() {
+        assertEquals(0.0, SessionCallbackAdapter.calculateUsagePercentage(100, 0), 0.0);
+        assertEquals(0.0, SessionCallbackAdapter.calculateUsagePercentage(100, -1), 0.0);
+    }
+
+    @Test
+    public void calculateUsagePercentageIsBounded() {
+        assertEquals(25.0, SessionCallbackAdapter.calculateUsagePercentage(250, 1000), 0.0);
+        assertEquals(0.0, SessionCallbackAdapter.calculateUsagePercentage(0, 1000), 0.0);
+        assertEquals(100.0, SessionCallbackAdapter.calculateUsagePercentage(1500, 1000), 0.0);
+    }
+}

--- a/src/test/java/com/github/claudecodegui/skill/SlashCommandSourceScannersTest.java
+++ b/src/test/java/com/github/claudecodegui/skill/SlashCommandSourceScannersTest.java
@@ -1,5 +1,6 @@
 package com.github.claudecodegui.skill;
 
+import com.google.gson.JsonObject;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -8,6 +9,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SlashCommandSourceScannersTest {
 
@@ -154,5 +156,46 @@ public class SlashCommandSourceScannersTest {
         assertEquals(1, pluginCommands.size());
         assertEquals("/demo:audit", pluginCommands.get(0).name());
         assertEquals("plugin:demo", pluginCommands.get(0).source());
+    }
+
+    @Test
+    public void codexSkillScannerDiscoversNestedSkillDefinitionFiles() throws IOException {
+        Path root = Files.createTempDirectory("codex-skill-nested-scanner");
+        Path skillDir = Files.createDirectories(
+                root.resolve("review").resolve("utility").resolve("agent-packaging-skill")
+        );
+        Path hiddenSkillDir = Files.createDirectories(
+                root.resolve(".internal").resolve("hidden-skill")
+        );
+        Files.writeString(
+                skillDir.resolve("SKILL.md"),
+                """
+                ---
+                name: agent-packaging-skill
+                description: Package a Codex agent skill
+                userInvocable: true
+                ---
+
+                Package skills.
+                """
+        );
+        Files.writeString(
+                hiddenSkillDir.resolve("SKILL.md"),
+                """
+                ---
+                name: hidden-skill
+                description: Hidden skill
+                ---
+                """
+        );
+
+        JsonObject skills = CodexSkillService.scanSkillsDirectory(root.toString(), "user");
+
+        assertEquals(1, skills.size());
+        JsonObject skill = skills.entrySet().iterator().next().getValue().getAsJsonObject();
+        assertEquals("agent-packaging-skill", skill.get("name").getAsString());
+        assertEquals("Package a Codex agent skill", skill.get("description").getAsString());
+        assertTrue(skill.get("userInvocable").getAsBoolean());
+        assertEquals(skillDir.toString(), Path.of(skill.get("path").getAsString()).toString());
     }
 }

--- a/src/test/java/com/github/claudecodegui/skill/SlashCommandSourceScannersTest.java
+++ b/src/test/java/com/github/claudecodegui/skill/SlashCommandSourceScannersTest.java
@@ -8,7 +8,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import static org.junit.Assume.assumeNoException;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class SlashCommandSourceScannersTest {
@@ -216,6 +218,87 @@ public class SlashCommandSourceScannersTest {
         JsonObject skills = CodexSkillService.scanSkillsDirectory(root.toString(), "user");
 
         assertEquals(0, skills.size());
+    }
+
+    @Test
+    public void codexSkillScannerTreatsSkillPackagesAsTraversalBoundaries() throws IOException {
+        Path root = Files.createTempDirectory("codex-skill-package-boundary");
+        Path largeSkill = Files.createDirectories(root.resolve("large-skill"));
+        Path nestedSkill = Files.createDirectories(largeSkill.resolve("assets").resolve("nested-skill"));
+        Path siblingSkill = Files.createDirectories(root.resolve("sibling-skill"));
+        Files.writeString(largeSkill.resolve("SKILL.md"), validSkill("large-skill"));
+        Files.writeString(nestedSkill.resolve("SKILL.md"), validSkill("nested-skill"));
+        Files.writeString(siblingSkill.resolve("SKILL.md"), validSkill("sibling-skill"));
+
+        JsonObject skills = CodexSkillService.scanSkillsDirectory(root.toString(), "user", 3);
+
+        assertEquals(2, skills.size());
+        assertTrue(hasSkillNamed(skills, "large-skill"));
+        assertTrue(hasSkillNamed(skills, "sibling-skill"));
+        assertFalse(hasSkillNamed(skills, "nested-skill"));
+    }
+
+    @Test
+    public void codexSkillScannerStopsAtInvalidSkillPackage() throws IOException {
+        Path root = Files.createTempDirectory("codex-invalid-skill-boundary");
+        Path invalidSkill = Files.createDirectories(root.resolve("invalid-skill"));
+        Path nestedSkill = Files.createDirectories(invalidSkill.resolve("resources").resolve("nested-skill"));
+        Files.writeString(invalidSkill.resolve("SKILL.md"), "Invalid skill metadata");
+        Files.writeString(nestedSkill.resolve("SKILL.md"), validSkill("nested-skill"));
+
+        JsonObject skills = CodexSkillService.scanSkillsDirectory(root.toString(), "user");
+
+        assertEquals(1, skills.size());
+        JsonObject skill = skills.entrySet().iterator().next().getValue().getAsJsonObject();
+        assertEquals("invalid-skill", skill.get("name").getAsString());
+        assertEquals("invalid_frontmatter", skill.get("warning").getAsString());
+        assertFalse(hasSkillNamed(skills, "nested-skill"));
+    }
+
+    @Test
+    public void codexSkillScannerSupportsLowercaseDefinitionFile() throws IOException {
+        Path root = Files.createTempDirectory("codex-lowercase-skill-definition");
+        Path skillDir = Files.createDirectories(root.resolve("lowercase-skill"));
+        Files.writeString(skillDir.resolve("skill.md"), validSkill("lowercase-skill"));
+
+        JsonObject skills = CodexSkillService.scanSkillsDirectory(root.toString(), "user");
+
+        assertEquals(1, skills.size());
+        assertTrue(hasSkillNamed(skills, "lowercase-skill"));
+    }
+
+    @Test
+    public void codexSkillScannerDoesNotFollowSymlinkedDefinitionFile() throws IOException {
+        Path root = Files.createTempDirectory("codex-symlink-skill-definition");
+        Path definition = root.resolve("definition.md");
+        Path skillDir = Files.createDirectories(root.resolve("linked-skill"));
+        Files.writeString(definition, validSkill("linked-skill"));
+        try {
+            Files.createSymbolicLink(skillDir.resolve("SKILL.md"), definition);
+        } catch (IOException | UnsupportedOperationException | SecurityException e) {
+            assumeNoException(e);
+        }
+
+        JsonObject skills = CodexSkillService.scanSkillsDirectory(root.toString(), "user");
+
+        assertEquals(0, skills.size());
+    }
+
+    @Test
+    public void codexSkillScannerStillEnforcesNodeLimitForCollectionDirectories() throws IOException {
+        Path root = Files.createTempDirectory("codex-skill-node-limit");
+        Path skillDir = Files.createDirectories(root.resolve("collection").resolve("nested").resolve("skill"));
+        Files.writeString(skillDir.resolve("SKILL.md"), validSkill("limited-skill"));
+
+        JsonObject skills = CodexSkillService.scanSkillsDirectory(root.toString(), "user", 3);
+
+        assertEquals(0, skills.size());
+    }
+
+    private boolean hasSkillNamed(JsonObject skills, String name) {
+        return skills.entrySet().stream()
+                .map(entry -> entry.getValue().getAsJsonObject())
+                .anyMatch(skill -> name.equals(skill.get("name").getAsString()));
     }
 
     private String validSkill(String name) {

--- a/src/test/java/com/github/claudecodegui/skill/SlashCommandSourceScannersTest.java
+++ b/src/test/java/com/github/claudecodegui/skill/SlashCommandSourceScannersTest.java
@@ -198,4 +198,35 @@ public class SlashCommandSourceScannersTest {
         assertTrue(skill.get("userInvocable").getAsBoolean());
         assertEquals(skillDir.toString(), Path.of(skill.get("path").getAsString()).toString());
     }
+
+    @Test
+    public void codexSkillScannerSkipsGeneratedAndExcessivelyDeepDirectories() throws IOException {
+        Path root = Files.createTempDirectory("codex-skill-bounded-scanner");
+        Path generatedSkill = Files.createDirectories(
+                root.resolve("package").resolve("node_modules").resolve("dependency")
+        );
+        Path deepSkill = root;
+        for (int depth = 0; depth < 10; depth++) {
+            deepSkill = deepSkill.resolve("level-" + depth);
+        }
+        Files.createDirectories(deepSkill);
+        Files.writeString(generatedSkill.resolve("SKILL.md"), validSkill("generated-skill"));
+        Files.writeString(deepSkill.resolve("SKILL.md"), validSkill("deep-skill"));
+
+        JsonObject skills = CodexSkillService.scanSkillsDirectory(root.toString(), "user");
+
+        assertEquals(0, skills.size());
+    }
+
+    private String validSkill(String name) {
+        return """
+                ---
+                name: %s
+                description: Test skill
+                userInvocable: true
+                ---
+
+                Test skill.
+                """.formatted(name);
+    }
 }

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -263,7 +263,7 @@ const App = () => {
     loadHistorySession, deleteHistorySession, deleteHistorySessions, exportHistorySession,
     toggleFavoriteSession, updateHistoryTitle, applyHistoryTitleLocal, convertToCliSession,
   } = useSessionManagement({
-    messages, loading, historyData, currentSessionId, currentSessionIdRef,
+    messages, loading, historyData, currentSessionId, currentSessionIdRef, currentProvider,
     setHistoryData, setMessages, setCurrentView, setCurrentSessionId,
     setCustomSessionTitle, setUsagePercentage, setUsageUsedTokens, setUsageMaxTokens,
     setStatus, setLoading, setIsThinking, setStreamingActive,

--- a/webview/src/components/ChatInputBox/TokenIndicator.test.tsx
+++ b/webview/src/components/ChatInputBox/TokenIndicator.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TokenIndicator } from './TokenIndicator';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { percentage?: string }) => options?.percentage ?? key,
+  }),
+}));
+
+describe('TokenIndicator', () => {
+  it('clamps labels and ring geometry above 100 percent', () => {
+    const { container } = render(<TokenIndicator percentage={145} usedTokens={2900} maxTokens={2000} />);
+
+    expect(screen.getByText('100%')).toBeTruthy();
+    const progressCircle = container.querySelector('.token-indicator-fill');
+    expect(progressCircle?.getAttribute('stroke-dashoffset')).toBe('0');
+    expect(screen.getByText(/2.9k \/ 2k/)).toBeTruthy();
+  });
+});

--- a/webview/src/components/ChatInputBox/TokenIndicator.tsx
+++ b/webview/src/components/ChatInputBox/TokenIndicator.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import type { TokenIndicatorProps } from './types';
+import { clampUsagePercentage } from '../../utils/usagePercentage';
 
 /**
  * TokenIndicator - Usage ring progress bar component
@@ -12,6 +13,7 @@ export const TokenIndicator = ({
   maxTokens,
 }: TokenIndicatorProps) => {
   const { t } = useTranslation();
+  const safePercentage = clampUsagePercentage(percentage);
   // Circle radius (accounting for stroke space)
   const radius = (size - 3) / 2;
   const center = size / 2;
@@ -20,12 +22,12 @@ export const TokenIndicator = ({
   const circumference = 2 * Math.PI * radius;
 
   // Calculate offset (fill clockwise from top)
-  const strokeOffset = circumference * (1 - percentage / 100);
+  const strokeOffset = circumference * (1 - safePercentage / 100);
 
   // Indicator label: integer percentage (no decimal)
-  const labelPercentage = `${Math.round(percentage)}%`;
+  const labelPercentage = `${Math.round(safePercentage)}%`;
   // Tooltip: one decimal place for precision
-  const tooltipPercentage = `${(Math.round(percentage * 10) / 10).toFixed(1)}%`;
+  const tooltipPercentage = `${(Math.round(safePercentage * 10) / 10).toFixed(1)}%`;
 
   const formatTokens = (value?: number) => {
     if (typeof value !== 'number' || !isFinite(value)) return undefined;

--- a/webview/src/components/ContextUsageDialog.test.tsx
+++ b/webview/src/components/ContextUsageDialog.test.tsx
@@ -100,4 +100,30 @@ describe('ContextUsageDialog', () => {
     expect(screen.getByText('服务器')).toBeTruthy();
     expect(screen.getAllByText('令牌').length).toBeGreaterThan(0);
   });
+
+  it('clamps visual percentages while preserving raw token counts', () => {
+    const { container } = render(
+      <ContextUsageDialog
+        isOpen
+        isLoading={false}
+        data={{ ...sampleData, totalTokens: 2400, percentage: 120 }}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(container.querySelector('.context-usage-tokens')?.textContent).toBe('2.4k / 2.0k (100%)');
+  });
+
+  it('uses a finite fallback opacity for invalid square fullness', () => {
+    const invalidData: ContextUsageData = {
+      ...sampleData,
+      gridRows: [[{ ...sampleData.gridRows[0][0], squareFullness: Number.NaN }]],
+    };
+    const { container } = render(
+      <ContextUsageDialog isOpen isLoading={false} data={invalidData} onClose={() => {}} />,
+    );
+
+    const square = container.querySelector<HTMLElement>('.context-usage-grid-cell.partial');
+    expect(square?.style.opacity).toBe('0.5');
+  });
 });

--- a/webview/src/components/ContextUsageDialog.tsx
+++ b/webview/src/components/ContextUsageDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useMemo, useCallback, useId, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import './ContextUsageDialog.css';
+import { clampUsagePercentage } from '../utils/usagePercentage';
 
 export interface ContextUsageData {
   categories: Array<{
@@ -268,6 +269,7 @@ const ContextUsageDialog = memo(function ContextUsageDialog({
     isAutoCompactEnabled = false,
     autoCompactThreshold,
   } = data;
+  const safePercentage = clampUsagePercentage(percentage);
 
   return (
     <div className="context-usage-overlay" onMouseDown={handleCloseMouseDown}>
@@ -303,13 +305,13 @@ const ContextUsageDialog = memo(function ContextUsageDialog({
         <div id={descriptionId} className="context-usage-summary">
           <span className="context-usage-model">{model}</span>
           <span className="context-usage-tokens">
-            {formatTokens(totalTokens)} / {formatTokens(rawMaxTokens)} ({percentage}%)
+            {formatTokens(totalTokens)} / {formatTokens(rawMaxTokens)} ({safePercentage}%)
           </span>
           {isAutoCompactEnabled && (
             <span className="context-usage-autocompact">
               {autoCompactThreshold && rawMaxTokens > 0
                 ? t('contextUsage.autoCompactEnabledWithThreshold', {
-                    threshold: Math.round((autoCompactThreshold / rawMaxTokens) * 100),
+                    threshold: Math.round(clampUsagePercentage((autoCompactThreshold / rawMaxTokens) * 100)),
                     defaultValue: 'Auto-compact: enabled ({{threshold}}%)',
                   })
                 : t('contextUsage.autoCompactEnabled', {
@@ -345,16 +347,19 @@ const ContextUsageDialog = memo(function ContextUsageDialog({
                       />
                     );
                   }
-                  const filled = sq.squareFullness >= 0.7;
+                  const safeFullness = Number.isFinite(sq.squareFullness)
+                    ? Math.max(0, Math.min(1, sq.squareFullness))
+                    : 0;
+                  const filled = safeFullness >= 0.7;
                   return (
                     <div
                       key={squareKey}
                       className={`context-usage-grid-cell ${filled ? 'filled' : 'partial'}`}
                       style={{
                         backgroundColor: resolveColor(sq.color),
-                        ...(filled ? {} : { opacity: 0.5 + sq.squareFullness * 0.5 }),
+                        ...(filled ? {} : { opacity: 0.5 + safeFullness * 0.5 }),
                       }}
-                      title={`${translateCategoryName(sq.categoryName)}: ${formatTokens(sq.tokens)} (${sq.percentage.toFixed(1)}%)`}
+                      title={`${translateCategoryName(sq.categoryName)}: ${formatTokens(sq.tokens)} (${clampUsagePercentage(sq.percentage).toFixed(1)}%)`}
                     />
                   );
                 })}

--- a/webview/src/hooks/useSessionManagement.test.ts
+++ b/webview/src/hooks/useSessionManagement.test.ts
@@ -620,6 +620,43 @@ describe('useSessionManagement', () => {
     );
   });
 
+  it('loadHistorySession falls back to current provider when history item has no provider', () => {
+    const historyData = {
+      success: true,
+      sessions: [
+        {
+          sessionId: 'hist-codex-missing-provider',
+          title: 'Codex Session',
+          messageCount: 2,
+          lastTimestamp: Date.now(),
+        },
+      ],
+      total: 2,
+    } as unknown as HistoryData;
+
+    const mocks = createMocks();
+
+    const { result } = renderHook(() =>
+      useSessionManagement({
+        messages: [],
+        loading: false,
+        historyData,
+        currentSessionId: null,
+        currentProvider: 'codex',
+        ...mocks,
+        t,
+      })
+    );
+
+    act(() => {
+      result.current.loadHistorySession('hist-codex-missing-provider');
+    });
+
+    expect(window.sendToJava).toHaveBeenCalledWith(
+      'load_session:{"sessionId":"hist-codex-missing-provider","provider":"codex"}'
+    );
+  });
+
   it('all transition paths reset usage tokens', () => {
     const mocks = createMocks();
 

--- a/webview/src/hooks/useSessionManagement.ts
+++ b/webview/src/hooks/useSessionManagement.ts
@@ -18,6 +18,7 @@ interface UseSessionManagementOptions {
   historyData: HistoryData | null;
   currentSessionId: string | null;
   currentSessionIdRef?: React.MutableRefObject<string | null>;
+  currentProvider?: string;
   setHistoryData: React.Dispatch<React.SetStateAction<HistoryData | null>>;
   setMessages: React.Dispatch<React.SetStateAction<ClaudeMessage[]>>;
   setCurrentView: (view: ViewMode) => void;
@@ -69,6 +70,7 @@ export function useSessionManagement({
   historyData,
   currentSessionId,
   currentSessionIdRef,
+  currentProvider,
   setHistoryData,
   setMessages,
   setCurrentView,
@@ -247,7 +249,7 @@ export function useSessionManagement({
   // Load history session
   const loadHistorySession = useCallback((sessionId: string, provider?: string) => {
     const session = historyDataRef.current?.sessions?.find(s => s.sessionId === sessionId);
-    const effectiveProvider = provider || session?.provider || 'claude';
+    const effectiveProvider = provider || session?.provider || currentProvider || 'claude';
 
     // Re-opening the very session already active: don't interrupt the in-flight
     // turn or wipe the view - just ask the backend to soft-reload the transcript
@@ -277,7 +279,7 @@ export function useSessionManagement({
       provider: effectiveProvider,
     }));
     setCurrentView('chat');
-  }, [beginSessionTransition, loading, setCurrentView, currentSessionId]);
+  }, [beginSessionTransition, currentProvider, loading, setCurrentView, currentSessionId]);
 
   // Delete history session
   const deleteHistorySession = useCallback((sessionId: string) => {

--- a/webview/src/utils/usagePercentage.test.ts
+++ b/webview/src/utils/usagePercentage.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { clampUsagePercentage } from './usagePercentage';
+
+describe('clampUsagePercentage', () => {
+  it('keeps visual percentages within the supported range', () => {
+    expect(clampUsagePercentage(-5)).toBe(0);
+    expect(clampUsagePercentage(45.5)).toBe(45.5);
+    expect(clampUsagePercentage(144)).toBe(100);
+    expect(clampUsagePercentage(Number.NaN)).toBe(0);
+    expect(clampUsagePercentage(Number.POSITIVE_INFINITY)).toBe(0);
+    expect(clampUsagePercentage(Number.NEGATIVE_INFINITY)).toBe(0);
+  });
+});

--- a/webview/src/utils/usagePercentage.ts
+++ b/webview/src/utils/usagePercentage.ts
@@ -1,0 +1,4 @@
+export function clampUsagePercentage(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, value));
+}


### PR DESCRIPTION
## Summary

- discover nested Codex skills with bounded traversal and portable compilation
- sanitize session usage callback payloads before forwarding them to the webview
- preserve the active provider during history loading and clamp usage percentages before rendering

## Problem

Nested skills could be missed or scanned without practical bounds, malformed usage payloads could reach JavaScript callbacks, and history loading could reset provider state or render invalid context usage percentages.

## Validation

- `git diff --check upstream/feature/v0.4.9...HEAD`
- clean merge simulation against `upstream/feature/v0.4.9`
- 27 targeted frontend regression tests passed
- 7 targeted Java regression tests passed
- test TypeScript compilation passed