### PR TITLE
fix(agents): tolerate migration metadata in agent config

### DIFF
--- a/src/main/java/com/github/claudecodegui/settings/AgentManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/AgentManager.java
@@ -2,6 +2,7 @@ package com.github.claudecodegui.settings;
 
 import com.github.claudecodegui.model.ConflictStrategy;
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.intellij.openapi.diagnostic.Logger;
@@ -45,8 +46,11 @@ public class AgentManager {
 
         try (FileReader reader = new FileReader(agentFile, StandardCharsets.UTF_8)) {
             JsonObject config = JsonParser.parseReader(reader).getAsJsonObject();
-            // Ensure the agents node exists
-            if (!config.has("agents")) {
+            JsonElement agentsElement = config.get("agents");
+            if (agentsElement == null || !agentsElement.isJsonObject()) {
+                if (agentsElement != null) {
+                    LOG.warn("[AgentManager] Ignoring invalid agents node in agent.json");
+                }
                 config.add("agents", new JsonObject());
             }
             return config;
@@ -83,8 +87,15 @@ public class AgentManager {
         JsonObject config = readAgentConfig();
 
         JsonObject agents = config.getAsJsonObject("agents");
-        for (String key : agents.keySet()) {
-            JsonObject agent = agents.getAsJsonObject(key);
+        for (Map.Entry<String, JsonElement> entry : agents.entrySet()) {
+            String key = entry.getKey();
+            JsonElement value = entry.getValue();
+            if (!value.isJsonObject()) {
+                LOG.warn("[AgentManager] Ignoring non-object agent entry: " + key);
+                continue;
+            }
+
+            JsonObject agent = value.getAsJsonObject();
             // Ensure ID exists
             if (!agent.has("id")) {
                 agent.addProperty("id", key);
@@ -93,11 +104,7 @@ public class AgentManager {
         }
 
         // Sort by creation time descending (newest first)
-        result.sort((a, b) -> {
-            long timeA = a.has("createdAt") ? a.get("createdAt").getAsLong() : 0;
-            long timeB = b.has("createdAt") ? b.get("createdAt").getAsLong() : 0;
-            return Long.compare(timeB, timeA);
-        });
+        result.sort((a, b) -> Long.compare(getCreatedAt(b), getCreatedAt(a)));
 
         LOG.info("[AgentManager] Loaded " + result.size() + " agents from agent.json");
         return result;
@@ -139,11 +146,10 @@ public class AgentManager {
         JsonObject config = readAgentConfig();
         JsonObject agents = config.getAsJsonObject("agents");
 
-        if (!agents.has(id)) {
+        JsonObject agent = getAgentObject(agents, id);
+        if (agent == null) {
             throw new IllegalArgumentException("Agent with id '" + id + "' not found");
         }
-
-        JsonObject agent = agents.getAsJsonObject(id);
 
         // Merge updates
         for (String key : updates.keySet()) {
@@ -190,16 +196,32 @@ public class AgentManager {
         JsonObject config = readAgentConfig();
         JsonObject agents = config.getAsJsonObject("agents");
 
-        if (!agents.has(id)) {
+        JsonObject agent = getAgentObject(agents, id);
+        if (agent == null) {
             return null;
         }
-
-        JsonObject agent = agents.getAsJsonObject(id);
         if (!agent.has("id")) {
             agent.addProperty("id", id);
         }
 
         return agent;
+    }
+
+    private JsonObject getAgentObject(JsonObject agents, String id) {
+        JsonElement value = agents.get(id);
+        return value != null && value.isJsonObject() ? value.getAsJsonObject() : null;
+    }
+
+    private long getCreatedAt(JsonObject agent) {
+        JsonElement value = agent.get("createdAt");
+        if (value == null || !value.isJsonPrimitive()) {
+            return 0L;
+        }
+        try {
+            return value.getAsLong();
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
     }
 
     /**

--- a/src/test/java/com/github/claudecodegui/settings/AgentManagerTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/AgentManagerTest.java
@@ -1,0 +1,131 @@
+package com.github.claudecodegui.settings;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression tests for AgentManager configuration compatibility.
+ */
+public class AgentManagerTest {
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    @Test
+    public void shouldIgnoreMigrationMarkerWithoutRewritingConfig() throws Exception {
+        String configJson = """
+                {
+                  "_deprecated": "Agents migrated to Skills",
+                  "agents": {
+                    "_disabled": true
+                  }
+                }
+                """;
+        Path agentPath = writeConfig(configJson);
+        AgentManager manager = newManager(agentPath);
+
+        assertTrue(manager.getAgents().isEmpty());
+        assertNull(manager.getAgent("_disabled"));
+        assertThrows(IllegalArgumentException.class,
+                () -> manager.updateAgent("_disabled", new JsonObject()));
+        assertEquals(configJson, Files.readString(agentPath, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void shouldLoadValidAgentsWhenOtherEntriesAreMalformed() throws Exception {
+        Path agentPath = writeConfig("""
+                {
+                  "agents": {
+                    "migration-marker": true,
+                    "string-timestamp": {
+                      "name": "String Timestamp",
+                      "createdAt": "300"
+                    },
+                    "new-agent": {
+                      "name": "New Agent",
+                      "createdAt": 200
+                    },
+                    "bad-timestamp": {
+                      "name": "Bad Timestamp",
+                      "createdAt": {"unexpected": true}
+                    }
+                  }
+                }
+                """);
+        AgentManager manager = newManager(agentPath);
+
+        List<JsonObject> agents = manager.getAgents();
+
+        assertEquals(3, agents.size());
+        assertEquals("string-timestamp", agents.get(0).get("id").getAsString());
+        assertEquals("new-agent", agents.get(1).get("id").getAsString());
+        assertEquals("bad-timestamp", agents.get(2).get("id").getAsString());
+    }
+
+    @Test
+    public void shouldRecoverInvalidAgentsNodeWhenAddingAgent() throws Exception {
+        Path agentPath = writeConfig("""
+                {
+                  "_deprecated": "keep this metadata",
+                  "agents": true
+                }
+                """);
+        AgentManager manager = newManager(agentPath);
+        JsonObject agent = new JsonObject();
+        agent.addProperty("id", "new-agent");
+        agent.addProperty("name", "New Agent");
+
+        assertTrue(manager.getAgents().isEmpty());
+        manager.addAgent(agent);
+
+        JsonObject savedConfig = JsonParser.parseString(
+                Files.readString(agentPath, StandardCharsets.UTF_8)).getAsJsonObject();
+        assertEquals("keep this metadata", savedConfig.get("_deprecated").getAsString());
+        assertTrue(savedConfig.get("agents").isJsonObject());
+        assertEquals("New Agent", savedConfig.getAsJsonObject("agents")
+                .getAsJsonObject("new-agent").get("name").getAsString());
+    }
+
+    private Path writeConfig(String content) throws IOException {
+        Path agentPath = temp.newFile("agent.json").toPath();
+        Files.writeString(agentPath, content, StandardCharsets.UTF_8);
+        return agentPath;
+    }
+
+    private AgentManager newManager(Path agentPath) {
+        return new AgentManager(new Gson(), new TestConfigPathManager(agentPath));
+    }
+
+    private static final class TestConfigPathManager extends ConfigPathManager {
+        private final Path agentPath;
+
+        private TestConfigPathManager(Path agentPath) {
+            this.agentPath = agentPath;
+        }
+
+        @Override
+        public Path getAgentFilePath() {
+            return agentPath;
+        }
+
+        @Override
+        public void ensureConfigDirectory() throws IOException {
+            Files.createDirectories(agentPath.getParent());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- normalize a missing or non-object `agents` node to an empty in-memory object
- ignore non-object entries such as legacy migration markers without rewriting the source config
- treat invalid `createdAt` values as the oldest entry while preserving numeric-string compatibility
- guard single-agent reads and updates against non-object entries
- add regression coverage for migrated, mixed, and malformed agent configurations

## Problem

A migrated `~/.codemoss/agent.json` can contain metadata such as `_disabled: true` inside the `agents` object. `AgentManager` cast every child entry directly to `JsonObject`, so loading the Agent settings raised a `JsonPrimitive cannot be cast to JsonObject` exception and returned an empty list through the handler fallback.

The same unchecked assumptions also allowed a malformed `agents` node or `createdAt` value to abort the whole Agent list.

## Validation

- `git diff --check upstream/feature/v0.4.9...HEAD`
- branch is based directly on latest `upstream/feature/v0.4.9` (`c1c30278`)
- clean merge simulation against `upstream/feature/v0.4.9`
- `AgentManagerTest`: 3 tests, 0 failures
- integrated workspace JVM suite: 813 tests, 0 failures, 0 errors, 9 skipped
- `checkstyleMain`, Webview production build, and `buildPlugin --offline` passed

## Test environment note

The focused branch test used an uncommitted local IntelliJ IDEA Ultimate 2024.3.5 dependency because the official `ideaIC:2024.3.1` artifact is not available in the local offline cache. The temporary build change was removed before push; GitHub CI remains responsible for validating the official Community dependency.