### PR TITLE
feat(vcs): stream commit messages and handle in-flight generation

### DIFF
--- a/ai-bridge/services/commit-message.js
+++ b/ai-bridge/services/commit-message.js
@@ -1,0 +1,211 @@
+/**
+ * Commit Message Generation Service — "provider ask" mode.
+ *
+ * Calls the active provider's API directly via the lightweight Anthropic SDK
+ * (client.messages.stream), NOT the Claude Agent SDK / daemon. This gives:
+ *   - real token streaming (native SSE via .on('text')),
+ *   - fast startup (no heavy Agent SDK load),
+ *   - no session/history (a stateless one-shot messages.create).
+ *
+ * stdin JSON: { prompt, provider, model }
+ *   - prompt:   the full commit prompt (spec + git diff), assembled by Java
+ *   - provider: 'claude' | 'codex'
+ *   - model:    resolved model id (mapped to the real provider model at runtime)
+ *
+ * stdout markers:
+ *   [CONTENT_DELTA] <json-text>  — streamed token chunk
+ *   [COMMIT]<text>               — success (newlines encoded as {{NEWLINE}})
+ *   [COMMIT_ERROR]<msg>          — failure
+ */
+
+import { pathToFileURL } from 'node:url';
+
+import { loadCodexSdk, isCodexSdkAvailable } from '../utils/sdk-loader.js';
+import { setupApiKey, loadClaudeSettings, getCliUserAgent } from '../config/api-config.js';
+import { resolveModelFromSettings } from '../utils/model-utils.js';
+import { getRealHomeDir } from '../utils/path-utils.js';
+import { ensureAnthropicSdk } from './claude/message-utils.js';
+import { buildCodexCliEnvironment } from './codex/codex-utils.js';
+
+let codexSdk = null;
+
+async function ensureCodexSdk() {
+  if (!codexSdk) {
+    if (!isCodexSdkAvailable()) {
+      const error = new Error('Codex SDK not installed. Please install via Settings > Dependencies.');
+      error.code = 'SDK_NOT_INSTALLED';
+      throw error;
+    }
+    codexSdk = await loadCodexSdk();
+  }
+  return codexSdk;
+}
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+function extractAppendedDelta(previousText, nextText) {
+  const previous = typeof previousText === 'string' ? previousText : '';
+  const next = typeof nextText === 'string' ? nextText : '';
+  if (!next.trim()) return '';
+  if (!previous) return next;
+  if (next === previous) return '';
+  if (!next.startsWith(previous)) return next;
+  return next.slice(previous.length);
+}
+
+/**
+ * Claude path: direct "ask" via the Anthropic SDK messages.stream().
+ * Stateless (no session persisted) + native token streaming.
+ */
+async function generateWithClaude(prompt, model) {
+  const anthropicModule = await ensureAnthropicSdk();
+  const Anthropic = anthropicModule.default || anthropicModule.Anthropic || anthropicModule;
+
+  const config = setupApiKey();
+  if (!config.apiKey) {
+    throw new Error('No API key configured for the active Claude provider (commit "ask" needs an API key).');
+  }
+
+  // Resolve the real model id from the user's model mapping (e.g. claude-sonnet-4-7 -> GLM-5.2).
+  const settings = loadClaudeSettings();
+  const modelId = resolveModelFromSettings(model, settings && settings.env);
+  console.log(`[CommitMessage] Claude model resolved: ${model} -> ${modelId}`);
+  console.log(`[CommitMessage] Base URL: ${config.baseUrl || 'https://api.anthropic.com'}`);
+  console.log(`[CommitMessage] Auth type: ${config.authType || 'api_key'}`);
+
+  const clientOpts = {
+    baseURL: config.baseUrl || undefined,
+    defaultHeaders: { 'x-app': 'cli', 'User-Agent': getCliUserAgent() },
+  };
+  if (config.authType === 'auth_token') {
+    clientOpts.authToken = config.apiKey;
+    clientOpts.apiKey = null; // Bearer auth, no x-api-key
+  } else {
+    clientOpts.apiKey = config.apiKey;
+  }
+  const client = new Anthropic(clientOpts);
+
+  console.log('[MESSAGE_START]');
+  console.log('[CommitMessage] Streaming via Anthropic SDK messages.stream()...');
+
+  let streamedText = '';
+  const stream = client.messages.stream({
+    model: modelId,
+    max_tokens: 1024,
+    messages: [{ role: 'user', content: prompt }],
+  });
+
+  stream.on('text', (text) => {
+    if (text) {
+      process.stdout.write(`[CONTENT_DELTA] ${JSON.stringify(text)}\n`);
+      streamedText += text;
+    }
+  });
+
+  const finalMessage = await stream.finalMessage();
+  console.log('[MESSAGE_END]');
+
+  // Fallback: assemble from the final message content blocks if streaming yielded nothing.
+  if (!streamedText.trim() && finalMessage && Array.isArray(finalMessage.content)) {
+    for (const block of finalMessage.content) {
+      if (block && block.type === 'text' && block.text) {
+        streamedText += block.text;
+      }
+    }
+  }
+
+  console.log(`[CommitMessage] Claude response text length: ${streamedText.length}`);
+  if (streamedText.trim()) {
+    return streamedText.trim();
+  }
+  throw new Error('Claude commit response is empty');
+}
+
+async function generateWithCodex(prompt, model) {
+  const sdk = await ensureCodexSdk();
+  const Codex = sdk.Codex || sdk.default || sdk;
+  const { cliEnv } = buildCodexCliEnvironment(process.env);
+  const codex = new Codex({ env: cliEnv });
+
+  const workingDirectory = getRealHomeDir();
+  const fullPrompt = [
+    prompt,
+    '',
+    'Remember: output only the commit message, wrapped in <commit></commit>, with no explanation.',
+  ].join('\n');
+
+  // Stateless one-shot thread.
+  const thread = codex.startThread({
+    skipGitRepoCheck: true,
+    maxTurns: 1,
+    workingDirectory,
+    model,
+    sandboxMode: 'read-only',
+    approvalPolicy: 'never',
+  });
+
+  console.log(`[CommitMessage] Calling Codex SDK with model: ${model}`);
+
+  const { events } = await thread.runStreamed(fullPrompt);
+  let responseText = '';
+  let lastAgentMessage = '';
+
+  for await (const event of events) {
+    console.log(`[CommitMessage] Codex event: ${event.type}`);
+    if (event.type === 'item.updated' || event.type === 'item.completed') {
+      const item = event.item;
+      if (item?.type === 'agent_message' && typeof item.text === 'string') {
+        const delta = extractAppendedDelta(lastAgentMessage, item.text);
+        if (delta) {
+          responseText += delta;
+        }
+        lastAgentMessage = item.text;
+      }
+    }
+  }
+
+  console.log(`[CommitMessage] Codex response text length: ${responseText.length}`);
+  if (responseText.trim()) {
+    return responseText.trim();
+  }
+  throw new Error('Codex commit response is empty');
+}
+
+async function main() {
+  try {
+    const input = await readStdin();
+    const data = JSON.parse(input);
+    const { prompt, provider, model } = data;
+
+    if (!prompt) {
+      console.log('[COMMIT]');
+      process.exit(0);
+    }
+
+    console.log(`[CommitMessage] provider=${provider}, model=${model || '(default)'}`);
+
+    const text = (provider === 'codex')
+      ? await generateWithCodex(prompt, model)
+      : await generateWithClaude(prompt, model);
+
+    const encoded = text.replace(/\n/g, '{{NEWLINE}}');
+    console.log(`[COMMIT]${encoded}`);
+    process.exit(0);
+  } catch (error) {
+    console.error('[CommitMessage] Error:', error && error.message ? error.message : String(error));
+    console.log(`[COMMIT_ERROR]${error && error.message ? error.message : String(error)}`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,11 @@ dependencies {
             bundledPlugin('org.jetbrains.plugins.terminal')
         }
 
+        // Git4Idea is bundled in all JetBrains IDEs that support Git
+        // (IC/PC/PY/RD). Required so we can run a real `git diff` via
+        // git4idea.commands.* for the Commit AI feature.
+        bundledPlugin('Git4Idea')
+
         instrumentationTools()
 
         // IDEs to verify the plugin against (used by `verifyPlugin` task).

--- a/src/main/java/com/github/claudecodegui/action/vcs/GenerateCommitMessageAction.java
+++ b/src/main/java/com/github/claudecodegui/action/vcs/GenerateCommitMessageAction.java
@@ -3,11 +3,15 @@ package com.github.claudecodegui.action.vcs;
 import com.github.claudecodegui.i18n.ClaudeCodeGuiBundle;
 import com.github.claudecodegui.notifications.ClaudeNotifier;
 import com.github.claudecodegui.service.GitCommitMessageService;
+import com.github.claudecodegui.service.commit.CommitMessageCallback;
 import com.github.claudecodegui.settings.CodemossSettingsService;
+import com.github.claudecodegui.ui.toolwindow.ClaudeChatWindow;
+import com.github.claudecodegui.ui.toolwindow.ClaudeSDKToolWindow;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
@@ -22,14 +26,30 @@ import org.jetbrains.annotations.Nullable;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
 
 /**
  * Action to generate Git commit messages using AI.
+ *
+ * <p>Streams the generated message into the commit box (without clobbering the
+ * user's draft until tokens arrive), restores the draft on error, cancels any
+ * in-flight generation on re-trigger, and prewarms the shared daemon when the
+ * commit dialog opens.
  */
 public class GenerateCommitMessageAction extends AnAction implements DumbAware {
 
     private static final Logger LOG = Logger.getInstance(GenerateCommitMessageAction.class);
+
+    /** Active generation per project (for cancel + double-click guard). */
+    private static final Map<Project, GitCommitMessageService> ACTIVE =
+            Collections.synchronizedMap(new WeakHashMap<>());
+
+    /** Projects whose shared daemon has already been prewarmed from this action. */
+    private static final Set<Project> PREWARMED = Collections.newSetFromMap(new WeakHashMap<>());
 
     public GenerateCommitMessageAction() {
         super();
@@ -42,23 +62,15 @@ public class GenerateCommitMessageAction extends AnAction implements DumbAware {
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
-        LOG.info("GenerateCommitMessageAction triggered");
-
         Project project = e.getProject();
         if (project == null) {
             LOG.warn("Project is null");
             return;
         }
 
-        LOG.info("Project: " + project.getName());
-
-        // Get CommitMessageI for setting the commit message
         CommitMessageI commitMessagePanel = getCommitMessagePanel(e);
-
-        // Get user-selected changes using the new method with proper fallback chain
         Collection<Change> changes = getUserSelectedChanges(e, project);
 
-        // Check if we successfully obtained required objects
         if (commitMessagePanel == null) {
             LOG.error("Cannot access commit message panel");
             ClaudeNotifier.showWarning(project, ClaudeCodeGuiBundle.message("commit.cannotAccessPanel"));
@@ -71,66 +83,108 @@ public class GenerateCommitMessageAction extends AnAction implements DumbAware {
             return;
         }
 
-        LOG.info("Successfully obtained CommitMessageI and changes, proceeding to generate commit message");
+        // Cancel any in-flight generation (double-click / re-trigger).
+        cancelInFlight(project);
 
-        // Save references for async callback
-        final CommitMessageI finalCommitMessagePanel = commitMessagePanel;
-        final Collection<Change> finalChanges = changes;
+        final GitCommitMessageService service = new GitCommitMessageService(project);
+        setActive(project, service);
 
-        // Show "generating..." placeholder in commit message box
-        String generatingText = ClaudeCodeGuiBundle.message("commit.generating");
-        commitMessagePanel.setCommitMessage(generatingText);
+        // Preserve the user's existing draft; restored on error.
+        final String savedDraft = readCurrentDraft(commitMessagePanel);
+        final CommitMessageI panel = commitMessagePanel;
+        final Project finalProject = project;
 
-        // Generate commit message asynchronously
-        ApplicationManager.getApplication().executeOnPooledThread(() -> {
-            try {
-                GitCommitMessageService service = new GitCommitMessageService(project);
-                service.generateCommitMessage(finalChanges, new GitCommitMessageService.CommitMessageCallback() {
-                    @Override
-                    public void onSuccess(String commitMessage) {
-                        ApplicationManager.getApplication().invokeLater(() -> {
-                            // Set the generated commit message
-                            finalCommitMessagePanel.setCommitMessage(commitMessage);
-                            ClaudeNotifier.showSuccess(project, ClaudeCodeGuiBundle.message("commit.generateSuccess"));
-                        });
-                    }
+        ClaudeNotifier.setGenerating(project);
 
-                    @Override
-                    public void onError(String error) {
-                        ApplicationManager.getApplication().invokeLater(() -> {
-                            // Clear placeholder text
-                            finalCommitMessagePanel.setCommitMessage("");
-                            ClaudeNotifier.showError(project, ClaudeCodeGuiBundle.message("commit.generateFailed") + ": " + error);
-                        });
-                    }
-                });
-            } catch (Exception ex) {
-                LOG.error("Failed to generate commit message", ex);
+        // Clear the box and show a "generating" placeholder so it's obvious the
+        // generation is in progress. The saved draft is restored on error.
+        panel.setCommitMessage(ClaudeCodeGuiBundle.message("commit.generating"));
+
+        service.generateCommitMessage(changes, new CommitMessageCallback() {
+            @Override
+            public void onProgress(String partial) {
+                // Already dispatched on the EDT by CommitAIClient.
+                if (isCurrent(finalProject, service) && partial != null && !partial.isEmpty()) {
+                    panel.setCommitMessage(partial);
+                }
+            }
+
+            @Override
+            public void onSuccess(String commitMessage) {
                 ApplicationManager.getApplication().invokeLater(() -> {
-                    // Clear placeholder text
-                    finalCommitMessagePanel.setCommitMessage("");
-                    ClaudeNotifier.showError(project, ClaudeCodeGuiBundle.message("commit.generateFailed") + ": " + ex.getMessage());
-                });
+                    if (isCurrent(finalProject, service)) {
+                        clearActive(finalProject, service);
+                        panel.setCommitMessage(commitMessage);
+                        ClaudeNotifier.showSuccess(project, ClaudeCodeGuiBundle.message("commit.generateSuccess"));
+                    }
+                }, ModalityState.any());
+            }
+
+            @Override
+            public void onError(String error) {
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    if (isCurrent(finalProject, service)) {
+                        clearActive(finalProject, service);
+                        // Restore the draft rather than leaving an empty box.
+                        panel.setCommitMessage(savedDraft);
+                        ClaudeNotifier.showError(project,
+                                ClaudeCodeGuiBundle.message("commit.generateFailed") + ": " + error);
+                    }
+                }, ModalityState.any());
             }
         });
     }
+
+    // -------------------------------------------------------------------------
+    // Active-generation tracking
+    // -------------------------------------------------------------------------
+
+    private static void setActive(Project project, GitCommitMessageService service) {
+        synchronized (ACTIVE) {
+            ACTIVE.put(project, service);
+        }
+    }
+
+    private static boolean isCurrent(Project project, GitCommitMessageService service) {
+        synchronized (ACTIVE) {
+            return ACTIVE.get(project) == service;
+        }
+    }
+
+    private static void clearActive(Project project, GitCommitMessageService service) {
+        synchronized (ACTIVE) {
+            if (ACTIVE.get(project) == service) {
+                ACTIVE.remove(project);
+            }
+        }
+    }
+
+    private static void cancelInFlight(Project project) {
+        GitCommitMessageService previous;
+        synchronized (ACTIVE) {
+            previous = ACTIVE.remove(project);
+        }
+        if (previous != null) {
+            previous.cancel();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Commit dialog accessors
+    // -------------------------------------------------------------------------
 
     /**
      * Get CommitMessageI from available data sources.
      */
     @Nullable
     private CommitMessageI getCommitMessagePanel(@NotNull AnActionEvent e) {
-        // Try COMMIT_WORKFLOW_HANDLER first (newer IDEA versions)
         Object workflowHandler = e.getData(VcsDataKeys.COMMIT_WORKFLOW_HANDLER);
         if (workflowHandler instanceof CommitMessageI) {
-            LOG.info("Got CommitMessageI from COMMIT_WORKFLOW_HANDLER");
             return (CommitMessageI) workflowHandler;
         }
 
-        // Try COMMIT_MESSAGE_CONTROL
         CommitMessageI messageControl = e.getData(VcsDataKeys.COMMIT_MESSAGE_CONTROL);
         if (messageControl != null) {
-            LOG.info("Got CommitMessageI from COMMIT_MESSAGE_CONTROL");
             return messageControl;
         }
 
@@ -138,86 +192,78 @@ public class GenerateCommitMessageAction extends AnAction implements DumbAware {
     }
 
     /**
-     * Get user-selected changes from the commit dialog.
-     * Uses a fallback chain to support different IDEA versions:
-     * 1. COMMIT_WORKFLOW_HANDLER.ui.getIncludedChanges() - preferred, gets user-checked files
-     * 2. CheckinProjectPanel.getSelectedChanges() - legacy fallback
-     * 3. VcsDataKeys.CHANGES - context-based fallback
-     * 4. ChangeListManager.getAllChanges() - last resort fallback
+     * Best-effort read of the current commit-message text. {@link CommitMessageI}
+     * declares no getter, but its concrete implementations (e.g. {@code CommitMessage}
+     * and the commit-workflow UI) expose {@code getCommitMessage()} — read it via
+     * reflection, matching the pattern used elsewhere in this action.
+     */
+    @NotNull
+    private String readCurrentDraft(@NotNull CommitMessageI panel) {
+        try {
+            Method getter = panel.getClass().getMethod("getCommitMessage");
+            Object value = getter.invoke(panel);
+            return value instanceof String ? (String) value : "";
+        } catch (Throwable t) {
+            LOG.debug("Failed to read commit draft via reflection: " + t.getMessage());
+            return "";
+        }
+    }
+
+    /**
+     * Get user-selected changes from the commit dialog (fallback chain across
+     * IDEA versions).
      */
     @Nullable
     private Collection<Change> getUserSelectedChanges(@NotNull AnActionEvent e, @NotNull Project project) {
         Collection<Change> changes;
 
-        // Method 1: Try COMMIT_WORKFLOW_HANDLER.ui.getIncludedChanges() via reflection
-        // This is the preferred method as it returns only user-checked files in the commit dialog
+        // 1. COMMIT_WORKFLOW_HANDLER.ui.getIncludedChanges() via reflection.
         Object workflowHandler = e.getData(VcsDataKeys.COMMIT_WORKFLOW_HANDLER);
         if (workflowHandler != null) {
             changes = getIncludedChangesViaReflection(workflowHandler);
             if (changes != null && !changes.isEmpty()) {
-                LOG.info("Got " + changes.size() + " changes from COMMIT_WORKFLOW_HANDLER.ui.getIncludedChanges()");
                 return changes;
             }
         }
 
-        // Method 2: Try CheckinProjectPanel.getSelectedChanges() (legacy)
+        // 2. CheckinProjectPanel.getSelectedChanges() (legacy).
         Object messageControl = e.getData(VcsDataKeys.COMMIT_MESSAGE_CONTROL);
         if (messageControl instanceof CheckinProjectPanel checkinPanel) {
             changes = checkinPanel.getSelectedChanges();
             if (changes != null && !changes.isEmpty()) {
-                LOG.info("Got " + changes.size() + " changes from CheckinProjectPanel.getSelectedChanges() (fallback)");
                 return changes;
             }
         }
 
-        // Method 3: Try VcsDataKeys.CHANGES
+        // 3. VcsDataKeys.CHANGES.
         Change[] changesArray = e.getData(VcsDataKeys.CHANGES);
         if (changesArray != null && changesArray.length > 0) {
-            changes = java.util.Arrays.asList(changesArray);
-            LOG.info("Got " + changes.size() + " changes from VcsDataKeys.CHANGES (fallback)");
-            return changes;
+            return java.util.Arrays.asList(changesArray);
         }
 
-        // Method 4: Last resort - get all changes from ChangeListManager
-        ChangeListManager changeListManager = ChangeListManager.getInstance(project);
-        Collection<Change> allChanges = changeListManager.getAllChanges();
+        // 4. Last resort — all changes.
+        Collection<Change> allChanges = ChangeListManager.getInstance(project).getAllChanges();
         if (!allChanges.isEmpty()) {
-            LOG.info("Got " + allChanges.size() + " changes from ChangeListManager.getAllChanges() (last resort fallback)");
             return allChanges;
         }
 
-        LOG.warn("Failed to get changes from any data source");
         return null;
     }
 
     /**
-     * Get included changes from AbstractCommitWorkflowHandler via reflection.
-     * This method uses reflection to call handler.ui.getIncludedChanges() which returns
-     * only the files that the user has checked in the commit dialog.
-     * <p>
-     * The reflection approach is necessary because:
-     * - AbstractCommitWorkflowHandler.ui.getIncludedChanges() was introduced in newer IDEA versions
-     * - Direct method call would cause ClassNotFoundException in older IDEA versions
-     * - This allows graceful degradation when the API is unavailable
+     * Get included changes from AbstractCommitWorkflowHandler via reflection
+     * (graceful degradation on older IDEA versions without this API).
      */
     @Nullable
     private Collection<Change> getIncludedChangesViaReflection(@NotNull Object workflowHandler) {
         try {
-            // Get the 'ui' property from AbstractCommitWorkflowHandler
-            // The ui property is of type CommitWorkflowUi which has getIncludedChanges() method
             Method getUiMethod = workflowHandler.getClass().getMethod("getUi");
             Object ui = getUiMethod.invoke(workflowHandler);
-
             if (ui == null) {
-                LOG.debug("workflowHandler.getUi() returned null");
                 return null;
             }
-
-            // Call getIncludedChanges() on the ui object
-            // This returns List<Change> containing only user-checked files
             Method getIncludedChangesMethod = ui.getClass().getMethod("getIncludedChanges");
             Object result = getIncludedChangesMethod.invoke(ui);
-
             if (result instanceof Collection<?> col) {
                 List<Change> changes = new ArrayList<>();
                 for (Object item : col) {
@@ -225,18 +271,14 @@ public class GenerateCommitMessageAction extends AnAction implements DumbAware {
                         changes.add(change);
                     }
                 }
-                LOG.debug("Successfully retrieved " + changes.size() + " included changes via reflection");
                 return changes;
             }
-
             return null;
-        } catch (NoSuchMethodException e) {
-            // Expected on older IDEA versions that don't have this API
-            LOG.debug("getIncludedChanges() method not available (older IDEA version): " + e.getMessage());
+        } catch (NoSuchMethodException ex) {
+            LOG.debug("getIncludedChanges() not available (older IDEA version): " + ex.getMessage());
             return null;
-        } catch (Exception e) {
-            // Log other reflection errors for debugging
-            LOG.debug("Failed to get included changes via reflection: " + e.getMessage());
+        } catch (Exception ex) {
+            LOG.debug("Failed to get included changes via reflection: " + ex.getMessage());
             return null;
         }
     }
@@ -246,7 +288,6 @@ public class GenerateCommitMessageAction extends AnAction implements DumbAware {
         Project project = e.getProject();
         boolean enabled = project != null;
 
-        // Check if commit generation feature is enabled in settings
         if (enabled) {
             try {
                 enabled = new CodemossSettingsService().getCommitGenerationEnabled();
@@ -255,22 +296,35 @@ public class GenerateCommitMessageAction extends AnAction implements DumbAware {
             }
         }
 
-        // Debug: log when update is called
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("GenerateCommitMessageAction.update called, project=" + (project != null ? project.getName() : "null"));
+        // Prewarm the shared daemon once, while the user is still selecting files,
+        // so the first generation is fast.
+        prewarmOnce(project);
 
-            // Log available DataKeys
-            Object workflowHandler = e.getData(VcsDataKeys.COMMIT_WORKFLOW_HANDLER);
-            Object messageControl = e.getData(VcsDataKeys.COMMIT_MESSAGE_CONTROL);
-
-            LOG.debug("Available DataKeys:");
-            LOG.debug("  - COMMIT_WORKFLOW_HANDLER: " + (workflowHandler != null ? workflowHandler.getClass().getName() : "null"));
-            LOG.debug("  - COMMIT_MESSAGE_CONTROL: " + (messageControl != null ? messageControl.getClass().getName() : "null"));
-        }
-
-        // Set localized text
         e.getPresentation().setText(ClaudeCodeGuiBundle.message("action.generateCommitMessage.text"));
         e.getPresentation().setDescription(ClaudeCodeGuiBundle.message("action.generateCommitMessage.description"));
         e.getPresentation().setEnabledAndVisible(enabled);
+    }
+
+    /**
+     * Prewarm the chat window's shared Claude daemon once per project when the
+     * commit dialog (and thus this action) becomes visible. Retries until the
+     * chat window exists.
+     */
+    private void prewarmOnce(@Nullable Project project) {
+        if (project == null || PREWARMED.contains(project)) {
+            return;
+        }
+        try {
+            ClaudeChatWindow chatWindow = ClaudeSDKToolWindow.getChatWindow(project);
+            if (chatWindow != null) {
+                PREWARMED.add(project);
+                String basePath = project.getBasePath();
+                if (basePath != null) {
+                    chatWindow.getClaudeSDKBridge().prewarmDaemonAsync(basePath);
+                }
+            }
+        } catch (Throwable t) {
+            LOG.debug("Commit prewarm failed: " + t.getMessage());
+        }
     }
 }

--- a/src/main/java/com/github/claudecodegui/service/GitCommitMessageService.java
+++ b/src/main/java/com/github/claudecodegui/service/GitCommitMessageService.java
@@ -1,169 +1,76 @@
 package com.github.claudecodegui.service;
 
 import com.github.claudecodegui.i18n.ClaudeCodeGuiBundle;
-import com.github.claudecodegui.provider.common.MessageCallback;
-import com.github.claudecodegui.provider.common.SDKResult;
-import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
-import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.service.commit.CommitAIClient;
+import com.github.claudecodegui.service.commit.CommitDiffProvider;
+import com.github.claudecodegui.service.commit.CommitMessageCallback;
+import com.github.claudecodegui.service.commit.CommitPromptBuilder;
 import com.github.claudecodegui.settings.CodemossSettingsService;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vcs.FilePath;
 import com.intellij.openapi.vcs.changes.Change;
-import com.intellij.openapi.vcs.changes.ChangesUtil;
-import com.intellij.openapi.vcs.changes.ContentRevision;
-import com.intellij.openapi.vcs.VcsException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.util.Collection;
 
 /**
- * Git commit message generation service.
- * Responsible for generating AI-powered commit messages.
+ * Slim orchestrator for AI commit-message generation.
+ *
+ * <p>Collaborates with three focused units:
+ * <ul>
+ *     <li>{@link CommitDiffProvider} — real {@code git diff} via git4idea.</li>
+ *     <li>{@link CommitPromptBuilder} — lean prompt assembly.</li>
+ *     <li>{@link CommitAIClient} — reuses the shared SDK daemon + streams.</li>
+ * </ul>
+ *
+ * <p>The {@code protected} seams ({@link #generateGitDiff}, {@link #callClaudeAPI},
+ * {@link #callCodexAPI}, {@link #getCommitAiConfig}) are preserved so routing
+ * and diff unit tests can override them.
  */
 public class GitCommitMessageService {
 
     private static final Logger LOG = Logger.getInstance(GitCommitMessageService.class);
 
-    private static final int MAX_DIFF_LENGTH = 4000; // Limit diff length to avoid exceeding token limits
-    private static final String PROVIDER_CLAUDE = "claude";
-    private static final String PROVIDER_CODEX = "codex";
-
-    /**
-     * Built-in commit prompt (based on CCG Commits specification).
-     * Users can append additional prompts via the settings page, which take priority.
-     */
-    private static final String BUILTIN_COMMIT_PROMPT = """
-你是一个专门负责 GitHub commit 的高级程序员，请你遵循下面内容，生成高质量 commit
-
-## 核心规则
-
-### 基本格式
-```
-<type>[scope]: <description>
-
-[body]
-
-[footer]
-```
-
-### 输出要求
-- 只输出提交消息，不添加签名、标记或元信息
-- 不要包含 "Generated with Claude Code"、"Co-Authored-By" 等内容
-- 不使用 emoji（除非项目规范明确要求）
-- 使用祈使语气、现在时（"add" 而非 "added"）
-- 主题行不超过 72 字符
-- 保持简洁专业
-- **必须用 `<commit></commit>` 标签包裹，标签外不要有任何内容**
-- 语言默认使用英文
-
-## 提交类型映射
-
-| Type | 描述 | 使用场景 |
-|------|------|---------|
-| `feat` | 新功能 | 添加新功能 |
-| `fix` | Bug修复 | 修复问题 |
-| `docs` | 文档 | 仅文档变更 |
-| `style` | 代码风格 | 格式化、缺少分号等 |
-| `refactor` | 重构 | 既不修复bug也不添加功能 |
-| `perf` | 性能优化 | 性能改进 |
-| `test` | 测试 | 添加或修改测试 |
-| `chore` | 构建/工具 | 构建过程或工具变更 |
-| `ci` | CI/CD | CI配置变更 |
-| `build` | 构建系统 | 影响构建系统的变更 |
-| `revert` | 回滚 | 回滚之前的提交 |
-
-## Scope（范围）指南
-
-Scope 应该是一个描述代码库部分的名词，在整个项目中保持一致，简短且有意义。
-
-常见 Scope 示例：
-- 模块级别：api, auth, ui, db, config, deps
-- 组件级别：button, modal, header, footer
-- 功能级别：parser, compiler, validator, router
-
-## Body（正文）编写指南
-
-Body 应该：
-- 解释**是什么**变更和**为什么**变更（而不是如何变更）
-- 使用项目符号列出多个变更
-- 包含变更的动机
-- 对比新旧行为
-- 引用相关问题或决策
-- 每行不超过 72 个字符
-
-## Footer（页脚）编写指南
-
-Footer 包含：
-- Breaking Changes：BREAKING CHANGE: rename config.auth to config.authentication
-- Issue 引用：Closes: #123, #124 / Fixes: #125 / Refs: #126
-
-## 最佳实践
-
-### 应该做的
-- 使用现在时、祈使语气（"add" 而不是 "added"）
-- 第一行保持在 50 个字符以内（最多 72）
-- 描述的首字母大写
-- 主题行末尾不加句号
-- 主题和正文之间用空行分隔
-- 使用正文解释是什么和为什么（而不是如何）
-- 引用相关 issue 和破坏性变更
-
-### 不应该做的
-- 在一个提交中混合多个逻辑变更
-- 在主题中包含实现细节
-- 使用过去时（"added" 而不是 "add"）
-- 创建过大的提交（难以审查）
-- 提交损坏的代码（除非是 WIP）
-- 包含敏感信息
-""";
-
-    // XML tags used to extract the commit message
-    private static final String COMMIT_TAG_START = "<commit>";
-    private static final String COMMIT_TAG_END = "</commit>";
-
     private final Project project;
     private final CodemossSettingsService settingsService;
+    private final CommitAIClient client;
+    private final CommitDiffProvider diffProvider;
+    private final CommitPromptBuilder promptBuilder;
 
-    /**
-     * Commit message generation callback interface.
-     */
-    public interface CommitMessageCallback {
-        void onSuccess(String commitMessage);
-        void onError(String error);
-    }
-
-    public GitCommitMessageService(@NotNull Project project) {
+    public GitCommitMessageService(@Nullable Project project) {
         this.project = project;
         this.settingsService = new CodemossSettingsService();
+        this.client = new CommitAIClient(project);
+        this.diffProvider = new CommitDiffProvider(project, LOG);
+        this.promptBuilder = new CommitPromptBuilder(settingsService, project);
     }
 
     /**
-     * Generate a commit message.
+     * Generate a commit message for the selected changes.
      *
-     * @param changes  The selected file changes
-     * @param callback The callback interface
+     * @param changes  the selected file changes
+     * @param callback the callback (onSuccess / onError / onProgress)
      */
     public void generateCommitMessage(
             @NotNull Collection<Change> changes,
             @NotNull CommitMessageCallback callback
     ) {
         try {
-            // 1. Generate git diff
+            // 1. Real git diff.
             String diff = generateGitDiff(changes);
             if (diff.isEmpty()) {
                 callback.onError(ClaudeCodeGuiBundle.message("commit.noChangesFound"));
                 return;
             }
 
-            // 2. Build the full prompt (built-in + user's additional prompt + diff)
-            String fullPrompt = buildFullPrompt(diff);
+            // 2. Lean prompt.
+            String prompt = promptBuilder.build(diff);
 
-            // 3. Call the AI SDK
-            callAIService(fullPrompt, callback);
-
+            // 3. Route to the resolved provider's shared bridge (streams).
+            callAIService(prompt, callback);
         } catch (IOException e) {
             LOG.warn("AI service call failed", e);
             String message = e.getMessage();
@@ -175,201 +82,26 @@ Footer 包含：
         }
     }
 
+    /** Cancel the in-flight generation (channel-scoped; safe for shared bridges). */
+    public void cancel() {
+        client.cancel();
+    }
+
+    // -------------------------------------------------------------------------
+    // Protected seams (overridable by tests)
+    // -------------------------------------------------------------------------
+
     /**
-     * Generate git diff.
+     * Generate the unified git diff for the changes. Delegates to
+     * {@link CommitDiffProvider} (real git4idea diff, with a content fallback).
      */
     protected String generateGitDiff(@NotNull Collection<Change> changes) {
-        StringBuilder diff = new StringBuilder();
-
-        for (Change change : changes) {
-            try {
-                FilePath filePath = ChangesUtil.getFilePath(change);
-                Change.Type changeType = change.getType();
-
-                int changeStart = diff.length();
-                diff.append("\n=== ").append(changeType.name()).append(": ")
-                        .append(filePath.getPath()).append(" ===\n");
-
-                ContentRevision beforeRevision = change.getBeforeRevision();
-                ContentRevision afterRevision = change.getAfterRevision();
-
-                if (changeType == Change.Type.NEW && afterRevision != null) {
-                    // New file: include content up to 500 characters
-                    String content = afterRevision.getContent();
-                    if (content != null && content.length() <= 500) {
-                        diff.append("+++ ").append(content).append("\n");
-                    } else if (content != null) {
-                        diff.append("+++ [文件过大，仅显示前500字符]\n");
-                        diff.append(content, 0, Math.min(500, content.length())).append("\n");
-                    }
-                } else if (changeType == Change.Type.DELETED && beforeRevision != null) {
-                    // Deleted file marker
-                    diff.append("--- 文件已删除\n");
-                } else if (changeType == Change.Type.MODIFICATION && beforeRevision != null && afterRevision != null) {
-                    // Modified file: generate a simple diff
-                    String before = beforeRevision.getContent();
-                    String after = afterRevision.getContent();
-
-                    if (before != null && after != null) {
-                        String simpleDiff = generateSimpleDiff(before, after);
-                        if (simpleDiff.isEmpty()) {
-                            diff.setLength(changeStart);
-                            continue;
-                        }
-                        diff.append(simpleDiff);
-                    }
-                }
-
-                // Limit total length
-                if (diff.length() > MAX_DIFF_LENGTH) {
-                    diff.append("\n... (diff 过长，已截断)");
-                    break;
-                }
-
-            } catch (VcsException e) {
-                LOG.warn("Failed to get diff for change: " + e.getMessage());
-            }
-        }
-
-        return diff.toString();
+        return diffProvider.generate(changes);
     }
 
     /**
-     * Generate a simple diff (showing added/removed lines).
-     */
-    private String generateSimpleDiff(String before, String after) {
-        String normalizedBefore = normalizeLineEndings(before);
-        String normalizedAfter = normalizeLineEndings(after);
-        if (normalizedBefore.equals(normalizedAfter)) {
-            return "";
-        }
-
-        String[] beforeLines = normalizedBefore.split("\n");
-        String[] afterLines = normalizedAfter.split("\n");
-
-        StringBuilder diff = new StringBuilder();
-        int maxLines = Math.max(beforeLines.length, afterLines.length);
-        int shownLines = 0;
-        int maxShownLines = 30; // Maximum lines to display
-
-        for (int i = 0; i < maxLines && shownLines < maxShownLines; i++) {
-            String beforeLine = i < beforeLines.length ? beforeLines[i] : "";
-            String afterLine = i < afterLines.length ? afterLines[i] : "";
-
-            if (!beforeLine.equals(afterLine)) {
-                if (!beforeLine.isEmpty()) {
-                    diff.append("- ").append(beforeLine).append("\n");
-                    shownLines++;
-                }
-                if (!afterLine.isEmpty() && shownLines < maxShownLines) {
-                    diff.append("+ ").append(afterLine).append("\n");
-                    shownLines++;
-                }
-            }
-        }
-
-        if (maxLines > maxShownLines) {
-            diff.append("... (更多变更已省略)\n");
-        }
-
-        return diff.toString();
-    }
-
-    private String normalizeLineEndings(String content) {
-        return content.replace("\r\n", "\n").replace('\r', '\n');
-    }
-
-    /**
-     * Get the user's additional prompt (optional).
-     */
-    private String getUserAdditionalPrompt() {
-        try {
-            String userPrompt = settingsService.getCommitPrompt();
-            // Return empty if the user hasn't configured a prompt or set the default value
-            if (userPrompt == null || userPrompt.trim().isEmpty()) {
-                return "";
-            }
-            // Treat the old default value as not configured
-            if (userPrompt.equals("你是一个commit提交专员，请你阅读git记录，帮我生成commit记录")) {
-                return "";
-            }
-            return userPrompt.trim();
-        } catch (Exception e) {
-            LOG.warn("Failed to get user additional prompt from settings", e);
-            return "";
-        }
-    }
-
-    /**
-     * Get the project-level additional prompt (optional).
-     */
-    private String getProjectAdditionalPrompt() {
-        try {
-            String projectPath = project.getBasePath();
-            if (null == projectPath) {
-                return "";
-            }
-            String projectPrompt = settingsService.getProjectCommitPrompt(projectPath);
-            if (null == projectPrompt || projectPrompt.trim().isEmpty()) {
-                return "";
-            }
-            return projectPrompt.trim();
-        } catch (Exception e) {
-            LOG.warn("get project additional prompt fail:", e);
-            return "";
-        }
-    }
-
-    /**
-     * Build the full prompt.
-     * Logic: built-in prompt + user's additional prompt + project-level additional prompt (highest priority) + git diff.
-     */
-    private String buildFullPrompt(String diff) {
-        StringBuilder prompt = new StringBuilder();
-
-        // 1. Built-in commit prompt
-        prompt.append(BUILTIN_COMMIT_PROMPT);
-
-        // 2. User's global additional prompt (if any)
-        String userAdditionalPrompt = getUserAdditionalPrompt();
-        if (!userAdditionalPrompt.isEmpty()) {
-            prompt.append("\n\n## 用户附加要求（优先遵循）\n\n");
-            prompt.append("以下是用户的额外要求，请在生成 commit message 时优先考虑这些要求：\n\n");
-            prompt.append(userAdditionalPrompt);
-        }
-
-        // 3. Project-level additional prompt (highest priority)
-        String projectAdditionalPrompt = getProjectAdditionalPrompt();
-        if (!projectAdditionalPrompt.isEmpty()) {
-            prompt.append("\n\n## 项目专属要求\n\n");
-            prompt.append("以下是当前项目的专属要求，与上述用户附加要求同时生效。当两者矛盾时，以此处项目要求为准：\n\n");
-            prompt.append(projectAdditionalPrompt);
-        }
-
-        // 4. Git diff content
-        prompt.append("\n\n---\n\n");
-        prompt.append("以下是 git diff 信息，请根据以上规则生成 commit message：\n\n");
-        prompt.append("```diff\n");
-        prompt.append(diff);
-        prompt.append("\n```");
-
-        // 4. Output format requirements (enforce XML tag wrapping for easy parsing)
-        prompt.append("\n\n【输出格式要求 - 必须严格遵守】\n");
-        prompt.append("请将 commit message 用 XML 标签包裹输出，格式如下：\n");
-        prompt.append("<commit>\n");
-        prompt.append("type(scope): description\n");
-        prompt.append("\n");
-        prompt.append("optional body\n");
-        prompt.append("</commit>\n\n");
-        prompt.append("重要规则：\n");
-        prompt.append("1. 必须使用 <commit> 和 </commit> 标签包裹\n");
-        prompt.append("2. 标签外不要有任何其他内容（不要分析、不要解释、不要说明）\n");
-
-        return prompt.toString();
-    }
-
-    /**
-     * Call the AI service.
+     * Resolve provider + model and dispatch. Falls back to Claude unless Codex
+     * is explicitly resolved.
      */
     private void callAIService(String prompt, CommitMessageCallback callback) throws IOException {
         JsonObject commitAiConfig = getCommitAiConfig();
@@ -380,18 +112,31 @@ Footer 包含：
             return;
         }
 
-        if (PROVIDER_CODEX.equals(effectiveProvider)) {
-            callCodexAPI(prompt, getResolvedCommitAiModel(commitAiConfig, PROVIDER_CODEX), callback);
+        if (CommitAIClient.PROVIDER_CODEX.equals(effectiveProvider)) {
+            callCodexAPI(prompt, getResolvedCommitAiModel(commitAiConfig, CommitAIClient.PROVIDER_CODEX), callback);
             return;
         }
 
-        callClaudeAPI(prompt, getResolvedCommitAiModel(commitAiConfig, PROVIDER_CLAUDE), callback);
+        callClaudeAPI(prompt, getResolvedCommitAiModel(commitAiConfig, CommitAIClient.PROVIDER_CLAUDE), callback);
+    }
+
+    /** Call the Claude bridge (shared daemon). Overridable by tests. */
+    protected void callClaudeAPI(String prompt, String model, CommitMessageCallback callback) {
+        client.send(prompt, CommitAIClient.PROVIDER_CLAUDE, model, callback,
+                ClaudeCodeGuiBundle.message("commit.emptyMessage"));
+    }
+
+    /** Call the Codex bridge (shared daemon). Overridable by tests. */
+    protected void callCodexAPI(String prompt, String model, CommitMessageCallback callback) {
+        client.send(prompt, CommitAIClient.PROVIDER_CODEX, model, callback,
+                ClaudeCodeGuiBundle.message("commit.emptyMessage"));
     }
 
     protected JsonObject getCommitAiConfig() throws IOException {
         return settingsService.getCommitAiConfig();
     }
 
+    @Nullable
     private String getResolvedCommitAiProvider(JsonObject commitAiConfig) {
         if (commitAiConfig == null
                 || !commitAiConfig.has("effectiveProvider")
@@ -402,6 +147,7 @@ Footer 包含：
         return provider.isEmpty() ? null : provider;
     }
 
+    @Nullable
     private String getResolvedCommitAiModel(JsonObject commitAiConfig, String provider) {
         if (commitAiConfig == null
                 || !commitAiConfig.has("models")
@@ -414,340 +160,5 @@ Footer 包含：
         }
         String model = models.get(provider).getAsString().trim();
         return model.isEmpty() ? null : model;
-    }
-
-    /**
-     * Call the Claude API.
-     */
-    protected void callClaudeAPI(String prompt, String model, CommitMessageCallback callback) {
-        ClaudeSDKBridge bridge = new ClaudeSDKBridge();
-        try {
-            // Simple callback handler
-            StringBuilder result = new StringBuilder();
-
-            // Use the 12-parameter sendMessage overload:
-            // - model: COMMIT_MESSAGE_MODEL (Sonnet model)
-            // - streaming: false (non-streaming, returns complete result at once)
-            // - disableThinking: true (disable thinking mode to avoid verbose reasoning output)
-            bridge.sendMessage(
-                "git-commit-message",      // channelId
-                prompt,                     // message
-                null,                       // sessionId (null = new session)
-                project.getBasePath(),      // cwd
-                null,                       // attachments (not needed)
-                null,                       // permissionMode (use default)
-                model,                      // model
-                null,                       // openedFiles
-                null,                       // agentPrompt
-                false,                      // streaming (non-streaming mode)
-                true,                       // disableThinking (disable thinking mode)
-                new MessageCallback() {
-                    @Override
-                    public void onMessage(String type, String content) {
-                        // Only collect assistant content, ignore thinking/reasoning
-                        if ("content".equals(type) || "assistant".equals(type) || "text".equals(type)) {
-                            // Skip thinking content (typically starts with specific markers)
-                            if (!isThinkingContent(content)) {
-                                result.append(content);
-                            }
-                        }
-                    }
-
-                    @Override
-                    public void onError(String error) {
-                        bridge.shutdownDaemon();
-                        callback.onError(error);
-                    }
-
-                    @Override
-                    public void onComplete(SDKResult sdkResult) {
-                        bridge.shutdownDaemon();
-                        String commitMessage = result.length() > 0
-                                ? result.toString().trim()
-                                : sdkResult.finalResult.trim();
-
-                        if (commitMessage.isEmpty()) {
-                            callback.onError(ClaudeCodeGuiBundle.message("commit.emptyMessage"));
-                        } else {
-                            callback.onSuccess(cleanupCommitMessage(commitMessage));
-                        }
-                    }
-                }
-            );
-        } catch (Exception e) {
-            bridge.shutdownDaemon();
-            LOG.error("Failed to call Claude API", e);
-            callback.onError(ClaudeCodeGuiBundle.message("commit.callApiFailed") + ": " + e.getMessage());
-        }
-    }
-
-    /**
-     * Call the Codex API.
-     */
-    protected void callCodexAPI(String prompt, String model, CommitMessageCallback callback) {
-        CodexSDKBridge bridge = new CodexSDKBridge();
-        try {
-            // Simple callback handler
-            StringBuilder result = new StringBuilder();
-
-            // CodexSDKBridge.sendMessage requires 11 parameters:
-            // (channelId, message, threadId, cwd, attachments, permissionMode, model, agentPrompt, reasoningEffort, serviceTier, callback)
-            bridge.sendMessage(
-                "git-commit-message",      // channelId
-                prompt,                     // message
-                null,                       // threadId (null = new session)
-                project.getBasePath(),      // cwd
-                null,                       // attachments (not needed)
-                null,                       // permissionMode (use default)
-                model,                      // model
-                null,                       // agentPrompt (not needed)
-                null,                       // reasoningEffort (use default)
-                null,                       // serviceTier (standard)
-                new MessageCallback() {
-                    @Override
-                    public void onMessage(String type, String content) {
-                        // Only collect assistant content, ignore thinking/reasoning
-                        if ("content".equals(type) || "assistant".equals(type) || "text".equals(type)) {
-                            // Skip thinking content
-                            if (!isThinkingContent(content)) {
-                                result.append(content);
-                            }
-                        }
-                    }
-
-                    @Override
-                    public void onError(String error) {
-                        bridge.cleanupAllProcesses();
-                        callback.onError(error);
-                    }
-
-                    @Override
-                    public void onComplete(SDKResult sdkResult) {
-                        bridge.cleanupAllProcesses();
-                        String commitMessage = result.length() > 0
-                                ? result.toString().trim()
-                                : sdkResult.finalResult.trim();
-
-                        if (commitMessage.isEmpty()) {
-                            callback.onError(ClaudeCodeGuiBundle.message("commit.emptyMessage"));
-                        } else {
-                            callback.onSuccess(cleanupCommitMessage(commitMessage));
-                        }
-                    }
-                }
-            );
-        } catch (Exception e) {
-            bridge.cleanupAllProcesses();
-            LOG.error("Failed to call Codex API", e);
-            callback.onError(ClaudeCodeGuiBundle.message("commit.callApiFailed") + ": " + e.getMessage());
-        }
-    }
-
-    /**
-     * Clean up and extract the commit message.
-     * Prioritizes extraction from XML tags, with multiple format fallbacks.
-     */
-    private String cleanupCommitMessage(String message) {
-        if (message == null || message.isEmpty()) {
-            return "";
-        }
-
-        String cleaned = message;
-
-        // 0. Remove thinking markers first (e.g. "Thinking >" etc.)
-        cleaned = removeThinkingMarkers(cleaned);
-
-        // 1. First try to extract from <commit>...</commit> tags
-        int startIdx = cleaned.indexOf(COMMIT_TAG_START);
-        int endIdx = cleaned.indexOf(COMMIT_TAG_END);
-
-        if (startIdx != -1 && endIdx != -1 && endIdx > startIdx) {
-            cleaned = cleaned.substring(startIdx + COMMIT_TAG_START.length(), endIdx);
-            // Convert literal \n to actual newlines
-            return convertLiteralNewlines(cleaned.trim());
-        }
-
-        // 2. Fallback: try to extract from markdown code blocks
-        if (cleaned.contains("```")) {
-            int codeBlockStart = cleaned.indexOf("```");
-            // Find the first newline after the code block opener
-            int contentStart = cleaned.indexOf('\n', codeBlockStart);
-            if (contentStart != -1) {
-                int codeBlockEnd = cleaned.indexOf("```", contentStart);
-                if (codeBlockEnd != -1) {
-                    cleaned = cleaned.substring(contentStart + 1, codeBlockEnd);
-                    return convertLiteralNewlines(cleaned.trim());
-                }
-            }
-        }
-
-        // 3. Fallback: try to extract the first conventional commit formatted line
-        // Format: type(scope): description or type: description
-        String[] lines = cleaned.split("\n");
-        for (String line : lines) {
-            String trimmedLine = line.trim();
-            if (isConventionalCommitLine(trimmedLine)) {
-                // After finding the first line, continue collecting the body until hitting analysis sections
-                StringBuilder result = new StringBuilder(trimmedLine);
-                int idx = java.util.Arrays.asList(lines).indexOf(line);
-                boolean inBody = false;
-
-                for (int i = idx + 1; i < lines.length; i++) {
-                    String nextLine = lines[i].trim();
-                    // Stop when hitting analysis keywords
-                    if (isAnalysisSection(nextLine)) {
-                        break;
-                    }
-                    // Empty line indicates body start
-                    if (nextLine.isEmpty()) {
-                        inBody = true;
-                        result.append("\n");
-                        continue;
-                    }
-                    // Collect body content
-                    if (inBody && !nextLine.startsWith("#") && !nextLine.startsWith("*")) {
-                        result.append("\n").append(nextLine);
-                    } else if (!inBody) {
-                        // Not in body yet but hit a non-empty line, means single-line commit
-                        break;
-                    }
-                }
-                return convertLiteralNewlines(result.toString().trim());
-            }
-        }
-
-        // 4. Last resort fallback: return the first few lines of raw content (excluding analysis sections)
-        StringBuilder fallback = new StringBuilder();
-        for (String line : lines) {
-            String trimmedLine = line.trim();
-            if (isAnalysisSection(trimmedLine)) {
-                break;
-            }
-            if (!trimmedLine.isEmpty()) {
-                fallback.append(trimmedLine).append("\n");
-            }
-            // Take at most 5 lines
-            if (fallback.toString().split("\n").length >= 5) {
-                break;
-            }
-        }
-
-        return convertLiteralNewlines(fallback.toString().trim());
-    }
-
-    /**
-     * Convert literal \n characters to actual newlines and clean up excess blank lines.
-     */
-    private String convertLiteralNewlines(String text) {
-        if (text == null) {
-            return null;
-        }
-        // Convert literal \n (two characters) to actual newlines
-        String result = text.replace("\\n", "\n");
-
-        // Remove leading blank lines
-        result = result.replaceFirst("^\\n+", "");
-
-        // Collapse multiple consecutive blank lines into a single one (preserve the conventional commit title/body separator)
-        result = result.replaceAll("\\n{3,}", "\n\n");
-
-        return result.trim();
-    }
-
-    /**
-     * Check whether a line follows the conventional commit format.
-     */
-    private boolean isConventionalCommitLine(String line) {
-        if (line == null || line.isEmpty()) {
-            return false;
-        }
-        // Match: feat:, fix:, refactor:, feat(scope):, etc.
-        String[] types = {"feat", "fix", "refactor", "docs", "test", "chore", "perf", "ci", "style", "build"};
-        for (String type : types) {
-            if (line.startsWith(type + ":") || line.startsWith(type + "(")) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Check whether a line belongs to an analysis section (content to exclude).
-     */
-    private boolean isAnalysisSection(String line) {
-        if (line == null) {
-            return false;
-        }
-        String[] analysisKeywords = {
-            "分析说明", "变更特征", "分析：", "说明：", "解释：", "备注：",
-            "Analysis:", "Explanation:", "Note:", "---", "===",
-            "1. 类型", "2. Scope", "3. 描述", "4. Body",
-            "• ", "- 无需", "- 不涉及"
-        };
-        for (String keyword : analysisKeywords) {
-            if (line.contains(keyword)) {
-                return true;
-            }
-        }
-        // Check for numbered list items (e.g. "1. xxx")
-        if (line.matches("^\\d+\\.\\s+.*")) {
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Check whether the content is a thinking/reasoning process.
-     */
-    private boolean isThinkingContent(String content) {
-        if (content == null || content.isEmpty()) {
-            return false;
-        }
-        // Common markers for thinking/reasoning content
-        String[] thinkingMarkers = {
-            "思考", "thinking", "Thinking", "<thinking>", "</thinking>",
-            "让我分析", "让我思考", "我来分析", "首先分析",
-            "Let me think", "Let me analyze"
-        };
-        String trimmed = content.trim();
-        for (String marker : thinkingMarkers) {
-            if (trimmed.startsWith(marker) || trimmed.contains("<thinking>")) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Remove thinking markers and their content.
-     */
-    private String removeThinkingMarkers(String content) {
-        if (content == null || content.isEmpty()) {
-            return content;
-        }
-
-        String result = content;
-
-        // Remove <thinking>...</thinking> tags and their content
-        while (result.contains("<thinking>") && result.contains("</thinking>")) {
-            int start = result.indexOf("<thinking>");
-            int end = result.indexOf("</thinking>") + "</thinking>".length();
-            if (start < end) {
-                result = result.substring(0, start) + result.substring(end);
-            } else {
-                break;
-            }
-        }
-
-        // Remove UI thinking markers like "Thinking >" etc.
-        String[] uiMarkers = {"思考 ▸", "思考▸", "思考 ►", "思考►", "Thinking ▸", "Thinking▸"};
-        for (String marker : uiMarkers) {
-            result = result.replace(marker, "");
-        }
-
-        // Remove leading blank lines
-        result = result.replaceFirst("^\\s*\\n+", "");
-
-        return result.trim();
     }
 }

--- a/src/main/java/com/github/claudecodegui/service/commit/CommitAIClient.java
+++ b/src/main/java/com/github/claudecodegui/service/commit/CommitAIClient.java
@@ -1,0 +1,294 @@
+package com.github.claudecodegui.service.commit;
+
+import com.github.claudecodegui.bridge.EnvironmentConfigurator;
+import com.github.claudecodegui.bridge.NodeDetector;
+import com.github.claudecodegui.bridge.ProcessManager;
+import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
+import com.github.claudecodegui.ui.toolwindow.ClaudeChatWindow;
+import com.github.claudecodegui.ui.toolwindow.ClaudeSDKToolWindow;
+import com.github.claudecodegui.util.PlatformUtils;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Generates commit messages via a dedicated, session-less Node.js one-shot
+ * process ({@code ai-bridge/services/commit-message.js}), mirroring the
+ * prompt-enhancer feature.
+ *
+ * <p>Why a separate process instead of the chat daemon's {@code sendMessage}:
+ * {@code sendMessage} registers a persisted session, so every commit generation
+ * would show up in the chat history. The {@code commit-message.js} script calls
+ * the Claude Agent SDK {@code query()} (or Codex {@code startThread}) directly
+ * with {@code maxTurns=1} and never resumes/persists a session — so generating a
+ * commit message leaves <b>no trace in the history</b>. It also streams
+ * {@code [CONTENT_DELTA]} tokens so the commit box renders incrementally.
+ */
+public class CommitAIClient {
+
+    public static final String PROVIDER_CLAUDE = "claude";
+    public static final String PROVIDER_CODEX = "codex";
+
+    private static final Logger LOG = Logger.getInstance(CommitAIClient.class);
+    private static final Gson GSON = new Gson();
+
+    private static final String COMMIT_SCRIPT = "services/commit-message.js";
+    private static final long TIMEOUT_SECONDS = 90;
+    private static final long READER_DRAIN_SECONDS = 5;
+
+    private final Project project;
+
+    /** The in-flight child process, for cancellation. */
+    private volatile Process currentProcess;
+    private volatile String currentChannelId;
+
+    // Streaming preview state (per request).
+    private final StringBuilder streamed = new StringBuilder();
+    private volatile String latestPreview = "";
+    private volatile boolean progressScheduled = false;
+
+    public CommitAIClient(@Nullable Project project) {
+        this.project = project;
+    }
+
+    /**
+     * Run the commit-message script for the resolved provider + model.
+     *
+     * @param provider {@link #PROVIDER_CLAUDE} or {@link #PROVIDER_CODEX}
+     * @param model    resolved model id (may be null → SDK default)
+     */
+    public void send(@NotNull String prompt, @NotNull String provider, @Nullable String model,
+                     @NotNull CommitMessageCallback callback, @NotNull String emptyErrorMessage) {
+        streamed.setLength(0);
+        latestPreview = "";
+        progressScheduled = false;
+        CompletableFuture.runAsync(() -> {
+            try {
+                String raw = runScript(prompt, provider, model, callback);
+                if (raw == null || raw.isEmpty()) {
+                    callback.onError(emptyErrorMessage);
+                    return;
+                }
+                callback.onSuccess(CommitMessageCleanup.clean(raw));
+            } catch (Throwable t) {
+                LOG.error("CommitAIClient: commit generation failed", t);
+                callback.onError(t.getMessage() != null ? t.getMessage() : t.getClass().getSimpleName());
+            }
+        });
+    }
+
+    /** Cancel the in-flight generation by killing the child process. */
+    public void cancel() {
+        Process p = currentProcess;
+        if (p != null && p.isAlive()) {
+            try {
+                PlatformUtils.terminateProcess(p);
+            } catch (Throwable t) {
+                LOG.debug("CommitAIClient: cancel terminate failed: " + t.getMessage());
+            }
+        }
+    }
+
+    @Nullable
+    private String runScript(@NotNull String prompt, @NotNull String provider, @Nullable String model,
+                             @NotNull CommitMessageCallback callback) throws Exception {
+        ClaudeSDKBridge bridge = obtainBridge();
+        String nodeExecutable = bridge.getNodeExecutable();
+        if (nodeExecutable == null) {
+            throw new IllegalStateException("Node.js is not configured");
+        }
+        File bridgeDir = bridge.getSdkTestDir();
+        if (bridgeDir == null || !bridgeDir.exists()) {
+            throw new IllegalStateException("AI Bridge directory is not ready");
+        }
+        File script = new File(bridgeDir, COMMIT_SCRIPT);
+        ProcessManager processManager = bridge.getProcessManager();
+        EnvironmentConfigurator envConfigurator = new EnvironmentConfigurator();
+
+        List<String> command = NodeDetector.buildNodeScriptCommand(nodeExecutable, script.getAbsolutePath());
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.directory(bridgeDir);
+        pb.redirectErrorStream(true);
+        envConfigurator.updateProcessEnvironment(pb, nodeExecutable);
+
+        JsonObject stdinInput = new JsonObject();
+        stdinInput.addProperty("prompt", prompt);
+        stdinInput.addProperty("provider", provider != null ? provider : PROVIDER_CLAUDE);
+        if (model != null && !model.isEmpty()) {
+            stdinInput.addProperty("model", model);
+        }
+        String stdinJson = GSON.toJson(stdinInput);
+
+        String channelId = ProcessManager.newChannelId("commit-message");
+        currentChannelId = channelId;
+        StringBuilder response = new StringBuilder();
+        StringBuilder errorMessage = new StringBuilder();
+        StringBuilder allOutput = new StringBuilder();
+        Process process = null;
+        CompletableFuture<Void> readerFuture = null;
+
+        LOG.info("[CommitAIClient] Starting commit-message.js: provider=" + provider + ", model=" + model);
+
+        try {
+            process = pb.start();
+            currentProcess = process;
+            processManager.registerProcess(channelId, process);
+
+            try (OutputStreamWriter writer = new OutputStreamWriter(
+                    process.getOutputStream(), StandardCharsets.UTF_8)) {
+                writer.write(stdinJson);
+                writer.flush();
+            }
+
+            final Process finalProcess = process;
+            readerFuture = CompletableFuture.runAsync(() -> {
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(finalProcess.getInputStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        allOutput.append(line).append("\n");
+                        LOG.info("[CommitAIClient] node: " + line);
+                        if (line.startsWith("[COMMIT_ERROR]")) {
+                            errorMessage.append(line.substring("[COMMIT_ERROR]".length()).trim());
+                        } else if (line.startsWith("[CONTENT_DELTA]")) {
+                            String payload = line.substring("[CONTENT_DELTA]".length()).trim();
+                            String delta = parseJsonString(payload);
+                            if (delta != null && !delta.isEmpty()) {
+                                streamed.append(delta);
+                                latestPreview = previewClean(streamed.toString());
+                                scheduleProgress(callback);
+                            }
+                        } else if (line.startsWith("[COMMIT]")) {
+                            String text = line.substring("[COMMIT]".length()).trim()
+                                    .replace("{{NEWLINE}}", "\n");
+                            response.append(text);
+                        }
+                    }
+                } catch (IOException e) {
+                    LOG.debug("[CommitAIClient] reader stream closed: " + e.getMessage());
+                }
+            });
+
+            boolean finished = process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!finished) {
+                LOG.warn("[CommitAIClient] Timeout after " + TIMEOUT_SECONDS + "s, killing process");
+                PlatformUtils.terminateProcess(process);
+                throw new TimeoutException("Commit generation timed out after " + TIMEOUT_SECONDS + "s");
+            }
+
+            try {
+                readerFuture.get(READER_DRAIN_SECONDS, TimeUnit.SECONDS);
+            } catch (TimeoutException te) {
+                LOG.warn("[CommitAIClient] Reader didn't drain within " + READER_DRAIN_SECONDS + "s");
+            } catch (ExecutionException ee) {
+                LOG.debug("[CommitAIClient] Reader failed: "
+                        + (ee.getCause() != null ? ee.getCause().getMessage() : ee.getMessage()));
+            } catch (CancellationException ce) {
+                LOG.debug("[CommitAIClient] Reader cancelled unexpectedly");
+            }
+
+            if (errorMessage.length() > 0) {
+                throw new RuntimeException(errorMessage.toString());
+            }
+            if (response.length() == 0 && allOutput.length() > 0) {
+                LOG.warn("[CommitAIClient] No [COMMIT] marker found. Full output:\n" + allOutput);
+            }
+            return response.toString();
+
+        } finally {
+            if (process != null) {
+                if (process.isAlive()) {
+                    PlatformUtils.terminateProcess(process);
+                }
+                processManager.unregisterProcess(channelId, process);
+            }
+            if (readerFuture != null && !readerFuture.isDone()) {
+                readerFuture.cancel(true);
+            }
+            currentProcess = null;
+            currentChannelId = null;
+        }
+    }
+
+    /** Parse a stdout delta payload that is a JSON-encoded string (e.g. {@code "Hello"}). */
+    @Nullable
+    private static String parseJsonString(@NotNull String payload) {
+        if (payload.isEmpty()) {
+            return null;
+        }
+        try {
+            return GSON.fromJson(payload, String.class);
+        } catch (Throwable t) {
+            return payload;
+        }
+    }
+
+    /** Strip the {@code <commit>} wrapper from a partial stream for a clean preview. */
+    @NotNull
+    private static String previewClean(@NotNull String raw) {
+        String s = raw;
+        int i = s.indexOf("<commit>");
+        if (i >= 0) {
+            s = s.substring(i + "<commit>".length());
+        }
+        int j = s.indexOf("</commit>");
+        if (j >= 0) {
+            s = s.substring(0, j);
+        }
+        return s;
+    }
+
+    /** Coalesce EDT preview updates so we never flood the event thread with deltas. */
+    private void scheduleProgress(@NotNull CommitMessageCallback callback) {
+        if (progressScheduled) {
+            return;
+        }
+        progressScheduled = true;
+        try {
+            // ModalityState.any() so previews render even while a modal commit dialog is open.
+            ApplicationManager.getApplication().invokeLater(() -> {
+                progressScheduled = false;
+                try {
+                    callback.onProgress(latestPreview);
+                } catch (Throwable ignored) {
+                    // Preview rendering must never break generation.
+                }
+            }, ModalityState.any());
+        } catch (Throwable t) {
+            progressScheduled = false;
+            LOG.debug("[CommitAIClient] invokeLater rejected: " + t.getMessage());
+        }
+    }
+
+    /**
+     * Reuse the chat window's Claude bridge for node/bridge-dir/process-manager
+     * discovery; fall back to a fresh bridge instance if the chat window isn't
+     * open. (No daemon is started — we only need filesystem/env helpers.)
+     */
+    @NotNull
+    private ClaudeSDKBridge obtainBridge() {
+        ClaudeChatWindow chatWindow = ClaudeSDKToolWindow.getChatWindow(project);
+        if (chatWindow != null) {
+            return chatWindow.getClaudeSDKBridge();
+        }
+        return new ClaudeSDKBridge();
+    }
+}

--- a/src/main/java/com/github/claudecodegui/service/commit/CommitDiffProvider.java
+++ b/src/main/java/com/github/claudecodegui/service/commit/CommitDiffProvider.java
@@ -1,0 +1,399 @@
+package com.github.claudecodegui.service.commit;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vcs.FilePath;
+import com.intellij.openapi.vcs.VcsException;
+import com.intellij.openapi.vcs.changes.Change;
+import com.intellij.openapi.vcs.changes.ChangesUtil;
+import com.intellij.openapi.vcs.changes.ContentRevision;
+import com.intellij.openapi.vfs.VirtualFile;
+import git4idea.commands.Git;
+import git4idea.commands.GitCommand;
+import git4idea.commands.GitCommandResult;
+import git4idea.commands.GitLineHandler;
+import git4idea.repo.GitRepository;
+import git4idea.repo.GitRepositoryManager;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Produces a real, canonical unified {@code git diff} for the user-selected
+ * {@link Change}s so the model sees the same diff the user sees in the terminal.
+ *
+ * <p>Primary path uses git4idea to run {@code git diff HEAD -- <paths>} grouped
+ * per repository (one process per repo, not per file — matters on Windows where
+ * process spawning is expensive). New (untracked) files are synthesized into a
+ * proper unified hunk from their content. If git4idea is unavailable (e.g. the
+ * project is null in unit tests, or a file is not under any git repo), it falls
+ * back to a content-based diff so the feature degrades gracefully.
+ *
+ * <p>The content fallback intentionally preserves the legacy line-format so the
+ * existing {@code GitCommitMessageServiceCommitAiConfigTest} assertions (which
+ * run against mock revisions with a null project) keep passing unchanged.
+ */
+public class CommitDiffProvider {
+
+    /** Total budget for the assembled diff (~12-16k tokens). */
+    private static final int MAX_TOTAL_LENGTH = 50000;
+    /** Per-file cap so one huge file cannot consume the whole budget. */
+    private static final int MAX_PER_FILE_LENGTH = 12000;
+    /** Legacy cap retained by the content fallback for backward compatibility. */
+    private static final int LEGACY_MAX_DIFF_LENGTH = 4000;
+    private static final int NEW_FILE_LINE_CAP = 200;
+
+    private final Project project;
+    private final Logger log;
+
+    public CommitDiffProvider(@Nullable Project project, @NotNull Logger log) {
+        this.project = project;
+        this.log = log;
+    }
+
+    /**
+     * Build the unified diff for the given changes.
+     *
+     * @return the diff text, or empty string when there is nothing to show.
+     */
+    @NotNull
+    public String generate(@NotNull Collection<Change> changes) {
+        if (project == null) {
+            return contentBasedDiff(changes);
+        }
+        try {
+            String gitDiff = gitBasedDiff(changes);
+            if (!gitDiff.trim().isEmpty()) {
+                return gitDiff;
+            }
+        } catch (Throwable t) {
+            // git4idea should always be present (declared as a required <depends>),
+            // but never let diff generation crash the commit flow.
+            log.warn("CommitDiffProvider: git4idea diff failed, falling back to content diff: " + t.getMessage());
+        }
+        return contentBasedDiff(changes);
+    }
+
+    // =========================================================================
+    // Primary path: real git diff via git4idea
+    // =========================================================================
+
+    @NotNull
+    private String gitBasedDiff(@NotNull Collection<Change> changes) {
+        GitRepositoryManager mgr = GitRepositoryManager.getInstance(project);
+
+        // Partition: tracked-and-resolvable (grouped by repo) vs new vs unresolved.
+        Map<GitRepository, List<Change>> trackedByRepo = new LinkedHashMap<>();
+        List<Change> newFiles = new ArrayList<>();
+        List<Change> unresolved = new ArrayList<>();
+
+        for (Change change : changes) {
+            Change.Type type = change.getType();
+            if (type == Change.Type.NEW) {
+                newFiles.add(change);
+                continue;
+            }
+            FilePath fp = ChangesUtil.getFilePath(change);
+            GitRepository repo = findRepository(mgr, fp);
+            if (repo == null || relativePath(repo, fp) == null) {
+                unresolved.add(change);
+            } else {
+                trackedByRepo.computeIfAbsent(repo, r -> new ArrayList<>()).add(change);
+            }
+        }
+
+        StringBuilder out = new StringBuilder();
+        int omittedFiles = 0;
+
+        // One `git diff HEAD -- <paths>` call per repository.
+        for (Map.Entry<GitRepository, List<Change>> entry : trackedByRepo.entrySet()) {
+            GitRepository repo = entry.getKey();
+            List<Change> repoChanges = entry.getValue();
+            List<String> relPaths = new ArrayList<>(repoChanges.size());
+            for (Change c : repoChanges) {
+                relPaths.add(relativePath(repo, ChangesUtil.getFilePath(c)));
+            }
+            String seg = runGitDiff(repo, relPaths);
+            if (seg.trim().isEmpty()) {
+                // No HEAD yet, or git returned nothing for these paths — degrade
+                // each file to the content fallback rather than dropping it.
+                for (Change c : repoChanges) {
+                    omittedFiles += appendSegment(out, contentDiffForChangeQuiet(c));
+                }
+            } else {
+                omittedFiles += appendSegment(out, capPerFile(seg));
+            }
+        }
+
+        for (Change c : newFiles) {
+            omittedFiles += appendSegment(out, synthesizeNewFile(c));
+        }
+        for (Change c : unresolved) {
+            omittedFiles += appendSegment(out, contentDiffForChangeQuiet(c));
+        }
+
+        if (omittedFiles > 0) {
+            out.append("\n... (")
+                    .append(omittedFiles)
+                    .append(" more file(s) omitted to fit context budget)\n");
+        }
+        return out.toString();
+    }
+
+    /**
+     * Append a segment if it fits the total budget; otherwise count it omitted.
+     *
+     * @return 0 if appended, 1 if omitted.
+     */
+    private int appendSegment(@NotNull StringBuilder out, @NotNull String segment) {
+        if (segment.isEmpty()) {
+            return 0;
+        }
+        if (out.length() + segment.length() > MAX_TOTAL_LENGTH) {
+            return 1;
+        }
+        out.append(segment);
+        return 0;
+    }
+
+    @NotNull
+    private String capPerFile(@NotNull String segment) {
+        if (segment.length() <= MAX_PER_FILE_LENGTH) {
+            return segment;
+        }
+        return segment.substring(0, MAX_PER_FILE_LENGTH) + "\n... (single-file diff truncated)\n";
+    }
+
+    @NotNull
+    private String runGitDiff(@NotNull GitRepository repo, @NotNull List<String> relPaths) {
+        try {
+            GitLineHandler handler = new GitLineHandler(project, repo.getRoot(), GitCommand.DIFF);
+            handler.addParameters("--unified=3", "--no-color", "-M", "--no-ext-diff", "HEAD");
+            handler.endOptions();
+            handler.addParameters("--");
+            for (String p : relPaths) {
+                handler.addParameters(p);
+            }
+            GitCommandResult result = Git.getInstance().runCommand(handler);
+            // GitCommandResult.getOutput() returns the stdout lines.
+            String output = String.join("\n", result.getOutput());
+            return output == null ? "" : output;
+        } catch (Throwable t) {
+            log.warn("CommitDiffProvider: git diff command failed: " + t.getMessage());
+            return "";
+        }
+    }
+
+    @Nullable
+    private GitRepository findRepository(@NotNull GitRepositoryManager mgr, @Nullable FilePath fp) {
+        if (fp == null) {
+            return null;
+        }
+        VirtualFile vf = fp.getVirtualFile();
+        if (vf != null) {
+            GitRepository repo = mgr.getRepositoryForFile(vf);
+            if (repo != null) {
+                return repo;
+            }
+        }
+        String abs = fp.getPath();
+        for (GitRepository r : mgr.getRepositories()) {
+            String root = r.getRoot().getPath();
+            if (abs.startsWith(root)) {
+                return r;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private String relativePath(@NotNull GitRepository repo, @Nullable FilePath fp) {
+        if (fp == null) {
+            return null;
+        }
+        try {
+            Path root = Paths.get(repo.getRoot().getPath());
+            Path abs = Paths.get(fp.getPath());
+            if (!abs.startsWith(root)) {
+                return null;
+            }
+            return root.relativize(abs).toString().replace('\\', '/');
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+
+    /**
+     * Synthesize a unified diff for a new (untracked) file from its content.
+     */
+    @NotNull
+    private String synthesizeNewFile(@NotNull Change change) {
+        FilePath fp = ChangesUtil.getFilePath(change);
+        String path = fp == null ? "(unknown)" : fp.getPath();
+        String content = null;
+        try {
+            ContentRevision after = change.getAfterRevision();
+            content = after != null ? after.getContent() : null;
+        } catch (VcsException e) {
+            log.warn("CommitDiffProvider: failed to read new file content: " + e.getMessage());
+        }
+        if (content == null) {
+            return "";
+        }
+        String normalized = normalizeLineEndings(content);
+        String[] lines = normalized.isEmpty() ? new String[0] : normalized.split("\n", -1);
+        boolean truncated = lines.length > NEW_FILE_LINE_CAP;
+        int shown = truncated ? NEW_FILE_LINE_CAP : lines.length;
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("diff --git a/").append(path).append(" b/").append(path).append("\n");
+        sb.append("new file mode 100644\n");
+        sb.append("--- /dev/null\n");
+        sb.append("+++ b/").append(path).append("\n");
+        sb.append("@@ -0,0 +1,").append(shown).append(" @@\n");
+        for (int i = 0; i < shown; i++) {
+            sb.append("+").append(lines[i]).append("\n");
+        }
+        if (truncated) {
+            sb.append("... (new file truncated at ").append(NEW_FILE_LINE_CAP).append(" lines)\n");
+        }
+        return sb.toString();
+    }
+
+    // =========================================================================
+    // Fallback path: content-based diff (legacy format, preserves test contract)
+    // =========================================================================
+
+    @NotNull
+    private String contentBasedDiff(@NotNull Collection<Change> changes) {
+        StringBuilder diff = new StringBuilder();
+        for (Change change : changes) {
+            String segment;
+            try {
+                segment = contentDiffForChange(change);
+            } catch (VcsException e) {
+                log.warn("CommitDiffProvider: failed to get diff for change: " + e.getMessage());
+                continue;
+            }
+            if (segment.isEmpty()) {
+                continue;
+            }
+            if (diff.length() + segment.length() > LEGACY_MAX_DIFF_LENGTH) {
+                diff.append("\n... (diff 过长，已截断)");
+                break;
+            }
+            diff.append(segment);
+        }
+        return diff.toString();
+    }
+
+    /** Content fallback for a single change, swallowing VcsException (git path). */
+    @NotNull
+    private String contentDiffForChangeQuiet(@NotNull Change change) {
+        try {
+            return contentDiffForChange(change);
+        } catch (VcsException e) {
+            log.warn("CommitDiffProvider: failed to get diff for change: " + e.getMessage());
+            return "";
+        }
+    }
+
+    /**
+     * Legacy per-change content diff. Returns the segment, or {@code ""} when
+     * there is no real change (e.g. line-ending-only diff) — matching the
+     * original rollback behavior.
+     */
+    @NotNull
+    private String contentDiffForChange(@NotNull Change change) throws VcsException {
+        FilePath filePath = ChangesUtil.getFilePath(change);
+        Change.Type type = change.getType();
+        String path = filePath == null ? "(unknown)" : filePath.getPath();
+
+        StringBuilder seg = new StringBuilder();
+        seg.append("\n=== ").append(type.name()).append(": ").append(path).append(" ===\n");
+
+        ContentRevision beforeRevision = change.getBeforeRevision();
+        ContentRevision afterRevision = change.getAfterRevision();
+
+        if (type == Change.Type.NEW && afterRevision != null) {
+            String content = afterRevision.getContent();
+            if (content != null) {
+                if (content.length() <= 500) {
+                    seg.append("+++ ").append(content).append("\n");
+                } else {
+                    seg.append("+++ [文件过大，仅显示前500字符]\n");
+                    seg.append(content, 0, 500).append("\n");
+                }
+            }
+        } else if (type == Change.Type.DELETED && beforeRevision != null) {
+            seg.append("--- 文件已删除\n");
+        } else if (type == Change.Type.MODIFICATION && beforeRevision != null && afterRevision != null) {
+            String before = beforeRevision.getContent();
+            String after = afterRevision.getContent();
+            if (before != null && after != null) {
+                String simpleDiff = generateSimpleDiff(before, after);
+                if (simpleDiff.isEmpty()) {
+                    // Pure line-ending change (or no change) — drop this file.
+                    return "";
+                }
+                seg.append(simpleDiff);
+            }
+        }
+        return seg.toString();
+    }
+
+    /**
+     * Generate a simple added/removed-line diff (legacy fallback only).
+     * Kept verbatim to preserve existing test assertions.
+     */
+    @NotNull
+    private String generateSimpleDiff(@NotNull String before, @NotNull String after) {
+        String normalizedBefore = normalizeLineEndings(before);
+        String normalizedAfter = normalizeLineEndings(after);
+        if (normalizedBefore.equals(normalizedAfter)) {
+            return "";
+        }
+
+        String[] beforeLines = normalizedBefore.split("\n");
+        String[] afterLines = normalizedAfter.split("\n");
+
+        StringBuilder diff = new StringBuilder();
+        int maxLines = Math.max(beforeLines.length, afterLines.length);
+        int shownLines = 0;
+        int maxShownLines = 30;
+
+        for (int i = 0; i < maxLines && shownLines < maxShownLines; i++) {
+            String beforeLine = i < beforeLines.length ? beforeLines[i] : "";
+            String afterLine = i < afterLines.length ? afterLines[i] : "";
+
+            if (!beforeLine.equals(afterLine)) {
+                if (!beforeLine.isEmpty()) {
+                    diff.append("- ").append(beforeLine).append("\n");
+                    shownLines++;
+                }
+                if (!afterLine.isEmpty() && shownLines < maxShownLines) {
+                    diff.append("+ ").append(afterLine).append("\n");
+                    shownLines++;
+                }
+            }
+        }
+
+        if (maxLines > maxShownLines) {
+            diff.append("... (更多变更已省略)\n");
+        }
+
+        return diff.toString();
+    }
+
+    @NotNull
+    private String normalizeLineEndings(@NotNull String content) {
+        return content.replace("\r\n", "\n").replace('\r', '\n');
+    }
+}

--- a/src/main/java/com/github/claudecodegui/service/commit/CommitMessageCallback.java
+++ b/src/main/java/com/github/claudecodegui/service/commit/CommitMessageCallback.java
@@ -1,0 +1,20 @@
+package com.github.claudecodegui.service.commit;
+
+/**
+ * Callback for commit-message generation.
+ *
+ * <p>{@code onProgress} is optional (default no-op) and invoked on the EDT with
+ * a partial preview while the model streams, so the commit box can render text
+ * incrementally.
+ */
+public interface CommitMessageCallback {
+
+    void onSuccess(String commitMessage);
+
+    void onError(String error);
+
+    /** Optional streaming preview (called on EDT). */
+    default void onProgress(String partial) {
+        // no-op by default
+    }
+}

--- a/src/main/java/com/github/claudecodegui/service/commit/CommitMessageCleanup.java
+++ b/src/main/java/com/github/claudecodegui/service/commit/CommitMessageCleanup.java
@@ -1,0 +1,74 @@
+package com.github.claudecodegui.service.commit;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Extracts the final commit message from the model's raw output.
+ *
+ * <p>Three-step extraction:
+ * <ol>
+ *     <li>{@code <commit>...</commit>} tags (the enforced contract).</li>
+ *     <li>The first markdown code fence as a fallback.</li>
+ *     <li>The trimmed raw text as a last resort.</li>
+ * </ol>
+ *
+ * <p>The legacy heuristic machinery ({@code isAnalysisSection},
+ * {@code isConventionalCommitLine}, thinking-marker stripping, …) was removed:
+ * with {@code disableThinking=true} + a strict {@code <commit>} output contract
+ * those band-aids are no longer needed.
+ */
+public final class CommitMessageCleanup {
+
+    private static final String COMMIT_TAG_START = "<commit>";
+    private static final String COMMIT_TAG_END = "</commit>";
+
+    private CommitMessageCleanup() {
+    }
+
+    @NotNull
+    public static String clean(@Nullable String message) {
+        if (message == null || message.isEmpty()) {
+            return "";
+        }
+        String cleaned = message.trim();
+
+        // 1. Extract from <commit>...</commit> tags.
+        int startIdx = cleaned.indexOf(COMMIT_TAG_START);
+        int endIdx = cleaned.indexOf(COMMIT_TAG_END);
+        if (startIdx != -1 && endIdx != -1 && endIdx > startIdx) {
+            return convertLiteralNewlines(
+                    cleaned.substring(startIdx + COMMIT_TAG_START.length(), endIdx).trim());
+        }
+
+        // 2. Fallback: first markdown code fence.
+        if (cleaned.contains("```")) {
+            int codeBlockStart = cleaned.indexOf("```");
+            int contentStart = cleaned.indexOf('\n', codeBlockStart);
+            if (contentStart != -1) {
+                int codeBlockEnd = cleaned.indexOf("```", contentStart);
+                if (codeBlockEnd != -1) {
+                    return convertLiteralNewlines(cleaned.substring(contentStart + 1, codeBlockEnd).trim());
+                }
+            }
+        }
+
+        // 3. Last resort: trimmed raw text.
+        return convertLiteralNewlines(cleaned);
+    }
+
+    /**
+     * Convert literal {@code \n} characters to real newlines and collapse runs
+     * of blank lines (preserving the conventional title/body separator).
+     */
+    @NotNull
+    public static String convertLiteralNewlines(@Nullable String text) {
+        if (text == null) {
+            return "";
+        }
+        String result = text.replace("\\n", "\n");
+        result = result.replaceFirst("^\\n+", "");
+        result = result.replaceAll("\\n{3,}", "\n\n");
+        return result.trim();
+    }
+}

--- a/src/main/java/com/github/claudecodegui/service/commit/CommitPromptBuilder.java
+++ b/src/main/java/com/github/claudecodegui/service/commit/CommitPromptBuilder.java
@@ -1,0 +1,131 @@
+package com.github.claudecodegui.service.commit;
+
+import com.github.claudecodegui.settings.CodemossSettingsService;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Assembles the full commit-message prompt.
+ *
+ * <p>Composition (lowest → highest priority):
+ * <ol>
+ *     <li>Built-in spec (Conventional Commits, kept short for low latency).</li>
+ *     <li>User's global additional prompt (Settings → Commit).</li>
+ *     <li>Project-level additional prompt (overrides the above on conflict).</li>
+ *     <li>The git diff itself.</li>
+ * </ol>
+ *
+ * <p>The built-in prompt is intentionally lean — every extra token adds TTFT
+ * and cost on a feature that runs on every commit. The verbose guide that used
+ * to live here was trimmed to the format spec + type table + output contract.
+ */
+public class CommitPromptBuilder {
+
+    private static final Logger LOG = Logger.getInstance(CommitPromptBuilder.class);
+
+    /**
+     * Lean built-in commit spec. Users can append additional prompts via the
+     * settings page, which take priority.
+     */
+    private static final String BUILTIN_COMMIT_PROMPT = """
+            你是一名资深软件工程师，请基于下方 git diff 撰写一条高质量的 Git commit message，遵循 Conventional Commits 规范。
+
+            输出格式：
+            <type>[scope]: <description>
+
+            <body>
+
+            [footer]
+
+            提交类型：feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+
+            要求：
+            - 主题行：祈使语气、现在时，不超过 72 字符，末尾不加句号。
+            - 正文（当改动多于一个逻辑点时【必须】写）：总结【改了什么】和【为什么改】（不要逐行复述 diff）。把相关的改动归纳成要点，每条以 "- " 开头，并提及主要涉及的文件/模块/区域，让审查者不读 diff 也能把握这次提交。请写出有实质内容的正文，而不是只有一行主题。
+            - 每行不超过 72 字符。
+            - 页脚：如适用，写 BREAKING CHANGE 与 issue 引用（Closes: #123）。
+            - 只输出 commit message 本身：不要前缀分析、不要解释、不要 "Generated with" / "Co-Authored-By"、不要 emoji。
+            - 必须用 <commit></commit> 标签包裹整条消息，标签外不要有任何内容。
+            """;
+
+    private final CodemossSettingsService settingsService;
+    private final Project project;
+
+    public CommitPromptBuilder(@NotNull CodemossSettingsService settingsService, Project project) {
+        this.settingsService = settingsService;
+        this.project = project;
+    }
+
+    /**
+     * Build the full prompt: built-in + user prompt + project prompt + diff.
+     */
+    @NotNull
+    public String build(@NotNull String diff) {
+        StringBuilder prompt = new StringBuilder();
+        prompt.append(BUILTIN_COMMIT_PROMPT);
+
+        String userAdditionalPrompt = getUserAdditionalPrompt();
+        if (!userAdditionalPrompt.isEmpty()) {
+            prompt.append("\n\n## 用户附加要求（优先遵循）\n\n");
+            prompt.append("以下是用户的额外要求，请在生成 commit message 时优先考虑：\n\n");
+            prompt.append(userAdditionalPrompt);
+        }
+
+        String projectAdditionalPrompt = getProjectAdditionalPrompt();
+        if (!projectAdditionalPrompt.isEmpty()) {
+            prompt.append("\n\n## 项目专属要求\n\n");
+            prompt.append("以下是当前项目的专属要求，与上述用户附加要求同时生效。当两者矛盾时，以此处项目要求为准：\n\n");
+            prompt.append(projectAdditionalPrompt);
+        }
+
+        prompt.append("\n\n---\n\n");
+        prompt.append("以下是 git diff，请据此生成 commit message：\n\n");
+        prompt.append("```diff\n");
+        prompt.append(diff);
+        prompt.append("\n```");
+
+        prompt.append("\n\n【输出格式要求 - 必须严格遵守】\n");
+        prompt.append("用 <commit> 和 </commit> 标签包裹 commit message，标签外不要有任何内容（不分析、不解释）。\n");
+
+        return prompt.toString();
+    }
+
+    /** User's global additional prompt (optional; legacy default treated as unset). */
+    @NotNull
+    private String getUserAdditionalPrompt() {
+        try {
+            String userPrompt = settingsService.getCommitPrompt();
+            if (userPrompt == null || userPrompt.trim().isEmpty()) {
+                return "";
+            }
+            // Treat the old default value as not configured.
+            if (userPrompt.equals("你是一个commit提交专员，请你阅读git记录，帮我生成commit记录")) {
+                return "";
+            }
+            return userPrompt.trim();
+        } catch (Exception e) {
+            LOG.warn("Failed to get user additional prompt from settings", e);
+            return "";
+        }
+    }
+
+    /** Project-level additional prompt (optional, highest priority). */
+    @NotNull
+    private String getProjectAdditionalPrompt() {
+        try {
+            String projectPath = project == null ? null : project.getBasePath();
+            if (projectPath == null) {
+                return "";
+            }
+            String projectPrompt = settingsService.getProjectCommitPrompt(projectPath);
+            if (projectPrompt == null || projectPrompt.trim().isEmpty()) {
+                return "";
+            }
+            return projectPrompt.trim();
+        } catch (Exception e) {
+            LOG.warn("get project additional prompt fail:", e);
+            return "";
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -57,6 +57,9 @@
     ]]></description>
 
     <depends>com.intellij.modules.platform</depends>
+    <!-- Git support — required for Commit AI to run a real `git diff`.
+         Git4Idea is bundled in all JetBrains IDEs that support Git. -->
+    <depends>Git4Idea</depends>
     <!-- JCEF is a separate platform module in IntelliJ IDEA 2026.2+, but older
          IDEs may provide JCEF from the platform without exposing this module. -->
     <depends optional="true" config-file="jcef-features.xml">com.intellij.modules.jcef</depends>

--- a/src/main/resources/messages/ClaudeCodeGuiBundle_zh.properties
+++ b/src/main/resources/messages/ClaudeCodeGuiBundle_zh.properties
@@ -103,7 +103,7 @@ tab.close.confirm.no=取消
 # Commit message generation
 action.generateCommitMessage.text=使用 CCG 生成提交信息
 action.generateCommitMessage.description=使用 AI 自动生成 Git commit message
-commit.generating=正在生成 commit message...（时间大约10~45s）（此功能为测试版本，效果有可能生成不好，后续还会迭代哦~）
+commit.generating=正在生成 commit message...（时间大约1~5s）
 commit.generateSuccess=Commit message 生成成功
 commit.generateFailed=生成失败
 commit.noChanges=请先选择要提交的文件

--- a/src/test/java/com/github/claudecodegui/service/GitCommitMessageServiceCommitAiConfigTest.java
+++ b/src/test/java/com/github/claudecodegui/service/GitCommitMessageServiceCommitAiConfigTest.java
@@ -2,6 +2,7 @@ package com.github.claudecodegui.service;
 
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
+import com.github.claudecodegui.service.commit.CommitMessageCallback;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vcs.FilePath;
 import com.intellij.openapi.vcs.LocalFilePath;
@@ -137,7 +138,7 @@ public class GitCommitMessageServiceCommitAiConfigTest {
         return config;
     }
 
-    private static class ResultCapture implements GitCommitMessageService.CommitMessageCallback {
+    private static class ResultCapture implements CommitMessageCallback {
         private String success;
         private String error;
 

--- a/src/test/java/com/github/claudecodegui/service/commit/CommitMessageCleanupTest.java
+++ b/src/test/java/com/github/claudecodegui/service/commit/CommitMessageCleanupTest.java
@@ -1,0 +1,61 @@
+package com.github.claudecodegui.service.commit;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for the (slimmed) commit-message extraction logic.
+ */
+public class CommitMessageCleanupTest {
+
+    @Test
+    public void extractsFromCommitTags() {
+        String raw = "Here you go:\n<commit>\nfeat(api): add login\n\nbody line\n</commit>\n";
+        assertEquals("feat(api): add login\n\nbody line", CommitMessageCleanup.clean(raw));
+    }
+
+    @Test
+    public void keepsOnlyFirstCommitBlockWhenMultiple() {
+        String raw = "<commit>feat: first</commit> extra <commit>feat: second</commit>";
+        assertEquals("feat: first", CommitMessageCleanup.clean(raw));
+    }
+
+    @Test
+    public void fallsBackToCodeFenceWithoutTags() {
+        String raw = "Sure:\n```\nfix(ui): align button\n```\n";
+        assertEquals("fix(ui): align button", CommitMessageCleanup.clean(raw));
+    }
+
+    @Test
+    public void fallsBackToTrimmedRawWhenNothingElse() {
+        String raw = "  refactor: trim me  \n";
+        assertEquals("refactor: trim me", CommitMessageCleanup.clean(raw));
+    }
+
+    @Test
+    public void convertsLiteralNewlines() {
+        String raw = "<commit>feat: a\\n\\nbody</commit>";
+        assertEquals("feat: a\n\nbody", CommitMessageCleanup.clean(raw));
+    }
+
+    @Test
+    public void collapsesExcessiveBlankLines() {
+        String raw = "<commit>feat: a\n\n\n\n\nbody</commit>";
+        assertEquals("feat: a\n\nbody", CommitMessageCleanup.clean(raw));
+    }
+
+    @Test
+    public void emptyInputReturnsEmpty() {
+        assertEquals("", CommitMessageCleanup.clean(null));
+        assertEquals("", CommitMessageCleanup.clean(""));
+        assertEquals("", CommitMessageCleanup.clean("   "));
+    }
+
+    @Test
+    public void truncatedCommitTagFallsBackToRaw() {
+        // No closing tag — should not extract a partial tag block.
+        String raw = "<commit>feat: incomplete";
+        assertEquals("<commit>feat: incomplete", CommitMessageCleanup.clean(raw));
+    }
+}

--- a/webview/src/components/settings/AiFeatureProviderModelPanel/index.tsx
+++ b/webview/src/components/settings/AiFeatureProviderModelPanel/index.tsx
@@ -1,7 +1,11 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CLAUDE_MODELS, CODEX_MODELS } from '../../ChatInputBox/types';
+import type { ModelInfo } from '../../ChatInputBox/types';
 import { ProviderModelIcon } from '../../shared/ProviderModelIcon';
+import { usePluginModels } from '../hooks/usePluginModels';
+import { STORAGE_KEYS } from '../../../types/provider';
+import { applyClaudeModelMapping, readClaudeModelMapping } from '../../../utils/claudeModelMapping';
 import type { AiFeatureConfig, AiFeatureProvider } from '../../../types/aiFeatureConfig';
 import styles from './style.module.less';
 
@@ -30,7 +34,49 @@ const AiFeatureProviderModelPanel = ({
     ?? config.effectiveProvider
     ?? fallbackProvider;
   const statusProvider = config.effectiveProvider ?? config.provider ?? fallbackProvider;
-  const modelOptions = selectedProvider === 'codex' ? CODEX_MODELS : CLAUDE_MODELS;
+
+  // Model list mirrors the main chat: the user's configured custom models
+  // (usePluginModels localStorage) merged with the built-ins; for Claude the
+  // model-mapping labels are applied (so the user's real provider models, e.g.
+  // GLM-5.x, show up). Duplicate labels (several built-in slots mapped to the
+  // same real model) are collapsed.
+  const claudeCustomModels = usePluginModels(STORAGE_KEYS.CLAUDE_CUSTOM_MODELS).models;
+  const codexCustomModels = usePluginModels(STORAGE_KEYS.CODEX_CUSTOM_MODELS).models;
+  const availableModels = useMemo<ModelInfo[]>(() => {
+    const customs: ModelInfo[] = (selectedProvider === 'codex' ? codexCustomModels : claudeCustomModels)
+      .map((m) => ({ id: m.id, label: m.label || m.id, description: m.description }));
+
+    let builtIns: ModelInfo[] = selectedProvider === 'codex' ? CODEX_MODELS : CLAUDE_MODELS;
+    if (selectedProvider !== 'codex') {
+      try {
+        const mapping = readClaudeModelMapping();
+        if (Object.keys(mapping).length > 0) {
+          builtIns = CLAUDE_MODELS.map((m) => applyClaudeModelMapping(m, mapping));
+        }
+      } catch {
+        // ignore — fall back to unmapped built-ins
+      }
+    }
+
+    const merged = [...customs, ...builtIns];
+    const seen = new Set<string>();
+    return merged.filter((m) => {
+      const key = m.label.trim().toLowerCase();
+      if (key && seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
+  }, [selectedProvider, claudeCustomModels, codexCustomModels]);
+
+  const currentModel = config.models[selectedProvider] ?? '';
+  const currentModelInList = availableModels.some((m) => m.id === currentModel);
+  // If the saved model isn't in the list (e.g. a custom id), still show it as an option.
+  const modelOptions: ModelInfo[] = (!currentModelInList && currentModel)
+    ? [{ id: currentModel, label: currentModel }, ...availableModels]
+    : availableModels;
+
   const isAutoMode = config.provider == null;
   const statusText = config.resolutionSource === 'auto'
     ? t(`${settingsKeyPrefix}.currentProviderAuto`, {
@@ -71,10 +117,13 @@ const AiFeatureProviderModelPanel = ({
         </div>
 
         <div className={styles.selectWrap}>
+          <span className={styles.iconWrap} aria-hidden="true">
+            <ProviderModelIcon providerId={selectedProvider} modelId={currentModel} size={14} colored />
+          </span>
           <select
             id={`${settingsKeyPrefix}-model`}
             className={styles.modelSelect}
-            value={config.models[selectedProvider]}
+            value={currentModel}
             onChange={(e) => onModelChange(e.target.value)}
             aria-label={t(`${settingsKeyPrefix}.modelLabel`)}
           >

--- a/webview/src/components/settings/AiFeatureProviderModelPanel/style.module.less
+++ b/webview/src/components/settings/AiFeatureProviderModelPanel/style.module.less
@@ -76,7 +76,7 @@
 }
 
 .modelSelect {
-  padding: 0 36px 0 12px;
+  padding: 0 36px;
 }
 
 .resetBtn {

--- a/webview/src/utils/claudeModelMapping.ts
+++ b/webview/src/utils/claudeModelMapping.ts
@@ -36,6 +36,43 @@ function hasMappingValue(mapping: ClaudeModelMapping): boolean {
 }
 
 /**
+ * Maps built-in Claude model ids to their mapping key. Models not listed here
+ * (e.g. Fable) fall back to `mapping.main`.
+ */
+const MODEL_KEY_MAP: Record<string, keyof ClaudeModelMapping> = {
+  'claude-fable-5': 'fable',
+  'claude-sonnet-5': 'sonnet',
+  'claude-sonnet-4-7': 'sonnet',
+  'claude-sonnet-4-6': 'sonnet',
+  'claude-opus-5': 'opus',
+  'claude-opus-4-8': 'opus',
+  'claude-haiku-4-5': 'haiku',
+};
+
+/**
+ * Apply the Claude model mapping to a built-in model entry: keeps its id
+ * (unique key — the CLI resolves it to the real model via settings), but
+ * rewrites the label to the user's configured real model name (e.g. GLM-5.2).
+ * Mirrors ButtonArea's applyModelMapping, extracted for reuse by the Commit AI
+ * settings panel so both surfaces show the same model list.
+ */
+export function applyClaudeModelMapping<T extends { id: string; label: string }>(
+  model: T,
+  mapping: ClaudeModelMapping,
+): T {
+  const key = MODEL_KEY_MAP[model.id];
+  const resolvedMapping = (key ? mapping[key] : undefined) || mapping.main;
+  if (resolvedMapping) {
+    const actualModel = String(resolvedMapping).trim();
+    if (actualModel.length > 0) {
+      // Keep the original id as the unique identifier; only change the label.
+      return { ...model, label: actualModel };
+    }
+  }
+  return model;
+}
+
+/**
  * Write the Claude model mapping and proactively notify listeners in the same tab to refresh.
  */
 export function writeClaudeModelMapping(mapping: ClaudeModelMapping): void {


### PR DESCRIPTION
- Add Git4Idea as a bundled plugin dependency to support real git diffing for the Commit AI feature.
- Rework the commit generation callback in GenerateCommitMessageAction to stream partial results (onProgress) directly into the commit panel, preventing UI freezing during generation.
- Introduce thread-safe active-generation tracking maps to cancel any in-flight generation if the action is triggered again.
- Preserve the user's draft before generation starts and restore it if the process fails, avoiding loss of manually typed messages.
- Add reflection-based draft reading utility to save existing messages, as CommitMessageI lacks a standard getter.