### PR TITLE
feat(codex): store provider credentials in PasswordSafe

### DIFF
--- a/src/main/java/com/github/claudecodegui/settings/CodexProviderCredentialStore.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodexProviderCredentialStore.java
@@ -1,0 +1,84 @@
+package com.github.claudecodegui.settings;
+
+import com.intellij.credentialStore.CredentialAttributes;
+import com.intellij.credentialStore.Credentials;
+import com.intellij.ide.passwordSafe.PasswordSafe;
+import com.intellij.openapi.diagnostic.Logger;
+import org.jetbrains.annotations.Nullable;
+
+/** Stores managed Codex provider auth JSON in JetBrains PasswordSafe. */
+public class CodexProviderCredentialStore {
+
+    private static final Logger LOG = Logger.getInstance(CodexProviderCredentialStore.class);
+    private static final String SERVICE_PREFIX = "CC GUI/Codex Provider/";
+
+    public boolean isPersistentStorageAvailable() {
+        try {
+            return !PasswordSafe.getInstance().isMemoryOnly();
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+
+    public boolean writeVerified(String providerId, String authJson) {
+        if (!isValidId(providerId) || authJson == null || !isPersistentStorageAvailable()) {
+            return false;
+        }
+        try {
+            PasswordSafe.getInstance().set(attributes(providerId), new Credentials(providerId, authJson));
+            return authJson.equals(read(providerId));
+        } catch (RuntimeException e) {
+            LOG.warn("[CodexCredentials] PasswordSafe write failed for provider " + providerId
+                    + "; errorClass=" + e.getClass().getSimpleName());
+            return false;
+        }
+    }
+
+    public @Nullable String read(String providerId) {
+        if (!isValidId(providerId)) {
+            return null;
+        }
+        try {
+            Credentials credentials = PasswordSafe.getInstance().get(attributes(providerId));
+            return credentials == null ? null : credentials.getPasswordAsString();
+        } catch (RuntimeException e) {
+            LOG.warn("[CodexCredentials] PasswordSafe read failed for provider " + providerId
+                    + "; errorClass=" + e.getClass().getSimpleName());
+            return null;
+        }
+    }
+
+    public void delete(String providerId) {
+        if (!isValidId(providerId)) {
+            return;
+        }
+        try {
+            PasswordSafe.getInstance().set(attributes(providerId), null);
+        } catch (RuntimeException e) {
+            LOG.warn("[CodexCredentials] PasswordSafe delete failed for provider " + providerId
+                    + "; errorClass=" + e.getClass().getSimpleName());
+        }
+    }
+
+    public boolean deleteVerified(String providerId) {
+        if (!isValidId(providerId) || !isPersistentStorageAvailable()) {
+            return false;
+        }
+        try {
+            PasswordSafe.getInstance().set(attributes(providerId), null);
+            return PasswordSafe.getInstance().get(attributes(providerId)) == null;
+        } catch (RuntimeException e) {
+            LOG.warn("[CodexCredentials] PasswordSafe verified delete failed for provider " + providerId
+                    + "; errorClass=" + e.getClass().getSimpleName());
+            return false;
+        }
+    }
+
+    private static CredentialAttributes attributes(String providerId) {
+        return new CredentialAttributes(SERVICE_PREFIX + providerId, providerId);
+    }
+
+    private static boolean isValidId(String providerId) {
+        return providerId != null && !providerId.isBlank() && providerId.length() <= 256;
+    }
+}

--- a/src/main/java/com/github/claudecodegui/settings/CodexProviderManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodexProviderManager.java
@@ -22,6 +22,8 @@ import java.util.function.Function;
  */
 public class CodexProviderManager {
     private static final Logger LOG = Logger.getInstance(CodexProviderManager.class);
+    private static final String AUTH_STORED_KEY = "authStoredInPasswordSafe";
+    private static final String CREDENTIAL_UNAVAILABLE_KEY = "credentialUnavailable";
     private static final String BACKUP_FILE_NAME = "config.json.bak";
     public static final String CODEX_CLI_LOGIN_PROVIDER_ID = "__codex_cli_login__";
 
@@ -30,6 +32,7 @@ public class CodexProviderManager {
     private final Consumer<JsonObject> configWriter;
     private final ConfigPathManager pathManager;
     private final CodexSettingsManager codexSettingsManager;
+    private final CodexProviderCredentialStore credentialStore;
 
     public CodexProviderManager(
             Gson gson,
@@ -37,11 +40,23 @@ public class CodexProviderManager {
             Consumer<JsonObject> configWriter,
             ConfigPathManager pathManager,
             CodexSettingsManager codexSettingsManager) {
+        this(gson, configReader, configWriter, pathManager, codexSettingsManager,
+                new CodexProviderCredentialStore());
+    }
+
+    CodexProviderManager(
+            Gson gson,
+            Function<Void, JsonObject> configReader,
+            Consumer<JsonObject> configWriter,
+            ConfigPathManager pathManager,
+            CodexSettingsManager codexSettingsManager,
+            CodexProviderCredentialStore credentialStore) {
         this.gson = gson;
         this.configReader = configReader;
         this.configWriter = configWriter;
         this.pathManager = pathManager;
         this.codexSettingsManager = codexSettingsManager;
+        this.credentialStore = credentialStore;
     }
 
     /**
@@ -49,6 +64,7 @@ public class CodexProviderManager {
      */
     public List<JsonObject> getCodexProviders() {
         JsonObject config = configReader.apply(null);
+        migrateLegacyCredentials(config);
         List<JsonObject> result = new ArrayList<>();
 
         String currentId = null;
@@ -86,6 +102,7 @@ public class CodexProviderManager {
                 if (!provider.has("id")) {
                     provider.addProperty("id", id);
                 }
+                hydrateCredential(provider, id);
                 // Add isActive flag
                 provider.addProperty("isActive", id.equals(currentId));
                 result.add(provider);
@@ -150,10 +167,11 @@ public class CodexProviderManager {
         JsonObject providers = codex.getAsJsonObject("providers");
 
         if (providers.has(currentId)) {
-            JsonObject provider = providers.getAsJsonObject(currentId);
+            JsonObject provider = providers.getAsJsonObject(currentId).deepCopy();
             if (!provider.has("id")) {
                 provider.addProperty("id", currentId);
             }
+            hydrateCredential(provider, currentId);
             provider.addProperty("isActive", true);
             return provider;
         }
@@ -169,6 +187,7 @@ public class CodexProviderManager {
             throw new IllegalArgumentException("Provider must have an id");
         }
 
+        JsonObject providerToPersist = provider.deepCopy();
         JsonObject config = configReader.apply(null);
 
         // Ensure codex configuration exists
@@ -182,7 +201,7 @@ public class CodexProviderManager {
         JsonObject codex = config.getAsJsonObject("codex");
         JsonObject providers = codex.getAsJsonObject("providers");
 
-        String id = provider.get("id").getAsString();
+        String id = providerToPersist.get("id").getAsString();
 
         // Check if ID already exists
         if (providers.has(id)) {
@@ -190,14 +209,19 @@ public class CodexProviderManager {
         }
 
         // Add creation timestamp
-        if (!provider.has("createdAt")) {
-            provider.addProperty("createdAt", System.currentTimeMillis());
+        if (!providerToPersist.has("createdAt")) {
+            providerToPersist.addProperty("createdAt", System.currentTimeMillis());
         }
 
-        // Add provider (not auto-activated)
-        providers.add(id, provider);
-
-        configWriter.accept(config);
+        String previousCredential = credentialStore.read(id);
+        try {
+            protectCredential(providerToPersist, id);
+            providers.add(id, providerToPersist);
+            configWriter.accept(config);
+        } catch (RuntimeException e) {
+            restoreCredential(id, previousCredential, false);
+            throw e;
+        }
         LOG.info("[CodexProviderManager] Added provider: " + id);
     }
 
@@ -209,6 +233,7 @@ public class CodexProviderManager {
             throw new IllegalArgumentException("Provider must have an id");
         }
 
+        JsonObject providerToPersist = provider.deepCopy();
         JsonObject config = configReader.apply(null);
 
         // Ensure codex configuration exists
@@ -222,22 +247,35 @@ public class CodexProviderManager {
         JsonObject codex = config.getAsJsonObject("codex");
         JsonObject providers = codex.getAsJsonObject("providers");
 
-        String id = provider.get("id").getAsString();
+        String id = providerToPersist.get("id").getAsString();
 
         // Preserve createdAt if updating existing provider
+        boolean hadStoredCredential = false;
         if (providers.has(id)) {
             JsonObject existing = providers.getAsJsonObject(id);
-            if (existing.has("createdAt") && !provider.has("createdAt")) {
-                provider.addProperty("createdAt", existing.get("createdAt").getAsLong());
+            hadStoredCredential = hasStoredCredential(existing);
+            if (existing.has("createdAt") && !providerToPersist.has("createdAt")) {
+                providerToPersist.addProperty("createdAt", existing.get("createdAt").getAsLong());
+            }
+            if (existing.has(AUTH_STORED_KEY) && !providerToPersist.has("authJson")
+                    && !providerToPersist.has(AUTH_STORED_KEY)) {
+                providerToPersist.add(AUTH_STORED_KEY, existing.get(AUTH_STORED_KEY));
             }
         } else {
-            if (!provider.has("createdAt")) {
-                provider.addProperty("createdAt", System.currentTimeMillis());
+            if (!providerToPersist.has("createdAt")) {
+                providerToPersist.addProperty("createdAt", System.currentTimeMillis());
             }
         }
 
-        providers.add(id, provider);
-        configWriter.accept(config);
+        String previousCredential = credentialStore.read(id);
+        try {
+            protectCredential(providerToPersist, id);
+            providers.add(id, providerToPersist);
+            configWriter.accept(config);
+        } catch (RuntimeException e) {
+            restoreCredential(id, previousCredential, hadStoredCredential);
+            throw e;
+        }
     }
 
     /**
@@ -257,7 +295,10 @@ public class CodexProviderManager {
             throw new IllegalArgumentException("Provider with id '" + id + "' not found");
         }
 
-        JsonObject provider = providers.getAsJsonObject(id);
+        JsonObject existingProvider = providers.getAsJsonObject(id);
+        JsonObject provider = existingProvider.deepCopy();
+        boolean hadStoredCredential = hasStoredCredential(existingProvider);
+        String previousCredential = credentialStore.read(id);
 
         // Merge updates
         for (String key : updates.keySet()) {
@@ -274,7 +315,14 @@ public class CodexProviderManager {
             }
         }
 
-        configWriter.accept(config);
+        try {
+            protectCredential(provider, id);
+            providers.add(id, provider);
+            configWriter.accept(config);
+        } catch (RuntimeException e) {
+            restoreCredential(id, previousCredential, hadStoredCredential);
+            throw e;
+        }
         LOG.info("[CodexProviderManager] Updated provider: " + id);
     }
 
@@ -286,6 +334,8 @@ public class CodexProviderManager {
     public DeleteResult deleteCodexProvider(String id) {
         Path configFilePath = null;
         Path backupFilePath = null;
+        String deletedCredential = null;
+        boolean credentialDeleted = false;
 
         try {
             JsonObject config = configReader.apply(null);
@@ -311,6 +361,15 @@ public class CodexProviderManager {
                     null,
                     "Please check if the provider ID is correct"
                 );
+            }
+
+            JsonObject providerToDelete = providers.getAsJsonObject(id);
+            if (hasStoredCredential(providerToDelete)) {
+                deletedCredential = credentialStore.read(id);
+                if (deletedCredential == null || !credentialStore.deleteVerified(id)) {
+                    throw new IllegalStateException("Unable to remove Codex credential from PasswordSafe");
+                }
+                credentialDeleted = true;
             }
 
             // Create backup before deletion
@@ -354,6 +413,10 @@ public class CodexProviderManager {
             return DeleteResult.success(id);
 
         } catch (Exception e) {
+            if (credentialDeleted && deletedCredential != null
+                    && !credentialStore.writeVerified(id, deletedCredential)) {
+                LOG.warn("[CodexProviderManager] Failed to restore credential after provider deletion failure");
+            }
             // Try to restore from backup
             if (backupFilePath != null && configFilePath != null) {
                 try {
@@ -432,6 +495,11 @@ public class CodexProviderManager {
             LOG.info("[CodexProviderManager] No active provider to sync to ~/.codex/");
             return;
         }
+        if (activeProvider.has(CREDENTIAL_UNAVAILABLE_KEY)
+                && activeProvider.get(CREDENTIAL_UNAVAILABLE_KEY).isJsonPrimitive()
+                && activeProvider.get(CREDENTIAL_UNAVAILABLE_KEY).getAsBoolean()) {
+            throw new IOException("Codex provider credential is unavailable in PasswordSafe");
+        }
         codexSettingsManager.applyProviderToCodexSettings(activeProvider);
     }
 
@@ -453,6 +521,103 @@ public class CodexProviderManager {
         provider.addProperty("isActive", isActive);
         provider.addProperty("isCodexCliLoginProvider", true);
         return provider;
+    }
+
+    private void migrateLegacyCredentials(JsonObject config) {
+        if (config == null || !credentialStore.isPersistentStorageAvailable()
+                || !config.has("codex") || !config.get("codex").isJsonObject()) {
+            return;
+        }
+        JsonObject codex = config.getAsJsonObject("codex");
+        if (!codex.has("providers") || !codex.get("providers").isJsonObject()) {
+            return;
+        }
+        boolean changed = false;
+        JsonObject providers = codex.getAsJsonObject("providers");
+        for (String id : providers.keySet()) {
+            if (!providers.get(id).isJsonObject()) {
+                continue;
+            }
+            JsonObject provider = providers.getAsJsonObject(id);
+            if (provider.has(AUTH_STORED_KEY) || !provider.has("authJson")
+                    || !provider.get("authJson").isJsonPrimitive()) {
+                continue;
+            }
+            String authJson = provider.get("authJson").getAsString();
+            if (!authJson.isBlank() && credentialStore.writeVerified(id, authJson)) {
+                provider.remove("authJson");
+                provider.addProperty(AUTH_STORED_KEY, true);
+                changed = true;
+            }
+        }
+        if (changed) {
+            try {
+                configWriter.accept(config);
+                LOG.info("[CodexProviderManager] Migrated legacy provider credentials to PasswordSafe");
+            } catch (RuntimeException e) {
+                LOG.warn("[CodexProviderManager] PasswordSafe migration config update failed; errorClass="
+                        + e.getClass().getSimpleName());
+            }
+        }
+    }
+
+    private void protectCredential(JsonObject provider, String id) {
+        boolean unavailable = provider.has(CREDENTIAL_UNAVAILABLE_KEY)
+                && provider.get(CREDENTIAL_UNAVAILABLE_KEY).isJsonPrimitive()
+                && provider.get(CREDENTIAL_UNAVAILABLE_KEY).getAsBoolean();
+        if (!provider.has("authJson") || !provider.get("authJson").isJsonPrimitive()) {
+            provider.remove(CREDENTIAL_UNAVAILABLE_KEY);
+            return;
+        }
+        String authJson = provider.get("authJson").getAsString();
+        if (unavailable && authJson.isBlank() && hasStoredCredential(provider)) {
+            provider.remove("authJson");
+            provider.remove(CREDENTIAL_UNAVAILABLE_KEY);
+            return;
+        }
+        provider.remove(CREDENTIAL_UNAVAILABLE_KEY);
+        if (authJson.isBlank()) {
+            if (hasStoredCredential(provider) && !credentialStore.deleteVerified(id)) {
+                throw new IllegalStateException("Unable to remove Codex credential from PasswordSafe");
+            }
+            provider.remove("authJson");
+            provider.remove(AUTH_STORED_KEY);
+            return;
+        }
+        if (credentialStore.writeVerified(id, authJson)) {
+            provider.remove("authJson");
+            provider.addProperty(AUTH_STORED_KEY, true);
+        } else {
+            provider.remove("authJson");
+            throw new IllegalStateException("Unable to store Codex credential in PasswordSafe");
+        }
+    }
+
+    private void hydrateCredential(JsonObject provider, String id) {
+        if (!hasStoredCredential(provider)) {
+            return;
+        }
+        String authJson = credentialStore.read(id);
+        if (authJson == null) {
+            provider.addProperty(CREDENTIAL_UNAVAILABLE_KEY, true);
+        } else {
+            provider.addProperty("authJson", authJson);
+            provider.remove(CREDENTIAL_UNAVAILABLE_KEY);
+        }
+    }
+
+    private void restoreCredential(String id, String previousCredential, boolean hadStoredCredential) {
+        if (previousCredential != null) {
+            credentialStore.writeVerified(id, previousCredential);
+        } else if (!hadStoredCredential) {
+            credentialStore.delete(id);
+        }
+    }
+
+    private static boolean hasStoredCredential(JsonObject provider) {
+        return provider.has(AUTH_STORED_KEY)
+                && provider.get(AUTH_STORED_KEY).isJsonPrimitive()
+                && provider.get(AUTH_STORED_KEY).getAsBoolean();
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/settings/CodexProviderManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodexProviderManager.java
@@ -257,8 +257,7 @@ public class CodexProviderManager {
             if (existing.has("createdAt") && !providerToPersist.has("createdAt")) {
                 providerToPersist.addProperty("createdAt", existing.get("createdAt").getAsLong());
             }
-            if (existing.has(AUTH_STORED_KEY) && !providerToPersist.has("authJson")
-                    && !providerToPersist.has(AUTH_STORED_KEY)) {
+            if (existing.has(AUTH_STORED_KEY) && !providerToPersist.has(AUTH_STORED_KEY)) {
                 providerToPersist.add(AUTH_STORED_KEY, existing.get(AUTH_STORED_KEY));
             }
         } else {
@@ -268,6 +267,9 @@ public class CodexProviderManager {
         }
 
         String previousCredential = credentialStore.read(id);
+        if (hadStoredCredential && previousCredential == null) {
+            providerToPersist.addProperty(CREDENTIAL_UNAVAILABLE_KEY, true);
+        }
         try {
             protectCredential(providerToPersist, id);
             providers.add(id, providerToPersist);
@@ -315,6 +317,9 @@ public class CodexProviderManager {
             }
         }
 
+        if (hadStoredCredential && previousCredential == null) {
+            provider.addProperty(CREDENTIAL_UNAVAILABLE_KEY, true);
+        }
         try {
             protectCredential(provider, id);
             providers.add(id, provider);

--- a/src/test/java/com/github/claudecodegui/settings/CodexProviderManagerCredentialTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/CodexProviderManagerCredentialTest.java
@@ -139,6 +139,67 @@ public class CodexProviderManagerCredentialTest {
         assertThrows(IOException.class, manager::applyActiveProviderToCodexSettings);
     }
 
+    @Test
+    public void unavailableCredentialIsNotDeletedWhenUpdatingOtherFields() throws Exception {
+        AtomicReference<JsonObject> config = new AtomicReference<>(configWithProvider());
+        JsonObject stored = config.get().getAsJsonObject("codex").getAsJsonObject("providers")
+                .getAsJsonObject("provider-a");
+        stored.addProperty("authStoredInPasswordSafe", true);
+        FakeCredentialStore credentials = new FakeCredentialStore();
+        CodexProviderManager manager = manager(config, credentials);
+        JsonObject updates = new JsonObject();
+        updates.addProperty("name", "Renamed Provider");
+        updates.addProperty("authJson", "");
+
+        manager.updateCodexProvider("provider-a", updates);
+
+        JsonObject persisted = config.get().getAsJsonObject("codex").getAsJsonObject("providers")
+                .getAsJsonObject("provider-a");
+        assertEquals("Renamed Provider", persisted.get("name").getAsString());
+        assertTrue(persisted.get("authStoredInPasswordSafe").getAsBoolean());
+        assertFalse(persisted.has("authJson"));
+        assertEquals(0, credentials.deleteAttempts);
+    }
+
+    @Test
+    public void unavailableCredentialIsNotDeletedWhenSavingProvider() throws Exception {
+        AtomicReference<JsonObject> config = new AtomicReference<>(configWithProvider());
+        JsonObject stored = config.get().getAsJsonObject("codex").getAsJsonObject("providers")
+                .getAsJsonObject("provider-a");
+        stored.addProperty("authStoredInPasswordSafe", true);
+        FakeCredentialStore credentials = new FakeCredentialStore();
+        JsonObject provider = provider("provider-a");
+        provider.addProperty("authJson", "");
+
+        manager(config, credentials).saveCodexProvider(provider);
+
+        JsonObject persisted = config.get().getAsJsonObject("codex").getAsJsonObject("providers")
+                .getAsJsonObject("provider-a");
+        assertTrue(persisted.get("authStoredInPasswordSafe").getAsBoolean());
+        assertFalse(persisted.has("authJson"));
+        assertEquals(0, credentials.deleteAttempts);
+    }
+
+    @Test
+    public void availableCredentialCanStillBeExplicitlyCleared() throws Exception {
+        AtomicReference<JsonObject> config = new AtomicReference<>(configWithProvider());
+        JsonObject stored = config.get().getAsJsonObject("codex").getAsJsonObject("providers")
+                .getAsJsonObject("provider-a");
+        stored.addProperty("authStoredInPasswordSafe", true);
+        FakeCredentialStore credentials = new FakeCredentialStore();
+        credentials.values.put("provider-a", "{\"OPENAI_API_KEY\":\"old\"}");
+        JsonObject updates = new JsonObject();
+        updates.addProperty("authJson", "");
+
+        manager(config, credentials).updateCodexProvider("provider-a", updates);
+
+        JsonObject persisted = config.get().getAsJsonObject("codex").getAsJsonObject("providers")
+                .getAsJsonObject("provider-a");
+        assertFalse(persisted.has("authStoredInPasswordSafe"));
+        assertFalse(persisted.has("authJson"));
+        assertEquals(1, credentials.deleteAttempts);
+    }
+
     private CodexProviderManager manager(AtomicReference<JsonObject> config,
                                          CodexProviderCredentialStore credentials) {
         return manager(config, config::set, credentials);
@@ -176,6 +237,7 @@ public class CodexProviderManagerCredentialTest {
         private final Map<String, String> values = new HashMap<>();
         private boolean failWrites;
         private boolean failDeletes;
+        private int deleteAttempts;
 
         @Override
         public boolean isPersistentStorageAvailable() {
@@ -205,6 +267,7 @@ public class CodexProviderManagerCredentialTest {
 
         @Override
         public boolean deleteVerified(String providerId) {
+            deleteAttempts++;
             if (failDeletes) {
                 return false;
             }

--- a/src/test/java/com/github/claudecodegui/settings/CodexProviderManagerCredentialTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/CodexProviderManagerCredentialTest.java
@@ -1,0 +1,215 @@
+package com.github.claudecodegui.settings;
+
+import com.github.claudecodegui.model.DeleteResult;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class CodexProviderManagerCredentialTest {
+
+    @Test
+    public void newCredentialIsStoredOutsideConfigAndHydratedOnRead() throws Exception {
+        AtomicReference<JsonObject> config = new AtomicReference<>(configWithProvider());
+        FakeCredentialStore credentials = new FakeCredentialStore();
+        CodexProviderManager manager = manager(config, credentials);
+        JsonObject provider = provider("provider-secret");
+        provider.addProperty("authJson", "{\"OPENAI_API_KEY\":\"secret\"}");
+
+        manager.addCodexProvider(provider);
+
+        JsonObject persisted = config.get().getAsJsonObject("codex").getAsJsonObject("providers")
+                .getAsJsonObject("provider-secret");
+        assertFalse(persisted.has("authJson"));
+        assertTrue(persisted.get("authStoredInPasswordSafe").getAsBoolean());
+        JsonObject hydrated = manager.getCodexProviders().stream()
+                .filter(candidate -> "provider-secret".equals(candidate.get("id").getAsString()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("{\"OPENAI_API_KEY\":\"secret\"}", hydrated.get("authJson").getAsString());
+    }
+
+    @Test
+    public void passwordSafeWriteFailureNeverPersistsPlaintextCredential() {
+        AtomicReference<JsonObject> config = new AtomicReference<>(configWithProvider());
+        FakeCredentialStore credentials = new FakeCredentialStore();
+        credentials.failWrites = true;
+        CodexProviderManager manager = manager(config, credentials);
+        JsonObject provider = provider("provider-secret");
+        provider.addProperty("authJson", "{\"OPENAI_API_KEY\":\"secret\"}");
+
+        assertThrows(IllegalStateException.class, () -> manager.addCodexProvider(provider));
+        assertFalse(config.get().getAsJsonObject("codex").getAsJsonObject("providers")
+                .has("provider-secret"));
+        assertFalse(config.get().toString().contains("secret"));
+    }
+
+    @Test
+    public void configWriteFailureRestoresPreviousCredential() {
+        AtomicReference<JsonObject> config = new AtomicReference<>(configWithProvider());
+        JsonObject stored = config.get().getAsJsonObject("codex").getAsJsonObject("providers")
+                .getAsJsonObject("provider-a");
+        stored.addProperty("authStoredInPasswordSafe", true);
+        FakeCredentialStore credentials = new FakeCredentialStore();
+        credentials.values.put("provider-a", "{\"OPENAI_API_KEY\":\"old\"}");
+        CodexProviderManager manager = manager(config, ignored -> {
+            throw new IllegalStateException("config write failed");
+        }, credentials);
+        JsonObject updates = new JsonObject();
+        updates.addProperty("authJson", "{\"OPENAI_API_KEY\":\"new\"}");
+
+        assertThrows(IllegalStateException.class,
+                () -> manager.updateCodexProvider("provider-a", updates));
+        assertEquals("{\"OPENAI_API_KEY\":\"old\"}", credentials.read("provider-a"));
+    }
+
+    @Test
+    public void passwordSafeDeleteFailurePreservesStoredCredentialMarker() {
+        AtomicReference<JsonObject> config = new AtomicReference<>(configWithProvider());
+        JsonObject stored = config.get().getAsJsonObject("codex").getAsJsonObject("providers")
+                .getAsJsonObject("provider-a");
+        stored.addProperty("authStoredInPasswordSafe", true);
+        FakeCredentialStore credentials = new FakeCredentialStore();
+        credentials.values.put("provider-a", "{\"OPENAI_API_KEY\":\"old\"}");
+        credentials.failDeletes = true;
+        CodexProviderManager manager = manager(config, credentials);
+        JsonObject updates = new JsonObject();
+        updates.addProperty("authJson", "");
+
+        assertThrows(IllegalStateException.class,
+                () -> manager.updateCodexProvider("provider-a", updates));
+        assertTrue(config.get().getAsJsonObject("codex").getAsJsonObject("providers")
+                .getAsJsonObject("provider-a").get("authStoredInPasswordSafe").getAsBoolean());
+    }
+
+    @Test
+    public void providerDeletionStopsWhenPasswordSafeCredentialCannotBeRemoved() {
+        AtomicReference<JsonObject> config = new AtomicReference<>(configWithProvider());
+        JsonObject stored = config.get().getAsJsonObject("codex").getAsJsonObject("providers")
+                .getAsJsonObject("provider-a");
+        stored.addProperty("authStoredInPasswordSafe", true);
+        FakeCredentialStore credentials = new FakeCredentialStore();
+        credentials.values.put("provider-a", "{\"OPENAI_API_KEY\":\"old\"}");
+        credentials.failDeletes = true;
+
+        DeleteResult result = manager(config, credentials).deleteCodexProvider("provider-a");
+
+        assertFalse(result.isSuccess());
+        assertTrue(config.get().getAsJsonObject("codex").getAsJsonObject("providers")
+                .has("provider-a"));
+        assertEquals("{\"OPENAI_API_KEY\":\"old\"}", credentials.read("provider-a"));
+    }
+
+    @Test
+    public void legacyAuthJsonIsMigratedOnlyAfterPasswordSafeVerification() {
+        AtomicReference<JsonObject> config = new AtomicReference<>(configWithProvider());
+        JsonObject stored = config.get().getAsJsonObject("codex").getAsJsonObject("providers")
+                .getAsJsonObject("provider-a");
+        stored.addProperty("authJson", "{\"OPENAI_API_KEY\":\"secret\"}");
+        FakeCredentialStore credentials = new FakeCredentialStore();
+        CodexProviderManager manager = manager(config, credentials);
+
+        JsonObject returned = manager.getCodexProviders().get(1);
+        JsonObject persisted = config.get().getAsJsonObject("codex").getAsJsonObject("providers")
+                .getAsJsonObject("provider-a");
+        assertEquals("{\"OPENAI_API_KEY\":\"secret\"}", returned.get("authJson").getAsString());
+        assertTrue(persisted.get("authStoredInPasswordSafe").getAsBoolean());
+        assertFalse(persisted.has("authJson"));
+    }
+
+    @Test
+    public void unavailablePasswordSafeCredentialBlocksProviderApply() {
+        AtomicReference<JsonObject> config = new AtomicReference<>(configWithProvider());
+        JsonObject stored = config.get().getAsJsonObject("codex").getAsJsonObject("providers")
+                .getAsJsonObject("provider-a");
+        stored.addProperty("authStoredInPasswordSafe", true);
+
+        CodexProviderManager manager = manager(config, new FakeCredentialStore());
+
+        assertThrows(IOException.class, manager::applyActiveProviderToCodexSettings);
+    }
+
+    private CodexProviderManager manager(AtomicReference<JsonObject> config,
+                                         CodexProviderCredentialStore credentials) {
+        return manager(config, config::set, credentials);
+    }
+
+    private CodexProviderManager manager(AtomicReference<JsonObject> config,
+                                         Consumer<JsonObject> configWriter,
+                                         CodexProviderCredentialStore credentials) {
+        Gson gson = new Gson();
+        return new CodexProviderManager(gson, ignored -> config.get().deepCopy(), configWriter,
+                new ConfigPathManager(), new CodexSettingsManager(gson), credentials);
+    }
+
+    private JsonObject configWithProvider() {
+        JsonObject provider = new JsonObject();
+        provider.addProperty("name", "Provider A");
+        JsonObject providers = new JsonObject();
+        providers.add("provider-a", provider);
+        JsonObject codex = new JsonObject();
+        codex.addProperty("current", "provider-a");
+        codex.add("providers", providers);
+        JsonObject config = new JsonObject();
+        config.add("codex", codex);
+        return config;
+    }
+
+    private JsonObject provider(String id) {
+        JsonObject provider = new JsonObject();
+        provider.addProperty("id", id);
+        provider.addProperty("name", "Provider");
+        return provider;
+    }
+
+    private static final class FakeCredentialStore extends CodexProviderCredentialStore {
+        private final Map<String, String> values = new HashMap<>();
+        private boolean failWrites;
+        private boolean failDeletes;
+
+        @Override
+        public boolean isPersistentStorageAvailable() {
+            return true;
+        }
+
+        @Override
+        public boolean writeVerified(String providerId, String authJson) {
+            if (failWrites) {
+                return false;
+            }
+            values.put(providerId, authJson);
+            return authJson.equals(read(providerId));
+        }
+
+        @Override
+        public String read(String providerId) {
+            return values.get(providerId);
+        }
+
+        @Override
+        public void delete(String providerId) {
+            if (!failDeletes) {
+                values.remove(providerId);
+            }
+        }
+
+        @Override
+        public boolean deleteVerified(String providerId) {
+            if (failDeletes) {
+                return false;
+            }
+            values.remove(providerId);
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- store managed Codex provider credentials in IntelliJ PasswordSafe instead of plaintext config
- hydrate credentials only when they are needed and preserve existing migration behavior
- retain unavailable stored credentials when users edit unrelated provider fields

## Problem

Managed Codex credentials were persisted in the plugin configuration file. Moving them to PasswordSafe also requires careful handling when secure storage is temporarily unavailable, otherwise an unrelated edit can accidentally clear an existing credential.

## Validation

- `git diff --check upstream/feature/v0.4.9...HEAD`
- clean merge simulation against `upstream/feature/v0.4.9`
- 7 targeted Java credential regression tests passed