### PR TITLE
fix: restore Codex subagent history and stable anchors

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/history/CodexSubagentHistoryLoader.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/CodexSubagentHistoryLoader.java
@@ -1,0 +1,415 @@
+package com.github.claudecodegui.handler.history;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * Resolves and converts one Codex subagent turn from local rollout files.
+ */
+final class CodexSubagentHistoryLoader {
+
+    private static final Logger LOG = Logger.getInstance(CodexSubagentHistoryLoader.class);
+    private static final Pattern SAFE_ID = Pattern.compile("[A-Za-z0-9_-]+");
+    private static final Pattern SAFE_AGENT_PATH =
+            Pattern.compile("/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*");
+    private static final int MAX_CACHE_ENTRIES = 256;
+
+    private final Path sessionsDir;
+    private final Map<LookupKey, Location> locationCache =
+            Collections.synchronizedMap(new LinkedHashMap<LookupKey, Location>(32, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<LookupKey, Location> eldest) {
+                    return size() > MAX_CACHE_ENTRIES;
+                }
+            });
+
+    CodexSubagentHistoryLoader(Path sessionsDir) {
+        this.sessionsDir = sessionsDir;
+    }
+
+    Result load(String parentSessionId, String toolUseId, String requestedAgentPath) throws IOException {
+        validateId("sessionId", parentSessionId);
+        if (toolUseId != null && !toolUseId.isBlank()) {
+            validateId("toolUseId", toolUseId);
+        }
+        if (requestedAgentPath != null && !requestedAgentPath.isBlank()) {
+            validateAgentPath(requestedAgentPath);
+        }
+        if ((toolUseId == null || toolUseId.isBlank())
+                && (requestedAgentPath == null || requestedAgentPath.isBlank())) {
+            throw new IllegalArgumentException("Missing toolUseId and agentPath");
+        }
+
+        LookupKey key = new LookupKey("codex", parentSessionId, toolUseId, requestedAgentPath);
+        Location location = locationCache.get(key);
+        if (location == null || !Files.isRegularFile(location.file())) {
+            location = resolveLocation(parentSessionId, toolUseId, requestedAgentPath);
+            locationCache.put(key, location);
+        }
+
+        JsonArray rollout = readInitialSubagentRollout(location.file());
+        TurnSlice turn = extractInitialSubagentTurn(rollout);
+        JsonArray frontendMessages = new JsonArray();
+        for (JsonObject message : HistoryMessageInjector.convertCodexMessagesToFrontendBatch(turn.messages())) {
+            frontendMessages.add(message);
+        }
+        return new Result(
+                location.agentThreadId(),
+                location.agentPath(),
+                frontendMessages,
+                turn.status(),
+                turn.error()
+        );
+    }
+
+    private Location resolveLocation(
+            String parentSessionId,
+            String toolUseId,
+            String requestedAgentPath
+    ) throws IOException {
+        if (toolUseId != null && !toolUseId.isBlank()) {
+            Path parentFile = findExactSessionFile(parentSessionId);
+            Location activityLocation = findActivityLocation(parentFile, toolUseId);
+            if (activityLocation != null) {
+                Path childFile = findExactSessionFile(activityLocation.agentThreadId());
+                return new Location(childFile, activityLocation.agentThreadId(), activityLocation.agentPath());
+            }
+        }
+
+        if (requestedAgentPath == null || requestedAgentPath.isBlank()) {
+            throw new PendingException("Codex subagent activity not found yet");
+        }
+        return findLegacyLocation(parentSessionId, requestedAgentPath);
+    }
+
+    private Location findActivityLocation(Path parentFile, String toolUseId) throws IOException {
+        Location matched = null;
+        try (Stream<String> lines = Files.lines(parentFile, StandardCharsets.UTF_8)) {
+            for (java.util.Iterator<String> iterator = lines.iterator(); iterator.hasNext();) {
+                String line = iterator.next();
+                if (line.isBlank()) {
+                    continue;
+                }
+                JsonObject record = parseObject(line);
+                JsonObject payload = eventPayload(record, "sub_agent_activity");
+                if (payload == null || !toolUseId.equals(getString(payload, "event_id"))) {
+                    continue;
+                }
+                String threadId = getString(payload, "agent_thread_id");
+                if (threadId == null || threadId.isBlank()) {
+                    continue;
+                }
+                validateId("agentThreadId", threadId);
+                String agentPath = getString(payload, "agent_path");
+                if (matched != null && !matched.agentThreadId().equals(threadId)) {
+                    throw new IllegalStateException("Ambiguous Codex subagent activity");
+                }
+                matched = new Location(null, threadId, agentPath);
+            }
+        }
+        return matched;
+    }
+
+    private Location findLegacyLocation(String parentSessionId, String agentPath) throws IOException {
+        List<Location> matches = new ArrayList<>();
+        if (!Files.isDirectory(sessionsDir)) {
+            throw new PendingException("Codex sessions directory not found yet");
+        }
+        try (Stream<Path> paths = Files.walk(sessionsDir)) {
+            paths.filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().endsWith(".jsonl"))
+                    .forEach(path -> {
+                        JsonObject meta = readSessionMeta(path);
+                        if (meta == null) {
+                            return;
+                        }
+                        String candidateParent = getParentThreadId(meta);
+                        String candidatePath = getAgentPath(meta);
+                        String threadId = getString(meta, "id");
+                        if (parentSessionId.equals(candidateParent)
+                                && matchesAgentPath(agentPath, candidatePath)
+                                && threadId != null) {
+                            matches.add(new Location(path, threadId, candidatePath));
+                        }
+                    });
+        }
+        if (matches.isEmpty()) {
+            throw new PendingException("Codex subagent rollout not found yet");
+        }
+        if (matches.size() > 1) {
+            throw new IllegalStateException("Ambiguous Codex subagent rollout for agentPath");
+        }
+        return matches.get(0);
+    }
+
+    private Path findExactSessionFile(String sessionId) throws IOException {
+        if (!Files.isDirectory(sessionsDir)) {
+            throw new PendingException("Codex sessions directory not found yet");
+        }
+        String suffix = "-" + sessionId + ".jsonl";
+        List<Path> matches;
+        try (Stream<Path> paths = Files.walk(sessionsDir)) {
+            matches = paths.filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().endsWith(suffix))
+                    .limit(2)
+                    .toList();
+        }
+        if (matches.isEmpty()) {
+            throw new PendingException("Codex session rollout not found yet: " + sessionId);
+        }
+        if (matches.size() > 1) {
+            throw new IllegalStateException("Ambiguous Codex session rollout: " + sessionId);
+        }
+        return matches.get(0);
+    }
+
+    private JsonObject readSessionMeta(Path file) {
+        try (Stream<String> lines = Files.lines(file, StandardCharsets.UTF_8)) {
+            for (java.util.Iterator<String> iterator = lines.iterator(); iterator.hasNext();) {
+                String line = iterator.next();
+                if (line.isBlank()) {
+                    continue;
+                }
+                JsonObject record = parseObject(line);
+                if (record == null || !"session_meta".equals(getString(record, "type"))
+                        || !record.has("payload") || !record.get("payload").isJsonObject()) {
+                    continue;
+                }
+                return record.getAsJsonObject("payload");
+            }
+            return null;
+        } catch (IOException e) {
+            LOG.debug("Failed to read Codex session metadata: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private JsonArray readInitialSubagentRollout(Path file) throws IOException {
+        JsonArray messages = new JsonArray();
+        boolean afterSessionMeta = false;
+        String turnId = null;
+        try (Stream<String> lines = Files.lines(file, StandardCharsets.UTF_8)) {
+            for (java.util.Iterator<String> iterator = lines.iterator(); iterator.hasNext();) {
+                String line = iterator.next();
+                if (line.isBlank()) {
+                    continue;
+                }
+                JsonObject record = parseObject(line);
+                if (record == null) {
+                    continue;
+                }
+                if ("session_meta".equals(getString(record, "type"))) {
+                    messages = new JsonArray();
+                    afterSessionMeta = true;
+                    turnId = null;
+                }
+                if (!afterSessionMeta) {
+                    continue;
+                }
+                messages.add(record);
+                if (turnId == null && "turn_context".equals(getString(record, "type"))
+                        && record.has("payload") && record.get("payload").isJsonObject()) {
+                    turnId = getString(record.getAsJsonObject("payload"), "turn_id");
+                    continue;
+                }
+                if (turnId != null && (matchesTurnEvent(record, "task_complete", turnId)
+                        || matchesTurnEvent(record, "turn_aborted", turnId))) {
+                    break;
+                }
+            }
+        }
+        return messages;
+    }
+
+    private static boolean matchesTurnEvent(JsonObject record, String eventType, String turnId) {
+        JsonObject payload = eventPayload(record, eventType);
+        return payload != null && turnId.equals(getString(payload, "turn_id"));
+    }
+
+    private JsonObject parseObject(String line) {
+        try {
+            JsonElement parsed = JsonParser.parseString(line);
+            return parsed.isJsonObject() ? parsed.getAsJsonObject() : null;
+        } catch (JsonSyntaxException e) {
+            LOG.warn("Skipping malformed JSONL line in Codex subagent history: " + e.getMessage());
+            return null;
+        }
+    }
+
+    static TurnSlice extractInitialSubagentTurn(JsonArray rollout) {
+        int sessionMetaIndex = -1;
+        for (int i = 0; i < rollout.size(); i++) {
+            if (rollout.get(i).isJsonObject()
+                    && "session_meta".equals(getString(rollout.get(i).getAsJsonObject(), "type"))) {
+                sessionMetaIndex = i;
+            }
+        }
+
+        String turnId = null;
+        int contextIndex = -1;
+        for (int i = sessionMetaIndex + 1; i < rollout.size(); i++) {
+            if (!rollout.get(i).isJsonObject()) {
+                continue;
+            }
+            JsonObject record = rollout.get(i).getAsJsonObject();
+            if (!"turn_context".equals(getString(record, "type"))
+                    || !record.has("payload") || !record.get("payload").isJsonObject()) {
+                continue;
+            }
+            turnId = getString(record.getAsJsonObject("payload"), "turn_id");
+            if (turnId != null) {
+                contextIndex = i;
+                break;
+            }
+        }
+        if (turnId == null) {
+            throw new PendingException("Codex subagent turn context not found yet");
+        }
+
+        int startIndex = -1;
+        for (int i = sessionMetaIndex + 1; i <= contextIndex; i++) {
+            JsonObject payload = eventPayload(rollout.get(i), "task_started");
+            if (payload != null && turnId.equals(getString(payload, "turn_id"))) {
+                startIndex = i;
+            }
+        }
+        if (startIndex < 0) {
+            throw new PendingException("Codex subagent turn start not found yet");
+        }
+
+        JsonArray turnMessages = new JsonArray();
+        String status = "running";
+        String error = null;
+        for (int i = startIndex; i < rollout.size(); i++) {
+            JsonElement record = rollout.get(i);
+            turnMessages.add(record.deepCopy());
+            JsonObject completed = eventPayload(record, "task_complete");
+            if (completed != null && turnId.equals(getString(completed, "turn_id"))) {
+                status = "completed";
+                break;
+            }
+            JsonObject aborted = eventPayload(record, "turn_aborted");
+            if (aborted != null && turnId.equals(getString(aborted, "turn_id"))) {
+                status = "error";
+                error = "Codex subagent turn was aborted";
+                break;
+            }
+        }
+        return new TurnSlice(turnMessages, status, error);
+    }
+
+    private static JsonObject eventPayload(JsonElement element, String payloadType) {
+        if (element == null || !element.isJsonObject()) {
+            return null;
+        }
+        JsonObject record = element.getAsJsonObject();
+        if (!"event_msg".equals(getString(record, "type"))
+                || !record.has("payload") || !record.get("payload").isJsonObject()) {
+            return null;
+        }
+        JsonObject payload = record.getAsJsonObject("payload");
+        return payloadType.equals(getString(payload, "type")) ? payload : null;
+    }
+
+    private static String getParentThreadId(JsonObject meta) {
+        String direct = getString(meta, "parent_thread_id");
+        if (direct != null) {
+            return direct;
+        }
+        JsonObject spawn = getThreadSpawn(meta);
+        return spawn != null ? getString(spawn, "parent_thread_id") : null;
+    }
+
+    private static String getAgentPath(JsonObject meta) {
+        String direct = getString(meta, "agent_path");
+        if (direct != null) {
+            return direct;
+        }
+        JsonObject spawn = getThreadSpawn(meta);
+        return spawn != null ? getString(spawn, "agent_path") : null;
+    }
+
+    private static JsonObject getThreadSpawn(JsonObject meta) {
+        if (!meta.has("source") || !meta.get("source").isJsonObject()) {
+            return null;
+        }
+        JsonObject source = meta.getAsJsonObject("source");
+        if (!source.has("subagent") || !source.get("subagent").isJsonObject()) {
+            return null;
+        }
+        JsonObject subagent = source.getAsJsonObject("subagent");
+        return subagent.has("thread_spawn") && subagent.get("thread_spawn").isJsonObject()
+                ? subagent.getAsJsonObject("thread_spawn") : null;
+    }
+
+    private static String getString(JsonObject object, String key) {
+        if (object == null || !object.has(key) || object.get(key).isJsonNull()) {
+            return null;
+        }
+        return object.get(key).getAsString();
+    }
+
+    private static void validateId(String name, String value) {
+        if (value == null || value.isBlank() || !SAFE_ID.matcher(value).matches()) {
+            throw new IllegalArgumentException("Invalid " + name);
+        }
+    }
+
+    private static void validateAgentPath(String value) {
+        if (value.length() > 500
+                || (!SAFE_AGENT_PATH.matcher(value).matches() && !SAFE_ID.matcher(value).matches())) {
+            throw new IllegalArgumentException("Invalid agentPath");
+        }
+    }
+
+    private static boolean matchesAgentPath(String requested, String candidate) {
+        if (candidate == null) {
+            return false;
+        }
+        return requested.equals(candidate)
+                || (!requested.startsWith("/") && candidate.endsWith("/" + requested));
+    }
+
+    record Result(
+            String agentThreadId,
+            String agentPath,
+            JsonArray messages,
+            String status,
+            String error
+    ) {
+        boolean completed() {
+            return "completed".equals(status);
+        }
+    }
+
+    record TurnSlice(JsonArray messages, String status, String error) {
+    }
+
+    private record LookupKey(String provider, String parentSessionId, String toolUseId, String agentPath) {
+    }
+
+    private record Location(Path file, String agentThreadId, String agentPath) {
+    }
+
+    static final class PendingException extends IllegalStateException {
+        PendingException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
@@ -17,6 +17,8 @@ import com.intellij.openapi.diagnostic.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -672,7 +674,7 @@ public class HistoryMessageInjector {
     /**
      * 将前端统一消息结构恢复为会话内存消息结构。
      */
-    private static ClaudeSession.Message toSessionMessage(JsonObject frontendMsg) {
+    static ClaudeSession.Message toSessionMessage(JsonObject frontendMsg) {
         if (frontendMsg == null || !frontendMsg.has("type")) {
             return null;
         }
@@ -700,9 +702,40 @@ public class HistoryMessageInjector {
         JsonObject raw = frontendMsg.has("raw") && frontendMsg.get("raw").isJsonObject()
             ? frontendMsg.getAsJsonObject("raw")
             : null;
-        return raw != null
+        ClaudeSession.Message restored = raw != null
             ? new ClaudeSession.Message(messageType, content, raw.deepCopy())
             : new ClaudeSession.Message(messageType, content);
+        Long sourceTimestamp = parseFrontendTimestamp(frontendMsg);
+        if (sourceTimestamp != null) {
+            restored.timestamp = sourceTimestamp;
+        }
+        return restored;
+    }
+
+    private static Long parseFrontendTimestamp(JsonObject frontendMsg) {
+        if (!frontendMsg.has("timestamp") || frontendMsg.get("timestamp").isJsonNull()) {
+            return null;
+        }
+        JsonElement timestamp = frontendMsg.get("timestamp");
+        if (!timestamp.isJsonPrimitive()) {
+            return null;
+        }
+        try {
+            if (timestamp.getAsJsonPrimitive().isNumber()) {
+                return timestamp.getAsLong();
+            }
+            String value = timestamp.getAsString();
+            if (value == null || value.isBlank()) {
+                return null;
+            }
+            try {
+                return Long.parseLong(value);
+            } catch (NumberFormatException ignored) {
+                return Instant.parse(value).toEpochMilli();
+            }
+        } catch (NumberFormatException | DateTimeParseException ignored) {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/handler/history/SubagentHistoryService.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/SubagentHistoryService.java
@@ -10,13 +10,19 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.util.concurrency.AppExecutorUtil;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -31,22 +37,42 @@ class SubagentHistoryService {
     private static final int MAX_JSONL_LINES = 50_000;
 
     private final HandlerContext context;
+    private final CodexSubagentHistoryLoader codexLoader;
+    private final Set<String> inFlightCodexRequests = ConcurrentHashMap.newKeySet();
 
     SubagentHistoryService(HandlerContext context) {
         this.context = context;
+        Path codexSessionsDir = Path.of(NodeDetector.resolveHomeForFileOps(), ".codex", "sessions");
+        this.codexLoader = new CodexSubagentHistoryLoader(codexSessionsDir);
     }
 
     void handleLoadSubagentSession(String content) {
         JsonObject request = parseRequest(content);
         String sessionId = getString(request, "sessionId");
         String agentId = getString(request, "agentId");
+        String agentPath = getString(request, "agentPath");
         String toolUseId = getString(request, "toolUseId");
         String description = getString(request, "description");
+        String provider = getString(request, "provider");
 
         JsonObject response = new JsonObject();
         response.addProperty("toolUseId", toolUseId);
         response.addProperty("agentId", agentId);
+        response.addProperty("agentPath", agentPath);
         response.addProperty("sessionId", sessionId);
+        response.addProperty("provider", provider);
+
+        if ("codex".equals(provider)) {
+            loadCodexSubagentAsync(sessionId, toolUseId, agentPath, response);
+            return;
+        }
+        if (provider != null && !"claude".equals(provider)) {
+            response.addProperty("success", false);
+            response.addProperty("status", "error");
+            response.addProperty("error", "Invalid provider");
+            sendResponse(response);
+            return;
+        }
 
         try {
             validateId("sessionId", sessionId);
@@ -56,6 +82,7 @@ class SubagentHistoryService {
                     : resolveSubagentFileByDescription(sessionId, description);
             if (!Files.exists(file) || !Files.isRegularFile(file)) {
                 response.addProperty("success", false);
+                response.addProperty("status", "running");
                 response.addProperty("error", "Subagent log not found");
                 sendResponse(response);
                 return;
@@ -67,14 +94,56 @@ class SubagentHistoryService {
             JsonArray messages = readJsonl(file);
             response.addProperty("success", true);
             response.addProperty("completed", hasCompleted(messages));
+            response.addProperty("status", hasCompleted(messages) ? "completed" : "running");
             response.add("messages", messages);
         } catch (Exception e) {
             LOG.warn("[SubagentHistory] Failed to load subagent log: " + e.getMessage());
             response.addProperty("success", false);
+            response.addProperty("status", "error");
             response.addProperty("error", e.getMessage() != null ? e.getMessage() : "Unknown error");
         }
 
         sendResponse(response);
+    }
+
+    private void loadCodexSubagentAsync(
+            String sessionId,
+            String toolUseId,
+            String agentPath,
+            JsonObject response
+    ) {
+        String requestKey = "codex:" + sessionId + ":" + toolUseId + ":" + agentPath;
+        if (!inFlightCodexRequests.add(requestKey)) {
+            return;
+        }
+        CompletableFuture.runAsync(() -> {
+            try {
+                CodexSubagentHistoryLoader.Result result = codexLoader.load(sessionId, toolUseId, agentPath);
+                response.addProperty("success", true);
+                response.addProperty("completed", result.completed());
+                response.addProperty("status", result.status());
+                response.addProperty("agentId", result.agentThreadId());
+                response.addProperty("agentPath", result.agentPath());
+                response.add("messages", result.messages());
+                if (result.error() != null) {
+                    response.addProperty("error", result.error());
+                }
+            } catch (CodexSubagentHistoryLoader.PendingException e) {
+                response.addProperty("success", false);
+                response.addProperty("completed", false);
+                response.addProperty("status", "running");
+                response.addProperty("error", e.getMessage());
+            } catch (Exception e) {
+                LOG.warn("[SubagentHistory] Failed to load Codex subagent log: " + e.getMessage());
+                response.addProperty("success", false);
+                response.addProperty("completed", false);
+                response.addProperty("status", "error");
+                response.addProperty("error", e.getMessage() != null ? e.getMessage() : "Unknown error");
+            } finally {
+                inFlightCodexRequests.remove(requestKey);
+            }
+            sendResponse(response);
+        }, AppExecutorUtil.getAppExecutorService());
     }
 
     private JsonObject parseRequest(String content) {
@@ -209,7 +278,25 @@ class SubagentHistoryService {
     }
 
     private void sendResponse(JsonObject response) {
-        String payload = JsUtils.escapeJs(GSON.toJson(response));
-        context.callJavaScript("onSubagentHistoryLoaded", payload);
+        if (context.getProject() == null || context.getProject().isDisposed()) {
+            return;
+        }
+        String responseJson = GSON.toJson(response);
+        String payload = JsUtils.escapeJs(responseJson);
+        if (payload.length() <= HistoryMessageInjector.HISTORY_BATCH_TARGET_CHAR_LIMIT) {
+            context.callJavaScript("onSubagentHistoryLoaded", payload);
+            return;
+        }
+
+        String transferId = UUID.randomUUID().toString();
+        List<String> chunks = HistoryMessageInjector.splitHistoryPayload(responseJson);
+        for (int i = 0; i < chunks.size(); i++) {
+            context.callJavaScript(
+                    "onSubagentHistoryChunk",
+                    transferId,
+                    JsUtils.escapeJs(chunks.get(i)),
+                    String.valueOf(i == chunks.size() - 1)
+            );
+        }
     }
 }

--- a/src/test/java/com/github/claudecodegui/handler/history/CodexSubagentHistoryLoaderTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/history/CodexSubagentHistoryLoaderTest.java
@@ -1,0 +1,162 @@
+package com.github.claudecodegui.handler.history;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CodexSubagentHistoryLoaderTest {
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void loadsChildByParentActivityAndSkipsForkedParentTurn() throws Exception {
+        Path sessionsDir = temporaryFolder.newFolder("sessions").toPath();
+        String parentId = "019fa70f-0653-73e2-a613-1fb0a9e83a2b";
+        String childId = "019fb0fe-c344-7da0-9d10-20659f884100";
+        writeRollout(sessionsDir.resolve("rollout-parent-" + parentId + ".jsonl"),
+                event("sub_agent_activity", "event_id", "call-123",
+                        "agent_thread_id", childId, "agent_path", "/root/audit_ui"));
+        writeRollout(sessionsDir.resolve("rollout-child-" + childId + ".jsonl"),
+                event("task_started", "turn_id", "forked-turn"),
+                turnContext("forked-turn"),
+                sessionMeta(childId, parentId, "/root/audit_ui"),
+                event("task_started", "turn_id", "child-turn"),
+                responseMessage("assistant", "child output"),
+                turnContext("child-turn"),
+                event("task_complete", "turn_id", "child-turn"));
+
+        CodexSubagentHistoryLoader.Result result =
+                new CodexSubagentHistoryLoader(sessionsDir).load(parentId, "call-123", "audit_ui");
+
+        assertEquals(childId, result.agentThreadId());
+        assertEquals("/root/audit_ui", result.agentPath());
+        assertTrue(result.completed());
+        assertEquals("completed", result.status());
+        assertTrue(result.messages().toString().contains("child output"));
+        assertFalse(result.messages().toString().contains("forked-turn"));
+    }
+
+    @Test
+    public void resolvesActivityRecordedAfterFormerLineLimit() throws Exception {
+        Path sessionsDir = temporaryFolder.newFolder("large-sessions").toPath();
+        String parentId = "019fa70f-0653-73e2-a613-1fb0a9e83a2b";
+        String childId = "019fb0fe-c344-7da0-9d10-20659f884100";
+        Path parentFile = sessionsDir.resolve("rollout-parent-" + parentId + ".jsonl");
+        StringBuilder parentContent = new StringBuilder();
+        for (int i = 0; i <= 50_000; i++) {
+            parentContent.append(event("noop").toString()).append(System.lineSeparator());
+        }
+        parentContent.append(event("sub_agent_activity", "event_id", "call-123",
+                "agent_thread_id", childId, "agent_path", "/root/audit_ui"));
+        Files.writeString(parentFile, parentContent, StandardCharsets.UTF_8);
+        StringBuilder childContent = new StringBuilder(parentContent);
+        childContent.append(System.lineSeparator())
+                .append(sessionMeta(childId, parentId, "/root/audit_ui"))
+                .append(System.lineSeparator())
+                .append(event("task_started", "turn_id", "child-turn"))
+                .append(System.lineSeparator())
+                .append(turnContext("child-turn"))
+                .append(System.lineSeparator())
+                .append(event("task_complete", "turn_id", "child-turn"));
+        Files.writeString(sessionsDir.resolve("rollout-child-" + childId + ".jsonl"),
+                childContent, StandardCharsets.UTF_8);
+
+        CodexSubagentHistoryLoader.Result result =
+                new CodexSubagentHistoryLoader(sessionsDir).load(parentId, "call-123", "audit_ui");
+
+        assertEquals(childId, result.agentThreadId());
+        assertTrue(result.completed());
+    }
+
+    @Test
+    public void reportsRunningUntilMatchingChildTurnCompletes() {
+        JsonArray rollout = new JsonArray();
+        rollout.add(sessionMeta("child", "parent", "/root/audit_ui"));
+        rollout.add(event("task_started", "turn_id", "child-turn"));
+        rollout.add(turnContext("child-turn"));
+
+        CodexSubagentHistoryLoader.TurnSlice result =
+                CodexSubagentHistoryLoader.extractInitialSubagentTurn(rollout);
+
+        assertEquals("running", result.status());
+        assertEquals(2, result.messages().size());
+    }
+
+    @Test
+    public void reportsAbortedMatchingChildTurnAsError() {
+        JsonArray rollout = new JsonArray();
+        rollout.add(sessionMeta("child", "parent", "/root/audit_ui"));
+        rollout.add(event("task_started", "turn_id", "child-turn"));
+        rollout.add(turnContext("child-turn"));
+        rollout.add(event("turn_aborted", "turn_id", "child-turn"));
+
+        CodexSubagentHistoryLoader.TurnSlice result =
+                CodexSubagentHistoryLoader.extractInitialSubagentTurn(rollout);
+
+        assertEquals("error", result.status());
+        assertEquals("Codex subagent turn was aborted", result.error());
+    }
+
+    private static void writeRollout(Path path, JsonObject... records) throws IOException {
+        String content = String.join(System.lineSeparator(),
+                java.util.Arrays.stream(records).map(JsonObject::toString).toList());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+
+    private static JsonObject sessionMeta(String id, String parentId, String agentPath) {
+        JsonObject spawn = object("parent_thread_id", parentId, "agent_path", agentPath);
+        JsonObject subagent = new JsonObject();
+        subagent.add("thread_spawn", spawn);
+        JsonObject source = new JsonObject();
+        source.add("subagent", subagent);
+        JsonObject payload = object("id", id);
+        payload.add("source", source);
+        return record("session_meta", payload);
+    }
+
+    private static JsonObject turnContext(String turnId) {
+        return record("turn_context", object("turn_id", turnId));
+    }
+
+    private static JsonObject event(String type, String... properties) {
+        JsonObject payload = object(properties);
+        payload.addProperty("type", type);
+        return record("event_msg", payload);
+    }
+
+    private static JsonObject responseMessage(String role, String text) {
+        JsonObject block = object("type", "output_text", "text", text);
+        JsonArray content = new JsonArray();
+        content.add(block);
+        JsonObject payload = object("type", "message", "role", role);
+        payload.add("content", content);
+        return record("response_item", payload);
+    }
+
+    private static JsonObject record(String type, JsonObject payload) {
+        JsonObject record = new JsonObject();
+        record.addProperty("type", type);
+        record.add("payload", payload);
+        return record;
+    }
+
+    private static JsonObject object(String... properties) {
+        JsonObject object = new JsonObject();
+        for (int i = 0; i < properties.length; i += 2) {
+            object.addProperty(properties[i], properties[i + 1]);
+        }
+        return object;
+    }
+}

--- a/src/test/java/com/github/claudecodegui/handler/history/HistoryMessageInjectorTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/history/HistoryMessageInjectorTest.java
@@ -1,6 +1,7 @@
 package com.github.claudecodegui.handler.history;
 
 import com.github.claudecodegui.handler.core.HandlerContext;
+import com.github.claudecodegui.session.ClaudeSession;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -98,6 +99,26 @@ public class HistoryMessageInjectorTest {
         assertEquals(1, result.size());
         assertEquals("user", result.get(0).get("type").getAsString());
         assertEquals("hello", result.get(0).get("content").getAsString());
+    }
+
+    @Test
+    public void restoresIsoTimestampWhenHydratingCodexMessagesIntoSessionState() {
+        JsonObject frontendMessage = frontendMessage("assistant", "done", "text");
+        frontendMessage.addProperty("timestamp", "2026-07-28T12:50:07.123Z");
+
+        ClaudeSession.Message restored = HistoryMessageInjector.toSessionMessage(frontendMessage);
+
+        assertEquals(1785243007123L, restored.timestamp);
+    }
+
+    @Test
+    public void restoresNumericStringTimestampWhenHydratingSessionState() {
+        JsonObject frontendMessage = frontendMessage("user", "hello", "text");
+        frontendMessage.addProperty("timestamp", "1785243007123");
+
+        ClaudeSession.Message restored = HistoryMessageInjector.toSessionMessage(frontendMessage);
+
+        assertEquals(1785243007123L, restored.timestamp);
     }
 
     @Test

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -407,7 +407,11 @@ const App = () => {
   );
 
   // Stabilize context value references for SubagentContext consumers.
-  const { subagentHistoryCtxValue, sessionIdCtxValue } = useSubagentContextValues(subagentHistories, currentSessionId);
+  const { subagentHistoryCtxValue, sessionIdCtxValue } = useSubagentContextValues(
+    subagentHistories,
+    currentSessionId,
+    currentProvider,
+  );
 
   const handleNavigateToProviderSettings = useCallback(() => {
     setSettingsInitialTab('providers');

--- a/webview/src/components/ChatScreen.tsx
+++ b/webview/src/components/ChatScreen.tsx
@@ -1,4 +1,4 @@
-import { type RefObject, useCallback, useMemo } from 'react';
+import { type RefObject, useCallback, useLayoutEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChatInputBox } from './ChatInputBox';
 import type {
@@ -27,6 +27,7 @@ import type { GetToolResultRawFn } from '../contexts/SubagentContext';
 import { CodexPetStatusBridge } from './codexPet/CodexPetStatusBridge';
 import { shouldToggleCodexPet } from './codexPet/petState';
 import { useCodexPetPreference } from './codexPet/useCodexPetPreference';
+import { reconcileMessageKeys, type MessageKeySnapshot } from '../utils/messageUtils';
 
 type SubagentHistoryMap = ReturnType<typeof useMessages>['subagentHistories'];
 type ProviderState = ReturnType<typeof useModelProviderState>;
@@ -49,7 +50,7 @@ export interface ChatScreenProps {
   globalTodos: TodoItem[];
   filteredFileChanges: FileChangeList;
   subagentHistoryCtxValue: SubagentHistoryMap;
-  sessionIdCtxValue: { currentSessionId: string | null };
+  sessionIdCtxValue: { currentSessionId: string | null; currentProvider: string };
 
   // Refs
   chatInputRef: RefObject<ChatInputBoxHandle | null>;
@@ -149,6 +150,18 @@ export const ChatScreen = ({
   const { t } = useTranslation();
   const { messages, status, loading, isThinking, streamingActive, loadingStartTime, subagentHistories } = useMessages();
   const { currentSessionId } = useSession();
+  const previousMessageKeySnapshotRef = useRef<MessageKeySnapshot | undefined>(undefined);
+  const messageKeySnapshot = useMemo(
+    () => reconcileMessageKeys(
+      mergedMessages,
+      previousMessageKeySnapshotRef.current,
+      `${currentProvider}:${currentSessionId ?? 'active-session'}`,
+    ),
+    [currentProvider, currentSessionId, mergedMessages],
+  );
+  useLayoutEffect(() => {
+    previousMessageKeySnapshotRef.current = messageKeySnapshot;
+  }, [messageKeySnapshot]);
   const {
     setSettingsInitialTab, setCurrentView,
     contextInfo, setContextInfo,
@@ -226,6 +239,7 @@ export const ChatScreen = ({
       <div className="messages-shell">
         <MessageAnchorRail
           messages={mergedMessages}
+          messageKeys={messageKeySnapshot.keys}
           collapsedCount={anchorCollapsedCount}
           containerRef={messagesContainerRef}
           messageNodeMap={messageNodeMapRef}
@@ -255,6 +269,7 @@ export const ChatScreen = ({
                 <MessageList
                   ref={messageListRef}
                   messages={mergedMessages}
+                  messageKeys={messageKeySnapshot.keys}
                   streamingActive={streamingActive}
                   isThinking={isThinking}
                   loading={loading}
@@ -301,6 +316,7 @@ export const ChatScreen = ({
           subagents={subagents}
           subagentHistories={subagentHistories}
           currentSessionId={currentSessionId}
+          currentProvider={currentProvider}
           expanded={statusPanelExpanded}
           isStreaming={streamingActive}
           onUndoFile={onUndoFile}

--- a/webview/src/components/MessageAnchorRail.tsx
+++ b/webview/src/components/MessageAnchorRail.tsx
@@ -1,6 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ClaudeMessage } from '../types';
-import { getMessageKey } from '../utils/messageUtils';
 
 interface AnchorItem {
   id: string;
@@ -10,6 +9,7 @@ interface AnchorItem {
 
 interface MessageAnchorRailProps {
   messages: ClaudeMessage[];
+  messageKeys: readonly string[];
   /** Number of messages hidden by the collapse feature. Anchors start after this offset. */
   collapsedCount?: number;
   containerRef: React.RefObject<HTMLDivElement | null>;
@@ -53,6 +53,7 @@ function getMessagePreview(message: ClaudeMessage): string {
 
 export const MessageAnchorRail = memo(function MessageAnchorRail({
   messages,
+  messageKeys,
   collapsedCount = 0,
   containerRef,
   messageNodeMap,
@@ -88,11 +89,13 @@ export const MessageAnchorRail = memo(function MessageAnchorRail({
     const userMessages: AnchorItem[] = [];
     const startIndex = collapsedCount;
     for (let i = startIndex; i < messages.length; i++) {
-      if (messages[i].type === 'user') {
+      const message = messages[i];
+      const messageKey = messageKeys[i];
+      if (message?.type === 'user' && messageKey) {
         userMessages.push({
-          id: getMessageKey(messages[i], i),
+          id: messageKey,
           position: 0,
-          preview: getMessagePreview(messages[i]),
+          preview: getMessagePreview(message),
         });
       }
     }
@@ -105,7 +108,13 @@ export const MessageAnchorRail = memo(function MessageAnchorRail({
       ...item,
       position: 0.04 + (idx / (visibleMessages.length - 1)) * 0.92,
     }));
-  }, [messages, collapsedCount]);
+  }, [messages, messageKeys, collapsedCount]);
+
+  useEffect(() => {
+    const anchorIds = new Set(anchors.map((anchor) => anchor.id));
+    setActiveAnchorId((current) => current && !anchorIds.has(current) ? null : current);
+    setTooltipAnchorId((current) => current && !anchorIds.has(current) ? null : current);
+  }, [anchors]);
 
   // Scroll to a specific anchor message
   const scrollToAnchor = useCallback((messageId: string) => {
@@ -156,6 +165,7 @@ export const MessageAnchorRail = memo(function MessageAnchorRail({
             return;
           }
         }
+        setActiveAnchorId(null);
       },
       {
         root: container,

--- a/webview/src/components/MessageList.test.tsx
+++ b/webview/src/components/MessageList.test.tsx
@@ -1,8 +1,9 @@
 import { act, fireEvent, render, screen, cleanup } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createRef, useState } from 'react';
+import { createRef, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { ClaudeMessage, ClaudeContentBlock, ToolResultBlock } from '../types';
 import { MessageList } from './MessageList';
+import { reconcileMessageKeys, type MessageKeySnapshot } from '../utils/messageUtils';
 
 // Mock MessageItem to keep this suite focused on list-level paging behaviour.
 vi.mock('./MessageItem', () => ({
@@ -90,12 +91,46 @@ const noopGetText = (m: ClaudeMessage) => m.content ?? '';
 const noopGetBlocks = (_m: ClaudeMessage): ClaudeContentBlock[] => [];
 const noopFindToolResult = (_id: string | undefined, _i: number): ToolResultBlock | null => null;
 const noopExtractMd = (_m: ClaudeMessage) => '';
+const keysFor = (messages: ClaudeMessage[]) =>
+  reconcileMessageKeys(messages, undefined, 'test-session').keys;
+
+function StableMessageList({
+  messages,
+}: {
+  messages: ClaudeMessage[];
+}) {
+  const previousRef = useRef<MessageKeySnapshot | undefined>(undefined);
+  const snapshot = useMemo(
+    () => reconcileMessageKeys(messages, previousRef.current, 'test-session'),
+    [messages],
+  );
+  useLayoutEffect(() => {
+    previousRef.current = snapshot;
+  }, [snapshot]);
+  return (
+    <MessageList
+      messages={messages}
+      messageKeys={snapshot.keys}
+      streamingActive
+      isThinking
+      loading={false}
+      loadingStartTime={null}
+      t={t}
+      getMessageText={noopGetText}
+      getContentBlocks={noopGetBlocks}
+      findToolResult={noopFindToolResult}
+      extractMarkdownContent={noopExtractMd}
+      messagesEndRef={createRef<HTMLDivElement>()}
+    />
+  );
+}
 
 function renderList(messages: ClaudeMessage[]) {
   const endRef = createRef<HTMLDivElement>();
   return render(
     <MessageList
       messages={messages}
+      messageKeys={keysFor(messages)}
       streamingActive={false}
       isThinking={false}
       loading={false}
@@ -182,6 +217,7 @@ describe('MessageList paged collapse', () => {
     const { rerender, container } = render(
       <MessageList
         messages={messages}
+        messageKeys={keysFor(messages)}
         streamingActive={false}
         isThinking={false}
         loading={false}
@@ -207,6 +243,7 @@ describe('MessageList paged collapse', () => {
     rerender(
       <MessageList
         messages={makeMessages(50, 'session2')}
+        messageKeys={keysFor(makeMessages(50, 'session2'))}
         streamingActive={false}
         isThinking={false}
         loading={false}
@@ -236,6 +273,7 @@ describe('MessageList paged collapse', () => {
     const { container, rerender } = render(
       <MessageList
         messages={firstSession}
+        messageKeys={keysFor(firstSession)}
         streamingActive={false}
         isThinking={false}
         loading={false}
@@ -255,6 +293,7 @@ describe('MessageList paged collapse', () => {
     rerender(
       <MessageList
         messages={secondSession}
+        messageKeys={keysFor(secondSession)}
         streamingActive={false}
         isThinking={false}
         loading={false}
@@ -278,6 +317,7 @@ describe('MessageList paged collapse', () => {
     const { container } = render(
       <MessageList
         messages={makeMessages(20)}
+        messageKeys={keysFor(makeMessages(20))}
         streamingActive={false}
         isThinking={false}
         loading={false}
@@ -337,22 +377,7 @@ describe('MessageList container behaviour', () => {
         },
       },
     };
-    const endRef = createRef<HTMLDivElement>();
-    const renderMessageList = (messages: ClaudeMessage[]) => (
-      <MessageList
-        messages={messages}
-        streamingActive
-        isThinking
-        loading={false}
-        loadingStartTime={null}
-        t={t}
-        getMessageText={noopGetText}
-        getContentBlocks={noopGetBlocks}
-        findToolResult={noopFindToolResult}
-        extractMarkdownContent={noopExtractMd}
-        messagesEndRef={endRef}
-      />
-    );
+    const renderMessageList = (messages: ClaudeMessage[]) => <StableMessageList messages={messages} />;
     const { rerender } = render(renderMessageList([initialMessage]));
     const liveItem = screen.getByTestId('message-item');
 
@@ -374,13 +399,13 @@ describe('MessageList container behaviour', () => {
     rerender(renderMessageList([toolSnapshot]));
 
     expect(screen.getByTestId('message-item')).toBe(liveItem);
-    expect(liveItem.getAttribute('data-key')).toBe('turn-42');
+    expect(liveItem.getAttribute('data-key')).toBe('test-session:turn-42');
     expect(liveItem.getAttribute('data-local-state')).toBe('preserved');
 
     rerender(renderMessageList([{ ...toolSnapshot, __turnId: undefined }]));
 
     expect(screen.getByTestId('message-item')).toBe(liveItem);
-    expect(liveItem.getAttribute('data-key')).toBe('turn-42');
+    expect(liveItem.getAttribute('data-key')).toBe('test-session:turn-42');
     expect(liveItem.getAttribute('data-local-state')).toBe('preserved');
   });
 
@@ -396,22 +421,7 @@ describe('MessageList container behaviour', () => {
         },
       },
     };
-    const endRef = createRef<HTMLDivElement>();
-    const renderMessageList = (message: ClaudeMessage) => (
-      <MessageList
-        messages={[message]}
-        streamingActive
-        isThinking
-        loading={false}
-        loadingStartTime={null}
-        t={t}
-        getMessageText={noopGetText}
-        getContentBlocks={noopGetBlocks}
-        findToolResult={noopFindToolResult}
-        extractMarkdownContent={noopExtractMd}
-        messagesEndRef={endRef}
-      />
-    );
+    const renderMessageList = (message: ClaudeMessage) => <StableMessageList messages={[message]} />;
     const { rerender } = render(renderMessageList(replayMessage));
     const replayItem = screen.getByTestId('message-item');
 
@@ -419,7 +429,7 @@ describe('MessageList container behaviour', () => {
     rerender(renderMessageList({ ...replayMessage, isStreaming: true, __turnId: 43 }));
 
     expect(screen.getByTestId('message-item')).toBe(replayItem);
-    expect(replayItem.getAttribute('data-key')).toBe('replay-assistant-uuid');
+    expect(replayItem.getAttribute('data-key')).toBe('test-session:replay-assistant-uuid');
     expect(replayItem.getAttribute('data-local-state')).toBe('preserved');
   });
 
@@ -437,6 +447,7 @@ describe('MessageList container behaviour', () => {
     render(
       <MessageList
         messages={makeMessages(3)}
+        messageKeys={keysFor(makeMessages(3))}
         streamingActive={false}
         isThinking={false}
         loading={true}

--- a/webview/src/components/MessageList.tsx
+++ b/webview/src/components/MessageList.tsx
@@ -1,7 +1,6 @@
-import { memo, useState, useEffect, useRef, useMemo, useCallback, forwardRef, useImperativeHandle, useLayoutEffect } from 'react';
+import { memo, useState, useEffect, useLayoutEffect, useRef, useMemo, useCallback, forwardRef, useImperativeHandle } from 'react';
 import type { TFunction } from 'i18next';
 import type { ClaudeMessage, ClaudeContentBlock, CodexHistoryPageInfo, ToolResultBlock } from '../types';
-import { getMessageKey } from '../utils/messageUtils';
 import { sendBridgeEvent } from '../utils/bridge';
 import { MessageItem } from './MessageItem';
 import WaitingIndicator from './WaitingIndicator';
@@ -47,58 +46,6 @@ function getFirstMessageBoundaryKey(message: ClaudeMessage | undefined): string 
   return `content:${message.type}:${message.content ?? ''}`;
 }
 
-interface MessageRenderKeySnapshot {
-  keys: string[];
-  identityToKey: Map<string, string>;
-}
-
-function keepMessageRenderKeysSteady(
-  messages: ClaudeMessage[],
-  rememberedIdentities: ReadonlyMap<string, string>,
-): MessageRenderKeySnapshot {
-  const turnOccurrences = new Map<number, number>();
-  const identityToKey = new Map<string, string>();
-
-  const keys = messages.map((message, index) => {
-    const rawUuid = typeof message.raw === 'object'
-      && message.raw !== null
-      && typeof message.raw.uuid === 'string'
-      && message.raw.uuid.length > 0
-      ? message.raw.uuid
-      : undefined;
-    const uuidIdentity = rawUuid ? `uuid:${rawUuid}` : undefined;
-    let turnIdentity: string | undefined;
-    let defaultTurnKey: string | undefined;
-
-    if (typeof message.__turnId === 'number') {
-      const occurrence = turnOccurrences.get(message.__turnId) ?? 0;
-      turnOccurrences.set(message.__turnId, occurrence + 1);
-      turnIdentity = `turn:${message.__turnId}:${occurrence}`;
-      defaultTurnKey = occurrence === 0
-        ? `turn-${message.__turnId}`
-        : `turn-${message.__turnId}-${occurrence}`;
-    }
-
-    // A streaming placeholder starts without a backend UUID. When the tool-use
-    // snapshot arrives, raw.uuid is added while __turnId continues to identify
-    // the same live bubble. Keep the turn key during that identity enrichment
-    // so React preserves MessageItem's thinking expansion state. Remember both
-    // identities once they meet, which also keeps UUID-first replay messages
-    // mounted when a runtime turn ID is attached later.
-    const rememberedKey = (turnIdentity && rememberedIdentities.get(turnIdentity))
-      || (uuidIdentity && rememberedIdentities.get(uuidIdentity));
-    const renderKey = rememberedKey
-      || (rawUuid ? getMessageKey(message, index) : defaultTurnKey)
-      || getMessageKey(message, index);
-
-    if (turnIdentity) identityToKey.set(turnIdentity, renderKey);
-    if (uuidIdentity) identityToKey.set(uuidIdentity, renderKey);
-    return renderKey;
-  });
-
-  return { keys, identityToKey };
-}
-
 function extractToolResultPreview(result: ToolResultBlock | null | undefined): string {
   if (!result) return 'pending';
 
@@ -134,6 +81,7 @@ function getMessageToolResultSignature(
 
 interface MessageListProps {
   messages: ClaudeMessage[];
+  messageKeys: readonly string[];
   streamingActive: boolean;
   isThinking: boolean;
   loading: boolean;
@@ -156,6 +104,7 @@ interface MessageListProps {
 
 export const MessageList = memo(forwardRef<MessageListRevealHandle, MessageListProps>(function MessageList({
   messages,
+  messageKeys,
   streamingActive,
   isThinking,
   loading,
@@ -293,7 +242,7 @@ export const MessageList = memo(forwardRef<MessageListRevealHandle, MessageListP
   }), [collapsedCount, userTurnStartIndexes.length]);
 
   // Notify parent of collapsed count changes (for anchor rail sync)
-  useEffect(() => {
+  useLayoutEffect(() => {
     onCollapsedCountChange?.(collapsedCount);
   }, [collapsedCount, onCollapsedCountChange]);
 
@@ -312,15 +261,6 @@ export const MessageList = memo(forwardRef<MessageListRevealHandle, MessageListP
     () => (shouldCollapse ? messages.slice(collapsedCount) : messages),
     [messages, shouldCollapse, collapsedCount]
   );
-  const rememberedMessageKeysRef = useRef<ReadonlyMap<string, string>>(new Map());
-  const messageRenderKeySnapshot = useMemo(
-    () => keepMessageRenderKeysSteady(messages, rememberedMessageKeysRef.current),
-    [messages],
-  );
-  useLayoutEffect(() => {
-    rememberedMessageKeysRef.current = messageRenderKeySnapshot.identityToKey;
-  }, [messageRenderKeySnapshot]);
-
   return (
     <div onContextMenu={handleMessageContextMenu}>
       {ctxMenu.visible && (
@@ -356,7 +296,7 @@ export const MessageList = memo(forwardRef<MessageListRevealHandle, MessageListP
 
       {visibleMessages.map((message, visibleIndex) => {
         const messageIndex = shouldCollapse ? visibleIndex + collapsedCount : visibleIndex;
-        const messageKey = messageRenderKeySnapshot.keys[messageIndex];
+        const messageKey = messageKeys[messageIndex];
         const toolResultSignature = getMessageToolResultSignature(message, messageIndex, getContentBlocks, findToolResult);
 
         return (

--- a/webview/src/components/StatusPanel/StatusPanel.tsx
+++ b/webview/src/components/StatusPanel/StatusPanel.tsx
@@ -11,7 +11,7 @@ import DiscardAllDialog from './DiscardAllDialog';
 import type { TabType, StatusPanelProps } from './types';
 import './StatusPanel.less';
 
-const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, currentSessionId, expanded = true, isStreaming = false, onUndoFile, onDiscardAll, onKeepAll }: StatusPanelProps) => {
+const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, currentSessionId, currentProvider, expanded = true, isStreaming = false, onUndoFile, onDiscardAll, onKeepAll }: StatusPanelProps) => {
   const { t } = useTranslation();
   const [openPopover, setOpenPopover] = useState<TabType | null>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -207,7 +207,7 @@ const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, current
       case 'todo':
         return <TodoList todos={todos} />;
       case 'subagent':
-        return <SubagentList subagents={subagents} histories={subagentHistories} currentSessionId={currentSessionId} isStreaming={isStreaming} />;
+        return <SubagentList subagents={subagents} histories={subagentHistories} currentSessionId={currentSessionId} currentProvider={currentProvider} isStreaming={isStreaming} />;
       case 'files':
         return (
           <FileChangesList

--- a/webview/src/components/StatusPanel/SubagentList.test.tsx
+++ b/webview/src/components/StatusPanel/SubagentList.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { SubagentInfo } from '../../types';
+import SubagentList from './SubagentList';
+
+const sendBridgeEventMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../utils/bridge', () => ({ sendBridgeEvent: sendBridgeEventMock }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('SubagentList', () => {
+  it('loads Codex history with provider and agent path', async () => {
+    const subagent: SubagentInfo = {
+      id: 'call-spawn',
+      type: 'audit',
+      description: 'Review anchors',
+      prompt: 'Review anchors',
+      status: 'running',
+      isAsync: true,
+      messageIndex: 0,
+      agentPath: 'audit_ui',
+    };
+
+    render(
+      <SubagentList
+        subagents={[subagent]}
+        currentSessionId="session-1"
+        currentProvider="codex"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(sendBridgeEventMock).toHaveBeenCalledWith(
+      'load_subagent_session',
+      JSON.stringify({
+        sessionId: 'session-1',
+        provider: 'codex',
+        agentPath: 'audit_ui',
+        description: 'Review anchors',
+        toolUseId: 'call-spawn',
+      }),
+    ));
+  });
+});

--- a/webview/src/components/StatusPanel/SubagentList.tsx
+++ b/webview/src/components/StatusPanel/SubagentList.tsx
@@ -10,6 +10,7 @@ interface SubagentListProps {
   subagents: SubagentInfo[];
   histories?: Record<string, SubagentHistoryResponse>;
   currentSessionId?: string | null;
+  currentProvider: string;
   isStreaming?: boolean;
 }
 
@@ -64,7 +65,7 @@ const SubagentRow = memo(({ subagent, isExpanded, history, canLoad, onToggle, t 
 
 SubagentRow.displayName = 'SubagentRow';
 
-const SubagentList = memo(({ subagents, histories = {}, currentSessionId }: SubagentListProps) => {
+const SubagentList = memo(({ subagents, histories = {}, currentSessionId, currentProvider }: SubagentListProps) => {
   const { t } = useTranslation();
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
@@ -79,11 +80,13 @@ const SubagentList = memo(({ subagents, histories = {}, currentSessionId }: Suba
     if (!currentSessionId) return;
     sendBridgeEvent('load_subagent_session', JSON.stringify({
       sessionId: currentSessionId,
+      provider: currentProvider,
       agentId: subagent.agentId,
+      agentPath: subagent.agentPath,
       description: subagent.description,
       toolUseId: subagent.id,
     }));
-  }, [currentSessionId]);
+  }, [currentProvider, currentSessionId]);
 
   // Track the expanded row's status so the polling effect re-runs (and clears
   // its interval) when it transitions out of "running", instead of leaving a

--- a/webview/src/components/StatusPanel/subagentProcess.ts
+++ b/webview/src/components/StatusPanel/subagentProcess.ts
@@ -19,8 +19,14 @@ export function formatSubagentDuration(
 
 function getRawContent(message: unknown): unknown[] {
   if (!message || typeof message !== 'object') return [];
-  const raw = message as Record<string, any>;
-  const content = raw.message?.content ?? raw.content;
+  const record = message as Record<string, unknown>;
+  const frontendRaw = record.raw && typeof record.raw === 'object'
+    ? record.raw as Record<string, unknown>
+    : undefined;
+  const nestedMessage = record.message && typeof record.message === 'object'
+    ? record.message as Record<string, unknown>
+    : undefined;
+  const content = frontendRaw?.content ?? nestedMessage?.content ?? record.content;
   return Array.isArray(content) ? content : [];
 }
 

--- a/webview/src/components/StatusPanel/types.ts
+++ b/webview/src/components/StatusPanel/types.ts
@@ -8,6 +8,7 @@ export interface StatusPanelProps {
   subagents: SubagentInfo[];
   subagentHistories?: Record<string, SubagentHistoryResponse>;
   currentSessionId?: string | null;
+  currentProvider: string;
   /** Whether the panel is expanded */
   expanded?: boolean;
   /** Whether the conversation is currently streaming (active) */

--- a/webview/src/components/toolBlocks/AgentGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/AgentGroupBlock.tsx
@@ -4,8 +4,19 @@ import type { ClaudeContentBlock, ToolResultBlock } from '../../types';
 import { normalizeToolName } from '../../utils/toolConstants';
 import { sendBridgeEvent } from '../../utils/bridge';
 import { getPersistedExpanded, setPersistedExpanded } from '../../utils/expandedState';
-import { extractResultText, isAsyncAgentInput, parseAgentToolMeta } from '../../utils/subagentResult';
-import { useSubagentHistories, useSessionId, useGetToolResultRaw, useTaskEvent } from '../../contexts/SubagentContext';
+import {
+  extractResultText,
+  isAsyncAgentInput,
+  parseAgentToolMeta,
+  parseSpawnAgentMeta,
+} from '../../utils/subagentResult';
+import {
+  useSubagentHistories,
+  useSessionId,
+  useSessionProvider,
+  useGetToolResultRaw,
+  useTaskEvent,
+} from '../../contexts/SubagentContext';
 import SubagentProcessDetails from '../StatusPanel/SubagentProcessDetails';
 import { ContentBlockRenderer } from '../MessageItem/ContentBlockRenderer';
 
@@ -51,6 +62,7 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
   const { t } = useTranslation();
   const histories = useSubagentHistories();
   const currentSessionId = useSessionId();
+  const currentProvider = useSessionProvider();
   const getToolResultRaw = useGetToolResultRaw();
 
   const toolId = agentBlock.type === 'tool_use' ? agentBlock.id : undefined;
@@ -67,23 +79,30 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
   const input = agentBlock.type === 'tool_use' ? (agentBlock.input as Record<string, unknown> | undefined) : undefined;
   const result = findToolResult(toolId, messageIndex);
   const hasTerminalResult = result !== undefined && result !== null;
+  const toolName = agentBlock.type === 'tool_use' ? normalizeToolName(agentBlock.name ?? '') : '';
 
   // A background (run_in_background) Agent only gets a launch acknowledgment
   // tool_result; its real terminal status arrives later via task_notification,
   // so stay "running" until that event lands. Sync agents complete inline.
   // isAsyncAgentInput centralizes the strict === true check (and the snake/camel
   // guard) shared with useSubagents and TaskExecutionBlock.
-  const isAsync = isAsyncAgentInput(input);
+  const isAsync = isAsyncAgentInput(input, toolName);
   const taskEvent = useTaskEvent(toolId);
   const taskFailed = taskEvent?.status === 'failed' || taskEvent?.status === 'stopped';
 
   const agentType = getAgentType(agentBlock);
   const summary = getAgentSummary(agentBlock);
-  const toolName = agentBlock.type === 'tool_use' ? normalizeToolName(agentBlock.name ?? '') : '';
-
   const agentToolMeta = parseAgentToolMeta(getToolResultRaw, toolId);
-  const agentId = agentToolMeta.agentId ?? (input?.agent_id as string | undefined) ?? (input?.agentId as string | undefined);
+  const spawnMeta = toolName === 'spawn_agent'
+    ? parseSpawnAgentMeta(input ?? {}, result)
+    : {};
+  const agentId = spawnMeta.agentId
+    ?? agentToolMeta.agentId
+    ?? (input?.agent_id as string | undefined)
+    ?? (input?.agentId as string | undefined);
+  const agentPath = spawnMeta.agentPath;
   const history = (toolId ? histories[toolId] : undefined) ?? (agentId ? histories[agentId] : undefined);
+  const historyFailed = history?.status === 'error';
   // A settled main turn is only the launch boundary for a background Agent. Use
   // the live task_notification or a terminal sidechain end_turn as completion.
   // A failed launch (validation error before the task was registered) returns an
@@ -93,7 +112,7 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
     ? (taskEvent ? !taskFailed : history?.completed === true)
     : hasTerminalResult;
   const isError = isAsync
-    ? (taskEvent ? taskFailed : result?.is_error === true)
+    ? (taskEvent ? taskFailed : historyFailed || result?.is_error === true)
     : hasTerminalResult && result?.is_error === true;
 
   const noopToggleThinking = useCallback(() => {}, []);
@@ -105,11 +124,13 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
     if (!expanded || !currentSessionId || !toolId || history) return;
     sendBridgeEvent('load_subagent_session', JSON.stringify({
       sessionId: currentSessionId,
+      provider: currentProvider,
       agentId,
+      agentPath,
       description: typeof summary === 'string' ? summary : undefined,
       toolUseId: toolId,
     }));
-  }, [agentId, currentSessionId, summary, expanded, history, toolId]);
+  }, [agentId, agentPath, currentProvider, currentSessionId, summary, expanded, history, toolId]);
 
   useEffect(() => {
     // Clear existing timer when dependencies change or conditions no longer met
@@ -126,7 +147,9 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
       pollingTimerRef.current = window.setInterval(() => {
         sendBridgeEvent('load_subagent_session', JSON.stringify({
           sessionId: currentSessionId,
+          provider: currentProvider,
           agentId,
+          agentPath,
           description: typeof summary === 'string' ? summary : undefined,
           toolUseId: toolId,
         }));
@@ -139,7 +162,7 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
         pollingTimerRef.current = null;
       }
     };
-  }, [agentId, currentSessionId, summary, expanded, isCompleted, isError, toolId]);
+  }, [agentId, agentPath, currentProvider, currentSessionId, summary, expanded, isCompleted, isError, toolId]);
 
   return (
     <div className="task-container agent-group-container">

--- a/webview/src/components/toolBlocks/TaskExecutionBlock.test.tsx
+++ b/webview/src/components/toolBlocks/TaskExecutionBlock.test.tsx
@@ -4,6 +4,7 @@ import TaskExecutionBlock from './TaskExecutionBlock';
 const mockSendBridgeEvent = vi.fn();
 let mockHistories: Record<string, unknown> = {};
 const mockUseSessionId = vi.fn<() => string | null>();
+const mockUseSessionProvider = vi.fn<() => string>();
 const mockGetToolResultRaw = vi.fn<(toolUseId: string) => Record<string, unknown> | null>();
 const mockUseTaskEvent = vi.fn<(toolUseId: string | undefined) => unknown>();
 
@@ -20,6 +21,7 @@ vi.mock('../../utils/bridge', () => ({
 vi.mock('../../contexts/SubagentContext', () => ({
   useSubagentHistories: () => mockHistories,
   useSessionId: () => mockUseSessionId(),
+  useSessionProvider: () => mockUseSessionProvider(),
   useGetToolResultRaw: () => mockGetToolResultRaw,
   useTaskEvent: (toolUseId: string | undefined) => mockUseTaskEvent(toolUseId),
 }));
@@ -30,11 +32,13 @@ describe('TaskExecutionBlock polling', () => {
     mockSendBridgeEvent.mockReset();
     mockGetToolResultRaw.mockReset();
     mockUseSessionId.mockReset();
+    mockUseSessionProvider.mockReset();
     mockUseTaskEvent.mockReset();
 
     mockHistories = {};
     mockGetToolResultRaw.mockReturnValue(null);
     mockUseSessionId.mockReturnValue('session-1');
+    mockUseSessionProvider.mockReturnValue('claude');
     mockUseTaskEvent.mockReturnValue(undefined);
   });
 
@@ -384,5 +388,36 @@ describe('TaskExecutionBlock polling', () => {
     expect(text).toContain('researcher');
     expect(text).toContain('claude-sonnet-4-6');
     expect(text).toContain('high');
+  });
+
+  it('loads Codex spawn_agent history with provider and task path', () => {
+    mockUseSessionProvider.mockReturnValue('codex');
+    const result = {
+      type: 'tool_result',
+      tool_use_id: 'call-1',
+      content: '{"task_name":"/root/reviewer"}',
+    } as any;
+
+    const { container } = render(
+      <TaskExecutionBlock
+        name="spawn_agent"
+        toolId="call-1"
+        result={result}
+        input={{ prompt: 'review' } as any}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('.task-header') as HTMLElement);
+
+    expect(mockSendBridgeEvent).toHaveBeenCalledWith(
+      'load_subagent_session',
+      JSON.stringify({
+        sessionId: 'session-1',
+        provider: 'codex',
+        agentPath: '/root/reviewer',
+        toolUseId: 'call-1',
+      }),
+    );
+    expect(container.querySelector('.tool-status-indicator')?.className).toContain('pending');
   });
 });

--- a/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
+++ b/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
@@ -3,8 +3,19 @@ import { useTranslation } from 'react-i18next';
 import type { ToolInput, ToolResultBlock } from '../../types';
 import { normalizeToolName } from '../../utils/toolConstants';
 import { sendBridgeEvent } from '../../utils/bridge';
-import { extractResultText, isAsyncAgentInput, parseAgentToolMeta } from '../../utils/subagentResult';
-import { useSubagentHistories, useSessionId, useGetToolResultRaw, useTaskEvent } from '../../contexts/SubagentContext';
+import {
+  extractResultText,
+  isAsyncAgentInput,
+  parseAgentToolMeta,
+  parseSpawnAgentMeta,
+} from '../../utils/subagentResult';
+import {
+  useSubagentHistories,
+  useSessionId,
+  useSessionProvider,
+  useGetToolResultRaw,
+  useTaskEvent,
+} from '../../contexts/SubagentContext';
 import SubagentProcessDetails from '../StatusPanel/SubagentProcessDetails';
 
 const MONO_FONT_STYLE: React.CSSProperties = {
@@ -20,67 +31,6 @@ interface TaskExecutionBlockProps {
   isStreaming?: boolean;
 }
 
-type SpawnAgentMeta = {
-  agentId?: string;
-  nickname?: string;
-  model?: string;
-  reasoningEffort?: string;
-};
-
-function parseSpawnAgentMeta(input: ToolInput, result?: ToolResultBlock | null): SpawnAgentMeta {
-  const text = extractResultText(result)?.trim();
-  let parsed: Record<string, unknown> | null = null;
-
-  if (text && (text.startsWith('{') || text.startsWith('['))) {
-    try {
-      const candidate = JSON.parse(text);
-      if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
-        parsed = candidate as Record<string, unknown>;
-      }
-    } catch {
-      parsed = null;
-    }
-  }
-
-  const getString = (...values: unknown[]): string | undefined => {
-    for (const value of values) {
-      if (typeof value === 'string' && value.trim()) {
-        return value.trim();
-      }
-    }
-    return undefined;
-  };
-
-  // Reuse a single regex match for both model and reasoningEffort instead of
-  // running the same pattern twice over the text.
-  const modelMatch = text?.match(/\(([A-Za-z0-9._:-]+)(?:\s+(low|medium|high|xhigh))?\)/i);
-  const agentId = getString(
-    parsed?.agent_id,
-    parsed?.agentId,
-    parsed?.agent_path,
-    parsed?.agentPath,
-  ) ?? text?.match(/\b([0-9a-f]{8}-[0-9a-f-]{27})\b/i)?.[1];
-
-  const nickname = getString(
-    parsed?.nickname,
-    parsed?.name,
-  );
-
-  const model = getString(
-    parsed?.model,
-    input.model,
-  ) ?? modelMatch?.[1];
-
-  const reasoningEffort = getString(
-    parsed?.reasoning_effort,
-    parsed?.reasoningEffort,
-    input.reasoning_effort,
-    input.reasoningEffort,
-  ) ?? modelMatch?.[2];
-
-  return { agentId, nickname, model, reasoningEffort };
-}
-
 function shortenAgentId(agentId?: string): string | undefined {
   if (!agentId) return undefined;
   return agentId.length > 8 ? `${agentId.slice(0, 8)}…` : agentId;
@@ -91,6 +41,7 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
   const [expanded, setExpanded] = useState(false);
   const histories = useSubagentHistories();
   const currentSessionId = useSessionId();
+  const currentProvider = useSessionProvider();
   const getToolResultRaw = useGetToolResultRaw();
   const taskEvent = useTaskEvent(toolId);
 
@@ -115,9 +66,12 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
     agentPath: _agentPathCamel,
     ...rest
   } = input ?? ({} as ToolInput);
-  const spawnMeta = isSpawnAgent && input ? parseSpawnAgentMeta(input, result) : {};
+  const spawnMeta = isSpawnAgent && input
+    ? parseSpawnAgentMeta(input as Record<string, unknown>, result)
+    : {};
   const agentToolMeta = !isSpawnAgent && input ? parseAgentToolMeta(getToolResultRaw, toolId) : {};
   const agentId = spawnMeta.agentId ?? agentToolMeta.agentId;
+  const agentPath = spawnMeta.agentPath;
   const identityLabel = spawnMeta.nickname || (typeof subagentType === 'string' && subagentType ? subagentType : undefined);
   const modelSummary = [spawnMeta.model, spawnMeta.reasoningEffort].filter(Boolean).join(' ');
   const shortAgentId = shortenAgentId(agentId);
@@ -131,7 +85,7 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
   // task_notification, so treat that as an error instead of staying stuck.
   // isAsyncAgentInput centralizes the strict === true check shared with
   // useSubagents and AgentGroupBlock.
-  const isAsync = input ? isAsyncAgentInput(input) : false;
+  const isAsync = input ? isAsyncAgentInput(input, normalizedName) : false;
   const hasTerminalResult = result !== undefined && result !== null;
   const taskFailed = taskEvent?.status === 'failed' || taskEvent?.status === 'stopped';
   // Async completion has two authoritative sources: the live task_notification,
@@ -139,11 +93,12 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
   // assistant/end_turn. A settled main turn alone proves only that the launch
   // turn ended; the background sidechain may still be running.
   const history = (toolId ? histories[toolId] : undefined) ?? (agentId ? histories[agentId] : undefined);
+  const historyFailed = history?.status === 'error';
   const isCompleted = isAsync
     ? (taskEvent ? !taskFailed : history?.completed === true)
     : hasTerminalResult;
   const isError = isAsync
-    ? (taskEvent ? taskFailed : result?.is_error === true)
+    ? (taskEvent ? taskFailed : historyFailed || result?.is_error === true)
     : hasTerminalResult && result?.is_error === true;
 
   // For background agents the task_notification carries the authoritative usage
@@ -159,11 +114,13 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
     if (!input || !expanded || !isAgentTool || !currentSessionId || !toolId || history) return;
     sendBridgeEvent('load_subagent_session', JSON.stringify({
       sessionId: currentSessionId,
+      provider: currentProvider,
       agentId,
+      agentPath,
       description: typeof description === 'string' ? description : undefined,
       toolUseId: toolId,
     }));
-  }, [input, agentId, currentSessionId, description, expanded, history, isAgentTool, toolId]);
+  }, [input, agentId, agentPath, currentProvider, currentSessionId, description, expanded, history, isAgentTool, toolId]);
 
   // Poll while an expanded async Agent is unresolved, including after a main
   // turn settles. This lets a reloaded session observe the sidechain's terminal
@@ -182,13 +139,15 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
     const timer = window.setInterval(() => {
       sendBridgeEvent('load_subagent_session', JSON.stringify({
         sessionId: currentSessionId,
+        provider: currentProvider,
         agentId,
+        agentPath,
         description: typeof description === 'string' ? description : undefined,
         toolUseId: toolId,
       }));
     }, 2_000);
     return () => window.clearInterval(timer);
-  }, [input, agentId, currentSessionId, description, shouldPollHistory, toolId]);
+  }, [input, agentId, agentPath, currentProvider, currentSessionId, description, shouldPollHistory, toolId]);
 
   if (!input) {
     return null;

--- a/webview/src/contexts/SubagentContext.tsx
+++ b/webview/src/contexts/SubagentContext.tsx
@@ -13,10 +13,12 @@ const SubagentHistoryContext = createContext<Record<string, SubagentHistoryRespo
 
 interface SessionIdContextValue {
   currentSessionId: string | null;
+  currentProvider: string;
 }
 
 const SessionIdContext = createContext<SessionIdContextValue>({
   currentSessionId: null,
+  currentProvider: 'claude',
 });
 
 export type GetToolResultRawFn = (toolUseId: string) => ClaudeRawMessage | null;
@@ -94,6 +96,11 @@ export function useSessionId(): string | null {
   return useContext(SessionIdContext).currentSessionId;
 }
 
+/** Current provider paired with the session ID for provider-specific history reads. */
+export function useSessionProvider(): string {
+  return useContext(SessionIdContext).currentProvider;
+}
+
 /**
  * Hook for looking up the raw message that contains a given tool result.
  */
@@ -120,8 +127,15 @@ export function useTaskEvent(toolUseId: string | undefined): TaskEvent | undefin
  * `currentSessionId` so SessionIdContext consumers don't re-render on every
  * history update.
  */
-export function useSubagentContextValues(subagentHistories: Record<string, SubagentHistoryResponse>, currentSessionId: string | null) {
-  const sessionIdCtxValue = useMemo(() => ({ currentSessionId }), [currentSessionId]);
+export function useSubagentContextValues(
+  subagentHistories: Record<string, SubagentHistoryResponse>,
+  currentSessionId: string | null,
+  currentProvider: string,
+) {
+  const sessionIdCtxValue = useMemo(
+    () => ({ currentSessionId, currentProvider }),
+    [currentProvider, currentSessionId],
+  );
   return { subagentHistoryCtxValue: subagentHistories, sessionIdCtxValue };
 }
 

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -92,6 +92,7 @@ interface Window {
    * Add single history message (used for Codex session loading)
    */
   addHistoryMessage?: (message: any) => void;
+  onSubagentHistoryChunk?: (transferId: string, chunk: string, isFinal: string | boolean) => void;
   beginCodexHistoryPage?: (json: string) => void;
   appendCodexHistoryPageBatch?: (pageId: string, json: string) => void;
   appendCodexHistoryPageChunk?: (

--- a/webview/src/hooks/useSubagents.test.ts
+++ b/webview/src/hooks/useSubagents.test.ts
@@ -78,6 +78,35 @@ const getToolResultRaw = (messages: ClaudeMessage[]) => (toolUseId: string) => {
 };
 
 describe('extractSubagentsFromMessages', () => {
+  it('retains Codex spawn_agent path metadata for history requests', () => {
+    const message: ClaudeMessage = {
+      type: 'assistant',
+      content: '',
+      raw: {
+        message: {
+          content: [{
+            type: 'tool_use',
+            id: 'call-spawn',
+            name: 'spawn_agent',
+            input: { task_name: 'audit_ui', message: 'Review anchors' },
+          }],
+        },
+      },
+    };
+
+    const subagents = extractSubagentsFromMessages(
+      [message], getContentBlocks, findToolResult([message]), getToolResultRaw([message]),
+    );
+
+    expect(subagents).toHaveLength(1);
+    expect(subagents[0]).toMatchObject({
+      id: 'call-spawn',
+      agentPath: 'audit_ui',
+      isAsync: true,
+      status: 'running',
+    });
+  });
+
   it('attaches completed Agent result metadata including stable agent id', () => {
     const messages = [assistantWithAgent('tooluse_backend'), toolResultMessage('tooluse_backend')];
 

--- a/webview/src/hooks/useSubagents.ts
+++ b/webview/src/hooks/useSubagents.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import type { ClaudeMessage, ClaudeRawMessage, ClaudeContentBlock, ToolResultBlock, SubagentHistoryResponse, SubagentInfo, SubagentStatus, TaskEvent, TaskEventMap } from '../types';
 import { normalizeToolInput } from '../utils/toolInputNormalization';
 import { normalizeToolName } from '../utils/toolConstants';
-import { extractResultText, isAsyncAgentInput } from '../utils/subagentResult';
+import { extractResultText, isAsyncAgentInput, parseSpawnAgentMeta } from '../utils/subagentResult';
 import { useTaskEvents } from '../contexts/SubagentContext';
 
 type GetToolResultRawFn = (toolUseId: string) => ClaudeRawMessage | null;
@@ -124,9 +124,10 @@ export function extractSubagentsFromMessages(
       const taskEvent = taskEvents[toolUseId];
       // isAsync is read via the shared isAsyncAgentInput helper so the
       // StatusPanel list and the inline Agent cards stay in lockstep.
-      const isAsync = isAsyncAgentInput(input);
+      const isAsync = isAsyncAgentInput(input, toolName);
       const status = determineStatus(result, isAsync, taskEvent);
       const resultMetadata = extractResultMetadata(result, getToolResultRaw, toolUseId, taskEvent);
+      const spawnMeta = toolName === 'spawn_agent' ? parseSpawnAgentMeta(input, result) : {};
 
       subagents.push({
         id,
@@ -137,6 +138,8 @@ export function extractSubagentsFromMessages(
         isAsync,
         messageIndex,
         ...resultMetadata,
+        ...(spawnMeta.agentId && { agentId: spawnMeta.agentId }),
+        ...(spawnMeta.agentPath && { agentPath: spawnMeta.agentPath }),
       });
     });
   });
@@ -152,6 +155,7 @@ export function applySubagentHistoryCompletion(
     if (!subagent.isAsync || subagent.status !== 'running') return subagent;
     const history = subagentHistories[subagent.id]
       ?? (subagent.agentId ? subagentHistories[subagent.agentId] : undefined);
+    if (history?.status === 'error') return { ...subagent, status: 'error' as const };
     return history?.completed ? { ...subagent, status: 'completed' as const } : subagent;
   });
 }

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -1200,6 +1200,30 @@ describe('useWindowCallbacks integration', () => {
     expect(updatedState['task-1'].messages[0].content[0].text).toBe('final result');
   });
 
+  it('reassembles oversized subagent history before updating state', () => {
+    const opts = createOptions();
+    renderHook(() => useWindowCallbacks(opts));
+    const payload = JSON.stringify({
+      success: true,
+      toolUseId: 'task-1',
+      messages: [{ type: 'assistant', content: 'large result' }],
+    });
+    const midpoint = Math.floor(payload.length / 2);
+
+    act(() => {
+      window.onSubagentHistoryChunk?.('transfer-1', payload.slice(0, midpoint), false);
+    });
+    expect(opts.setSubagentHistories).not.toHaveBeenCalled();
+
+    act(() => {
+      window.onSubagentHistoryChunk?.('transfer-1', payload.slice(midpoint), true);
+    });
+
+    expect(opts.setSubagentHistories).toHaveBeenCalledTimes(1);
+    const updater = (opts.setSubagentHistories as any).mock.calls[0][0] as (prev: Record<string, unknown>) => Record<string, any>;
+    expect(updater({})['task-1'].messages[0].content).toBe('large result');
+  });
+
   // ===== onStreamEnd idempotency (dual-path delivery) =====
 
   describe('onStreamEnd idempotency', () => {

--- a/webview/src/hooks/windowCallbacks/registerCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks.ts
@@ -39,6 +39,25 @@ function areSubagentMessagesEquivalent(previousMessages: unknown[] | undefined, 
   return deepEqual(previousMessages, nextMessages);
 }
 
+const pendingSubagentHistoryChunks = new Map<string, string[]>();
+const MAX_PENDING_SUBAGENT_HISTORY_TRANSFERS = 16;
+
+function appendSubagentHistoryChunk(transferId: string, chunk: string, isFinal: string | boolean): void {
+  if (!transferId) return;
+  const chunks = pendingSubagentHistoryChunks.get(transferId) ?? [];
+  chunks.push(chunk);
+  if (isFinal === true || isFinal === 'true') {
+    pendingSubagentHistoryChunks.delete(transferId);
+    window.onSubagentHistoryLoaded?.(chunks.join(''));
+    return;
+  }
+  if (pendingSubagentHistoryChunks.size >= MAX_PENDING_SUBAGENT_HISTORY_TRANSFERS) {
+    const oldestTransferId = pendingSubagentHistoryChunks.keys().next().value;
+    if (oldestTransferId) pendingSubagentHistoryChunks.delete(oldestTransferId);
+  }
+  pendingSubagentHistoryChunks.set(transferId, chunks);
+}
+
 export function registerWindowCallbacks(
   options: UseWindowCallbacksOptions,
   tRef: MutableRefObject<UseWindowCallbacksOptions['t']>,
@@ -81,6 +100,8 @@ export function registerWindowCallbacks(
   registerPermissionCallbacks(options);
   registerAgentAndSelectionCallbacks(options);
 
+  window.onSubagentHistoryChunk = appendSubagentHistoryChunk;
+
   window.onSubagentHistoryLoaded = (json: string) => {
     try {
       if (!options.setSubagentHistories) return;
@@ -93,10 +114,14 @@ export function registerWindowCallbacks(
         // This prevents cascading re-renders and scroll jumps caused by
         // periodic subagent polling (every 2 s) returning unchanged data.
         if (existing && existing.success === result.success
+          && existing.completed === result.completed
+          && existing.status === result.status
           && existing.error === result.error
           && existing.sessionId === result.sessionId
+          && existing.provider === result.provider
           && existing.toolUseId === result.toolUseId
           && existing.agentId === result.agentId
+          && existing.agentPath === result.agentPath
           && areSubagentMessagesEquivalent(existing.messages, result.messages)) {
           return prev;
         }

--- a/webview/src/types/subagent.ts
+++ b/webview/src/types/subagent.ts
@@ -44,7 +44,10 @@ export interface SubagentHistoryResponse {
   completed?: boolean;
   toolUseId?: string;
   agentId?: string;
+  agentPath?: string;
   sessionId?: string;
+  provider?: string;
+  status?: SubagentStatus;
   error?: string;
   messages?: unknown[];
 }
@@ -73,6 +76,8 @@ export interface SubagentInfo {
   messageIndex: number;
   /** Stable runtime agent id returned by Claude Code, used to locate sidechain logs */
   agentId?: string;
+  /** Codex agent path derived from spawn_agent task_name. */
+  agentPath?: string;
   /** Total runtime in milliseconds */
   totalDurationMs?: number;
   /** Total tokens reported by the Agent tool */

--- a/webview/src/utils/messageUtils.test.ts
+++ b/webview/src/utils/messageUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { ClaudeMessage } from '../types';
 import {
   getMessageKey,
+  reconcileMessageKeys,
   getContentBlocks,
   mergeConsecutiveAssistantMessages,
   formatCommandForDisplay,
@@ -70,6 +71,89 @@ describe('getMessageKey', () => {
   it('falls back to type-index when no uuid, __turnId, or timestamp', () => {
     const msg: ClaudeMessage = { type: 'assistant', content: 'hi' };
     expect(getMessageKey(msg, 7)).toBe('assistant-7');
+  });
+});
+
+describe('reconcileMessageKeys', () => {
+  it('deduplicates repeated UUIDs, turn IDs, timestamps, and fallback keys', () => {
+    const messages = [
+      { type: 'user', content: 'a', raw: { uuid: 'same' } },
+      { type: 'user', content: 'b', raw: { uuid: 'same' } },
+      { type: 'assistant', content: 'c', __turnId: 7 },
+      { type: 'assistant', content: 'd', __turnId: 7 },
+      { type: 'user', content: 'e', timestamp: '2026-01-01T00:00:00Z' },
+      { type: 'user', content: 'f', timestamp: '2026-01-01T00:00:00Z' },
+      { type: 'error', content: 'g' },
+      { type: 'error', content: 'h' },
+    ] as ClaudeMessage[];
+
+    const snapshot = reconcileMessageKeys(messages, undefined, 'session-a');
+
+    expect(new Set(snapshot.keys).size).toBe(messages.length);
+  });
+
+  it('keeps existing keys when a duplicate is prepended', () => {
+    const existing = { type: 'user', content: 'existing', raw: { uuid: 'duplicate' } } as ClaudeMessage;
+    const first = reconcileMessageKeys([existing], undefined, 'session-a');
+    const prepended = { type: 'user', content: 'new', raw: { uuid: 'duplicate' } } as ClaudeMessage;
+
+    const next = reconcileMessageKeys([prepended, existing], first, 'session-a');
+
+    expect(next.keys[1]).toBe(first.keys[0]);
+    expect(next.keys[0]).not.toBe(next.keys[1]);
+  });
+
+  it('does not let a prepended timestamp match steal a later UUID key', () => {
+    const oldA = {
+      type: 'user', content: 'A', timestamp: 'shared-time', raw: { uuid: 'uuid-a' },
+    } as ClaudeMessage;
+    const oldB = {
+      type: 'user', content: 'B', timestamp: 'shared-time', raw: { uuid: 'uuid-b' },
+    } as ClaudeMessage;
+    const first = reconcileMessageKeys([oldA, oldB], undefined, 'session-a');
+    const newC = {
+      type: 'user', content: 'C', timestamp: 'shared-time', raw: { uuid: 'uuid-c' },
+    } as ClaudeMessage;
+    const replayA = { ...oldA, raw: { uuid: 'uuid-a' } } as ClaudeMessage;
+    const replayB = { ...oldB, raw: { uuid: 'uuid-b' } } as ClaudeMessage;
+
+    const next = reconcileMessageKeys([newC, replayA, replayB], first, 'session-a');
+
+    expect(next.keys[1]).toBe(first.keys[0]);
+    expect(next.keys[2]).toBe(first.keys[1]);
+    expect(next.keys[0]).not.toBe(first.keys[0]);
+  });
+
+  it('retains one key through turn ID and UUID identity enrichment', () => {
+    const turnOnly = { type: 'assistant', content: '', __turnId: 42 } as ClaudeMessage;
+    const first = reconcileMessageKeys([turnOnly], undefined, 'session-a');
+    const enriched = {
+      ...turnOnly,
+      raw: { uuid: 'assistant-uuid' },
+    } as ClaudeMessage;
+    const second = reconcileMessageKeys([enriched], first, 'session-a');
+    const uuidOnly = { ...enriched, __turnId: undefined } as ClaudeMessage;
+    const third = reconcileMessageKeys([uuidOnly], second, 'session-a');
+
+    expect(second.keys[0]).toBe(first.keys[0]);
+    expect(third.keys[0]).toBe(first.keys[0]);
+  });
+
+  it('keeps duplicate references unique and stable by occurrence', () => {
+    const message = { type: 'assistant', content: 'duplicate reference' } as ClaudeMessage;
+    const first = reconcileMessageKeys([message, message], undefined, 'session-a');
+    const second = reconcileMessageKeys([message, message], first, 'session-a');
+
+    expect(new Set(first.keys).size).toBe(2);
+    expect(second.keys).toEqual(first.keys);
+  });
+
+  it('changes the key namespace when the session scope changes', () => {
+    const message = { type: 'user', content: 'same', raw: { uuid: 'message-1' } } as ClaudeMessage;
+    const first = reconcileMessageKeys([message], undefined, 'session-a');
+    const second = reconcileMessageKeys([message], first, 'session-b');
+
+    expect(second.keys[0]).not.toBe(first.keys[0]);
   });
 });
 

--- a/webview/src/utils/messageUtils.ts
+++ b/webview/src/utils/messageUtils.ts
@@ -51,9 +51,111 @@ export type { LocalizeMessageFn } from './contentBlockNormalize';
  */
 export function getMessageKey(message: ClaudeMessage, index: number): string {
   const rawObj = typeof message.raw === 'object' ? message.raw as Record<string, unknown> : null;
-  if (rawObj?.uuid) return rawObj.uuid as string;
+  if (typeof rawObj?.uuid === 'string' && rawObj.uuid) return rawObj.uuid;
   if (message.__turnId !== undefined) return `turn-${message.__turnId}`;
   return message.timestamp ? `${message.type}-${message.timestamp}` : `${message.type}-${index}`;
+}
+
+interface MessageKeyRecord {
+  message: ClaudeMessage;
+  key: string;
+  aliases: string[];
+}
+
+export interface MessageKeySnapshot {
+  scope: string;
+  keys: string[];
+  records: MessageKeyRecord[];
+}
+
+function getMessageKeyAliases(message: ClaudeMessage): string[] {
+  const aliases: string[] = [];
+  const rawObj = typeof message.raw === 'object' && message.raw !== null
+    ? message.raw as Record<string, unknown>
+    : null;
+  if (typeof rawObj?.uuid === 'string' && rawObj.uuid) aliases.push(`uuid:${rawObj.uuid}`);
+  if (typeof message.__turnId === 'number') aliases.push(`turn:${message.__turnId}`);
+  if (typeof message.id === 'string' && message.id) aliases.push(`id:${message.id}`);
+  if (message.timestamp !== undefined && message.timestamp !== null && message.timestamp !== '') {
+    aliases.push(`timestamp:${message.type}:${message.timestamp}`);
+  }
+  return aliases;
+}
+
+/**
+ * Reconcile one unique message key per array item while retaining keys across
+ * streaming identity enrichment and history prepends. The returned snapshot is
+ * shared by MessageList and MessageAnchorRail so DOM registration and anchor
+ * navigation always use the same identifiers.
+ */
+export function reconcileMessageKeys(
+  messages: ClaudeMessage[],
+  previous: MessageKeySnapshot | undefined,
+  scope: string,
+): MessageKeySnapshot {
+  const reusablePrevious = previous?.scope === scope ? previous : undefined;
+  const records: MessageKeyRecord[] = messages.map((message) => ({
+    message,
+    key: '',
+    aliases: getMessageKeyAliases(message),
+  }));
+  const usedPreviousRecords = new Set<MessageKeyRecord>();
+  const usedKeys = new Set<string>();
+
+  if (reusablePrevious) {
+    const previousByMessage = new Map<ClaudeMessage, MessageKeyRecord[]>();
+    for (const record of reusablePrevious.records) {
+      const candidates = previousByMessage.get(record.message) ?? [];
+      candidates.push(record);
+      previousByMessage.set(record.message, candidates);
+    }
+    for (const record of records) {
+      const matched = previousByMessage.get(record.message)
+        ?.find((candidate) => !usedPreviousRecords.has(candidate));
+      if (!matched) continue;
+      record.key = matched.key;
+      usedPreviousRecords.add(matched);
+      usedKeys.add(matched.key);
+    }
+
+    const previousByAlias = new Map<string, MessageKeyRecord[]>();
+    for (const record of reusablePrevious.records) {
+      if (usedPreviousRecords.has(record)) continue;
+      for (const alias of record.aliases) {
+        const candidates = previousByAlias.get(alias) ?? [];
+        candidates.push(record);
+        previousByAlias.set(alias, candidates);
+      }
+    }
+    for (const aliasPrefix of ['uuid:', 'turn:', 'id:', 'timestamp:']) {
+      for (const record of records) {
+        if (record.key) continue;
+        const aliases = record.aliases.filter((alias) => alias.startsWith(aliasPrefix));
+        const matched = aliases
+          .flatMap((alias) => previousByAlias.get(alias) ?? [])
+          .find((candidate) => !usedPreviousRecords.has(candidate));
+        if (!matched) continue;
+        record.key = matched.key;
+        usedPreviousRecords.add(matched);
+        usedKeys.add(matched.key);
+      }
+    }
+  }
+
+  records.forEach((record, index) => {
+    if (record.key) return;
+    const base = `${scope}:${getMessageKey(record.message, index)}`;
+    let key = base;
+    let occurrence = 1;
+    while (usedKeys.has(key)) {
+      key = `${base}-${occurrence}`;
+      occurrence += 1;
+    }
+    record.key = key;
+    usedKeys.add(key);
+  });
+
+  return { scope, keys: records.map((record) => record.key), records };
 }
 
 // ---------------------------------------------------------------------------

--- a/webview/src/utils/subagentResult.test.ts
+++ b/webview/src/utils/subagentResult.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { isAsyncAgentInput, extractResultText, parseAgentToolMeta } from './subagentResult';
+import {
+  isAsyncAgentInput,
+  extractResultText,
+  parseAgentToolMeta,
+  parseSpawnAgentMeta,
+} from './subagentResult';
 
 describe('isAsyncAgentInput', () => {
   it('returns true for run_in_background: true (snake_case)', () => {
@@ -31,6 +36,35 @@ describe('isAsyncAgentInput', () => {
     expect(isAsyncAgentInput(undefined)).toBe(false);
     expect(isAsyncAgentInput('not-an-object')).toBe(false);
     expect(isAsyncAgentInput(42)).toBe(false);
+  });
+
+  it('treats Codex spawn_agent as asynchronous without a background flag', () => {
+    expect(isAsyncAgentInput({ task_name: 'audit_ui' }, 'spawn_agent')).toBe(true);
+    expect(isAsyncAgentInput({ task_name: 'audit_ui' }, 'functions.spawn_agent')).toBe(true);
+  });
+});
+
+describe('parseSpawnAgentMeta', () => {
+  it('uses Codex task_name as the stable agent path', () => {
+    expect(parseSpawnAgentMeta({
+      task_name: 'audit_ui',
+      model: 'gpt-5.6-terra',
+      reasoning_effort: 'high',
+    })).toEqual({
+      agentPath: 'audit_ui',
+      model: 'gpt-5.6-terra',
+      reasoningEffort: 'high',
+    });
+  });
+
+  it('keeps Claude agent_id and description metadata', () => {
+    expect(parseSpawnAgentMeta({
+      agent_id: 'agent-123',
+      description: 'Review the bridge',
+    })).toEqual({
+      agentId: 'agent-123',
+      description: 'Review the bridge',
+    });
   });
 });
 

--- a/webview/src/utils/subagentResult.ts
+++ b/webview/src/utils/subagentResult.ts
@@ -34,10 +34,77 @@ export function extractResultText(result?: ToolResultBlock | null): string | und
  * camelCase `runInBackground` form is also checked as a guard against future
  * normalization changes. Shared by all three call sites so they cannot drift.
  */
-export function isAsyncAgentInput(input: unknown): boolean {
+export function isAsyncAgentInput(input: unknown, normalizedToolName?: string): boolean {
+  if (normalizedToolName?.split('.').at(-1) === 'spawn_agent') return true;
   if (!input || typeof input !== 'object') return false;
   const record = input as Record<string, unknown>;
   return record.run_in_background === true || record.runInBackground === true;
+}
+
+export interface SpawnAgentMeta {
+  agentId?: string;
+  agentPath?: string;
+  description?: string;
+  nickname?: string;
+  model?: string;
+  reasoningEffort?: string;
+}
+
+/** Parse Codex spawn_agent launch metadata without conflating task_name with an agent UUID. */
+export function parseSpawnAgentMeta(
+  input: Record<string, unknown>,
+  result?: ToolResultBlock | null,
+): SpawnAgentMeta {
+  const text = extractResultText(result)?.trim();
+  let parsed: Record<string, unknown> | null = null;
+
+  if (text && (text.startsWith('{') || text.startsWith('['))) {
+    try {
+      const candidate = JSON.parse(text);
+      if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
+        parsed = candidate as Record<string, unknown>;
+      }
+    } catch {
+      parsed = null;
+    }
+  }
+
+  const getString = (...values: unknown[]): string | undefined => {
+    for (const value of values) {
+      if (typeof value === 'string' && value.trim()) return value.trim();
+    }
+    return undefined;
+  };
+  const modelMatch = text?.match(/\(([A-Za-z0-9._:-]+)(?:\s+(low|medium|high|xhigh))?\)/i);
+  const agentId = getString(parsed?.agent_id, parsed?.agentId, input.agent_id, input.agentId)
+    ?? text?.match(/\b([0-9a-f]{8}-[0-9a-f-]{27})\b/i)?.[1];
+  const agentPath = getString(
+      parsed?.agent_path,
+      parsed?.agentPath,
+      parsed?.task_name,
+      parsed?.taskName,
+      input.agent_path,
+      input.agentPath,
+      input.task_name,
+      input.taskName,
+    );
+  const description = getString(parsed?.description, input.description);
+  const nickname = getString(parsed?.nickname, parsed?.name, input.nickname);
+  const model = getString(parsed?.model, input.model) ?? modelMatch?.[1];
+  const reasoningEffort = getString(
+      parsed?.reasoning_effort,
+      parsed?.reasoningEffort,
+      input.reasoning_effort,
+      input.reasoningEffort,
+    ) ?? modelMatch?.[2];
+  return {
+    ...(agentId && { agentId }),
+    ...(agentPath && { agentPath }),
+    ...(description && { description }),
+    ...(nickname && { nickname }),
+    ...(model && { model }),
+    ...(reasoningEffort && { reasoningEffort }),
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- restore Codex subagent history by resolving child rollout files from provider-aware tool-use and thread metadata
- return the matching child turn for running, completed, and aborted agents, including long transcripts and chunked payloads
- share stable occurrence-safe message keys between the transcript and anchor rail to prevent duplicate highlights
- preserve source timestamps and propagate Codex provider metadata through task and status-panel entry points
- add regression coverage for rollout resolution, terminal states, large payloads, key reconciliation, and callback reassembly

## Verification

- `npm run build`
- `npm test` (117 files, 989 tests)
- targeted Gradle tests for Codex subagent history and timestamp preservation
- full Gradle test suite and `checkstyleMain` (offline, generated package and instrumentation tasks excluded)
