### PR TITLE
fix(webview): recover delayed bridge startup

### DIFF
--- a/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
@@ -53,8 +53,9 @@ public class WebviewInitializer {
 
     private static final Logger LOG = Logger.getInstance(WebviewInitializer.class);
     private static final String NODE_PATH_PROPERTY_KEY = "claude.code.node.path";
-    private static final int BRIDGE_INJECTION_RETRY_INTERVAL_MS = 100;
-    private static final int BRIDGE_INJECTION_MAX_ATTEMPTS = 50;
+    private static final int BRIDGE_INJECTION_FAST_RETRY_INTERVAL_MS = 100;
+    private static final int BRIDGE_INJECTION_SLOW_RETRY_INTERVAL_MS = 1000;
+    private static final int BRIDGE_INJECTION_FAST_RETRY_ATTEMPTS = 50;
 
     /**
      * Host interface providing access to window-level dependencies.
@@ -69,7 +70,8 @@ public class WebviewInitializer {
         JBCefBrowser getBrowser();
         void setBrowser(JBCefBrowser browser);
         boolean isDisposed();
-        void handleJavaScriptMessage(String message);
+        void activatePageGeneration(int pageGeneration);
+        void handleJavaScriptMessage(int pageGeneration, String message);
         WebviewWatchdog getWebviewWatchdog();
         boolean isFrontendReady();
         void setFrontendReady(boolean ready);
@@ -85,6 +87,7 @@ public class WebviewInitializer {
      * native callback handles during a watchdog recreation.
      */
     private volatile BrowserBridges bridges;
+    private int pageGeneration;
 
     public WebviewInitializer(WebviewHost host) {
         this.host = host;
@@ -226,9 +229,14 @@ public class WebviewInitializer {
             }
             currentBridges.jsQuery.addHandler((msg) -> {
                 boolean dispatch;
+                int pageGeneration;
+                String message;
                 synchronized (this.bridgeLock) {
-                    dispatch = !host.isDisposed() && this.bridges == currentBridges
-                            && currentBridges.isCurrentFor(createdBrowser);
+                    pageGeneration = currentBridges.getPageGeneration();
+                    message = unwrapBridgeMessage(msg, pageGeneration);
+                    dispatch = message != null && !host.isDisposed()
+                            && this.bridges == currentBridges
+                            && currentBridges.isCurrentPage(createdBrowser, pageGeneration);
                 }
                 // Dispatch outside bridgeLock: handleJavaScriptMessage serializes on the dispatch
                 // gate (MessageDispatchGate), not the host window, and dispose() runs
@@ -239,9 +247,9 @@ public class WebviewInitializer {
                 // that races this gap is caught by the gate: runInDispatch refuses once
                 // beginTeardown has flipped disposed.
                 if (dispatch) {
-                    host.handleJavaScriptMessage(msg);
+                    host.handleJavaScriptMessage(pageGeneration, message);
                 }
-                return new JBCefJSQuery.Response(dispatch ? "ok" : "closed");
+                return new JBCefJSQuery.Response(dispatch ? "ok" : "stale");
             });
 
             currentBridges.clipboardPathQuery.addHandler((msg) -> {
@@ -292,7 +300,10 @@ public class WebviewInitializer {
                 return new JBCefJSQuery.Response("ok");
             });
 
-            String htmlContent = loadChatHtmlWithInitialTabState();
+            int initialPageGeneration = beginPageLoad(currentBridges);
+            host.activatePageGeneration(initialPageGeneration);
+            host.setFrontendReady(false);
+            String htmlContent = loadChatHtmlWithInitialTabState(initialPageGeneration);
 
             // LoadHandler must be registered before loadHTML, otherwise the
             // first frame's onLoadEnd is missed and the JS bridge injection
@@ -313,25 +324,29 @@ public class WebviewInitializer {
                     String injection;
                     String shiftEscInjection;
                     String clipboardPathInjection;
+                    int pageGeneration;
                     synchronized (WebviewInitializer.this.bridgeLock) {
                         if (WebviewInitializer.this.bridges != currentBridges
                                 || !currentBridges.isCurrentFor(createdBrowser)) {
                             return;
                         }
-                        injection = "window.sendToJava = function(msg) { "
-                                + currentBridges.jsQuery.inject("msg") + " };";
-                        shiftEscInjection = buildShiftEscInjection(
-                                currentBridges.hidePanelQuery.inject("''",
-                                        "function() {}",
-                                        "function() {}"));
-                        clipboardPathInjection =
+                        pageGeneration = currentBridges.getPageGeneration();
+                        injection = guardPageScript(pageGeneration,
+                                buildBridgeInjection(currentBridges.jsQuery.inject(
+                                        buildBridgeMessageExpression(pageGeneration))));
+                        shiftEscInjection = guardPageScript(pageGeneration,
+                                buildShiftEscInjection(
+                                        currentBridges.hidePanelQuery.inject("''",
+                                                "function() {}",
+                                                "function() {}")));
+                        clipboardPathInjection = guardPageScript(pageGeneration,
                             "window.getClipboardFilePath = function() {" +
                             "  return new Promise((resolve) => {" +
                             "    " + currentBridges.clipboardPathQuery.inject("''",
                                 "function(response) { resolve(response); }",
                                 "function(error_code, error_message) { console.error('Failed to get clipboard path:', error_message); resolve(''); }") +
                             "  });" +
-                            "};";
+                            "};");
                     }
 
                     try {
@@ -365,7 +380,7 @@ public class WebviewInitializer {
                             cefBrowser.executeJavaScript(consoleForward, cefBrowser.getURL(), 0);
                         }
 
-                        injectFrontendConfiguration(cefBrowser);
+                        injectFrontendConfiguration(cefBrowser, pageGeneration);
 
                         LOG.debug("onLoadEnd completed, waiting for frontend_ready signal");
                     } catch (Exception | LinkageError e) {
@@ -380,7 +395,7 @@ public class WebviewInitializer {
             // registered, so it is safe to load the HTML - the first frame's
             // onLoadEnd will fire and inject the sendToJava bridge as expected.
             createdBrowser.loadHTML(htmlContent);
-            scheduleBridgeInjectionRetries(createdBrowser, currentBridges);
+            scheduleBridgeInjectionRetries(createdBrowser, currentBridges, initialPageGeneration);
 
             JComponent browserComponent = createdBrowser.getComponent();
 
@@ -468,25 +483,60 @@ public class WebviewInitializer {
 
     private void scheduleBridgeInjectionRetries(
             JBCefBrowser browser,
-            BrowserBridges currentBridges
+            BrowserBridges currentBridges,
+            int pageGeneration
     ) {
         AtomicInteger attempts = new AtomicInteger();
-        Timer timer = new Timer(BRIDGE_INJECTION_RETRY_INTERVAL_MS, null);
+        Timer timer = new Timer(BRIDGE_INJECTION_FAST_RETRY_INTERVAL_MS, null);
         timer.addActionListener(event -> {
             int attempt = attempts.incrementAndGet();
-            if (host.isDisposed() || host.isFrontendReady()
-                    || attempt > BRIDGE_INJECTION_MAX_ATTEMPTS) {
-                currentBridges.stopBridgeInjectionTimer();
+            if (host.isDisposed() || host.isFrontendReady()) {
+                currentBridges.stopBridgeInjectionTimer(timer);
                 return;
             }
-            if (!injectBridgeFallback(browser, currentBridges, attempt)) {
-                currentBridges.stopBridgeInjectionTimer();
+            timer.setDelay(bridgeInjectionRetryDelayMs(attempt + 1));
+            if (!injectBridgeFallback(browser, currentBridges, pageGeneration, attempt)) {
+                currentBridges.stopBridgeInjectionTimer(timer);
             }
         });
-        timer.setInitialDelay(BRIDGE_INJECTION_RETRY_INTERVAL_MS);
+        timer.setInitialDelay(BRIDGE_INJECTION_FAST_RETRY_INTERVAL_MS);
         currentBridges.setBridgeInjectionTimer(timer);
-        LOG.info("[JCEF] Scheduled fallback bridge injection retries for remote-mode startup");
+        LOG.info("[JCEF] Scheduled fallback bridge injection retries until frontend readiness");
         timer.start();
+    }
+
+    private int beginPageLoad(BrowserBridges expectedBridges) {
+        synchronized (this.bridgeLock) {
+            if (this.bridges != expectedBridges) {
+                throw new IllegalStateException("Cannot load a page for stale browser bridges");
+            }
+            int nextPageGeneration = nextPageGeneration();
+            expectedBridges.beginPageLoad(nextPageGeneration);
+            return nextPageGeneration;
+        }
+    }
+
+    private int invalidateCurrentPage() {
+        synchronized (this.bridgeLock) {
+            int nextPageGeneration = nextPageGeneration();
+            if (this.bridges != null) {
+                this.bridges.beginPageLoad(nextPageGeneration);
+            }
+            return nextPageGeneration;
+        }
+    }
+
+    int nextPageGeneration() {
+        synchronized (this.bridgeLock) {
+            this.pageGeneration += 1;
+            return this.pageGeneration;
+        }
+    }
+
+    static int bridgeInjectionRetryDelayMs(int attempt) {
+        return attempt <= BRIDGE_INJECTION_FAST_RETRY_ATTEMPTS
+                ? BRIDGE_INJECTION_FAST_RETRY_INTERVAL_MS
+                : BRIDGE_INJECTION_SLOW_RETRY_INTERVAL_MS;
     }
 
     /**
@@ -494,34 +544,38 @@ public class WebviewInitializer {
      * browser-scoped onLoadEnd callback. Retry the minimum bootstrap directly
      * in the active page so the frontend can establish its Java bridge and
      * request dependency status. The timer stops as soon as frontend_ready is
-     * received, or after a bounded five-second startup window.
+     * received. Retries slow down after the initial five-second startup window.
      */
     private boolean injectBridgeFallback(
             JBCefBrowser browser,
             BrowserBridges currentBridges,
+            int pageGeneration,
             int attempt
     ) {
         String bridgeInjection;
         String shiftEscInjection;
         String clipboardPathInjection;
         synchronized (this.bridgeLock) {
-            if (this.bridges != currentBridges || !currentBridges.isCurrentFor(browser)) {
+            if (this.bridges != currentBridges
+                    || !currentBridges.isCurrentPage(browser, pageGeneration)) {
                 return false;
             }
-            bridgeInjection = "window.sendToJava = function(msg) { "
-                    + currentBridges.jsQuery.inject("msg") + " };";
-            shiftEscInjection = buildShiftEscInjection(
-                    currentBridges.hidePanelQuery.inject("''",
-                            "function() {}",
-                            "function() {}"));
-            clipboardPathInjection =
+            bridgeInjection = guardPageScript(pageGeneration,
+                    buildBridgeInjection(currentBridges.jsQuery.inject(
+                            buildBridgeMessageExpression(pageGeneration))));
+            shiftEscInjection = guardPageScript(pageGeneration,
+                    buildShiftEscInjection(
+                            currentBridges.hidePanelQuery.inject("''",
+                                    "function() {}",
+                                    "function() {}")));
+            clipboardPathInjection = guardPageScript(pageGeneration,
                     "window.getClipboardFilePath = function() {" +
                     "  return new Promise((resolve) => {" +
                     "    " + currentBridges.clipboardPathQuery.inject("''",
                             "function(response) { resolve(response); }",
                             "function(error_code, error_message) { console.error('Failed to get clipboard path:', error_message); resolve(''); }") +
                     "  });" +
-                    "};";
+                    "};");
         }
 
         try {
@@ -531,14 +585,17 @@ public class WebviewInitializer {
             cefBrowser.executeJavaScript(shiftEscInjection, url, 0);
             cefBrowser.executeJavaScript(clipboardPathInjection, url, 0);
 
-            injectFrontendConfiguration(cefBrowser);
+            injectFrontendConfiguration(cefBrowser, pageGeneration);
             if (attempt == 1) {
                 LOG.info("[JCEF] Executed first fallback bridge injection for remote-mode startup");
             }
             return true;
-        } catch (Exception | LinkageError e) {
+        } catch (Exception e) {
             LOG.debug("Fallback bridge injection failed on attempt " + attempt + ": " + e.getMessage(), e);
-            return attempt < BRIDGE_INJECTION_MAX_ATTEMPTS;
+            return true;
+        } catch (LinkageError e) {
+            LOG.warn("Fallback bridge injection is unavailable: " + e.getMessage(), e);
+            return false;
         }
     }
 
@@ -553,6 +610,31 @@ public class WebviewInitializer {
                 "    }" +
                 "  }, true);" +
                 "}";
+    }
+
+    static String buildBridgeInjection(String queryInvocation) {
+        return "window.sendToJava = function(msg) { " + queryInvocation + " };"
+                + "if (typeof window.__ccgOnBridgeReady === 'function') {"
+                + "  window.__ccgOnBridgeReady();"
+                + "}";
+    }
+
+    static String buildBridgeMessageExpression(int pageGeneration) {
+        return "'__CCG_PAGE_GENERATION__:" + pageGeneration + ":' + String(msg)";
+    }
+
+    static String unwrapBridgeMessage(String message, int expectedPageGeneration) {
+        String prefix = "__CCG_PAGE_GENERATION__:" + expectedPageGeneration + ":";
+        if (message == null || !message.startsWith(prefix)) {
+            return null;
+        }
+        return message.substring(prefix.length());
+    }
+
+    static String guardPageScript(int pageGeneration, String script) {
+        return "if (window.__CCG_PAGE_GENERATION__ === " + pageGeneration + ") {"
+                + script
+                + "}";
     }
 
     static List<String> buildConfigurationInjections(
@@ -585,7 +667,7 @@ public class WebviewInitializer {
         );
     }
 
-    private void injectFrontendConfiguration(CefBrowser cefBrowser) {
+    private void injectFrontendConfiguration(CefBrowser cefBrowser, int pageGeneration) {
         String editorFontConfig = FontConfigService.getEditorFontConfigJson();
         String uiFontConfig = FontConfigService.getResolvedUiFontConfigJson(
                 host.getHandlerContext().getSettingsService());
@@ -595,11 +677,20 @@ public class WebviewInitializer {
                 host.getHandlerContext().getSettingsService());
         String url = cefBrowser.getURL();
 
-        for (String injection : buildConfigurationInjections(
-                editorFontConfig, uiFontConfig, codeFontConfig, languageConfig)) {
-            cefBrowser.executeJavaScript(injection, url, 0);
-        }
-        LOG.info("[WebviewConfigSync] Frontend configuration injected");
+        String configurationScript = joinConfigurationInjections(buildConfigurationInjections(
+                editorFontConfig, uiFontConfig, codeFontConfig, languageConfig));
+        String idempotentConfigurationScript =
+                "if (window.__CCG_CONFIG_GENERATION__ !== " + pageGeneration + ") {"
+                + configurationScript
+                + "window.__CCG_CONFIG_GENERATION__ = " + pageGeneration + ";"
+                + "}";
+        cefBrowser.executeJavaScript(
+                guardPageScript(pageGeneration, idempotentConfigurationScript), url, 0);
+        LOG.debug("[WebviewConfigSync] Frontend configuration injected");
+    }
+
+    static String joinConfigurationInjections(List<String> injections) {
+        return String.join(";", injections) + ";";
     }
 
     private JBCefJSQuery.Response handleClipboardPathRequest() {
@@ -926,17 +1017,22 @@ public class WebviewInitializer {
                 recreateWebview(reason + "_no_browser");
                 return;
             }
-            host.setFrontendReady(false);
             try {
                 LOG.info("[WebviewWatchdog] Reloading webview (" + reason + ")");
-                browser.loadHTML(loadChatHtmlWithInitialTabState());
                 BrowserBridges currentBridges;
+                int pageGeneration;
                 synchronized (this.bridgeLock) {
                     currentBridges = this.bridges;
+                    if (currentBridges == null || !currentBridges.belongsTo(browser)) {
+                        recreateWebview(reason + "_stale_bridges");
+                        return;
+                    }
+                    pageGeneration = beginPageLoad(currentBridges);
                 }
-                if (currentBridges != null && currentBridges.belongsTo(browser)) {
-                    scheduleBridgeInjectionRetries(browser, currentBridges);
-                }
+                host.activatePageGeneration(pageGeneration);
+                host.setFrontendReady(false);
+                browser.loadHTML(loadChatHtmlWithInitialTabState(pageGeneration));
+                scheduleBridgeInjectionRetries(browser, currentBridges, pageGeneration);
                 host.getWebviewWatchdog().resetTimestamps();
                 host.getMainPanel().revalidate();
                 host.getMainPanel().repaint();
@@ -947,7 +1043,7 @@ public class WebviewInitializer {
         });
     }
 
-    private String loadChatHtmlWithInitialTabState() {
+    private String loadChatHtmlWithInitialTabState(int pageGeneration) {
         HtmlLoader htmlLoader = host.getHtmlLoader();
         String htmlContent = htmlLoader.loadChatHtml();
 
@@ -957,7 +1053,8 @@ public class WebviewInitializer {
                 ? host.getHandlerContext().getSession() : null;
         String tabProvider = session != null ? session.getProvider() : null;
         String tabModel = session != null ? session.getModel() : null;
-        return htmlLoader.injectInitialTabState(htmlContent, tabProvider, tabModel);
+        String htmlWithTabState = htmlLoader.injectInitialTabState(htmlContent, tabProvider, tabModel);
+        return htmlLoader.injectPageGeneration(htmlWithTabState, pageGeneration);
     }
 
     /**
@@ -967,6 +1064,8 @@ public class WebviewInitializer {
         ApplicationManager.getApplication().invokeLater(() -> {
             if (host.isDisposed()) { return; }
 
+            int invalidationGeneration = invalidateCurrentPage();
+            host.activatePageGeneration(invalidationGeneration);
             host.setFrontendReady(false);
             JPanel mainPanel = host.getMainPanel();
             JBCefBrowser browser = host.getBrowser();
@@ -1035,6 +1134,7 @@ public class WebviewInitializer {
         private final JBCefJSQuery clipboardPathQuery;
         private final JBCefJSQuery hidePanelQuery;
         private Timer bridgeInjectionTimer;
+        private int pageGeneration;
 
         private BrowserBridges(JBCefBrowser browser) {
             this.browser = browser;
@@ -1057,6 +1157,15 @@ public class WebviewInitializer {
             this.hidePanelQuery = createdHidePanelQuery;
         }
 
+        private synchronized void beginPageLoad(int newPageGeneration) {
+            stopBridgeInjectionTimer();
+            this.pageGeneration = newPageGeneration;
+        }
+
+        private synchronized int getPageGeneration() {
+            return pageGeneration;
+        }
+
         private boolean belongsTo(JBCefBrowser browser) {
             return this.browser == browser;
         }
@@ -1070,6 +1179,10 @@ public class WebviewInitializer {
             return this.belongsTo(browser);
         }
 
+        private synchronized boolean isCurrentPage(JBCefBrowser browser, int expectedPageGeneration) {
+            return this.belongsTo(browser) && pageGeneration == expectedPageGeneration;
+        }
+
         private synchronized void setBridgeInjectionTimer(Timer timer) {
             stopBridgeInjectionTimer();
             this.bridgeInjectionTimer = timer;
@@ -1078,6 +1191,13 @@ public class WebviewInitializer {
         private synchronized void stopBridgeInjectionTimer() {
             if (this.bridgeInjectionTimer != null) {
                 this.bridgeInjectionTimer.stop();
+                this.bridgeInjectionTimer = null;
+            }
+        }
+
+        private synchronized void stopBridgeInjectionTimer(Timer expectedTimer) {
+            expectedTimer.stop();
+            if (this.bridgeInjectionTimer == expectedTimer) {
                 this.bridgeInjectionTimer = null;
             }
         }

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -760,7 +760,7 @@ public class ClaudeChatWindow {
         });
     }
 
-    void handleJavaScriptMessage(String message) {
+    void handleJavaScriptMessage(int pageGeneration, String message) {
         if (message == null) {
             return;
         }
@@ -770,7 +770,8 @@ public class ClaudeChatWindow {
         // gate monitor is held only across dispatch - dispose runs its heavy teardown (browser
         // disposal, process cleanup) outside it, so the JCEF thread never waits on the EDT. That
         // keeps the old dispatch/dispose lifecycle exclusion without the EDT<->JCEF deadlock.
-        this.dispatchGate.runInDispatch(() -> this.handleJavaScriptMessageLocked(message));
+        this.dispatchGate.runInDispatch(
+                pageGeneration, () -> this.handleJavaScriptMessageLocked(message));
     }
 
     /**
@@ -1475,8 +1476,13 @@ public class ClaudeChatWindow {
             }
 
             @Override
-            public void handleJavaScriptMessage(String msg) {
-                ClaudeChatWindow.this.handleJavaScriptMessage(msg);
+            public void activatePageGeneration(int pageGeneration) {
+                dispatchGate.activatePageGeneration(pageGeneration);
+            }
+
+            @Override
+            public void handleJavaScriptMessage(int pageGeneration, String msg) {
+                ClaudeChatWindow.this.handleJavaScriptMessage(pageGeneration, msg);
             }
 
             @Override

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/MessageDispatchGate.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/MessageDispatchGate.java
@@ -27,6 +27,7 @@ package com.github.claudecodegui.ui.toolwindow;
 public final class MessageDispatchGate {
 
     private boolean disposed = false;
+    private int activePageGeneration;
 
     /**
      * Run a dispatch section while holding the gate.
@@ -41,6 +42,32 @@ public final class MessageDispatchGate {
         }
         task.run();
         return true;
+    }
+
+    /**
+     * Run a webview dispatch only when it belongs to the active page load.
+     *
+     * @param pageGeneration generation carried by the webview bridge message.
+     * @param task dispatch work to run.
+     * @return {@code true} when the task ran; {@code false} for a stale page or after teardown.
+     */
+    public synchronized boolean runInDispatch(int pageGeneration, Runnable task) {
+        if (this.disposed || pageGeneration != this.activePageGeneration) {
+            return false;
+        }
+        task.run();
+        return true;
+    }
+
+    /**
+     * Activate a new page generation after any in-flight dispatch from the old page completes.
+     *
+     * @param pageGeneration generation assigned before the page is loaded.
+     */
+    public synchronized void activatePageGeneration(int pageGeneration) {
+        if (!this.disposed) {
+            this.activePageGeneration = pageGeneration;
+        }
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/util/HtmlLoader.java
+++ b/src/main/java/com/github/claudecodegui/util/HtmlLoader.java
@@ -128,6 +128,18 @@ public class HtmlLoader {
         return html;
     }
 
+    /** Injects the page generation before the frontend bundle executes. */
+    public String injectPageGeneration(String html, int pageGeneration) {
+        String scriptInjection = "\n    <script>window.__CCG_PAGE_GENERATION__ = "
+                + pageGeneration + ";</script>";
+        int headIndex = html.indexOf("<head>");
+        if (headIndex == -1) {
+            return html;
+        }
+        int insertPos = headIndex + "<head>".length();
+        return html.substring(0, insertPos) + scriptInjection + html.substring(insertPos);
+    }
+
     private static String escapeForSingleQuotedJs(String value) {
         // Restricted set — provider/model IDs only contain safe chars in
         // practice, but a malicious settings.json provider list could carry

--- a/src/test/java/com/github/claudecodegui/ui/WebviewInitializerTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/WebviewInitializerTest.java
@@ -5,6 +5,9 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 public class WebviewInitializerTest {
 
     @Test
@@ -30,5 +33,63 @@ public class WebviewInitializerTest {
         Assert.assertTrue(injection.contains("if (!window.__ccgShiftEscInstalled)"));
         Assert.assertTrue(injection.contains("window.__ccgShiftEscInstalled = true"));
         Assert.assertTrue(injection.contains("hidePanelQuery();"));
+    }
+
+    @Test
+    public void slowsBridgeInjectionRetriesAfterStartupWindow() {
+        int fastDelay = WebviewInitializer.bridgeInjectionRetryDelayMs(50);
+        int slowDelay = WebviewInitializer.bridgeInjectionRetryDelayMs(51);
+
+        Assert.assertEquals(fastDelay, WebviewInitializer.bridgeInjectionRetryDelayMs(1));
+        Assert.assertTrue(slowDelay > fastDelay);
+        Assert.assertEquals(slowDelay, WebviewInitializer.bridgeInjectionRetryDelayMs(500));
+    }
+
+    @Test
+    public void bridgeInjectionNotifiesFrontendBootstrapOnceBridgeExists() {
+        String injection = WebviewInitializer.buildBridgeInjection("query(msg);");
+
+        Assert.assertTrue(injection.contains("window.sendToJava = function(msg)"));
+        Assert.assertTrue(injection.contains("window.__ccgOnBridgeReady();"));
+    }
+
+    @Test
+    public void bridgeEnvelopeRejectsMessagesFromOtherPageGenerations() {
+        String expression = WebviewInitializer.buildBridgeMessageExpression(7);
+        String message = "__CCG_PAGE_GENERATION__:7:frontend_ready:";
+
+        Assert.assertTrue(expression.contains("__CCG_PAGE_GENERATION__:7:"));
+        assertEquals("frontend_ready:", WebviewInitializer.unwrapBridgeMessage(message, 7));
+        assertNull(WebviewInitializer.unwrapBridgeMessage(message, 8));
+        assertNull(WebviewInitializer.unwrapBridgeMessage("frontend_ready:", 7));
+    }
+
+    @Test
+    public void configurationInjectionsAreSeparatedAsStatements() {
+        String script = WebviewInitializer.joinConfigurationInjections(
+                List.of("first()", "second()"));
+
+        assertEquals("first();second();", script);
+    }
+
+    @Test
+    public void pageGuardRejectsScriptsForOtherGenerations() {
+        String injection = WebviewInitializer.guardPageScript(7, "bootstrap();");
+
+        Assert.assertTrue(injection.startsWith("if (window.__CCG_PAGE_GENERATION__ === 7)"));
+        Assert.assertTrue(injection.contains("bootstrap();"));
+    }
+
+    @Test
+    public void pageGenerationsDoNotRepeatAcrossBrowserRecreation() {
+        WebviewInitializer initializer = new WebviewInitializer(null);
+
+        int oldBrowserGeneration = initializer.nextPageGeneration();
+        int invalidationGeneration = initializer.nextPageGeneration();
+        int replacementBrowserGeneration = initializer.nextPageGeneration();
+
+        Assert.assertTrue(invalidationGeneration > oldBrowserGeneration);
+        Assert.assertTrue(replacementBrowserGeneration > invalidationGeneration);
+        Assert.assertNotEquals(oldBrowserGeneration, replacementBrowserGeneration);
     }
 }

--- a/src/test/java/com/github/claudecodegui/ui/WebviewWatchdogTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/WebviewWatchdogTest.java
@@ -63,6 +63,15 @@ public class WebviewWatchdogTest {
     }
 
     @Test
+    public void timestampResetDoesNotRestoreStartupRecoveryBudget() {
+        WebviewWatchdog watchdog = exhaustedWatchdog();
+
+        watchdog.resetTimestamps();
+
+        assertFalse(watchdog.tryAcquireRecoveryPermit(false));
+    }
+
+    @Test
     public void tabActivationRestoresStartupRecoveryBudget() {
         WebviewWatchdog watchdog = exhaustedWatchdog();
 

--- a/src/test/java/com/github/claudecodegui/ui/toolwindow/MessageDispatchGateTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/toolwindow/MessageDispatchGateTest.java
@@ -142,6 +142,37 @@ public class MessageDispatchGateTest {
         assertFalse(gate.isDisposed());
     }
 
+    @Test(timeout = 5000)
+    public void pageActivationWaitsForOldDispatchAndRejectsStaleMessages() throws Exception {
+        MessageDispatchGate gate = new MessageDispatchGate();
+        gate.activatePageGeneration(1);
+        CountDownLatch dispatchEntered = new CountDownLatch(1);
+        CountDownLatch releaseDispatch = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Boolean> dispatchFuture = executor.submit(() ->
+                    gate.runInDispatch(1, () -> {
+                        dispatchEntered.countDown();
+                        awaitUninterrupted(releaseDispatch);
+                    }));
+            assertTrue(dispatchEntered.await(2, TimeUnit.SECONDS));
+
+            Future<?> activationFuture = executor.submit(() -> gate.activatePageGeneration(2));
+            Thread.sleep(150);
+            assertFalse("page activation must wait for old dispatch", activationFuture.isDone());
+
+            releaseDispatch.countDown();
+            assertTrue(dispatchFuture.get(2, TimeUnit.SECONDS));
+            activationFuture.get(2, TimeUnit.SECONDS);
+
+            assertFalse(gate.runInDispatch(1, () -> { }));
+            assertTrue(gate.runInDispatch(2, () -> { }));
+        } finally {
+            executor.shutdownNow();
+            executor.awaitTermination(2, TimeUnit.SECONDS);
+        }
+    }
+
     private static void awaitUninterrupted(CountDownLatch latch) {
         try {
             latch.await();

--- a/src/test/java/com/github/claudecodegui/util/HtmlLoaderTest.java
+++ b/src/test/java/com/github/claudecodegui/util/HtmlLoaderTest.java
@@ -1,0 +1,21 @@
+package com.github.claudecodegui.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class HtmlLoaderTest {
+
+    @Test
+    public void injectsPageGenerationBeforeFrontendBundle() {
+        HtmlLoader loader = new HtmlLoader(HtmlLoaderTest.class);
+        String html = "<html><head><script src=\"main.js\"></script></head><body></body></html>";
+
+        String injected = loader.injectPageGeneration(html, 42);
+
+        int generationIndex = injected.indexOf("window.__CCG_PAGE_GENERATION__ = 42");
+        int bundleIndex = injected.indexOf("main.js");
+        assertTrue(generationIndex > 0);
+        assertTrue(generationIndex < bundleIndex);
+    }
+}

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -147,7 +147,7 @@ const App = () => {
   // ── Model/Provider state ──
   const {
     currentProvider, selectedModel, permissionMode,
-    selectedAgent, sdkStatusLoaded, currentSdkInstalled,
+    selectedAgent, sdkStatusLoading, sdkStatusError, currentSdkInstalled,
     claudeSdkMeetsMinimum,
     currentProviderRef,
     activeProviderConfig, claudeSettingsAlwaysThinkingEnabled,
@@ -160,7 +160,7 @@ const App = () => {
     setProviderConfigVersion, setActiveProviderConfig,
     setClaudeSettingsAlwaysThinkingEnabled, setStreamingEnabledSetting,
     setSendShortcut, setAutoOpenFileEnabled,
-    setSdkStatus, setSdkStatusLoaded, setSelectedAgent,
+    setSdkStatus, setSdkStatusLoaded, setSdkStatusError, retrySdkStatus, setSelectedAgent,
     setUsagePercentage, setUsageUsedTokens, setUsageMaxTokens,
     syncActiveProviderModelMapping,
     handleModeSelect, handleModelSelect, handleProviderSelect,
@@ -286,7 +286,7 @@ const App = () => {
     setProviderConfigVersion, setActiveProviderConfig,
     setClaudeSettingsAlwaysThinkingEnabled, setStreamingEnabledSetting,
     setSendShortcut, setAutoOpenFileEnabled,
-    setSdkStatus, setSdkStatusLoaded,
+    setSdkStatus, setSdkStatusLoaded, setSdkStatusError,
     setIsRewinding, setRewindDialogOpen, setCurrentRewindRequest,
     setContextInfo, setSelectedAgent,
     setSubagentHistories,
@@ -332,7 +332,7 @@ const App = () => {
   } = useMessageSender({
     t, addToast,
     currentProvider, selectedModel, permissionMode, reasoningEffort, selectedAgent, codexFastMode,
-    sdkStatusLoaded, currentSdkInstalled,
+    sdkStatusLoading, currentSdkInstalled,
     sentAttachmentsRef, chatInputRef, messagesContainerRef,
     isUserAtBottomRef, userPausedRef, isStreamingRef,
     setMessages, setLoading, setLoadingStartTime, setStreamingActive,
@@ -532,7 +532,9 @@ const App = () => {
           selectedModel={selectedModel}
           permissionMode={permissionMode}
           selectedAgent={selectedAgent}
-          sdkStatusLoaded={sdkStatusLoaded}
+          sdkStatusLoading={sdkStatusLoading}
+          sdkStatusError={sdkStatusError}
+          onRetrySdkStatus={retrySdkStatus}
           currentSdkInstalled={currentSdkInstalled}
           activeProviderConfig={activeProviderConfig}
           claudeSettingsAlwaysThinkingEnabled={claudeSettingsAlwaysThinkingEnabled}

--- a/webview/src/components/ChatInputBox/ChatInputBox.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBox.tsx
@@ -102,6 +102,8 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
       onToggleStatusPanel,
       sdkInstalled = true, // Default to true to avoid disabling input box on initial state
       sdkStatusLoading = false, // SDK status loading state
+      sdkStatusError = false,
+      onRetrySdkStatus,
       onInstallSdk,
       addToast,
       messageQueue,
@@ -590,8 +592,10 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
 
         <ChatInputBoxHeader
           sdkStatusLoading={sdkStatusLoading}
+          sdkStatusError={sdkStatusError}
           sdkInstalled={sdkInstalled}
           currentProvider={currentProvider}
+          onRetrySdkStatus={onRetrySdkStatus}
           onInstallSdk={onInstallSdk}
           t={t}
           attachments={attachments}

--- a/webview/src/components/ChatInputBox/ChatInputBoxHeader.test.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBoxHeader.test.tsx
@@ -1,0 +1,43 @@
+import type { ComponentProps } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ChatInputBoxHeader } from './ChatInputBoxHeader';
+
+vi.mock('../../contexts/UIStateContext', () => ({
+  useUIState: () => ({ addToast: vi.fn() }),
+}));
+
+const createProps = (): ComponentProps<typeof ChatInputBoxHeader> => ({
+  sdkInstalled: true,
+  sdkStatusLoading: false,
+  sdkStatusError: false,
+  currentProvider: 'codex',
+  t: ((key: string) => key) as never,
+  attachments: [],
+  onRemoveAttachment: vi.fn(),
+  usagePercentage: 0,
+  showUsage: false,
+  onAddAttachment: vi.fn(),
+  onClearAgent: vi.fn(),
+  hasMessages: false,
+  statusPanelExpanded: false,
+});
+
+describe('ChatInputBoxHeader SDK status', () => {
+  it('shows a retry action for query errors without showing the install warning', () => {
+    const onRetrySdkStatus = vi.fn();
+    render(
+      <ChatInputBoxHeader
+        {...createProps()}
+        sdkStatusError
+        onRetrySdkStatus={onRetrySdkStatus}
+      />,
+    );
+
+    expect(screen.getByText('chat.sdkStatusUnavailable')).toBeTruthy();
+    expect(screen.queryByText('chat.sdkNotInstalled')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'chat.retrySdkStatus' }));
+
+    expect(onRetrySdkStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/webview/src/components/ChatInputBox/ChatInputBoxHeader.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBoxHeader.tsx
@@ -10,8 +10,10 @@ const GITHUB_REPO_URL = 'https://github.com/zhukunpenglinyutong/jetbrains-cc-gui
 
 export function ChatInputBoxHeader({
   sdkStatusLoading,
+  sdkStatusError,
   sdkInstalled,
   currentProvider,
+  onRetrySdkStatus,
   onInstallSdk,
   t,
   attachments,
@@ -39,7 +41,9 @@ export function ChatInputBoxHeader({
 }: {
   sdkInstalled: boolean;
   sdkStatusLoading: boolean;
+  sdkStatusError: boolean;
   currentProvider: string;
+  onRetrySdkStatus?: () => void;
   onInstallSdk?: () => void;
   t: TFunction;
   attachments: Attachment[];
@@ -107,8 +111,8 @@ export function ChatInputBoxHeader({
         </div>
       )}
 
-      {/* SDK status loading or not installed warning bar */}
-      {(sdkStatusLoading || !sdkInstalled) && (
+      {/* SDK status loading, query error, or not installed warning bar */}
+      {(sdkStatusLoading || sdkStatusError || !sdkInstalled) && (
         <div className={`sdk-warning-bar ${sdkStatusLoading ? 'sdk-loading' : ''}`}>
           <span
             className={`codicon ${sdkStatusLoading ? 'codicon-loading codicon-modifier-spin' : 'codicon-warning'}`}
@@ -116,11 +120,24 @@ export function ChatInputBoxHeader({
           <span className="sdk-warning-text">
             {sdkStatusLoading
               ? t('chat.sdkStatusLoading')
+              : sdkStatusError
+                ? t('chat.sdkStatusUnavailable')
               : t('chat.sdkNotInstalled', {
                   provider: currentProvider === 'codex' ? 'Codex' : 'Claude Code',
                 })}
           </span>
-          {!sdkStatusLoading && (
+          {sdkStatusError ? (
+            <button
+              className="sdk-install-btn"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRetrySdkStatus?.();
+              }}
+            >
+              <span className="codicon codicon-refresh" />
+              <span>{t('chat.retrySdkStatus')}</span>
+            </button>
+          ) : !sdkStatusLoading && (
             <button
               className="sdk-install-btn"
               onClick={(e) => {
@@ -170,4 +187,3 @@ export function ChatInputBoxHeader({
     </>
   );
 }
-

--- a/webview/src/components/ChatInputBox/types.ts
+++ b/webview/src/components/ChatInputBox/types.ts
@@ -663,6 +663,10 @@ export interface ChatInputBoxProps {
   sdkInstalled?: boolean;
   /** SDK status loading state */
   sdkStatusLoading?: boolean;
+  /** SDK status query failed; chat remains available until the user retries */
+  sdkStatusError?: boolean;
+  /** Retry SDK status query callback */
+  onRetrySdkStatus?: () => void;
   /** Go to install SDK callback */
   onInstallSdk?: () => void;
   /** Show toast message */

--- a/webview/src/components/ChatScreen.tsx
+++ b/webview/src/components/ChatScreen.tsx
@@ -87,7 +87,9 @@ export interface ChatScreenProps {
   selectedModel: ProviderState['selectedModel'];
   permissionMode: ProviderState['permissionMode'];
   selectedAgent: ProviderState['selectedAgent'];
-  sdkStatusLoaded: ProviderState['sdkStatusLoaded'];
+  sdkStatusLoading: ProviderState['sdkStatusLoading'];
+  sdkStatusError: ProviderState['sdkStatusError'];
+  onRetrySdkStatus: ProviderState['retrySdkStatus'];
   currentSdkInstalled: ProviderState['currentSdkInstalled'];
   activeProviderConfig: ProviderState['activeProviderConfig'];
   claudeSettingsAlwaysThinkingEnabled: ProviderState['claudeSettingsAlwaysThinkingEnabled'];
@@ -137,7 +139,7 @@ export const ChatScreen = ({
   onSubmit, onInterrupt, onRewind,
   onNavigateToProviderSettings, onProviderSelect,
   currentProvider, selectedModel, permissionMode, selectedAgent,
-  sdkStatusLoaded, currentSdkInstalled,
+  sdkStatusLoading, sdkStatusError, onRetrySdkStatus, currentSdkInstalled,
   activeProviderConfig, claudeSettingsAlwaysThinkingEnabled,
   reasoningEffort, codexFastMode, streamingEnabledSetting, sendShortcut, autoOpenFileEnabled,
   longContextEnabled, usagePercentage, usageUsedTokens, usageMaxTokens,
@@ -323,7 +325,9 @@ export const ChatScreen = ({
           alwaysThinkingEnabled={activeProviderConfig?.settingsConfig?.alwaysThinkingEnabled ?? claudeSettingsAlwaysThinkingEnabled}
           placeholder={sendShortcut === 'cmdEnter' ? t('chat.inputPlaceholderCmdEnter') : t('chat.inputPlaceholderEnter')}
           sdkInstalled={currentSdkInstalled}
-          sdkStatusLoading={!sdkStatusLoaded}
+          sdkStatusLoading={sdkStatusLoading}
+          sdkStatusError={sdkStatusError !== null}
+          onRetrySdkStatus={onRetrySdkStatus}
           onInstallSdk={() => {
             setSettingsInitialTab('dependencies');
             setCurrentView('settings');

--- a/webview/src/components/settings/DependencySection/index.test.tsx
+++ b/webview/src/components/settings/DependencySection/index.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { requestDependencyStatusUntilSettled } from '../../../utils/bridgeStartup';
 import DependencySection from './index';
 
 const translations: Record<string, string> = {
@@ -48,6 +49,84 @@ describe('DependencySection', () => {
     window.sendToJava = vi.fn();
     window.__pendingDependencyUpdates = undefined;
     window.__pendingDependencyVersions = undefined;
+    window.__dependencyStatusState = 'pending';
+  });
+
+  afterEach(() => {
+    window.dispatchEvent(new Event('pagehide'));
+  });
+
+  it('shows an error state with manual retry instead of SDK install actions', () => {
+    render(<DependencySection isActive={false} />);
+
+    act(() => {
+      window.updateDependencyStatus?.(JSON.stringify({
+        success: false,
+        error: 'status unavailable',
+      }));
+    });
+
+    expect(screen.getByText('chat.sdkStatusUnavailable')).toBeTruthy();
+    expect(screen.queryByText('Claude Code SDK')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'chat.retrySdkStatus' }));
+
+    expect(window.sendToJava).toHaveBeenCalledWith('get_dependency_status:');
+    expect(screen.getByText(translations['settings.dependency.loading'])).toBeTruthy();
+  });
+
+  it('returns to loading when the dependency tab retries a previous error', () => {
+    const view = render(<DependencySection isActive={false} />);
+
+    act(() => {
+      window.updateDependencyStatus?.(JSON.stringify({
+        success: false,
+        error: 'status unavailable',
+      }));
+    });
+    expect(screen.getByText('chat.sdkStatusUnavailable')).toBeTruthy();
+
+    view.rerender(<DependencySection isActive />);
+
+    expect(screen.queryByText('chat.sdkStatusUnavailable')).toBeNull();
+    expect(screen.getByText(translations['settings.dependency.loading'])).toBeTruthy();
+  });
+
+  it('reuses the startup request while dependency status is pending', () => {
+    requestDependencyStatusUntilSettled();
+
+    render(<DependencySection isActive />);
+
+    const sendToJavaMock = vi.mocked(window.sendToJava!);
+    const statusRequests = sendToJavaMock.mock.calls
+      .filter(([message]) => message === 'get_dependency_status:');
+    expect(statusRequests).toHaveLength(1);
+  });
+
+  it('queues an installation refresh behind the active status request', async () => {
+    requestDependencyStatusUntilSettled();
+    render(<DependencySection isActive={false} />);
+
+    act(() => {
+      window.dependencyInstallResult?.(JSON.stringify({
+        success: true,
+        sdkId: 'claude-sdk',
+      }));
+    });
+
+    const sendToJavaMock = vi.mocked(window.sendToJava!);
+    const countStatusRequests = () => sendToJavaMock.mock.calls
+      .filter(([message]) => message === 'get_dependency_status:').length;
+    expect(countStatusRequests()).toBe(1);
+
+    await act(async () => {
+      window.updateDependencyStatus?.(JSON.stringify({
+        'claude-sdk': { status: 'installed' },
+      }));
+      await Promise.resolve();
+    });
+
+    expect(countStatusRequests()).toBe(2);
   });
 
   it('removes the custom version input and keeps a compact version selector with actions', () => {

--- a/webview/src/components/settings/DependencySection/index.tsx
+++ b/webview/src/components/settings/DependencySection/index.tsx
@@ -16,6 +16,13 @@ import {
   getRequestedVersion,
   getVersionAction,
 } from './versioning';
+import {
+  isDependencyStatusResponse,
+  requestFreshDependencyStatus,
+  requestDependencyStatusUntilSettled,
+  retryDependencyStatusRequest,
+  settleDependencyStatusRequest,
+} from '../../../utils/bridgeStartup';
 import styles from './style.module.less';
 
 interface DependencySectionProps {
@@ -158,6 +165,7 @@ const DependencySection = ({ addToast, isActive }: DependencySectionProps) => {
   const { t } = useTranslation();
   const [sdkStatus, setSdkStatus] = useState<Record<SdkId, SdkStatus>>({} as Record<SdkId, SdkStatus>);
   const [loading, setLoading] = useState(true);
+  const [statusError, setStatusError] = useState(false);
   const [installingSdk, setInstallingSdk] = useState<SdkId | null>(null);
   const [uninstallingSdk, setUninstallingSdk] = useState<SdkId | null>(null);
   const [updatingSdk, setUpdatingSdk] = useState<SdkId | null>(null);
@@ -218,12 +226,22 @@ const DependencySection = ({ addToast, isActive }: DependencySectionProps) => {
     window.updateDependencyStatus = (jsonStr: string) => {
       try {
         const status = JSON.parse(jsonStr);
-        setSdkStatus(status);
-        sdkStatusRef.current = status;
-        setLoading(false);
+        if (!isDependencyStatusResponse(status)) {
+          setStatusError(true);
+          setLoading(false);
+          settleDependencyStatusRequest('error');
+        } else {
+          setSdkStatus(status);
+          sdkStatusRef.current = status;
+          setStatusError(false);
+          setLoading(false);
+          settleDependencyStatusRequest('ready');
+        }
       } catch (error) {
         console.error('[DependencySection] Failed to parse dependency status:', error);
+        setStatusError(true);
         setLoading(false);
+        settleDependencyStatusRequest('error');
       }
       if (typeof savedUpdateDependencyStatus === 'function') {
         try { savedUpdateDependencyStatus(jsonStr); } catch (e) {
@@ -259,7 +277,9 @@ const DependencySection = ({ addToast, isActive }: DependencySectionProps) => {
           const sdkName = sdkDef ? tRef.current(sdkDef.nameKey) : result.sdkId;
           const msgKey = wasUpdating ? 'settings.dependency.updateSuccess' : 'settings.dependency.installSuccess';
           addToastRef.current?.(tRef.current(msgKey, { name: sdkName }), 'success');
-          sendToJava('get_dependency_status:');
+          setStatusError(false);
+          setLoading(true);
+          requestFreshDependencyStatus();
           sendToJava(`check_dependency_updates:${JSON.stringify({ id: result.sdkId })}`);
           sendToJava(`get_dependency_versions:${JSON.stringify({ id: result.sdkId })}`);
         } else if (result.error === 'node_not_configured') {
@@ -436,7 +456,13 @@ const DependencySection = ({ addToast, isActive }: DependencySectionProps) => {
       'claude-sdk': true,
       'codex-sdk': true,
     });
-    sendToJava('get_dependency_status:');
+    setStatusError(false);
+    setLoading(true);
+    if (window.__dependencyStatusState === 'pending') {
+      requestDependencyStatusUntilSettled();
+    } else {
+      retryDependencyStatusRequest();
+    }
     sendToJava('check_dependency_updates:');
     sendToJava('get_dependency_versions:');
     if (isNodePathReadyRef.current) {
@@ -513,6 +539,12 @@ const DependencySection = ({ addToast, isActive }: DependencySectionProps) => {
     return t('settings.dependency.updateToVersion', { version: `v${targetVersion}` });
   };
 
+  const handleRetryStatus = () => {
+    setStatusError(false);
+    setLoading(true);
+    retryDependencyStatusRequest();
+  };
+
   return (
     <div className={styles.dependencySection}>
       <h3 className={styles.sectionTitle}>{t('settings.dependency.title')}</h3>
@@ -538,6 +570,15 @@ const DependencySection = ({ addToast, isActive }: DependencySectionProps) => {
           <div className={styles.loadingState}>
             <span className="codicon codicon-loading codicon-modifier-spin" />
             <span>{t('settings.dependency.loading')}</span>
+          </div>
+        ) : statusError ? (
+          <div className={styles.loadingState}>
+            <span className="codicon codicon-warning" />
+            <span>{t('chat.sdkStatusUnavailable')}</span>
+            <button type="button" className={styles.retryButton} onClick={handleRetryStatus}>
+              <span className="codicon codicon-refresh" />
+              <span>{t('chat.retrySdkStatus')}</span>
+            </button>
           </div>
         ) : (
           SDK_DEFINITIONS.map((sdk) => {

--- a/webview/src/components/settings/DependencySection/style.module.less
+++ b/webview/src/components/settings/DependencySection/style.module.less
@@ -95,6 +95,23 @@
   }
 }
 
+.retryButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border: 1px solid var(--border-secondary);
+  border-radius: 4px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--border-hover);
+    background: var(--bg-tertiary);
+  }
+}
+
 .sdkCard {
   background: var(--bg-secondary);
   border: 1px solid var(--border-secondary);

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -941,7 +941,7 @@ interface Window {
    * Pending dependency status payload before React initialization
    */
   __pendingDependencyStatus?: string;
-  __dependencyStatusReady?: boolean;
+  __dependencyStatusState?: 'pending' | 'ready' | 'error';
   __ccgOnBridgeReady?: () => void;
 
   /**

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -941,6 +941,8 @@ interface Window {
    * Pending dependency status payload before React initialization
    */
   __pendingDependencyStatus?: string;
+  __dependencyStatusReady?: boolean;
+  __ccgOnBridgeReady?: () => void;
 
   /**
    * Pending streaming enabled status before React initialization

--- a/webview/src/hooks/providers/useUsageTracking.test.ts
+++ b/webview/src/hooks/providers/useUsageTracking.test.ts
@@ -1,0 +1,48 @@
+import { act, renderHook } from '@testing-library/react';
+import { retryDependencyStatusRequest } from '../../utils/bridgeStartup';
+import { useUsageTracking } from './useUsageTracking';
+
+vi.mock('../../utils/bridgeStartup', () => ({
+  DEPENDENCY_STATUS_REQUEST_STARTED_EVENT: 'ccg:dependency-status-request-started',
+  retryDependencyStatusRequest: vi.fn(),
+}));
+
+describe('useUsageTracking', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fails open after a status error and supports an explicit retry', () => {
+    const { result } = renderHook(() => useUsageTracking());
+
+    act(() => {
+      result.current.setSdkStatusError('status unavailable');
+    });
+
+    expect(result.current.sdkStatusLoading).toBe(false);
+    expect(result.current.isSdkInstalled('codex')).toBe(true);
+
+    act(() => {
+      result.current.retrySdkStatus();
+    });
+
+    expect(result.current.sdkStatusError).toBeNull();
+    expect(result.current.sdkStatusLoading).toBe(true);
+    expect(retryDependencyStatusRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let a later query error override an explicit not-installed status', () => {
+    const { result } = renderHook(() => useUsageTracking());
+
+    act(() => {
+      result.current.setSdkStatus({
+        'codex-sdk': { status: 'not_installed', installed: false },
+      });
+      result.current.setSdkStatusLoaded(false);
+      result.current.setSdkStatusError('status unavailable');
+    });
+
+    expect(result.current.isSdkStatusKnown('codex')).toBe(true);
+    expect(result.current.isSdkInstalled('codex')).toBe(false);
+  });
+});

--- a/webview/src/hooks/providers/useUsageTracking.ts
+++ b/webview/src/hooks/providers/useUsageTracking.ts
@@ -1,4 +1,8 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  DEPENDENCY_STATUS_REQUEST_STARTED_EVENT,
+  retryDependencyStatusRequest,
+} from '../../utils/bridgeStartup';
 
 const PROVIDER_TO_SDK: Record<string, string> = {
   claude: 'claude-sdk',
@@ -28,16 +32,48 @@ export function useUsageTracking() {
   const [usageMaxTokens, setUsageMaxTokens] = useState<number | undefined>(undefined);
   const [sdkStatus, setSdkStatus] = useState<SdkStatus>({});
   const [sdkStatusLoaded, setSdkStatusLoaded] = useState(false);
+  const [sdkStatusError, setSdkStatusError] = useState<string | null>(null);
+  const sdkStatusLoading = !sdkStatusLoaded && sdkStatusError === null;
+
+  useEffect(() => {
+    const handleStatusRequestStarted = () => {
+      setSdkStatusError(null);
+      setSdkStatusLoaded(false);
+    };
+    window.addEventListener(DEPENDENCY_STATUS_REQUEST_STARTED_EVENT, handleStatusRequestStarted);
+    return () => {
+      window.removeEventListener(DEPENDENCY_STATUS_REQUEST_STARTED_EVENT, handleStatusRequestStarted);
+    };
+  }, []);
 
   const isSdkInstalled = useCallback(
     (providerId: string): boolean => {
-      if (!sdkStatusLoaded) return false;
       const sdkId = PROVIDER_TO_SDK[providerId] || 'claude-sdk';
       const status = sdkStatus[sdkId];
-      return status?.status === 'installed' || status?.installed === true;
+      if (status?.status === 'installed' || status?.installed === true) return true;
+      if (status?.status === 'not_installed' || status?.installed === false) return false;
+      // A failed query means "unknown", not "not installed". Let chat proceed;
+      // the backend will still report an actionable SDK startup error if needed.
+      if (sdkStatusError !== null) return true;
+      if (!sdkStatusLoaded) return false;
+      return false;
     },
-    [sdkStatusLoaded, sdkStatus],
+    [sdkStatusError, sdkStatusLoaded, sdkStatus],
   );
+
+  const isSdkStatusKnown = useCallback((providerId: string): boolean => {
+    const sdkId = PROVIDER_TO_SDK[providerId] || 'claude-sdk';
+    const status = sdkStatus[sdkId];
+    return status?.status === 'installed'
+      || status?.status === 'not_installed'
+      || typeof status?.installed === 'boolean';
+  }, [sdkStatus]);
+
+  const retrySdkStatus = useCallback(() => {
+    setSdkStatusError(null);
+    setSdkStatusLoaded(false);
+    retryDependencyStatusRequest();
+  }, []);
 
   return {
     usagePercentage,
@@ -50,7 +86,12 @@ export function useUsageTracking() {
     setSdkStatus,
     sdkStatusLoaded,
     setSdkStatusLoaded,
+    sdkStatusLoading,
+    sdkStatusError,
+    setSdkStatusError,
+    retrySdkStatus,
     isSdkInstalled,
+    isSdkStatusKnown,
   };
 }
 

--- a/webview/src/hooks/useMessageSender.context.test.ts
+++ b/webview/src/hooks/useMessageSender.context.test.ts
@@ -14,7 +14,7 @@ describe('useMessageSender - /context command', () => {
     reasoningEffort: 'high',
     codexFastMode: 'normal',
     selectedAgent: null,
-    sdkStatusLoaded: true,
+    sdkStatusLoading: false,
     currentSdkInstalled: true,
     sentAttachmentsRef: { current: new Map() },
     chatInputRef: { current: null },

--- a/webview/src/hooks/useMessageSender.ts
+++ b/webview/src/hooks/useMessageSender.ts
@@ -43,7 +43,7 @@ export interface UseMessageSenderOptions {
   reasoningEffort: ReasoningEffort;
   codexFastMode: CodexFastMode;
   selectedAgent: SelectedAgent | null;
-  sdkStatusLoaded: boolean;
+  sdkStatusLoading: boolean;
   currentSdkInstalled: boolean;
   sentAttachmentsRef: RefObject<Map<string, Array<{ fileName: string; mediaType: string }>>>;
   chatInputRef: RefObject<ChatInputBoxHandle | null>;
@@ -76,7 +76,7 @@ export function useMessageSender({
   reasoningEffort,
   codexFastMode,
   selectedAgent,
-  sdkStatusLoaded,
+  sdkStatusLoading,
   currentSdkInstalled,
   sentAttachmentsRef,
   chatInputRef,
@@ -318,7 +318,7 @@ export function useMessageSender({
     if (!text && !hasAttachments) return;
 
     // Check SDK status
-    if (!sdkStatusLoaded) {
+    if (sdkStatusLoading) {
       addToast(t('chat.sdkStatusLoading'), 'info');
       return;
     }
@@ -397,7 +397,7 @@ export function useMessageSender({
     // Send message to backend
     sendMessageToBackend(text, attachments, agentInfo, fileTagsInfo, permissionMode);
   }, [
-    sdkStatusLoaded,
+    sdkStatusLoading,
     currentSdkInstalled,
     currentProvider,
     permissionMode,

--- a/webview/src/hooks/useModelProviderState.ts
+++ b/webview/src/hooks/useModelProviderState.ts
@@ -49,7 +49,7 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
   // ── Provider-specific sub-hooks ──
   const claude = useClaudeProvider();
   const codex = useCodexProvider();
-  const { isSdkInstalled, sdkStatus, ...usage } = useUsageTracking();
+  const { isSdkInstalled, isSdkStatusKnown, sdkStatus, ...usage } = useUsageTracking();
   const settings = useProviderSettings({ addToast, t });
 
   const {
@@ -91,6 +91,12 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
   const currentSdkInstalled = useMemo(
     () => isSdkInstalled(currentProvider),
     [isSdkInstalled, currentProvider],
+  );
+  const currentSdkStatusError = useMemo(
+    () => usage.sdkStatusError !== null && !isSdkStatusKnown(currentProvider)
+      ? usage.sdkStatusError
+      : null,
+    [currentProvider, isSdkStatusKnown, usage.sdkStatusError],
   );
   // Whether the installed Claude SDK meets the minimum version required for the
   // selected model's tier (Fable needs >= 0.3.182). `undefined` means the backend
@@ -198,6 +204,7 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
     ...usage,
     ...settings,
     sdkStatus,
+    sdkStatusError: currentSdkStatusError,
     currentProvider, setCurrentProvider,
     permissionMode, setPermissionMode,
     selectedModel,

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -51,6 +51,7 @@ describe('useWindowCallbacks integration', () => {
     setPermissionDialogTimeoutSeconds: vi.fn(),
     setSdkStatus: vi.fn(),
     setSdkStatusLoaded: vi.fn(),
+    setSdkStatusError: vi.fn(),
     setIsRewinding: vi.fn(),
     setRewindDialogOpen: vi.fn(),
     setCurrentRewindRequest: vi.fn(),
@@ -111,10 +112,14 @@ describe('useWindowCallbacks integration', () => {
     window.__pendingSessionTransitionToast = undefined;
     window.__deniedToolIds = new Set();
     window.sendToJava = vi.fn();
+    window.updateDependencyStatus = undefined;
+    delete (window as unknown as Record<string, unknown>)._appUpdateDependencyStatus;
     // The drain test inspects this slot; if a prior test (or earlier suite run)
     // leaked a value onto window we'd see a false-positive drain. Wipe it here
     // so each test starts from a clean pending state.
     delete (window as unknown as Record<string, unknown>).__pendingPermissionDialogTimeout;
+    delete (window as unknown as Record<string, unknown>).__pendingDependencyStatus;
+    window.__dependencyStatusState = 'pending';
   });
 
   /** Stub timer/rAF globals to execute synchronously for streaming tests. */
@@ -130,6 +135,53 @@ describe('useWindowCallbacks integration', () => {
     });
     vi.stubGlobal('cancelAnimationFrame', vi.fn());
   };
+
+  it('settles dependency status errors without reporting an SDK installation state', () => {
+    const opts = createOptions();
+    renderHook(() => useWindowCallbacks(opts));
+
+    act(() => {
+      window.updateDependencyStatus?.(JSON.stringify({
+        success: false,
+        error: 'status unavailable',
+      }));
+    });
+
+    expect(opts.setSdkStatus).not.toHaveBeenCalled();
+    expect(opts.setSdkStatusLoaded).toHaveBeenCalledWith(false);
+    expect(opts.setSdkStatusError).toHaveBeenCalledWith('status unavailable');
+    expect(window.__dependencyStatusState).toBe('error');
+  });
+
+  it('clears a dependency status error after a valid response', () => {
+    const opts = createOptions();
+    renderHook(() => useWindowCallbacks(opts));
+    const status = {
+      'codex-sdk': { status: 'installed' },
+    };
+
+    act(() => {
+      window.updateDependencyStatus?.(JSON.stringify(status));
+    });
+
+    expect(opts.setSdkStatus).toHaveBeenCalledWith(status);
+    expect(opts.setSdkStatusLoaded).toHaveBeenCalledWith(true);
+    expect(opts.setSdkStatusError).toHaveBeenCalledWith(null);
+    expect(window.__dependencyStatusState).toBe('ready');
+  });
+
+  it('settles malformed dependency status payloads as errors', () => {
+    const opts = createOptions();
+    renderHook(() => useWindowCallbacks(opts));
+
+    act(() => {
+      window.updateDependencyStatus?.('{invalid');
+    });
+
+    expect(opts.setSdkStatusLoaded).toHaveBeenCalledWith(false);
+    expect(opts.setSdkStatusError).toHaveBeenCalledWith(expect.any(String));
+    expect(window.__dependencyStatusState).toBe('error');
+  });
 
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/webview/src/hooks/useWindowCallbacks.ts
+++ b/webview/src/hooks/useWindowCallbacks.ts
@@ -52,6 +52,7 @@ export interface UseWindowCallbacksOptions {
   setPermissionDialogTimeoutSeconds: React.Dispatch<React.SetStateAction<number>>;
   setSdkStatus: React.Dispatch<React.SetStateAction<Record<string, { installed?: boolean; status?: string }>>>;
   setSdkStatusLoaded: React.Dispatch<React.SetStateAction<boolean>>;
+  setSdkStatusError: React.Dispatch<React.SetStateAction<string | null>>;
   setIsRewinding: (loading: boolean) => void;
   setRewindDialogOpen: (open: boolean) => void;
   setCurrentRewindRequest: (request: RewindRequest | null) => void;

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/sessionCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/sessionCallbacks.ts
@@ -10,9 +10,12 @@ import type { MutableRefObject } from 'react';
 import type { UseWindowCallbacksOptions } from '../../useWindowCallbacks';
 import { downloadJSON } from '../../../utils/exportMarkdown';
 import { releaseSessionTransition } from '../sessionTransition';
-import { drainAndRequestDependencyStatus } from '../settingsBootstrap';
+import { drainPendingDependencyStatus } from '../settingsBootstrap';
 import { sendBridgeEvent } from '../../../utils/bridge';
-import { isDependencyStatusResponse } from '../../../utils/bridgeStartup';
+import {
+  isDependencyStatusResponse,
+  settleDependencyStatusRequest,
+} from '../../../utils/bridgeStartup';
 
 // Matches session-titles-service.cjs#updateTitle, which rejects longer titles.
 const CUSTOM_TITLE_MAX_LENGTH = 50;
@@ -26,6 +29,7 @@ export function registerSessionAndSdkCallbacks(
     setCurrentSessionId,
     setSdkStatus,
     setSdkStatusLoaded,
+    setSdkStatusError,
     setIsRewinding,
     setRewindDialogOpen,
     setCurrentRewindRequest,
@@ -95,13 +99,23 @@ export function registerSessionAndSdkCallbacks(
       const data = JSON.parse(jsonStr);
       if (!isDependencyStatusResponse(data)) {
         console.error('[Frontend] Dependency status request failed:', data);
+        const error = typeof data.error === 'string' && data.error.trim()
+          ? data.error
+          : 'dependency_status_unavailable';
+        setSdkStatusLoaded(false);
+        setSdkStatusError(error);
+        settleDependencyStatusRequest('error');
         return;
       }
       setSdkStatus(data);
       setSdkStatusLoaded(true);
-      window.__dependencyStatusReady = true;
+      setSdkStatusError(null);
+      settleDependencyStatusRequest('ready');
     } catch (error) {
       console.error('[Frontend] Failed to parse dependency status:', error);
+      setSdkStatusLoaded(false);
+      setSdkStatusError(error instanceof Error ? error.message : 'invalid_dependency_status');
+      settleDependencyStatusRequest('error');
     }
     if (
       originalUpdateDependencyStatus &&
@@ -113,7 +127,7 @@ export function registerSessionAndSdkCallbacks(
   (window as unknown as Record<string, unknown>)._appUpdateDependencyStatus =
     window.updateDependencyStatus;
 
-  drainAndRequestDependencyStatus();
+  drainPendingDependencyStatus();
 
   // =========================================================================
   // Rewind Result Callback

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/sessionCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/sessionCallbacks.ts
@@ -12,6 +12,7 @@ import { downloadJSON } from '../../../utils/exportMarkdown';
 import { releaseSessionTransition } from '../sessionTransition';
 import { drainAndRequestDependencyStatus } from '../settingsBootstrap';
 import { sendBridgeEvent } from '../../../utils/bridge';
+import { isDependencyStatusResponse } from '../../../utils/bridgeStartup';
 
 // Matches session-titles-service.cjs#updateTitle, which rejects longer titles.
 const CUSTOM_TITLE_MAX_LENGTH = 50;
@@ -92,8 +93,13 @@ export function registerSessionAndSdkCallbacks(
   window.updateDependencyStatus = (jsonStr: string) => {
     try {
       const data = JSON.parse(jsonStr);
+      if (!isDependencyStatusResponse(data)) {
+        console.error('[Frontend] Dependency status request failed:', data);
+        return;
+      }
       setSdkStatus(data);
       setSdkStatusLoaded(true);
+      window.__dependencyStatusReady = true;
     } catch (error) {
       console.error('[Frontend] Failed to parse dependency status:', error);
     }

--- a/webview/src/hooks/windowCallbacks/settingsBootstrap.ts
+++ b/webview/src/hooks/windowCallbacks/settingsBootstrap.ts
@@ -160,9 +160,10 @@ export const drainPendingSettings = (): void => {
 
 /**
  * Drain any dependency-status payload that arrived before the callback was
- * registered, then trigger a fresh fetch.
+ * registered. The startup poller in main.tsx owns the initial request so this
+ * callback registration cannot create a duplicate in-flight query.
  */
-export const drainAndRequestDependencyStatus = (): void => {
+export const drainPendingDependencyStatus = (): void => {
   if (typeof window === 'undefined') {
     return;
   }
@@ -173,9 +174,5 @@ export const drainAndRequestDependencyStatus = (): void => {
     const pending = w.__pendingDependencyStatus as string;
     delete w.__pendingDependencyStatus;
     window.updateDependencyStatus?.(pending);
-  }
-
-  if (window.sendToJava) {
-    window.sendToJava('get_dependency_status:');
   }
 };

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -98,6 +98,8 @@
     "disabled": "Disabled",
     "sdkNotInstalled": "{{provider}} SDK is not installed. Please install the SDK to start chatting.",
     "sdkStatusLoading": "Checking SDK status...",
+    "sdkStatusUnavailable": "Could not check SDK status.",
+    "retrySdkStatus": "Retry",
     "openSourceBanner": "This project is guaranteed to be 100% open source and free (beware of pirated projects)",
     "openSourceBannerStar": "Star",
     "openSourceBannerStarToast": "Repo link copied to clipboard — paste it in your browser to visit ⭐",

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -81,6 +81,8 @@
     "disabled": "Deshabilitado",
     "sdkNotInstalled": "{{provider}} SDK no está instalado. Instala el SDK para comenzar a chatear.",
     "sdkStatusLoading": "Checking SDK status...",
+    "sdkStatusUnavailable": "No se pudo comprobar el estado del SDK.",
+    "retrySdkStatus": "Reintentar",
     "openSourceBanner": "Este proyecto garantiza ser 100% de código abierto y gratuito (cuidado con los proyectos pirateados)",
     "openSourceBannerStar": "Star",
     "openSourceBannerStarToast": "Enlace copiado al portapapeles — pégalo en el navegador para acceder ⭐",

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -81,6 +81,8 @@
     "disabled": "Désactivé",
     "sdkNotInstalled": "{{provider}} SDK n'est pas installé. Veuillez installer le SDK pour commencer à discuter.",
     "sdkStatusLoading": "Checking SDK status...",
+    "sdkStatusUnavailable": "Impossible de vérifier l'état du SDK.",
+    "retrySdkStatus": "Réessayer",
     "openSourceBanner": "Ce projet est garanti 100% open source et gratuit (méfiez-vous des projets piratés)",
     "openSourceBannerStar": "Star",
     "openSourceBannerStarToast": "Lien copié dans le presse-papiers — collez-le dans votre navigateur pour y accéder ⭐",

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -81,6 +81,8 @@
     "disabled": "अक्षम",
     "sdkNotInstalled": "{{provider}} SDK इंस्टॉल नहीं है। चैट शुरू करने के लिए कृपया SDK इंस्टॉल करें।",
     "sdkStatusLoading": "Checking SDK status...",
+    "sdkStatusUnavailable": "SDK स्थिति की जांच नहीं हो सकी।",
+    "retrySdkStatus": "पुनः प्रयास करें",
     "openSourceBanner": "यह प्रोजेक्ट 100% ओपन सोर्स और मुफ़्त है (नकली प्रोजेक्ट से सावधान रहें)",
     "openSourceBannerStar": "Star",
     "openSourceBannerStarToast": "रिपॉजिटरी लिंक क्लिपबोर्ड पर कॉपी हो गया — ब्राउज़र में पेस्ट करके खोलें ⭐",

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -81,6 +81,8 @@
     "disabled": "無効",
     "sdkNotInstalled": "{{provider}} SDKがインストールされていません。チャットを開始するにはSDKをインストールしてください。",
     "sdkStatusLoading": "Checking SDK status...",
+    "sdkStatusUnavailable": "SDK の状態を確認できませんでした。",
+    "retrySdkStatus": "再試行",
     "openSourceBanner": "このプロジェクトは100%オープンソースかつ無料を保証します（海賊版プロジェクトにご注意ください）",
     "openSourceBannerStar": "Star",
     "openSourceBannerStarToast": "リポジトリのURLをクリップボードにコピーしました。ブラウザに貼り付けてアクセスできます ⭐",

--- a/webview/src/i18n/locales/ko.json
+++ b/webview/src/i18n/locales/ko.json
@@ -81,6 +81,8 @@
     "disabled": "비활성화됨",
     "sdkNotInstalled": "{{provider}} SDK가 설치되어 있지 않습니다. 채팅을 시작하려면 SDK를 설치해주세요.",
     "sdkStatusLoading": "SDK 상태 확인 중...",
+    "sdkStatusUnavailable": "SDK 상태를 확인할 수 없습니다.",
+    "retrySdkStatus": "다시 시도",
     "openSourceBanner": "이 프로젝트는 100% 오픈소스이며 무료입니다 (유사품에 주의하세요)",
     "openSourceBannerStar": "Star",
     "openSourceBannerStarToast": "저장소 주소를 클립보드에 복사했습니다. 브라우저에 붙여넣어 방문하세요 ⭐",

--- a/webview/src/i18n/locales/pt-BR.json
+++ b/webview/src/i18n/locales/pt-BR.json
@@ -81,6 +81,8 @@
     "disabled": "Desativado",
     "sdkNotInstalled": "O SDK de {{provider}} não está instalado. Por favor, instale o SDK para iniciar o chat.",
     "sdkStatusLoading": "Verificando status do SDK...",
+    "sdkStatusUnavailable": "Não foi possível verificar o status do SDK.",
+    "retrySdkStatus": "Tentar novamente",
     "openSourceBanner": "Este projeto é garantidamente 100% open source e gratuito (cuidado com projetos piratas)",
     "openSourceBannerStar": "Star",
     "openSourceBannerStarToast": "Link copiado para a área de transferência — cole no navegador para acessar ⭐",

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -81,6 +81,8 @@
     "disabled": "Отключено",
     "sdkNotInstalled": "SDK {{provider}} не установлен. Установите SDK для начала работы.",
     "sdkStatusLoading": "Проверка статуса SDK...",
+    "sdkStatusUnavailable": "Не удалось проверить состояние SDK.",
+    "retrySdkStatus": "Повторить",
     "openSourceBanner": "Этот проект гарантированно 100% с открытым исходным кодом и бесплатный (остерегайтесь пиратских проектов)",
     "openSourceBannerStar": "Star",
     "openSourceBannerStarToast": "Ссылка скопирована в буфер обмена — вставьте её в браузере, чтобы открыть ⭐",

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -81,6 +81,8 @@
     "disabled": "已停用",
     "sdkNotInstalled": "{{provider}} SDK 尚未安裝，請先安裝 SDK 才能開始對話",
     "sdkStatusLoading": "Checking SDK status...",
+    "sdkStatusUnavailable": "無法檢查 SDK 狀態。",
+    "retrySdkStatus": "重試",
     "openSourceBanner": "本專案保證100%開源和免費（謹防盜版項目）",
     "openSourceBannerStar": "點個 Star",
     "openSourceBannerStarToast": "已複製倉庫地址到剪貼簿，複製到瀏覽器即可訪問 ⭐",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -98,6 +98,8 @@
     "disabled": "已停用",
     "sdkNotInstalled": "{{provider}} SDK 尚未安装，请先安装 SDK 才能开始对话",
     "sdkStatusLoading": "正在检查 SDK 状态...",
+    "sdkStatusUnavailable": "无法检查 SDK 状态。",
+    "retrySdkStatus": "重试",
     "openSourceBanner": "本项目保证100%开源和免费（谨防盗版项目）",
     "openSourceBannerStar": "点个 Star",
     "openSourceBannerStarToast": "已复制仓库地址到剪切板，复制到浏览器即可访问 ⭐",

--- a/webview/src/main.tsx
+++ b/webview/src/main.tsx
@@ -17,6 +17,7 @@ import { installRuntimeProviderDispatchers } from './utils/runtimeProviderCapabi
 import { sendBridgeEvent } from './utils/bridge';
 import { debugLog } from './utils/debug';
 import { forceWebviewRepaint } from './utils/forceWebviewRepaint';
+import { requestDependencyStatusUntilReady, waitForBridge } from './utils/bridgeStartup';
 import type { UiFontConfig, CodeFontConfig } from './types/uiFontConfig';
 
 // Silence noisy console output in production (including third-party libs).
@@ -582,6 +583,7 @@ if (typeof window !== 'undefined' && !window.setSessionId) {
 
 // Pre-register updateDependencyStatus to handle backend status responses that arrive before React initializes
 if (typeof window !== 'undefined' && !window.updateDependencyStatus) {
+  window.__dependencyStatusReady = false;
   debugLog('[Main] Pre-registering updateDependencyStatus placeholder');
   window.updateDependencyStatus = (json: string) => {
     debugLog('[Main] Storing pending dependency status, length=' + (json ? json.length : 0));
@@ -692,24 +694,6 @@ ReactDOM.createRoot(document.getElementById('app') as HTMLElement).render(
  */
 setupScaleRecovery();
 
-function waitForBridge(callback: () => void, maxAttempts = 50, interval = 100) {
-  let attempts = 0;
-
-  const check = () => {
-    attempts++;
-    if (window.sendToJava) {
-      debugLog('[Main] Bridge available after ' + attempts + ' attempts');
-      callback();
-    } else if (attempts < maxAttempts) {
-      setTimeout(check, interval);
-    } else {
-      console.error('[Main] Bridge not available after ' + maxAttempts + ' attempts');
-    }
-  };
-
-  check();
-}
-
 // Once the bridge is available, initialize slash commands
 waitForBridge(() => {
   debugLog('[Main] Bridge ready, setting up slash commands');
@@ -725,7 +709,7 @@ waitForBridge(() => {
 
   // Ensure SDK dependency status is fetched on initial load (not only after opening Settings).
   debugLog('[Main] Requesting dependency status');
-  sendBridgeEvent('get_dependency_status');
+  requestDependencyStatusUntilReady();
 
   sendBridgeEvent('get_linkify_capabilities');
 });

--- a/webview/src/main.tsx
+++ b/webview/src/main.tsx
@@ -17,7 +17,7 @@ import { installRuntimeProviderDispatchers } from './utils/runtimeProviderCapabi
 import { sendBridgeEvent } from './utils/bridge';
 import { debugLog } from './utils/debug';
 import { forceWebviewRepaint } from './utils/forceWebviewRepaint';
-import { requestDependencyStatusUntilReady, waitForBridge } from './utils/bridgeStartup';
+import { requestDependencyStatusUntilSettled, waitForBridge } from './utils/bridgeStartup';
 import type { UiFontConfig, CodeFontConfig } from './types/uiFontConfig';
 
 // Silence noisy console output in production (including third-party libs).
@@ -583,7 +583,7 @@ if (typeof window !== 'undefined' && !window.setSessionId) {
 
 // Pre-register updateDependencyStatus to handle backend status responses that arrive before React initializes
 if (typeof window !== 'undefined' && !window.updateDependencyStatus) {
-  window.__dependencyStatusReady = false;
+  window.__dependencyStatusState = 'pending';
   debugLog('[Main] Pre-registering updateDependencyStatus placeholder');
   window.updateDependencyStatus = (json: string) => {
     debugLog('[Main] Storing pending dependency status, length=' + (json ? json.length : 0));
@@ -709,7 +709,7 @@ waitForBridge(() => {
 
   // Ensure SDK dependency status is fetched on initial load (not only after opening Settings).
   debugLog('[Main] Requesting dependency status');
-  requestDependencyStatusUntilReady();
+  requestDependencyStatusUntilSettled();
 
   sendBridgeEvent('get_linkify_capabilities');
 });

--- a/webview/src/utils/bridgeStartup.test.ts
+++ b/webview/src/utils/bridgeStartup.test.ts
@@ -1,0 +1,72 @@
+import {
+  isDependencyStatusResponse,
+  requestDependencyStatusUntilReady,
+  waitForBridge,
+} from './bridgeStartup';
+
+describe('bridge startup recovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    delete window.sendToJava;
+    delete window.__ccgOnBridgeReady;
+    window.__dependencyStatusReady = false;
+  });
+
+  afterEach(() => {
+    window.dispatchEvent(new Event('pagehide'));
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('bootstraps once when the bridge appears after the fast retry window', () => {
+    const callback = vi.fn();
+    waitForBridge(callback);
+    const bridgeReady = window.__ccgOnBridgeReady;
+
+    vi.advanceTimersByTime(6000);
+    expect(callback).not.toHaveBeenCalled();
+
+    window.sendToJava = vi.fn();
+    bridgeReady?.();
+    bridgeReady?.();
+    vi.runOnlyPendingTimers();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(window.__ccgOnBridgeReady).toBeUndefined();
+  });
+
+  it('cancels bridge polling when the page is hidden', () => {
+    const callback = vi.fn();
+    waitForBridge(callback);
+
+    window.dispatchEvent(new Event('pagehide'));
+    window.sendToJava = vi.fn();
+    vi.runOnlyPendingTimers();
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(window.__ccgOnBridgeReady).toBeUndefined();
+  });
+
+  it('stops dependency status retries after a valid response', () => {
+    const sendToJava = vi.fn();
+    window.sendToJava = sendToJava;
+    requestDependencyStatusUntilReady();
+
+    expect(sendToJava).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(2000);
+    expect(sendToJava).toHaveBeenCalledTimes(2);
+
+    window.__dependencyStatusReady = true;
+    vi.advanceTimersByTime(2000);
+    vi.runOnlyPendingTimers();
+
+    expect(sendToJava).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects backend error payloads as dependency status responses', () => {
+    expect(isDependencyStatusResponse({ 'claude-sdk': { installed: true } })).toBe(true);
+    expect(isDependencyStatusResponse({ success: false, error: 'unavailable' })).toBe(false);
+    expect(isDependencyStatusResponse({ success: false, error: null })).toBe(false);
+    expect(isDependencyStatusResponse(null)).toBe(false);
+  });
+});

--- a/webview/src/utils/bridgeStartup.test.ts
+++ b/webview/src/utils/bridgeStartup.test.ts
@@ -1,6 +1,9 @@
 import {
   isDependencyStatusResponse,
-  requestDependencyStatusUntilReady,
+  requestFreshDependencyStatus,
+  requestDependencyStatusUntilSettled,
+  retryDependencyStatusRequest,
+  settleDependencyStatusRequest,
   waitForBridge,
 } from './bridgeStartup';
 
@@ -9,7 +12,7 @@ describe('bridge startup recovery', () => {
     vi.useFakeTimers();
     delete window.sendToJava;
     delete window.__ccgOnBridgeReady;
-    window.__dependencyStatusReady = false;
+    window.__dependencyStatusState = 'pending';
   });
 
   afterEach(() => {
@@ -50,17 +53,70 @@ describe('bridge startup recovery', () => {
   it('stops dependency status retries after a valid response', () => {
     const sendToJava = vi.fn();
     window.sendToJava = sendToJava;
-    requestDependencyStatusUntilReady();
+    requestDependencyStatusUntilSettled();
 
     expect(sendToJava).toHaveBeenCalledTimes(1);
     vi.advanceTimersByTime(2000);
     expect(sendToJava).toHaveBeenCalledTimes(2);
 
-    window.__dependencyStatusReady = true;
-    vi.advanceTimersByTime(2000);
-    vi.runOnlyPendingTimers();
+    settleDependencyStatusRequest('ready');
+    vi.advanceTimersByTime(10000);
 
     expect(sendToJava).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops dependency status retries after an explicit backend error', () => {
+    const sendToJava = vi.fn();
+    window.sendToJava = sendToJava;
+    requestDependencyStatusUntilSettled();
+
+    settleDependencyStatusRequest('error');
+    vi.advanceTimersByTime(20000);
+
+    expect(sendToJava).toHaveBeenCalledTimes(1);
+    expect(window.__dependencyStatusState).toBe('error');
+  });
+
+  it('keeps a single dependency status loop when startup is requested twice', () => {
+    const sendToJava = vi.fn();
+    window.sendToJava = sendToJava;
+
+    requestDependencyStatusUntilSettled();
+    requestDependencyStatusUntilSettled();
+    vi.advanceTimersByTime(2000);
+    settleDependencyStatusRequest('ready');
+
+    expect(sendToJava).toHaveBeenCalledTimes(2);
+  });
+
+  it('restarts dependency status polling as a single request loop', () => {
+    const sendToJava = vi.fn();
+    window.sendToJava = sendToJava;
+    requestDependencyStatusUntilSettled();
+
+    retryDependencyStatusRequest();
+    vi.advanceTimersByTime(2000);
+    settleDependencyStatusRequest('ready');
+    vi.advanceTimersByTime(10000);
+
+    expect(sendToJava).toHaveBeenCalledTimes(3);
+  });
+
+  it('queues one fresh request behind an active dependency status request', async () => {
+    const sendToJava = vi.fn();
+    window.sendToJava = sendToJava;
+    requestDependencyStatusUntilSettled();
+
+    requestFreshDependencyStatus();
+    requestFreshDependencyStatus();
+    expect(sendToJava).toHaveBeenCalledTimes(1);
+
+    settleDependencyStatusRequest('ready');
+    await Promise.resolve();
+
+    expect(sendToJava).toHaveBeenCalledTimes(2);
+    expect(window.__dependencyStatusState).toBe('pending');
+    settleDependencyStatusRequest('ready');
   });
 
   it('rejects backend error payloads as dependency status responses', () => {

--- a/webview/src/utils/bridgeStartup.ts
+++ b/webview/src/utils/bridgeStartup.ts
@@ -1,0 +1,102 @@
+import { sendBridgeEvent } from './bridge';
+
+const BRIDGE_FAST_RETRY_ATTEMPTS = 50;
+const BRIDGE_FAST_RETRY_INTERVAL_MS = 100;
+const BRIDGE_SLOW_RETRY_INTERVAL_MS = 1000;
+const DEPENDENCY_STATUS_FAST_RETRY_ATTEMPTS = 3;
+const DEPENDENCY_STATUS_FAST_RETRY_INTERVAL_MS = 2000;
+const DEPENDENCY_STATUS_SLOW_RETRY_INTERVAL_MS = 5000;
+
+export function waitForBridge(callback: () => void): () => void {
+  let attempt = 0;
+  let completed = false;
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const cancel = () => {
+    completed = true;
+    if (retryTimer !== undefined) {
+      clearTimeout(retryTimer);
+      retryTimer = undefined;
+    }
+    delete window.__ccgOnBridgeReady;
+  };
+
+  const check = () => {
+    if (completed) {
+      return;
+    }
+    attempt++;
+    if (window.sendToJava) {
+      completed = true;
+      if (retryTimer !== undefined) {
+        clearTimeout(retryTimer);
+        retryTimer = undefined;
+      }
+      delete window.__ccgOnBridgeReady;
+      window.removeEventListener('pagehide', cancel);
+      callback();
+      return;
+    }
+
+    if (attempt === BRIDGE_FAST_RETRY_ATTEMPTS) {
+      console.warn('[Main] Bridge startup is delayed; continuing low-frequency retries');
+    }
+    const retryInterval = attempt < BRIDGE_FAST_RETRY_ATTEMPTS
+      ? BRIDGE_FAST_RETRY_INTERVAL_MS
+      : BRIDGE_SLOW_RETRY_INTERVAL_MS;
+    retryTimer = setTimeout(check, retryInterval);
+  };
+
+  window.__ccgOnBridgeReady = check;
+  window.addEventListener('pagehide', cancel, { once: true });
+  check();
+  return cancel;
+}
+
+export function requestDependencyStatusUntilReady(): () => void {
+  let attempt = 0;
+  let cancelled = false;
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const cancel = () => {
+    cancelled = true;
+    if (retryTimer !== undefined) {
+      clearTimeout(retryTimer);
+      retryTimer = undefined;
+    }
+  };
+
+  const request = () => {
+    if (cancelled) {
+      return;
+    }
+    if (window.__dependencyStatusReady) {
+      cancel();
+      window.removeEventListener('pagehide', cancel);
+      return;
+    }
+
+    attempt++;
+    sendBridgeEvent('get_dependency_status');
+    if (attempt === DEPENDENCY_STATUS_FAST_RETRY_ATTEMPTS) {
+      console.warn('[Main] SDK status response is delayed; continuing low-frequency retries');
+    }
+
+    const retryInterval = attempt < DEPENDENCY_STATUS_FAST_RETRY_ATTEMPTS
+      ? DEPENDENCY_STATUS_FAST_RETRY_INTERVAL_MS
+      : DEPENDENCY_STATUS_SLOW_RETRY_INTERVAL_MS;
+    retryTimer = setTimeout(request, retryInterval);
+  };
+
+  window.addEventListener('pagehide', cancel, { once: true });
+  request();
+  return cancel;
+}
+
+export function isDependencyStatusResponse(payload: unknown): boolean {
+  if (payload === null || typeof payload !== 'object' || Array.isArray(payload)) {
+    return false;
+  }
+  const response = payload as Record<string, unknown>;
+  return response.success !== false;
+}

--- a/webview/src/utils/bridgeStartup.ts
+++ b/webview/src/utils/bridgeStartup.ts
@@ -7,6 +7,12 @@ const DEPENDENCY_STATUS_FAST_RETRY_ATTEMPTS = 3;
 const DEPENDENCY_STATUS_FAST_RETRY_INTERVAL_MS = 2000;
 const DEPENDENCY_STATUS_SLOW_RETRY_INTERVAL_MS = 5000;
 
+export const DEPENDENCY_STATUS_REQUEST_STARTED_EVENT = 'ccg:dependency-status-request-started';
+
+let cancelActiveDependencyStatusRequest: (() => void) | undefined;
+let dependencyStatusRefreshQueued = false;
+let dependencyStatusRefreshScheduled = false;
+
 export function waitForBridge(callback: () => void): () => void {
   let attempt = 0;
   let completed = false;
@@ -53,26 +59,55 @@ export function waitForBridge(callback: () => void): () => void {
   return cancel;
 }
 
-export function requestDependencyStatusUntilReady(): () => void {
+function startDependencyStatusRequest(force: boolean): () => void {
+  if (!force && cancelActiveDependencyStatusRequest) {
+    return () => {};
+  }
+
+  if (!force && (
+    window.__dependencyStatusState === 'ready'
+    || window.__dependencyStatusState === 'error'
+  )) {
+    return () => {};
+  }
+
+  cancelActiveDependencyStatusRequest?.();
+  window.__dependencyStatusState = 'pending';
+  window.dispatchEvent(new Event(DEPENDENCY_STATUS_REQUEST_STARTED_EVENT));
+
   let attempt = 0;
   let cancelled = false;
   let retryTimer: ReturnType<typeof setTimeout> | undefined;
 
-  const cancel = () => {
+  const cancel = (event?: Event) => {
+    if (cancelled) {
+      return;
+    }
     cancelled = true;
+    if (event?.type === 'pagehide') {
+      dependencyStatusRefreshQueued = false;
+    }
     if (retryTimer !== undefined) {
       clearTimeout(retryTimer);
       retryTimer = undefined;
     }
+    window.removeEventListener('pagehide', cancel);
+    if (cancelActiveDependencyStatusRequest === cancel) {
+      cancelActiveDependencyStatusRequest = undefined;
+    }
   };
+
+  cancelActiveDependencyStatusRequest = cancel;
 
   const request = () => {
     if (cancelled) {
       return;
     }
-    if (window.__dependencyStatusReady) {
+    if (
+      window.__dependencyStatusState === 'ready'
+      || window.__dependencyStatusState === 'error'
+    ) {
       cancel();
-      window.removeEventListener('pagehide', cancel);
       return;
     }
 
@@ -91,6 +126,42 @@ export function requestDependencyStatusUntilReady(): () => void {
   window.addEventListener('pagehide', cancel, { once: true });
   request();
   return cancel;
+}
+
+export function requestDependencyStatusUntilSettled(): () => void {
+  return startDependencyStatusRequest(false);
+}
+
+export function retryDependencyStatusRequest(): () => void {
+  dependencyStatusRefreshQueued = false;
+  return startDependencyStatusRequest(true);
+}
+
+export function requestFreshDependencyStatus(): () => void {
+  if (cancelActiveDependencyStatusRequest && window.__dependencyStatusState === 'pending') {
+    dependencyStatusRefreshQueued = true;
+    return () => {
+      dependencyStatusRefreshQueued = false;
+    };
+  }
+  return retryDependencyStatusRequest();
+}
+
+export function settleDependencyStatusRequest(state: 'ready' | 'error'): void {
+  window.__dependencyStatusState = state;
+  cancelActiveDependencyStatusRequest?.();
+  if (!dependencyStatusRefreshQueued || dependencyStatusRefreshScheduled) {
+    return;
+  }
+  dependencyStatusRefreshScheduled = true;
+  queueMicrotask(() => {
+    dependencyStatusRefreshScheduled = false;
+    if (!dependencyStatusRefreshQueued) {
+      return;
+    }
+    dependencyStatusRefreshQueued = false;
+    startDependencyStatusRequest(true);
+  });
 }
 
 export function isDependencyStatusResponse(payload: unknown): boolean {


### PR DESCRIPTION
## Summary

- keep the JCEF bridge bootstrap recoverable after the initial five-second startup window
- reject stale page messages and timers across reload/recreate with monotonic page generations
- retry SDK status requests until a valid response without reporting backend errors as missing SDKs
- make repeated configuration injection generation-safe and idempotent
- #1545 fix this

## Verification

- `npm test -- --run` (117 files, 980 tests)
- `npm run build`
- targeted Java tests for bridge retry, page generation, dispatch gating, watchdog budget, and HTML injection
- `gradlew.bat checkstyleMain`
- `gradlew.bat buildPlugin`