### PR TITLE
fix(codex): preserve provider credentials and global config access

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ repositories {
 
 dependencies {
     implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'org.tomlj:tomlj:1.1.1'
     implementation 'javazoom:jlayer:1.0.1'
     implementation 'org.snakeyaml:snakeyaml-engine:3.0.1'
     implementation 'com.twelvemonkeys.imageio:imageio-webp:3.12.0'

--- a/src/main/java/com/github/claudecodegui/handler/CodexMcpServerHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/CodexMcpServerHandler.java
@@ -86,7 +86,7 @@ public class CodexMcpServerHandler extends BaseMessageHandler {
     private void handleGetMcpServers() {
         CompletableFuture.runAsync(() -> {
             try {
-                if (!isCodexLocalConfigAuthorized()) {
+                if (!isCodexConfigManagementAllowed()) {
                     ApplicationManager.getApplication().invokeLater(() -> {
                         callJavaScript("window.updateCodexMcpServers", escapeJs("[]"));
                     });
@@ -123,7 +123,7 @@ public class CodexMcpServerHandler extends BaseMessageHandler {
     private void handleGetMcpServerStatus() {
         CompletableFuture.runAsync(() -> {
             try {
-                if (!isCodexLocalConfigAuthorized()) {
+                if (!isCodexConfigManagementAllowed()) {
                     ApplicationManager.getApplication().invokeLater(() -> {
                         callJavaScript("window.updateCodexMcpServerStatus", escapeJs("[]"));
                     });
@@ -163,7 +163,7 @@ public class CodexMcpServerHandler extends BaseMessageHandler {
      */
     private void handleGetMcpServerTools(String content) {
         try {
-            if (!isCodexLocalConfigAuthorized()) {
+            if (!isCodexConfigManagementAllowed()) {
                 Gson gson = new Gson();
                 sendToolsError("", com.github.claudecodegui.i18n.ClaudeCodeGuiBundle.message("error.codexLocalAccessNotAuthorized"), gson);
                 return;
@@ -241,13 +241,23 @@ public class CodexMcpServerHandler extends BaseMessageHandler {
         return serverConfig;
     }
 
-    private boolean isCodexLocalConfigAuthorized() {
+    private boolean isCodexConfigManagementAllowed() {
         try {
-            return context.getSettingsService().isCodexLocalConfigAuthorized();
+            return context.getSettingsService().isCodexConfigManagementAllowed();
         } catch (Exception e) {
-            LOG.warn("[CodexMcpServerHandler] Failed to read Codex local authorization state: " + e.getMessage());
+            LOG.warn("[CodexMcpServerHandler] Failed to read Codex config management state: " + e.getMessage());
             return false;
         }
+    }
+
+    private boolean requireCodexConfigManagement() {
+        if (isCodexConfigManagementAllowed()) {
+            return true;
+        }
+        ApplicationManager.getApplication().invokeLater(() ->
+                callJavaScript("window.showError", escapeJs(
+                        com.github.claudecodegui.i18n.ClaudeCodeGuiBundle.message("error.codexLocalAccessNotAuthorized"))));
+        return false;
     }
 
     /**
@@ -255,6 +265,9 @@ public class CodexMcpServerHandler extends BaseMessageHandler {
      */
     private void handleAddMcpServer(String content) {
         try {
+            if (!requireCodexConfigManagement()) {
+                return;
+            }
             Gson gson = new Gson();
             JsonObject server = gson.fromJson(content, JsonObject.class);
 
@@ -265,7 +278,6 @@ public class CodexMcpServerHandler extends BaseMessageHandler {
 
             ApplicationManager.getApplication().invokeLater(() -> {
                 callJavaScript("window.codexMcpServerAdded", escapeJs(content));
-                handleGetMcpServers();
             });
         } catch (Exception e) {
             LOG.error("[CodexMcpServerHandler] Failed to add Codex MCP server: " + e.getMessage(), e);
@@ -281,17 +293,26 @@ public class CodexMcpServerHandler extends BaseMessageHandler {
      */
     private void handleUpdateMcpServer(String content) {
         try {
+            if (!requireCodexConfigManagement()) {
+                return;
+            }
             Gson gson = new Gson();
             JsonObject server = gson.fromJson(content, JsonObject.class);
 
-            codexMcpServerManager.upsertMcpServer(server);
+            String oldServerId = server.has("oldId") && server.get("oldId").isJsonPrimitive()
+                    ? server.get("oldId").getAsString()
+                    : null;
+            if (oldServerId != null && !oldServerId.equals(server.get("id").getAsString())) {
+                codexMcpServerManager.renameMcpServer(oldServerId, server);
+            } else {
+                codexMcpServerManager.upsertMcpServer(server);
+            }
 
             String serverId = server.has("id") ? server.get("id").getAsString() : "unknown";
             LOG.info("[CodexMcpServerHandler] Updated Codex MCP server: " + serverId);
 
             ApplicationManager.getApplication().invokeLater(() -> {
                 callJavaScript("window.codexMcpServerUpdated", escapeJs(content));
-                handleGetMcpServers();
             });
         } catch (Exception e) {
             LOG.error("[CodexMcpServerHandler] Failed to update Codex MCP server: " + e.getMessage(), e);
@@ -307,6 +328,9 @@ public class CodexMcpServerHandler extends BaseMessageHandler {
      */
     private void handleDeleteMcpServer(String content) {
         try {
+            if (!requireCodexConfigManagement()) {
+                return;
+            }
             Gson gson = new Gson();
             JsonObject json = gson.fromJson(content, JsonObject.class);
             String serverId = json.get("id").getAsString();
@@ -317,7 +341,6 @@ public class CodexMcpServerHandler extends BaseMessageHandler {
                 LOG.info("[CodexMcpServerHandler] Deleted Codex MCP server: " + serverId);
                 ApplicationManager.getApplication().invokeLater(() -> {
                     callJavaScript("window.codexMcpServerDeleted", escapeJs(serverId));
-                    handleGetMcpServers();
                 });
             } else {
                 LOG.warn("[CodexMcpServerHandler] Codex MCP server not found: " + serverId);
@@ -340,6 +363,9 @@ public class CodexMcpServerHandler extends BaseMessageHandler {
      */
     private void handleToggleMcpServer(String content) {
         try {
+            if (!requireCodexConfigManagement()) {
+                return;
+            }
             Gson gson = new Gson();
             JsonObject server = gson.fromJson(content, JsonObject.class);
 
@@ -353,7 +379,6 @@ public class CodexMcpServerHandler extends BaseMessageHandler {
 
             ApplicationManager.getApplication().invokeLater(() -> {
                 callJavaScript("window.codexMcpServerToggled", escapeJs(content));
-                handleGetMcpServers();
             });
         } catch (Exception e) {
             LOG.error("[CodexMcpServerHandler] Failed to toggle Codex MCP server: " + e.getMessage(), e);

--- a/src/main/java/com/github/claudecodegui/handler/SkillHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SkillHandler.java
@@ -243,16 +243,18 @@ public class SkillHandler extends BaseMessageHandler {
         try {
             JsonObject json = GSON.fromJson(content, JsonObject.class);
             String skillName = json.get("name").getAsString();
+            String skillId = json.has("id") ? json.get("id").getAsString() : null;
+            String requestId = json.has("requestId") ? json.get("requestId").getAsString() : null;
             String scope = json.has("scope") ? json.get("scope").getAsString() : "global";
             boolean currentEnabled = json.has("enabled") ? json.get("enabled").getAsBoolean() : true;
             String workspaceRoot = context.getProject().getBasePath();
             boolean isCodex = "codex".equalsIgnoreCase(context.getCurrentProvider());
+            String skillPath = isCodex && json.has("skillPath") ? json.get("skillPath").getAsString() : null;
 
             CompletableFuture.runAsync(() -> {
                 try {
                     JsonObject result;
                     if (isCodex) {
-                        String skillPath = json.has("skillPath") ? json.get("skillPath").getAsString() : null;
                         if (skillPath == null || skillPath.isEmpty()) {
                             result = new JsonObject();
                             result.addProperty("success", false);
@@ -276,6 +278,7 @@ public class SkillHandler extends BaseMessageHandler {
                     } else {
                         result = SkillService.toggleSkill(skillName, scope, currentEnabled, workspaceRoot);
                     }
+                    attachToggleCorrelation(result, skillId, requestId, skillName);
                     String resultJson = GSON.toJson(result);
 
                     ApplicationManager.getApplication().invokeLater(() -> {
@@ -286,6 +289,7 @@ public class SkillHandler extends BaseMessageHandler {
                     JsonObject errorResult = new JsonObject();
                     errorResult.addProperty("success", false);
                     errorResult.addProperty("error", e.getMessage());
+                    attachToggleCorrelation(errorResult, skillId, requestId, skillName);
                     ApplicationManager.getApplication().invokeLater(() -> {
                         callJavaScript("window.skillToggleResult", escapeJs(GSON.toJson(errorResult)));
                     });
@@ -296,9 +300,42 @@ public class SkillHandler extends BaseMessageHandler {
             JsonObject errorResult = new JsonObject();
             errorResult.addProperty("success", false);
             errorResult.addProperty("error", e.getMessage());
+            attachToggleCorrelationFromContent(errorResult, content);
             ApplicationManager.getApplication().invokeLater(() -> {
                 callJavaScript("window.skillToggleResult", escapeJs(GSON.toJson(errorResult)));
             });
+        }
+    }
+
+    private static void attachToggleCorrelation(
+            JsonObject result,
+            String skillId,
+            String requestId,
+            String skillName) {
+        if (skillId != null && !skillId.isEmpty()) {
+            result.addProperty("id", skillId);
+        }
+        if (requestId != null && !requestId.isEmpty()) {
+            result.addProperty("requestId", requestId);
+        }
+        result.addProperty("name", skillName);
+    }
+
+    private static void attachToggleCorrelationFromContent(JsonObject result, String content) {
+        try {
+            JsonObject request = GSON.fromJson(content, JsonObject.class);
+            String skillId = request.has("id") && request.get("id").isJsonPrimitive()
+                    ? request.get("id").getAsString()
+                    : null;
+            String skillName = request.has("name") && request.get("name").isJsonPrimitive()
+                    ? request.get("name").getAsString()
+                    : null;
+            String requestId = request.has("requestId") && request.get("requestId").isJsonPrimitive()
+                    ? request.get("requestId").getAsString()
+                    : null;
+            attachToggleCorrelation(result, skillId, requestId, skillName);
+        } catch (Exception ignored) {
+            // Invalid requests cannot be correlated safely.
         }
     }
 

--- a/src/main/java/com/github/claudecodegui/handler/SkillHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SkillHandler.java
@@ -243,16 +243,18 @@ public class SkillHandler extends BaseMessageHandler {
         try {
             JsonObject json = GSON.fromJson(content, JsonObject.class);
             String skillName = json.get("name").getAsString();
+            String skillId = json.has("id") ? json.get("id").getAsString() : null;
+            String requestId = json.has("requestId") ? json.get("requestId").getAsString() : null;
             String scope = json.has("scope") ? json.get("scope").getAsString() : "global";
             boolean currentEnabled = json.has("enabled") ? json.get("enabled").getAsBoolean() : true;
             String workspaceRoot = context.getProject().getBasePath();
             boolean isCodex = "codex".equalsIgnoreCase(context.getCurrentProvider());
+            String skillPath = isCodex && json.has("skillPath") ? json.get("skillPath").getAsString() : null;
 
             CompletableFuture.runAsync(() -> {
                 try {
                     JsonObject result;
                     if (isCodex) {
-                        String skillPath = json.has("skillPath") ? json.get("skillPath").getAsString() : null;
                         if (skillPath == null || skillPath.isEmpty()) {
                             result = new JsonObject();
                             result.addProperty("success", false);
@@ -267,6 +269,7 @@ public class SkillHandler extends BaseMessageHandler {
                     } else {
                         result = SkillService.toggleSkill(skillName, scope, currentEnabled, workspaceRoot);
                     }
+                    attachToggleCorrelation(result, skillId, requestId, skillName);
                     String resultJson = GSON.toJson(result);
 
                     ApplicationManager.getApplication().invokeLater(() -> {
@@ -277,6 +280,7 @@ public class SkillHandler extends BaseMessageHandler {
                     JsonObject errorResult = new JsonObject();
                     errorResult.addProperty("success", false);
                     errorResult.addProperty("error", e.getMessage());
+                    attachToggleCorrelation(errorResult, skillId, requestId, skillName);
                     ApplicationManager.getApplication().invokeLater(() -> {
                         callJavaScript("window.skillToggleResult", escapeJs(GSON.toJson(errorResult)));
                     });
@@ -287,9 +291,42 @@ public class SkillHandler extends BaseMessageHandler {
             JsonObject errorResult = new JsonObject();
             errorResult.addProperty("success", false);
             errorResult.addProperty("error", e.getMessage());
+            attachToggleCorrelationFromContent(errorResult, content);
             ApplicationManager.getApplication().invokeLater(() -> {
                 callJavaScript("window.skillToggleResult", escapeJs(GSON.toJson(errorResult)));
             });
+        }
+    }
+
+    private static void attachToggleCorrelation(
+            JsonObject result,
+            String skillId,
+            String requestId,
+            String skillName) {
+        if (skillId != null && !skillId.isEmpty()) {
+            result.addProperty("id", skillId);
+        }
+        if (requestId != null && !requestId.isEmpty()) {
+            result.addProperty("requestId", requestId);
+        }
+        result.addProperty("name", skillName);
+    }
+
+    private static void attachToggleCorrelationFromContent(JsonObject result, String content) {
+        try {
+            JsonObject request = GSON.fromJson(content, JsonObject.class);
+            String skillId = request.has("id") && request.get("id").isJsonPrimitive()
+                    ? request.get("id").getAsString()
+                    : null;
+            String skillName = request.has("name") && request.get("name").isJsonPrimitive()
+                    ? request.get("name").getAsString()
+                    : null;
+            String requestId = request.has("requestId") && request.get("requestId").isJsonPrimitive()
+                    ? request.get("requestId").getAsString()
+                    : null;
+            attachToggleCorrelation(result, skillId, requestId, skillName);
+        } catch (Exception ignored) {
+            // Invalid requests cannot be correlated safely.
         }
     }
 

--- a/src/main/java/com/github/claudecodegui/handler/provider/CodexProviderOperations.java
+++ b/src/main/java/com/github/claudecodegui/handler/provider/CodexProviderOperations.java
@@ -91,7 +91,6 @@ public class CodexProviderOperations {
             if (activeProvider != null &&
                         activeProvider.has("id") &&
                         id.equals(activeProvider.get("id").getAsString())) {
-                context.getSettingsService().applyActiveProviderToCodexSettings();
                 syncedActiveProvider = true;
             }
 
@@ -186,7 +185,6 @@ public class CodexProviderOperations {
             }
 
             context.getSettingsService().switchCodexProvider(id);
-            context.getSettingsService().applyActiveProviderToCodexSettings();
             invalidateCodexQuotaCache();
 
             ApplicationManager.getApplication().invokeLater(() -> {
@@ -229,9 +227,6 @@ public class CodexProviderOperations {
 
             if (wasCliLoginActive) {
                 context.getSettingsService().switchCodexProvider(fallbackProviderId);
-                if (fallbackProviderId != null && !fallbackProviderId.isBlank()) {
-                    context.getSettingsService().applyActiveProviderToCodexSettings();
-                }
             }
 
             ApplicationManager.getApplication().invokeLater(() -> {
@@ -256,11 +251,7 @@ public class CodexProviderOperations {
      */
     private void handleSwitchToCodexCliLogin() {
         try {
-            context.getSettingsService().setCodexLocalConfigAuthorized(true);
-
-            // Update config.json to set CLI login as current
-            context.getSettingsService().switchCodexProvider(
-                    com.github.claudecodegui.settings.CodexProviderManager.CODEX_CLI_LOGIN_PROVIDER_ID);
+            context.getSettingsService().switchToCodexCliLogin();
             invalidateCodexQuotaCache();
 
             LOG.info("[ProviderHandler] Authorized local Codex config provider");

--- a/src/main/java/com/github/claudecodegui/settings/CodemossSettingsService.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodemossSettingsService.java
@@ -19,8 +19,9 @@ import com.intellij.openapi.project.Project;
 
 import java.io.File;
 import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -354,12 +355,8 @@ public class CodemossSettingsService {
         // Initialize CodexSettingsManager
         this.codexSettingsManager = new CodexSettingsManager(gson);
 
-        // Initialize CodexMcpServerManager
-        this.codexMcpServerManager = new CodexMcpServerManager(codexSettingsManager);
-
         // Initialize CodexProviderManager
         this.codexProviderManager = new CodexProviderManager(
-                gson,
                 (ignored) -> {
                     try {
                         return readConfig();
@@ -376,6 +373,12 @@ public class CodemossSettingsService {
                 },
                 pathManager,
                 codexSettingsManager
+        );
+
+        // Initialize CodexMcpServerManager after the provider manager used by its access guard.
+        this.codexMcpServerManager = new CodexMcpServerManager(
+                codexSettingsManager,
+                this::isCodexConfigManagementAllowed
         );
     }
 
@@ -419,16 +422,28 @@ public class CodemossSettingsService {
         // Back up existing config
         backupConfig();
 
-        String configPath = getConfigPath();
-        try (FileWriter writer = new FileWriter(configPath, StandardCharsets.UTF_8)) {
-            gson.toJson(config, writer);
+        Path configPath = pathManager.getConfigFilePath();
+        Path parent = configPath.getParent();
+        Path tempPath = Files.createTempFile(parent, "config.json-", ".tmp");
+        try {
+            hardenFilePermissions(tempPath);
+            try (Writer writer = Files.newBufferedWriter(tempPath, StandardCharsets.UTF_8)) {
+                gson.toJson(config, writer);
+            }
+            try {
+                Files.move(tempPath, configPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException ignored) {
+                Files.move(tempPath, configPath, StandardCopyOption.REPLACE_EXISTING);
+            }
             LOG.info("[CodemossSettings] Successfully wrote config to: " + configPath);
         } catch (Exception e) {
             LOG.warn("[CodemossSettings] Failed to write config: " + e.getMessage());
             throw e;
+        } finally {
+            Files.deleteIfExists(tempPath);
         }
         // Security (J): config.json holds provider API keys/tokens; restrict to 0600.
-        hardenFilePermissions(Paths.get(configPath));
+        hardenFilePermissions(configPath);
     }
 
     private void backupConfig() {
@@ -2323,12 +2338,12 @@ public class CodemossSettingsService {
         codexProviderManager.switchCodexProvider(id);
     }
 
-    public void applyActiveProviderToCodexSettings() throws IOException {
-        codexProviderManager.applyActiveProviderToCodexSettings();
+    public void switchToCodexCliLogin() throws IOException {
+        codexProviderManager.switchToCodexCliLogin();
     }
 
     public JsonObject getCurrentCodexConfig() throws IOException {
-        if (!isCodexLocalConfigAuthorized()) {
+        if (!isCodexLocalConfigAuthorized() && !codexProviderManager.isManagedProviderReady()) {
             return new JsonObject();
         }
         return codexProviderManager.getCurrentCodexConfig();
@@ -2344,14 +2359,6 @@ public class CodemossSettingsService {
             LOG.warn("[CodemossSettings] Failed to check Codex local authorization: " + e.getMessage());
             return false;
         }
-    }
-
-    public void applyCodexCliLoginToSettings() throws IOException {
-        codexSettingsManager.applyCodexCliLoginToSettings();
-    }
-
-    public void removeCodexCliLoginFromSettings() throws IOException {
-        codexSettingsManager.removeCodexCliLoginFromSettings();
     }
 
     public JsonObject readCodexCliLoginAccountInfo() {
@@ -2377,20 +2384,21 @@ public class CodemossSettingsService {
                 && codex.get("localConfigAuthorized").getAsBoolean();
     }
 
-    public void setCodexLocalConfigAuthorized(boolean authorized) throws IOException {
-        JsonObject config = readConfig();
-        JsonObject codex;
-        if (config.has("codex") && config.get("codex").isJsonObject()) {
-            codex = config.getAsJsonObject("codex");
-        } else {
-            codex = new JsonObject();
-            codex.add("providers", new JsonObject());
-            codex.addProperty("current", "");
-            config.add("codex", codex);
+    /**
+     * Returns whether the plugin may manage the currently active Codex config.toml.
+     * Managed providers own the active config written by the plugin, while local
+     * CLI configuration still requires explicit authorization.
+     */
+    public boolean isCodexConfigManagementAllowed() throws IOException {
+        String accessMode = getCodexRuntimeAccessMode();
+        if (CODEX_RUNTIME_ACCESS_CLI_LOGIN.equals(accessMode)) {
+            return isCodexLocalConfigAuthorized();
         }
+        return CODEX_RUNTIME_ACCESS_MANAGED.equals(accessMode);
+    }
 
-        codex.addProperty("localConfigAuthorized", authorized);
-        writeConfig(config);
+    public void setCodexLocalConfigAuthorized(boolean authorized) throws IOException {
+        codexProviderManager.setLocalConfigAuthorized(authorized);
     }
 
     public String getCodexRuntimeAccessMode() throws IOException {
@@ -2410,10 +2418,7 @@ public class CodemossSettingsService {
                     : CODEX_RUNTIME_ACCESS_INACTIVE;
         }
 
-        if (!currentId.isEmpty()
-                && codex.has("providers")
-                && codex.get("providers").isJsonObject()
-                && codex.getAsJsonObject("providers").has(currentId)) {
+        if (!currentId.isEmpty() && codexProviderManager.isManagedProviderReady()) {
             return CODEX_RUNTIME_ACCESS_MANAGED;
         }
 

--- a/src/main/java/com/github/claudecodegui/settings/CodemossSettingsService.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodemossSettingsService.java
@@ -16,8 +16,9 @@ import com.intellij.openapi.project.Project;
 
 import java.io.File;
 import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -180,12 +181,8 @@ public class CodemossSettingsService {
         // Initialize CodexSettingsManager
         this.codexSettingsManager = new CodexSettingsManager(gson);
 
-        // Initialize CodexMcpServerManager
-        this.codexMcpServerManager = new CodexMcpServerManager(codexSettingsManager);
-
         // Initialize CodexProviderManager
         this.codexProviderManager = new CodexProviderManager(
-                gson,
                 (ignored) -> {
                     try {
                         return readConfig();
@@ -202,6 +199,12 @@ public class CodemossSettingsService {
                 },
                 pathManager,
                 codexSettingsManager
+        );
+
+        // Initialize CodexMcpServerManager after the provider manager used by its access guard.
+        this.codexMcpServerManager = new CodexMcpServerManager(
+                codexSettingsManager,
+                this::isCodexConfigManagementAllowed
         );
     }
 
@@ -245,16 +248,28 @@ public class CodemossSettingsService {
         // Back up existing config
         backupConfig();
 
-        String configPath = getConfigPath();
-        try (FileWriter writer = new FileWriter(configPath, StandardCharsets.UTF_8)) {
-            gson.toJson(config, writer);
+        Path configPath = pathManager.getConfigFilePath();
+        Path parent = configPath.getParent();
+        Path tempPath = Files.createTempFile(parent, "config.json-", ".tmp");
+        try {
+            hardenFilePermissions(tempPath);
+            try (Writer writer = Files.newBufferedWriter(tempPath, StandardCharsets.UTF_8)) {
+                gson.toJson(config, writer);
+            }
+            try {
+                Files.move(tempPath, configPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException ignored) {
+                Files.move(tempPath, configPath, StandardCopyOption.REPLACE_EXISTING);
+            }
             LOG.info("[CodemossSettings] Successfully wrote config to: " + configPath);
         } catch (Exception e) {
             LOG.warn("[CodemossSettings] Failed to write config: " + e.getMessage());
             throw e;
+        } finally {
+            Files.deleteIfExists(tempPath);
         }
         // Security (J): config.json holds provider API keys/tokens; restrict to 0600.
-        hardenFilePermissions(Paths.get(configPath));
+        hardenFilePermissions(configPath);
     }
 
     private void backupConfig() {
@@ -1966,12 +1981,12 @@ public class CodemossSettingsService {
         codexProviderManager.switchCodexProvider(id);
     }
 
-    public void applyActiveProviderToCodexSettings() throws IOException {
-        codexProviderManager.applyActiveProviderToCodexSettings();
+    public void switchToCodexCliLogin() throws IOException {
+        codexProviderManager.switchToCodexCliLogin();
     }
 
     public JsonObject getCurrentCodexConfig() throws IOException {
-        if (!isCodexLocalConfigAuthorized()) {
+        if (!isCodexLocalConfigAuthorized() && !codexProviderManager.isManagedProviderReady()) {
             return new JsonObject();
         }
         return codexProviderManager.getCurrentCodexConfig();
@@ -1987,14 +2002,6 @@ public class CodemossSettingsService {
             LOG.warn("[CodemossSettings] Failed to check Codex local authorization: " + e.getMessage());
             return false;
         }
-    }
-
-    public void applyCodexCliLoginToSettings() throws IOException {
-        codexSettingsManager.applyCodexCliLoginToSettings();
-    }
-
-    public void removeCodexCliLoginFromSettings() throws IOException {
-        codexSettingsManager.removeCodexCliLoginFromSettings();
     }
 
     public JsonObject readCodexCliLoginAccountInfo() {
@@ -2020,20 +2027,21 @@ public class CodemossSettingsService {
                 && codex.get("localConfigAuthorized").getAsBoolean();
     }
 
-    public void setCodexLocalConfigAuthorized(boolean authorized) throws IOException {
-        JsonObject config = readConfig();
-        JsonObject codex;
-        if (config.has("codex") && config.get("codex").isJsonObject()) {
-            codex = config.getAsJsonObject("codex");
-        } else {
-            codex = new JsonObject();
-            codex.add("providers", new JsonObject());
-            codex.addProperty("current", "");
-            config.add("codex", codex);
+    /**
+     * Returns whether the plugin may manage the currently active Codex config.toml.
+     * Managed providers own the active config written by the plugin, while local
+     * CLI configuration still requires explicit authorization.
+     */
+    public boolean isCodexConfigManagementAllowed() throws IOException {
+        String accessMode = getCodexRuntimeAccessMode();
+        if (CODEX_RUNTIME_ACCESS_CLI_LOGIN.equals(accessMode)) {
+            return isCodexLocalConfigAuthorized();
         }
+        return CODEX_RUNTIME_ACCESS_MANAGED.equals(accessMode);
+    }
 
-        codex.addProperty("localConfigAuthorized", authorized);
-        writeConfig(config);
+    public void setCodexLocalConfigAuthorized(boolean authorized) throws IOException {
+        codexProviderManager.setLocalConfigAuthorized(authorized);
     }
 
     public String getCodexRuntimeAccessMode() throws IOException {
@@ -2053,10 +2061,7 @@ public class CodemossSettingsService {
                     : CODEX_RUNTIME_ACCESS_INACTIVE;
         }
 
-        if (!currentId.isEmpty()
-                && codex.has("providers")
-                && codex.get("providers").isJsonObject()
-                && codex.getAsJsonObject("providers").has(currentId)) {
+        if (!currentId.isEmpty() && codexProviderManager.isManagedProviderReady()) {
             return CODEX_RUNTIME_ACCESS_MANAGED;
         }
 

--- a/src/main/java/com/github/claudecodegui/settings/CodexMcpServerManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodexMcpServerManager.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Codex MCP Server Manager
@@ -58,9 +59,13 @@ public class CodexMcpServerManager {
     private static final int STDIO_HANDSHAKE_TIMEOUT_MS = 3000; // 3 seconds timeout for STDIO checks
 
     private final CodexSettingsManager settingsManager;
+    private final CodexSettingsManager.ConfigAccessGuard accessGuard;
 
-    public CodexMcpServerManager(CodexSettingsManager settingsManager) {
+    public CodexMcpServerManager(
+            CodexSettingsManager settingsManager,
+            CodexSettingsManager.ConfigAccessGuard accessGuard) {
         this.settingsManager = settingsManager;
+        this.accessGuard = accessGuard;
     }
 
     /**
@@ -196,27 +201,42 @@ public class CodexMcpServerManager {
         }
 
         String serverId = server.get("id").getAsString();
-
-        // Read current config
-        Map<String, Object> config = settingsManager.readConfigToml();
-        if (config == null) {
-            config = new LinkedHashMap<>();
-        }
-
-        // Ensure mcp_servers section exists
-        @SuppressWarnings("unchecked")
-        Map<String, Object> mcpServers = (Map<String, Object>) config.computeIfAbsent("mcp_servers",
-                k -> new LinkedHashMap<String, Object>());
-
-        // Build server config map from JsonObject
         Map<String, Object> serverConfig = buildServerConfigMap(server);
-
-        // Add or update server
-        mcpServers.put(serverId, serverConfig);
-
-        // Write back
-        settingsManager.writeConfigToml(config);
+        settingsManager.updateConfigToml(accessGuard, config -> {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> mcpServers = (Map<String, Object>) config.computeIfAbsent(
+                    "mcp_servers", key -> new LinkedHashMap<String, Object>());
+            mcpServers.put(serverId, serverConfig);
+            return true;
+        });
         LOG.info("[CodexMcpServerManager] Upserted MCP server: " + serverId);
+    }
+
+    /** Atomically renames and updates an MCP server. */
+    public void renameMcpServer(String oldServerId, JsonObject server) throws IOException {
+        if (oldServerId == null || oldServerId.isBlank() || !server.has("id")) {
+            throw new IllegalArgumentException("Old and new server IDs are required");
+        }
+        String newServerId = server.get("id").getAsString();
+        Map<String, Object> serverConfig = buildServerConfigMap(server);
+        settingsManager.updateConfigToml(accessGuard, config -> {
+            Object mcpServersValue = config.get("mcp_servers");
+            if (!(mcpServersValue instanceof Map)) {
+                throw new IOException("MCP server '" + oldServerId + "' not found");
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, Object> mcpServers = (Map<String, Object>) mcpServersValue;
+            if (!mcpServers.containsKey(oldServerId)) {
+                throw new IOException("MCP server '" + oldServerId + "' not found");
+            }
+            if (!oldServerId.equals(newServerId) && mcpServers.containsKey(newServerId)) {
+                throw new IOException("MCP server '" + newServerId + "' already exists");
+            }
+            mcpServers.remove(oldServerId);
+            mcpServers.put(newServerId, serverConfig);
+            return true;
+        });
+        LOG.info("[CodexMcpServerManager] Renamed MCP server: " + oldServerId + " -> " + newServerId);
     }
 
     /**
@@ -292,29 +312,21 @@ public class CodexMcpServerManager {
      * Delete an MCP server by ID
      */
     public boolean deleteMcpServer(String serverId) throws IOException {
-        Map<String, Object> config = settingsManager.readConfigToml();
-        if (config == null) {
-            return false;
+        AtomicBoolean deleted = new AtomicBoolean();
+        settingsManager.updateConfigToml(accessGuard, config -> {
+            Object mcpServersObj = config.get("mcp_servers");
+            if (!(mcpServersObj instanceof Map)) {
+                return false;
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, Object> mcpServers = (Map<String, Object>) mcpServersObj;
+            deleted.set(mcpServers.remove(serverId) != null);
+            return deleted.get();
+        });
+        if (deleted.get()) {
+            LOG.info("[CodexMcpServerManager] Deleted MCP server: " + serverId);
         }
-
-        Object mcpServersObj = config.get("mcp_servers");
-        if (!(mcpServersObj instanceof Map)) {
-            return false;
-        }
-
-        @SuppressWarnings("unchecked")
-        Map<String, Object> mcpServers = (Map<String, Object>) mcpServersObj;
-
-        if (!mcpServers.containsKey(serverId)) {
-            return false;
-        }
-
-        mcpServers.remove(serverId);
-
-        // Write back
-        settingsManager.writeConfigToml(config);
-        LOG.info("[CodexMcpServerManager] Deleted MCP server: " + serverId);
-        return true;
+        return deleted.get();
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/settings/CodexProviderCredentialStore.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodexProviderCredentialStore.java
@@ -1,0 +1,84 @@
+package com.github.claudecodegui.settings;
+
+import com.intellij.credentialStore.CredentialAttributes;
+import com.intellij.credentialStore.Credentials;
+import com.intellij.ide.passwordSafe.PasswordSafe;
+import com.intellij.openapi.diagnostic.Logger;
+import org.jetbrains.annotations.Nullable;
+
+/** Stores managed Codex provider auth JSON in JetBrains PasswordSafe. */
+public class CodexProviderCredentialStore {
+
+    private static final Logger LOG = Logger.getInstance(CodexProviderCredentialStore.class);
+    private static final String SERVICE_PREFIX = "CC GUI/Codex Provider/";
+
+    public boolean isPersistentStorageAvailable() {
+        try {
+            return !PasswordSafe.getInstance().isMemoryOnly();
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+
+    public boolean writeVerified(String providerId, String authJson) {
+        if (!isValidId(providerId) || authJson == null || !isPersistentStorageAvailable()) {
+            return false;
+        }
+        try {
+            PasswordSafe.getInstance().set(attributes(providerId), new Credentials(providerId, authJson));
+            return authJson.equals(read(providerId));
+        } catch (RuntimeException e) {
+            LOG.warn("[CodexCredentials] PasswordSafe write failed for provider " + providerId
+                    + "; errorClass=" + e.getClass().getSimpleName());
+            return false;
+        }
+    }
+
+    public @Nullable String read(String providerId) {
+        if (!isValidId(providerId)) {
+            return null;
+        }
+        try {
+            Credentials credentials = PasswordSafe.getInstance().get(attributes(providerId));
+            return credentials == null ? null : credentials.getPasswordAsString();
+        } catch (RuntimeException e) {
+            LOG.warn("[CodexCredentials] PasswordSafe read failed for provider " + providerId
+                    + "; errorClass=" + e.getClass().getSimpleName());
+            return null;
+        }
+    }
+
+    public void delete(String providerId) {
+        if (!isValidId(providerId)) {
+            return;
+        }
+        try {
+            PasswordSafe.getInstance().set(attributes(providerId), null);
+        } catch (RuntimeException e) {
+            LOG.warn("[CodexCredentials] PasswordSafe delete failed for provider " + providerId
+                    + "; errorClass=" + e.getClass().getSimpleName());
+        }
+    }
+
+    public boolean deleteVerified(String providerId) {
+        if (!isValidId(providerId) || !isPersistentStorageAvailable()) {
+            return false;
+        }
+        try {
+            PasswordSafe.getInstance().set(attributes(providerId), null);
+            return PasswordSafe.getInstance().get(attributes(providerId)) == null;
+        } catch (RuntimeException e) {
+            LOG.warn("[CodexCredentials] PasswordSafe verified delete failed for provider " + providerId
+                    + "; errorClass=" + e.getClass().getSimpleName());
+            return false;
+        }
+    }
+
+    private static CredentialAttributes attributes(String providerId) {
+        return new CredentialAttributes(SERVICE_PREFIX + providerId, providerId);
+    }
+
+    private static boolean isValidId(String providerId) {
+        return providerId != null && !providerId.isBlank() && providerId.length() <= 256;
+    }
+}

--- a/src/main/java/com/github/claudecodegui/settings/CodexProviderManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodexProviderManager.java
@@ -2,15 +2,16 @@ package com.github.claudecodegui.settings;
 
 import com.github.claudecodegui.i18n.ClaudeCodeGuiBundle;
 import com.github.claudecodegui.model.DeleteResult;
-import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 
 import java.io.IOException;
-import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -22,33 +23,50 @@ import java.util.function.Function;
  */
 public class CodexProviderManager {
     private static final Logger LOG = Logger.getInstance(CodexProviderManager.class);
-    private static final String BACKUP_FILE_NAME = "config.json.bak";
+    private static final String AUTH_STORED_KEY = "authStoredInPasswordSafe";
+    private static final String CREDENTIAL_UNAVAILABLE_KEY = "credentialUnavailable";
+    private static final String APPLIED_PROVIDER_ID_KEY = "appliedProviderId";
+    private static final String APPLIED_PROVIDER_REVISION_KEY = "appliedProviderRevision";
+    private static final Object PROVIDER_STATE_LOCK = new Object();
     public static final String CODEX_CLI_LOGIN_PROVIDER_ID = "__codex_cli_login__";
 
-    private final Gson gson;
     private final Function<Void, JsonObject> configReader;
     private final Consumer<JsonObject> configWriter;
     private final ConfigPathManager pathManager;
     private final CodexSettingsManager codexSettingsManager;
+    private final CodexProviderCredentialStore credentialStore;
 
     public CodexProviderManager(
-            Gson gson,
             Function<Void, JsonObject> configReader,
             Consumer<JsonObject> configWriter,
             ConfigPathManager pathManager,
             CodexSettingsManager codexSettingsManager) {
-        this.gson = gson;
+        this(configReader, configWriter, pathManager, codexSettingsManager,
+                new CodexProviderCredentialStore());
+    }
+
+    CodexProviderManager(
+            Function<Void, JsonObject> configReader,
+            Consumer<JsonObject> configWriter,
+            ConfigPathManager pathManager,
+            CodexSettingsManager codexSettingsManager,
+            CodexProviderCredentialStore credentialStore) {
         this.configReader = configReader;
         this.configWriter = configWriter;
         this.pathManager = pathManager;
         this.codexSettingsManager = codexSettingsManager;
+        this.credentialStore = credentialStore;
     }
 
     /**
      * Get all Codex providers
      */
     public List<JsonObject> getCodexProviders() {
-        JsonObject config = configReader.apply(null);
+        JsonObject config;
+        synchronized (PROVIDER_STATE_LOCK) {
+            config = configReader.apply(null);
+            migrateLegacyCredentials(config);
+        }
         List<JsonObject> result = new ArrayList<>();
 
         String currentId = null;
@@ -86,6 +104,7 @@ public class CodexProviderManager {
                 if (!provider.has("id")) {
                     provider.addProperty("id", id);
                 }
+                hydrateCredential(provider, id);
                 // Add isActive flag
                 provider.addProperty("isActive", id.equals(currentId));
                 result.add(provider);
@@ -99,6 +118,12 @@ public class CodexProviderManager {
      * Save provider order.
      */
     public void saveProviderOrder(List<String> orderedIds) throws IOException {
+        synchronized (PROVIDER_STATE_LOCK) {
+            saveProviderOrderLocked(orderedIds);
+        }
+    }
+
+    private void saveProviderOrderLocked(List<String> orderedIds) throws IOException {
         JsonObject config = configReader.apply(null);
 
         if (!config.has("codex")) {
@@ -111,7 +136,7 @@ public class CodexProviderManager {
         JsonObject codex = config.getAsJsonObject("codex");
         ProviderOrderHelper.setProviderOrder(codex, orderedIds);
 
-        configWriter.accept(config);
+        writeConfig(config);
         LOG.info("[CodexProviderManager] Saved provider order: " + orderedIds);
     }
 
@@ -119,7 +144,11 @@ public class CodexProviderManager {
      * Get currently active Codex provider
      */
     public JsonObject getActiveCodexProvider() {
-        JsonObject config = configReader.apply(null);
+        JsonObject config;
+        synchronized (PROVIDER_STATE_LOCK) {
+            config = configReader.apply(null);
+            migrateLegacyCredentials(config);
+        }
 
         if (!config.has("codex")) {
             return null;
@@ -150,10 +179,11 @@ public class CodexProviderManager {
         JsonObject providers = codex.getAsJsonObject("providers");
 
         if (providers.has(currentId)) {
-            JsonObject provider = providers.getAsJsonObject(currentId);
+            JsonObject provider = providers.getAsJsonObject(currentId).deepCopy();
             if (!provider.has("id")) {
                 provider.addProperty("id", currentId);
             }
+            hydrateCredential(provider, currentId);
             provider.addProperty("isActive", true);
             return provider;
         }
@@ -165,9 +195,16 @@ public class CodexProviderManager {
      * Add a new Codex provider
      */
     public void addCodexProvider(JsonObject provider) throws IOException {
+        synchronized (PROVIDER_STATE_LOCK) {
+            addCodexProviderLocked(provider);
+        }
+    }
+
+    private void addCodexProviderLocked(JsonObject provider) throws IOException {
         if (!provider.has("id")) {
             throw new IllegalArgumentException("Provider must have an id");
         }
+        JsonObject providerToPersist = provider.deepCopy();
 
         JsonObject config = configReader.apply(null);
 
@@ -182,7 +219,7 @@ public class CodexProviderManager {
         JsonObject codex = config.getAsJsonObject("codex");
         JsonObject providers = codex.getAsJsonObject("providers");
 
-        String id = provider.get("id").getAsString();
+        String id = providerToPersist.get("id").getAsString();
 
         // Check if ID already exists
         if (providers.has(id)) {
@@ -190,14 +227,19 @@ public class CodexProviderManager {
         }
 
         // Add creation timestamp
-        if (!provider.has("createdAt")) {
-            provider.addProperty("createdAt", System.currentTimeMillis());
+        if (!providerToPersist.has("createdAt")) {
+            providerToPersist.addProperty("createdAt", System.currentTimeMillis());
         }
 
-        // Add provider (not auto-activated)
-        providers.add(id, provider);
-
-        configWriter.accept(config);
+        String previousCredential = credentialStore.read(id);
+        try {
+            protectCredential(providerToPersist, id);
+            providers.add(id, providerToPersist);
+            writeConfig(config);
+        } catch (IOException | RuntimeException e) {
+            restoreCredential(id, previousCredential, false);
+            throw e;
+        }
         LOG.info("[CodexProviderManager] Added provider: " + id);
     }
 
@@ -205,9 +247,16 @@ public class CodexProviderManager {
      * Save provider (update if exists, add if not)
      */
     public void saveCodexProvider(JsonObject provider) throws IOException {
+        synchronized (PROVIDER_STATE_LOCK) {
+            saveCodexProviderLocked(provider);
+        }
+    }
+
+    private void saveCodexProviderLocked(JsonObject provider) throws IOException {
         if (!provider.has("id")) {
             throw new IllegalArgumentException("Provider must have an id");
         }
+        JsonObject savedProvider = provider.deepCopy();
 
         JsonObject config = configReader.apply(null);
 
@@ -222,28 +271,63 @@ public class CodexProviderManager {
         JsonObject codex = config.getAsJsonObject("codex");
         JsonObject providers = codex.getAsJsonObject("providers");
 
-        String id = provider.get("id").getAsString();
+        String id = savedProvider.get("id").getAsString();
+        JsonObject existingProvider = providers.has(id) ? providers.getAsJsonObject(id).deepCopy() : null;
+        JsonObject previousProvider = existingProvider == null ? null : providerWithId(existingProvider, id);
+        String previousCredential = credentialStore.read(id);
+        boolean hadStoredCredential = hasStoredCredential(existingProvider)
+                || (!hasInlineCredential(existingProvider) && previousCredential != null);
 
         // Preserve createdAt if updating existing provider
-        if (providers.has(id)) {
-            JsonObject existing = providers.getAsJsonObject(id);
-            if (existing.has("createdAt") && !provider.has("createdAt")) {
-                provider.addProperty("createdAt", existing.get("createdAt").getAsLong());
+        if (existingProvider != null) {
+            JsonObject existing = existingProvider;
+            if (existing.has("createdAt") && !savedProvider.has("createdAt")) {
+                savedProvider.addProperty("createdAt", existing.get("createdAt").getAsLong());
+            }
+            if (hadStoredCredential && !savedProvider.has(AUTH_STORED_KEY)) {
+                savedProvider.addProperty(AUTH_STORED_KEY, true);
             }
         } else {
-            if (!provider.has("createdAt")) {
-                provider.addProperty("createdAt", System.currentTimeMillis());
+            if (!savedProvider.has("createdAt")) {
+                savedProvider.addProperty("createdAt", System.currentTimeMillis());
             }
         }
 
-        providers.add(id, provider);
-        configWriter.accept(config);
+        if (hadStoredCredential && previousCredential == null) {
+            savedProvider.addProperty(CREDENTIAL_UNAVAILABLE_KEY, true);
+        }
+        try {
+            protectCredential(savedProvider, id);
+            JsonObject providerToApply = providerWithId(savedProvider, id);
+            boolean activeSettingsChanged = id.equals(getCurrentId(codex))
+                    && managedSettingsChanged(previousProvider, providerToApply);
+            if (activeSettingsChanged) {
+                requireCredentialAvailable(providerToApply);
+                codexSettingsManager.transitionProvider(previousProvider, providerToApply, false, () -> {
+                    providers.add(id, savedProvider);
+                    commitManagedProviderState(codex, id, providerToApply);
+                    writeConfig(config);
+                });
+            } else {
+                providers.add(id, savedProvider);
+                writeConfig(config);
+            }
+        } catch (IOException | RuntimeException e) {
+            restoreCredential(id, previousCredential, hadStoredCredential);
+            throw e;
+        }
     }
 
     /**
      * Update an existing Codex provider
      */
     public void updateCodexProvider(String id, JsonObject updates) throws IOException {
+        synchronized (PROVIDER_STATE_LOCK) {
+            updateCodexProviderLocked(id, updates);
+        }
+    }
+
+    private void updateCodexProviderLocked(String id, JsonObject updates) throws IOException {
         JsonObject config = configReader.apply(null);
 
         if (!config.has("codex")) {
@@ -257,7 +341,12 @@ public class CodexProviderManager {
             throw new IllegalArgumentException("Provider with id '" + id + "' not found");
         }
 
-        JsonObject provider = providers.getAsJsonObject(id);
+        JsonObject persistedProvider = providers.getAsJsonObject(id).deepCopy();
+        JsonObject previousProvider = providerWithId(persistedProvider, id);
+        JsonObject updatedProvider = persistedProvider.deepCopy();
+        String previousCredential = credentialStore.read(id);
+        boolean hadStoredCredential = hasStoredCredential(persistedProvider)
+                || (!hasInlineCredential(persistedProvider) && previousCredential != null);
 
         // Merge updates
         for (String key : updates.keySet()) {
@@ -268,13 +357,38 @@ public class CodexProviderManager {
 
             // If value is null (JsonNull), remove the field
             if (updates.get(key).isJsonNull()) {
-                provider.remove(key);
+                updatedProvider.remove(key);
             } else {
-                provider.add(key, updates.get(key));
+                updatedProvider.add(key, updates.get(key));
             }
         }
 
-        configWriter.accept(config);
+        if (hadStoredCredential) {
+            updatedProvider.addProperty(AUTH_STORED_KEY, true);
+        }
+        if (hadStoredCredential && previousCredential == null) {
+            updatedProvider.addProperty(CREDENTIAL_UNAVAILABLE_KEY, true);
+        }
+        try {
+            protectCredential(updatedProvider, id);
+            JsonObject providerToApply = providerWithId(updatedProvider, id);
+            boolean activeSettingsChanged = id.equals(getCurrentId(codex))
+                    && managedSettingsChanged(previousProvider, providerToApply);
+            if (activeSettingsChanged) {
+                requireCredentialAvailable(providerToApply);
+                codexSettingsManager.transitionProvider(previousProvider, providerToApply, false, () -> {
+                    providers.add(id, updatedProvider);
+                    commitManagedProviderState(codex, id, providerToApply);
+                    writeConfig(config);
+                });
+            } else {
+                providers.add(id, updatedProvider);
+                writeConfig(config);
+            }
+        } catch (IOException | RuntimeException e) {
+            restoreCredential(id, previousCredential, hadStoredCredential);
+            throw e;
+        }
         LOG.info("[CodexProviderManager] Updated provider: " + id);
     }
 
@@ -284,14 +398,17 @@ public class CodexProviderManager {
      * @return DeleteResult with operation status and error details
      */
     public DeleteResult deleteCodexProvider(String id) {
-        Path configFilePath = null;
-        Path backupFilePath = null;
+        synchronized (PROVIDER_STATE_LOCK) {
+            return deleteCodexProviderLocked(id);
+        }
+    }
 
+    private DeleteResult deleteCodexProviderLocked(String id) {
+        Path configFilePath = pathManager.getConfigFilePath();
+        String deletedCredential = null;
+        boolean credentialDeleted = false;
         try {
             JsonObject config = configReader.apply(null);
-            configFilePath = pathManager.getConfigFilePath();
-            backupFilePath = pathManager.getConfigDir().resolve(BACKUP_FILE_NAME);
-
             if (!config.has("codex")) {
                 return DeleteResult.failure(
                     DeleteResult.ErrorType.FILE_NOT_FOUND,
@@ -303,7 +420,6 @@ public class CodexProviderManager {
 
             JsonObject codex = config.getAsJsonObject("codex");
             JsonObject providers = codex.getAsJsonObject("providers");
-
             if (!providers.has(id)) {
                 return DeleteResult.failure(
                     DeleteResult.ErrorType.FILE_NOT_FOUND,
@@ -313,60 +429,46 @@ public class CodexProviderManager {
                 );
             }
 
-            // Create backup before deletion
-            try {
-                Files.copy(configFilePath, backupFilePath, StandardCopyOption.REPLACE_EXISTING);
-                LOG.info("[CodexProviderManager] Created backup: " + backupFilePath);
-            } catch (IOException e) {
-                LOG.warn("[CodexProviderManager] Warning: Failed to create backup: " + e.getMessage());
-            }
-
-            // Delete provider
-            providers.remove(id);
-
-            // If deleting the active provider, switch to first available
-            String currentId = codex.has("current") ? codex.get("current").getAsString() : null;
-            if (id.equals(currentId)) {
-                if (providers.size() > 0) {
-                    String firstKey = providers.keySet().iterator().next();
-                    codex.addProperty("current", firstKey);
-                    LOG.info("[CodexProviderManager] Switched to provider: " + firstKey);
-                } else {
-                    codex.addProperty("current", "");
-                    LOG.info("[CodexProviderManager] No remaining providers");
+            JsonObject persistedProvider = providers.getAsJsonObject(id).deepCopy();
+            JsonObject deletedProvider = providerWithId(persistedProvider, id);
+            deletedCredential = credentialStore.read(id);
+            if (hasStoredCredential(persistedProvider)
+                    || (!hasInlineCredential(persistedProvider) && deletedCredential != null)) {
+                if (deletedCredential == null || !credentialStore.deleteVerified(id)) {
+                    throw new IOException("Unable to remove Codex credential from PasswordSafe");
                 }
+                credentialDeleted = true;
             }
-
-            // Remove deleted provider from providerOrder to avoid stale IDs
+            boolean active = id.equals(getCurrentId(codex));
+            providers.remove(id);
             ProviderOrderHelper.removeFromOrder(codex, id);
 
-            // Write config
-            configWriter.accept(config);
-            LOG.info("[CodexProviderManager] Deleted provider: " + id);
-
-            // Remove backup on success
-            try {
-                Files.deleteIfExists(backupFilePath);
-            } catch (IOException e) {
-                // Ignore backup deletion failure
-            }
-
-            return DeleteResult.success(id);
-
-        } catch (Exception e) {
-            // Try to restore from backup
-            if (backupFilePath != null && configFilePath != null) {
-                try {
-                    if (Files.exists(backupFilePath)) {
-                        Files.copy(backupFilePath, configFilePath, StandardCopyOption.REPLACE_EXISTING);
-                        LOG.info("[CodexProviderManager] Restored from backup after failure");
+            if (active) {
+                String fallbackId = providers.size() > 0 ? providers.keySet().iterator().next() : "";
+                JsonObject fallbackProvider = fallbackId.isEmpty()
+                        ? null
+                        : providerWithId(providers.getAsJsonObject(fallbackId), fallbackId);
+                requireCredentialAvailable(fallbackProvider);
+                codexSettingsManager.transitionProvider(deletedProvider, fallbackProvider, false, () -> {
+                    if (fallbackProvider == null) {
+                        clearAppliedProviderState(codex);
+                        codex.addProperty("current", "");
+                    } else {
+                        commitManagedProviderState(codex, fallbackId, fallbackProvider);
                     }
-                } catch (IOException restoreEx) {
-                    LOG.warn("[CodexProviderManager] Failed to restore backup: " + restoreEx.getMessage());
-                }
+                    writeConfig(config);
+                });
+            } else {
+                writeConfig(config);
             }
-
-            return DeleteResult.fromException(e, configFilePath != null ? configFilePath.toString() : null);
+            LOG.info("[CodexProviderManager] Deleted provider: " + id);
+            return DeleteResult.success(id);
+        } catch (Exception e) {
+            if (credentialDeleted && deletedCredential != null
+                    && !credentialStore.writeVerified(id, deletedCredential)) {
+                LOG.warn("[CodexProviderManager] Failed to restore credential after provider deletion failure");
+            }
+            return DeleteResult.fromException(e, configFilePath.toString());
         }
     }
 
@@ -374,6 +476,39 @@ public class CodexProviderManager {
      * Switch to a different Codex provider
      */
     public void switchCodexProvider(String id) throws IOException {
+        switchCodexProvider(id, false);
+    }
+
+    public void switchToCodexCliLogin() throws IOException {
+        switchCodexProvider(CODEX_CLI_LOGIN_PROVIDER_ID, true);
+    }
+
+    public void setLocalConfigAuthorized(boolean authorized) throws IOException {
+        synchronized (PROVIDER_STATE_LOCK) {
+            codexSettingsManager.runWithConfigAccess(() -> true, () -> {
+                JsonObject config = configReader.apply(null);
+                JsonObject codex;
+                if (config.has("codex") && config.get("codex").isJsonObject()) {
+                    codex = config.getAsJsonObject("codex");
+                } else {
+                    codex = new JsonObject();
+                    codex.add("providers", new JsonObject());
+                    codex.addProperty("current", "");
+                    config.add("codex", codex);
+                }
+                codex.addProperty("localConfigAuthorized", authorized);
+                writeConfig(config);
+            });
+        }
+    }
+
+    private void switchCodexProvider(String id, boolean authorizeCliLogin) throws IOException {
+        synchronized (PROVIDER_STATE_LOCK) {
+            switchCodexProviderLocked(id, authorizeCliLogin);
+        }
+    }
+
+    private void switchCodexProviderLocked(String id, boolean authorizeCliLogin) throws IOException {
         JsonObject config = configReader.apply(null);
 
         if (!config.has("codex")) {
@@ -384,25 +519,43 @@ public class CodexProviderManager {
         }
 
         JsonObject codex = config.getAsJsonObject("codex");
-
-        if (id == null || id.trim().isEmpty()) {
-            codex.addProperty("current", "");
-            configWriter.accept(config);
-            LOG.info("[CodexProviderManager] Cleared active provider");
-            return;
-        }
+        JsonObject providers = codex.has("providers") && codex.get("providers").isJsonObject()
+                ? codex.getAsJsonObject("providers")
+                : new JsonObject();
+        codex.add("providers", providers);
+        String nextId = id == null ? "" : id.trim();
+        boolean useCliLogin = CODEX_CLI_LOGIN_PROVIDER_ID.equals(nextId);
 
         // CLI Login is a virtual provider — no need to check providers map
-        if (!CODEX_CLI_LOGIN_PROVIDER_ID.equals(id)) {
-            JsonObject providers = codex.getAsJsonObject("providers");
-            if (providers == null || !providers.has(id)) {
-                throw new IllegalArgumentException("Provider with id '" + id + "' not found");
-            }
+        if (!nextId.isEmpty() && !useCliLogin && !providers.has(nextId)) {
+            throw new IllegalArgumentException("Provider with id '" + nextId + "' not found");
         }
 
-        codex.addProperty("current", id);
-        configWriter.accept(config);
-        LOG.info("[CodexProviderManager] Switched to provider: " + id);
+        String previousId = getCurrentId(codex);
+        JsonObject previousProvider = providers.has(previousId)
+                ? providerWithId(providers.getAsJsonObject(previousId), previousId)
+                : null;
+        JsonObject nextProvider = !nextId.isEmpty() && !useCliLogin
+                ? providerWithId(providers.getAsJsonObject(nextId), nextId)
+                : null;
+        requireCredentialAvailable(nextProvider);
+
+        codexSettingsManager.transitionProvider(previousProvider, nextProvider, useCliLogin, () -> {
+            if (useCliLogin) {
+                clearAppliedProviderState(codex);
+                if (authorizeCliLogin) {
+                    codex.addProperty("localConfigAuthorized", true);
+                }
+                codex.addProperty("current", CODEX_CLI_LOGIN_PROVIDER_ID);
+            } else if (nextProvider != null) {
+                commitManagedProviderState(codex, nextId, nextProvider);
+            } else {
+                clearAppliedProviderState(codex);
+                codex.addProperty("current", "");
+            }
+            writeConfig(config);
+        });
+        LOG.info("[CodexProviderManager] Switched to provider: " + (nextId.isEmpty() ? "none" : nextId));
     }
 
     /**
@@ -424,22 +577,139 @@ public class CodexProviderManager {
     }
 
     /**
-     * Apply active provider to ~/.codex/ settings files
-     */
-    public void applyActiveProviderToCodexSettings() throws IOException {
-        JsonObject activeProvider = getActiveCodexProvider();
-        if (activeProvider == null) {
-            LOG.info("[CodexProviderManager] No active provider to sync to ~/.codex/");
-            return;
-        }
-        codexSettingsManager.applyProviderToCodexSettings(activeProvider);
-    }
-
-    /**
      * Get current Codex CLI configuration (from ~/.codex/)
      */
     public JsonObject getCurrentCodexConfig() throws IOException {
         return codexSettingsManager.getCurrentCodexConfig();
+    }
+
+    /**
+     * A managed provider is ready only after its exact saved revision reached ~/.codex.
+     * Legacy installations without markers are accepted only after file-content verification.
+     */
+    public boolean isManagedProviderReady() throws IOException {
+        if (codexSettingsManager.isConfigLockHeldByCurrentThread()) {
+            return isManagedProviderReadyInternal(false);
+        }
+        synchronized (PROVIDER_STATE_LOCK) {
+            boolean[] ready = new boolean[1];
+            codexSettingsManager.runWithConfigAccess(
+                    () -> true,
+                    () -> ready[0] = isManagedProviderReadyInternal(true));
+            return ready[0];
+        }
+    }
+
+    private boolean isManagedProviderReadyInternal(boolean migrateState) throws IOException {
+        JsonObject config = configReader.apply(null);
+        if (migrateState) {
+            migrateLegacyCredentials(config);
+        }
+        if (!config.has("codex") || !config.get("codex").isJsonObject()) {
+            return false;
+        }
+        JsonObject codex = config.getAsJsonObject("codex");
+        String currentId = getCurrentId(codex);
+        if (currentId.isEmpty() || CODEX_CLI_LOGIN_PROVIDER_ID.equals(currentId)
+                || !codex.has("providers") || !codex.get("providers").isJsonObject()
+                || !codex.getAsJsonObject("providers").has(currentId)) {
+            return false;
+        }
+
+        JsonObject provider = providerWithId(codex.getAsJsonObject("providers").getAsJsonObject(currentId), currentId);
+        if (isCredentialUnavailable(provider)) {
+            return false;
+        }
+        boolean applied = codexSettingsManager.isProviderApplied(provider);
+        if (codex.has(APPLIED_PROVIDER_ID_KEY) && codex.has(APPLIED_PROVIDER_REVISION_KEY)) {
+            return currentId.equals(codex.get(APPLIED_PROVIDER_ID_KEY).getAsString())
+                    && providerRevision(provider).equals(codex.get(APPLIED_PROVIDER_REVISION_KEY).getAsString())
+                    && applied;
+        }
+        if (applied && migrateState) {
+            commitManagedProviderState(codex, currentId, provider);
+            writeConfig(config);
+        }
+        return applied;
+    }
+
+    private void commitManagedProviderState(JsonObject codex, String providerId, JsonObject provider) {
+        codex.addProperty(APPLIED_PROVIDER_ID_KEY, providerId);
+        codex.addProperty(APPLIED_PROVIDER_REVISION_KEY, providerRevision(provider));
+        codex.addProperty("current", providerId);
+    }
+
+    private void clearAppliedProviderState(JsonObject codex) {
+        codex.remove(APPLIED_PROVIDER_ID_KEY);
+        codex.remove(APPLIED_PROVIDER_REVISION_KEY);
+    }
+
+    private String getCurrentId(JsonObject codex) {
+        return codex.has("current") && !codex.get("current").isJsonNull()
+                ? codex.get("current").getAsString().trim()
+                : "";
+    }
+
+    private JsonObject providerWithId(JsonObject provider, String id) {
+        JsonObject copy = provider.deepCopy();
+        copy.addProperty("id", id);
+        hydrateCredential(copy, id);
+        return copy;
+    }
+
+    private boolean managedSettingsChanged(JsonObject previousProvider, JsonObject nextProvider) {
+        if (previousProvider == null || nextProvider == null) {
+            return previousProvider != nextProvider;
+        }
+        return !providerValue(previousProvider, "configToml").equals(providerValue(nextProvider, "configToml"))
+                || !providerValue(previousProvider, "authJson").equals(providerValue(nextProvider, "authJson"));
+    }
+
+    private String providerValue(JsonObject provider, String key) {
+        return provider.has(key) && provider.get(key).isJsonPrimitive()
+                ? provider.get(key).getAsString()
+                : "";
+    }
+
+    private void requireCredentialAvailable(JsonObject provider) throws IOException {
+        if (isCredentialUnavailable(provider)) {
+            throw new IOException("Codex provider credential is unavailable in PasswordSafe");
+        }
+    }
+
+    private boolean isCredentialUnavailable(JsonObject provider) {
+        return provider != null && provider.has(CREDENTIAL_UNAVAILABLE_KEY)
+                && provider.get(CREDENTIAL_UNAVAILABLE_KEY).isJsonPrimitive()
+                && provider.get(CREDENTIAL_UNAVAILABLE_KEY).getAsBoolean();
+    }
+
+    private String providerRevision(JsonObject provider) {
+        String configToml = provider.has("configToml") && provider.get("configToml").isJsonPrimitive()
+                ? provider.get("configToml").getAsString()
+                : "";
+        String authJson = provider.has("authJson") && provider.get("authJson").isJsonPrimitive()
+                ? provider.get("authJson").getAsString()
+                : "";
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(configToml.getBytes(StandardCharsets.UTF_8));
+            digest.update((byte) 0);
+            digest.update(authJson.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(digest.digest());
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+
+    private void writeConfig(JsonObject config) throws IOException {
+        try {
+            configWriter.accept(config);
+        } catch (RuntimeException e) {
+            if (e.getCause() instanceof IOException) {
+                throw (IOException) e.getCause();
+            }
+            throw new IOException("Failed to save Codex provider state", e);
+        }
     }
 
     /**
@@ -453,6 +723,116 @@ public class CodexProviderManager {
         provider.addProperty("isActive", isActive);
         provider.addProperty("isCodexCliLoginProvider", true);
         return provider;
+    }
+
+    private void migrateLegacyCredentials(JsonObject config) {
+        if (config == null || !credentialStore.isPersistentStorageAvailable()
+                || !config.has("codex") || !config.get("codex").isJsonObject()) {
+            return;
+        }
+        JsonObject codex = config.getAsJsonObject("codex");
+        if (!codex.has("providers") || !codex.get("providers").isJsonObject()) {
+            return;
+        }
+
+        boolean changed = false;
+        JsonObject providers = codex.getAsJsonObject("providers");
+        for (String id : providers.keySet()) {
+            if (!providers.get(id).isJsonObject()) {
+                continue;
+            }
+            JsonObject provider = providers.getAsJsonObject(id);
+            if (hasStoredCredential(provider)) {
+                continue;
+            }
+            if (hasInlineCredential(provider)) {
+                String authJson = provider.get("authJson").getAsString();
+                if (credentialStore.writeVerified(id, authJson)) {
+                    provider.remove("authJson");
+                    provider.addProperty(AUTH_STORED_KEY, true);
+                    changed = true;
+                }
+            } else if (credentialStore.read(id) != null) {
+                // Older builds could save an empty editor payload after losing the marker.
+                provider.remove("authJson");
+                provider.addProperty(AUTH_STORED_KEY, true);
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            try {
+                writeConfig(config);
+                LOG.info("[CodexProviderManager] Recovered provider credentials from PasswordSafe");
+            } catch (IOException e) {
+                LOG.warn("[CodexProviderManager] Credential migration config update failed: " + e.getMessage());
+            }
+        }
+    }
+
+    private void protectCredential(JsonObject provider, String id) {
+        boolean unavailable = isCredentialUnavailable(provider);
+        if (!provider.has("authJson") || !provider.get("authJson").isJsonPrimitive()) {
+            provider.remove(CREDENTIAL_UNAVAILABLE_KEY);
+            return;
+        }
+
+        String authJson = provider.get("authJson").getAsString();
+        if (unavailable && authJson.isBlank() && hasStoredCredential(provider)) {
+            provider.remove("authJson");
+            provider.remove(CREDENTIAL_UNAVAILABLE_KEY);
+            return;
+        }
+        provider.remove(CREDENTIAL_UNAVAILABLE_KEY);
+        if (authJson.isBlank()) {
+            if (hasStoredCredential(provider) && !credentialStore.deleteVerified(id)) {
+                throw new IllegalStateException("Unable to remove Codex credential from PasswordSafe");
+            }
+            provider.remove("authJson");
+            provider.remove(AUTH_STORED_KEY);
+            return;
+        }
+        if (!credentialStore.writeVerified(id, authJson)) {
+            provider.remove("authJson");
+            throw new IllegalStateException("Unable to store Codex credential in PasswordSafe");
+        }
+        provider.remove("authJson");
+        provider.addProperty(AUTH_STORED_KEY, true);
+    }
+
+    private void hydrateCredential(JsonObject provider, String id) {
+        if (hasInlineCredential(provider)) {
+            return;
+        }
+        String authJson = credentialStore.read(id);
+        if (authJson != null) {
+            provider.addProperty(AUTH_STORED_KEY, true);
+            provider.addProperty("authJson", authJson);
+            provider.remove(CREDENTIAL_UNAVAILABLE_KEY);
+        } else if (hasStoredCredential(provider)) {
+            provider.addProperty(CREDENTIAL_UNAVAILABLE_KEY, true);
+        }
+    }
+
+    private void restoreCredential(String id, String previousCredential, boolean hadStoredCredential) {
+        if (previousCredential != null) {
+            if (!credentialStore.writeVerified(id, previousCredential)) {
+                LOG.warn("[CodexProviderManager] Failed to restore previous PasswordSafe credential");
+            }
+        } else if (!hadStoredCredential) {
+            credentialStore.delete(id);
+        }
+    }
+
+    private static boolean hasInlineCredential(JsonObject provider) {
+        return provider != null && provider.has("authJson") && provider.get("authJson").isJsonPrimitive()
+                && !provider.get("authJson").getAsString().isBlank();
+    }
+
+    private static boolean hasStoredCredential(JsonObject provider) {
+        return provider != null && provider.has(AUTH_STORED_KEY)
+                && provider.get(AUTH_STORED_KEY).isJsonPrimitive()
+                && provider.get(AUTH_STORED_KEY).getAsBoolean();
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/settings/CodexSettingsManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodexSettingsManager.java
@@ -6,6 +6,10 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.intellij.openapi.diagnostic.Logger;
+import org.tomlj.Toml;
+import org.tomlj.TomlArray;
+import org.tomlj.TomlParseResult;
+import org.tomlj.TomlTable;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -16,10 +20,15 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -28,8 +37,12 @@ import java.util.regex.Pattern;
  */
 public class CodexSettingsManager {
     private static final Logger LOG = Logger.getInstance(CodexSettingsManager.class);
-    private static final String MCP_SERVERS_KEY = "mcp_servers";
     private static final String MODEL_ALIASES_KEY = "model_aliases";
+    private static final String MODEL_PROVIDERS_KEY = "model_providers";
+    private static final String CLI_AUTH_BACKUP_FILE_NAME = "auth.json.cli_backup";
+    private static final String PROVIDER_CONFIG_BASELINE_FILE_NAME = "config.toml.provider_backup";
+    private static final Set<String> GLOBAL_CONFIG_KEYS = Set.of("mcp_servers", "skills");
+    private static final Object CONFIG_FILE_LOCK = new Object();
 
     // Pattern to validate TOML bare keys (letters, digits, hyphens, underscores)
     private static final Pattern TOML_KEY_PATTERN = Pattern.compile("^[a-zA-Z0-9_-]+$");
@@ -72,6 +85,12 @@ public class CodexSettingsManager {
      * Returns null if file doesn't exist
      */
     public Map<String, Object> readConfigToml() throws IOException {
+        synchronized (CONFIG_FILE_LOCK) {
+            return readConfigTomlUnlocked();
+        }
+    }
+
+    private Map<String, Object> readConfigTomlUnlocked() throws IOException {
         Path configPath = getConfigTomlPath();
         if (!Files.exists(configPath)) {
             LOG.info("[CodexSettingsManager] config.toml not found at: " + configPath);
@@ -91,27 +110,83 @@ public class CodexSettingsManager {
      * Write config.toml from a map structure
      */
     public void writeConfigToml(Map<String, Object> config) throws IOException {
-        Path configPath = getConfigTomlPath();
+        synchronized (CONFIG_FILE_LOCK) {
+            writeConfigTomlUnlocked(config);
+        }
+    }
 
-        String tomlContent = generateToml(config);
-        writeStringAtomically(configPath, tomlContent);
+    private void writeConfigTomlUnlocked(Map<String, Object> config) throws IOException {
+        Path configPath = getConfigTomlPath();
+        writeStringAtomically(configPath, generateToml(config));
         LOG.info("[CodexSettingsManager] Wrote config.toml to: " + configPath);
     }
 
-    /**
-     * Write config.toml from raw string content
-     */
-    public void writeConfigTomlRaw(String content) throws IOException {
-        Path configPath = getConfigTomlPath();
+    @FunctionalInterface
+    public interface ConfigEditor {
+        boolean edit(Map<String, Object> config) throws IOException;
+    }
 
-        writeStringAtomically(configPath, content);
-        LOG.info("[CodexSettingsManager] Wrote raw config.toml to: " + configPath);
+    @FunctionalInterface
+    public interface IoAction {
+        void run() throws IOException;
+    }
+
+    @FunctionalInterface
+    public interface ConfigAccessGuard {
+        boolean isAllowed() throws IOException;
+    }
+
+    /**
+     * Runs one config.toml read-modify-write operation under the shared Codex config lock.
+     */
+    public void updateConfigToml(ConfigEditor editor) throws IOException {
+        updateConfigToml(() -> true, editor);
+    }
+
+    /**
+     * Runs a guarded config.toml update. The guard is rechecked while holding the
+     * same lock used by provider transitions, preventing access-mode changes
+     * between authorization and the write.
+     */
+    public void updateConfigToml(ConfigAccessGuard guard, ConfigEditor editor) throws IOException {
+        synchronized (CONFIG_FILE_LOCK) {
+            if (!guard.isAllowed()) {
+                throw new IOException("Codex config management is not authorized");
+            }
+            Map<String, Object> config = readConfigTomlUnlocked();
+            if (config == null) {
+                config = new LinkedHashMap<>();
+            }
+            if (editor.edit(config)) {
+                writeConfigTomlUnlocked(config);
+            }
+        }
+    }
+
+    /** Runs a guarded file operation under the provider/config transition lock. */
+    public void runWithConfigAccess(ConfigAccessGuard guard, IoAction action) throws IOException {
+        synchronized (CONFIG_FILE_LOCK) {
+            if (!guard.isAllowed()) {
+                throw new IOException("Codex config management is not authorized");
+            }
+            action.run();
+        }
+    }
+
+    boolean isConfigLockHeldByCurrentThread() {
+        return Thread.holdsLock(CONFIG_FILE_LOCK);
     }
 
     /**
      * Read auth.json
      */
     public JsonObject readAuthJson() throws IOException {
+        synchronized (CONFIG_FILE_LOCK) {
+            return readAuthJsonUnlocked();
+        }
+    }
+
+    private JsonObject readAuthJsonUnlocked() throws IOException {
         Path authPath = getAuthJsonPath();
         if (!Files.exists(authPath)) {
             LOG.info("[CodexSettingsManager] auth.json not found at: " + authPath);
@@ -130,78 +205,415 @@ public class CodexSettingsManager {
      * Write auth.json
      */
     public void writeAuthJson(JsonObject auth) throws IOException {
-        Path authPath = getAuthJsonPath();
+        synchronized (CONFIG_FILE_LOCK) {
+            writeAuthJsonUnlocked(auth);
+        }
+    }
 
+    private void writeAuthJsonUnlocked(JsonObject auth) throws IOException {
+        Path authPath = getAuthJsonPath();
         writeStringAtomically(authPath, gson.toJson(auth));
         LOG.info("[CodexSettingsManager] Wrote auth.json to: " + authPath);
     }
 
     /**
-     * Apply provider configuration to ~/.codex files
-     *
-     * @param provider The provider configuration containing config and auth data
+     * Atomically transitions the provider-owned config/auth values and commits provider state last.
+     * Global MCP and Skill configuration is never owned by a provider fragment.
      */
-    public void applyProviderToCodexSettings(JsonObject provider) throws IOException {
+    public void transitionProvider(
+            JsonObject previousProvider,
+            JsonObject nextProvider,
+            boolean useCliLogin,
+            IoAction commitProviderState) throws IOException {
+        Map<String, Object> previousFragment = parseProviderFragment(previousProvider, false);
+        Map<String, Object> nextFragment = parseProviderFragment(nextProvider, true);
+        JsonObject nextAuth = parseProviderAuth(nextProvider);
+
+        synchronized (CONFIG_FILE_LOCK) {
+            Map<String, Object> nextConfig = readConfigTomlUnlocked();
+            if (nextConfig == null) {
+                nextConfig = new LinkedHashMap<>();
+            }
+
+            Path configPath = getConfigTomlPath();
+            Path authPath = getAuthJsonPath();
+            Path cliAuthBackupPath = codexDir.resolve(CLI_AUTH_BACKUP_FILE_NAME);
+            Path configBaselinePath = codexDir.resolve(PROVIDER_CONFIG_BASELINE_FILE_NAME);
+            Map<String, Object> configBaseline = prepareProviderConfigBaseline(
+                    previousProvider != null,
+                    configBaselinePath);
+
+            if (previousProvider != null) {
+                restoreProviderOwnedValues(nextConfig, configBaseline, previousFragment, true);
+            }
+            if (nextProvider != null) {
+                configBaseline = new LinkedHashMap<>();
+                captureMissingProviderBaselines(configBaseline, nextConfig, nextFragment, true);
+                mergeProviderValues(nextConfig, nextFragment, true);
+            }
+
+            FileSnapshot configSnapshot = FileSnapshot.capture(configPath);
+            FileSnapshot authSnapshot = FileSnapshot.capture(authPath);
+            FileSnapshot cliAuthBackupSnapshot = FileSnapshot.capture(cliAuthBackupPath);
+            FileSnapshot configBaselineSnapshot = FileSnapshot.capture(configBaselinePath);
+
+            try {
+                if (nextProvider != null) {
+                    writeStringAtomically(configBaselinePath, generateToml(configBaseline));
+                }
+                writeConfigTomlUnlocked(nextConfig);
+                if (nextProvider != null) {
+                    if (previousProvider == null) {
+                        backupLocalAuthUnlocked(cliAuthBackupPath);
+                    }
+                    if (nextAuth != null) {
+                        writeAuthJsonUnlocked(nextAuth);
+                    } else {
+                        Files.deleteIfExists(authPath);
+                    }
+                } else if (previousProvider != null) {
+                    restoreLocalAuthUnlocked(cliAuthBackupPath);
+                }
+                if (nextProvider == null) {
+                    Files.deleteIfExists(configBaselinePath);
+                }
+                commitProviderState.run();
+            } catch (Exception e) {
+                IOException failure = toIOException("Failed to activate Codex provider", e);
+                restoreSnapshot(configPath, configSnapshot, failure);
+                restoreSnapshot(authPath, authSnapshot, failure);
+                restoreSnapshot(cliAuthBackupPath, cliAuthBackupSnapshot, failure);
+                restoreSnapshot(configBaselinePath, configBaselineSnapshot, failure);
+                throw failure;
+            }
+        }
+
+        String providerId = nextProvider != null && nextProvider.has("id")
+                ? nextProvider.get("id").getAsString()
+                : useCliLogin ? "cli-login" : "none";
+        LOG.info("[CodexSettingsManager] Activated Codex provider: " + providerId);
+    }
+
+    /**
+     * Verifies legacy managed-provider state before granting config management access.
+     */
+    public boolean isProviderApplied(JsonObject provider) throws IOException {
         if (provider == null) {
-            LOG.warn("[CodexSettingsManager] Cannot apply null provider");
-            return;
+            return false;
         }
-
-        // Check if provider has configToml (raw string format)
-        if (provider.has("configToml") && provider.get("configToml").isJsonPrimitive()) {
-            String configTomlContent = provider.get("configToml").getAsString();
-            String mergedConfigTomlContent = preserveExistingMcpServers(configTomlContent);
-            writeConfigTomlRaw(mergedConfigTomlContent);
+        Map<String, Object> fragment = parseProviderFragment(provider, true);
+        JsonObject providerAuth = parseProviderAuth(provider);
+        synchronized (CONFIG_FILE_LOCK) {
+            Map<String, Object> currentConfig = readConfigTomlUnlocked();
+            if (currentConfig == null || !containsProviderValues(currentConfig, fragment, true)) {
+                return false;
+            }
+            if (providerAuth == null) {
+                return readAuthJsonUnlocked() == null;
+            }
+            JsonObject currentAuth = readAuthJsonUnlocked();
+            return providerAuth.equals(currentAuth);
         }
+    }
 
-        // Check if provider has authJson (raw string format)
-        if (provider.has("authJson") && provider.get("authJson").isJsonPrimitive()) {
-            String authJsonContent = provider.get("authJson").getAsString();
-            if (authJsonContent != null && !authJsonContent.trim().isEmpty()) {
-                try {
-                    JsonObject authObj = JsonParser.parseString(authJsonContent).getAsJsonObject();
-                    writeAuthJson(authObj);
-                } catch (Exception e) {
-                    LOG.warn("[CodexSettingsManager] Failed to parse authJson: " + e.getMessage());
+    private Map<String, Object> parseProviderFragment(JsonObject provider, boolean rejectGlobalKeys) throws IOException {
+        if (provider == null || !provider.has("configToml") || !provider.get("configToml").isJsonPrimitive()) {
+            return new LinkedHashMap<>();
+        }
+        Map<String, Object> fragment = parseToml(provider.get("configToml").getAsString());
+        if (rejectGlobalKeys) {
+            for (String globalKey : GLOBAL_CONFIG_KEYS) {
+                if (fragment.containsKey(globalKey)) {
+                    throw new IOException("Provider config.toml must not declare global '" + globalKey + "' configuration");
                 }
             }
         }
-
-        String providerId = provider.has("id") ? provider.get("id").getAsString() : "unknown";
-        LOG.info("[CodexSettingsManager] Applied provider to ~/.codex: " + providerId);
+        return fragment;
     }
 
-    private String preserveExistingMcpServers(String providerConfigToml) throws IOException {
-        Map<String, Object> existingConfig = readConfigToml();
-        if (existingConfig == null) {
-            return providerConfigToml;
+    private JsonObject parseProviderAuth(JsonObject provider) throws IOException {
+        if (provider == null || !provider.has("authJson") || !provider.get("authJson").isJsonPrimitive()) {
+            return null;
         }
-
-        Object existingMcpServersObj = existingConfig.get(MCP_SERVERS_KEY);
-        if (!(existingMcpServersObj instanceof Map)) {
-            return providerConfigToml;
+        String authJson = provider.get("authJson").getAsString();
+        if (authJson == null || authJson.trim().isEmpty()) {
+            return null;
         }
-
-        @SuppressWarnings("unchecked")
-        Map<String, Object> existingMcpServers = (Map<String, Object>) existingMcpServersObj;
-        if (existingMcpServers.isEmpty()) {
-            return providerConfigToml;
+        try {
+            return JsonParser.parseString(authJson).getAsJsonObject();
+        } catch (Exception e) {
+            throw new IOException("Provider authJson must be a valid JSON object", e);
         }
+    }
 
-        Map<String, Object> providerConfig = parseToml(providerConfigToml == null ? "" : providerConfigToml);
-        Object providerMcpServersObj = providerConfig.get(MCP_SERVERS_KEY);
-        if (providerMcpServersObj instanceof Map) {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> providerMcpServers = (Map<String, Object>) providerMcpServersObj;
-            for (Map.Entry<String, Object> entry : existingMcpServers.entrySet()) {
-                providerMcpServers.putIfAbsent(entry.getKey(), entry.getValue());
+    private Map<String, Object> prepareProviderConfigBaseline(
+            boolean hasPreviousProvider,
+            Path baselinePath) throws IOException {
+        if (hasPreviousProvider && Files.exists(baselinePath)) {
+            return parseToml(Files.readString(baselinePath, StandardCharsets.UTF_8));
+        }
+        return new LinkedHashMap<>();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void restoreProviderOwnedValues(
+            Map<String, Object> target,
+            Map<String, Object> baseline,
+            Map<String, Object> owned,
+            boolean topLevel) {
+        for (Map.Entry<String, Object> entry : owned.entrySet()) {
+            String key = entry.getKey();
+            if (topLevel && GLOBAL_CONFIG_KEYS.contains(key)) {
+                continue;
             }
-        } else {
-            providerConfig.put(MCP_SERVERS_KEY, existingMcpServers);
-        }
 
-        LOG.info("[CodexSettingsManager] Preserved existing Codex MCP servers while applying provider");
-        return generateToml(providerConfig);
+            Object ownedValue = entry.getValue();
+            Object baselineValue = baseline.get(key);
+            boolean baselineContainsKey = baseline.containsKey(key);
+            if (topLevel && MODEL_PROVIDERS_KEY.equals(key) && ownedValue instanceof Map) {
+                if (baselineContainsKey && !(baselineValue instanceof Map)) {
+                    target.put(key, deepCopyValue(baselineValue));
+                } else {
+                    restoreModelProviderEntries(
+                            target,
+                            baselineValue instanceof Map ? (Map<String, Object>) baselineValue : Map.of(),
+                            (Map<String, Object>) ownedValue,
+                            key);
+                }
+            } else if (ownedValue instanceof Map) {
+                if (baselineContainsKey && !(baselineValue instanceof Map)) {
+                    target.put(key, deepCopyValue(baselineValue));
+                    continue;
+                }
+                Map<String, Object> targetMap = target.get(key) instanceof Map
+                        ? (Map<String, Object>) target.get(key)
+                        : new LinkedHashMap<>();
+                restoreProviderOwnedValues(
+                        targetMap,
+                        baselineValue instanceof Map ? (Map<String, Object>) baselineValue : Map.of(),
+                        (Map<String, Object>) ownedValue,
+                        false);
+                if (targetMap.isEmpty() && !baselineContainsKey) {
+                    target.remove(key);
+                } else {
+                    target.put(key, targetMap);
+                }
+            } else if (baselineContainsKey) {
+                target.put(key, deepCopyValue(baselineValue));
+            } else {
+                target.remove(key);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void restoreModelProviderEntries(
+            Map<String, Object> target,
+            Map<String, Object> baselineProviders,
+            Map<String, Object> ownedProviders,
+            String key) {
+        Map<String, Object> targetProviders = target.get(key) instanceof Map
+                ? (Map<String, Object>) target.get(key)
+                : new LinkedHashMap<>();
+        for (String providerId : ownedProviders.keySet()) {
+            if (baselineProviders.containsKey(providerId)) {
+                targetProviders.put(providerId, deepCopyValue(baselineProviders.get(providerId)));
+            } else {
+                targetProviders.remove(providerId);
+            }
+        }
+        if (targetProviders.isEmpty() && baselineProviders.isEmpty()) {
+            target.remove(key);
+        } else {
+            target.put(key, targetProviders);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void captureMissingProviderBaselines(
+            Map<String, Object> baseline,
+            Map<String, Object> current,
+            Map<String, Object> owned,
+            boolean topLevel) {
+        for (Map.Entry<String, Object> entry : owned.entrySet()) {
+            String key = entry.getKey();
+            if (topLevel && GLOBAL_CONFIG_KEYS.contains(key)) {
+                continue;
+            }
+
+            Object ownedValue = entry.getValue();
+            Object currentValue = current.get(key);
+            if (topLevel && MODEL_PROVIDERS_KEY.equals(key) && ownedValue instanceof Map) {
+                if (baseline.containsKey(key) && !(baseline.get(key) instanceof Map)) {
+                    continue;
+                }
+                Map<String, Object> baselineProviders = baseline.get(key) instanceof Map
+                        ? (Map<String, Object>) baseline.get(key)
+                        : new LinkedHashMap<>();
+                Map<String, Object> currentProviders = currentValue instanceof Map
+                        ? (Map<String, Object>) currentValue
+                        : Map.of();
+                for (String providerId : ((Map<String, Object>) ownedValue).keySet()) {
+                    if (!baselineProviders.containsKey(providerId) && currentProviders.containsKey(providerId)) {
+                        baselineProviders.put(providerId, deepCopyValue(currentProviders.get(providerId)));
+                    }
+                }
+                if (!baselineProviders.isEmpty()) {
+                    baseline.put(key, baselineProviders);
+                }
+            } else if (ownedValue instanceof Map && baseline.get(key) instanceof Map) {
+                captureMissingProviderBaselines(
+                        (Map<String, Object>) baseline.get(key),
+                        currentValue instanceof Map ? (Map<String, Object>) currentValue : Map.of(),
+                        (Map<String, Object>) ownedValue,
+                        false);
+            } else if (ownedValue instanceof Map && !baseline.containsKey(key) && currentValue instanceof Map) {
+                Map<String, Object> nestedBaseline = new LinkedHashMap<>();
+                captureMissingProviderBaselines(
+                        nestedBaseline,
+                        (Map<String, Object>) currentValue,
+                        (Map<String, Object>) ownedValue,
+                        false);
+                if (!nestedBaseline.isEmpty()) {
+                    baseline.put(key, nestedBaseline);
+                }
+            } else if (!baseline.containsKey(key) && current.containsKey(key)) {
+                baseline.put(key, deepCopyValue(currentValue));
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void mergeProviderValues(
+            Map<String, Object> target,
+            Map<String, Object> fragment,
+            boolean topLevel) {
+        for (Map.Entry<String, Object> entry : fragment.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if (value instanceof Map && !(topLevel && MODEL_PROVIDERS_KEY.equals(key))) {
+                Object currentValue = target.get(key);
+                Map<String, Object> targetMap;
+                if (currentValue instanceof Map) {
+                    targetMap = (Map<String, Object>) currentValue;
+                } else {
+                    targetMap = new LinkedHashMap<>();
+                    target.put(key, targetMap);
+                }
+                mergeProviderValues(targetMap, (Map<String, Object>) value, false);
+            } else if (value instanceof Map) {
+                Map<String, Object> providers = target.get(key) instanceof Map
+                        ? (Map<String, Object>) target.get(key)
+                        : new LinkedHashMap<>();
+                for (Map.Entry<String, Object> providerEntry : ((Map<String, Object>) value).entrySet()) {
+                    providers.put(providerEntry.getKey(), deepCopyValue(providerEntry.getValue()));
+                }
+                target.put(key, providers);
+            } else {
+                target.put(key, deepCopyValue(value));
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private boolean containsProviderValues(
+            Map<String, Object> current,
+            Map<String, Object> expected,
+            boolean topLevel) {
+        for (Map.Entry<String, Object> entry : expected.entrySet()) {
+            boolean globalConfig = topLevel && GLOBAL_CONFIG_KEYS.contains(entry.getKey());
+            if (globalConfig || !current.containsKey(entry.getKey())) {
+                if (!globalConfig) {
+                    return false;
+                }
+                continue;
+            }
+            Object currentValue = current.get(entry.getKey());
+            Object expectedValue = entry.getValue();
+            if (topLevel && MODEL_PROVIDERS_KEY.equals(entry.getKey())
+                    && currentValue instanceof Map && expectedValue instanceof Map) {
+                Map<String, Object> currentProviders = (Map<String, Object>) currentValue;
+                for (Map.Entry<String, Object> providerEntry
+                        : ((Map<String, Object>) expectedValue).entrySet()) {
+                    if (!providerEntry.getValue().equals(currentProviders.get(providerEntry.getKey()))) {
+                        return false;
+                    }
+                }
+            } else if (currentValue instanceof Map && expectedValue instanceof Map) {
+                if (!containsProviderValues(
+                        (Map<String, Object>) currentValue,
+                        (Map<String, Object>) expectedValue,
+                        false)) {
+                    return false;
+                }
+            } else if (!expectedValue.equals(currentValue)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object deepCopyValue(Object value) {
+        if (value instanceof Map) {
+            Map<String, Object> copy = new LinkedHashMap<>();
+            ((Map<String, Object>) value).forEach((key, nestedValue) -> copy.put(key, deepCopyValue(nestedValue)));
+            return copy;
+        }
+        if (value instanceof List) {
+            List<Object> copy = new ArrayList<>();
+            for (Object item : (List<Object>) value) {
+                copy.add(deepCopyValue(item));
+            }
+            return copy;
+        }
+        return value;
+    }
+
+    private void backupLocalAuthUnlocked(Path backupPath) throws IOException {
+        Path authPath = getAuthJsonPath();
+        if (Files.exists(authPath)) {
+            writeStringAtomically(backupPath, Files.readString(authPath, StandardCharsets.UTF_8));
+            LOG.info("[CodexSettingsManager] Backed up local Codex credentials");
+        } else {
+            Files.deleteIfExists(backupPath);
+        }
+    }
+
+    private void restoreLocalAuthUnlocked(Path backupPath) throws IOException {
+        if (Files.exists(backupPath)) {
+            writeStringAtomically(getAuthJsonPath(), Files.readString(backupPath, StandardCharsets.UTF_8));
+            Files.deleteIfExists(backupPath);
+            return;
+        }
+        Files.deleteIfExists(getAuthJsonPath());
+    }
+
+    private void restoreSnapshot(Path path, FileSnapshot snapshot, IOException failure) {
+        try {
+            if (snapshot.exists()) {
+                writeStringAtomically(path, new String(snapshot.content(), StandardCharsets.UTF_8));
+            } else {
+                Files.deleteIfExists(path);
+            }
+        } catch (Exception restoreError) {
+            failure.addSuppressed(restoreError);
+        }
+    }
+
+    private IOException toIOException(String message, Exception cause) {
+        if (cause instanceof IOException) {
+            return (IOException) cause;
+        }
+        return new IOException(message + ": " + cause.getMessage(), cause);
+    }
+
+    private record FileSnapshot(boolean exists, byte[] content) {
+        private static FileSnapshot capture(Path path) throws IOException {
+            return Files.exists(path)
+                    ? new FileSnapshot(true, Files.readAllBytes(path))
+                    : new FileSnapshot(false, new byte[0]);
+        }
     }
 
     /**
@@ -261,6 +673,10 @@ public class CodexSettingsManager {
             JsonObject auth = readAuthJson();
             if (auth == null) {
                 return false;
+            }
+            if (auth.has("OPENAI_API_KEY") && auth.get("OPENAI_API_KEY").isJsonPrimitive()
+                    && !auth.get("OPENAI_API_KEY").getAsString().isBlank()) {
+                return true;
             }
             // Check for chatgpt auth mode with tokens
             if (auth.has("auth_mode") && "chatgpt".equals(auth.get("auth_mode").getAsString())) {
@@ -340,52 +756,6 @@ public class CodexSettingsManager {
     }
 
     /**
-     * Apply Codex CLI login mode to ~/.codex/ settings.
-     * Clears config.toml (to use official defaults) while preserving auth.json (OAuth tokens).
-     * Backs up existing config.toml before clearing.
-     *
-     * @throws IOException if backup or write fails
-     */
-    public void applyCodexCliLoginToSettings() throws IOException {
-        Path configTomlPath = getConfigTomlPath();
-        Path backupPath = codexDir.resolve("config.toml.cli_backup");
-
-        // Backup existing config.toml if it exists and has content
-        if (Files.exists(configTomlPath)) {
-            String content = Files.readString(configTomlPath, StandardCharsets.UTF_8);
-            if (content != null && !content.trim().isEmpty()) {
-                Files.copy(configTomlPath, backupPath, StandardCopyOption.REPLACE_EXISTING);
-                LOG.info("[CodexSettingsManager] Backed up config.toml to: " + backupPath);
-            }
-        }
-
-        // Clear config.toml — empty file means Codex SDK uses official defaults
-        writeConfigTomlRaw("");
-
-        // auth.json is left untouched — it already contains the OAuth tokens from 'codex login'
-        LOG.info("[CodexSettingsManager] Applied Codex CLI login mode (config.toml cleared, auth.json preserved)");
-    }
-
-    /**
-     * Remove Codex CLI login mode by restoring the backed-up config.toml.
-     * Called when switching away from CLI login mode.
-     *
-     * @throws IOException if restore fails
-     */
-    public void removeCodexCliLoginFromSettings() throws IOException {
-        Path backupPath = codexDir.resolve("config.toml.cli_backup");
-
-        if (Files.exists(backupPath)) {
-            Path configTomlPath = getConfigTomlPath();
-            Files.copy(backupPath, configTomlPath, StandardCopyOption.REPLACE_EXISTING);
-            Files.deleteIfExists(backupPath);
-            LOG.info("[CodexSettingsManager] Restored config.toml from CLI login backup");
-        } else {
-            LOG.info("[CodexSettingsManager] No CLI login backup found, nothing to restore");
-        }
-    }
-
-    /**
      * Get current Codex configuration (combined from config.toml and auth.json)
      */
     public JsonObject getCurrentCodexConfig() throws IOException {
@@ -437,327 +807,44 @@ public class CodexSettingsManager {
     // ==================== TOML Parsing Utilities ====================
 
     /**
-     * Simple TOML parser (handles basic key=value and [section] syntax)
+     * Parses TOML 1.0 into mutable maps/lists used by the existing settings managers.
      */
-    private Map<String, Object> parseToml(String content) {
-        Map<String, Object> result = new LinkedHashMap<>();
-        Map<String, Object> currentSection = result;
-
-        String[] lines = content.split("\n");
-        for (String line : lines) {
-            line = line.trim();
-
-            // Skip empty lines and comments
-            if (line.isEmpty() || line.startsWith("#")) {
-                continue;
-            }
-
-            // Array of tables header [[section.subsection]]
-            if (line.startsWith("[[") && line.endsWith("]]")) {
-                String sectionName = line.substring(2, line.length() - 2).trim();
-
-                // Navigate to parent, then append a new map to the List at the leaf key
-                String[] parts = sectionName.split("\\.");
-                Map<String, Object> nav = result;
-                boolean navFailed = false;
-                for (int i = 0; i < parts.length - 1; i++) {
-                    if (!nav.containsKey(parts[i])) {
-                        nav.put(parts[i], new LinkedHashMap<String, Object>());
-                    }
-                    Object next = nav.get(parts[i]);
-                    if (next instanceof Map) {
-                        @SuppressWarnings("unchecked")
-                        Map<String, Object> nextMap = (Map<String, Object>) next;
-                        nav = nextMap;
-                    } else {
-                        // Type conflict: intermediate node is not a Map
-                        LOG.warn("[CodexSettingsManager] Type conflict at key '" + parts[i] + "' in [[" + sectionName + "]], skipping");
-                        navFailed = true;
-                        break;
-                    }
+    private Map<String, Object> parseToml(String content) throws IOException {
+        TomlParseResult parsed = Toml.parse(content == null ? "" : content);
+        if (parsed.hasErrors()) {
+            StringBuilder errors = new StringBuilder();
+            parsed.errors().forEach(error -> {
+                if (errors.length() > 0) {
+                    errors.append("; ");
                 }
-
-                if (navFailed) {
-                    // Use a throwaway map so subsequent key=value lines don't corrupt other sections
-                    currentSection = new LinkedHashMap<>();
-                    continue;
-                }
-                currentSection = nav;
-
-                // At the leaf key, create or get a List<Map> and append a new entry
-                String leafKey = parts[parts.length - 1];
-                if (!nav.containsKey(leafKey)) {
-                    nav.put(leafKey, new ArrayList<Map<String, Object>>());
-                }
-                Object leafVal = nav.get(leafKey);
-                if (leafVal instanceof List) {
-                    @SuppressWarnings("unchecked")
-                    List<Map<String, Object>> tableList = (List<Map<String, Object>>) leafVal;
-                    Map<String, Object> newEntry = new LinkedHashMap<>();
-                    tableList.add(newEntry);
-                    currentSection = newEntry;
-                } else {
-                    LOG.warn("[CodexSettingsManager] Type conflict at leaf key '" + leafKey + "' in [[" + sectionName + "]], expected List");
-                    currentSection = new LinkedHashMap<>();
-                }
-                continue;
-            }
-
-            // Section header [section] or [section.subsection]
-            if (line.startsWith("[") && line.endsWith("]")) {
-                String sectionName = line.substring(1, line.length() - 1).trim();
-
-                // Navigate/create nested sections
-                String[] parts = sectionName.split("\\.");
-                Map<String, Object> nav = result;
-                boolean navFailed = false;
-                for (String part : parts) {
-                    if (!nav.containsKey(part)) {
-                        nav.put(part, new LinkedHashMap<String, Object>());
-                    }
-                    Object next = nav.get(part);
-                    if (next instanceof Map) {
-                        @SuppressWarnings("unchecked")
-                        Map<String, Object> nextMap = (Map<String, Object>) next;
-                        nav = nextMap;
-                    } else {
-                        // Type conflict: node is not a Map (could be a List or simple value)
-                        LOG.warn("[CodexSettingsManager] Type conflict at key '" + part + "' in [" + sectionName + "], skipping");
-                        navFailed = true;
-                        break;
-                    }
-                }
-
-                currentSection = navFailed ? new LinkedHashMap<>() : nav;
-                continue;
-            }
-
-            // Key = value
-            int eqIndex = line.indexOf('=');
-            if (eqIndex > 0) {
-                String key = line.substring(0, eqIndex).trim();
-                key = normalizeTomlKey(key);
-                String valueStr = line.substring(eqIndex + 1).trim();
-                Object value = parseTomlValue(valueStr);
-                currentSection.put(key, value);
-            }
+                errors.append(error);
+            });
+            throw new IOException("Invalid TOML: " + errors);
         }
+        return convertTomlTable(parsed);
+    }
 
+    private Map<String, Object> convertTomlTable(TomlTable table) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : table.entrySet()) {
+            result.put(entry.getKey(), convertTomlValue(entry.getValue()));
+        }
         return result;
     }
 
-    /**
-     * Parse a TOML value string
-     */
-    private Object parseTomlValue(String valueStr) {
-        if (valueStr.isEmpty()) {
-            return "";
+    private Object convertTomlValue(Object value) {
+        if (value instanceof TomlTable) {
+            return convertTomlTable((TomlTable) value);
         }
-
-        // Boolean
-        if (valueStr.equals("true")) {
-            return true;
-        }
-        if (valueStr.equals("false")) {
-            return false;
-        }
-
-        // Array: [value1, value2, ...]
-        if (valueStr.startsWith("[") && valueStr.endsWith("]")) {
-            return parseTomlArray(valueStr);
-        }
-
-        // Inline table: { key = "value", ... }
-        if (valueStr.startsWith("{") && valueStr.endsWith("}")) {
-            return parseTomlInlineTable(valueStr);
-        }
-
-        // String (quoted)
-        if (valueStr.length() >= 2 && valueStr.startsWith("\"") && valueStr.endsWith("\"")) {
-            return unescapeTomlString(valueStr.substring(1, valueStr.length() - 1));
-        }
-        if (valueStr.length() >= 2 && valueStr.startsWith("'") && valueStr.endsWith("'")) {
-            return valueStr.substring(1, valueStr.length() - 1);
-        }
-
-        // Number
-        try {
-            if (valueStr.contains(".")) {
-                return Double.parseDouble(valueStr);
-            } else {
-                return Long.parseLong(valueStr);
+        if (value instanceof TomlArray) {
+            TomlArray array = (TomlArray) value;
+            List<Object> result = new ArrayList<>();
+            for (int i = 0; i < array.size(); i++) {
+                result.add(convertTomlValue(array.get(i)));
             }
-        } catch (NumberFormatException ignored) {
-        }
-
-        // Default: treat as unquoted string
-        return valueStr;
-    }
-
-    /**
-     * Parse a TOML array: [value1, value2, ...]
-     */
-    private List<Object> parseTomlArray(String arrayStr) {
-        List<Object> result = new ArrayList<>();
-        String content = arrayStr.substring(1, arrayStr.length() - 1).trim();
-
-        if (content.isEmpty()) {
             return result;
         }
-
-        // Split by comma, respecting quotes and nested structures
-        List<String> elements = splitTomlElements(content, ',');
-        for (String element : elements) {
-            element = element.trim();
-            if (!element.isEmpty()) {
-                result.add(parseTomlValue(element));
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Parse a TOML inline table: { key = "value", ... }
-     */
-    private Map<String, Object> parseTomlInlineTable(String tableStr) {
-        Map<String, Object> result = new LinkedHashMap<>();
-        String content = tableStr.substring(1, tableStr.length() - 1).trim();
-
-        if (content.isEmpty()) {
-            return result;
-        }
-
-        // Split by comma, respecting quotes and nested structures
-        List<String> pairs = splitTomlElements(content, ',');
-        for (String pair : pairs) {
-            pair = pair.trim();
-            int eqIndex = pair.indexOf('=');
-            if (eqIndex > 0) {
-                String key = pair.substring(0, eqIndex).trim();
-                String valueStr = pair.substring(eqIndex + 1).trim();
-                result.put(normalizeTomlKey(key), parseTomlValue(valueStr));
-            }
-        }
-        return result;
-    }
-
-    private String normalizeTomlKey(String key) {
-        String trimmed = key == null ? "" : key.trim();
-        if (trimmed.length() >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
-            return unescapeTomlString(trimmed.substring(1, trimmed.length() - 1));
-        }
-        if (trimmed.length() >= 2 && trimmed.startsWith("'") && trimmed.endsWith("'")) {
-            return trimmed.substring(1, trimmed.length() - 1);
-        }
-        return trimmed;
-    }
-
-    /**
-     * Split TOML elements by delimiter, respecting quotes and nested structures
-     */
-    private List<String> splitTomlElements(String content, char delimiter) {
-        List<String> result = new ArrayList<>();
-        StringBuilder current = new StringBuilder();
-        int depth = 0;
-        boolean inDoubleQuote = false;
-        boolean inSingleQuote = false;
-        boolean escaped = false;
-
-        for (int i = 0; i < content.length(); i++) {
-            char c = content.charAt(i);
-
-            if (escaped) {
-                current.append(c);
-                escaped = false;
-                continue;
-            }
-
-            if (c == '\\') {
-                current.append(c);
-                escaped = true;
-                continue;
-            }
-
-            if (c == '"' && !inSingleQuote) {
-                inDoubleQuote = !inDoubleQuote;
-                current.append(c);
-                continue;
-            }
-
-            if (c == '\'' && !inDoubleQuote) {
-                inSingleQuote = !inSingleQuote;
-                current.append(c);
-                continue;
-            }
-
-            if (!inDoubleQuote && !inSingleQuote) {
-                if (c == '[' || c == '{') {
-                    depth++;
-                } else if (c == ']' || c == '}') {
-                    depth--;
-                } else if (c == delimiter && depth == 0) {
-                    result.add(current.toString());
-                    current = new StringBuilder();
-                    continue;
-                }
-            }
-
-            current.append(c);
-        }
-
-        if (current.length() > 0) {
-            result.add(current.toString());
-        }
-
-        return result;
-    }
-
-    /**
-     * Unescape TOML string (handle \n, \t, \\, \", etc.)
-     */
-    private String unescapeTomlString(String str) {
-        StringBuilder result = new StringBuilder();
-        boolean escaped = false;
-
-        for (int i = 0; i < str.length(); i++) {
-            char c = str.charAt(i);
-            if (escaped) {
-                switch (c) {
-                    case 'n':
-                        result.append('\n');
-                        break;
-                    case 't':
-                        result.append('\t');
-                        break;
-                    case 'r':
-                        result.append('\r');
-                        break;
-                    case '\\':
-                        result.append('\\');
-                        break;
-                    case '"':
-                        result.append('"');
-                        break;
-                    case '\'':
-                        result.append('\'');
-                        break;
-                    default:
-                        result.append('\\').append(c);
-                        break;
-                }
-                escaped = false;
-            } else if (c == '\\') {
-                escaped = true;
-            } else {
-                result.append(c);
-            }
-        }
-
-        if (escaped) {
-            result.append('\\');
-        }
-
-        return result.toString();
+        return value;
     }
 
     /**
@@ -777,27 +864,19 @@ public class CodexSettingsManager {
         // Then write Map sections
         for (Map.Entry<String, Object> entry : config.entrySet()) {
             if (entry.getValue() instanceof Map) {
-                if (!isValidTomlKey(entry.getKey())) {
-                    LOG.warn("[CodexSettingsManager] Skipping invalid TOML section key: " + entry.getKey());
-                    continue;
-                }
                 @SuppressWarnings("unchecked")
                 Map<String, Object> section = (Map<String, Object>) entry.getValue();
-                writeTomlSection(sb, entry.getKey(), section);
+                writeTomlSection(sb, toTomlKey(entry.getKey()), section);
             }
         }
 
         // Finally, write top-level array of tables ([[key]])
         for (Map.Entry<String, Object> entry : config.entrySet()) {
             if (isArrayOfTables(entry.getValue())) {
-                if (!isValidTomlKey(entry.getKey())) {
-                    LOG.warn("[CodexSettingsManager] Skipping invalid TOML array key: " + entry.getKey());
-                    continue;
-                }
                 @SuppressWarnings("unchecked")
                 List<Map<String, Object>> tableList = (List<Map<String, Object>>) entry.getValue();
                 for (Map<String, Object> tableEntry : tableList) {
-                    sb.append("\n[[").append(entry.getKey()).append("]]\n");
+                    sb.append("\n[[").append(toTomlKey(entry.getKey())).append("]]\n");
                     for (Map.Entry<String, Object> kv : tableEntry.entrySet()) {
                         sb.append(toTomlKey(kv.getKey())).append(" = ")
                                 .append(toTomlValue(kv.getValue())).append("\n");
@@ -814,20 +893,16 @@ public class CodexSettingsManager {
      * Handles nested Map sections and List&lt;Map&gt; array of tables.
      */
     private void writeTomlSection(StringBuilder sb, String sectionPath, Map<String, Object> section) {
-        // A "simple value" is anything that is NOT a nested Map, NOT an array of tables (List<Map>),
-        // and NOT an empty list (which would be an empty array of tables with no TOML representation).
+        // A simple value is anything that is not a nested table or array of tables.
         boolean hasSimpleValues = section.values().stream()
-                                          .anyMatch(v -> !(v instanceof Map) && !isArrayOfTables(v)
-                                                                 && !(v instanceof List && ((List<?>) v).isEmpty()));
+                                          .anyMatch(v -> !(v instanceof Map) && !isArrayOfTables(v));
 
         // Write section header and simple values
         if (hasSimpleValues) {
             sb.append("[").append(sectionPath).append("]\n");
             for (Map.Entry<String, Object> entry : section.entrySet()) {
                 Object val = entry.getValue();
-                // Skip Maps, array of tables, and empty lists
-                if (val instanceof Map || isArrayOfTables(val)
-                            || (val instanceof List && ((List<?>) val).isEmpty())) {
+                if (val instanceof Map || isArrayOfTables(val)) {
                     continue;
                 }
                 sb.append(toTomlKey(entry.getKey())).append(" = ").append(toTomlValue(val)).append("\n");
@@ -837,33 +912,19 @@ public class CodexSettingsManager {
         // Write nested sections (Map values)
         for (Map.Entry<String, Object> entry : section.entrySet()) {
             if (entry.getValue() instanceof Map) {
-                if (!isValidTomlKey(entry.getKey())) {
-                    LOG.warn("[CodexSettingsManager] Skipping invalid TOML section key: " + entry.getKey());
-                    continue;
-                }
                 @SuppressWarnings("unchecked")
                 Map<String, Object> nestedSection = (Map<String, Object>) entry.getValue();
-                writeTomlSection(sb, sectionPath + "." + entry.getKey(), nestedSection);
+                writeTomlSection(sb, sectionPath + "." + toTomlKey(entry.getKey()), nestedSection);
             }
         }
 
         // Write array of tables (List<Map> values) as [[section.key]]
-        // Note: empty lists (isArrayOfTables returns false) are intentionally skipped
-        // because empty array of tables have no valid TOML representation.
         for (Map.Entry<String, Object> entry : section.entrySet()) {
             Object entryVal = entry.getValue();
-            // Skip empty lists - they cannot be represented as array of tables in TOML
-            if (entryVal instanceof List && ((List<?>) entryVal).isEmpty()) {
-                continue;
-            }
             if (isArrayOfTables(entryVal)) {
-                if (!isValidTomlKey(entry.getKey())) {
-                    LOG.warn("[CodexSettingsManager] Skipping invalid TOML array key: " + entry.getKey());
-                    continue;
-                }
                 @SuppressWarnings("unchecked")
                 List<Map<String, Object>> tableList = (List<Map<String, Object>>) entry.getValue();
-                String arrayPath = sectionPath + "." + entry.getKey();
+                String arrayPath = sectionPath + "." + toTomlKey(entry.getKey());
                 for (Map<String, Object> tableEntry : tableList) {
                     sb.append("\n[[").append(arrayPath).append("]]\n");
                     for (Map.Entry<String, Object> kv : tableEntry.entrySet()) {
@@ -917,7 +978,20 @@ public class CodexSettingsManager {
         if (value instanceof Boolean) {
             return value.toString();
         }
+        if (value instanceof Double) {
+            double number = (Double) value;
+            if (Double.isNaN(number)) {
+                return "nan";
+            }
+            if (Double.isInfinite(number)) {
+                return number > 0 ? "inf" : "-inf";
+            }
+        }
         if (value instanceof Number) {
+            return value.toString();
+        }
+        if (value instanceof OffsetDateTime || value instanceof LocalDateTime
+                || value instanceof LocalDate || value instanceof LocalTime) {
             return value.toString();
         }
         // List -> TOML array
@@ -941,7 +1015,7 @@ public class CodexSettingsManager {
             for (Map.Entry<String, Object> entry : map.entrySet()) {
                 if (!first) { sb.append(", "); }
                 first = false;
-                sb.append("\"").append(escapeTomlString(entry.getKey())).append("\" = ");
+                sb.append(toTomlKey(entry.getKey())).append(" = ");
                 sb.append(toTomlValue(entry.getValue()));
             }
             sb.append(" }");
@@ -956,11 +1030,50 @@ public class CodexSettingsManager {
      * Escape special characters in TOML string
      */
     private String escapeTomlString(String str) {
-        return str.replace("\\", "\\\\")
-                       .replace("\"", "\\\"")
-                       .replace("\n", "\\n")
-                       .replace("\t", "\\t")
-                       .replace("\r", "\\r");
+        StringBuilder escaped = new StringBuilder(str.length());
+        for (int i = 0; i < str.length(); i++) {
+            char value = str.charAt(i);
+            switch (value) {
+                case '\b':
+                    escaped.append("\\b");
+                    break;
+                case '\t':
+                    escaped.append("\\t");
+                    break;
+                case '\n':
+                    escaped.append("\\n");
+                    break;
+                case '\f':
+                    escaped.append("\\f");
+                    break;
+                case '\r':
+                    escaped.append("\\r");
+                    break;
+                case '"':
+                    escaped.append("\\\"");
+                    break;
+                case '\\':
+                    escaped.append("\\\\");
+                    break;
+                default:
+                    if (value <= 0x1F || value == 0x7F) {
+                        escaped.append("\\u");
+                        appendHex4(escaped, value);
+                    } else {
+                        escaped.append(value);
+                    }
+                    break;
+            }
+        }
+        return escaped.toString();
+    }
+
+    private void appendHex4(StringBuilder target, char value) {
+        String hexDigits = "0123456789ABCDEF";
+        target.append(hexDigits.charAt((value >> 12) & 0xF));
+        target.append(hexDigits.charAt((value >> 8) & 0xF));
+        target.append(hexDigits.charAt((value >> 4) & 0xF));
+        target.append(hexDigits.charAt(value & 0xF));
     }
 
 

--- a/src/main/java/com/github/claudecodegui/skill/CodexSkillService.java
+++ b/src/main/java/com/github/claudecodegui/skill/CodexSkillService.java
@@ -56,9 +56,6 @@ public class CodexSkillService {
     // Shared instance to avoid repeated instantiation (I1)
     private static final CodexSettingsManager codexSettingsManager = new CodexSettingsManager(gson);
 
-    // Lock for config.toml read-modify-write operations to prevent data loss (B2)
-    private static final Object CONFIG_TOML_LOCK = new Object();
-
     /**
      * Represents a directory to scan for skills, with its scope.
      */
@@ -96,6 +93,32 @@ public class CodexSkillService {
     private static String normalizePath(String path) {
         if (path == null || path.isEmpty()) { return path; }
         return Paths.get(path).toAbsolutePath().normalize().toString();
+    }
+
+    static boolean isToggleSkillPathAllowed(String skillPath, String cwd) {
+        if (skillPath == null || skillPath.isEmpty()) {
+            return false;
+        }
+        try {
+            Path candidate = Paths.get(skillPath).toAbsolutePath().normalize();
+            Path fileName = candidate.getFileName();
+            boolean hasValidFileName = fileName != null
+                    && ("SKILL.md".equals(fileName.toString()) || "skill.md".equals(fileName.toString()));
+            if (!hasValidFileName || !Files.isRegularFile(candidate, LinkOption.NOFOLLOW_LINKS)) {
+                return false;
+            }
+
+            Path realCandidate = candidate.toRealPath();
+            for (SkillScanDir scanDir : getSkillScanDirs(cwd)) {
+                Path scanRoot = Paths.get(scanDir.path());
+                if (Files.isDirectory(scanRoot) && realCandidate.startsWith(scanRoot.toRealPath())) {
+                    return true;
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("[CodexSkills] Failed to validate toggle path: " + e.getMessage());
+        }
+        return false;
     }
 
     /**
@@ -169,7 +192,7 @@ public class CodexSkillService {
         }
 
         // ~/.codex/skills/ (Codex CLI installed skills)
-        if (isCodexLocalConfigAuthorized()) {
+        if (isCodexConfigManagementAllowed()) {
             String codexDir = Paths.get(userHome, ".codex", "skills").toString();
             if (Files.isDirectory(Path.of(codexDir)) && seen.add(normalizePath(codexDir))) {
                 dirs.add(new SkillScanDir(codexDir, "user"));
@@ -337,14 +360,11 @@ public class CodexSkillService {
     @SuppressWarnings("unchecked")
     public static Set<String> getDisabledSkillPaths() {
         Set<String> disabled = new HashSet<>();
-        if (!isCodexLocalConfigAuthorized()) {
+        if (!isCodexConfigManagementAllowed()) {
             return disabled;
         }
         try {
-            Map<String, Object> config;
-            synchronized (CONFIG_TOML_LOCK) {
-                config = codexSettingsManager.readConfigToml();
-            }
+            Map<String, Object> config = codexSettingsManager.readConfigToml();
             if (config == null) {
                 return disabled;
             }
@@ -440,7 +460,7 @@ public class CodexSkillService {
     public static JsonObject toggleSkill(String skillPath, boolean currentEnabled, String cwd) {
         JsonObject result = new JsonObject();
 
-        if (!isCodexLocalConfigAuthorized()) {
+        if (!isCodexConfigManagementAllowed()) {
             result.addProperty("success", false);
             result.addProperty("error", com.github.claudecodegui.i18n.ClaudeCodeGuiBundle.message("error.codexLocalAccessNotAuthorized"));
             return result;
@@ -452,12 +472,9 @@ public class CodexSkillService {
             return result;
         }
 
-        // Validate skillPath: must point to an existing SKILL.md or skill.md file
-        Path skillFilePath = Paths.get(skillPath).toAbsolutePath().normalize();
-        String skillFileName = skillFilePath.getFileName().toString();
-        if (!"SKILL.md".equals(skillFileName) && !"skill.md".equals(skillFileName)) {
+        if (!isToggleSkillPathAllowed(skillPath, cwd)) {
             result.addProperty("success", false);
-            result.addProperty("error", "Skill path must point to a SKILL.md file");
+            result.addProperty("error", "Skill path must point to an existing SKILL.md inside a configured skills directory");
             return result;
         }
 
@@ -465,12 +482,7 @@ public class CodexSkillService {
         String normalizedSkillPath = normalizePath(skillPath);
 
         try {
-            synchronized (CONFIG_TOML_LOCK) {
-                Map<String, Object> config = codexSettingsManager.readConfigToml();
-                if (config == null) {
-                    config = new LinkedHashMap<>();
-                }
-
+            codexSettingsManager.updateConfigToml(CodexSkillService::isCodexConfigManagementAllowed, config -> {
                 // Navigate to skills -> config list
                 Map<String, Object> skillsMap = (Map<String, Object>) config
                         .computeIfAbsent("skills", k -> new LinkedHashMap<String, Object>());
@@ -496,9 +508,8 @@ public class CodexSkillService {
                     });
                     result.addProperty("enabled", true);
                 }
-
-                codexSettingsManager.writeConfigToml(config);
-            }
+                return true;
+            });
             result.addProperty("success", true);
             LOG.info("[CodexSkills] Toggled skill: " + normalizedSkillPath + " -> enabled=" + !currentEnabled);
         } catch (Exception e) {
@@ -709,18 +720,25 @@ public class CodexSkillService {
             return result;
         }
 
+        Path codexSkillsDir = Paths.get(userHome, ".codex", "skills").toAbsolutePath().normalize();
+        boolean isCodexManagedSkill = isPathSafe(normalizedSkillDir, codexSkillsDir);
+
         try {
-            // B1: Handle symlinks safely - delete only the link, not the target
-            if (Files.isSymbolicLink(skillDir.toPath())) {
-                Files.delete(skillDir.toPath());
-                LOG.info("[CodexSkills] Deleted symbolic link skill: " + skillDir);
+            if (isCodexManagedSkill) {
+                codexSettingsManager.runWithConfigAccess(
+                        CodexSkillService::isCodexConfigManagementAllowed,
+                        () -> deleteSkillDirectory(skillDir));
             } else {
-                deleteDirectory(skillDir.toPath());
-                LOG.info("[CodexSkills] Deleted skill directory: " + skillDir);
+                deleteSkillDirectory(skillDir);
             }
         } catch (IOException e) {
             result.addProperty("success", false);
-            result.addProperty("error", "Delete failed: " + e.getMessage());
+            if (isCodexManagedSkill && !isCodexConfigManagementAllowed()) {
+                result.addProperty("error", com.github.claudecodegui.i18n.ClaudeCodeGuiBundle.message(
+                        "error.codexLocalAccessNotAuthorized"));
+            } else {
+                result.addProperty("error", "Delete failed: " + e.getMessage());
+            }
             return result;
         }
 
@@ -738,22 +756,19 @@ public class CodexSkillService {
      */
     @SuppressWarnings("unchecked")
     private static void cleanupConfigTomlEntry(String skillPath) {
-        if (!isCodexLocalConfigAuthorized()) {
+        if (!isCodexConfigManagementAllowed()) {
             return;
         }
         try {
             // Normalize for consistent cross-platform comparison
             String normalizedSkillPath = normalizePath(skillPath);
-            synchronized (CONFIG_TOML_LOCK) {
-                Map<String, Object> config = codexSettingsManager.readConfigToml();
-                if (config == null) { return; }
-
+            codexSettingsManager.updateConfigToml(CodexSkillService::isCodexConfigManagementAllowed, config -> {
                 Object skillsObj = config.get("skills");
-                if (!(skillsObj instanceof Map)) { return; }
+                if (!(skillsObj instanceof Map)) { return false; }
 
                 Map<String, Object> skillsMap = (Map<String, Object>) skillsObj;
                 Object configObj = skillsMap.get("config");
-                if (!(configObj instanceof List)) { return; }
+                if (!(configObj instanceof List)) { return false; }
 
                 List<Map<String, Object>> configList = (List<Map<String, Object>>) configObj;
                 boolean removed = configList.removeIf(e -> {
@@ -761,10 +776,10 @@ public class CodexSkillService {
                     return pathVal instanceof String && normalizedSkillPath.equals(normalizePath((String) pathVal));
                 });
                 if (removed) {
-                    codexSettingsManager.writeConfigToml(config);
                     LOG.info("[CodexSkills] Cleaned up config.toml entry for: " + skillPath);
                 }
-            }
+                return removed;
+            });
         } catch (Exception e) {
             LOG.warn("[CodexSkills] Failed to cleanup config.toml: " + e.getMessage());
         }
@@ -813,12 +828,23 @@ public class CodexSkillService {
         });
     }
 
-    private static boolean isCodexLocalConfigAuthorized() {
+    private static boolean isCodexConfigManagementAllowed() {
         try {
-            return new CodemossSettingsService().isCodexLocalConfigAuthorized();
+            return new CodemossSettingsService().isCodexConfigManagementAllowed();
         } catch (Exception e) {
-            LOG.warn("[CodexSkills] Failed to read Codex local authorization state: " + e.getMessage());
+            LOG.warn("[CodexSkills] Failed to read Codex config management state: " + e.getMessage());
             return false;
+        }
+    }
+
+    private static void deleteSkillDirectory(File skillDir) throws IOException {
+        // Delete a directory symlink itself, never the target it references.
+        if (Files.isSymbolicLink(skillDir.toPath())) {
+            Files.delete(skillDir.toPath());
+            LOG.info("[CodexSkills] Deleted symbolic link skill: " + skillDir);
+        } else {
+            deleteDirectory(skillDir.toPath());
+            LOG.info("[CodexSkills] Deleted skill directory: " + skillDir);
         }
     }
 

--- a/src/test/java/com/github/claudecodegui/settings/CodemossSettingsServiceCodexCliLoginTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/CodemossSettingsServiceCodexCliLoginTest.java
@@ -1,5 +1,6 @@
 package com.github.claudecodegui.settings;
 
+import com.github.claudecodegui.skill.CodexSkillService;
 import com.github.claudecodegui.util.PlatformUtils;
 import com.google.gson.JsonObject;
 import org.junit.After;
@@ -36,6 +37,23 @@ public class CodemossSettingsServiceCodexCliLoginTest {
         Files.writeString(
                 tempHome.resolve(".codex").resolve("auth.json"),
                 "{\"auth_mode\":\"chatgpt\",\"tokens\":{\"access_token\":\"token-value\"}}",
+                StandardCharsets.UTF_8
+        );
+
+        CodemossSettingsService service = new CodemossSettingsService();
+        service.setCodexLocalConfigAuthorized(true);
+
+        assertTrue(service.isCodexCliLoginAvailable());
+    }
+
+    @Test
+    public void shouldExposeApiKeyCliLoginAvailabilityViaFacade() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-cli-api-key-home");
+        useTemporaryHomeDirectory(tempHome);
+        Files.createDirectories(tempHome.resolve(".codex"));
+        Files.writeString(
+                tempHome.resolve(".codex").resolve("auth.json"),
+                "{\"OPENAI_API_KEY\":\"local-key\"}",
                 StandardCharsets.UTF_8
         );
 
@@ -141,12 +159,15 @@ public class CodemossSettingsServiceCodexCliLoginTest {
         CodemossSettingsService service = new CodemossSettingsService();
 
         assertEquals(CodemossSettingsService.CODEX_RUNTIME_ACCESS_INACTIVE, service.getCodexRuntimeAccessMode());
+        assertFalse(service.isCodexConfigManagementAllowed());
 
         service.switchCodexProvider(CodexProviderManager.CODEX_CLI_LOGIN_PROVIDER_ID);
         assertEquals(CodemossSettingsService.CODEX_RUNTIME_ACCESS_INACTIVE, service.getCodexRuntimeAccessMode());
+        assertFalse(service.isCodexConfigManagementAllowed());
 
         service.setCodexLocalConfigAuthorized(true);
         assertEquals(CodemossSettingsService.CODEX_RUNTIME_ACCESS_CLI_LOGIN, service.getCodexRuntimeAccessMode());
+        assertTrue(service.isCodexConfigManagementAllowed());
 
         JsonObject provider = new JsonObject();
         provider.addProperty("id", "managed-provider");
@@ -157,6 +178,98 @@ public class CodemossSettingsServiceCodexCliLoginTest {
         service.switchCodexProvider("managed-provider");
 
         assertEquals(CodemossSettingsService.CODEX_RUNTIME_ACCESS_MANAGED, service.getCodexRuntimeAccessMode());
+        assertTrue(service.isCodexConfigManagementAllowed());
+        Path codexSkillsDir = Files.createDirectories(tempHome.resolve(".codex").resolve("skills"));
+        assertTrue(CodexSkillService.getSkillScanDirs(tempHome.toString()).stream()
+                .map(scanDir -> Path.of(scanDir.path()).toAbsolutePath().normalize())
+                .anyMatch(codexSkillsDir.toAbsolutePath().normalize()::equals));
+
+        JsonObject persisted = service.readConfig().getAsJsonObject("codex");
+        assertEquals("managed-provider", persisted.get("appliedProviderId").getAsString());
+        assertTrue(persisted.has("appliedProviderRevision"));
+
+        Files.writeString(
+                tempHome.resolve(".codex").resolve("config.toml"),
+                "model = \"tampered\"",
+                StandardCharsets.UTF_8
+        );
+
+        assertEquals(CodemossSettingsService.CODEX_RUNTIME_ACCESS_INACTIVE, service.getCodexRuntimeAccessMode());
+        assertFalse(service.isCodexConfigManagementAllowed());
+    }
+
+    @Test
+    public void shouldMigrateMatchingLegacyActiveProviderToAppliedMarkers() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-legacy-provider-migration-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = Files.createDirectories(tempHome.resolve(".codex"));
+        Files.writeString(codexDir.resolve("config.toml"), "model = \"legacy-model\"\n", StandardCharsets.UTF_8);
+
+        CodemossSettingsService service = new CodemossSettingsService();
+        JsonObject provider = new JsonObject();
+        provider.addProperty("id", "legacy-provider");
+        provider.addProperty("name", "Legacy Provider");
+        provider.addProperty("configToml", "model = \"legacy-model\"\n");
+        service.addCodexProvider(provider);
+        JsonObject config = service.readConfig();
+        config.getAsJsonObject("codex").addProperty("current", "legacy-provider");
+        service.writeConfig(config);
+
+        assertEquals(CodemossSettingsService.CODEX_RUNTIME_ACCESS_MANAGED, service.getCodexRuntimeAccessMode());
+        JsonObject migrated = service.readConfig().getAsJsonObject("codex");
+        assertEquals("legacy-provider", migrated.get("appliedProviderId").getAsString());
+        assertTrue(migrated.has("appliedProviderRevision"));
+    }
+
+    @Test
+    public void shouldRejectMismatchedLegacyActiveProviderWithoutWritingMarkers() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-legacy-provider-mismatch-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = Files.createDirectories(tempHome.resolve(".codex"));
+        Files.writeString(codexDir.resolve("config.toml"), "model = \"other-model\"\n", StandardCharsets.UTF_8);
+
+        CodemossSettingsService service = new CodemossSettingsService();
+        JsonObject provider = new JsonObject();
+        provider.addProperty("id", "legacy-provider");
+        provider.addProperty("name", "Legacy Provider");
+        provider.addProperty("configToml", "model = \"legacy-model\"\n");
+        service.addCodexProvider(provider);
+        JsonObject config = service.readConfig();
+        config.getAsJsonObject("codex").addProperty("current", "legacy-provider");
+        service.writeConfig(config);
+
+        assertEquals(CodemossSettingsService.CODEX_RUNTIME_ACCESS_INACTIVE, service.getCodexRuntimeAccessMode());
+        JsonObject unchanged = service.readConfig().getAsJsonObject("codex");
+        assertFalse(unchanged.has("appliedProviderId"));
+        assertFalse(unchanged.has("appliedProviderRevision"));
+    }
+
+    @Test
+    public void shouldBlockUnauthorizedDeletionFromCodexSkillsDirectory() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-unauthorized-skill-delete-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path skillDir = Files.createDirectories(tempHome.resolve(".codex").resolve("skills").resolve("protected-skill"));
+        Path skillFile = Files.writeString(skillDir.resolve("SKILL.md"), "# Protected", StandardCharsets.UTF_8);
+
+        JsonObject result = CodexSkillService.deleteSkill(
+                "protected-skill", "user", skillFile.toString(), tempHome.toString());
+
+        assertFalse(result.get("success").getAsBoolean());
+        assertTrue(Files.exists(skillFile));
+    }
+
+    @Test
+    public void shouldAllowAgentsSkillDeletionWithoutCodexAuthorization() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-agents-skill-delete-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path skillDir = Files.createDirectories(tempHome.resolve(".agents").resolve("skills").resolve("local-skill"));
+        Path skillFile = Files.writeString(skillDir.resolve("SKILL.md"), "# Local", StandardCharsets.UTF_8);
+
+        JsonObject result = CodexSkillService.deleteSkill(
+                "local-skill", "user", skillFile.toString(), tempHome.toString());
+
+        assertTrue(result.get("success").getAsBoolean());
+        assertFalse(Files.exists(skillDir));
     }
 
     private void useTemporaryHomeDirectory(Path tempHome) throws Exception {

--- a/src/test/java/com/github/claudecodegui/settings/CodexMcpServerManagerTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/CodexMcpServerManagerTest.java
@@ -1,0 +1,117 @@
+package com.github.claudecodegui.settings;
+
+import com.github.claudecodegui.util.PlatformUtils;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class CodexMcpServerManagerTest {
+
+    private String originalHomeDir;
+
+    @After
+    public void tearDown() throws Exception {
+        if (originalHomeDir != null) {
+            setCachedHomeDirectory(originalHomeDir);
+            originalHomeDir = null;
+        }
+    }
+
+    @Test
+    public void shouldRenameServerAtomically() throws Exception {
+        CodexSettingsManager settings = settingsWithConfig(
+                "[mcp_servers.old]\ncommand = \"old-command\"\n"
+                        + "[mcp_servers.keep]\ncommand = \"keep-command\"\n");
+        CodexMcpServerManager manager = new CodexMcpServerManager(settings, () -> true);
+
+        manager.renameMcpServer("old", server("new", "new-command"));
+
+        Map<String, Object> servers = mcpServers(settings);
+        assertFalse(servers.containsKey("old"));
+        assertTrue(servers.containsKey("new"));
+        assertTrue(servers.containsKey("keep"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> renamed = (Map<String, Object>) servers.get("new");
+        assertEquals("new-command", renamed.get("command"));
+    }
+
+    @Test
+    public void shouldLeaveConfigUnchangedWhenRenameTargetExists() throws Exception {
+        CodexSettingsManager settings = settingsWithConfig(
+                "[mcp_servers.old]\ncommand = \"old-command\"\n"
+                        + "[mcp_servers.existing]\ncommand = \"existing-command\"\n");
+        CodexMcpServerManager manager = new CodexMcpServerManager(settings, () -> true);
+        String before = Files.readString(settings.getConfigTomlPath(), StandardCharsets.UTF_8);
+
+        assertThrows(IOException.class,
+                () -> manager.renameMcpServer("old", server("existing", "replacement")));
+
+        assertEquals(before, Files.readString(settings.getConfigTomlPath(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void shouldRecheckAccessGuardInsideConfigTransaction() throws Exception {
+        CodexSettingsManager settings = settingsWithConfig(
+                "[mcp_servers.old]\ncommand = \"old-command\"\n");
+        CodexMcpServerManager manager = new CodexMcpServerManager(settings, () -> false);
+        String before = Files.readString(settings.getConfigTomlPath(), StandardCharsets.UTF_8);
+
+        assertThrows(IOException.class, () -> manager.upsertMcpServer(server("new", "new-command")));
+
+        assertEquals(before, Files.readString(settings.getConfigTomlPath(), StandardCharsets.UTF_8));
+    }
+
+    private CodexSettingsManager settingsWithConfig(String configToml) throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-mcp-manager-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = Files.createDirectories(tempHome.resolve(".codex"));
+        Files.writeString(codexDir.resolve("config.toml"), configToml, StandardCharsets.UTF_8);
+        return new CodexSettingsManager(new Gson());
+    }
+
+    private JsonObject server(String id, String command) {
+        JsonObject spec = new JsonObject();
+        spec.addProperty("command", command);
+        JsonObject server = new JsonObject();
+        server.addProperty("id", id);
+        server.add("server", spec);
+        return server;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> mcpServers(CodexSettingsManager settings) throws IOException {
+        return (Map<String, Object>) settings.readConfigToml().get("mcp_servers");
+    }
+
+    private void useTemporaryHomeDirectory(Path tempHome) throws Exception {
+        if (originalHomeDir == null) {
+            originalHomeDir = getCachedHomeDirectory();
+        }
+        setCachedHomeDirectory(tempHome.toString());
+    }
+
+    private String getCachedHomeDirectory() throws Exception {
+        Field field = PlatformUtils.class.getDeclaredField("cachedRealHomeDir");
+        field.setAccessible(true);
+        return (String) field.get(null);
+    }
+
+    private void setCachedHomeDirectory(String homeDir) throws Exception {
+        Field field = PlatformUtils.class.getDeclaredField("cachedRealHomeDir");
+        field.setAccessible(true);
+        field.set(null, homeDir);
+    }
+}

--- a/src/test/java/com/github/claudecodegui/settings/CodexProviderManagerCredentialTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/CodexProviderManagerCredentialTest.java
@@ -1,0 +1,191 @@
+package com.github.claudecodegui.settings;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class CodexProviderManagerCredentialTest {
+
+    @Test
+    public void newCredentialIsStoredOutsideConfigAndHydratedOnRead() throws Exception {
+        AtomicReference<JsonObject> config = new AtomicReference<>(configWithProvider());
+        FakeCredentialStore credentials = new FakeCredentialStore();
+        CodexProviderManager manager = manager(config, credentials);
+        JsonObject provider = provider("provider-secret");
+        provider.addProperty("authJson", "{\"OPENAI_API_KEY\":\"secret\"}");
+
+        manager.addCodexProvider(provider);
+
+        JsonObject persisted = provider(config, "provider-secret");
+        assertFalse(persisted.has("authJson"));
+        assertTrue(persisted.get("authStoredInPasswordSafe").getAsBoolean());
+        JsonObject hydrated = manager.getCodexProviders().stream()
+                .filter(candidate -> "provider-secret".equals(candidate.get("id").getAsString()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("{\"OPENAI_API_KEY\":\"secret\"}", hydrated.get("authJson").getAsString());
+    }
+
+    @Test
+    public void recoversCredentialWhenOlderUpdateLostPasswordSafeMarker() {
+        AtomicReference<JsonObject> config = new AtomicReference<>(configWithProvider());
+        provider(config, "provider-a").addProperty("authJson", "");
+        FakeCredentialStore credentials = new FakeCredentialStore();
+        credentials.values.put("provider-a", "{\"OPENAI_API_KEY\":\"recovered\"}");
+
+        JsonObject returned = manager(config, credentials).getCodexProviders().stream()
+                .filter(candidate -> "provider-a".equals(candidate.get("id").getAsString()))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals("{\"OPENAI_API_KEY\":\"recovered\"}", returned.get("authJson").getAsString());
+        assertTrue(provider(config, "provider-a").get("authStoredInPasswordSafe").getAsBoolean());
+        assertFalse(provider(config, "provider-a").has("authJson"));
+    }
+
+    @Test
+    public void unavailableCredentialIsNotDeletedWhenUpdatingOtherFields() throws Exception {
+        AtomicReference<JsonObject> config = new AtomicReference<>(configWithProvider());
+        provider(config, "provider-a").addProperty("authStoredInPasswordSafe", true);
+        config.get().getAsJsonObject("codex").addProperty("current", "provider-a");
+        FakeCredentialStore credentials = new FakeCredentialStore();
+        JsonObject updates = new JsonObject();
+        updates.addProperty("name", "Renamed Provider");
+        updates.addProperty("authJson", "");
+
+        manager(config, credentials).updateCodexProvider("provider-a", updates);
+
+        JsonObject persisted = provider(config, "provider-a");
+        assertEquals("Renamed Provider", persisted.get("name").getAsString());
+        assertTrue(persisted.get("authStoredInPasswordSafe").getAsBoolean());
+        assertFalse(persisted.has("authJson"));
+        assertEquals(0, credentials.deleteAttempts);
+    }
+
+    @Test
+    public void availableCredentialCanBeExplicitlyCleared() throws Exception {
+        AtomicReference<JsonObject> config = new AtomicReference<>(configWithProvider());
+        provider(config, "provider-a").addProperty("authStoredInPasswordSafe", true);
+        FakeCredentialStore credentials = new FakeCredentialStore();
+        credentials.values.put("provider-a", "{\"OPENAI_API_KEY\":\"old\"}");
+        JsonObject updates = new JsonObject();
+        updates.addProperty("authJson", "");
+
+        manager(config, credentials).updateCodexProvider("provider-a", updates);
+
+        JsonObject persisted = provider(config, "provider-a");
+        assertFalse(persisted.has("authStoredInPasswordSafe"));
+        assertFalse(persisted.has("authJson"));
+        assertEquals(1, credentials.deleteAttempts);
+    }
+
+    @Test
+    public void configWriteFailureRestoresPreviousCredential() {
+        AtomicReference<JsonObject> config = new AtomicReference<>(configWithProvider());
+        provider(config, "provider-a").addProperty("authStoredInPasswordSafe", true);
+        FakeCredentialStore credentials = new FakeCredentialStore();
+        credentials.values.put("provider-a", "{\"OPENAI_API_KEY\":\"old\"}");
+        CodexProviderManager manager = manager(config, ignored -> {
+            throw new IllegalStateException("config write failed");
+        }, credentials);
+        JsonObject updates = new JsonObject();
+        updates.addProperty("authJson", "{\"OPENAI_API_KEY\":\"new\"}");
+
+        assertThrows(IOException.class, () -> manager.updateCodexProvider("provider-a", updates));
+        assertEquals("{\"OPENAI_API_KEY\":\"old\"}", credentials.read("provider-a"));
+    }
+
+    @Test
+    public void unavailableCredentialBlocksProviderSwitch() {
+        AtomicReference<JsonObject> config = new AtomicReference<>(configWithProvider());
+        provider(config, "provider-a").addProperty("authStoredInPasswordSafe", true);
+
+        assertThrows(IOException.class,
+                () -> manager(config, new FakeCredentialStore()).switchCodexProvider("provider-a"));
+    }
+
+    private CodexProviderManager manager(
+            AtomicReference<JsonObject> config,
+            CodexProviderCredentialStore credentials) {
+        return manager(config, config::set, credentials);
+    }
+
+    private CodexProviderManager manager(
+            AtomicReference<JsonObject> config,
+            Consumer<JsonObject> configWriter,
+            CodexProviderCredentialStore credentials) {
+        Gson gson = new Gson();
+        return new CodexProviderManager(
+                ignored -> config.get().deepCopy(),
+                configWriter,
+                new ConfigPathManager(),
+                new CodexSettingsManager(gson),
+                credentials);
+    }
+
+    private JsonObject configWithProvider() {
+        JsonObject providers = new JsonObject();
+        providers.add("provider-a", provider("provider-a"));
+        JsonObject codex = new JsonObject();
+        codex.addProperty("current", "");
+        codex.add("providers", providers);
+        JsonObject config = new JsonObject();
+        config.add("codex", codex);
+        return config;
+    }
+
+    private JsonObject provider(AtomicReference<JsonObject> config, String id) {
+        return config.get().getAsJsonObject("codex").getAsJsonObject("providers").getAsJsonObject(id);
+    }
+
+    private JsonObject provider(String id) {
+        JsonObject provider = new JsonObject();
+        provider.addProperty("id", id);
+        provider.addProperty("name", "Provider");
+        return provider;
+    }
+
+    private static final class FakeCredentialStore extends CodexProviderCredentialStore {
+        private final Map<String, String> values = new HashMap<>();
+        private int deleteAttempts;
+
+        @Override
+        public boolean isPersistentStorageAvailable() {
+            return true;
+        }
+
+        @Override
+        public boolean writeVerified(String providerId, String authJson) {
+            values.put(providerId, authJson);
+            return authJson.equals(read(providerId));
+        }
+
+        @Override
+        public String read(String providerId) {
+            return values.get(providerId);
+        }
+
+        @Override
+        public void delete(String providerId) {
+            values.remove(providerId);
+        }
+
+        @Override
+        public boolean deleteVerified(String providerId) {
+            deleteAttempts++;
+            values.remove(providerId);
+            return true;
+        }
+    }
+}

--- a/src/test/java/com/github/claudecodegui/settings/CodexSettingsManagerModelAliasTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/CodexSettingsManagerModelAliasTest.java
@@ -57,7 +57,7 @@ public class CodexSettingsManagerModelAliasTest {
         provider.addProperty("id", "proxy");
         provider.addProperty("configToml", "model = \"gpt-5.5\"\n\n[model_aliases]\n\"gpt-5.5\" = \"proxy-gpt-5.5\"\n");
 
-        manager.applyProviderToCodexSettings(provider);
+        manager.transitionProvider(null, provider, false, () -> { });
 
         String written = Files.readString(home.resolve(".codex/config.toml"), StandardCharsets.UTF_8);
         assertTrue(written.contains("[model_aliases]"));

--- a/src/test/java/com/github/claudecodegui/settings/CodexSettingsManagerTomlRoundTripTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/CodexSettingsManagerTomlRoundTripTest.java
@@ -16,7 +16,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class CodexSettingsManagerTomlRoundTripTest {
 
@@ -52,13 +54,45 @@ public class CodexSettingsManagerTomlRoundTripTest {
                 + "[model_aliases]\n"
                 + "\"gpt-5.4\" = \"vendor/gpt-5.4\"\n");
 
-        manager.applyProviderToCodexSettings(provider);
+        manager.transitionProvider(null, provider, false, () -> { });
 
         String writtenConfig = Files.readString(codexDir.resolve("config.toml"), StandardCharsets.UTF_8);
         assertTrue(writtenConfig.contains("\"provider.name\" = \"proxy\""));
         assertTrue(writtenConfig.contains("\"gpt-5.4\" = \"vendor/gpt-5.4\""));
         assertTrue(writtenConfig.contains("[mcp_servers.codegraph]"));
         assertTrue(writtenConfig.contains("command = \"uvx\""));
+    }
+
+    @Test
+    public void shouldPreserveExistingSkillConfigWhenProviderOmitsIt() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-toml-skill-config-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = tempHome.resolve(".codex");
+        Files.createDirectories(codexDir);
+        Files.writeString(
+                codexDir.resolve("config.toml"),
+                "[[skills.config]]\npath = \"C:/skills/review/SKILL.md\"\nenabled = false\n",
+                StandardCharsets.UTF_8
+        );
+
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+        JsonObject provider = new JsonObject();
+        provider.addProperty("id", "proxy");
+        provider.addProperty("configToml", "model = \"gpt-5\"\n");
+
+        manager.transitionProvider(null, provider, false, () -> { });
+
+        Map<String, Object> writtenConfig = manager.readConfigToml();
+        assertEquals("gpt-5", writtenConfig.get("model"));
+        assertTrue(writtenConfig.get("skills") instanceof Map);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> skills = (Map<String, Object>) writtenConfig.get("skills");
+        assertTrue(skills.get("config") instanceof List);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> skillConfigs = (List<Map<String, Object>>) skills.get("config");
+        assertEquals(1, skillConfigs.size());
+        assertEquals("C:/skills/review/SKILL.md", skillConfigs.get(0).get("path"));
+        assertEquals(Boolean.FALSE, skillConfigs.get(0).get("enabled"));
     }
 
     @Test
@@ -104,6 +138,400 @@ public class CodexSettingsManagerTomlRoundTripTest {
         assertTrue(writtenConfig.contains("\"top.level\" = \"root\""));
         assertTrue(writtenConfig.contains("\"nested.key\" = \"nested\""));
         assertTrue(writtenConfig.contains("\"entry.key\" = \"entry\""));
+    }
+
+    @Test
+    public void shouldReplaceOnlyProviderOwnedValuesAcrossProviderSwitches() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-provider-ownership-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = tempHome.resolve(".codex");
+        Files.createDirectories(codexDir);
+        Files.writeString(
+                codexDir.resolve("config.toml"),
+                "custom_global = \"keep\"\n"
+                        + "[mcp_servers.codegraph]\ncommand = \"uvx\"\n"
+                        + "[[skills.config]]\npath = \"C:/skills/review/SKILL.md\"\nenabled = false\n",
+                StandardCharsets.UTF_8
+        );
+
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+        JsonObject providerA = provider(
+                "provider-a",
+                "model = \"model-a\"\nlegacy_provider_option = true\n"
+                        + "[model_providers.a]\nbase_url = \"https://a.example/v1\"\n"
+                        + "[vendor_options.skills]\nenabled = true\n"
+                        + "[vendor_options.model_providers.inner]\nmode = \"legacy\"\n",
+                "{\"OPENAI_API_KEY\":\"a-key\"}"
+        );
+        JsonObject providerB = provider(
+                "provider-b",
+                "model = \"model-b\"\n"
+                        + "[model_providers.b]\nbase_url = \"https://b.example/v1\"\n",
+                "{\"OPENAI_API_KEY\":\"b-key\"}"
+        );
+
+        manager.transitionProvider(null, providerA, false, () -> { });
+        manager.transitionProvider(providerA, providerB, false, () -> { });
+
+        Map<String, Object> config = manager.readConfigToml();
+        assertEquals("keep", config.get("custom_global"));
+        assertEquals("model-b", config.get("model"));
+        assertFalse(config.containsKey("legacy_provider_option"));
+        assertFalse(config.containsKey("vendor_options"));
+        assertTrue(config.containsKey("mcp_servers"));
+        assertTrue(config.containsKey("skills"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> modelProviders = (Map<String, Object>) config.get("model_providers");
+        assertFalse(modelProviders.containsKey("a"));
+        assertTrue(modelProviders.containsKey("b"));
+        assertEquals("b-key", manager.readAuthJson().get("OPENAI_API_KEY").getAsString());
+    }
+
+    @Test
+    public void shouldRestoreOverwrittenCliValuesWithoutRestoringStaleGlobalConfig() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-provider-baseline-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = tempHome.resolve(".codex");
+        Files.createDirectories(codexDir);
+        Files.writeString(
+                codexDir.resolve("config.toml"),
+                "model = \"cli-model\"\nmodel_reasoning_effort = \"high\"\n"
+                        + "[model_providers.proxy]\nbase_url = \"https://original.example/v1\"\n"
+                        + "[mcp_servers.original]\ncommand = \"uvx\"\n",
+                StandardCharsets.UTF_8
+        );
+
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+        JsonObject provider = provider(
+                "custom",
+                "model = \"custom-model\"\nmodel_reasoning_effort = \"low\"\n"
+                        + "[model_providers.proxy]\nbase_url = \"https://custom.example/v1\"\n",
+                "{\"OPENAI_API_KEY\":\"custom-key\"}"
+        );
+
+        manager.transitionProvider(null, provider, false, () -> { });
+        manager.updateConfigToml(config -> {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> mcpServers = (Map<String, Object>) config.get("mcp_servers");
+            Map<String, Object> added = new java.util.LinkedHashMap<>();
+            added.put("command", "node");
+            mcpServers.put("added-while-managed", added);
+            return true;
+        });
+        CodexSettingsManager restartedManager = new CodexSettingsManager(new Gson());
+        restartedManager.transitionProvider(provider, null, true, () -> { });
+
+        Map<String, Object> restored = restartedManager.readConfigToml();
+        assertEquals("cli-model", restored.get("model"));
+        assertEquals("high", restored.get("model_reasoning_effort"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> modelProviders = (Map<String, Object>) restored.get("model_providers");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> restoredProxy = (Map<String, Object>) modelProviders.get("proxy");
+        assertEquals("https://original.example/v1", restoredProxy.get("base_url"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> mcpServers = (Map<String, Object>) restored.get("mcp_servers");
+        assertTrue(mcpServers.containsKey("original"));
+        assertTrue(mcpServers.containsKey("added-while-managed"));
+        assertFalse(Files.exists(codexDir.resolve("config.toml.provider_backup")));
+    }
+
+    @Test
+    public void shouldCaptureEachProvidersBaselineFromTheLatestGlobalConfig() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-provider-latest-baseline-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = tempHome.resolve(".codex");
+        Files.createDirectories(codexDir);
+        Files.writeString(codexDir.resolve("config.toml"), "shared_option = 1\n", StandardCharsets.UTF_8);
+
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+        JsonObject providerA = provider("provider-a", "shared_option = 10\n", "");
+        JsonObject providerB = provider("provider-b", "provider_b_option = true\n", "");
+        JsonObject providerC = provider("provider-c", "shared_option = 30\n", "");
+
+        manager.transitionProvider(null, providerA, false, () -> { });
+        manager.transitionProvider(providerA, providerB, false, () -> { });
+        assertEquals(1L, manager.readConfigToml().get("shared_option"));
+
+        manager.updateConfigToml(config -> {
+            config.put("shared_option", 2L);
+            return true;
+        });
+        manager.transitionProvider(providerB, providerC, false, () -> { });
+        manager.transitionProvider(providerC, null, false, () -> { });
+
+        assertEquals(2L, manager.readConfigToml().get("shared_option"));
+    }
+
+    @Test
+    public void shouldPreserveUnownedSiblingAddedInsideProviderTable() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-provider-nested-sibling-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = tempHome.resolve(".codex");
+        Files.createDirectories(codexDir);
+
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+        JsonObject provider = provider("custom", "[provider_options]\nowned = true\n", "");
+        manager.transitionProvider(null, provider, false, () -> { });
+        manager.updateConfigToml(config -> {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> options = (Map<String, Object>) config.get("provider_options");
+            options.put("global_sibling", "keep");
+            return true;
+        });
+
+        manager.transitionProvider(provider, null, false, () -> { });
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> options = (Map<String, Object>) manager.readConfigToml().get("provider_options");
+        assertFalse(options.containsKey("owned"));
+        assertEquals("keep", options.get("global_sibling"));
+    }
+
+    @Test
+    public void shouldClearProviderAuthWhenNextProviderHasNoAuth() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-provider-empty-auth-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = tempHome.resolve(".codex");
+        Files.createDirectories(codexDir);
+
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+        JsonObject authenticatedProvider = provider(
+                "authenticated",
+                "model = \"authenticated-model\"\n",
+                "{\"OPENAI_API_KEY\":\"custom-key\"}"
+        );
+        JsonObject configOnlyProvider = new JsonObject();
+        configOnlyProvider.addProperty("id", "config-only");
+        configOnlyProvider.addProperty("configToml", "model = \"config-only-model\"\n");
+
+        manager.transitionProvider(null, authenticatedProvider, false, () -> { });
+        manager.transitionProvider(authenticatedProvider, configOnlyProvider, false, () -> { });
+
+        assertFalse(Files.exists(codexDir.resolve("auth.json")));
+        assertTrue(manager.isProviderApplied(configOnlyProvider));
+
+        Files.writeString(
+                codexDir.resolve("auth.json"),
+                "{\"OPENAI_API_KEY\":\"stale-key\"}",
+                StandardCharsets.UTF_8
+        );
+        assertFalse(manager.isProviderApplied(configOnlyProvider));
+    }
+
+    @Test
+    public void shouldRemoveManagedAuthWhenCliBackupDoesNotExist() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-provider-cli-without-backup-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = tempHome.resolve(".codex");
+        Files.createDirectories(codexDir);
+
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+        JsonObject provider = provider(
+                "custom",
+                "model = \"custom-model\"\n",
+                "{\"OPENAI_API_KEY\":\"custom-key\"}"
+        );
+        manager.transitionProvider(null, provider, false, () -> { });
+        manager.transitionProvider(provider, null, true, () -> { });
+
+        assertFalse(Files.exists(codexDir.resolve("auth.json")));
+        assertFalse(Files.exists(codexDir.resolve("auth.json.cli_backup")));
+    }
+
+    @Test
+    public void shouldRestoreOAuthWhenLeavingManagedModeAndKeepNewerLogin() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-provider-none-oauth-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = tempHome.resolve(".codex");
+        Files.createDirectories(codexDir);
+        Path authPath = codexDir.resolve("auth.json");
+        Files.writeString(
+                authPath,
+                "{\"auth_mode\":\"chatgpt\",\"tokens\":{\"access_token\":\"oauth-a\"}}",
+                StandardCharsets.UTF_8
+        );
+
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+        JsonObject provider = provider(
+                "custom",
+                "model = \"custom-model\"\n",
+                "{\"OPENAI_API_KEY\":\"custom-key\"}"
+        );
+        manager.transitionProvider(null, provider, false, () -> { });
+        manager.transitionProvider(provider, null, false, () -> { });
+
+        assertEquals("oauth-a", manager.readAuthJson()
+                .getAsJsonObject("tokens").get("access_token").getAsString());
+        assertFalse(Files.exists(codexDir.resolve("auth.json.cli_backup")));
+
+        Files.writeString(
+                authPath,
+                "{\"auth_mode\":\"chatgpt\",\"tokens\":{\"access_token\":\"oauth-b\"}}",
+                StandardCharsets.UTF_8
+        );
+        manager.transitionProvider(null, null, true, () -> { });
+
+        assertEquals("oauth-b", manager.readAuthJson()
+                .getAsJsonObject("tokens").get("access_token").getAsString());
+    }
+
+    @Test
+    public void shouldRestoreLocalApiKeyAfterLeavingManagedProvider() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-provider-api-key-backup-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = tempHome.resolve(".codex");
+        Files.createDirectories(codexDir);
+        Files.writeString(
+                codexDir.resolve("auth.json"),
+                "{\"OPENAI_API_KEY\":\"local-key\"}",
+                StandardCharsets.UTF_8
+        );
+
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+        JsonObject provider = provider(
+                "custom",
+                "model = \"custom-model\"\n",
+                "{\"OPENAI_API_KEY\":\"provider-key\"}"
+        );
+
+        manager.transitionProvider(null, provider, false, () -> { });
+        assertEquals("provider-key", manager.readAuthJson().get("OPENAI_API_KEY").getAsString());
+
+        manager.transitionProvider(provider, null, true, () -> { });
+        assertEquals("local-key", manager.readAuthJson().get("OPENAI_API_KEY").getAsString());
+        assertFalse(Files.exists(codexDir.resolve("auth.json.cli_backup")));
+    }
+
+    @Test
+    public void shouldNotConfuseProviderOAuthWithLocalCredentialBackup() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-provider-oauth-ownership-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = tempHome.resolve(".codex");
+        Files.createDirectories(codexDir);
+        Files.writeString(
+                codexDir.resolve("auth.json"),
+                "{\"OPENAI_API_KEY\":\"local-key\"}",
+                StandardCharsets.UTF_8
+        );
+
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+        JsonObject oauthProvider = provider(
+                "oauth-provider",
+                "model = \"oauth-model\"\n",
+                "{\"auth_mode\":\"chatgpt\",\"tokens\":{\"access_token\":\"provider-oauth\"}}"
+        );
+        JsonObject nextProvider = provider(
+                "next-provider",
+                "model = \"next-model\"\n",
+                "{\"OPENAI_API_KEY\":\"next-key\"}"
+        );
+
+        manager.transitionProvider(null, oauthProvider, false, () -> { });
+        manager.transitionProvider(oauthProvider, nextProvider, false, () -> { });
+        manager.transitionProvider(nextProvider, null, true, () -> { });
+
+        assertEquals("local-key", manager.readAuthJson().get("OPENAI_API_KEY").getAsString());
+    }
+
+    @Test
+    public void shouldRoundTripAllTomlBasicStringControlEscapes() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-toml-control-escape-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = tempHome.resolve(".codex");
+        Files.createDirectories(codexDir);
+        Files.writeString(
+                codexDir.resolve("config.toml"),
+                "control = \"a\\bb\\fc\\u0001z\"\n",
+                StandardCharsets.UTF_8
+        );
+
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+        manager.updateConfigToml(config -> {
+            config.put("touched", true);
+            return true;
+        });
+
+        String written = Files.readString(codexDir.resolve("config.toml"), StandardCharsets.UTF_8);
+        assertTrue(written.contains("a\\bb\\fc\\u0001z"));
+        assertEquals("a\bb\fc" + (char) 1 + "z", manager.readConfigToml().get("control"));
+    }
+
+    @Test
+    public void shouldRejectProviderOwnedGlobalSectionsWithoutChangingFiles() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-provider-global-section-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = tempHome.resolve(".codex");
+        Files.createDirectories(codexDir);
+        Path configPath = codexDir.resolve("config.toml");
+        Files.writeString(configPath, "model = \"existing\"\n", StandardCharsets.UTF_8);
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+        JsonObject provider = provider(
+                "invalid",
+                "model = \"invalid\"\n[mcp_servers.bad]\ncommand = \"bad\"\n",
+                "{\"OPENAI_API_KEY\":\"new-key\"}"
+        );
+
+        try {
+            manager.transitionProvider(null, provider, false, () -> { });
+            fail("Expected provider-owned MCP section to be rejected");
+        } catch (java.io.IOException expected) {
+            assertTrue(expected.getMessage().contains("mcp_servers"));
+        }
+
+        assertEquals("model = \"existing\"\n", Files.readString(configPath, StandardCharsets.UTF_8));
+        assertFalse(Files.exists(codexDir.resolve("auth.json")));
+    }
+
+    @Test
+    public void shouldRestoreCliOAuthAfterCustomProviderAndRollbackCommitFailure() throws Exception {
+        Path tempHome = Files.createTempDirectory("codex-provider-auth-transaction-home");
+        useTemporaryHomeDirectory(tempHome);
+        Path codexDir = tempHome.resolve(".codex");
+        Files.createDirectories(codexDir);
+        Path configPath = codexDir.resolve("config.toml");
+        Path authPath = codexDir.resolve("auth.json");
+        String oauth = "{\"auth_mode\":\"chatgpt\",\"tokens\":{\"access_token\":\"oauth-token\"}}";
+        Files.writeString(configPath, "custom_global = \"keep\"\n", StandardCharsets.UTF_8);
+        Files.writeString(authPath, oauth, StandardCharsets.UTF_8);
+
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson());
+        JsonObject provider = provider(
+                "custom",
+                "model = \"custom-model\"\n",
+                "{\"OPENAI_API_KEY\":\"custom-key\"}"
+        );
+        manager.transitionProvider(null, provider, false, () -> { });
+        assertEquals("custom-key", manager.readAuthJson().get("OPENAI_API_KEY").getAsString());
+
+        manager.transitionProvider(provider, null, true, () -> { });
+        assertEquals("oauth-token", manager.readAuthJson()
+                .getAsJsonObject("tokens").get("access_token").getAsString());
+        assertFalse(Files.exists(codexDir.resolve("auth.json.cli_backup")));
+        assertEquals("keep", manager.readConfigToml().get("custom_global"));
+        assertFalse(manager.readConfigToml().containsKey("model"));
+
+        String configBeforeFailure = Files.readString(configPath, StandardCharsets.UTF_8);
+        String authBeforeFailure = Files.readString(authPath, StandardCharsets.UTF_8);
+        try {
+            manager.transitionProvider(null, provider, false, () -> {
+                throw new java.io.IOException("commit failed");
+            });
+            fail("Expected provider-state commit failure");
+        } catch (java.io.IOException expected) {
+            assertTrue(expected.getMessage().contains("commit failed"));
+        }
+        assertEquals(configBeforeFailure, Files.readString(configPath, StandardCharsets.UTF_8));
+        assertEquals(authBeforeFailure, Files.readString(authPath, StandardCharsets.UTF_8));
+        assertFalse(Files.exists(codexDir.resolve("config.toml.provider_backup")));
+    }
+
+    private JsonObject provider(String id, String configToml, String authJson) {
+        JsonObject provider = new JsonObject();
+        provider.addProperty("id", id);
+        provider.addProperty("configToml", configToml);
+        provider.addProperty("authJson", authJson);
+        return provider;
     }
 
     private void useTemporaryHomeDirectory(Path tempHome) throws Exception {

--- a/src/test/java/com/github/claudecodegui/skill/SlashCommandSourceScannersTest.java
+++ b/src/test/java/com/github/claudecodegui/skill/SlashCommandSourceScannersTest.java
@@ -295,6 +295,22 @@ public class SlashCommandSourceScannersTest {
         assertEquals(0, skills.size());
     }
 
+    @Test
+    public void codexSkillTogglePathMustExistInsideConfiguredSkillDirectory() throws IOException {
+        Path root = Files.createTempDirectory("codex-skill-toggle-path");
+        Path allowedSkill = Files.createDirectories(
+                root.resolve(".agents").resolve("skills").resolve("review"));
+        Path allowedSkillFile = allowedSkill.resolve("SKILL.md");
+        Files.writeString(allowedSkillFile, validSkill("review"));
+        Path outsideSkill = Files.createDirectories(root.resolve("outside")).resolve("SKILL.md");
+        Files.writeString(outsideSkill, validSkill("outside"));
+
+        assertTrue(CodexSkillService.isToggleSkillPathAllowed(allowedSkillFile.toString(), root.toString()));
+        assertFalse(CodexSkillService.isToggleSkillPathAllowed(outsideSkill.toString(), root.toString()));
+        assertFalse(CodexSkillService.isToggleSkillPathAllowed(
+                allowedSkill.resolve("missing").resolve("SKILL.md").toString(), root.toString()));
+    }
+
     private boolean hasSkillNamed(JsonObject skills, String name) {
         return skills.entrySet().stream()
                 .map(entry -> entry.getValue().getAsJsonObject())

--- a/webview/src/components/mcp/McpSettingsSection.tsx
+++ b/webview/src/components/mcp/McpSettingsSection.tsx
@@ -3,7 +3,7 @@
  * Supports both Claude and Codex modes
  */
 
-import { useState, useRef, useMemo, useCallback } from 'react';
+import { useState, useRef, useMemo, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { McpServer, McpPreset } from '../../types/mcp';
 import { sendToJava } from '../../utils/bridge';
@@ -203,6 +203,47 @@ function McpProviderPanel({ currentProvider }: { currentProvider: McpProvider })
     onLog: addLog,
   });
 
+  // Codex mutations report success only after config.toml was written.
+  useEffect(() => {
+    if (!isCodexMode) {
+      return;
+    }
+    const readServer = (json: string): McpServer | null => {
+      try {
+        return JSON.parse(json) as McpServer;
+      } catch {
+        return null;
+      }
+    };
+    window.codexMcpServerAdded = (json) => {
+      const server = readServer(json);
+      addToast(`${t('mcp.added')} ${server?.name || server?.id || ''}`, 'success');
+      loadServers();
+    };
+    window.codexMcpServerUpdated = (json) => {
+      const server = readServer(json);
+      addToast(`${t('mcp.saved')} ${server?.name || server?.id || ''}`, 'success');
+      loadServers();
+    };
+    window.codexMcpServerDeleted = (serverId) => {
+      addToast(`${t('mcp.deleted')} ${serverId}`, 'success');
+      loadServers();
+    };
+    window.codexMcpServerToggled = (json) => {
+      const server = readServer(json);
+      const enabled = server?.enabled !== false;
+      addToast(`${enabled ? t('mcp.enabled') : t('mcp.disabled')} ${server?.name || server?.id || ''}`, 'success');
+      loadServers();
+      loadServerStatus();
+    };
+    return () => {
+      window.codexMcpServerAdded = undefined;
+      window.codexMcpServerUpdated = undefined;
+      window.codexMcpServerDeleted = undefined;
+      window.codexMcpServerToggled = undefined;
+    };
+  }, [isCodexMode, addToast, loadServers, loadServerStatus, t]);
+
   // Toggle server expand/collapse
   const toggleExpand = useCallback((serverId: string) => {
     const server = servers.find(s => s.id === serverId);
@@ -244,15 +285,14 @@ function McpProviderPanel({ currentProvider }: { currentProvider: McpProvider })
   const confirmDelete = useCallback(() => {
     if (deletingServer) {
       sendToJava(`delete_${messagePrefix}mcp_server`, { id: deletingServer.id });
-      addToast(`${t('mcp.deleted')} ${deletingServer.name || deletingServer.id}`, 'success');
-
-      setTimeout(() => {
-        loadServers();
-      }, 100);
+      if (!isCodexMode) {
+        addToast(`${t('mcp.deleted')} ${deletingServer.name || deletingServer.id}`, 'success');
+        setTimeout(() => loadServers(), 100);
+      }
     }
     setShowConfirmDialog(false);
     setDeletingServer(null);
-  }, [deletingServer, messagePrefix, addToast, t, loadServers]);
+  }, [deletingServer, messagePrefix, isCodexMode, addToast, t, loadServers]);
 
   // Cancel deletion
   const cancelDelete = useCallback(() => {
@@ -284,35 +324,43 @@ function McpProviderPanel({ currentProvider }: { currentProvider: McpProvider })
     importedServers.forEach((server) => {
       sendToJava(`add_${messagePrefix}mcp_server`, server);
     });
-    addToast(`${t('mcp.added')} ${importedServers.length}`, 'success');
-    setTimeout(() => {
-      loadServers();
-    }, 100);
-  }, [messagePrefix, addToast, t, loadServers]);
+    if (!isCodexMode) {
+      addToast(`${t('mcp.added')} ${importedServers.length}`, 'success');
+      setTimeout(() => loadServers(), 100);
+    }
+  }, [messagePrefix, isCodexMode, addToast, t, loadServers]);
 
   // Save server
   const handleSaveServer = useCallback((server: McpServer) => {
     if (editingServer) {
       if (editingServer.id !== server.id) {
-        sendToJava(`delete_${messagePrefix}mcp_server`, { id: editingServer.id });
-        sendToJava(`add_${messagePrefix}mcp_server`, server);
-        addToast(`${t('mcp.updated')} ${server.name || server.id}`, 'success');
+        if (isCodexMode) {
+          sendToJava('update_codex_mcp_server', { ...server, oldId: editingServer.id });
+        } else {
+          sendToJava(`delete_${messagePrefix}mcp_server`, { id: editingServer.id });
+          sendToJava(`add_${messagePrefix}mcp_server`, server);
+          addToast(`${t('mcp.updated')} ${server.name || server.id}`, 'success');
+        }
       } else {
         sendToJava(`update_${messagePrefix}mcp_server`, server);
-        addToast(`${t('mcp.saved')} ${server.name || server.id}`, 'success');
+        if (!isCodexMode) {
+          addToast(`${t('mcp.saved')} ${server.name || server.id}`, 'success');
+        }
       }
     } else {
       sendToJava(`add_${messagePrefix}mcp_server`, server);
-      addToast(`${t('mcp.added')} ${server.name || server.id}`, 'success');
+      if (!isCodexMode) {
+        addToast(`${t('mcp.added')} ${server.name || server.id}`, 'success');
+      }
     }
 
-    setTimeout(() => {
-      loadServers();
-    }, 100);
+    if (!isCodexMode) {
+      setTimeout(() => loadServers(), 100);
+    }
 
     setShowServerDialog(false);
     setEditingServer(null);
-  }, [editingServer, messagePrefix, addToast, t, loadServers]);
+  }, [editingServer, messagePrefix, isCodexMode, addToast, t, loadServers]);
 
   // Select preset
   const handleSelectPreset = useCallback((preset: McpPreset) => {
@@ -332,11 +380,10 @@ function McpProviderPanel({ currentProvider }: { currentProvider: McpProvider })
       enabled: true,
     };
     sendToJava(`add_${messagePrefix}mcp_server`, server);
-    addToast(`${t('mcp.added')} ${preset.name}`, 'success');
-
-    setTimeout(() => {
-      loadServers();
-    }, 100);
+    if (!isCodexMode) {
+      addToast(`${t('mcp.added')} ${preset.name}`, 'success');
+      setTimeout(() => loadServers(), 100);
+    }
 
     setShowPresetDialog(false);
   }, [isCodexMode, messagePrefix, addToast, t, loadServers]);

--- a/webview/src/components/mcp/hooks/useServerManagement.test.ts
+++ b/webview/src/components/mcp/hooks/useServerManagement.test.ts
@@ -61,4 +61,34 @@ describe('useServerManagement tool cache invalidation', () => {
       enabled: false,
     }));
   });
+
+  it('waits for the backend result before reporting a Codex toggle success', () => {
+    const onToast = vi.fn();
+    const loadServers = vi.fn();
+    const loadServerStatus = vi.fn();
+    const hook = renderHook(() => useServerManagement({
+      isCodexMode: true,
+      messagePrefix: 'codex_',
+      cacheKeys,
+      setServerTools: vi.fn() as unknown as React.Dispatch<React.SetStateAction<ServerToolsState>>,
+      loadServers,
+      loadServerStatus,
+      loadServerTools: vi.fn(),
+      onLog: vi.fn(),
+      onToast,
+      t: (key) => key,
+    }));
+
+    act(() => {
+      hook.result.current.handleToggleServer(server, false);
+    });
+
+    expect(sendToJavaMock).toHaveBeenCalledWith('toggle_codex_mcp_server', expect.objectContaining({
+      id: server.id,
+      enabled: false,
+    }));
+    expect(onToast).not.toHaveBeenCalled();
+    expect(loadServers).not.toHaveBeenCalled();
+    expect(loadServerStatus).not.toHaveBeenCalled();
+  });
 });

--- a/webview/src/components/mcp/hooks/useServerManagement.ts
+++ b/webview/src/components/mcp/hooks/useServerManagement.ts
@@ -123,16 +123,16 @@ export function useServerManagement({
       return next;
     });
 
-    // Show toast notification
-    onToast(
-      enabled
-        ? `${t('mcp.enabled')} ${server.name || server.id}`
-        : `${t('mcp.disabled')} ${server.name || server.id}`,
-      'success'
-    );
-
-    loadServers();
-    loadServerStatus();
+    if (!isCodexMode) {
+      onToast(
+        enabled
+          ? `${t('mcp.enabled')} ${server.name || server.id}`
+          : `${t('mcp.disabled')} ${server.name || server.id}`,
+        'success'
+      );
+      loadServers();
+      loadServerStatus();
+    }
   }, [isCodexMode, messagePrefix, cacheKeys, setServerTools, onToast, t, loadServers, loadServerStatus]);
 
   return {

--- a/webview/src/components/skills/SkillsSettingsSection.test.tsx
+++ b/webview/src/components/skills/SkillsSettingsSection.test.tsx
@@ -1,0 +1,125 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { sendToJava } from '../../utils/bridge';
+import { SkillsSettingsSection } from './SkillsSettingsSection';
+
+vi.mock('../../utils/bridge', () => ({
+  sendToJava: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('SkillsSettingsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('correlates Codex toggle responses by the stable skill id', () => {
+    const skillId = 'user:C:/skills/review';
+    render(<SkillsSettingsSection currentProvider="codex" />);
+
+    act(() => {
+      window.updateSkills?.(JSON.stringify({
+        user: {
+          [skillId]: {
+            id: skillId,
+            name: 'review',
+            type: 'directory',
+            scope: 'user',
+            path: 'C:/skills/review',
+            skillPath: 'C:/skills/review/SKILL.md',
+            enabled: true,
+          },
+        },
+        repo: {},
+      }));
+    });
+
+    const toggleButton = screen.getByTitle('chat.clickToDisable') as HTMLButtonElement;
+    fireEvent.click(toggleButton);
+
+    expect(toggleButton.disabled).toBe(true);
+    expect(sendToJava).toHaveBeenLastCalledWith('toggle_skill', {
+      id: skillId,
+      requestId: expect.any(String),
+      name: 'review',
+      scope: 'user',
+      enabled: true,
+      skillPath: 'C:/skills/review/SKILL.md',
+    });
+
+    act(() => {
+      const request = vi.mocked(sendToJava).mock.calls.at(-1)?.[1] as { requestId: string };
+      window.skillToggleResult?.(JSON.stringify({
+        success: false,
+        id: skillId,
+        requestId: request.requestId,
+        name: 'review',
+        error: 'denied',
+      }));
+    });
+
+    expect(toggleButton.disabled).toBe(false);
+  });
+
+  it('ignores a late response after a timed-out toggle is retried', () => {
+    vi.useFakeTimers();
+    const skillId = 'user:C:/skills/review';
+    render(<SkillsSettingsSection currentProvider="codex" />);
+
+    act(() => {
+      window.updateSkills?.(JSON.stringify({
+        user: {
+          [skillId]: {
+            id: skillId,
+            name: 'review',
+            type: 'directory',
+            scope: 'user',
+            path: 'C:/skills/review',
+            skillPath: 'C:/skills/review/SKILL.md',
+            enabled: true,
+          },
+        },
+        repo: {},
+      }));
+    });
+
+    fireEvent.click(screen.getByTitle('chat.clickToDisable'));
+    const firstRequest = vi.mocked(sendToJava).mock.calls.at(-1)?.[1] as { requestId: string };
+    act(() => vi.advanceTimersByTime(15000));
+
+    fireEvent.click(screen.getByTitle('chat.clickToDisable'));
+    const secondRequest = vi.mocked(sendToJava).mock.calls.at(-1)?.[1] as { requestId: string };
+    expect(secondRequest.requestId).not.toBe(firstRequest.requestId);
+
+    act(() => {
+      window.skillToggleResult?.(JSON.stringify({
+        success: true,
+        enabled: false,
+        id: skillId,
+        requestId: firstRequest.requestId,
+        name: 'review',
+      }));
+    });
+    expect((screen.getByTitle('chat.clickToDisable') as HTMLButtonElement).disabled).toBe(true);
+
+    act(() => {
+      window.skillToggleResult?.(JSON.stringify({
+        success: false,
+        id: skillId,
+        requestId: secondRequest.requestId,
+        name: 'review',
+        error: 'denied',
+      }));
+    });
+    expect((screen.getByTitle('chat.clickToDisable') as HTMLButtonElement).disabled).toBe(false);
+  });
+});

--- a/webview/src/components/skills/SkillsSettingsSection.tsx
+++ b/webview/src/components/skills/SkillsSettingsSection.tsx
@@ -10,6 +10,16 @@ interface SkillsSettingsSectionProps {
   currentProvider?: string;
 }
 
+interface SkillToggleResult {
+  success: boolean;
+  enabled?: boolean;
+  id?: string;
+  requestId?: string;
+  name?: string;
+  error?: string;
+  conflict?: boolean;
+}
+
 /**
  * Skills settings component
  * Manages Claude/Codex Skills
@@ -37,6 +47,9 @@ export function SkillsSettingsSection({ currentProvider = 'claude' }: SkillsSett
 
   // Skills currently being toggled (used to disable buttons and prevent duplicate clicks)
   const [togglingSkills, setTogglingSkills] = useState<Set<string>>(new Set());
+  const toggleTimeoutsRef = useRef<Map<string, number>>(new Map());
+  const latestToggleRequestsRef = useRef<Map<string, string>>(new Map());
+  const toggleRequestSequenceRef = useRef(0);
 
   // Toast state
   const [toasts, setToasts] = useState<ToastMessage[]>([]);
@@ -52,6 +65,10 @@ export function SkillsSettingsSection({ currentProvider = 'claude' }: SkillsSett
   };
 
   const isCodex = currentProvider === 'codex';
+
+  useEffect(() => {
+    setTogglingSkills(new Set());
+  }, [currentProvider]);
 
   // Compute Skills lists (provider-aware: Claude uses global/local, Codex uses user/repo)
   const primarySkillList = useMemo(
@@ -188,19 +205,22 @@ export function SkillsSettingsSection({ currentProvider = 'claude' }: SkillsSett
     // Register callback: enable/disable result
     window.skillToggleResult = (jsonStr: string) => {
       try {
-        const result = JSON.parse(jsonStr);
-        // Remove in-progress state
+        const result = JSON.parse(jsonStr) as SkillToggleResult;
+        if (!result.id || !result.requestId
+            || latestToggleRequestsRef.current.get(result.id) !== result.requestId) {
+          return;
+        }
+
+        latestToggleRequestsRef.current.delete(result.id);
+        const timeoutId = toggleTimeoutsRef.current.get(result.id);
+        if (timeoutId !== undefined) {
+          window.clearTimeout(timeoutId);
+          toggleTimeoutsRef.current.delete(result.id);
+        }
         setTogglingSkills(prev => {
-          const newSet = new Set(prev);
-          if (result.name) {
-            // Try to remove possible ID variants
-            newSet.forEach(id => {
-              if (id.includes(result.name)) {
-                newSet.delete(id);
-              }
-            });
-          }
-          return newSet;
+          const next = new Set(prev);
+          next.delete(result.id as string);
+          return next;
         });
 
         if (result.success) {
@@ -215,7 +235,6 @@ export function SkillsSettingsSection({ currentProvider = 'claude' }: SkillsSett
         }
       } catch (error) {
         console.error('[SkillsSettings] Failed to parse toggle result:', error);
-        setTogglingSkills(new Set()); // Clear on error
       }
     };
 
@@ -235,6 +254,9 @@ export function SkillsSettingsSection({ currentProvider = 'claude' }: SkillsSett
       window.skillImportResult = undefined;
       window.skillDeleteResult = undefined;
       window.skillToggleResult = undefined;
+      toggleTimeoutsRef.current.forEach(timeoutId => window.clearTimeout(timeoutId));
+      toggleTimeoutsRef.current.clear();
+      latestToggleRequestsRef.current.clear();
       document.removeEventListener('click', handleClickOutside);
     };
   }, [loadSkills, addToast]);
@@ -314,10 +336,28 @@ export function SkillsSettingsSection({ currentProvider = 'claude' }: SkillsSett
   // Enable/disable Skill
   const handleToggle = (skill: Skill, e: React.MouseEvent) => {
     e.stopPropagation(); // Prevent triggering card expand
-    if (togglingSkills.has(skill.id)) return; // Prevent duplicate clicks
+    if (togglingSkills.has(skill.id) || toggleTimeoutsRef.current.has(skill.id)) return;
 
+    const requestId = `${Date.now()}-${++toggleRequestSequenceRef.current}`;
+    latestToggleRequestsRef.current.set(skill.id, requestId);
     setTogglingSkills(prev => new Set(prev).add(skill.id));
+    const timeoutId = window.setTimeout(() => {
+      if (latestToggleRequestsRef.current.get(skill.id) !== requestId) {
+        return;
+      }
+      latestToggleRequestsRef.current.delete(skill.id);
+      toggleTimeoutsRef.current.delete(skill.id);
+      setTogglingSkills(prev => {
+        const next = new Set(prev);
+        next.delete(skill.id);
+        return next;
+      });
+      addToast(t('skills.operationError'), 'error');
+    }, 15000);
+    toggleTimeoutsRef.current.set(skill.id, timeoutId);
     sendToJava('toggle_skill', {
+      id: skill.id,
+      requestId,
       name: skill.name,
       scope: skill.scope,
       enabled: skill.enabled,


### PR DESCRIPTION
## Problem

Codex custom providers can be active and usable for chat while the plugin still rejects access to the same user's global Codex configuration. A common reproduction is:

1. enable a managed/custom Codex provider;
2. upgrade the plugin, or edit/switch that provider;
3. open the MCP or Skills settings and try to list, enable, disable, rename, or remove an entry.

The operation can fail with a message equivalent to:

> Local Codex configuration access has not been authorized. Authorize access to `~/.codex`, or enable a managed Codex provider first.

This is especially confusing because a managed provider is already enabled. Two related upgrade failures were also reproducible:

- the provider editor shows an empty `auth.json` even though the provider had credentials before the upgrade;
- a provider that was enabled before the new applied-provider markers existed is treated as unauthorized after the upgrade.

Provider switching could additionally lose or overwrite authentication state in edge cases. In particular, the previous ownership heuristic tried to infer whether the current `auth.json` belonged to local Codex CLI login by inspecting JSON fields. That is not reliable for API-key and OAuth variants.

## Root cause

Several independent state models had drifted apart:

1. **Activation and local-config authorization were conflated.** The provider could be active in plugin state without having the newer `appliedProviderId` / `appliedProviderRevision` markers, so MCP/Skill code rejected a valid historical provider.
2. **The PasswordSafe compatibility read path was incomplete.** Historical credentials had been migrated out of ordinary settings, but provider loading no longer consistently read them back. An empty editor value could therefore be mistaken for an intentional credential deletion.
3. **Provider activation was not one atomic ownership transition.** `config.toml`, `auth.json`, PasswordSafe, backup files, and applied-provider state could be updated in separate steps, leaving a partially switched provider when a later step failed.
4. **Local CLI auth ownership was guessed from payload shape.** Different Codex login methods do not provide a stable JSON signature for deciding whether a file belongs to the user or to a managed provider.
5. **MCP and Skill authorization had time-of-check/time-of-use gaps.** Authorization could change between the initial check and the eventual `config.toml` or filesystem mutation. MCP rename also used delete-then-add, so a failed add could lose the original entry.
6. **The frontend could accept stale async responses.** A timed-out Skill toggle response could settle a newer operation, and successful MCP mutations triggered redundant refreshes.

## Why this PR is needed

A custom provider changes which AI endpoint and credentials Codex uses; it must not create a separate copy of the user's global Codex home. MCP servers, Skills, and sessions are global Codex resources and should remain shared in `~/.codex` when providers are switched.

Simply granting every provider unrestricted ownership of all files would make provider switching capable of overwriting global MCP/Skill state. Copying MCP, Skills, or sessions per provider would introduce a second source of truth and cause data divergence. The required boundary is narrower:

- a managed provider owns only the provider fields it declares in `config.toml` and its `auth.json`;
- MCP, Skills, sessions, and unrelated Codex configuration remain global and are preserved;
- authorization-sensitive mutations must revalidate under the same lock as the write.

## Fix

### Atomic provider activation

- parse and validate TOML structurally with `tomlj`;
- reject provider payloads that try to own global `mcp_servers` or Skills configuration;
- snapshot `config.toml`, `auth.json`, local-login backups, PasswordSafe credentials, and applied-provider state before switching;
- atomically replace only provider-owned TOML fields and `auth.json`;
- roll all snapshots back if any state or credential commit fails;
- decide backup/restore behavior from the explicit transition into or out of a managed provider, rather than guessing from JSON fields.

### Credential and upgrade compatibility

- add a provider-ID-scoped JetBrains PasswordSafe credential store;
- restore historical provider credentials when editing or activating a provider;
- do not treat a temporarily unavailable credential as an intentional empty value;
- reconcile missing historical applied-provider markers only after the current `config.toml` and `auth.json` are verified to match that provider;
- keep the provider unauthorized when the live files do not match, rather than silently claiming ownership.

### MCP and Skill consistency

- use a fixed provider-state-lock -> config-lock order;
- revalidate authorization inside the final mutation lock;
- protect `.codex/skills` mutations without incorrectly blocking project `.agents/skills` operations;
- rename MCP servers in one locked config mutation instead of delete + add;
- return request IDs for Skill toggles and ignore late responses from an older operation;
- remove duplicate MCP refreshes after successful mutations.

## Compatibility and scope

- no MCP, Skill, or session directory is copied or migrated;
- `~/.codex/sessions` is not modified;
- current `auth.json` is never assigned to another provider unless it is verified as that provider's state;
- a PasswordSafe entry that was permanently deleted cannot be reconstructed; the UI keeps the credential-unavailable state and requires the user to enter it again;
- this PR does not change the AI bridge protocol or Codex conversation behavior.

## Testing

- targeted provider activation, credential migration, CLI login, TOML round-trip, MCP, and Skill tests;
- rollback, historical-marker, unavailable-credential, authorization-race, atomic-rename, and stale-response regression coverage;
- full Java test suite;
- `checkstyleMain`;
- full Webview test suite and TypeScript test configuration check;
- Webview production build;
- `git diff --check`.