### PR TITLE
fix(codex): separate local config authorization from activation

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/provider/CodexProviderOperations.java
+++ b/src/main/java/com/github/claudecodegui/handler/provider/CodexProviderOperations.java
@@ -206,6 +206,29 @@ public class CodexProviderOperations {
     }
 
     /**
+     * Authorize read access to ~/.codex/{config.toml,auth.json} without changing the active provider.
+     */
+    public void handleAuthorizeCodexLocalConfig() {
+        try {
+            context.getSettingsService().setCodexLocalConfigAuthorized(true);
+
+            ApplicationManager.getApplication().invokeLater(() -> {
+                context.callJavaScript("window.showSwitchSuccess", context.escapeJs(
+                        com.github.claudecodegui.i18n.ClaudeCodeGuiBundle.message("toast.codexCliLoginSwitchSuccess")));
+                handleGetCodexProviders();
+                handleGetCurrentCodexConfig();
+            });
+        } catch (Exception e) {
+            LOG.error("[ProviderHandler] Failed to authorize local Codex config: " + e.getMessage(), e);
+            ApplicationManager.getApplication().invokeLater(() -> {
+                context.callJavaScript("window.showError", context.escapeJs(
+                        com.github.claudecodegui.i18n.ClaudeCodeGuiBundle.message("toast.providerSwitchFailed")
+                                + ": " + e.getMessage()));
+            });
+        }
+    }
+
+    /**
      * Revoke local Codex config authorization and stop reading ~/.codex/{config.toml,auth.json}.
      */
     public void handleRevokeCodexLocalConfigAuthorization(String content) {
@@ -256,7 +279,14 @@ public class CodexProviderOperations {
      */
     private void handleSwitchToCodexCliLogin() {
         try {
-            context.getSettingsService().setCodexLocalConfigAuthorized(true);
+            if (!context.getSettingsService().isCodexLocalConfigAuthorized()) {
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    context.callJavaScript("window.showError", context.escapeJs(
+                            com.github.claudecodegui.i18n.ClaudeCodeGuiBundle.message(
+                                    "error.codexLocalAccessNotAuthorized")));
+                });
+                return;
+            }
 
             // Update config.json to set CLI login as current
             context.getSettingsService().switchCodexProvider(

--- a/src/main/java/com/github/claudecodegui/handler/provider/ProviderHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/provider/ProviderHandler.java
@@ -32,6 +32,7 @@ public class ProviderHandler extends BaseMessageHandler {
             "update_codex_provider",
             "delete_codex_provider",
             "switch_codex_provider",
+            "authorize_codex_local_config",
             "revoke_codex_local_config_authorization",
             "get_active_codex_provider",
             "sort_codex_providers"
@@ -116,6 +117,9 @@ public class ProviderHandler extends BaseMessageHandler {
                 return true;
             case "switch_codex_provider":
                 codexOps.handleSwitchCodexProvider(content);
+                return true;
+            case "authorize_codex_local_config":
+                codexOps.handleAuthorizeCodexLocalConfig();
                 return true;
             case "revoke_codex_local_config_authorization":
                 codexOps.handleRevokeCodexLocalConfigAuthorization(content);

--- a/src/main/java/com/github/claudecodegui/settings/CodexProviderManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodexProviderManager.java
@@ -62,7 +62,8 @@ public class CodexProviderManager {
 
         // Add CLI Login virtual provider at the top
         result.add(createCodexCliLoginProviderObject(
-                CODEX_CLI_LOGIN_PROVIDER_ID.equals(currentId) && cliLoginAuthorized));
+                CODEX_CLI_LOGIN_PROVIDER_ID.equals(currentId) && cliLoginAuthorized,
+                cliLoginAuthorized));
 
         if (!config.has("codex")) {
             return result;
@@ -140,7 +141,7 @@ public class CodexProviderManager {
             if (!isCodexCliLoginAuthorized(config)) {
                 return null;
             }
-            return createCodexCliLoginProviderObject(true);
+            return createCodexCliLoginProviderObject(true, true);
         }
 
         if (!codex.has("providers")) {
@@ -446,11 +447,12 @@ public class CodexProviderManager {
      * Create virtual CLI Login provider object.
      * Unlike regular providers, this is not stored in config but generated dynamically.
      */
-    private JsonObject createCodexCliLoginProviderObject(boolean isActive) {
+    private JsonObject createCodexCliLoginProviderObject(boolean isActive, boolean localConfigAuthorized) {
         JsonObject provider = new JsonObject();
         provider.addProperty("id", CODEX_CLI_LOGIN_PROVIDER_ID);
         provider.addProperty("name", ClaudeCodeGuiBundle.message("provider.codexCliLogin.name"));
         provider.addProperty("isActive", isActive);
+        provider.addProperty("localConfigAuthorized", localConfigAuthorized);
         provider.addProperty("isCodexCliLoginProvider", true);
         return provider;
     }

--- a/src/test/java/com/github/claudecodegui/settings/CodexProviderManagerAuthorizationTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/CodexProviderManagerAuthorizationTest.java
@@ -1,0 +1,43 @@
+package com.github.claudecodegui.settings;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CodexProviderManagerAuthorizationTest {
+
+    @Test
+    public void cliLoginProviderExposesAuthorizationSeparatelyFromActiveState() {
+        JsonObject config = new JsonObject();
+        JsonObject codex = new JsonObject();
+        codex.addProperty("current", "managed-provider");
+        codex.addProperty("localConfigAuthorized", true);
+        codex.add("providers", new JsonObject());
+        config.add("codex", codex);
+
+        List<JsonObject> providers = manager(config).getCodexProviders();
+
+        assertTrue(providers.get(0).get("localConfigAuthorized").getAsBoolean());
+        assertFalse(providers.get(0).get("isActive").getAsBoolean());
+    }
+
+    @Test
+    public void cliLoginProviderReportsUnauthorizedState() {
+        JsonObject config = new JsonObject();
+
+        List<JsonObject> providers = manager(config).getCodexProviders();
+
+        assertFalse(providers.get(0).get("localConfigAuthorized").getAsBoolean());
+        assertFalse(providers.get(0).get("isActive").getAsBoolean());
+    }
+
+    private CodexProviderManager manager(JsonObject config) {
+        return new CodexProviderManager(new Gson(), ignored -> config, ignored -> {
+        }, null, null);
+    }
+}

--- a/webview/src/components/settings/CodexProviderSection/CodexProviderSection.test.tsx
+++ b/webview/src/components/settings/CodexProviderSection/CodexProviderSection.test.tsx
@@ -18,6 +18,7 @@ const translations: Record<string, string> = {
   'settings.codexProvider.dialog.cliLoginAuthorizeTitle': 'Authorize Local Codex Config Access',
   'settings.codexProvider.dialog.cliLoginAuthorizeMessage': 'Read local Codex config files.',
   'settings.codexProvider.dialog.cliLoginAuthorizeDetail': 'Do not overwrite config.toml or auth.json.',
+  'settings.codexProvider.dialog.cliLoginAuthorizeAction': 'Authorize Access',
   'settings.codexProvider.dialog.cliLoginDisableTitle': 'Revoke Local Codex Config Authorization',
   'settings.codexProvider.dialog.cliLoginDisableMessage': 'Stop reading local Codex config files.',
   'settings.provider.loading': 'Loading',
@@ -56,6 +57,7 @@ describe('CodexProviderSection', () => {
   const onEditCodexProvider = vi.fn();
   const onDeleteCodexProvider = vi.fn();
   const onSwitchCodexProvider = vi.fn();
+  const onAuthorizeCodexLocalConfig = vi.fn();
   const onRevokeCodexLocalConfigAuthorization = vi.fn();
 
   beforeEach(() => {
@@ -70,6 +72,7 @@ describe('CodexProviderSection', () => {
             id: SPECIAL_PROVIDER_IDS.CODEX_CLI_LOGIN,
             name: 'Virtual CLI Login',
             isActive: false,
+            localConfigAuthorized: false,
           },
         ]}
         codexLoading={false}
@@ -77,6 +80,7 @@ describe('CodexProviderSection', () => {
         onEditCodexProvider={onEditCodexProvider}
         onDeleteCodexProvider={onDeleteCodexProvider}
         onSwitchCodexProvider={onSwitchCodexProvider}
+        onAuthorizeCodexLocalConfig={onAuthorizeCodexLocalConfig}
         onRevokeCodexLocalConfigAuthorization={onRevokeCodexLocalConfigAuthorization}
       />
     );
@@ -84,7 +88,7 @@ describe('CodexProviderSection', () => {
     expect(screen.getByText('使用本地配置信息')).toBeTruthy();
     expect(screen.getByText('显式授权读取：~/.codex/config.toml 和 auth.json')).toBeTruthy();
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Authorize and Enable' })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Authorize Access' })[0]);
 
     expect(screen.getByText('Authorize Local Codex Config Access')).toBeTruthy();
 
@@ -93,7 +97,8 @@ describe('CodexProviderSection', () => {
     expect(confirmButton).toBeTruthy();
     fireEvent.click(confirmButton as HTMLButtonElement);
 
-    expect(onSwitchCodexProvider).toHaveBeenCalledWith(SPECIAL_PROVIDER_IDS.CODEX_CLI_LOGIN);
+    expect(onAuthorizeCodexLocalConfig).toHaveBeenCalledOnce();
+    expect(onSwitchCodexProvider).not.toHaveBeenCalled();
   });
 
   it('does not show account info when CLI login is active', () => {
@@ -104,6 +109,7 @@ describe('CodexProviderSection', () => {
             id: SPECIAL_PROVIDER_IDS.CODEX_CLI_LOGIN,
             name: 'Virtual CLI Login',
             isActive: true,
+            localConfigAuthorized: true,
           },
         ]}
         codexLoading={false}
@@ -111,6 +117,7 @@ describe('CodexProviderSection', () => {
         onEditCodexProvider={onEditCodexProvider}
         onDeleteCodexProvider={onDeleteCodexProvider}
         onSwitchCodexProvider={onSwitchCodexProvider}
+        onAuthorizeCodexLocalConfig={onAuthorizeCodexLocalConfig}
         onRevokeCodexLocalConfigAuthorization={onRevokeCodexLocalConfigAuthorization}
       />
     );
@@ -127,6 +134,7 @@ describe('CodexProviderSection', () => {
             id: SPECIAL_PROVIDER_IDS.CODEX_CLI_LOGIN,
             name: 'Virtual CLI Login',
             isActive: true,
+            localConfigAuthorized: true,
           },
           {
             id: 'provider-1',
@@ -139,6 +147,7 @@ describe('CodexProviderSection', () => {
         onEditCodexProvider={onEditCodexProvider}
         onDeleteCodexProvider={onDeleteCodexProvider}
         onSwitchCodexProvider={onSwitchCodexProvider}
+        onAuthorizeCodexLocalConfig={onAuthorizeCodexLocalConfig}
         onRevokeCodexLocalConfigAuthorization={onRevokeCodexLocalConfigAuthorization}
       />
     );
@@ -152,6 +161,34 @@ describe('CodexProviderSection', () => {
 
     expect(onRevokeCodexLocalConfigAuthorization).toHaveBeenCalledWith('provider-1');
     expect(onSwitchCodexProvider).not.toHaveBeenCalled();
+  });
+
+  it('enables an authorized local config without requesting authorization again', () => {
+    render(
+      <CodexProviderSection
+        codexProviders={[
+          {
+            id: SPECIAL_PROVIDER_IDS.CODEX_CLI_LOGIN,
+            name: 'Virtual CLI Login',
+            isActive: false,
+            localConfigAuthorized: true,
+          },
+        ]}
+        codexLoading={false}
+        onAddCodexProvider={onAddCodexProvider}
+        onEditCodexProvider={onEditCodexProvider}
+        onDeleteCodexProvider={onDeleteCodexProvider}
+        onSwitchCodexProvider={onSwitchCodexProvider}
+        onAuthorizeCodexLocalConfig={onAuthorizeCodexLocalConfig}
+        onRevokeCodexLocalConfigAuthorization={onRevokeCodexLocalConfigAuthorization}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Enable' }));
+
+    expect(onSwitchCodexProvider).toHaveBeenCalledWith(SPECIAL_PROVIDER_IDS.CODEX_CLI_LOGIN);
+    expect(onAuthorizeCodexLocalConfig).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Revoke Authorization' })).toBeTruthy();
   });
 
   it('allows long remarks to truncate instead of squeezing the action area', () => {
@@ -173,6 +210,7 @@ describe('CodexProviderSection', () => {
         onEditCodexProvider={onEditCodexProvider}
         onDeleteCodexProvider={onDeleteCodexProvider}
         onSwitchCodexProvider={onSwitchCodexProvider}
+        onAuthorizeCodexLocalConfig={onAuthorizeCodexLocalConfig}
         onRevokeCodexLocalConfigAuthorization={onRevokeCodexLocalConfigAuthorization}
       />
     );

--- a/webview/src/components/settings/CodexProviderSection/index.tsx
+++ b/webview/src/components/settings/CodexProviderSection/index.tsx
@@ -16,6 +16,7 @@ interface CodexProviderSectionProps {
   onEditCodexProvider: (provider: CodexProviderConfig) => void;
   onDeleteCodexProvider: (provider: CodexProviderConfig) => void;
   onSwitchCodexProvider: (id: string) => void;
+  onAuthorizeCodexLocalConfig: () => void;
   onRevokeCodexLocalConfigAuthorization: (fallbackProviderId?: string) => void;
   showHeader?: boolean;
 }
@@ -27,6 +28,7 @@ const CodexProviderSection = ({
   onEditCodexProvider,
   onDeleteCodexProvider,
   onSwitchCodexProvider,
+  onAuthorizeCodexLocalConfig,
   onRevokeCodexLocalConfigAuthorization,
   showHeader = true,
 }: CodexProviderSectionProps) => {
@@ -65,6 +67,7 @@ const CodexProviderSection = ({
     [codexProviders]
   );
   const isCliLoginActive = cliLoginProvider?.isActive === true;
+  const isCliLoginAuthorized = cliLoginProvider?.localConfigAuthorized === true;
 
   return (
     <div className={styles.configSection}>
@@ -100,10 +103,10 @@ const CodexProviderSection = ({
                 className={sharedStyles.btnPrimary}
                 onClick={() => {
                   setShowCliLoginConfirm(false);
-                  onSwitchCodexProvider(SPECIAL_PROVIDER_IDS.CODEX_CLI_LOGIN);
+                  onAuthorizeCodexLocalConfig();
                 }}
               >
-                {t('settings.provider.authorizeAndEnable')}
+                {t('settings.codexProvider.dialog.cliLoginAuthorizeAction')}
               </button>
             </div>
           </div>
@@ -182,22 +185,38 @@ const CodexProviderSection = ({
                 </div>
 
                 <div className={sharedStyles.cardActions}>
-                  {isCliLoginActive ? (
-                    <button
-                      className={sharedStyles.revokeButton}
-                      onClick={() => setShowCliLoginDisableConfirm(true)}
-                    >
-                      <span className="codicon codicon-circle-slash" />
-                      {t('settings.provider.revokeAuthorization')}
-                    </button>
-                  ) : (
+                  {!isCliLoginAuthorized ? (
                     <button
                       className={sharedStyles.useButton}
                       onClick={() => setShowCliLoginConfirm(true)}
                     >
-                      <span className="codicon codicon-play" />
-                      {t('settings.provider.authorizeAndEnable')}
+                      <span className="codicon codicon-key" />
+                      {t('settings.codexProvider.dialog.cliLoginAuthorizeAction')}
                     </button>
+                  ) : (
+                    <>
+                      {isCliLoginActive ? (
+                        <span className={sharedStyles.activeBadge}>
+                          <span className="codicon codicon-check" />
+                          {t('settings.provider.inUse')}
+                        </span>
+                      ) : (
+                        <button
+                          className={sharedStyles.useButton}
+                          onClick={() => onSwitchCodexProvider(SPECIAL_PROVIDER_IDS.CODEX_CLI_LOGIN)}
+                        >
+                          <span className="codicon codicon-play" />
+                          {t('settings.provider.enable')}
+                        </button>
+                      )}
+                      <button
+                        className={sharedStyles.revokeButton}
+                        onClick={() => setShowCliLoginDisableConfirm(true)}
+                      >
+                        <span className="codicon codicon-circle-slash" />
+                        {t('settings.provider.revokeAuthorization')}
+                      </button>
+                    </>
                   )}
                 </div>
               </div>

--- a/webview/src/components/settings/ProviderTabSection/index.tsx
+++ b/webview/src/components/settings/ProviderTabSection/index.tsx
@@ -30,6 +30,7 @@ interface ProviderTabSectionProps {
   onEditCodexProvider: (provider: CodexProviderConfig) => void;
   onDeleteCodexProvider: (provider: CodexProviderConfig) => void;
   onSwitchCodexProvider: (id: string) => void;
+  onAuthorizeCodexLocalConfig: () => void;
   onRevokeCodexLocalConfigAuthorization: (fallbackProviderId?: string) => void;
   // Shared
   addToast: (message: string, type: 'info' | 'success' | 'warning' | 'error') => void;
@@ -49,6 +50,7 @@ const ProviderTabSection = ({
   onEditCodexProvider,
   onDeleteCodexProvider,
   onSwitchCodexProvider,
+  onAuthorizeCodexLocalConfig,
   onRevokeCodexLocalConfigAuthorization,
   addToast,
 }: ProviderTabSectionProps) => {
@@ -176,6 +178,7 @@ const ProviderTabSection = ({
           onEditCodexProvider={onEditCodexProvider}
           onDeleteCodexProvider={onDeleteCodexProvider}
           onSwitchCodexProvider={onSwitchCodexProvider}
+          onAuthorizeCodexLocalConfig={onAuthorizeCodexLocalConfig}
           onRevokeCodexLocalConfigAuthorization={onRevokeCodexLocalConfigAuthorization}
           showHeader={false}
         />

--- a/webview/src/components/settings/hooks/useCodexProviderManagement.test.ts
+++ b/webview/src/components/settings/hooks/useCodexProviderManagement.test.ts
@@ -13,6 +13,20 @@ describe('useCodexProviderManagement', () => {
     window.sendToJava = vi.fn();
   });
 
+  it('authorizes local Codex config without switching providers', () => {
+    const { result } = renderHook(() => useCodexProviderManagement());
+
+    act(() => {
+      result.current.handleAuthorizeCodexLocalConfig();
+    });
+
+    expect(window.sendToJava).toHaveBeenCalledWith('authorize_codex_local_config:');
+    expect(window.sendToJava).not.toHaveBeenCalledWith(
+      expect.stringContaining('switch_codex_provider:')
+    );
+    expect(result.current.codexLoading).toBe(true);
+  });
+
   it('sends a revoke message when local Codex authorization is canceled', () => {
     const { result } = renderHook(() => useCodexProviderManagement());
 

--- a/webview/src/components/settings/hooks/useCodexProviderManagement.ts
+++ b/webview/src/components/settings/hooks/useCodexProviderManagement.ts
@@ -133,6 +133,12 @@ export function useCodexProviderManagement(options: UseCodexProviderManagementOp
     setCodexLoading(true);
   }, []);
 
+  const handleAuthorizeCodexLocalConfig = useCallback(() => {
+    sendToJava('authorize_codex_local_config:');
+    setCodexLoading(true);
+    setCodexConfigLoading(true);
+  }, []);
+
   const handleRevokeCodexLocalConfigAuthorization = useCallback((fallbackProviderId?: string) => {
     const data = {
       fallbackProviderId: fallbackProviderId ?? '',
@@ -180,6 +186,7 @@ export function useCodexProviderManagement(options: UseCodexProviderManagementOp
     handleCloseCodexProviderDialog,
     handleSaveCodexProvider,
     handleSwitchCodexProvider,
+    handleAuthorizeCodexLocalConfig,
     handleRevokeCodexLocalConfigAuthorization,
     handleDeleteCodexProvider,
     confirmDeleteCodexProvider,

--- a/webview/src/components/settings/index.tsx
+++ b/webview/src/components/settings/index.tsx
@@ -259,6 +259,7 @@ const SettingsView = ({
     handleCloseCodexProviderDialog,
     handleSaveCodexProvider,
     handleSwitchCodexProvider,
+    handleAuthorizeCodexLocalConfig,
     handleRevokeCodexLocalConfigAuthorization,
     handleDeleteCodexProvider,
     confirmDeleteCodexProvider,
@@ -561,6 +562,7 @@ const SettingsView = ({
                 onEditCodexProvider={handleEditCodexProvider}
                 onDeleteCodexProvider={handleDeleteCodexProvider}
                 onSwitchCodexProvider={handleSwitchCodexProvider}
+                onAuthorizeCodexLocalConfig={handleAuthorizeCodexLocalConfig}
                 onRevokeCodexLocalConfigAuthorization={handleRevokeCodexLocalConfigAuthorization}
                 addToast={addToast}
               />

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -768,6 +768,7 @@
         "cliLoginAuthorizeTitle": "Authorize Local Codex Config Access",
         "cliLoginAuthorizeMessage": "The plugin will read the existing local configuration from ~/.codex/config.toml and auth.json.",
         "cliLoginAuthorizeDetail": "This will not modify or overwrite your config.toml or auth.json, and you can revoke the authorization at any time.",
+        "cliLoginAuthorizeAction": "Authorize access",
         "cliLoginDisableTitle": "Revoke Local Codex Config Authorization",
         "cliLoginDisableMessage": "The plugin will stop reading ~/.codex/config.toml and auth.json.",
         "modelIdRequired": "Model ID is required",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -773,6 +773,7 @@
         "cliLoginAuthorizeTitle": "授权读取本地 Codex 配置",
         "cliLoginAuthorizeMessage": "插件将读取 ~/.codex/config.toml 和 auth.json 中已有的本地配置。",
         "cliLoginAuthorizeDetail": "此操作不会修改或覆盖您的 config.toml 和 auth.json，您可以随时取消授权。",
+        "cliLoginAuthorizeAction": "授权读取",
         "cliLoginDisableTitle": "取消本地 Codex 配置授权",
         "cliLoginDisableMessage": "插件将停止读取 ~/.codex/config.toml 和 auth.json。",
         "modelIdRequired": "请输入模型 ID",

--- a/webview/src/types/provider.ts
+++ b/webview/src/types/provider.ts
@@ -341,6 +341,8 @@ export interface CodexProviderConfig {
   createdAt?: number;
   /** Whether this is the currently active provider */
   isActive?: boolean;
+  /** Whether reading ~/.codex/config.toml and auth.json was explicitly authorized */
+  localConfigAuthorized?: boolean;
   /** config.toml content (raw string) */
   configToml?: string;
   /** auth.json content (raw string) */


### PR DESCRIPTION
## Summary

- separate permission to read the local Codex configuration from provider activation
- expose authorization state independently and reject activation until access is explicitly granted
- restore distinct authorize, enable, in-use, and revoke actions in the provider UI

## Problem

The local Codex provider treated authorization and activation as one action. Users could not authorize config access without switching providers, and the UI could not represent an authorized but inactive local configuration.

## Validation

- `git diff --check upstream/feature/v0.4.9...HEAD`
- branch is based directly on the latest `upstream/feature/v0.4.9`
- 7 targeted frontend regression tests passed
- 2 targeted Java authorization tests passed
- TypeScript compilation and production webview build passed