### PR TITLE
fix(history): hide Codex subagent sessions

### DIFF
--- a/src/main/java/com/github/claudecodegui/cache/SessionIndexManager.java
+++ b/src/main/java/com/github/claudecodegui/cache/SessionIndexManager.java
@@ -30,12 +30,14 @@ public class SessionIndexManager {
     // total (sum 1..N-1 * base) within ~100ms to avoid blocking concurrent index reads/writes.
     private static final long INDEX_REPLACE_RETRY_DELAY_MS = 10L;
 
+    // v6 (2026-07): Codex subagent rollouts could be persisted as regular history sessions.
+    // Rebuild the indexes once so stale Codex entries do not survive the parser fix.
     // v5 (2026-06): entrypoint (added in v4) could be persisted as null by interim v4
     // builds that bumped the version before the extraction pipeline was fully wired.
     // Restore paths trust index entries while the file mtime is unchanged, so those
     // nulls would never self-heal. Bumping once more forces a clean rebuild that
     // populates entrypoint for every session.
-    private static final int INDEX_VERSION = 5;
+    private static final int INDEX_VERSION = 6;
 
     private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
     private final Path codemossCacheDir;

--- a/src/main/java/com/github/claudecodegui/provider/codex/CodexHistoryParser.java
+++ b/src/main/java/com/github/claudecodegui/provider/codex/CodexHistoryParser.java
@@ -59,6 +59,9 @@ class CodexHistoryParser {
                     messages.add(msg);
 
                     if ("session_meta".equals(msg.type) && msg.payload != null) {
+                        if (CodexSessionMetadata.isSubagent(msg.payload)) {
+                            return null;
+                        }
                         // Use session_meta.id as the canonical session ID.
                         // This matches the thread_id the Codex SDK returns via [THREAD_ID],
                         // ensuring custom titles saved under this ID are found when loading history.

--- a/src/main/java/com/github/claudecodegui/provider/codex/CodexSessionLiteReader.java
+++ b/src/main/java/com/github/claudecodegui/provider/codex/CodexSessionLiteReader.java
@@ -1,6 +1,7 @@
 package com.github.claudecodegui.provider.codex;
 
 import com.github.claudecodegui.provider.common.SessionLiteReader;
+import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 
 import java.nio.file.Path;
@@ -94,6 +95,11 @@ public class CodexSessionLiteReader {
             SessionLiteReader.LiteSessionFile lite
     ) {
         if (lite == null || sessionId == null) {
+            return null;
+        }
+
+        JsonObject sessionMeta = CodexSessionMetadata.findSessionMetaPayload(lite.head);
+        if (CodexSessionMetadata.isSubagent(sessionMeta)) {
             return null;
         }
 

--- a/src/main/java/com/github/claudecodegui/provider/codex/CodexSessionMetadata.java
+++ b/src/main/java/com/github/claudecodegui/provider/codex/CodexSessionMetadata.java
@@ -1,0 +1,55 @@
+package com.github.claudecodegui.provider.codex;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * Reads Codex session metadata shared by lite and fallback history scans.
+ */
+final class CodexSessionMetadata {
+
+    private CodexSessionMetadata() {
+    }
+
+    static boolean isSubagent(JsonObject payload) {
+        if (payload == null || !payload.has("source")) {
+            return false;
+        }
+        JsonElement source = payload.get("source");
+        return source != null && source.isJsonObject() && source.getAsJsonObject().has("subagent");
+    }
+
+    static JsonObject findSessionMetaPayload(String head) {
+        if (head == null || head.isEmpty()) {
+            return null;
+        }
+
+        int start = 0;
+        while (start < head.length()) {
+            int newlineIndex = head.indexOf('\n', start);
+            String line = newlineIndex >= 0 ? head.substring(start, newlineIndex) : head.substring(start);
+            start = newlineIndex >= 0 ? newlineIndex + 1 : head.length();
+
+            if (!line.contains("\"session_meta\"")) {
+                continue;
+            }
+
+            try {
+                JsonElement element = JsonParser.parseString(line);
+                if (!element.isJsonObject()) {
+                    continue;
+                }
+                JsonObject message = element.getAsJsonObject();
+                if (!message.has("type") || !"session_meta".equals(message.get("type").getAsString())) {
+                    continue;
+                }
+                JsonElement payload = message.get("payload");
+                return payload != null && payload.isJsonObject() ? payload.getAsJsonObject() : null;
+            } catch (RuntimeException ignored) {
+                // A malformed metadata line is not sufficient evidence to hide the session.
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/codex/CodexHistoryIndexServiceTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/codex/CodexHistoryIndexServiceTest.java
@@ -138,6 +138,22 @@ public class CodexHistoryIndexServiceTest {
         assertNotNull(byId.get("thread_new0987654321"));
     }
 
+    @Test
+    public void incrementalScan_skipsSubagentSession() throws IOException {
+        Path sessionsDir = tmp.newFolder("codex-index-subagent").toPath();
+        Path nested = sessionsDir.resolve("2026/07/29");
+        Files.createDirectories(nested);
+
+        writeSessionFile(nested, "rollout-main.jsonl", "thread_main1234567890");
+        writeSubagentSessionFile(nested, "rollout-subagent.jsonl", "thread_subagent123456");
+
+        SessionIndexManager.ProjectIndex existing = new SessionIndexManager.ProjectIndex();
+        CodexHistoryIndexService.ScanResult result = newService(sessionsDir).incrementalScanLite(existing);
+
+        assertEquals(1, result.sessions().size());
+        assertEquals("thread_main1234567890", result.sessions().get(0).sessionId);
+    }
+
     // --- helpers -----------------------------------------------------------
 
     private CodexHistoryIndexService newService(Path sessionsDir) {
@@ -154,6 +170,21 @@ public class CodexHistoryIndexServiceTest {
                 .append("\"payload\":{\"type\":\"user_message\",\"message\":\"Fresh title for ")
                 .append(sessionMetaId).append("\"}}\n");
         sb.append("{\"timestamp\":\"2026-04-21T10:00:10Z\",\"type\":\"response_item\",")
+                .append("\"payload\":{\"type\":\"message\"}}\n");
+        Files.writeString(file, sb.toString());
+        return file;
+    }
+
+    private Path writeSubagentSessionFile(Path dir, String fileName, String sessionMetaId) throws IOException {
+        Path file = dir.resolve(fileName);
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"timestamp\":\"2026-07-29T10:00:00Z\",\"type\":\"session_meta\",")
+                .append("\"payload\":{\"id\":\"").append(sessionMetaId)
+                .append("\",\"cwd\":\"/workspace/demo\",\"source\":{\"subagent\":{\"thread_spawn\":{")
+                .append("\"parent_thread_id\":\"thread_main1234567890\",\"depth\":1}}}}}\n");
+        sb.append("{\"timestamp\":\"2026-07-29T10:00:05Z\",\"type\":\"event_msg\",")
+                .append("\"payload\":{\"type\":\"user_message\",\"message\":\"Inherited parent context\"}}\n");
+        sb.append("{\"timestamp\":\"2026-07-29T10:00:10Z\",\"type\":\"response_item\",")
                 .append("\"payload\":{\"type\":\"message\"}}\n");
         Files.writeString(file, sb.toString());
         return file;

--- a/src/test/java/com/github/claudecodegui/provider/codex/CodexHistoryReaderRefactorTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/codex/CodexHistoryReaderRefactorTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class CodexHistoryReaderRefactorTest {
@@ -72,6 +73,29 @@ public class CodexHistoryReaderRefactorTest {
             assertTrue(session.title.contains("review"));
             assertTrue(session.title.endsWith("..."));
             assertTrue(parser.isValidSession(session));
+        } finally {
+            deleteDirectory(sessionsDir);
+        }
+    }
+
+    @Test
+    public void parserSkipsSubagentSession() throws IOException {
+        Path sessionsDir = Files.createTempDirectory("codex-history-subagent-parser");
+        try {
+            Path sessionFile = writeSessionFile(
+                    sessionsDir,
+                    "session-subagent",
+                    line("2026-03-10T10:00:00Z", "session_meta",
+                            "{\"cwd\":\"/workspace/demo\",\"source\":{\"subagent\":{\"thread_spawn\":{"
+                                    + "\"parent_thread_id\":\"session-parent\",\"depth\":1}}}}"),
+                    line("2026-03-10T10:01:00Z", "event_msg",
+                            "{\"type\":\"user_message\",\"message\":\"Inherited parent context\"}"),
+                    line("2026-03-10T10:02:00Z", "response_item", "{\"type\":\"message\"}")
+            );
+
+            CodexHistoryParser parser = new CodexHistoryParser(new Gson());
+
+            assertNull(parser.parseSessionFile(sessionFile));
         } finally {
             deleteDirectory(sessionsDir);
         }

--- a/src/test/java/com/github/claudecodegui/provider/codex/CodexSessionLiteReaderTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/codex/CodexSessionLiteReaderTest.java
@@ -21,7 +21,7 @@ public class CodexSessionLiteReaderTest {
         Path tempDir = Files.createTempDirectory("codex-lite-test");
         try {
             Path tempFile = tempDir.resolve("thread_abc123def456.jsonl");
-            String content = "{\"type\":\"session_meta\",\"payload\":{\"id\":\"thread_abc123def456\",\"cwd\":\"/workspace/demo\",\"timestamp\":\"2026-03-10T10:00:00Z\"}}\n" +
+            String content = "{\"type\":\"session_meta\",\"payload\":{\"id\":\"thread_abc123def456\",\"cwd\":\"/workspace/demo\",\"timestamp\":\"2026-03-10T10:00:00Z\",\"source\":\"exec\"}}\n" +
                     "{\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"Hello Codex\"},\"timestamp\":\"2026-03-10T10:01:00Z\"}\n" +
                     "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\"},\"timestamp\":\"2026-03-10T10:02:00Z\"}\n";
             Files.writeString(tempFile, content);
@@ -64,6 +64,22 @@ public class CodexSessionLiteReaderTest {
                 System.currentTimeMillis(), 1000,
                 "{\"type\":\"session_meta\",\"payload\":{\"id\":\"thread_abc123def456\"}}\n" +
                         "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\"}}\n",
+                ""
+        );
+
+        assertNull(reader.parseSessionInfoFromLite(sessionId, lite));
+    }
+
+    @Test
+    public void parseSessionInfoFromLite_subagentReturnsNull() {
+        String sessionId = "thread_subagent123456";
+        SessionLiteReader.LiteSessionFile lite = new SessionLiteReader.LiteSessionFile(
+                System.currentTimeMillis(), 1000,
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"thread_subagent123456\","
+                        + "\"cwd\":\"/workspace\",\"source\":{\"subagent\":{\"thread_spawn\":{"
+                        + "\"parent_thread_id\":\"thread_parent123456\",\"depth\":1}}}}}\n"
+                        + "{\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\","
+                        + "\"message\":\"Inherited parent context\"}}\n",
                 ""
         );
 


### PR DESCRIPTION
## Summary
- exclude Codex rollout files whose `session_meta.source` identifies a subagent
- apply the same filter in full parsing and lightweight history indexing
- bump the history index version so previously indexed subagent sessions are removed
- add regression coverage for both history paths

## Verification
- `gradlew.bat test --tests com.github.claudecodegui.provider.codex.CodexHistoryIndexServiceTest --tests com.github.claudecodegui.provider.codex.CodexHistoryReaderRefactorTest --tests com.github.claudecodegui.provider.codex.CodexSessionLiteReaderTest checkstyleMain`
- `gradlew.bat buildPlugin`