### PR TITLE
test(codex): build image payloads safely on Windows

### DIFF
--- a/src/test/java/com/github/claudecodegui/session/CodexMessageHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/session/CodexMessageHandlerTest.java
@@ -4,6 +4,7 @@ import com.github.claudecodegui.provider.common.SDKResult;
 import com.github.claudecodegui.session.ClaudeSession.Message;
 import com.github.claudecodegui.permission.PermissionRequest;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -245,8 +246,18 @@ public class CodexMessageHandlerTest {
             callbackHandler.setCallback(callback);
 
             CodexMessageHandler handler = new CodexMessageHandler(state, callbackHandler);
-            handler.onMessage("user", "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\","
-                    + "\"text\":\"<image name=[Image #1] path=\\\"" + imagePath + "\\\">\\n</image>\\n\\n测试通讯\"}]}}");
+            JsonObject textBlock = new JsonObject();
+            textBlock.addProperty("type", "text");
+            textBlock.addProperty("text", "<image name=[Image #1] path=\"" + imagePath
+                    + "\">\n</image>\n\n测试通讯");
+            JsonArray inputBlocks = new JsonArray();
+            inputBlocks.add(textBlock);
+            JsonObject inputMessage = new JsonObject();
+            inputMessage.addProperty("role", "user");
+            inputMessage.add("content", inputBlocks);
+            JsonObject payload = new JsonObject();
+            payload.add("message", inputMessage);
+            handler.onMessage("user", payload.toString());
 
             assertEquals(1, state.getMessages().size());
             Message message = state.getMessages().get(0);


### PR DESCRIPTION
## Summary

- construct the Codex image-placeholder test payload with Gson instead of JSON string concatenation
- preserve the existing placeholder stripping and image block assertions

## Problem

Windows temporary paths contain backslashes. Concatenating those paths directly into a JSON string creates invalid escape sequences, so the regression test fails before exercising the production sanitizer.

## Validation

- `git diff --check upstream/feature/v0.4.9...HEAD`
- branch is based directly on the latest `upstream/feature/v0.4.9`
- identical patch verified in the integrated workspace JVM suite: 810 tests, 0 failures, 9 skipped