### PR TITLE
fix(bridge): reset heartbeat baseline on daemon restart to prevent restart storm

### DIFF
--- a/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
@@ -148,6 +148,10 @@ public class DaemonBridge {
                 isRunning.set(true);
                 lastSuccessfulStart.set(System.currentTimeMillis());
                 markDaemonActivity();
+                // Reset the heartbeat baseline so a stale timestamp from the previous
+                // (dead) daemon does not cause the watchdog to immediately kill this
+                // freshly spawned process before it has responded to its first heartbeat.
+                lastHeartbeatResponse.set(System.currentTimeMillis());
 
                 LOG.info("[DaemonBridge] Daemon process started, PID: " + daemonProcess.pid());
 
@@ -720,6 +724,15 @@ public class DaemonBridge {
         long uptime = System.currentTimeMillis() - lastSuccessfulStart.get();
         if (uptime > RESTART_WINDOW_MS) {
             restartAttempts.set(0);
+        }
+
+        // Interrupt the previous heartbeat thread (unless we ARE that thread)
+        // so it cannot wake up during the restart and kill the new process
+        // using a stale heartbeat timestamp. A new heartbeat thread is created
+        // by start().
+        Thread oldHeartbeat = heartbeatThread;
+        if (oldHeartbeat != null && oldHeartbeat != Thread.currentThread()) {
+            oldHeartbeat.interrupt();
         }
 
         int attempts = restartAttempts.incrementAndGet();

--- a/src/test/java/com/github/claudecodegui/provider/common/DaemonBridgeTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/common/DaemonBridgeTest.java
@@ -28,4 +28,26 @@ public class DaemonBridgeTest {
     public void activeRequestWithNoRecentOutputEventuallyTimesOut() {
         assertTrue(DaemonBridge.shouldTreatAsUnresponsive(OVER_ACTIVE_REQUEST_THRESHOLD, OVER_ACTIVE_REQUEST_THRESHOLD, 1));
     }
+
+    /**
+     * Regression test for issue #1512: after a daemon restart the heartbeat
+     * baseline is reset, so a fresh heartbeat age must NOT be flagged as
+     * unresponsive even when there are no active requests.
+     */
+    @Test
+    public void freshHeartbeatAfterRestartIsNotUnresponsive() {
+        assertFalse(DaemonBridge.shouldTreatAsUnresponsive(RECENT_ACTIVITY, RECENT_ACTIVITY, 0));
+    }
+
+    /**
+     * Documents the exact restart-storm scenario from issue #1512: a stale
+     * heartbeat age (left over from the previous dead process) combined with
+     * a fresh activity age and no active requests IS treated as unresponsive.
+     * The fix prevents this stale value from ever reaching the check by
+     * resetting lastHeartbeatResponse when a new process is spawned.
+     */
+    @Test
+    public void staleHeartbeatWithFreshActivityIsUnresponsive() {
+        assertTrue(DaemonBridge.shouldTreatAsUnresponsive(297_132, 149, 0));
+    }
 }


### PR DESCRIPTION
# Fix: Stale heartbeat timestamp causes restart storm after sleep/wake

## Problem (Issue #1512)

After the machine wakes from sleep, the heartbeat watchdog correctly detects that the daemon's heartbeat age exceeds the timeout and kills it. However, the bug is what happens next: **lastHeartbeatResponse is not reset when a new daemon process is spawned**, so the watchdog immediately re-evaluates the *stale* heartbeat age against the *brand-new* process and force-kills it within milliseconds - repeatedly, up to MAX_RESTART_ATTEMPTS.

The smoking gun from the logs:
`
00:22:23,682 INFO  Daemon process started, PID: 46748
00:22:23,831 WARN  Daemon unresponsive (heartbeatAgeMs=297132, activityAgeMs=149, activeRequests=0)
`

A process that is 149 ms old cannot have a ~297 s heartbeat age. ctivityAgeMs=149 (correctly reset) vs heartbeatAgeMs=297132 (stale, not reset) shows the two timestamps are handled inconsistently on restart.

## Root Cause

When handleDaemonDeath() is triggered by a non-heartbeat thread (e.g. the reader thread), the old heartbeat thread is **not interrupted** and continues sleeping. During the restart:

1. start() spawns a new process and calls markDaemonActivity() (resets lastDaemonActivity)
2. But lastHeartbeatResponse is **not reset** until startHeartbeatThread() runs (after the ready wait)
3. The old heartbeat thread wakes up during this window, sees isRunning=true and the new process alive
4. It calculates heartbeatAgeMs from the stale lastHeartbeatResponse and kills the new process

## Fix

**1. Reset lastHeartbeatResponse in start()** when spawning a new process, alongside the existing markDaemonActivity() call. This ensures any heartbeat check sees a fresh baseline during the startup grace period.

**2. Interrupt the old heartbeat thread in handleDaemonDeath()** before calling start(), so it cannot wake up mid-restart. The check excludes the current thread (Thread.currentThread()) to avoid self-interruption when handleDaemonDeath() is called from the heartbeat thread itself.

## Tests

Added two regression tests to DaemonBridgeTest:
- reshHeartbeatAfterRestartIsNotUnresponsive: verifies a fresh heartbeat age is not flagged as unresponsive (the post-fix state)
- staleHeartbeatWithFreshActivityIsUnresponsive: documents the exact restart-storm scenario from the bug report (stale heartbeat + fresh activity + no active requests = unresponsive), confirming shouldTreatAsUnresponsive is correct and the fix is in preventing the stale value from reaching it

Fixes #1512