### PR TITLE
fix(codex): restore subagent lifecycle and plan rendering

### DIFF
--- a/ai-bridge/services/codex/codex-event-handler.js
+++ b/ai-bridge/services/codex/codex-event-handler.js
@@ -18,6 +18,7 @@ import { readFile, unlink, writeFile } from 'fs/promises';
 import { requestPermissionFromJava } from '../../permission-handler.js';
 import { findSessionFileByThreadId } from './codex-agents-loader.js';
 import { extractPatchFromResponseItemPayload, parseApplyPatchToOperations } from './codex-patch-parser.js';
+import { extractUpdatePlanFromResponseItemPayload } from './codex-plan-parser.js';
 import {
   truncateForDisplay, getStableItemId, extractCommand,
   smartToolName, smartDescription, mapCommandToolNameToPermissionToolName,
@@ -226,8 +227,24 @@ function emitSyntheticPatchToolResults(state, batch, isError) {
 function handleCustomToolCallPayload(payload, state, config) {
   if (!payload || payload.type !== 'custom_tool_call') return false;
 
+  let handled = false;
+  const callId = getResponseItemCallId(payload);
+  const planInput = extractUpdatePlanFromResponseItemPayload(payload);
+  if (callId && planInput) {
+    const toolUseId = `codex_plan_${callId}`;
+    if (!state.processedCustomPlanCallIds.has(callId)) {
+      state.processedCustomPlanCallIds.add(callId);
+      if (!state.emittedToolUseIds.has(toolUseId)) {
+        state.emitMessage(toolUseMsg(toolUseId, 'update_plan', planInput));
+        state.emittedToolUseIds.add(toolUseId);
+      }
+      state.pendingCustomPlanToolUseIds.set(callId, toolUseId);
+    }
+    handled = true;
+  }
+
   const batch = createPatchBatchFromPayload(payload, config);
-  if (!batch) return false;
+  if (!batch) return handled;
   if (state.processedPatchCallIds.has(batch.callId)) return true;
 
   state.processedPatchCallIds.add(batch.callId);
@@ -236,15 +253,40 @@ function handleCustomToolCallPayload(payload, state, config) {
   return true;
 }
 
+function extractCustomToolOutputText(output) {
+  if (typeof output === 'string') return output;
+  if (Array.isArray(output)) {
+    return output.map((item) => {
+      if (typeof item === 'string') return item;
+      if (item && typeof item.text === 'string') return item.text;
+      return JSON.stringify(item ?? '');
+    }).join('\n');
+  }
+  if (output && typeof output.text === 'string') return output.text;
+  return JSON.stringify(output ?? '');
+}
+
 function handleCustomToolCallOutputPayload(payload, state) {
   if (!payload || payload.type !== 'custom_tool_call_output') return false;
 
   const callId = getResponseItemCallId(payload);
-  const batch = callId ? state.pendingCustomPatchBatches.get(callId) : null;
-  if (!batch) return false;
+  const output = extractCustomToolOutputText(payload.output);
+  const errorOutput = /(?:^|\n)\s*(?:error:|failed to parse|permission denied|command denied|script failed\b|script error:|exit code:\s*[1-9]\d*)/i;
+  const isError = payload.status === 'error' || payload.is_error === true || errorOutput.test(output);
+  let handled = false;
+  const planToolUseId = callId ? state.pendingCustomPlanToolUseIds.get(callId) : null;
+  if (planToolUseId) {
+    if (!state.emittedToolResultIds.has(planToolUseId)) {
+      state.emitMessage(toolResultMsg(planToolUseId, isError, isError ? 'Plan update failed' : 'Plan updated'));
+      state.emittedToolResultIds.add(planToolUseId);
+    }
+    state.pendingCustomPlanToolUseIds.delete(callId);
+    handled = true;
+  }
 
-  const output = typeof payload.output === 'string' ? payload.output : JSON.stringify(payload.output ?? '');
-  const isError = payload.status === 'error' || /^(?:error:|failed to parse|permission denied|command denied)/i.test(output);
+  const batch = callId ? state.pendingCustomPatchBatches.get(callId) : null;
+  if (!batch) return handled;
+
   emitSyntheticPatchToolResults(state, batch, isError);
   state.pendingCustomPatchBatches.delete(callId);
   return true;
@@ -255,6 +297,15 @@ function flushPendingCustomPatchBatches(state, isError = false) {
     emitSyntheticPatchToolResults(state, batch, isError);
   }
   state.pendingCustomPatchBatches.clear();
+}
+
+function flushPendingCustomPlanCalls(state, isError = false) {
+  for (const toolUseId of state.pendingCustomPlanToolUseIds.values()) {
+    if (state.emittedToolResultIds.has(toolUseId)) continue;
+    state.emitMessage(toolResultMsg(toolUseId, isError, isError ? 'Plan update failed' : 'Plan updated'));
+    state.emittedToolResultIds.add(toolUseId);
+  }
+  state.pendingCustomPlanToolUseIds.clear();
 }
 
 
@@ -279,6 +330,8 @@ export function createInitialEventState(emitMessage) {
     sessionTurnBoundaryWarningLogged: false,
     processedPatchCallIds: new Set(),
     pendingCustomPatchBatches: new Map(),
+    processedCustomPlanCallIds: new Set(),
+    pendingCustomPlanToolUseIds: new Map(),
     processedSessionFunctionCallIds: new Set(),
     processedSessionFunctionOutputIds: new Set(),
     processedSessionCustomToolCallIds: new Set(),
@@ -1028,6 +1081,7 @@ export async function processCodexEventStream(events, state, config) {
           logDebug('CONTEXT_USAGE', `Replayed current-turn token_count events: ${replayedTokenCounts}`);
         }
         flushPendingCustomPatchBatches(state);
+        flushPendingCustomPlanCalls(state);
         const completedTurnUsage = resolveCompletedTurnUsage(state);
         if (completedTurnUsage) {
           console.log('[DEBUG] Token usage:', completedTurnUsage);

--- a/ai-bridge/services/codex/codex-event-handler.test.js
+++ b/ai-bridge/services/codex/codex-event-handler.test.js
@@ -56,6 +56,17 @@ const CUSTOM_EXEC_PATCH = [
 ].join('\n');
 
 const CUSTOM_EXEC_SOURCE = `const patch = ${JSON.stringify(CUSTOM_EXEC_PATCH)}; text(await tools.apply_patch(patch));`;
+const CUSTOM_EXEC_PLAN_SOURCE = [
+  'const result = await tools.update_plan({',
+  '  explanation: "Implement and verify",',
+  '  plan: [',
+  '    { step: "Inspect current behavior", status: "completed" },',
+  "    { step: 'Implement parser', status: 'in_progress' },",
+  '    { step: `Run tests`, status: "pending" },',
+  '  ],',
+  '});',
+  'text(result);',
+].join('\n');
 
 test('custom_tool_call exec apply_patch emits edit and result messages without file_change', async () => {
   const emittedMessages = [];
@@ -99,6 +110,145 @@ test('custom_tool_call exec apply_patch emits edit and result messages without f
     is_error: false,
     content: 'Patch applied',
   });
+});
+
+test('custom_tool_call exec update_plan emits normalized plan and result messages', async () => {
+  const emittedMessages = [];
+  const state = createInitialEventState((message) => emittedMessages.push(message));
+
+  await captureStdout(async () => {
+    await processCodexEventStream(
+      eventsFrom([
+        {
+          type: 'response_item',
+          payload: { type: 'custom_tool_call', call_id: 'plan-1', name: 'exec', input: CUSTOM_EXEC_PLAN_SOURCE },
+        },
+        {
+          type: 'response_item',
+          payload: { type: 'custom_tool_call_output', call_id: 'plan-1', output: '{}' },
+        },
+      ]),
+      state,
+      makeConfig(),
+    );
+  });
+
+  assert.equal(emittedMessages.length, 2);
+  assert.deepEqual(emittedMessages[0].message.content[0], {
+    type: 'tool_use',
+    id: 'codex_plan_plan-1',
+    name: 'update_plan',
+    input: {
+      explanation: 'Implement and verify',
+      plan: [
+        { step: 'Inspect current behavior', status: 'completed', content: 'Inspect current behavior' },
+        { step: 'Implement parser', status: 'in_progress', content: 'Implement parser' },
+        { step: 'Run tests', status: 'pending', content: 'Run tests' },
+      ],
+    },
+  });
+  assert.deepEqual(emittedMessages[1].message.content[0], {
+    type: 'tool_result',
+    tool_use_id: 'codex_plan_plan-1',
+    is_error: false,
+    content: 'Plan updated',
+  });
+});
+
+test('custom_tool_call exec update_plan treats array script failure output as an error', async () => {
+  const emittedMessages = [];
+  const state = createInitialEventState((message) => emittedMessages.push(message));
+
+  await captureStdout(async () => {
+    await processCodexEventStream(
+      eventsFrom([
+        {
+          type: 'response_item',
+          payload: { type: 'custom_tool_call', call_id: 'plan-failure', name: 'exec', input: CUSTOM_EXEC_PLAN_SOURCE },
+        },
+        {
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call_output',
+            call_id: 'plan-failure',
+            output: [
+              { type: 'input_text', text: 'Script failed\nThe update was not applied.' },
+              { type: 'input_text', text: 'Script error:\nExit code: 1' },
+            ],
+          },
+        },
+      ]),
+      state,
+      makeConfig(),
+    );
+  });
+
+  assert.equal(emittedMessages.length, 2);
+  assert.deepEqual(emittedMessages[1].message.content[0], {
+    type: 'tool_result',
+    tool_use_id: 'codex_plan_plan-failure',
+    is_error: true,
+    content: 'Plan update failed',
+  });
+});
+
+test('current-turn session replay emits custom_tool_call exec plans found only in JSONL', async () => {
+  const tempDirectory = await mkdtemp(join(tmpdir(), 'codex-custom-plan-replay-'));
+  const tempSessionPath = join(tempDirectory, 'fixture-session.jsonl');
+  await writeFile(tempSessionPath, '', 'utf8');
+
+  const emittedMessages = [];
+  const state = createInitialEventState((message) => emittedMessages.push(message));
+  state.sessionFilePath = tempSessionPath;
+  state.sessionTurnBoundaryReady = true;
+  state.sessionTurnStartCursor = 0;
+  state.sessionFunctionCursor = 0;
+
+  try {
+    await writeFile(
+      tempSessionPath,
+      [
+        { type: 'turn_context', payload: { cwd: 'C:/fixture' } },
+        {
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call',
+            call_id: 'session-plan-1',
+            name: 'exec',
+            input: CUSTOM_EXEC_PLAN_SOURCE,
+          },
+        },
+        {
+          type: 'response_item',
+          payload: { type: 'custom_tool_call_output', call_id: 'session-plan-1', output: '{}' },
+        },
+      ].map((entry) => JSON.stringify(entry)).join('\n') + '\n',
+      'utf8',
+    );
+
+    await captureStdout(async () => {
+      await processCodexEventStream(
+        eventsFrom([{ type: 'event_msg', payload: { type: 'status' } }, { type: 'turn.completed' }]),
+        state,
+        makeConfig(),
+      );
+    });
+
+    assert.equal(emittedMessages.length, 2);
+    assert.equal(emittedMessages[0].message.content[0].name, 'update_plan');
+    assert.equal(emittedMessages[0].message.content[0].id, 'codex_plan_session-plan-1');
+    assert.deepEqual(
+      emittedMessages[0].message.content[0].input.plan.map(({ step, status }) => ({ step, status })),
+      [
+        { step: 'Inspect current behavior', status: 'completed' },
+        { step: 'Implement parser', status: 'in_progress' },
+        { step: 'Run tests', status: 'pending' },
+      ],
+    );
+    assert.equal(emittedMessages[1].message.content[0].tool_use_id, 'codex_plan_session-plan-1');
+  } finally {
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
 });
 
 test('current-turn session replay emits custom_tool_call exec patches found only in JSONL', async () => {

--- a/ai-bridge/services/codex/codex-plan-parser.js
+++ b/ai-bridge/services/codex/codex-plan-parser.js
@@ -1,0 +1,231 @@
+import { normalizeUpdatePlanInput } from './codex-tool-normalization.js';
+
+const UPDATE_PLAN_TOKEN = 'tools.update_plan';
+const INVALID = Symbol('invalid-js-literal');
+
+function isIdentifierStart(char) {
+  return /[A-Za-z_$]/.test(char ?? '');
+}
+
+function isIdentifierPart(char) {
+  return /[A-Za-z0-9_$]/.test(char ?? '');
+}
+
+function skipString(source, start) {
+  const quote = source[start];
+  let cursor = start + 1;
+  while (cursor < source.length) {
+    const current = source[cursor++];
+    if (current === '\\' && cursor < source.length) {
+      cursor += 1;
+    } else if (current === quote) {
+      break;
+    }
+  }
+  return cursor;
+}
+
+function skipTrivia(source, start) {
+  let cursor = start;
+  while (cursor < source.length) {
+    if (/\s/.test(source[cursor])) {
+      cursor += 1;
+      continue;
+    }
+    if (source.startsWith('//', cursor)) {
+      const lineEnd = source.indexOf('\n', cursor + 2);
+      cursor = lineEnd >= 0 ? lineEnd + 1 : source.length;
+      continue;
+    }
+    if (source.startsWith('/*', cursor)) {
+      const blockEnd = source.indexOf('*/', cursor + 2);
+      cursor = blockEnd >= 0 ? blockEnd + 2 : source.length;
+      continue;
+    }
+    break;
+  }
+  return cursor;
+}
+
+function findToken(source, token, start) {
+  let cursor = Math.max(0, start);
+  while (cursor < source.length) {
+    const current = source[cursor];
+    if (current === '"' || current === "'" || current === '`') {
+      cursor = skipString(source, cursor);
+      continue;
+    }
+    if (source.startsWith('//', cursor)) {
+      cursor = skipTrivia(source, cursor);
+      continue;
+    }
+    if (source.startsWith('/*', cursor)) {
+      cursor = skipTrivia(source, cursor);
+      continue;
+    }
+    if (source.startsWith(token, cursor)) {
+      const before = cursor > 0 ? source[cursor - 1] : '';
+      const after = source[cursor + token.length] ?? '';
+      if (!isIdentifierPart(before) && before !== '.' && !isIdentifierPart(after)) {
+        return cursor;
+      }
+    }
+    cursor += 1;
+  }
+  return -1;
+}
+
+function parseJavaScriptLiteral(source, start) {
+  let cursor = start;
+
+  function parseStringLiteral() {
+    const quote = source[cursor++];
+    let value = '';
+    while (cursor < source.length) {
+      const current = source[cursor++];
+      if (current === quote) return value;
+      if (quote === '`' && current === '$' && source[cursor] === '{') return INVALID;
+      if (current !== '\\' || cursor >= source.length) {
+        value += current;
+        continue;
+      }
+
+      const escaped = source[cursor++];
+      const simpleEscapes = {
+        b: '\b', f: '\f', n: '\n', r: '\r', t: '\t', v: '\v', 0: '\0',
+      };
+      if (Object.hasOwn(simpleEscapes, escaped)) {
+        value += simpleEscapes[escaped];
+      } else if (escaped === 'x' || escaped === 'u') {
+        const length = escaped === 'x' ? 2 : 4;
+        const hex = source.slice(cursor, cursor + length);
+        if (!new RegExp(`^[0-9a-fA-F]{${length}}$`).test(hex)) return INVALID;
+        value += String.fromCharCode(Number.parseInt(hex, 16));
+        cursor += length;
+      } else if (escaped === '\r') {
+        if (source[cursor] === '\n') cursor += 1;
+      } else if (escaped !== '\n') {
+        value += escaped;
+      }
+    }
+    return INVALID;
+  }
+
+  function parseIdentifier() {
+    if (!isIdentifierStart(source[cursor])) return INVALID;
+    const startIndex = cursor++;
+    while (isIdentifierPart(source[cursor])) cursor += 1;
+    return source.slice(startIndex, cursor);
+  }
+
+  function parseArray() {
+    const values = [];
+    cursor += 1;
+    while (cursor < source.length) {
+      cursor = skipTrivia(source, cursor);
+      if (source[cursor] === ']') {
+        cursor += 1;
+        return values;
+      }
+      const value = parseValue();
+      if (value === INVALID) return INVALID;
+      values.push(value);
+      cursor = skipTrivia(source, cursor);
+      if (source[cursor] === ',') {
+        cursor += 1;
+        continue;
+      }
+      if (source[cursor] !== ']') return INVALID;
+    }
+    return INVALID;
+  }
+
+  function parseObject() {
+    const value = Object.create(null);
+    cursor += 1;
+    while (cursor < source.length) {
+      cursor = skipTrivia(source, cursor);
+      if (source[cursor] === '}') {
+        cursor += 1;
+        return value;
+      }
+
+      const key = source[cursor] === '"' || source[cursor] === "'" || source[cursor] === '`'
+        ? parseStringLiteral()
+        : parseIdentifier();
+      if (key === INVALID || typeof key !== 'string') return INVALID;
+      cursor = skipTrivia(source, cursor);
+      if (source[cursor] !== ':') return INVALID;
+      cursor = skipTrivia(source, cursor + 1);
+      const propertyValue = parseValue();
+      if (propertyValue === INVALID) return INVALID;
+      value[key] = propertyValue;
+      cursor = skipTrivia(source, cursor);
+      if (source[cursor] === ',') {
+        cursor += 1;
+        continue;
+      }
+      if (source[cursor] !== '}') return INVALID;
+    }
+    return INVALID;
+  }
+
+  function parseValue() {
+    cursor = skipTrivia(source, cursor);
+    const current = source[cursor];
+    if (current === '"' || current === "'" || current === '`') return parseStringLiteral();
+    if (current === '{') return parseObject();
+    if (current === '[') return parseArray();
+
+    const numberMatch = source.slice(cursor).match(/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/);
+    if (numberMatch) {
+      cursor += numberMatch[0].length;
+      return Number(numberMatch[0]);
+    }
+
+    const identifier = parseIdentifier();
+    if (identifier === 'true') return true;
+    if (identifier === 'false') return false;
+    if (identifier === 'null') return null;
+    if (identifier === 'undefined') return undefined;
+    return INVALID;
+  }
+
+  const value = parseValue();
+  return value === INVALID ? null : { value, nextIndex: cursor };
+}
+
+function extractSource(payload) {
+  if (typeof payload?.input === 'string') return payload.input;
+  if (payload?.input && typeof payload.input === 'object' && typeof payload.input.code === 'string') {
+    return payload.input.code;
+  }
+  return '';
+}
+
+export function extractUpdatePlanFromResponseItemPayload(payload) {
+  if (!payload || payload.type !== 'custom_tool_call') return null;
+  if (String(payload.name || '').toLowerCase() !== 'exec') return null;
+
+  const source = extractSource(payload);
+  if (!source) return null;
+
+  let searchStart = 0;
+  let latestPlan = null;
+  while (searchStart < source.length) {
+    const callStart = findToken(source, UPDATE_PLAN_TOKEN, searchStart);
+    if (callStart < 0) break;
+    let cursor = skipTrivia(source, callStart + UPDATE_PLAN_TOKEN.length);
+    if (source[cursor] === '(') {
+      latestPlan = null;
+      cursor = skipTrivia(source, cursor + 1);
+      const parsed = parseJavaScriptLiteral(source, cursor);
+      if (parsed?.value && typeof parsed.value === 'object' && !Array.isArray(parsed.value)
+          && Array.isArray(parsed.value.plan)) {
+        latestPlan = normalizeUpdatePlanInput(parsed.value);
+      }
+    }
+    searchStart = callStart + UPDATE_PLAN_TOKEN.length;
+  }
+  return latestPlan;
+}

--- a/ai-bridge/services/codex/codex-plan-parser.test.js
+++ b/ai-bridge/services/codex/codex-plan-parser.test.js
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { extractUpdatePlanFromResponseItemPayload } from './codex-plan-parser.js';
+
+function execPayload(input) {
+  return { type: 'custom_tool_call', name: 'exec', call_id: 'plan-1', input };
+}
+
+test('extracts the latest update_plan literal without evaluating JavaScript', () => {
+  const input = [
+    'const oldPlan = await tools.update_plan({plan:[{step:"Old",status:"pending"}]});',
+    'const currentPlan = await tools.update_plan({',
+    '  explanation: "Current plan",',
+    '  plan: [',
+    '    {step:"Inspect, parse { safely }",status:"done"},',
+    "    {step:'Implement parser',status:'running'},",
+    '  ],',
+    '});',
+  ].join('\n');
+
+  assert.deepEqual(extractUpdatePlanFromResponseItemPayload(execPayload(input)), {
+    explanation: 'Current plan',
+    plan: [
+      { step: 'Inspect, parse { safely }', status: 'completed', content: 'Inspect, parse { safely }' },
+      { step: 'Implement parser', status: 'in_progress', content: 'Implement parser' },
+    ],
+  });
+});
+
+test('preserves an explicit empty plan snapshot', () => {
+  assert.deepEqual(
+    extractUpdatePlanFromResponseItemPayload(execPayload('text(await tools.update_plan({ plan: [] }));')),
+    { plan: [] },
+  );
+});
+
+test('ignores update_plan text in strings and comments', () => {
+  const input = [
+    'const example = "tools.update_plan({plan:[{step:\'fake\'}]})";',
+    '// tools.update_plan({plan:[{step:"fake"}]})',
+    '/* tools.update_plan({plan:[{step:"fake"}]}) */',
+  ].join('\n');
+
+  assert.equal(extractUpdatePlanFromResponseItemPayload(execPayload(input)), null);
+});
+
+test('rejects dynamic plan expressions instead of evaluating them', () => {
+  assert.equal(
+    extractUpdatePlanFromResponseItemPayload(execPayload('await tools.update_plan(buildPlan());')),
+    null,
+  );
+});
+
+test('rejects a dynamic latest call instead of falling back to an earlier plan', () => {
+  const input = [
+    'await tools.update_plan({plan:[{step:"Old",status:"pending"}]});',
+    'await tools.update_plan({plan:[{step:buildStep(),status:"pending"}]});',
+  ].join('\n');
+
+  assert.equal(extractUpdatePlanFromResponseItemPayload(execPayload(input)), null);
+});
+
+test('reads only direct plan properties from plain literal objects', () => {
+  const nestedMetadata = 'tools.update_plan({plan:[{step:"Real",metadata:{content:"Not a task"}}]})';
+  const parsed = extractUpdatePlanFromResponseItemPayload(execPayload(nestedMetadata));
+  assert.equal(parsed.plan.length, 1);
+  assert.equal(parsed.plan[0].step, 'Real');
+  assert.equal(parsed.plan[0].status, 'pending');
+  assert.equal(parsed.plan[0].metadata.content, 'Not a task');
+
+  const inheritedPlan = 'tools.update_plan({__proto__:{plan:[{step:"Injected"}]}})';
+  assert.equal(extractUpdatePlanFromResponseItemPayload(execPayload(inheritedPlan)), null);
+  assert.equal(
+    extractUpdatePlanFromResponseItemPayload(execPayload('other.tools.update_plan({plan:[]})')),
+    null,
+  );
+});

--- a/src/main/java/com/github/claudecodegui/handler/CodexMessageConverter.java
+++ b/src/main/java/com/github/claudecodegui/handler/CodexMessageConverter.java
@@ -639,6 +639,7 @@ public class CodexMessageConverter {
             output = safeGetAsString(outputElement, "");
         }
         toolResult.addProperty("content", output);
+        toolResult.addProperty("is_error", isExplicitToolError(payload, outputElement, output));
 
         JsonArray content = new JsonArray();
         content.add(toolResult);
@@ -655,6 +656,29 @@ public class CodexMessageConverter {
         }
 
         return frontendMsg;
+    }
+
+    private static boolean isExplicitToolError(JsonObject payload, JsonElement outputElement, String output) {
+        if (hasErrorStatus(payload)
+                || (outputElement != null && outputElement.isJsonObject()
+                && hasErrorStatus(outputElement.getAsJsonObject()))) {
+            return true;
+        }
+        if (output == null) {
+            return false;
+        }
+        String normalized = output.stripLeading().toLowerCase(Locale.ROOT);
+        return normalized.startsWith("error:")
+                || normalized.startsWith("failed to parse")
+                || normalized.startsWith("failed-to-parse")
+                || normalized.startsWith("permission denied")
+                || normalized.startsWith("permission-denied")
+                || normalized.startsWith("command denied")
+                || normalized.startsWith("command-denied");
+    }
+
+    private static boolean hasErrorStatus(JsonObject object) {
+        return "error".equalsIgnoreCase(safeGetAsString(object.get("status"), ""));
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/handler/history/CodexExecHistoryReplay.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/CodexExecHistoryReplay.java
@@ -1,9 +1,11 @@
 package com.github.claudecodegui.handler.history;
 
+import com.github.claudecodegui.handler.CodexMessageConverter;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -14,8 +16,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Restores the nested shell commands persisted inside Codex Responses API
- * {@code exec} wrappers.
+ * Restores nested shell commands and plan updates persisted inside Codex
+ * Responses API {@code exec} wrappers.
  *
  * <p>The live bridge receives command-execution events and renders them as
  * normal Bash tool cards. A cold history load instead sees the outer
@@ -26,6 +28,11 @@ import java.util.regex.Pattern;
 final class CodexExecHistoryReplay {
 
     private static final int MAX_REPLAYED_SHELL_COMMANDS = 100;
+    private static final int MAX_REPLAYED_PLAN_ITEMS = 100;
+    private static final String UPDATE_PLAN_TOKEN = "tools.update_plan";
+    private static final Pattern JAVASCRIPT_NUMBER_PATTERN = Pattern.compile(
+        "-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?"
+    );
     private static final Pattern OUTPUT_MARKER_PATTERN = Pattern.compile(
         "(?m)^---(\\d+)---[\\t ]*\\r?$"
     );
@@ -82,6 +89,64 @@ final class CodexExecHistoryReplay {
             }
         }
         return commands;
+    }
+
+    static JsonObject extractUpdatePlanInput(JsonObject payload) {
+        String script = getStringProperty(payload, "input");
+        if (script == null) {
+            script = getStringProperty(payload, "arguments");
+        }
+        if (script == null || script.isBlank()) {
+            return null;
+        }
+
+        JsonObject latestPlan = null;
+        int searchStart = 0;
+        while (searchStart < script.length()) {
+            int callStart = findJavaScriptToken(script, UPDATE_PLAN_TOKEN, searchStart);
+            if (callStart < 0) {
+                break;
+            }
+            int invocationStart = skipTrivia(
+                script,
+                callStart + UPDATE_PLAN_TOKEN.length(),
+                script.length()
+            );
+            if (invocationStart < script.length() && script.charAt(invocationStart) == '(') {
+                latestPlan = parseUpdatePlanCall(script, callStart);
+            }
+            searchStart = callStart + UPDATE_PLAN_TOKEN.length();
+        }
+        return latestPlan;
+    }
+
+    static JsonObject createPlanToolUseMessage(
+            String callId,
+            JsonObject planInput,
+            String timestamp
+    ) {
+        JsonObject functionCall = new JsonObject();
+        functionCall.addProperty("name", "update_plan");
+        functionCall.addProperty("call_id", planToolUseId(callId));
+        functionCall.addProperty("arguments", planInput.toString());
+        return CodexMessageConverter.convertFunctionCallToToolUse(functionCall, timestamp);
+    }
+
+    static JsonObject createPlanToolResultMessage(
+            String callId,
+            Output output,
+            String fallbackTimestamp
+    ) {
+        boolean failed = isFailedOutputPayload(output.payload)
+            || FAILED_OUTPUT_PATTERN.matcher(output.payload.toString()).find();
+        JsonObject functionOutput = new JsonObject();
+        functionOutput.addProperty("call_id", planToolUseId(callId));
+        functionOutput.addProperty("output", failed ? "Plan update failed" : "Plan updated");
+        if (failed) {
+            functionOutput.addProperty("status", "error");
+        }
+        String timestamp = output.timestamp != null ? output.timestamp : fallbackTimestamp;
+        return CodexMessageConverter.convertFunctionCallOutputToToolResult(functionOutput, timestamp);
     }
 
     static JsonObject createToolUseMessage(
@@ -203,6 +268,266 @@ final class CodexExecHistoryReplay {
             cursor++;
         }
         return spans;
+    }
+
+    private static JsonObject parseUpdatePlanCall(String script, int callStart) {
+        int cursor = skipTrivia(script, callStart + UPDATE_PLAN_TOKEN.length(), script.length());
+        if (cursor >= script.length() || script.charAt(cursor) != '(') {
+            return null;
+        }
+        cursor = skipTrivia(script, cursor + 1, script.length());
+        if (cursor >= script.length() || script.charAt(cursor) != '{') {
+            return null;
+        }
+
+        int objectEnd = findMatchingObjectEnd(script, cursor);
+        if (objectEnd < 0) {
+            return null;
+        }
+
+        String normalizedLiteral = normalizeJavaScriptLiteralToJson(
+            script.substring(cursor, objectEnd + 1)
+        );
+        if (normalizedLiteral == null) {
+            return null;
+        }
+
+        JsonObject inputObject;
+        try {
+            JsonElement parsed = JsonParser.parseString(normalizedLiteral);
+            if (!parsed.isJsonObject()) {
+                return null;
+            }
+            inputObject = parsed.getAsJsonObject();
+        } catch (RuntimeException ignored) {
+            return null;
+        }
+        if (!inputObject.has("plan") || !inputObject.get("plan").isJsonArray()) {
+            return null;
+        }
+
+        JsonArray plan = new JsonArray();
+        for (JsonElement planItem : inputObject.getAsJsonArray("plan")) {
+            if (!planItem.isJsonObject()) {
+                continue;
+            }
+            JsonObject itemObject = planItem.getAsJsonObject();
+            String content = firstNonBlankString(itemObject, "content", "step", "title", "text");
+            if (content == null) {
+                continue;
+            }
+
+            JsonObject item = new JsonObject();
+            item.addProperty("step", content);
+            item.addProperty("status", normalizePlanStatus(itemObject.get("status")));
+            plan.add(item);
+            if (plan.size() >= MAX_REPLAYED_PLAN_ITEMS) {
+                break;
+            }
+        }
+
+        JsonObject input = new JsonObject();
+        if (inputObject.has("explanation") && inputObject.get("explanation").isJsonPrimitive()
+                && inputObject.getAsJsonPrimitive("explanation").isString()) {
+            input.add("explanation", inputObject.get("explanation"));
+        }
+        input.add("plan", plan);
+        return input;
+    }
+
+    private static String normalizeJavaScriptLiteralToJson(String literal) {
+        StringBuilder normalized = new StringBuilder(literal.length());
+        int cursor = 0;
+        while (cursor < literal.length()) {
+            char current = literal.charAt(cursor);
+            if (Character.isWhitespace(current)) {
+                normalized.append(current);
+                cursor++;
+                continue;
+            }
+            if (current == '/' && cursor + 1 < literal.length()) {
+                char next = literal.charAt(cursor + 1);
+                if (next == '/') {
+                    cursor = skipLineComment(literal, cursor + 2);
+                    continue;
+                }
+                if (next == '*') {
+                    cursor = skipBlockComment(literal, cursor + 2);
+                    continue;
+                }
+                return null;
+            }
+            if (isQuote(current)) {
+                int stringStart = cursor;
+                ParsedString parsed = readJavaScriptString(literal, cursor);
+                if (parsed.nextIndex <= stringStart + 1
+                        || literal.charAt(parsed.nextIndex - 1) != current
+                        || (current == '`' && containsTemplateInterpolation(
+                            literal,
+                            stringStart,
+                            parsed.nextIndex
+                        ))) {
+                    return null;
+                }
+                normalized.append(new JsonPrimitive(parsed.value));
+                cursor = parsed.nextIndex;
+                continue;
+            }
+            if (isJavaScriptIdentifierStart(current)) {
+                int identifierEnd = cursor + 1;
+                while (identifierEnd < literal.length()
+                        && isJavaScriptIdentifierPart(literal.charAt(identifierEnd))) {
+                    identifierEnd++;
+                }
+                String identifier = literal.substring(cursor, identifierEnd);
+                int nextToken = skipTrivia(literal, identifierEnd, literal.length());
+                if (nextToken < literal.length() && literal.charAt(nextToken) == ':') {
+                    normalized.append(new JsonPrimitive(identifier));
+                } else if ("true".equals(identifier)
+                        || "false".equals(identifier)
+                        || "null".equals(identifier)) {
+                    normalized.append(identifier);
+                } else if ("undefined".equals(identifier)) {
+                    normalized.append("null");
+                } else {
+                    return null;
+                }
+                cursor = identifierEnd;
+                continue;
+            }
+
+            Matcher numberMatcher = JAVASCRIPT_NUMBER_PATTERN.matcher(literal);
+            numberMatcher.region(cursor, literal.length());
+            if (numberMatcher.lookingAt()) {
+                normalized.append(numberMatcher.group());
+                cursor = numberMatcher.end();
+                continue;
+            }
+            if (current == ',') {
+                int nextToken = skipTrivia(literal, cursor + 1, literal.length());
+                if (nextToken < literal.length()
+                        && (literal.charAt(nextToken) == '}' || literal.charAt(nextToken) == ']')) {
+                    cursor++;
+                    continue;
+                }
+            }
+            if (current != '{' && current != '}' && current != '[' && current != ']'
+                    && current != ':' && current != ',') {
+                return null;
+            }
+            normalized.append(current);
+            cursor++;
+        }
+        return normalized.toString();
+    }
+
+    private static boolean containsTemplateInterpolation(String source, int start, int end) {
+        for (int cursor = start + 1; cursor + 1 < end; cursor++) {
+            char current = source.charAt(cursor);
+            if (current == '\\') {
+                cursor++;
+            } else if (current == '$' && source.charAt(cursor + 1) == '{') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static int findMatchingObjectEnd(String script, int objectStart) {
+        int depth = 0;
+        int cursor = objectStart;
+        while (cursor < script.length()) {
+            char current = script.charAt(cursor);
+            if (isQuote(current)) {
+                cursor = skipJavaScriptString(script, cursor);
+                continue;
+            }
+            if (current == '/' && cursor + 1 < script.length()) {
+                char next = script.charAt(cursor + 1);
+                if (next == '/') {
+                    cursor = skipLineComment(script, cursor + 2);
+                    continue;
+                }
+                if (next == '*') {
+                    cursor = skipBlockComment(script, cursor + 2);
+                    continue;
+                }
+            }
+            if (current == '{') {
+                depth++;
+            } else if (current == '}') {
+                depth--;
+                if (depth == 0) {
+                    return cursor;
+                }
+            }
+            cursor++;
+        }
+        return -1;
+    }
+
+    private static int findJavaScriptToken(String script, String token, int start) {
+        int cursor = Math.max(0, start);
+        while (cursor < script.length()) {
+            char current = script.charAt(cursor);
+            if (isQuote(current)) {
+                cursor = skipJavaScriptString(script, cursor);
+                continue;
+            }
+            if (current == '/' && cursor + 1 < script.length()) {
+                char next = script.charAt(cursor + 1);
+                if (next == '/') {
+                    cursor = skipLineComment(script, cursor + 2);
+                    continue;
+                }
+                if (next == '*') {
+                    cursor = skipBlockComment(script, cursor + 2);
+                    continue;
+                }
+            }
+            if (script.startsWith(token, cursor)) {
+                char before = cursor > 0 ? script.charAt(cursor - 1) : '\0';
+                int afterIndex = cursor + token.length();
+                char after = afterIndex < script.length() ? script.charAt(afterIndex) : '\0';
+                if (!isJavaScriptIdentifierPart(before)
+                        && before != '.'
+                        && !isJavaScriptIdentifierPart(after)) {
+                    return cursor;
+                }
+            }
+            cursor++;
+        }
+        return -1;
+    }
+
+    private static String firstNonBlankString(JsonObject values, String... keys) {
+        for (String key : keys) {
+            JsonElement value = values.get(key);
+            if (value != null && value.isJsonPrimitive()
+                    && value.getAsJsonPrimitive().isString()
+                    && !value.getAsString().isBlank()) {
+                String text = value.getAsString();
+                return text.trim();
+            }
+        }
+        return null;
+    }
+
+    private static String normalizePlanStatus(JsonElement status) {
+        if (status == null || !status.isJsonPrimitive() || !status.getAsJsonPrimitive().isString()) {
+            return "pending";
+        }
+        String normalized = status.getAsString().trim().toLowerCase(Locale.ROOT);
+        if ("completed".equals(normalized) || "done".equals(normalized)) {
+            return "completed";
+        }
+        if ("in_progress".equals(normalized)
+                || "in-progress".equals(normalized)
+                || "active".equals(normalized)
+                || "running".equals(normalized)) {
+            return "in_progress";
+        }
+        return "pending";
     }
 
     private static Map<String, String> parseJavaScriptObjectProperties(
@@ -413,6 +738,30 @@ final class CodexExecHistoryReplay {
         return end >= 0 ? end + 2 : script.length();
     }
 
+    private static int skipTrivia(String script, int start, int limit) {
+        int cursor = start;
+        while (cursor < limit) {
+            char current = script.charAt(cursor);
+            if (Character.isWhitespace(current)) {
+                cursor++;
+                continue;
+            }
+            if (current == '/' && cursor + 1 < limit) {
+                char next = script.charAt(cursor + 1);
+                if (next == '/') {
+                    cursor = Math.min(skipLineComment(script, cursor + 2), limit);
+                    continue;
+                }
+                if (next == '*') {
+                    cursor = Math.min(skipBlockComment(script, cursor + 2), limit);
+                    continue;
+                }
+            }
+            break;
+        }
+        return cursor;
+    }
+
     private static int skipWhitespaceAndCommas(String script, int start, int limit) {
         int cursor = start;
         while (cursor < limit) {
@@ -601,6 +950,11 @@ final class CodexExecHistoryReplay {
     private static String shellToolUseId(String callId, int commandIndex) {
         String stableCallId = callId == null || callId.isBlank() ? "unknown" : callId;
         return "codex_exec_" + stableCallId + "_" + commandIndex;
+    }
+
+    private static String planToolUseId(String callId) {
+        String stableCallId = callId == null || callId.isBlank() ? "unknown" : callId;
+        return "codex_plan_" + stableCallId;
     }
 
     private static String smartShellToolName(String command) {

--- a/src/main/java/com/github/claudecodegui/handler/history/CodexSubagentHistoryLoader.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/CodexSubagentHistoryLoader.java
@@ -13,9 +13,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -29,6 +32,7 @@ final class CodexSubagentHistoryLoader {
     private static final Pattern SAFE_AGENT_PATH =
             Pattern.compile("/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*");
     private static final int MAX_CACHE_ENTRIES = 256;
+    static final int MAX_STATUS_REQUESTS = 64;
 
     private final Path sessionsDir;
     private final Map<LookupKey, Location> locationCache =
@@ -56,7 +60,7 @@ final class CodexSubagentHistoryLoader {
             throw new IllegalArgumentException("Missing toolUseId and agentPath");
         }
 
-        LookupKey key = new LookupKey("codex", parentSessionId, toolUseId, requestedAgentPath);
+        LookupKey key = new LookupKey("codex", parentSessionId, toolUseId, requestedAgentPath, null);
         Location location = locationCache.get(key);
         if (location == null || !Files.isRegularFile(location.file())) {
             location = resolveLocation(parentSessionId, toolUseId, requestedAgentPath);
@@ -76,6 +80,362 @@ final class CodexSubagentHistoryLoader {
                 turn.status(),
                 turn.error()
         );
+    }
+
+    List<StatusResult> loadStatuses(String parentSessionId, List<StatusRequest> requests) throws IOException {
+        validateId("sessionId", parentSessionId);
+        if (requests == null || requests.size() > MAX_STATUS_REQUESTS) {
+            throw new IllegalArgumentException("Invalid agents count");
+        }
+        for (StatusRequest request : requests) {
+            validateStatusRequest(request);
+        }
+        if (requests.isEmpty()) {
+            return List.of();
+        }
+
+        List<StatusResult> results = new ArrayList<>(Collections.nCopies(requests.size(), null));
+        List<Integer> unresolvedIndexes = new ArrayList<>();
+        for (int i = 0; i < requests.size(); i++) {
+            StatusRequest request = requests.get(i);
+            Location cached = locationCache.get(statusLookupKey(parentSessionId, request));
+            if (cached != null && Files.isRegularFile(cached.file())) {
+                results.set(i, readStatus(request, cached));
+            } else {
+                unresolvedIndexes.add(i);
+            }
+        }
+        if (unresolvedIndexes.isEmpty()) {
+            return results;
+        }
+
+        Set<String> requestedToolUseIds = new HashSet<>();
+        for (int index : unresolvedIndexes) {
+            String toolUseId = requests.get(index).toolUseId();
+            if (toolUseId != null && !toolUseId.isBlank()) {
+                requestedToolUseIds.add(toolUseId);
+            }
+        }
+
+        ActivityLookup activities = ActivityLookup.empty();
+        String activityPendingError = null;
+        String activityFailure = null;
+        if (!requestedToolUseIds.isEmpty()) {
+            try {
+                activities = findActivityLocations(findExactSessionFile(parentSessionId), requestedToolUseIds);
+            } catch (PendingException e) {
+                activityPendingError = e.getMessage();
+            } catch (Exception e) {
+                activityFailure = errorMessage(e);
+            }
+        }
+
+        Set<String> requiredThreadIds = new HashSet<>();
+        boolean needsLegacyLookup = false;
+        for (int index : unresolvedIndexes) {
+            StatusRequest request = requests.get(index);
+            Location activity = activities.locations().get(request.toolUseId());
+            if (activity != null) {
+                requiredThreadIds.add(activity.agentThreadId());
+            }
+            if (request.agentId() != null && !request.agentId().isBlank()) {
+                requiredThreadIds.add(request.agentId());
+            }
+            if (activity == null && activityPendingError == null
+                    && request.agentPath() != null && !request.agentPath().isBlank()) {
+                needsLegacyLookup = true;
+            }
+        }
+
+        SessionIndex sessionIndex;
+        try {
+            sessionIndex = buildSessionIndex(parentSessionId, requiredThreadIds, needsLegacyLookup);
+        } catch (PendingException e) {
+            sessionIndex = SessionIndex.empty();
+            if (activityPendingError == null) {
+                activityPendingError = e.getMessage();
+            }
+        }
+
+        for (int index : unresolvedIndexes) {
+            StatusRequest request = requests.get(index);
+            StatusResult resolutionFailure = resolveFailure(
+                    request,
+                    activities,
+                    activityPendingError,
+                    activityFailure
+            );
+            if (resolutionFailure != null) {
+                results.set(index, resolutionFailure);
+                continue;
+            }
+
+            Location location;
+            try {
+                location = resolveBatchLocation(parentSessionId, request, activities, sessionIndex);
+            } catch (PendingException e) {
+                results.set(index, pendingStatus(request, e.getMessage()));
+                continue;
+            } catch (Exception e) {
+                results.set(index, failedStatus(request, errorMessage(e)));
+                continue;
+            }
+
+            locationCache.put(statusLookupKey(parentSessionId, request), location);
+            results.set(index, readStatus(request, location));
+        }
+        return results;
+    }
+
+    private static void validateStatusRequest(StatusRequest request) {
+        if (request == null) {
+            throw new IllegalArgumentException("Invalid agent request");
+        }
+        if (request.toolUseId() != null && !request.toolUseId().isBlank()) {
+            validateId("toolUseId", request.toolUseId());
+        }
+        if (request.agentId() != null && !request.agentId().isBlank()) {
+            validateId("agentId", request.agentId());
+        }
+        if (request.agentPath() != null && !request.agentPath().isBlank()) {
+            validateAgentPath(request.agentPath());
+        }
+        if ((request.toolUseId() == null || request.toolUseId().isBlank())
+                && (request.agentId() == null || request.agentId().isBlank())
+                && (request.agentPath() == null || request.agentPath().isBlank())) {
+            throw new IllegalArgumentException("Missing agent identifier");
+        }
+    }
+
+    private LookupKey statusLookupKey(String parentSessionId, StatusRequest request) {
+        return new LookupKey("codex", parentSessionId, request.toolUseId(), request.agentPath(), request.agentId());
+    }
+
+    private StatusResult resolveFailure(
+            StatusRequest request,
+            ActivityLookup activities,
+            String activityPendingError,
+            String activityFailure
+    ) {
+        if (request.toolUseId() == null || request.toolUseId().isBlank()) {
+            return null;
+        }
+        if (activities.ambiguousToolUseIds().contains(request.toolUseId())) {
+            return failedStatus(request, "Ambiguous Codex subagent activity");
+        }
+        if (activityFailure != null) {
+            return failedStatus(request, activityFailure);
+        }
+        if (activityPendingError != null && (request.agentId() == null || request.agentId().isBlank())) {
+            return pendingStatus(request, activityPendingError);
+        }
+        return null;
+    }
+
+    private Location resolveBatchLocation(
+            String parentSessionId,
+            StatusRequest request,
+            ActivityLookup activities,
+            SessionIndex sessionIndex
+    ) {
+        Location activity = activities.locations().get(request.toolUseId());
+        if (activity != null) {
+            return exactLocation(activity.agentThreadId(), activity.agentPath(), sessionIndex);
+        }
+        if (request.agentId() != null && !request.agentId().isBlank()) {
+            Location direct = exactLocation(request.agentId(), request.agentPath(), sessionIndex);
+            JsonObject meta = readSessionMeta(direct.file());
+            if (meta == null || !parentSessionId.equals(getParentThreadId(meta))) {
+                throw new IllegalStateException("Codex subagent does not belong to parent session");
+            }
+            return new Location(direct.file(), request.agentId(), getAgentPath(meta));
+        }
+        if (request.agentPath() == null || request.agentPath().isBlank()) {
+            throw new PendingException("Codex subagent activity not found yet");
+        }
+
+        List<Location> matches = sessionIndex.legacyLocations().stream()
+                .filter(location -> matchesAgentPath(request.agentPath(), location.agentPath()))
+                .toList();
+        if (matches.isEmpty()) {
+            throw new PendingException("Codex subagent rollout not found yet");
+        }
+        if (matches.size() > 1) {
+            throw new IllegalStateException("Ambiguous Codex subagent rollout for agentPath");
+        }
+        return matches.get(0);
+    }
+
+    private Location exactLocation(String threadId, String agentPath, SessionIndex sessionIndex) {
+        List<Path> matches = sessionIndex.filesByThreadId().getOrDefault(threadId, List.of());
+        if (matches.isEmpty()) {
+            throw new PendingException("Codex session rollout not found yet: " + threadId);
+        }
+        if (matches.size() > 1) {
+            throw new IllegalStateException("Ambiguous Codex session rollout: " + threadId);
+        }
+        return new Location(matches.get(0), threadId, agentPath);
+    }
+
+    private ActivityLookup findActivityLocations(Path parentFile, Set<String> requestedToolUseIds) throws IOException {
+        Map<String, Location> locations = new HashMap<>();
+        Set<String> ambiguousToolUseIds = new HashSet<>();
+        try (Stream<String> lines = Files.lines(parentFile, StandardCharsets.UTF_8)) {
+            for (java.util.Iterator<String> iterator = lines.iterator(); iterator.hasNext();) {
+                String line = iterator.next();
+                if (line.isBlank()) {
+                    continue;
+                }
+                JsonObject payload = eventPayload(parseObject(line), "sub_agent_activity");
+                String toolUseId = getString(payload, "event_id");
+                if (toolUseId == null || !requestedToolUseIds.contains(toolUseId)) {
+                    continue;
+                }
+                String threadId = getString(payload, "agent_thread_id");
+                if (threadId == null || threadId.isBlank()) {
+                    continue;
+                }
+                validateId("agentThreadId", threadId);
+                Location previous = locations.get(toolUseId);
+                if (previous != null && !previous.agentThreadId().equals(threadId)) {
+                    ambiguousToolUseIds.add(toolUseId);
+                    locations.remove(toolUseId);
+                    continue;
+                }
+                if (!ambiguousToolUseIds.contains(toolUseId)) {
+                    locations.put(toolUseId, new Location(null, threadId, getString(payload, "agent_path")));
+                }
+            }
+        }
+        return new ActivityLookup(locations, ambiguousToolUseIds);
+    }
+
+    private SessionIndex buildSessionIndex(
+            String parentSessionId,
+            Set<String> requiredThreadIds,
+            boolean needsLegacyLookup
+    ) throws IOException {
+        if (!Files.isDirectory(sessionsDir)) {
+            throw new PendingException("Codex sessions directory not found yet");
+        }
+        Map<String, List<Path>> filesByThreadId = new HashMap<>();
+        List<Location> legacyLocations = new ArrayList<>();
+        try (Stream<Path> paths = Files.walk(sessionsDir)) {
+            for (java.util.Iterator<Path> iterator = paths.iterator(); iterator.hasNext();) {
+                Path path = iterator.next();
+                if (!Files.isRegularFile(path) || !path.getFileName().toString().endsWith(".jsonl")) {
+                    continue;
+                }
+                String fileName = path.getFileName().toString();
+                for (String threadId : requiredThreadIds) {
+                    if (fileName.endsWith("-" + threadId + ".jsonl")) {
+                        filesByThreadId.computeIfAbsent(threadId, ignored -> new ArrayList<>()).add(path);
+                    }
+                }
+                if (!needsLegacyLookup) {
+                    continue;
+                }
+                JsonObject meta = readSessionMeta(path);
+                if (meta == null || !parentSessionId.equals(getParentThreadId(meta))) {
+                    continue;
+                }
+                String threadId = getString(meta, "id");
+                if (threadId != null) {
+                    legacyLocations.add(new Location(path, threadId, getAgentPath(meta)));
+                }
+            }
+        }
+        return new SessionIndex(filesByThreadId, legacyLocations);
+    }
+
+    private StatusResult readStatus(StatusRequest request, Location location) {
+        try {
+            StatusSlice status = readInitialSubagentStatus(location.file());
+            return new StatusResult(
+                    request.toolUseId(),
+                    location.agentPath() != null ? location.agentPath() : request.agentPath(),
+                    location.agentThreadId(),
+                    true,
+                    status.status(),
+                    status.error()
+            );
+        } catch (PendingException e) {
+            return pendingStatus(request, e.getMessage());
+        } catch (Exception e) {
+            return failedStatus(request, errorMessage(e));
+        }
+    }
+
+    private StatusSlice readInitialSubagentStatus(Path file) throws IOException {
+        boolean afterSessionMeta = false;
+        Set<String> startedTurnIds = new HashSet<>();
+        String turnId = null;
+        try (Stream<String> lines = Files.lines(file, StandardCharsets.UTF_8)) {
+            for (java.util.Iterator<String> iterator = lines.iterator(); iterator.hasNext();) {
+                String line = iterator.next();
+                if (line.isBlank()) {
+                    continue;
+                }
+                JsonObject record = parseObject(line);
+                if (record == null) {
+                    continue;
+                }
+                if ("session_meta".equals(getString(record, "type"))) {
+                    afterSessionMeta = true;
+                    startedTurnIds.clear();
+                    turnId = null;
+                    continue;
+                }
+                if (!afterSessionMeta) {
+                    continue;
+                }
+                JsonObject started = eventPayload(record, "task_started");
+                if (started != null) {
+                    String startedTurnId = getString(started, "turn_id");
+                    if (startedTurnId != null) {
+                        startedTurnIds.add(startedTurnId);
+                    }
+                }
+                if (turnId == null && "turn_context".equals(getString(record, "type"))
+                        && record.has("payload") && record.get("payload").isJsonObject()) {
+                    turnId = getString(record.getAsJsonObject("payload"), "turn_id");
+                    continue;
+                }
+                if (turnId != null && matchesTurnEvent(record, "task_complete", turnId)) {
+                    if (!startedTurnIds.contains(turnId)) {
+                        throw new PendingException("Codex subagent turn start not found yet");
+                    }
+                    return new StatusSlice("completed", null);
+                }
+                if (turnId != null && matchesTurnEvent(record, "turn_aborted", turnId)) {
+                    if (!startedTurnIds.contains(turnId)) {
+                        throw new PendingException("Codex subagent turn start not found yet");
+                    }
+                    return new StatusSlice("error", "Codex subagent turn was aborted");
+                }
+            }
+        }
+        if (turnId == null) {
+            throw new PendingException("Codex subagent turn context not found yet");
+        }
+        if (!startedTurnIds.contains(turnId)) {
+            throw new PendingException("Codex subagent turn start not found yet");
+        }
+        return new StatusSlice("running", null);
+    }
+
+    private static StatusResult pendingStatus(StatusRequest request, String error) {
+        return new StatusResult(
+                request.toolUseId(), request.agentPath(), request.agentId(), false, "running", error);
+    }
+
+    private static StatusResult failedStatus(StatusRequest request, String error) {
+        return new StatusResult(
+                request.toolUseId(), request.agentPath(), request.agentId(), false, "error", error);
+    }
+
+    private static String errorMessage(Exception e) {
+        return e.getMessage() != null ? e.getMessage() : "Unknown error";
     }
 
     private Location resolveLocation(
@@ -401,10 +761,47 @@ final class CodexSubagentHistoryLoader {
     record TurnSlice(JsonArray messages, String status, String error) {
     }
 
-    private record LookupKey(String provider, String parentSessionId, String toolUseId, String agentPath) {
+    record StatusRequest(String toolUseId, String agentPath, String agentId) {
+    }
+
+    record StatusResult(
+            String toolUseId,
+            String agentPath,
+            String agentId,
+            boolean success,
+            String status,
+            String error
+    ) {
+        boolean completed() {
+            return "completed".equals(status);
+        }
+    }
+
+    private record StatusSlice(String status, String error) {
+    }
+
+    private record LookupKey(
+            String provider,
+            String parentSessionId,
+            String toolUseId,
+            String agentPath,
+            String agentId
+    ) {
     }
 
     private record Location(Path file, String agentThreadId, String agentPath) {
+    }
+
+    private record ActivityLookup(Map<String, Location> locations, Set<String> ambiguousToolUseIds) {
+        private static ActivityLookup empty() {
+            return new ActivityLookup(Map.of(), Set.of());
+        }
+    }
+
+    private record SessionIndex(Map<String, List<Path>> filesByThreadId, List<Location> legacyLocations) {
+        private static SessionIndex empty() {
+            return new SessionIndex(Map.of(), List.of());
+        }
     }
 
     static final class PendingException extends IllegalStateException {

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryHandler.java
@@ -26,6 +26,7 @@ public class HistoryHandler extends BaseMessageHandler {
             "delete_title",    // Delete orphaned custom title (B-011)
             "deep_search_history", // Deep search (clear cache and reload)
             "load_subagent_session", // Load Claude Code sidechain Agent process log
+            "load_subagent_statuses", // Load lightweight Codex subagent statuses
             "convert_to_cli_session" // Convert sidechain session to CLI-recognizable session
     };
 
@@ -117,6 +118,10 @@ public class HistoryHandler extends BaseMessageHandler {
             case "load_subagent_session":
                 LOG.debug("[HistoryHandler] 处理: load_subagent_session");
                 subagentHistoryService.handleLoadSubagentSession(content);
+                return true;
+            case "load_subagent_statuses":
+                LOG.debug("[HistoryHandler] Processing: load_subagent_statuses");
+                subagentHistoryService.handleLoadSubagentStatuses(content);
                 return true;
             case "convert_to_cli_session":
                 LOG.debug("[HistoryHandler] 处理: convert_to_cli_session");

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryHandler.java
@@ -26,6 +26,7 @@ public class HistoryHandler extends BaseMessageHandler {
             "delete_title",    // Delete orphaned custom title (B-011)
             "deep_search_history", // Deep search (clear cache and reload)
             "load_subagent_session", // Load Claude Code sidechain Agent process log
+            "load_subagent_statuses", // Load lightweight Codex subagent statuses
             "convert_to_cli_session" // Convert sidechain session to CLI-recognizable session
     };
 
@@ -114,6 +115,10 @@ public class HistoryHandler extends BaseMessageHandler {
             case "load_subagent_session":
                 LOG.debug("[HistoryHandler] 处理: load_subagent_session");
                 subagentHistoryService.handleLoadSubagentSession(content);
+                return true;
+            case "load_subagent_statuses":
+                LOG.debug("[HistoryHandler] Processing: load_subagent_statuses");
+                subagentHistoryService.handleLoadSubagentStatuses(content);
                 return true;
             case "convert_to_cli_session":
                 LOG.debug("[HistoryHandler] 处理: convert_to_cli_session");

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
@@ -440,14 +440,29 @@ public class HistoryMessageInjector {
                 if (CodexExecHistoryReplay.isExecCall(payload)) {
                     String callId = getStringProperty(payload, "call_id");
                     String timestamp = getStringProperty(msg, "timestamp");
+                    CodexExecHistoryReplay.Output output =
+                        callId != null ? outputsByCallId.get(callId) : null;
+                    JsonObject planInput = CodexExecHistoryReplay.extractUpdatePlanInput(payload);
+                    if (planInput != null) {
+                        accumulator.acceptConverted(
+                            CodexExecHistoryReplay.createPlanToolUseMessage(callId, planInput, timestamp)
+                        );
+                        if (output != null) {
+                            accumulator.acceptConverted(
+                                CodexExecHistoryReplay.createPlanToolResultMessage(
+                                    callId,
+                                    output,
+                                    timestamp
+                                )
+                            );
+                        }
+                    }
                     List<CodexExecHistoryReplay.Command> commands =
                         CodexExecHistoryReplay.extractCommands(payload);
                     if (!commands.isEmpty()) {
                         accumulator.acceptConverted(
                             CodexExecHistoryReplay.createToolUseMessage(callId, commands, timestamp)
                         );
-                        CodexExecHistoryReplay.Output output =
-                            callId != null ? outputsByCallId.get(callId) : null;
                         if (output != null) {
                             accumulator.acceptConverted(
                                 CodexExecHistoryReplay.createToolResultMessage(

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
@@ -425,14 +425,29 @@ public class HistoryMessageInjector {
                 if (CodexExecHistoryReplay.isExecCall(payload)) {
                     String callId = getStringProperty(payload, "call_id");
                     String timestamp = getStringProperty(msg, "timestamp");
+                    CodexExecHistoryReplay.Output output =
+                        callId != null ? outputsByCallId.get(callId) : null;
+                    JsonObject planInput = CodexExecHistoryReplay.extractUpdatePlanInput(payload);
+                    if (planInput != null) {
+                        accumulator.acceptConverted(
+                            CodexExecHistoryReplay.createPlanToolUseMessage(callId, planInput, timestamp)
+                        );
+                        if (output != null) {
+                            accumulator.acceptConverted(
+                                CodexExecHistoryReplay.createPlanToolResultMessage(
+                                    callId,
+                                    output,
+                                    timestamp
+                                )
+                            );
+                        }
+                    }
                     List<CodexExecHistoryReplay.Command> commands =
                         CodexExecHistoryReplay.extractCommands(payload);
                     if (!commands.isEmpty()) {
                         accumulator.acceptConverted(
                             CodexExecHistoryReplay.createToolUseMessage(callId, commands, timestamp)
                         );
-                        CodexExecHistoryReplay.Output output =
-                            callId != null ? outputsByCallId.get(callId) : null;
                         if (output != null) {
                             accumulator.acceptConverted(
                                 CodexExecHistoryReplay.createToolResultMessage(

--- a/src/main/java/com/github/claudecodegui/handler/history/SubagentHistoryService.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/SubagentHistoryService.java
@@ -6,6 +6,7 @@ import com.github.claudecodegui.util.PathUtils;
 import com.github.claudecodegui.util.JsUtils;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
@@ -33,17 +34,23 @@ class SubagentHistoryService {
 
     private static final Logger LOG = Logger.getInstance(SubagentHistoryService.class);
     private static final Pattern SAFE_ID = Pattern.compile("[A-Za-z0-9_-]+");
+    private static final Pattern SAFE_REQUEST_ID = Pattern.compile("[A-Za-z0-9_:-]{1,256}");
     private static final Gson GSON = new Gson();
     private static final int MAX_JSONL_LINES = 50_000;
 
     private final HandlerContext context;
     private final CodexSubagentHistoryLoader codexLoader;
     private final Set<String> inFlightCodexRequests = ConcurrentHashMap.newKeySet();
+    private final Set<String> inFlightCodexStatusSessions = ConcurrentHashMap.newKeySet();
 
     SubagentHistoryService(HandlerContext context) {
+        this(context, new CodexSubagentHistoryLoader(
+                Path.of(NodeDetector.resolveHomeForFileOps(), ".codex", "sessions")));
+    }
+
+    SubagentHistoryService(HandlerContext context, CodexSubagentHistoryLoader codexLoader) {
         this.context = context;
-        Path codexSessionsDir = Path.of(NodeDetector.resolveHomeForFileOps(), ".codex", "sessions");
-        this.codexLoader = new CodexSubagentHistoryLoader(codexSessionsDir);
+        this.codexLoader = codexLoader;
     }
 
     void handleLoadSubagentSession(String content) {
@@ -106,6 +113,107 @@ class SubagentHistoryService {
         sendResponse(response);
     }
 
+    void handleLoadSubagentStatuses(String content) {
+        JsonObject response = new JsonObject();
+        response.add("statuses", new JsonArray());
+
+        String sessionId = null;
+        String provider = null;
+        String requestId = null;
+        List<CodexSubagentHistoryLoader.StatusRequest> agents;
+        try {
+            JsonObject request = parseRequest(content);
+            sessionId = getString(request, "sessionId");
+            provider = getString(request, "provider");
+            requestId = getString(request, "requestId");
+            response.addProperty("sessionId", sessionId);
+            response.addProperty("provider", provider);
+            response.addProperty("requestId", requestId);
+
+            validateId("sessionId", sessionId);
+            validateRequestId(requestId);
+            if (!"codex".equals(provider)) {
+                throw new IllegalArgumentException("Invalid provider");
+            }
+            if (!request.has("agents") || !request.get("agents").isJsonArray()) {
+                throw new IllegalArgumentException("Invalid agents");
+            }
+            JsonArray agentArray = request.getAsJsonArray("agents");
+            if (agentArray.size() > CodexSubagentHistoryLoader.MAX_STATUS_REQUESTS) {
+                throw new IllegalArgumentException("Too many agents");
+            }
+            agents = parseStatusRequests(agentArray);
+        } catch (Exception e) {
+            response.addProperty("success", false);
+            response.addProperty("error", e.getMessage() != null ? e.getMessage() : "Invalid request");
+            sendStatusesResponse(response);
+            return;
+        }
+
+        String responseSessionId = sessionId;
+        if (!inFlightCodexStatusSessions.add(responseSessionId)) {
+            response.addProperty("success", false);
+            response.addProperty("error", "Codex subagent status request already in progress");
+            sendStatusesResponse(response);
+            return;
+        }
+        CompletableFuture.runAsync(() -> {
+            try {
+                List<CodexSubagentHistoryLoader.StatusResult> results =
+                        codexLoader.loadStatuses(responseSessionId, agents);
+                JsonArray statuses = new JsonArray();
+                for (CodexSubagentHistoryLoader.StatusResult result : results) {
+                    statuses.add(toJson(result));
+                }
+                response.addProperty("success", true);
+                response.add("statuses", statuses);
+            } catch (Exception e) {
+                LOG.warn("[SubagentHistory] Failed to load Codex subagent statuses: " + e.getMessage());
+                response.addProperty("success", false);
+                response.addProperty("error", e.getMessage() != null ? e.getMessage() : "Unknown error");
+            } finally {
+                inFlightCodexStatusSessions.remove(responseSessionId);
+            }
+            sendStatusesResponse(response);
+        }, AppExecutorUtil.getAppExecutorService());
+    }
+
+    private static List<CodexSubagentHistoryLoader.StatusRequest> parseStatusRequests(JsonArray agents) {
+        List<CodexSubagentHistoryLoader.StatusRequest> requests = new java.util.ArrayList<>(agents.size());
+        for (JsonElement element : agents) {
+            if (!element.isJsonObject()) {
+                throw new IllegalArgumentException("Invalid agent request");
+            }
+            JsonObject agent = element.getAsJsonObject();
+            requests.add(new CodexSubagentHistoryLoader.StatusRequest(
+                    getString(agent, "toolUseId"),
+                    getString(agent, "agentPath"),
+                    getString(agent, "agentId")
+            ));
+        }
+        return requests;
+    }
+
+    private static JsonObject toJson(CodexSubagentHistoryLoader.StatusResult result) {
+        JsonObject status = new JsonObject();
+        if (result.toolUseId() != null) {
+            status.addProperty("toolUseId", result.toolUseId());
+        }
+        if (result.agentPath() != null) {
+            status.addProperty("agentPath", result.agentPath());
+        }
+        if (result.agentId() != null) {
+            status.addProperty("agentId", result.agentId());
+        }
+        status.addProperty("success", result.success());
+        status.addProperty("completed", result.completed());
+        status.addProperty("status", result.status());
+        if (result.error() != null) {
+            status.addProperty("error", result.error());
+        }
+        return status;
+    }
+
     private void loadCodexSubagentAsync(
             String sessionId,
             String toolUseId,
@@ -163,6 +271,12 @@ class SubagentHistoryService {
     private static void validateId(String name, String value) {
         if (value == null || value.isEmpty() || !SAFE_ID.matcher(value).matches()) {
             throw new IllegalArgumentException("Invalid " + name);
+        }
+    }
+
+    private static void validateRequestId(String value) {
+        if (value == null || !SAFE_REQUEST_ID.matcher(value).matches()) {
+            throw new IllegalArgumentException("Invalid requestId");
         }
     }
 
@@ -298,5 +412,12 @@ class SubagentHistoryService {
                     String.valueOf(i == chunks.size() - 1)
             );
         }
+    }
+
+    private void sendStatusesResponse(JsonObject response) {
+        if (context.getProject() == null || context.getProject().isDisposed()) {
+            return;
+        }
+        context.callJavaScript("onSubagentStatusesLoaded", JsUtils.escapeJs(GSON.toJson(response)));
     }
 }

--- a/src/test/java/com/github/claudecodegui/handler/CodexMessageConverterTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/CodexMessageConverterTest.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -28,6 +29,52 @@ public class CodexMessageConverterTest {
         assertEquals("tool_result", toolResult.get("type").getAsString());
         assertEquals("call-1", toolResult.get("tool_use_id").getAsString());
         assertEquals("command executed successfully", toolResult.get("content").getAsString());
+        assertFalse(toolResult.get("is_error").getAsBoolean());
+    }
+
+    @Test
+    public void toolResultUsesExplicitErrorStatus() {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("call_id", "call-error-status");
+        payload.addProperty("status", "error");
+        payload.addProperty("output", "request finished");
+
+        JsonObject result = CodexMessageConverter.convertFunctionCallOutputToToolResult(payload, null);
+
+        assertTrue(extractFirstToolResult(result).get("is_error").getAsBoolean());
+    }
+
+    @Test
+    public void customToolResultUsesKnownErrorPrefix() {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("call_id", "call-parse-error");
+        payload.addProperty("output", "failed to parse function arguments: missing field message");
+
+        JsonObject result = CodexMessageConverter.convertCustomToolCallOutputToToolResult(payload, null);
+
+        assertTrue(extractFirstToolResult(result).get("is_error").getAsBoolean());
+    }
+
+    @Test
+    public void benignToolOutputContainingErrorWordsIsNotMarkedAsError() {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("call_id", "call-benign");
+        payload.addProperty("output", "Validation completed; error count: 0; permission denied checks: 0");
+
+        JsonObject result = CodexMessageConverter.convertFunctionCallOutputToToolResult(payload, null);
+
+        assertFalse(extractFirstToolResult(result).get("is_error").getAsBoolean());
+    }
+
+    @Test
+    public void benignToolOutputStartingWithErrorWordIsNotMarkedAsError() {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("call_id", "call-benign-prefix");
+        payload.addProperty("output", "Error handling is implemented and tests passed");
+
+        JsonObject result = CodexMessageConverter.convertFunctionCallOutputToToolResult(payload, null);
+
+        assertFalse(extractFirstToolResult(result).get("is_error").getAsBoolean());
     }
 
     @Test

--- a/src/test/java/com/github/claudecodegui/handler/history/CodexSubagentHistoryLoaderTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/history/CodexSubagentHistoryLoaderTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -107,6 +108,64 @@ public class CodexSubagentHistoryLoaderTest {
 
         assertEquals("error", result.status());
         assertEquals("Codex subagent turn was aborted", result.error());
+    }
+
+    @Test
+    public void loadsMultipleStatusesFromOneParentActivityMap() throws Exception {
+        Path sessionsDir = temporaryFolder.newFolder("status-sessions").toPath();
+        String parentId = "019fa70f-0653-73e2-a613-1fb0a9e83a2b";
+        String completedChildId = "019fb0fe-c344-7da0-9d10-20659f884100";
+        String runningChildId = "019fb0fe-c344-7da0-9d10-20659f884101";
+        writeRollout(sessionsDir.resolve("rollout-parent-" + parentId + ".jsonl"),
+                event("sub_agent_activity", "event_id", "call-completed",
+                        "agent_thread_id", completedChildId, "agent_path", "/root/completed"),
+                event("sub_agent_activity", "event_id", "call-running",
+                        "agent_thread_id", runningChildId, "agent_path", "/root/running"));
+        writeRollout(sessionsDir.resolve("rollout-child-" + completedChildId + ".jsonl"),
+                sessionMeta(completedChildId, parentId, "/root/completed"),
+                event("task_started", "turn_id", "completed-turn"),
+                turnContext("completed-turn"),
+                responseMessage("assistant", "large transcript must not be returned"),
+                event("task_complete", "turn_id", "completed-turn"));
+        writeRollout(sessionsDir.resolve("rollout-child-" + runningChildId + ".jsonl"),
+                sessionMeta(runningChildId, parentId, "/root/running"),
+                event("task_started", "turn_id", "running-turn"),
+                turnContext("running-turn"),
+                responseMessage("assistant", "still working"));
+
+        List<CodexSubagentHistoryLoader.StatusResult> results =
+                new CodexSubagentHistoryLoader(sessionsDir).loadStatuses(parentId, List.of(
+                        new CodexSubagentHistoryLoader.StatusRequest("call-completed", "/root/completed", null),
+                        new CodexSubagentHistoryLoader.StatusRequest("call-running", "/root/running", null)
+                ));
+
+        assertEquals(2, results.size());
+        assertTrue(results.get(0).success());
+        assertEquals(completedChildId, results.get(0).agentId());
+        assertEquals("completed", results.get(0).status());
+        assertTrue(results.get(0).completed());
+        assertTrue(results.get(1).success());
+        assertEquals(runningChildId, results.get(1).agentId());
+        assertEquals("running", results.get(1).status());
+        assertFalse(results.get(1).completed());
+    }
+
+    @Test
+    public void missingActivityRemainsPending() throws Exception {
+        Path sessionsDir = temporaryFolder.newFolder("pending-status-sessions").toPath();
+        String parentId = "019fa70f-0653-73e2-a613-1fb0a9e83a2b";
+        writeRollout(sessionsDir.resolve("rollout-parent-" + parentId + ".jsonl"), event("noop"));
+
+        List<CodexSubagentHistoryLoader.StatusResult> results =
+                new CodexSubagentHistoryLoader(sessionsDir).loadStatuses(parentId, List.of(
+                        new CodexSubagentHistoryLoader.StatusRequest("call-pending", null, null)
+                ));
+
+        assertEquals(1, results.size());
+        assertFalse(results.get(0).success());
+        assertEquals("running", results.get(0).status());
+        assertFalse(results.get(0).completed());
+        assertEquals("Codex subagent activity not found yet", results.get(0).error());
     }
 
     private static void writeRollout(Path path, JsonObject... records) throws IOException {

--- a/src/test/java/com/github/claudecodegui/handler/history/HistoryMessageInjectorTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/history/HistoryMessageInjectorTest.java
@@ -394,6 +394,134 @@ public class HistoryMessageInjectorTest {
     }
 
     @Test
+    public void convertCodexMessagesReplaysNestedUpdatePlan() {
+        JsonArray messages = new JsonArray();
+        messages.add(customToolCall(
+                "2026-07-23T02:00:00.000Z",
+                "plan-1",
+                "exec",
+                "const r = await tools.update_plan({"
+                    + "explanation:\"Implement and verify\","
+                    + "plan:["
+                    + "{step:\"Inspect current behavior\",status:\"completed\"},"
+                    + "{step:'Implement parser',status:'in_progress'},"
+                    + "{step:`Run tests`,status:\"pending\"}"
+                    + "]}); text(r);"
+        ));
+        messages.add(customToolCallOutput("2026-07-23T02:00:01.000Z", "plan-1", "{}"));
+
+        List<JsonObject> result = HistoryMessageInjector.convertCodexMessagesToFrontendBatch(messages);
+
+        assertEquals(2, result.size());
+        JsonObject toolUse = getOnlyRawContentBlock(result.get(0));
+        assertEquals("tool_use", toolUse.get("type").getAsString());
+        assertEquals("todowrite", toolUse.get("name").getAsString());
+        assertEquals("codex_plan_plan-1", toolUse.get("id").getAsString());
+        JsonArray todos = toolUse.getAsJsonObject("input").getAsJsonArray("todos");
+        assertEquals(3, todos.size());
+        assertEquals("Inspect current behavior", todos.get(0).getAsJsonObject().get("content").getAsString());
+        assertEquals("completed", todos.get(0).getAsJsonObject().get("status").getAsString());
+        assertEquals("Implement parser", todos.get(1).getAsJsonObject().get("content").getAsString());
+        assertEquals("in_progress", todos.get(1).getAsJsonObject().get("status").getAsString());
+        JsonObject toolResult = getOnlyRawContentBlock(result.get(1));
+        assertEquals("codex_plan_plan-1", toolResult.get("tool_use_id").getAsString());
+        assertFalse(toolResult.get("is_error").getAsBoolean());
+    }
+
+    @Test
+    public void convertCodexMessagesReplaysOnlyTopLevelPlanItems() {
+        JsonArray messages = new JsonArray();
+        messages.add(customToolCall(
+                "2026-07-23T02:00:00.000Z",
+                "plan-literal",
+                "exec",
+                "await tools.update_plan({plan:["
+                    + "{step:'Keep this item',status:'pending',metadata:{content:'Not a task'}}"
+                    + "]});"
+        ));
+
+        List<JsonObject> result = HistoryMessageInjector.convertCodexMessagesToFrontendBatch(messages);
+
+        assertEquals(1, result.size());
+        JsonArray todos = getOnlyRawContentBlock(result.get(0))
+                .getAsJsonObject("input").getAsJsonArray("todos");
+        assertEquals(1, todos.size());
+        assertEquals("Keep this item", todos.get(0).getAsJsonObject().get("content").getAsString());
+    }
+
+    @Test
+    public void convertCodexMessagesRejectsDynamicUpdatePlanExpressions() {
+        JsonArray messages = new JsonArray();
+        messages.add(customToolCall(
+                "2026-07-23T02:00:00.000Z",
+                "plan-dynamic",
+                "exec",
+                "await tools.update_plan({plan:[{step:buildStep(),status:'pending'}]});"
+        ));
+
+        List<JsonObject> result = HistoryMessageInjector.convertCodexMessagesToFrontendBatch(messages);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void convertCodexMessagesDoesNotFallBackFromDynamicLatestPlan() {
+        JsonArray messages = new JsonArray();
+        messages.add(customToolCall(
+                "2026-07-23T02:00:00.000Z",
+                "plan-latest-dynamic",
+                "exec",
+                "await tools.update_plan({plan:[{step:'Old',status:'pending'}]});"
+                    + "await tools.update_plan({plan:[{step:buildStep(),status:'pending'}]});"
+        ));
+        messages.add(customToolCall(
+                "2026-07-23T02:00:01.000Z",
+                "plan-other-object",
+                "exec",
+                "await other.tools.update_plan({plan:[{step:'Injected',status:'pending'}]});"
+        ));
+
+        List<JsonObject> result = HistoryMessageInjector.convertCodexMessagesToFrontendBatch(messages);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void convertCodexMessagesIgnoresUpdatePlanTextInStringsAndComments() {
+        JsonArray messages = new JsonArray();
+        messages.add(customToolCall(
+                "2026-07-23T02:00:00.000Z",
+                "plan-docs",
+                "exec",
+                "const example = \"tools.update_plan({plan:[{step:'Fake'}]})\";"
+                    + "// tools.update_plan({plan:[{step:'Fake'}]})\n"
+                    + "/* tools.update_plan({plan:[{step:'Fake'}]}) */"
+        ));
+
+        List<JsonObject> result = HistoryMessageInjector.convertCodexMessagesToFrontendBatch(messages);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void convertCodexMessagesPreservesEmptyUpdatePlanSnapshot() {
+        JsonArray messages = new JsonArray();
+        messages.add(customToolCall(
+                "2026-07-23T02:00:00.000Z",
+                "plan-empty",
+                "exec",
+                "await tools.update_plan({ /* clear */ plan: [], });"
+        ));
+
+        List<JsonObject> result = HistoryMessageInjector.convertCodexMessagesToFrontendBatch(messages);
+
+        assertEquals(1, result.size());
+        JsonObject toolUse = getOnlyRawContentBlock(result.get(0));
+        assertEquals("todowrite", toolUse.get("name").getAsString());
+        assertTrue(toolUse.getAsJsonObject("input").getAsJsonArray("todos").isEmpty());
+    }
+
+    @Test
     public void convertCodexMessagesSkipsWaitAndNonShellExecProtocolCards() {
         JsonArray messages = new JsonArray();
         messages.add(customToolCall(

--- a/src/test/java/com/github/claudecodegui/handler/history/HistoryMessageInjectorTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/history/HistoryMessageInjectorTest.java
@@ -392,6 +392,134 @@ public class HistoryMessageInjectorTest {
     }
 
     @Test
+    public void convertCodexMessagesReplaysNestedUpdatePlan() {
+        JsonArray messages = new JsonArray();
+        messages.add(customToolCall(
+                "2026-07-23T02:00:00.000Z",
+                "plan-1",
+                "exec",
+                "const r = await tools.update_plan({"
+                    + "explanation:\"Implement and verify\","
+                    + "plan:["
+                    + "{step:\"Inspect current behavior\",status:\"completed\"},"
+                    + "{step:'Implement parser',status:'in_progress'},"
+                    + "{step:`Run tests`,status:\"pending\"}"
+                    + "]}); text(r);"
+        ));
+        messages.add(customToolCallOutput("2026-07-23T02:00:01.000Z", "plan-1", "{}"));
+
+        List<JsonObject> result = HistoryMessageInjector.convertCodexMessagesToFrontendBatch(messages);
+
+        assertEquals(2, result.size());
+        JsonObject toolUse = getOnlyRawContentBlock(result.get(0));
+        assertEquals("tool_use", toolUse.get("type").getAsString());
+        assertEquals("todowrite", toolUse.get("name").getAsString());
+        assertEquals("codex_plan_plan-1", toolUse.get("id").getAsString());
+        JsonArray todos = toolUse.getAsJsonObject("input").getAsJsonArray("todos");
+        assertEquals(3, todos.size());
+        assertEquals("Inspect current behavior", todos.get(0).getAsJsonObject().get("content").getAsString());
+        assertEquals("completed", todos.get(0).getAsJsonObject().get("status").getAsString());
+        assertEquals("Implement parser", todos.get(1).getAsJsonObject().get("content").getAsString());
+        assertEquals("in_progress", todos.get(1).getAsJsonObject().get("status").getAsString());
+        JsonObject toolResult = getOnlyRawContentBlock(result.get(1));
+        assertEquals("codex_plan_plan-1", toolResult.get("tool_use_id").getAsString());
+        assertFalse(toolResult.get("is_error").getAsBoolean());
+    }
+
+    @Test
+    public void convertCodexMessagesReplaysOnlyTopLevelPlanItems() {
+        JsonArray messages = new JsonArray();
+        messages.add(customToolCall(
+                "2026-07-23T02:00:00.000Z",
+                "plan-literal",
+                "exec",
+                "await tools.update_plan({plan:["
+                    + "{step:'Keep this item',status:'pending',metadata:{content:'Not a task'}}"
+                    + "]});"
+        ));
+
+        List<JsonObject> result = HistoryMessageInjector.convertCodexMessagesToFrontendBatch(messages);
+
+        assertEquals(1, result.size());
+        JsonArray todos = getOnlyRawContentBlock(result.get(0))
+                .getAsJsonObject("input").getAsJsonArray("todos");
+        assertEquals(1, todos.size());
+        assertEquals("Keep this item", todos.get(0).getAsJsonObject().get("content").getAsString());
+    }
+
+    @Test
+    public void convertCodexMessagesRejectsDynamicUpdatePlanExpressions() {
+        JsonArray messages = new JsonArray();
+        messages.add(customToolCall(
+                "2026-07-23T02:00:00.000Z",
+                "plan-dynamic",
+                "exec",
+                "await tools.update_plan({plan:[{step:buildStep(),status:'pending'}]});"
+        ));
+
+        List<JsonObject> result = HistoryMessageInjector.convertCodexMessagesToFrontendBatch(messages);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void convertCodexMessagesDoesNotFallBackFromDynamicLatestPlan() {
+        JsonArray messages = new JsonArray();
+        messages.add(customToolCall(
+                "2026-07-23T02:00:00.000Z",
+                "plan-latest-dynamic",
+                "exec",
+                "await tools.update_plan({plan:[{step:'Old',status:'pending'}]});"
+                    + "await tools.update_plan({plan:[{step:buildStep(),status:'pending'}]});"
+        ));
+        messages.add(customToolCall(
+                "2026-07-23T02:00:01.000Z",
+                "plan-other-object",
+                "exec",
+                "await other.tools.update_plan({plan:[{step:'Injected',status:'pending'}]});"
+        ));
+
+        List<JsonObject> result = HistoryMessageInjector.convertCodexMessagesToFrontendBatch(messages);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void convertCodexMessagesIgnoresUpdatePlanTextInStringsAndComments() {
+        JsonArray messages = new JsonArray();
+        messages.add(customToolCall(
+                "2026-07-23T02:00:00.000Z",
+                "plan-docs",
+                "exec",
+                "const example = \"tools.update_plan({plan:[{step:'Fake'}]})\";"
+                    + "// tools.update_plan({plan:[{step:'Fake'}]})\n"
+                    + "/* tools.update_plan({plan:[{step:'Fake'}]}) */"
+        ));
+
+        List<JsonObject> result = HistoryMessageInjector.convertCodexMessagesToFrontendBatch(messages);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void convertCodexMessagesPreservesEmptyUpdatePlanSnapshot() {
+        JsonArray messages = new JsonArray();
+        messages.add(customToolCall(
+                "2026-07-23T02:00:00.000Z",
+                "plan-empty",
+                "exec",
+                "await tools.update_plan({ /* clear */ plan: [], });"
+        ));
+
+        List<JsonObject> result = HistoryMessageInjector.convertCodexMessagesToFrontendBatch(messages);
+
+        assertEquals(1, result.size());
+        JsonObject toolUse = getOnlyRawContentBlock(result.get(0));
+        assertEquals("todowrite", toolUse.get("name").getAsString());
+        assertTrue(toolUse.getAsJsonObject("input").getAsJsonArray("todos").isEmpty());
+    }
+
+    @Test
     public void convertCodexMessagesSkipsWaitAndNonShellExecProtocolCards() {
         JsonArray messages = new JsonArray();
         messages.add(customToolCall(

--- a/src/test/java/com/github/claudecodegui/handler/history/SubagentHistoryServiceStatusTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/history/SubagentHistoryServiceStatusTest.java
@@ -1,0 +1,210 @@
+package com.github.claudecodegui.handler.history;
+
+import com.github.claudecodegui.handler.core.HandlerContext;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.project.Project;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SubagentHistoryServiceStatusTest {
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void returnsLightweightStatusesWithRequestMetadata() throws Exception {
+        Path sessionsDir = temporaryFolder.newFolder("sessions").toPath();
+        String parentId = "019fa70f-0653-73e2-a613-1fb0a9e83a2b";
+        String childId = "019fb0fe-c344-7da0-9d10-20659f884100";
+        Files.writeString(sessionsDir.resolve("rollout-parent-" + parentId + ".jsonl"),
+                event("sub_agent_activity", "event_id", "call-123",
+                        "agent_thread_id", childId, "agent_path", "/root/audit_ui").toString(),
+                StandardCharsets.UTF_8);
+        Files.writeString(sessionsDir.resolve("rollout-child-" + childId + ".jsonl"),
+                String.join(System.lineSeparator(),
+                        sessionMeta(childId, parentId, "/root/audit_ui").toString(),
+                        event("task_started", "turn_id", "child-turn").toString(),
+                        turnContext("child-turn").toString(),
+                        responseMessage("transcript must stay local").toString(),
+                        event("task_complete", "turn_id", "child-turn").toString()),
+                StandardCharsets.UTF_8);
+
+        CapturingJsCallback callback = new CapturingJsCallback();
+        SubagentHistoryService service = new SubagentHistoryService(
+                createContext(callback), new CodexSubagentHistoryLoader(sessionsDir));
+
+        JsonObject request = new JsonObject();
+        request.addProperty("sessionId", parentId);
+        request.addProperty("provider", "codex");
+        request.addProperty("requestId", parentId + ":1");
+        JsonObject agent = new JsonObject();
+        agent.addProperty("toolUseId", "call-123");
+        agent.addProperty("agentPath", "/root/audit_ui");
+        JsonArray agents = new JsonArray();
+        agents.add(agent);
+        request.add("agents", agents);
+
+        service.handleLoadSubagentStatuses(request.toString());
+
+        assertTrue(callback.await());
+        assertEquals("onSubagentStatusesLoaded", callback.functionName);
+        assertTrue(callback.payload.contains(parentId + ":1"));
+        assertTrue(callback.payload.contains(childId));
+        assertTrue(callback.payload.contains("completed"));
+        assertFalse(callback.payload.contains("messages"));
+        assertFalse(callback.payload.contains("transcript must stay local"));
+    }
+
+    @Test
+    public void rejectsRequestsAboveAgentLimitBeforeLoading() throws Exception {
+        CapturingJsCallback callback = new CapturingJsCallback();
+        SubagentHistoryService service = new SubagentHistoryService(
+                createContext(callback), new CodexSubagentHistoryLoader(temporaryFolder.newFolder("empty").toPath()));
+        JsonObject request = new JsonObject();
+        request.addProperty("sessionId", "session-1");
+        request.addProperty("provider", "codex");
+        request.addProperty("requestId", "status-request-limit");
+        JsonArray agents = new JsonArray();
+        for (int i = 0; i <= CodexSubagentHistoryLoader.MAX_STATUS_REQUESTS; i++) {
+            JsonObject agent = new JsonObject();
+            agent.addProperty("toolUseId", "call-" + i);
+            agents.add(agent);
+        }
+        request.add("agents", agents);
+
+        service.handleLoadSubagentStatuses(request.toString());
+
+        assertTrue(callback.await());
+        assertEquals("onSubagentStatusesLoaded", callback.functionName);
+        assertTrue(callback.payload.contains("Too many agents"));
+        assertTrue(callback.payload.contains("\\\"success\\\":false"));
+    }
+
+    private static HandlerContext createContext(CapturingJsCallback callback) {
+        Project project = (Project) Proxy.newProxyInstance(
+                SubagentHistoryServiceStatusTest.class.getClassLoader(),
+                new Class<?>[]{Project.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getBasePath" -> "D:\\Projects\\test";
+                    case "getName" -> "test-project";
+                    case "isDisposed" -> false;
+                    case "toString" -> "test-project";
+                    case "hashCode" -> 1;
+                    case "equals" -> proxy == args[0];
+                    default -> defaultValue(method.getReturnType());
+                }
+        );
+        return new HandlerContext(project, null, null, null, callback);
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        if (boolean.class.equals(returnType)) {
+            return false;
+        }
+        if (int.class.equals(returnType)) {
+            return 0;
+        }
+        if (long.class.equals(returnType)) {
+            return 0L;
+        }
+        if (double.class.equals(returnType)) {
+            return 0D;
+        }
+        if (float.class.equals(returnType)) {
+            return 0F;
+        }
+        if (short.class.equals(returnType)) {
+            return (short) 0;
+        }
+        if (byte.class.equals(returnType)) {
+            return (byte) 0;
+        }
+        if (char.class.equals(returnType)) {
+            return (char) 0;
+        }
+        return null;
+    }
+
+    private static JsonObject sessionMeta(String id, String parentId, String agentPath) {
+        JsonObject spawn = object("parent_thread_id", parentId, "agent_path", agentPath);
+        JsonObject subagent = new JsonObject();
+        subagent.add("thread_spawn", spawn);
+        JsonObject source = new JsonObject();
+        source.add("subagent", subagent);
+        JsonObject payload = object("id", id);
+        payload.add("source", source);
+        return record("session_meta", payload);
+    }
+
+    private static JsonObject turnContext(String turnId) {
+        return record("turn_context", object("turn_id", turnId));
+    }
+
+    private static JsonObject event(String type, String... properties) {
+        JsonObject payload = object(properties);
+        payload.addProperty("type", type);
+        return record("event_msg", payload);
+    }
+
+    private static JsonObject responseMessage(String text) {
+        JsonObject block = object("type", "output_text", "text", text);
+        JsonArray content = new JsonArray();
+        content.add(block);
+        JsonObject payload = object("type", "message", "role", "assistant");
+        payload.add("content", content);
+        return record("response_item", payload);
+    }
+
+    private static JsonObject record(String type, JsonObject payload) {
+        JsonObject record = new JsonObject();
+        record.addProperty("type", type);
+        record.add("payload", payload);
+        return record;
+    }
+
+    private static JsonObject object(String... properties) {
+        JsonObject object = new JsonObject();
+        for (int i = 0; i < properties.length; i += 2) {
+            object.addProperty(properties[i], properties[i + 1]);
+        }
+        return object;
+    }
+
+    private static final class CapturingJsCallback implements HandlerContext.JsCallback {
+        private final CountDownLatch latch = new CountDownLatch(1);
+        private volatile String functionName;
+        private volatile String payload;
+
+        @Override
+        public void callJavaScript(String name, String... args) {
+            functionName = name;
+            payload = args.length > 0 ? args[0] : "";
+            latch.countDown();
+        }
+
+        @Override
+        public String escapeJs(String str) {
+            return str;
+        }
+
+        private boolean await() throws InterruptedException {
+            return latch.await(5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/webview/src/components/StatusPanel/StatusPanel.less
+++ b/webview/src/components/StatusPanel/StatusPanel.less
@@ -642,6 +642,9 @@
 
   &.status-in-progress .codicon {
     color: var(--color-todo-panel-progress);
+  }
+
+  &.status-in-progress.is-streaming .codicon {
     animation: status-spin 1s linear infinite;
   }
 

--- a/webview/src/components/StatusPanel/StatusPanel.less
+++ b/webview/src/components/StatusPanel/StatusPanel.less
@@ -641,6 +641,9 @@
 
   &.status-in-progress .codicon {
     color: var(--color-todo-panel-progress);
+  }
+
+  &.status-in-progress.is-streaming .codicon {
     animation: status-spin 1s linear infinite;
   }
 

--- a/webview/src/components/StatusPanel/StatusPanel.test.tsx
+++ b/webview/src/components/StatusPanel/StatusPanel.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import StatusPanel from './StatusPanel';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('StatusPanel', () => {
+  it.each([
+    ['codex', 'statusPanel.todoTab'],
+    ['claude', 'statusPanel.tasksTab'],
+  ])('uses the provider-specific todo label for %s', (currentProvider, expectedLabel) => {
+    render(
+      <StatusPanel
+        todos={[]}
+        fileChanges={[]}
+        subagents={[]}
+        currentProvider={currentProvider}
+      />,
+    );
+
+    expect(screen.getByText(expectedLabel)).toBeTruthy();
+  });
+});

--- a/webview/src/components/StatusPanel/StatusPanel.tsx
+++ b/webview/src/components/StatusPanel/StatusPanel.tsx
@@ -205,7 +205,7 @@ const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, current
   const renderPopoverContent = () => {
     switch (openPopover) {
       case 'todo':
-        return <TodoList todos={todos} />;
+        return <TodoList todos={todos} isStreaming={isStreaming} />;
       case 'subagent':
         return <SubagentList subagents={subagents} histories={subagentHistories} currentSessionId={currentSessionId} currentProvider={currentProvider} isStreaming={isStreaming} />;
       case 'files':
@@ -234,7 +234,9 @@ const StatusPanel = ({ todos, fileChanges, subagents, subagentHistories, current
           onClick={() => handleTabClick('todo')}
         >
           <span className="codicon codicon-checklist" />
-          <span className="tab-label">{t('statusPanel.tasksTab')}</span>
+          <span className="tab-label">
+            {t(currentProvider === 'codex' ? 'statusPanel.todoTab' : 'statusPanel.tasksTab')}
+          </span>
           {hasTodos && (
             <span className="tab-progress">
               {completedCount}/{totalCount}

--- a/webview/src/components/StatusPanel/SubagentList.test.tsx
+++ b/webview/src/components/StatusPanel/SubagentList.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import type { SubagentInfo } from '../../types';
+import type { SubagentHistoryResponse, SubagentInfo } from '../../types';
 import SubagentList from './SubagentList';
 
 const sendBridgeEventMock = vi.hoisted(() => vi.fn());
@@ -39,6 +39,51 @@ describe('SubagentList', () => {
         sessionId: 'session-1',
         provider: 'codex',
         agentPath: 'audit_ui',
+        description: 'Review anchors',
+        toolUseId: 'call-spawn',
+      }),
+    ));
+  });
+
+  it('loads the full transcript when only a lightweight status snapshot exists', async () => {
+    const subagent: SubagentInfo = {
+      id: 'call-spawn',
+      type: 'audit',
+      description: 'Review anchors',
+      status: 'running',
+      isAsync: true,
+      messageIndex: 0,
+      agentPath: 'audit_ui',
+    };
+    const histories: Record<string, SubagentHistoryResponse> = {
+      'call-spawn': {
+        success: true,
+        completed: false,
+        status: 'running',
+        toolUseId: 'call-spawn',
+        agentId: 'agent-resolved',
+        agentPath: '/root/audit_ui',
+      },
+    };
+
+    render(
+      <SubagentList
+        subagents={[subagent]}
+        histories={histories}
+        currentSessionId="session-1"
+        currentProvider="codex"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(sendBridgeEventMock).toHaveBeenCalledWith(
+      'load_subagent_session',
+      JSON.stringify({
+        sessionId: 'session-1',
+        provider: 'codex',
+        agentId: 'agent-resolved',
+        agentPath: '/root/audit_ui',
         description: 'Review anchors',
         toolUseId: 'call-spawn',
       }),

--- a/webview/src/components/StatusPanel/SubagentList.tsx
+++ b/webview/src/components/StatusPanel/SubagentList.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import type { SubagentHistoryResponse, SubagentInfo } from '../../types';
 import { sendBridgeEvent } from '../../utils/bridge';
+import { hasSubagentTranscript } from '../../utils/subagentResult';
 import { subagentStatusIconMap } from './types';
 import SubagentProcessDetails from './SubagentProcessDetails';
 
@@ -50,7 +51,7 @@ const SubagentRow = memo(({ subagent, isExpanded, history, canLoad, onToggle, t 
 
       {isExpanded && (
         <SubagentProcessDetails
-          agentId={subagent.agentId}
+          agentId={history?.agentId ?? subagent.agentId}
           totalDurationMs={subagent.totalDurationMs}
           totalTokens={subagent.totalTokens}
           totalToolUseCount={subagent.totalToolUseCount}
@@ -79,11 +80,13 @@ const SubagentList = memo(({ subagents, histories = {}, currentSessionId, curren
 
   const requestHistory = useCallback((subagent: SubagentInfo) => {
     if (!currentSessionId) return;
+    const history = historiesRef.current[subagent.id]
+      ?? (subagent.agentId ? historiesRef.current[subagent.agentId] : undefined);
     sendBridgeEvent('load_subagent_session', JSON.stringify({
       sessionId: currentSessionId,
       provider: currentProvider,
-      agentId: subagent.agentId,
-      agentPath: subagent.agentPath,
+      agentId: history?.agentId ?? subagent.agentId,
+      agentPath: history?.agentPath ?? subagent.agentPath,
       description: subagent.description,
       toolUseId: subagent.id,
     }));
@@ -98,7 +101,9 @@ const SubagentList = memo(({ subagents, histories = {}, currentSessionId, curren
     if (!expandedId) return;
     const subagent = subagentsRef.current.find((item) => item.id === expandedId);
     if (!subagent || !currentSessionId) return;
-    if (!historiesRef.current[expandedId]) {
+    const history = historiesRef.current[expandedId]
+      ?? (subagent.agentId ? historiesRef.current[subagent.agentId] : undefined);
+    if (!hasSubagentTranscript(history)) {
       requestHistory(subagent);
     }
     if (!currentSessionId || subagent.status !== 'running') return;

--- a/webview/src/components/StatusPanel/SubagentList.tsx
+++ b/webview/src/components/StatusPanel/SubagentList.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import type { SubagentHistoryResponse, SubagentInfo } from '../../types';
 import { sendBridgeEvent } from '../../utils/bridge';
+import { hasSubagentTranscript } from '../../utils/subagentResult';
 import { subagentStatusIconMap } from './types';
 import SubagentProcessDetails from './SubagentProcessDetails';
 
@@ -50,7 +51,7 @@ const SubagentRow = memo(({ subagent, isExpanded, history, canLoad, onToggle, t 
 
       {isExpanded && (
         <SubagentProcessDetails
-          agentId={subagent.agentId}
+          agentId={history?.agentId ?? subagent.agentId}
           totalDurationMs={subagent.totalDurationMs}
           totalTokens={subagent.totalTokens}
           totalToolUseCount={subagent.totalToolUseCount}
@@ -78,11 +79,13 @@ const SubagentList = memo(({ subagents, histories = {}, currentSessionId, curren
 
   const requestHistory = useCallback((subagent: SubagentInfo) => {
     if (!currentSessionId) return;
+    const history = historiesRef.current[subagent.id]
+      ?? (subagent.agentId ? historiesRef.current[subagent.agentId] : undefined);
     sendBridgeEvent('load_subagent_session', JSON.stringify({
       sessionId: currentSessionId,
       provider: currentProvider,
-      agentId: subagent.agentId,
-      agentPath: subagent.agentPath,
+      agentId: history?.agentId ?? subagent.agentId,
+      agentPath: history?.agentPath ?? subagent.agentPath,
       description: subagent.description,
       toolUseId: subagent.id,
     }));
@@ -97,7 +100,9 @@ const SubagentList = memo(({ subagents, histories = {}, currentSessionId, curren
     if (!expandedId) return;
     const subagent = subagentsRef.current.find((item) => item.id === expandedId);
     if (!subagent || !currentSessionId) return;
-    if (!historiesRef.current[expandedId]) {
+    const history = historiesRef.current[expandedId]
+      ?? (subagent.agentId ? historiesRef.current[subagent.agentId] : undefined);
+    if (!hasSubagentTranscript(history)) {
       requestHistory(subagent);
     }
     if (!currentSessionId || subagent.status !== 'running') return;

--- a/webview/src/components/StatusPanel/SubagentProcessDetails.test.tsx
+++ b/webview/src/components/StatusPanel/SubagentProcessDetails.test.tsx
@@ -39,4 +39,24 @@ describe('SubagentProcessDetails', () => {
     const { container } = render(<SubagentProcessDetails history={history} canLoad />);
     expect(container.querySelector('.subagent-prompt-card')).toBeNull();
   });
+
+  it('shows history errors only for terminal error status', () => {
+    const { container, rerender } = render(
+      <SubagentProcessDetails
+        history={{ success: false, status: 'running', error: 'Codex subagent activity not found yet' }}
+        canLoad
+      />,
+    );
+
+    expect(container.querySelector('.subagent-error')).toBeNull();
+
+    rerender(
+      <SubagentProcessDetails
+        history={{ success: false, status: 'error', error: 'Subagent history failed' }}
+        canLoad
+      />,
+    );
+
+    expect(container.querySelector('.subagent-error')?.textContent).toBe('Subagent history failed');
+  });
 });

--- a/webview/src/components/StatusPanel/SubagentProcessDetails.test.tsx
+++ b/webview/src/components/StatusPanel/SubagentProcessDetails.test.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import SubagentProcessDetails from './SubagentProcessDetails';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('SubagentProcessDetails', () => {
+  it('shows history errors only for terminal error status', () => {
+    const { container, rerender } = render(
+      <SubagentProcessDetails
+        history={{ success: false, status: 'running', error: 'Codex subagent activity not found yet' }}
+        canLoad
+      />,
+    );
+
+    expect(container.querySelector('.subagent-error')).toBeNull();
+
+    rerender(
+      <SubagentProcessDetails
+        history={{ success: false, status: 'error', error: 'Subagent history failed' }}
+        canLoad
+      />,
+    );
+
+    expect(container.querySelector('.subagent-error')?.textContent).toBe('Subagent history failed');
+  });
+});

--- a/webview/src/components/StatusPanel/SubagentProcessDetails.tsx
+++ b/webview/src/components/StatusPanel/SubagentProcessDetails.tsx
@@ -58,7 +58,7 @@ const SubagentProcessDetails = memo(function SubagentProcessDetails({
         {stats && <div className="subagent-process-stats">{stats}</div>}
       </div>
 
-      {history?.error && <div className="subagent-error">{history.error}</div>}
+      {history?.status === 'error' && history.error && <div className="subagent-error">{history.error}</div>}
 
       {hasContent ? (
         <div className="subagent-process-sections">

--- a/webview/src/components/StatusPanel/SubagentProcessDetails.tsx
+++ b/webview/src/components/StatusPanel/SubagentProcessDetails.tsx
@@ -54,7 +54,7 @@ const SubagentProcessDetails = memo(function SubagentProcessDetails({
         {stats && <div className="subagent-process-stats">{stats}</div>}
       </div>
 
-      {history?.error && <div className="subagent-error">{history.error}</div>}
+      {history?.status === 'error' && history.error && <div className="subagent-error">{history.error}</div>}
 
       {hasContent ? (
         <div className="subagent-process-sections">

--- a/webview/src/components/StatusPanel/TodoList.test.tsx
+++ b/webview/src/components/StatusPanel/TodoList.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import TodoList from './TodoList';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('TodoList', () => {
+  it('only animates an in-progress item while the conversation is streaming', () => {
+    const todo = [{ content: 'Implement', status: 'in_progress' as const }];
+    const { container, rerender } = render(<TodoList todos={todo} isStreaming={false} />);
+
+    expect(container.querySelector('.status-panel-todo-icon')?.classList.contains('is-streaming')).toBe(false);
+
+    rerender(<TodoList todos={todo} isStreaming />);
+    expect(container.querySelector('.status-panel-todo-icon')?.classList.contains('is-streaming')).toBe(true);
+  });
+});

--- a/webview/src/components/StatusPanel/TodoList.tsx
+++ b/webview/src/components/StatusPanel/TodoList.tsx
@@ -5,9 +5,10 @@ import { statusClassMap, statusIconMap } from './types';
 
 interface TodoListProps {
   todos: TodoItem[];
+  isStreaming?: boolean;
 }
 
-const TodoList = memo(({ todos }: TodoListProps) => {
+const TodoList = memo(({ todos, isStreaming = false }: TodoListProps) => {
   const { t } = useTranslation();
 
   if (todos.length === 0) {
@@ -24,7 +25,7 @@ const TodoList = memo(({ todos }: TodoListProps) => {
 
         return (
           <div key={todo.id ?? index} className={`status-panel-todo-item ${statusClass}`}>
-            <div className={`status-panel-todo-icon ${statusClass}`}>
+            <div className={`status-panel-todo-icon ${statusClass}${status === 'in_progress' && isStreaming ? ' is-streaming' : ''}`}>
               <span className={`codicon ${iconClass}`} />
             </div>
             <div className="status-panel-todo-content">

--- a/webview/src/components/toolBlocks/AgentGroupBlock.test.tsx
+++ b/webview/src/components/toolBlocks/AgentGroupBlock.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render } from '@testing-library/react';
+import type { ClaudeContentBlock } from '../../types';
+import AgentGroupBlock from './AgentGroupBlock';
+
+const mockSendBridgeEvent = vi.fn();
+let mockHistories: Record<string, unknown> = {};
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../utils/bridge', () => ({
+  sendBridgeEvent: (...args: unknown[]) => mockSendBridgeEvent(...args),
+}));
+
+vi.mock('../../utils/expandedState', () => ({
+  getPersistedExpanded: () => false,
+  setPersistedExpanded: () => undefined,
+}));
+
+vi.mock('../../contexts/SubagentContext', () => ({
+  useSubagentHistories: () => mockHistories,
+  useSessionId: () => 'session-1',
+  useSessionProvider: () => 'codex',
+  useGetToolResultRaw: () => () => null,
+  useTaskEvent: () => undefined,
+}));
+
+vi.mock('../MessageItem/ContentBlockRenderer', () => ({
+  ContentBlockRenderer: () => null,
+}));
+
+describe('AgentGroupBlock', () => {
+  beforeEach(() => {
+    mockSendBridgeEvent.mockReset();
+    mockHistories = {};
+  });
+
+  it('uses safe spawn identity and loads details from a status-only snapshot', () => {
+    const opaqueMessage = 'gAAAAABopaque-transport-content';
+    mockHistories = { 'call-agent-group': { success: true, status: 'running' } };
+    const agentBlock = {
+      type: 'tool_use',
+      id: 'call-agent-group',
+      name: 'spawn_agent',
+      input: { task_name: '/root/reviewer', message: opaqueMessage, prompt: opaqueMessage },
+    } as ClaudeContentBlock;
+
+    const { container } = render(
+      <AgentGroupBlock
+        agentBlock={agentBlock}
+        followingBlocks={[]}
+        messageIndex={0}
+        isStreaming={false}
+        isLastMessage
+        isThinking={false}
+        findToolResult={() => null}
+      />,
+    );
+
+    expect(container.querySelector('.task-header')?.textContent).toContain('reviewer');
+    expect(container.textContent).not.toContain(opaqueMessage);
+
+    fireEvent.click(container.querySelector('.task-header') as HTMLElement);
+    expect(mockSendBridgeEvent).toHaveBeenCalledWith(
+      'load_subagent_session',
+      expect.stringContaining('"toolUseId":"call-agent-group"'),
+    );
+  });
+});

--- a/webview/src/components/toolBlocks/AgentGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/AgentGroupBlock.tsx
@@ -219,7 +219,7 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
             totalTokens={(isAsync ? taskEvent?.totalTokens : undefined) ?? agentToolMeta.totalTokens}
             totalToolUseCount={(isAsync ? taskEvent?.totalToolUseCount : undefined) ?? agentToolMeta.totalToolUseCount}
             resultText={(isAsync ? taskEvent?.summary : undefined) ?? extractResultText(result)}
-            prompt={typeof input?.prompt === 'string' ? input.prompt : undefined}
+            prompt={toolName !== 'spawn_agent' && typeof input?.prompt === 'string' ? input.prompt : undefined}
             history={history}
             canLoad={Boolean(currentSessionId)}
           />

--- a/webview/src/components/toolBlocks/AgentGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/AgentGroupBlock.tsx
@@ -6,6 +6,7 @@ import { sendBridgeEvent } from '../../utils/bridge';
 import { getPersistedExpanded, setPersistedExpanded } from '../../utils/expandedState';
 import {
   extractResultText,
+  hasSubagentTranscript,
   isAsyncAgentInput,
   parseAgentToolMeta,
   parseSpawnAgentMeta,
@@ -93,18 +94,24 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
   const taskEvent = useTaskEvent(toolId);
   const taskFailed = taskEvent?.status === 'failed' || taskEvent?.status === 'stopped';
 
-  const agentType = getAgentType(agentBlock);
-  const summary = getAgentSummary(agentBlock);
   const agentToolMeta = parseAgentToolMeta(getToolResultRaw, toolId);
   const spawnMeta = toolName === 'spawn_agent'
     ? parseSpawnAgentMeta(input ?? {}, result)
     : {};
+  const agentType = toolName === 'spawn_agent'
+    ? spawnMeta.identityLabel ?? ''
+    : getAgentType(agentBlock);
+  const summary = toolName === 'spawn_agent'
+    ? spawnMeta.description?.slice(0, MAX_SUMMARY_LENGTH) ?? ''
+    : getAgentSummary(agentBlock);
   const agentId = spawnMeta.agentId
     ?? agentToolMeta.agentId
     ?? (input?.agent_id as string | undefined)
     ?? (input?.agentId as string | undefined);
   const agentPath = spawnMeta.agentPath;
   const history = (toolId ? histories[toolId] : undefined) ?? (agentId ? histories[agentId] : undefined);
+  const resolvedAgentId = history?.agentId ?? agentId;
+  const resolvedAgentPath = history?.agentPath ?? agentPath;
   const historyFailed = history?.status === 'error';
   // A settled main turn is only the launch boundary for a background Agent. Use
   // the live task_notification or a terminal sidechain end_turn as completion.
@@ -124,16 +131,16 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
   const pollingTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (!expanded || !currentSessionId || !toolId || history) return;
+    if (!expanded || !currentSessionId || !toolId || hasSubagentTranscript(history)) return;
     sendBridgeEvent('load_subagent_session', JSON.stringify({
       sessionId: currentSessionId,
       provider: currentProvider,
-      agentId,
-      agentPath,
+      agentId: resolvedAgentId,
+      agentPath: resolvedAgentPath,
       description: typeof summary === 'string' ? summary : undefined,
       toolUseId: toolId,
     }));
-  }, [agentId, agentPath, currentProvider, currentSessionId, summary, expanded, history, toolId]);
+  }, [currentProvider, currentSessionId, summary, expanded, history, resolvedAgentId, resolvedAgentPath, toolId]);
 
   useEffect(() => {
     // Clear existing timer when dependencies change or conditions no longer met
@@ -151,8 +158,8 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
         sendBridgeEvent('load_subagent_session', JSON.stringify({
           sessionId: currentSessionId,
           provider: currentProvider,
-          agentId,
-          agentPath,
+          agentId: resolvedAgentId,
+          agentPath: resolvedAgentPath,
           description: typeof summary === 'string' ? summary : undefined,
           toolUseId: toolId,
         }));
@@ -165,7 +172,7 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
         pollingTimerRef.current = null;
       }
     };
-  }, [agentId, agentPath, currentProvider, currentSessionId, summary, expanded, isCompleted, isError, toolId]);
+  }, [currentProvider, currentSessionId, summary, expanded, isCompleted, isError, resolvedAgentId, resolvedAgentPath, toolId]);
 
   return (
     <div className="task-container agent-group-container">
@@ -207,7 +214,7 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
       {expanded && (
         <div className="task-details agent-group-content">
           <SubagentProcessDetails
-            agentId={(isAsync ? taskEvent?.agentId : undefined) ?? agentId}
+            agentId={(isAsync ? taskEvent?.agentId : undefined) ?? resolvedAgentId}
             totalDurationMs={(isAsync ? taskEvent?.totalDurationMs : undefined) ?? agentToolMeta.totalDurationMs}
             totalTokens={(isAsync ? taskEvent?.totalTokens : undefined) ?? agentToolMeta.totalTokens}
             totalToolUseCount={(isAsync ? taskEvent?.totalToolUseCount : undefined) ?? agentToolMeta.totalToolUseCount}

--- a/webview/src/components/toolBlocks/AgentGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/AgentGroupBlock.tsx
@@ -6,6 +6,7 @@ import { sendBridgeEvent } from '../../utils/bridge';
 import { getPersistedExpanded, setPersistedExpanded } from '../../utils/expandedState';
 import {
   extractResultText,
+  hasSubagentTranscript,
   isAsyncAgentInput,
   parseAgentToolMeta,
   parseSpawnAgentMeta,
@@ -90,18 +91,24 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
   const taskEvent = useTaskEvent(toolId);
   const taskFailed = taskEvent?.status === 'failed' || taskEvent?.status === 'stopped';
 
-  const agentType = getAgentType(agentBlock);
-  const summary = getAgentSummary(agentBlock);
   const agentToolMeta = parseAgentToolMeta(getToolResultRaw, toolId);
   const spawnMeta = toolName === 'spawn_agent'
     ? parseSpawnAgentMeta(input ?? {}, result)
     : {};
+  const agentType = toolName === 'spawn_agent'
+    ? spawnMeta.identityLabel ?? ''
+    : getAgentType(agentBlock);
+  const summary = toolName === 'spawn_agent'
+    ? spawnMeta.description?.slice(0, MAX_SUMMARY_LENGTH) ?? ''
+    : getAgentSummary(agentBlock);
   const agentId = spawnMeta.agentId
     ?? agentToolMeta.agentId
     ?? (input?.agent_id as string | undefined)
     ?? (input?.agentId as string | undefined);
   const agentPath = spawnMeta.agentPath;
   const history = (toolId ? histories[toolId] : undefined) ?? (agentId ? histories[agentId] : undefined);
+  const resolvedAgentId = history?.agentId ?? agentId;
+  const resolvedAgentPath = history?.agentPath ?? agentPath;
   const historyFailed = history?.status === 'error';
   // A settled main turn is only the launch boundary for a background Agent. Use
   // the live task_notification or a terminal sidechain end_turn as completion.
@@ -121,16 +128,16 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
   const pollingTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (!expanded || !currentSessionId || !toolId || history) return;
+    if (!expanded || !currentSessionId || !toolId || hasSubagentTranscript(history)) return;
     sendBridgeEvent('load_subagent_session', JSON.stringify({
       sessionId: currentSessionId,
       provider: currentProvider,
-      agentId,
-      agentPath,
+      agentId: resolvedAgentId,
+      agentPath: resolvedAgentPath,
       description: typeof summary === 'string' ? summary : undefined,
       toolUseId: toolId,
     }));
-  }, [agentId, agentPath, currentProvider, currentSessionId, summary, expanded, history, toolId]);
+  }, [currentProvider, currentSessionId, summary, expanded, history, resolvedAgentId, resolvedAgentPath, toolId]);
 
   useEffect(() => {
     // Clear existing timer when dependencies change or conditions no longer met
@@ -148,8 +155,8 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
         sendBridgeEvent('load_subagent_session', JSON.stringify({
           sessionId: currentSessionId,
           provider: currentProvider,
-          agentId,
-          agentPath,
+          agentId: resolvedAgentId,
+          agentPath: resolvedAgentPath,
           description: typeof summary === 'string' ? summary : undefined,
           toolUseId: toolId,
         }));
@@ -162,7 +169,7 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
         pollingTimerRef.current = null;
       }
     };
-  }, [agentId, agentPath, currentProvider, currentSessionId, summary, expanded, isCompleted, isError, toolId]);
+  }, [currentProvider, currentSessionId, summary, expanded, isCompleted, isError, resolvedAgentId, resolvedAgentPath, toolId]);
 
   return (
     <div className="task-container agent-group-container">
@@ -204,7 +211,7 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
       {expanded && (
         <div className="task-details agent-group-content">
           <SubagentProcessDetails
-            agentId={(isAsync ? taskEvent?.agentId : undefined) ?? agentId}
+            agentId={(isAsync ? taskEvent?.agentId : undefined) ?? resolvedAgentId}
             totalDurationMs={(isAsync ? taskEvent?.totalDurationMs : undefined) ?? agentToolMeta.totalDurationMs}
             totalTokens={(isAsync ? taskEvent?.totalTokens : undefined) ?? agentToolMeta.totalTokens}
             totalToolUseCount={(isAsync ? taskEvent?.totalToolUseCount : undefined) ?? agentToolMeta.totalToolUseCount}

--- a/webview/src/components/toolBlocks/TaskExecutionBlock.test.tsx
+++ b/webview/src/components/toolBlocks/TaskExecutionBlock.test.tsx
@@ -420,4 +420,40 @@ describe('TaskExecutionBlock polling', () => {
     );
     expect(container.querySelector('.tool-status-indicator')?.className).toContain('pending');
   });
+
+  it('uses task identity without rendering Codex spawn_agent message content', () => {
+    mockUseSessionProvider.mockReturnValue('codex');
+    const opaqueMessage = 'gAAAAABopaque-transport-content';
+
+    const { container } = render(
+      <TaskExecutionBlock
+        name="spawn_agent"
+        toolId="call-safe"
+        input={{ task_name: '/root/reviewer', message: opaqueMessage, prompt: opaqueMessage } as any}
+      />,
+    );
+
+    expect(container.querySelector('.task-header')?.textContent).toContain('reviewer');
+    fireEvent.click(container.querySelector('.task-header') as HTMLElement);
+    expect(container.textContent).not.toContain(opaqueMessage);
+  });
+
+  it('loads full details when only a lightweight status snapshot exists', () => {
+    mockUseSessionProvider.mockReturnValue('codex');
+    mockHistories = { 'call-status': { success: true, status: 'running' } };
+
+    const { container } = render(
+      <TaskExecutionBlock
+        name="spawn_agent"
+        toolId="call-status"
+        input={{ task_name: '/root/reviewer', message: 'opaque' } as any}
+      />,
+    );
+
+    fireEvent.click(container.querySelector('.task-header') as HTMLElement);
+    expect(mockSendBridgeEvent).toHaveBeenCalledWith(
+      'load_subagent_session',
+      expect.stringContaining('"toolUseId":"call-status"'),
+    );
+  });
 });

--- a/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
+++ b/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
@@ -5,6 +5,7 @@ import { normalizeToolName } from '../../utils/toolConstants';
 import { sendBridgeEvent } from '../../utils/bridge';
 import {
   extractResultText,
+  hasSubagentTranscript,
   isAsyncAgentInput,
   parseAgentToolMeta,
   parseSpawnAgentMeta,
@@ -73,9 +74,13 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
   const agentToolMeta = !isSpawnAgent && input ? parseAgentToolMeta(getToolResultRaw, toolId) : {};
   const agentId = spawnMeta.agentId ?? agentToolMeta.agentId;
   const agentPath = spawnMeta.agentPath;
-  const identityLabel = spawnMeta.nickname || (typeof subagentType === 'string' && subagentType ? subagentType : undefined);
+  const identityLabel = spawnMeta.identityLabel
+    ?? (typeof subagentType === 'string' && subagentType ? subagentType : undefined);
   const modelSummary = [spawnMeta.model, spawnMeta.reasoningEffort].filter(Boolean).join(' ');
   const shortAgentId = shortenAgentId(agentId);
+  const historyDescription = isSpawnAgent
+    ? spawnMeta.description
+    : typeof description === 'string' ? description : undefined;
 
   // A background (run_in_background) Agent only gets a launch acknowledgment
   // tool_result; its real terminal status arrives later via a task_notification
@@ -98,6 +103,8 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
   // assistant/end_turn. A settled main turn alone proves only that the launch
   // turn ended; the background sidechain may still be running.
   const history = (toolId ? histories[toolId] : undefined) ?? (agentId ? histories[agentId] : undefined);
+  const resolvedAgentId = history?.agentId ?? agentId;
+  const resolvedAgentPath = history?.agentPath ?? agentPath;
   const historyFailed = history?.status === 'error';
   const isCompleted = isAsync
     ? (taskEvent ? !taskFailed : history?.completed === true)
@@ -109,23 +116,23 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
   // For background agents the task_notification carries the authoritative usage
   // and summary (the launch ack has none); prefer it over toolUseResult. Sync
   // agents keep reading toolUseResult as before.
-  const detailAgentId = (isAsync ? taskEvent?.agentId : undefined) ?? agentId;
+  const detailAgentId = (isAsync ? taskEvent?.agentId : undefined) ?? resolvedAgentId;
   const detailDurationMs = (isAsync ? taskEvent?.totalDurationMs : undefined) ?? agentToolMeta.totalDurationMs;
   const detailTokens = (isAsync ? taskEvent?.totalTokens : undefined) ?? agentToolMeta.totalTokens;
   const detailToolUseCount = (isAsync ? taskEvent?.totalToolUseCount : undefined) ?? agentToolMeta.totalToolUseCount;
   const detailResultText = (isAsync ? taskEvent?.summary : undefined) ?? extractResultText(result);
 
   useEffect(() => {
-    if (!input || !expanded || !isAgentTool || !currentSessionId || !toolId || history) return;
+    if (!input || !expanded || !isAgentTool || !currentSessionId || !toolId || hasSubagentTranscript(history)) return;
     sendBridgeEvent('load_subagent_session', JSON.stringify({
       sessionId: currentSessionId,
       provider: currentProvider,
-      agentId,
-      agentPath,
-      description: typeof description === 'string' ? description : undefined,
+      agentId: resolvedAgentId,
+      agentPath: resolvedAgentPath,
+      description: historyDescription,
       toolUseId: toolId,
     }));
-  }, [input, agentId, agentPath, currentProvider, currentSessionId, description, expanded, history, isAgentTool, toolId]);
+  }, [input, currentProvider, currentSessionId, expanded, history, historyDescription, isAgentTool, resolvedAgentId, resolvedAgentPath, toolId]);
 
   // Poll while an expanded async Agent is unresolved, including after a main
   // turn settles. This lets a reloaded session observe the sidechain's terminal
@@ -145,14 +152,14 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
       sendBridgeEvent('load_subagent_session', JSON.stringify({
         sessionId: currentSessionId,
         provider: currentProvider,
-        agentId,
-        agentPath,
-        description: typeof description === 'string' ? description : undefined,
+        agentId: resolvedAgentId,
+        agentPath: resolvedAgentPath,
+        description: historyDescription,
         toolUseId: toolId,
       }));
     }, 2_000);
     return () => window.clearInterval(timer);
-  }, [input, agentId, agentPath, currentProvider, currentSessionId, description, shouldPollHistory, toolId]);
+  }, [input, currentProvider, currentSessionId, historyDescription, resolvedAgentId, resolvedAgentPath, shouldPollHistory, toolId]);
 
   if (!input) {
     return null;
@@ -238,7 +245,7 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
               />
             )}
 
-            {typeof prompt === 'string' && (
+            {!isSpawnAgent && typeof prompt === 'string' && (
               <div className="task-field">
                 <div className="task-field-label">
                   <span className="codicon codicon-comment" />
@@ -248,7 +255,9 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
               </div>
             )}
 
-            {Object.entries(rest).map(([key, value]) => (
+            {Object.entries(rest)
+              .filter(([key]) => !isSpawnAgent || !['message', 'items', 'task_name', 'taskName'].includes(key))
+              .map(([key, value]) => (
               <div key={key} className="task-field">
                 <div className="task-field-label">{key}</div>
                 <div className="task-field-content">
@@ -257,7 +266,7 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
                     : String(value)}
                 </div>
               </div>
-            ))}
+              ))}
           </div>
         </div>
       )}

--- a/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
+++ b/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
@@ -239,7 +239,7 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
                 totalTokens={detailTokens}
                 totalToolUseCount={detailToolUseCount}
                 resultText={detailResultText}
-                prompt={typeof prompt === 'string' ? prompt : undefined}
+                prompt={!isSpawnAgent && typeof prompt === 'string' ? prompt : undefined}
                 history={history}
                 canLoad={Boolean(currentSessionId)}
               />

--- a/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
+++ b/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
@@ -5,6 +5,7 @@ import { normalizeToolName } from '../../utils/toolConstants';
 import { sendBridgeEvent } from '../../utils/bridge';
 import {
   extractResultText,
+  hasSubagentTranscript,
   isAsyncAgentInput,
   parseAgentToolMeta,
   parseSpawnAgentMeta,
@@ -72,9 +73,13 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
   const agentToolMeta = !isSpawnAgent && input ? parseAgentToolMeta(getToolResultRaw, toolId) : {};
   const agentId = spawnMeta.agentId ?? agentToolMeta.agentId;
   const agentPath = spawnMeta.agentPath;
-  const identityLabel = spawnMeta.nickname || (typeof subagentType === 'string' && subagentType ? subagentType : undefined);
+  const identityLabel = spawnMeta.identityLabel
+    ?? (typeof subagentType === 'string' && subagentType ? subagentType : undefined);
   const modelSummary = [spawnMeta.model, spawnMeta.reasoningEffort].filter(Boolean).join(' ');
   const shortAgentId = shortenAgentId(agentId);
+  const historyDescription = isSpawnAgent
+    ? spawnMeta.description
+    : typeof description === 'string' ? description : undefined;
 
   // A background (run_in_background) Agent only gets a launch acknowledgment
   // tool_result; its real terminal status arrives later via a task_notification
@@ -93,6 +98,8 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
   // assistant/end_turn. A settled main turn alone proves only that the launch
   // turn ended; the background sidechain may still be running.
   const history = (toolId ? histories[toolId] : undefined) ?? (agentId ? histories[agentId] : undefined);
+  const resolvedAgentId = history?.agentId ?? agentId;
+  const resolvedAgentPath = history?.agentPath ?? agentPath;
   const historyFailed = history?.status === 'error';
   const isCompleted = isAsync
     ? (taskEvent ? !taskFailed : history?.completed === true)
@@ -104,23 +111,23 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
   // For background agents the task_notification carries the authoritative usage
   // and summary (the launch ack has none); prefer it over toolUseResult. Sync
   // agents keep reading toolUseResult as before.
-  const detailAgentId = (isAsync ? taskEvent?.agentId : undefined) ?? agentId;
+  const detailAgentId = (isAsync ? taskEvent?.agentId : undefined) ?? resolvedAgentId;
   const detailDurationMs = (isAsync ? taskEvent?.totalDurationMs : undefined) ?? agentToolMeta.totalDurationMs;
   const detailTokens = (isAsync ? taskEvent?.totalTokens : undefined) ?? agentToolMeta.totalTokens;
   const detailToolUseCount = (isAsync ? taskEvent?.totalToolUseCount : undefined) ?? agentToolMeta.totalToolUseCount;
   const detailResultText = (isAsync ? taskEvent?.summary : undefined) ?? extractResultText(result);
 
   useEffect(() => {
-    if (!input || !expanded || !isAgentTool || !currentSessionId || !toolId || history) return;
+    if (!input || !expanded || !isAgentTool || !currentSessionId || !toolId || hasSubagentTranscript(history)) return;
     sendBridgeEvent('load_subagent_session', JSON.stringify({
       sessionId: currentSessionId,
       provider: currentProvider,
-      agentId,
-      agentPath,
-      description: typeof description === 'string' ? description : undefined,
+      agentId: resolvedAgentId,
+      agentPath: resolvedAgentPath,
+      description: historyDescription,
       toolUseId: toolId,
     }));
-  }, [input, agentId, agentPath, currentProvider, currentSessionId, description, expanded, history, isAgentTool, toolId]);
+  }, [input, currentProvider, currentSessionId, expanded, history, historyDescription, isAgentTool, resolvedAgentId, resolvedAgentPath, toolId]);
 
   // Poll while an expanded async Agent is unresolved, including after a main
   // turn settles. This lets a reloaded session observe the sidechain's terminal
@@ -140,14 +147,14 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
       sendBridgeEvent('load_subagent_session', JSON.stringify({
         sessionId: currentSessionId,
         provider: currentProvider,
-        agentId,
-        agentPath,
-        description: typeof description === 'string' ? description : undefined,
+        agentId: resolvedAgentId,
+        agentPath: resolvedAgentPath,
+        description: historyDescription,
         toolUseId: toolId,
       }));
     }, 2_000);
     return () => window.clearInterval(timer);
-  }, [input, agentId, agentPath, currentProvider, currentSessionId, description, shouldPollHistory, toolId]);
+  }, [input, currentProvider, currentSessionId, historyDescription, resolvedAgentId, resolvedAgentPath, shouldPollHistory, toolId]);
 
   if (!input) {
     return null;
@@ -232,7 +239,7 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
               />
             )}
 
-            {typeof prompt === 'string' && (
+            {!isSpawnAgent && typeof prompt === 'string' && (
               <div className="task-field">
                 <div className="task-field-label">
                   <span className="codicon codicon-comment" />
@@ -242,7 +249,9 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
               </div>
             )}
 
-            {Object.entries(rest).map(([key, value]) => (
+            {Object.entries(rest)
+              .filter(([key]) => !isSpawnAgent || !['message', 'items', 'task_name', 'taskName'].includes(key))
+              .map(([key, value]) => (
               <div key={key} className="task-field">
                 <div className="task-field-label">{key}</div>
                 <div className="task-field-content">
@@ -251,7 +260,7 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
                     : String(value)}
                 </div>
               </div>
-            ))}
+              ))}
           </div>
         </div>
       )}

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -142,6 +142,9 @@ interface Window {
    */
   onSubagentHistoryLoaded?: (json: string) => void;
 
+  /** Batched lightweight Codex subagent lifecycle status callback. */
+  onSubagentStatusesLoaded?: (json: string) => void;
+
   /**
    * task_* SDK system event callback (async subagent lifecycle).
    * Payload: { subtype: 'task_started'|'task_progress'|'task_notification',

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -127,6 +127,9 @@ interface Window {
    */
   onSubagentHistoryLoaded?: (json: string) => void;
 
+  /** Batched lightweight Codex subagent lifecycle status callback. */
+  onSubagentStatusesLoaded?: (json: string) => void;
+
   /**
    * task_* SDK system event callback (async subagent lifecycle).
    * Payload: { subtype: 'task_started'|'task_progress'|'task_notification',

--- a/webview/src/hooks/index.ts
+++ b/webview/src/hooks/index.ts
@@ -8,6 +8,7 @@ export { useRewindHandlers } from './useRewindHandlers';
 export { useHistoryLoader } from './useHistoryLoader';
 export { useFileChanges } from './useFileChanges';
 export { useSubagents } from './useSubagents';
+export { useCodexSubagentStatusPolling } from './useCodexSubagentStatusPolling';
 export { useMessageQueue } from './useMessageQueue';
 export { useThemeInit } from './useThemeInit';
 export { useContextActions } from './useContextActions';

--- a/webview/src/hooks/useChatComputations.test.ts
+++ b/webview/src/hooks/useChatComputations.test.ts
@@ -34,7 +34,7 @@ describe('deriveTodosForTurn', () => {
     ];
 
     const latestTurn = sliceLatestConversationTurn(messages);
-    expect(deriveTodosForTurn(latestTurn, getContentBlocks, true)).toEqual([]);
+    expect(deriveTodosForTurn(latestTurn, getContentBlocks, true, 'codex')).toEqual([]);
   });
 
   it('shows the latest plan created in the current turn', () => {
@@ -54,7 +54,7 @@ describe('deriveTodosForTurn', () => {
     ];
 
     const latestTurn = sliceLatestConversationTurn(messages);
-    expect(deriveTodosForTurn(latestTurn, getContentBlocks, true)).toEqual([
+    expect(deriveTodosForTurn(latestTurn, getContentBlocks, true, 'codex')).toEqual([
       { content: 'First', status: 'in_progress' },
       { content: 'Second', status: 'pending' },
       { content: 'Third', status: 'pending' },
@@ -80,7 +80,7 @@ describe('deriveTodosForTurn', () => {
     ];
 
     const latestTurn = sliceLatestConversationTurn(messages);
-    expect(deriveTodosForTurn(latestTurn, getContentBlocks, true)).toEqual([]);
+    expect(deriveTodosForTurn(latestTurn, getContentBlocks, true, 'claude')).toEqual([]);
   });
 
   it('keeps earlier todos when the full transcript is scoped (settled history replay)', () => {
@@ -98,9 +98,66 @@ describe('deriveTodosForTurn', () => {
       user('Only answer OK'),
     ];
 
-    expect(deriveTodosForTurn(messages, getContentBlocks, false)).toEqual([
+    expect(deriveTodosForTurn(messages, getContentBlocks, false, 'claude')).toEqual([
       { content: 'Kept step', status: 'completed' },
       { content: 'In-flight step', status: 'completed' },
+    ]);
+  });
+
+  it('preserves Codex in-progress plan state after streaming settles', () => {
+    const messages = [
+      user('implement the fix'),
+      assistant([toolUse('plan-1', 'update_plan', {
+        plan: [
+          { step: 'Inspect', status: 'completed' },
+          { step: 'Implement', status: 'in_progress' },
+        ],
+      })]),
+    ];
+
+    expect(deriveTodosForTurn(messages, getContentBlocks, false, 'codex')).toEqual([
+      { content: 'Inspect', status: 'completed' },
+      { content: 'Implement', status: 'in_progress' },
+    ]);
+  });
+
+  it.each([
+    ['update_plan', { plan: [] }],
+    ['TodoWrite', { todos: [] }],
+  ])('treats a Codex empty %s snapshot as clearing the previous plan', (name, input) => {
+    const messages = [
+      user('implement the fix'),
+      assistant([toolUse('plan-1', 'update_plan', {
+        plan: [{ step: 'Old step', status: 'in_progress' }],
+      })]),
+      assistant([toolUse('plan-2', name, input)]),
+    ];
+
+    expect(deriveTodosForTurn(messages, getContentBlocks, false, 'codex')).toEqual([]);
+  });
+
+  it('lets Claude structured tasks survive an empty TodoWrite snapshot', () => {
+    const messages = [
+      user('implement the fix'),
+      assistant([toolUse('legacy-todos', 'TodoWrite', {
+        todos: [{ content: 'Legacy task', status: 'in_progress' }],
+      })]),
+      assistant([toolUse('task-create-1', 'TaskCreate', { subject: 'Review implementation' })]),
+      {
+        type: 'user',
+        raw: {
+          content: [{
+            type: 'tool_result',
+            tool_use_id: 'task-create-1',
+            content: 'Task #1 created successfully',
+          }],
+        },
+      } as ClaudeMessage,
+      assistant([toolUse('empty-todos', 'TodoWrite', { todos: [] })]),
+    ];
+
+    expect(deriveTodosForTurn(messages, getContentBlocks, false, 'claude')).toEqual([
+      { id: '1', content: 'Review implementation', status: 'pending' },
     ]);
   });
 });

--- a/webview/src/hooks/useChatComputations.test.ts
+++ b/webview/src/hooks/useChatComputations.test.ts
@@ -37,6 +37,25 @@ describe('deriveTodosForTurn', () => {
     expect(deriveTodosForTurn(latestTurn, getContentBlocks, true, 'codex')).toEqual([]);
   });
 
+  it('does not revive an earlier Codex plan after a later turn settles', () => {
+    const messages = [
+      user('previous request'),
+      assistant([
+        toolUse('plan-1', 'update_plan', {
+          plan: [
+            { step: 'Inspect existing UI', status: 'in_progress' },
+            { step: 'Implement page', status: 'pending' },
+            { step: 'Verify integration', status: 'pending' },
+          ],
+        }),
+      ]),
+      user('follow-up request without a plan'),
+      assistant([]),
+    ];
+
+    expect(deriveTodosForTurn(messages, getContentBlocks, false, 'codex')).toEqual([]);
+  });
+
   it('shows the latest plan created in the current turn', () => {
     const messages = [
       user('previous request'),

--- a/webview/src/hooks/useChatComputations.ts
+++ b/webview/src/hooks/useChatComputations.ts
@@ -21,10 +21,12 @@ import {
   computeStatusScopeMessages,
   finalizeSubagentsForSettledTurn,
   finalizeTodosForSettledTurn,
+  selectLatestSubagentTurn,
   sliceLatestConversationTurn,
 } from '../utils/turnScope';
 import { FILE_MODIFY_TOOL_NAMES, isToolName } from '../utils/toolConstants';
 import { extractSubagentsFromMessages, useSubagents } from './useSubagents';
+import { useCodexSubagentStatusPolling } from './useCodexSubagentStatusPolling';
 import { useFileChanges } from './useFileChanges';
 import { useFileChangesManagement } from './useFileChangesManagement';
 import type { useMessageProcessing } from './useMessageProcessing';
@@ -67,27 +69,49 @@ export function deriveTodosForTurn(
   turnMessages: ClaudeMessage[],
   getContentBlocks: (message: ClaudeMessage) => ClaudeContentBlock[],
   streamingActive: boolean,
+  currentProvider: string,
 ): TodoItem[] {
   let latestTodos: ReturnType<typeof extractTodosFromToolUse> = null;
+  let sawEmptyClaudeSnapshot = false;
   for (let i = turnMessages.length - 1; i >= 0; i--) {
     const msg = turnMessages[i];
     if (msg.type !== 'assistant') continue;
     const blocks = getContentBlocks(msg);
     for (let j = blocks.length - 1; j >= 0; j--) {
-      const todos = extractTodosFromToolUse(blocks[j]);
+      const block = blocks[j];
+      const todos = extractTodosFromToolUse(block);
+      const input = block.type === 'tool_use' ? block.input : undefined;
+      const isExplicitEmptySnapshot = Boolean(input) && (
+        (Array.isArray(input?.todos) && input.todos.length === 0)
+        || (Array.isArray(input?.plan) && input.plan.length === 0)
+      );
       if (todos && todos.length > 0) {
         latestTodos = todos;
         break;
+      }
+      if (todos && isExplicitEmptySnapshot) {
+        if (currentProvider === 'codex') {
+          latestTodos = todos;
+          break;
+        }
+        sawEmptyClaudeSnapshot = true;
       }
     }
     if (latestTodos) break;
   }
 
-  if (latestTodos) {
-    return finalizeTodosForSettledTurn(latestTodos, streamingActive);
+  const accumulatedTasks = sawEmptyClaudeSnapshot
+    ? extractAccumulatedTasks(turnMessages, getContentBlocks)
+    : null;
+  if (accumulatedTasks && accumulatedTasks.length > 0) {
+    return accumulatedTasks;
   }
 
-  return extractAccumulatedTasks(turnMessages, getContentBlocks);
+  if (latestTodos !== null) {
+    return finalizeTodosForSettledTurn(latestTodos, streamingActive, currentProvider);
+  }
+
+  return accumulatedTasks ?? extractAccumulatedTasks(turnMessages, getContentBlocks);
 }
 
 /**
@@ -195,7 +219,7 @@ export function useChatComputations({
   // Exception: if the latest-turn slice carries no tool_use at all (e.g. a
   // same-session reload snapshot whose latest turn predates the active work, or
   // a text-only turn), widen to the full conversation. Without this, the
-  // StatusPanel subagent/todo lists can briefly disappear when a deferred
+  // StatusPanel subagent list can briefly disappear when a deferred
   // reload's message refresh lands at the frontend a moment before the
   // stream-end signal flips streamingActive back to false. Widening only adds
   // content (earlier turns' settled items) - it never drops the current turn's.
@@ -205,22 +229,40 @@ export function useChatComputations({
     return computeStatusScopeMessages(streamingActive, asyncAgentPresence, latestTurnMessages, messages, latestTurnHasToolUse);
   }, [streamingActive, asyncAgentPresence, latestTurnMessages, messages, getContentBlocks]);
 
-  const latestTurnSubagents = useSubagents({
-    messages: statusScopeMessages,
+  // Plans belong to the current user turn while streaming. Unlike subagents,
+  // a text-only new turn must not temporarily revive a previous turn's plan.
+  // Settled/history views still scan the full transcript to restore the latest
+  // persisted plan snapshot.
+  const todoScopeMessages = useMemo(
+    () => (streamingActive ? latestTurnMessages : messages),
+    [streamingActive, latestTurnMessages, messages],
+  );
+
+  const extractedSubagents = useSubagents({
+    messages: currentProvider === 'codex' ? messages : statusScopeMessages,
     getContentBlocks,
     findToolResult,
     getToolResultRaw,
     subagentHistories,
   });
 
+  const latestTurnSubagents = useMemo(
+    () => (currentProvider === 'codex'
+      ? selectLatestSubagentTurn(messages, extractedSubagents)
+      : extractedSubagents),
+    [currentProvider, messages, extractedSubagents],
+  );
+
   const subagents = useMemo(
     () => finalizeSubagentsForSettledTurn(latestTurnSubagents, streamingActive),
     [latestTurnSubagents, streamingActive],
   );
 
+  useCodexSubagentStatusPolling({ subagents, currentSessionId, currentProvider });
+
   const globalTodos = useMemo(() => {
-    return deriveTodosForTurn(statusScopeMessages, getContentBlocks, streamingActive);
-  }, [statusScopeMessages, getContentBlocks, streamingActive]);
+    return deriveTodosForTurn(todoScopeMessages, getContentBlocks, streamingActive, currentProvider);
+  }, [todoScopeMessages, getContentBlocks, streamingActive, currentProvider]);
 
   const canRewindFromMessageIndex = useCallback(
     (userMessageIndex: number) => {

--- a/webview/src/hooks/useChatComputations.ts
+++ b/webview/src/hooks/useChatComputations.ts
@@ -71,10 +71,13 @@ export function deriveTodosForTurn(
   streamingActive: boolean,
   currentProvider: string,
 ): TodoItem[] {
+  const scopedMessages = currentProvider === 'codex'
+    ? sliceLatestConversationTurn(turnMessages)
+    : turnMessages;
   let latestTodos: ReturnType<typeof extractTodosFromToolUse> = null;
   let sawEmptyClaudeSnapshot = false;
-  for (let i = turnMessages.length - 1; i >= 0; i--) {
-    const msg = turnMessages[i];
+  for (let i = scopedMessages.length - 1; i >= 0; i--) {
+    const msg = scopedMessages[i];
     if (msg.type !== 'assistant') continue;
     const blocks = getContentBlocks(msg);
     for (let j = blocks.length - 1; j >= 0; j--) {
@@ -101,7 +104,7 @@ export function deriveTodosForTurn(
   }
 
   const accumulatedTasks = sawEmptyClaudeSnapshot
-    ? extractAccumulatedTasks(turnMessages, getContentBlocks)
+    ? extractAccumulatedTasks(scopedMessages, getContentBlocks)
     : null;
   if (accumulatedTasks && accumulatedTasks.length > 0) {
     return accumulatedTasks;
@@ -111,7 +114,7 @@ export function deriveTodosForTurn(
     return finalizeTodosForSettledTurn(latestTodos, streamingActive, currentProvider);
   }
 
-  return accumulatedTasks ?? extractAccumulatedTasks(turnMessages, getContentBlocks);
+  return accumulatedTasks ?? extractAccumulatedTasks(scopedMessages, getContentBlocks);
 }
 
 /**
@@ -231,8 +234,8 @@ export function useChatComputations({
 
   // Plans belong to the current user turn while streaming. Unlike subagents,
   // a text-only new turn must not temporarily revive a previous turn's plan.
-  // Settled/history views still scan the full transcript to restore the latest
-  // persisted plan snapshot.
+  // Settled/history views scan the full transcript for Claude; Codex is always
+  // narrowed to its latest user turn inside deriveTodosForTurn.
   const todoScopeMessages = useMemo(
     () => (streamingActive ? latestTurnMessages : messages),
     [streamingActive, latestTurnMessages, messages],

--- a/webview/src/hooks/useChatComputations.ts
+++ b/webview/src/hooks/useChatComputations.ts
@@ -69,10 +69,13 @@ export function deriveTodosForTurn(
   streamingActive: boolean,
   currentProvider: string,
 ): TodoItem[] {
+  const scopedMessages = currentProvider === 'codex'
+    ? sliceLatestConversationTurn(turnMessages)
+    : turnMessages;
   let latestTodos: ReturnType<typeof extractTodosFromToolUse> = null;
   let sawEmptyClaudeSnapshot = false;
-  for (let i = turnMessages.length - 1; i >= 0; i--) {
-    const msg = turnMessages[i];
+  for (let i = scopedMessages.length - 1; i >= 0; i--) {
+    const msg = scopedMessages[i];
     if (msg.type !== 'assistant') continue;
     const blocks = getContentBlocks(msg);
     for (let j = blocks.length - 1; j >= 0; j--) {
@@ -99,7 +102,7 @@ export function deriveTodosForTurn(
   }
 
   const accumulatedTasks = sawEmptyClaudeSnapshot
-    ? extractAccumulatedTasks(turnMessages, getContentBlocks)
+    ? extractAccumulatedTasks(scopedMessages, getContentBlocks)
     : null;
   if (accumulatedTasks && accumulatedTasks.length > 0) {
     return accumulatedTasks;
@@ -109,7 +112,7 @@ export function deriveTodosForTurn(
     return finalizeTodosForSettledTurn(latestTodos, streamingActive, currentProvider);
   }
 
-  return accumulatedTasks ?? extractAccumulatedTasks(turnMessages, getContentBlocks);
+  return accumulatedTasks ?? extractAccumulatedTasks(scopedMessages, getContentBlocks);
 }
 
 /**
@@ -212,8 +215,8 @@ export function useChatComputations({
 
   // Plans belong to the current user turn while streaming. Unlike subagents,
   // a text-only new turn must not temporarily revive a previous turn's plan.
-  // Settled/history views still scan the full transcript to restore the latest
-  // persisted plan snapshot.
+  // Settled/history views scan the full transcript for Claude; Codex is always
+  // narrowed to its latest user turn inside deriveTodosForTurn.
   const todoScopeMessages = useMemo(
     () => (streamingActive ? latestTurnMessages : messages),
     [streamingActive, latestTurnMessages, messages],

--- a/webview/src/hooks/useChatComputations.ts
+++ b/webview/src/hooks/useChatComputations.ts
@@ -18,12 +18,13 @@ import {
 } from '../utils/messageUtils';
 import { extractTodosFromToolUse, extractAccumulatedTasks } from '../utils/todoToolNormalization';
 import {
-  finalizeSubagentsForSettledTurn,
   finalizeTodosForSettledTurn,
+  selectLatestSubagentTurn,
   sliceLatestConversationTurn,
 } from '../utils/turnScope';
 import { FILE_MODIFY_TOOL_NAMES, isToolName } from '../utils/toolConstants';
 import { useSubagents } from './useSubagents';
+import { useCodexSubagentStatusPolling } from './useCodexSubagentStatusPolling';
 import { useFileChanges } from './useFileChanges';
 import { useFileChangesManagement } from './useFileChangesManagement';
 import type { useMessageProcessing } from './useMessageProcessing';
@@ -66,27 +67,49 @@ export function deriveTodosForTurn(
   turnMessages: ClaudeMessage[],
   getContentBlocks: (message: ClaudeMessage) => ClaudeContentBlock[],
   streamingActive: boolean,
+  currentProvider: string,
 ): TodoItem[] {
   let latestTodos: ReturnType<typeof extractTodosFromToolUse> = null;
+  let sawEmptyClaudeSnapshot = false;
   for (let i = turnMessages.length - 1; i >= 0; i--) {
     const msg = turnMessages[i];
     if (msg.type !== 'assistant') continue;
     const blocks = getContentBlocks(msg);
     for (let j = blocks.length - 1; j >= 0; j--) {
-      const todos = extractTodosFromToolUse(blocks[j]);
+      const block = blocks[j];
+      const todos = extractTodosFromToolUse(block);
+      const input = block.type === 'tool_use' ? block.input : undefined;
+      const isExplicitEmptySnapshot = Boolean(input) && (
+        (Array.isArray(input?.todos) && input.todos.length === 0)
+        || (Array.isArray(input?.plan) && input.plan.length === 0)
+      );
       if (todos && todos.length > 0) {
         latestTodos = todos;
         break;
+      }
+      if (todos && isExplicitEmptySnapshot) {
+        if (currentProvider === 'codex') {
+          latestTodos = todos;
+          break;
+        }
+        sawEmptyClaudeSnapshot = true;
       }
     }
     if (latestTodos) break;
   }
 
-  if (latestTodos) {
-    return finalizeTodosForSettledTurn(latestTodos, streamingActive);
+  const accumulatedTasks = sawEmptyClaudeSnapshot
+    ? extractAccumulatedTasks(turnMessages, getContentBlocks)
+    : null;
+  if (accumulatedTasks && accumulatedTasks.length > 0) {
+    return accumulatedTasks;
   }
 
-  return extractAccumulatedTasks(turnMessages, getContentBlocks);
+  if (latestTodos !== null) {
+    return finalizeTodosForSettledTurn(latestTodos, streamingActive, currentProvider);
+  }
+
+  return accumulatedTasks ?? extractAccumulatedTasks(turnMessages, getContentBlocks);
 }
 
 /**
@@ -168,7 +191,7 @@ export function useChatComputations({
 
   const latestTurnMessages = useMemo(() => sliceLatestConversationTurn(messages), [messages]);
 
-  // While streaming, focus on the current turn's task progress; once settled
+  // While streaming, focus on the current turn's subagent progress; once settled
   // (history replay or idle), widen the scope to the whole conversation -
   // otherwise a multi-turn history session whose last turn has no task tool
   // would lose its task and subagent lists entirely.
@@ -176,7 +199,7 @@ export function useChatComputations({
   // Exception: if the latest-turn slice carries no tool_use at all (e.g. a
   // same-session reload snapshot whose latest turn predates the active work, or
   // a text-only turn), widen to the full conversation. Without this, the
-  // StatusPanel subagent/todo lists can briefly disappear when a deferred
+  // StatusPanel subagent list can briefly disappear when a deferred
   // reload's message refresh lands at the frontend a moment before the
   // stream-end signal flips streamingActive back to false. Widening only adds
   // content (earlier turns' settled items) - it never drops the current turn's.
@@ -187,22 +210,37 @@ export function useChatComputations({
       : messages;
   }, [streamingActive, latestTurnMessages, messages, getContentBlocks]);
 
-  const latestTurnSubagents = useSubagents({
-    messages: statusScopeMessages,
+  // Plans belong to the current user turn while streaming. Unlike subagents,
+  // a text-only new turn must not temporarily revive a previous turn's plan.
+  // Settled/history views still scan the full transcript to restore the latest
+  // persisted plan snapshot.
+  const todoScopeMessages = useMemo(
+    () => (streamingActive ? latestTurnMessages : messages),
+    [streamingActive, latestTurnMessages, messages],
+  );
+
+  const extractedSubagents = useSubagents({
+    messages: currentProvider === 'codex' ? messages : statusScopeMessages,
     getContentBlocks,
     findToolResult,
     getToolResultRaw,
     subagentHistories,
   });
 
-  const subagents = useMemo(
-    () => finalizeSubagentsForSettledTurn(latestTurnSubagents, streamingActive),
-    [latestTurnSubagents, streamingActive],
+  const latestTurnSubagents = useMemo(
+    () => (currentProvider === 'codex'
+      ? selectLatestSubagentTurn(messages, extractedSubagents)
+      : extractedSubagents),
+    [currentProvider, messages, extractedSubagents],
   );
 
+  const subagents = latestTurnSubagents;
+
+  useCodexSubagentStatusPolling({ subagents, currentSessionId, currentProvider });
+
   const globalTodos = useMemo(() => {
-    return deriveTodosForTurn(statusScopeMessages, getContentBlocks, streamingActive);
-  }, [statusScopeMessages, getContentBlocks, streamingActive]);
+    return deriveTodosForTurn(todoScopeMessages, getContentBlocks, streamingActive, currentProvider);
+  }, [todoScopeMessages, getContentBlocks, streamingActive, currentProvider]);
 
   const canRewindFromMessageIndex = useCallback(
     (userMessageIndex: number) => {

--- a/webview/src/hooks/useCodexSubagentStatusPolling.test.ts
+++ b/webview/src/hooks/useCodexSubagentStatusPolling.test.ts
@@ -1,0 +1,82 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SubagentInfo } from '../types';
+import {
+  MAX_CODEX_SUBAGENT_STATUS_TARGETS,
+  useCodexSubagentStatusPolling,
+} from './useCodexSubagentStatusPolling';
+
+const sendBridgeEventMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../utils/bridge', () => ({
+  sendBridgeEvent: (...args: unknown[]) => sendBridgeEventMock(...args),
+}));
+
+const runningAgent = (id: string): SubagentInfo => ({
+  id,
+  type: 'review',
+  description: '',
+  status: 'running',
+  isAsync: true,
+  messageIndex: 1,
+  agentPath: `/root/${id}`,
+});
+
+describe('useCodexSubagentStatusPolling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sendBridgeEventMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses one immediate batch request and one shared polling timer', () => {
+    renderHook(() => useCodexSubagentStatusPolling({
+      subagents: [runningAgent('call-1'), runningAgent('call-2')],
+      currentSessionId: 'session-1',
+      currentProvider: 'codex',
+    }));
+
+    expect(sendBridgeEventMock).toHaveBeenCalledTimes(1);
+    const [, payload] = sendBridgeEventMock.mock.calls[0];
+    expect(JSON.parse(String(payload)).agents).toHaveLength(2);
+
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+    expect(sendBridgeEventMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not poll Claude or terminal subagents', () => {
+    const terminal = { ...runningAgent('call-1'), status: 'completed' as const };
+    renderHook(() => useCodexSubagentStatusPolling({
+      subagents: [terminal],
+      currentSessionId: 'session-1',
+      currentProvider: 'codex',
+    }));
+    renderHook(() => useCodexSubagentStatusPolling({
+      subagents: [runningAgent('call-2')],
+      currentSessionId: 'session-1',
+      currentProvider: 'claude',
+    }));
+
+    expect(sendBridgeEventMock).not.toHaveBeenCalled();
+  });
+
+  it('bounds the number of agents in a batch', () => {
+    const subagents = Array.from(
+      { length: MAX_CODEX_SUBAGENT_STATUS_TARGETS + 3 },
+      (_, index) => runningAgent(`call-${index}`),
+    );
+    renderHook(() => useCodexSubagentStatusPolling({
+      subagents,
+      currentSessionId: 'session-1',
+      currentProvider: 'codex',
+    }));
+
+    const [, payload] = sendBridgeEventMock.mock.calls[0];
+    expect(JSON.parse(String(payload)).agents).toHaveLength(MAX_CODEX_SUBAGENT_STATUS_TARGETS);
+  });
+});

--- a/webview/src/hooks/useCodexSubagentStatusPolling.ts
+++ b/webview/src/hooks/useCodexSubagentStatusPolling.ts
@@ -1,0 +1,55 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { SubagentInfo } from '../types';
+import { sendBridgeEvent } from '../utils/bridge';
+
+const STATUS_POLL_INTERVAL_MS = 2_000;
+export const MAX_CODEX_SUBAGENT_STATUS_TARGETS = 64;
+
+interface UseCodexSubagentStatusPollingParams {
+  subagents: SubagentInfo[];
+  currentSessionId: string | null;
+  currentProvider: string;
+}
+
+export function useCodexSubagentStatusPolling({
+  subagents,
+  currentSessionId,
+  currentProvider,
+}: UseCodexSubagentStatusPollingParams): void {
+  const requestSequenceRef = useRef(0);
+  const agentsJson = useMemo(() => JSON.stringify(
+    subagents
+      .filter((subagent) => subagent.isAsync && subagent.status === 'running')
+      .slice(0, MAX_CODEX_SUBAGENT_STATUS_TARGETS)
+      .map((subagent) => ({
+        toolUseId: subagent.id,
+        agentId: subagent.agentId,
+        agentPath: subagent.agentPath,
+      })),
+  ), [subagents]);
+
+  useEffect(() => {
+    if (currentProvider !== 'codex' || !currentSessionId) return;
+
+    const agents = JSON.parse(agentsJson) as Array<{
+      toolUseId: string;
+      agentId?: string;
+      agentPath?: string;
+    }>;
+    if (agents.length === 0) return;
+
+    const requestStatuses = () => {
+      requestSequenceRef.current += 1;
+      sendBridgeEvent('load_subagent_statuses', JSON.stringify({
+        sessionId: currentSessionId,
+        provider: currentProvider,
+        requestId: `${currentSessionId}:${requestSequenceRef.current}`,
+        agents,
+      }));
+    };
+
+    requestStatuses();
+    const timer = window.setInterval(requestStatuses, STATUS_POLL_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [agentsJson, currentProvider, currentSessionId]);
+}

--- a/webview/src/hooks/useSubagents.test.ts
+++ b/webview/src/hooks/useSubagents.test.ts
@@ -101,10 +101,100 @@ describe('extractSubagentsFromMessages', () => {
     expect(subagents).toHaveLength(1);
     expect(subagents[0]).toMatchObject({
       id: 'call-spawn',
+      type: 'audit_ui',
       agentPath: 'audit_ui',
       isAsync: true,
       status: 'running',
     });
+    expect(subagents[0].description).toBe('');
+    expect(subagents[0].prompt).toBeUndefined();
+  });
+
+  it('does not expose Codex spawn_agent message content in StatusPanel fields', () => {
+    const opaqueMessage = 'gAAAAABopaque-transport-content';
+    const message: ClaudeMessage = {
+      type: 'assistant',
+      content: '',
+      raw: {
+        message: {
+          content: [{
+            type: 'tool_use',
+            id: 'call-safe-spawn',
+            name: 'spawn_agent',
+            input: { task_name: '/root/reviewer', message: opaqueMessage },
+          }],
+        },
+      },
+    };
+
+    const [subagent] = extractSubagentsFromMessages(
+      [message], getContentBlocks, findToolResult([message]), getToolResultRaw([message]),
+    );
+
+    expect(subagent).toMatchObject({ type: 'reviewer', description: '', agentPath: '/root/reviewer' });
+    expect(subagent.prompt).toBeUndefined();
+    expect(JSON.stringify(subagent)).not.toContain(opaqueMessage);
+  });
+
+  it('filters only empty spawn_agent argument parsing noise', () => {
+    const messages: ClaudeMessage[] = [{
+      type: 'assistant',
+      content: '',
+      raw: {
+        message: {
+          content: [{ type: 'tool_use', id: 'call-invalid-spawn', name: 'spawn_agent', input: {} }],
+        },
+      },
+    }, {
+      type: 'user',
+      content: '',
+      raw: {
+        content: [{
+          type: 'tool_result',
+          tool_use_id: 'call-invalid-spawn',
+          content: 'failed to parse function arguments: EOF while parsing a value',
+        }],
+      },
+    }];
+
+    expect(extractSubagentsFromMessages(
+      messages, getContentBlocks, findToolResult(messages), getToolResultRaw(messages),
+    )).toEqual([]);
+  });
+
+  it('retains a valid spawn_agent request that fails at runtime', () => {
+    const messages: ClaudeMessage[] = [{
+      type: 'assistant',
+      content: '',
+      raw: {
+        message: {
+          content: [{
+            type: 'tool_use',
+            id: 'call-valid-failure',
+            name: 'spawn_agent',
+            input: { task_name: 'reviewer', message: 'opaque' },
+          }],
+        },
+      },
+    }, {
+      type: 'user',
+      content: '',
+      raw: {
+        content: [{
+          type: 'tool_result',
+          tool_use_id: 'call-valid-failure',
+          content: 'permission denied while starting agent',
+          is_error: true,
+        }],
+      },
+    }];
+
+    const subagents = extractSubagentsFromMessages(
+      messages, getContentBlocks, findToolResult(messages), getToolResultRaw(messages),
+    );
+
+    expect(subagents).toHaveLength(1);
+    expect(subagents[0]).toMatchObject({ type: 'reviewer', status: 'error' });
   });
 
   it('attaches completed Agent result metadata including stable agent id', () => {

--- a/webview/src/hooks/useSubagents.ts
+++ b/webview/src/hooks/useSubagents.ts
@@ -2,7 +2,13 @@ import { useMemo } from 'react';
 import type { ClaudeMessage, ClaudeRawMessage, ClaudeContentBlock, ToolResultBlock, SubagentHistoryResponse, SubagentInfo, SubagentStatus, TaskEvent, TaskEventMap } from '../types';
 import { normalizeToolInput } from '../utils/toolInputNormalization';
 import { normalizeToolName } from '../utils/toolConstants';
-import { extractResultText, isAsyncAgentInput, parseSpawnAgentMeta, readToolUseStatus } from '../utils/subagentResult';
+import {
+  extractResultText,
+  isAsyncAgentInput,
+  isSpawnAgentArgumentFailureNoise,
+  parseSpawnAgentMeta,
+  readToolUseStatus,
+} from '../utils/subagentResult';
 import { useTaskEvents } from '../contexts/SubagentContext';
 
 type GetToolResultRawFn = (toolUseId: string) => ClaudeRawMessage | null;
@@ -109,18 +115,15 @@ export function extractSubagentsFromMessages(
       if (toolName !== 'task' && toolName !== 'agent' && toolName !== 'spawn_agent') return;
 
       const rawInput = block.input as Record<string, unknown> | undefined;
-      const input = rawInput ? normalizeToolInput(block.name, rawInput) as Record<string, unknown> : undefined;
+      if (!rawInput) return;
+      const input = normalizeToolInput(block.name, rawInput) as Record<string, unknown> | undefined;
       if (!input) return;
 
-      // Defensive: ensure all string values are actually strings
       const id = String(block.id ?? `task-${messageIndex}-${subagents.length}`);
-      const subagentType = String((input.subagent_type as string) ?? (input.subagentType as string) ?? 'Unknown');
-      const description = String((input.description as string) ?? '');
-      const prompt = String((input.prompt as string) ?? '');
-
-      // Check tool result to determine status
       const toolUseId = block.id ?? '';
       const result = findToolResult(toolUseId, messageIndex);
+      if (toolName === 'spawn_agent' && isSpawnAgentArgumentFailureNoise(rawInput, result)) return;
+
       const taskEvent = taskEvents[toolUseId];
       // isAsync is read via the shared isAsyncAgentInput helper so the
       // StatusPanel list and the inline Agent cards stay in lockstep. The
@@ -132,7 +135,18 @@ export function extractSubagentsFromMessages(
       const isAsync = isAsyncAgentInput(input, toolName, result, toolUseStatus);
       const status = determineStatus(result, isAsync, taskEvent);
       const resultMetadata = extractResultMetadata(result, getToolResultRaw, toolUseId, taskEvent);
-      const spawnMeta = toolName === 'spawn_agent' ? parseSpawnAgentMeta(input, result) : {};
+      const spawnMeta = toolName === 'spawn_agent' ? parseSpawnAgentMeta(rawInput, result) : {};
+      // Codex message may be opaque transport data. Only expose explicit,
+      // human-readable spawn metadata in the StatusPanel.
+      const subagentType = toolName === 'spawn_agent'
+        ? spawnMeta.identityLabel ?? 'spawn_agent'
+        : String((input.subagent_type as string) ?? (input.subagentType as string) ?? 'Unknown');
+      const description = toolName === 'spawn_agent'
+        ? spawnMeta.description ?? ''
+        : String((input.description as string) ?? '');
+      const prompt = toolName === 'spawn_agent'
+        ? undefined
+        : String((input.prompt as string) ?? '');
 
       subagents.push({
         id,

--- a/webview/src/hooks/useSubagents.ts
+++ b/webview/src/hooks/useSubagents.ts
@@ -2,7 +2,12 @@ import { useMemo } from 'react';
 import type { ClaudeMessage, ClaudeRawMessage, ClaudeContentBlock, ToolResultBlock, SubagentHistoryResponse, SubagentInfo, SubagentStatus, TaskEvent, TaskEventMap } from '../types';
 import { normalizeToolInput } from '../utils/toolInputNormalization';
 import { normalizeToolName } from '../utils/toolConstants';
-import { extractResultText, isAsyncAgentInput, parseSpawnAgentMeta } from '../utils/subagentResult';
+import {
+  extractResultText,
+  isAsyncAgentInput,
+  isSpawnAgentArgumentFailureNoise,
+  parseSpawnAgentMeta,
+} from '../utils/subagentResult';
 import { useTaskEvents } from '../contexts/SubagentContext';
 
 type GetToolResultRawFn = (toolUseId: string) => ClaudeRawMessage | null;
@@ -109,25 +114,33 @@ export function extractSubagentsFromMessages(
       if (toolName !== 'task' && toolName !== 'agent' && toolName !== 'spawn_agent') return;
 
       const rawInput = block.input as Record<string, unknown> | undefined;
-      const input = rawInput ? normalizeToolInput(block.name, rawInput) as Record<string, unknown> : undefined;
+      if (!rawInput) return;
+      const input = normalizeToolInput(block.name, rawInput) as Record<string, unknown> | undefined;
       if (!input) return;
 
-      // Defensive: ensure all string values are actually strings
       const id = String(block.id ?? `task-${messageIndex}-${subagents.length}`);
-      const subagentType = String((input.subagent_type as string) ?? (input.subagentType as string) ?? 'Unknown');
-      const description = String((input.description as string) ?? '');
-      const prompt = String((input.prompt as string) ?? '');
-
-      // Check tool result to determine status
       const toolUseId = block.id ?? '';
       const result = findToolResult(toolUseId, messageIndex);
+      if (toolName === 'spawn_agent' && isSpawnAgentArgumentFailureNoise(rawInput, result)) return;
+
       const taskEvent = taskEvents[toolUseId];
       // isAsync is read via the shared isAsyncAgentInput helper so the
       // StatusPanel list and the inline Agent cards stay in lockstep.
       const isAsync = isAsyncAgentInput(input, toolName);
       const status = determineStatus(result, isAsync, taskEvent);
       const resultMetadata = extractResultMetadata(result, getToolResultRaw, toolUseId, taskEvent);
-      const spawnMeta = toolName === 'spawn_agent' ? parseSpawnAgentMeta(input, result) : {};
+      const spawnMeta = toolName === 'spawn_agent' ? parseSpawnAgentMeta(rawInput, result) : {};
+      // Codex message may be opaque transport data. Only expose explicit,
+      // human-readable spawn metadata in the StatusPanel.
+      const subagentType = toolName === 'spawn_agent'
+        ? spawnMeta.identityLabel ?? 'spawn_agent'
+        : String((input.subagent_type as string) ?? (input.subagentType as string) ?? 'Unknown');
+      const description = toolName === 'spawn_agent'
+        ? spawnMeta.description ?? ''
+        : String((input.description as string) ?? '');
+      const prompt = toolName === 'spawn_agent'
+        ? undefined
+        : String((input.prompt as string) ?? '');
 
       subagents.push({
         id,

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -1436,7 +1436,7 @@ describe('useWindowCallbacks integration', () => {
   });
 
   it('onSubagentHistoryLoaded skips updates only when history payload is truly unchanged', () => {
-    const opts = createOptions();
+    const opts = createOptions({ currentSessionIdRef: { current: 'session-1' } });
     renderHook(() => useWindowCallbacks(opts));
 
     const firstPayload = {

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -1280,7 +1280,7 @@ describe('useWindowCallbacks integration', () => {
   });
 
   it('onSubagentHistoryLoaded skips updates only when history payload is truly unchanged', () => {
-    const opts = createOptions();
+    const opts = createOptions({ currentSessionIdRef: { current: 'session-1' } });
     renderHook(() => useWindowCallbacks(opts));
 
     const firstPayload = {

--- a/webview/src/hooks/windowCallbacks/__tests__/subagentHistoryMerge.test.ts
+++ b/webview/src/hooks/windowCallbacks/__tests__/subagentHistoryMerge.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isCurrentSubagentResponse,
+  mergeSubagentHistory,
+  toSubagentHistoryResponse,
+} from '../subagentHistoryMerge';
+
+describe('subagentHistoryMerge', () => {
+  it('does not let a late running response overwrite a completed status', () => {
+    expect(mergeSubagentHistory(
+      { success: true, completed: true, status: 'completed' },
+      { success: false, completed: false, status: 'running', error: 'not found yet' },
+    )).toEqual({
+      success: true,
+      completed: true,
+      status: 'completed',
+      error: undefined,
+    });
+  });
+
+  it('adds a transcript without regressing an existing terminal status', () => {
+    expect(mergeSubagentHistory(
+      { success: true, completed: true, status: 'completed' },
+      { success: true, completed: false, status: 'running', messages: [{ type: 'assistant' }] },
+    )).toMatchObject({
+      completed: true,
+      status: 'completed',
+      messages: [{ type: 'assistant' }],
+    });
+  });
+
+  it('attaches batch session identity to a lightweight snapshot', () => {
+    expect(toSubagentHistoryResponse(
+      { success: false, toolUseId: 'call-1', status: 'running' },
+      { sessionId: 'session-1', provider: 'codex', requestId: 'request-1' },
+    )).toEqual({
+      success: false,
+      toolUseId: 'call-1',
+      status: 'running',
+      sessionId: 'session-1',
+      provider: 'codex',
+    });
+  });
+
+  it('rejects responses from an inactive session or provider', () => {
+    expect(isCurrentSubagentResponse(
+      { sessionId: 'old-session', provider: 'codex' },
+      'current-session',
+      'codex',
+    )).toBe(false);
+    expect(isCurrentSubagentResponse(
+      { sessionId: 'current-session', provider: 'claude' },
+      'current-session',
+      'codex',
+    )).toBe(false);
+    expect(isCurrentSubagentResponse(
+      { sessionId: 'current-session', provider: 'codex' },
+      'current-session',
+      'codex',
+    )).toBe(true);
+  });
+});

--- a/webview/src/hooks/windowCallbacks/registerCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks.ts
@@ -12,6 +12,10 @@
 
 import type { MutableRefObject } from 'react';
 import type { UseWindowCallbacksOptions } from '../useWindowCallbacks';
+import type {
+  SubagentHistoryResponse,
+  SubagentStatusesResponse,
+} from '../../types';
 import { parseTaskNotification } from '../../utils/taskEventParser';
 import { deepEqual } from '../../utils/deepEqual';
 import {
@@ -33,11 +37,11 @@ import { registerSessionAndSdkCallbacks } from './registerCallbacks/sessionCallb
 import { registerUsageModeCallbacks } from './registerCallbacks/usageModeCallbacks';
 import { registerPermissionCallbacks } from './registerCallbacks/permissionCallbacks';
 import { registerAgentAndSelectionCallbacks } from './registerCallbacks/agentCallbacks';
-
-function areSubagentMessagesEquivalent(previousMessages: unknown[] | undefined, nextMessages: unknown[] | undefined): boolean {
-  if (previousMessages === nextMessages) return true;
-  return deepEqual(previousMessages, nextMessages);
-}
+import {
+  isCurrentSubagentResponse,
+  mergeSubagentHistory,
+  toSubagentHistoryResponse,
+} from './subagentHistoryMerge';
 
 const pendingSubagentHistoryChunks = new Map<string, string[]>();
 const MAX_PENDING_SUBAGENT_HISTORY_TRANSFERS = 16;
@@ -106,30 +110,58 @@ export function registerWindowCallbacks(
   window.onSubagentHistoryLoaded = (json: string) => {
     try {
       if (!options.setSubagentHistories) return;
-      const result = JSON.parse(json);
+      const result = JSON.parse(json) as SubagentHistoryResponse;
+      if (!isCurrentSubagentResponse(
+        result,
+        options.currentSessionIdRef.current,
+        options.currentProviderRef.current,
+      )) return;
       const key = result.toolUseId || result.agentId;
       if (!key) return;
       options.setSubagentHistories((prev) => {
         const existing = prev[key];
+        const merged = mergeSubagentHistory(existing, result);
         // Skip state update when the payload is structurally identical.
         // This prevents cascading re-renders and scroll jumps caused by
         // periodic subagent polling (every 2 s) returning unchanged data.
-        if (existing && existing.success === result.success
-          && existing.completed === result.completed
-          && existing.status === result.status
-          && existing.error === result.error
-          && existing.sessionId === result.sessionId
-          && existing.provider === result.provider
-          && existing.toolUseId === result.toolUseId
-          && existing.agentId === result.agentId
-          && existing.agentPath === result.agentPath
-          && areSubagentMessagesEquivalent(existing.messages, result.messages)) {
+        if (existing && deepEqual(existing, merged)) {
           return prev;
         }
-        return { ...prev, [key]: result };
+        return { ...prev, [key]: merged };
       });
     } catch {
       // Ignore malformed callback payloads; the request can be retried by reopening the Agent row.
+    }
+  };
+
+  window.onSubagentStatusesLoaded = (json: string) => {
+    try {
+      if (!options.setSubagentHistories) return;
+      const result = JSON.parse(json) as SubagentStatusesResponse;
+      if (!isCurrentSubagentResponse(
+        result,
+        options.currentSessionIdRef.current,
+        options.currentProviderRef.current,
+      ) || !Array.isArray(result.statuses)) return;
+
+      options.setSubagentHistories((prev) => {
+        let next = prev;
+        for (const snapshot of result.statuses ?? []) {
+          const key = snapshot.toolUseId || snapshot.agentId;
+          if (!key) continue;
+          const existing = next[key];
+          const merged = mergeSubagentHistory(
+            existing,
+            toSubagentHistoryResponse(snapshot, result),
+          );
+          if (existing && deepEqual(existing, merged)) continue;
+          if (next === prev) next = { ...prev };
+          next[key] = merged;
+        }
+        return next;
+      });
+    } catch {
+      // Ignore malformed status batches; the next bounded poll will retry.
     }
   };
 

--- a/webview/src/hooks/windowCallbacks/registerCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks.ts
@@ -12,6 +12,10 @@
 
 import type { MutableRefObject } from 'react';
 import type { UseWindowCallbacksOptions } from '../useWindowCallbacks';
+import type {
+  SubagentHistoryResponse,
+  SubagentStatusesResponse,
+} from '../../types';
 import { parseTaskNotification } from '../../utils/taskEventParser';
 import { deepEqual } from '../../utils/deepEqual';
 import {
@@ -33,11 +37,11 @@ import { registerSessionAndSdkCallbacks } from './registerCallbacks/sessionCallb
 import { registerUsageModeCallbacks } from './registerCallbacks/usageModeCallbacks';
 import { registerPermissionCallbacks } from './registerCallbacks/permissionCallbacks';
 import { registerAgentAndSelectionCallbacks } from './registerCallbacks/agentCallbacks';
-
-function areSubagentMessagesEquivalent(previousMessages: unknown[] | undefined, nextMessages: unknown[] | undefined): boolean {
-  if (previousMessages === nextMessages) return true;
-  return deepEqual(previousMessages, nextMessages);
-}
+import {
+  isCurrentSubagentResponse,
+  mergeSubagentHistory,
+  toSubagentHistoryResponse,
+} from './subagentHistoryMerge';
 
 const pendingSubagentHistoryChunks = new Map<string, string[]>();
 const MAX_PENDING_SUBAGENT_HISTORY_TRANSFERS = 16;
@@ -105,30 +109,58 @@ export function registerWindowCallbacks(
   window.onSubagentHistoryLoaded = (json: string) => {
     try {
       if (!options.setSubagentHistories) return;
-      const result = JSON.parse(json);
+      const result = JSON.parse(json) as SubagentHistoryResponse;
+      if (!isCurrentSubagentResponse(
+        result,
+        options.currentSessionIdRef.current,
+        options.currentProviderRef.current,
+      )) return;
       const key = result.toolUseId || result.agentId;
       if (!key) return;
       options.setSubagentHistories((prev) => {
         const existing = prev[key];
+        const merged = mergeSubagentHistory(existing, result);
         // Skip state update when the payload is structurally identical.
         // This prevents cascading re-renders and scroll jumps caused by
         // periodic subagent polling (every 2 s) returning unchanged data.
-        if (existing && existing.success === result.success
-          && existing.completed === result.completed
-          && existing.status === result.status
-          && existing.error === result.error
-          && existing.sessionId === result.sessionId
-          && existing.provider === result.provider
-          && existing.toolUseId === result.toolUseId
-          && existing.agentId === result.agentId
-          && existing.agentPath === result.agentPath
-          && areSubagentMessagesEquivalent(existing.messages, result.messages)) {
+        if (existing && deepEqual(existing, merged)) {
           return prev;
         }
-        return { ...prev, [key]: result };
+        return { ...prev, [key]: merged };
       });
     } catch {
       // Ignore malformed callback payloads; the request can be retried by reopening the Agent row.
+    }
+  };
+
+  window.onSubagentStatusesLoaded = (json: string) => {
+    try {
+      if (!options.setSubagentHistories) return;
+      const result = JSON.parse(json) as SubagentStatusesResponse;
+      if (!isCurrentSubagentResponse(
+        result,
+        options.currentSessionIdRef.current,
+        options.currentProviderRef.current,
+      ) || !Array.isArray(result.statuses)) return;
+
+      options.setSubagentHistories((prev) => {
+        let next = prev;
+        for (const snapshot of result.statuses ?? []) {
+          const key = snapshot.toolUseId || snapshot.agentId;
+          if (!key) continue;
+          const existing = next[key];
+          const merged = mergeSubagentHistory(
+            existing,
+            toSubagentHistoryResponse(snapshot, result),
+          );
+          if (existing && deepEqual(existing, merged)) continue;
+          if (next === prev) next = { ...prev };
+          next[key] = merged;
+        }
+        return next;
+      });
+    } catch {
+      // Ignore malformed status batches; the next bounded poll will retry.
     }
   };
 

--- a/webview/src/hooks/windowCallbacks/subagentHistoryMerge.ts
+++ b/webview/src/hooks/windowCallbacks/subagentHistoryMerge.ts
@@ -1,0 +1,51 @@
+import type {
+  SubagentHistoryResponse,
+  SubagentStatusesResponse,
+  SubagentStatusSnapshot,
+} from '../../types';
+
+function isTerminal(history: SubagentHistoryResponse | undefined): boolean {
+  return history?.completed === true || history?.status === 'completed' || history?.status === 'error';
+}
+
+export function mergeSubagentHistory(
+  existing: SubagentHistoryResponse | undefined,
+  incoming: SubagentHistoryResponse,
+): SubagentHistoryResponse {
+  const merged = { ...existing, ...incoming };
+  if (!isTerminal(existing)) {
+    return merged;
+  }
+
+  // Lifecycle is monotonic, but late responses may still contribute identity
+  // fields or the transcript loaded by an expanded row.
+  return {
+    ...merged,
+    success: existing?.success ?? incoming.success,
+    completed: existing?.completed,
+    status: existing?.status,
+    error: existing?.error,
+  };
+}
+
+export function toSubagentHistoryResponse(
+  snapshot: SubagentStatusSnapshot,
+  batch: SubagentStatusesResponse,
+): SubagentHistoryResponse {
+  return {
+    ...snapshot,
+    sessionId: batch.sessionId,
+    provider: batch.provider,
+  };
+}
+
+export function isCurrentSubagentResponse(
+  result: { sessionId?: string; provider?: string },
+  currentSessionId: string | null,
+  currentProvider: string,
+): boolean {
+  if (result.sessionId && result.sessionId !== currentSessionId) {
+    return false;
+  }
+  return !result.provider || result.provider === currentProvider;
+}

--- a/webview/src/types/index.ts
+++ b/webview/src/types/index.ts
@@ -142,4 +142,13 @@ export interface HistoryData {
 export type { FileChangeStatus, EditOperation, FileChangeSummary } from './fileChanges';
 
 // Subagent types
-export type { SubagentStatus, SubagentInfo, SubagentHistoryResponse, TaskEvent, TaskEventMap, TaskEventStatus } from './subagent';
+export type {
+  SubagentStatus,
+  SubagentInfo,
+  SubagentHistoryResponse,
+  SubagentStatusSnapshot,
+  SubagentStatusesResponse,
+  TaskEvent,
+  TaskEventMap,
+  TaskEventStatus,
+} from './subagent';

--- a/webview/src/types/index.ts
+++ b/webview/src/types/index.ts
@@ -138,4 +138,13 @@ export interface HistoryData {
 export type { FileChangeStatus, EditOperation, FileChangeSummary } from './fileChanges';
 
 // Subagent types
-export type { SubagentStatus, SubagentInfo, SubagentHistoryResponse, TaskEvent, TaskEventMap, TaskEventStatus } from './subagent';
+export type {
+  SubagentStatus,
+  SubagentInfo,
+  SubagentHistoryResponse,
+  SubagentStatusSnapshot,
+  SubagentStatusesResponse,
+  TaskEvent,
+  TaskEventMap,
+  TaskEventStatus,
+} from './subagent';

--- a/webview/src/types/subagent.ts
+++ b/webview/src/types/subagent.ts
@@ -52,6 +52,25 @@ export interface SubagentHistoryResponse {
   messages?: unknown[];
 }
 
+/** Lightweight Codex sidechain status returned without loading its transcript. */
+export interface SubagentStatusSnapshot {
+  success: boolean;
+  completed?: boolean;
+  toolUseId?: string;
+  agentId?: string;
+  agentPath?: string;
+  status?: SubagentStatus;
+  error?: string;
+}
+
+/** Batched response for restoring Codex subagent lifecycle state. */
+export interface SubagentStatusesResponse {
+  sessionId?: string;
+  provider?: string;
+  requestId?: string;
+  statuses?: SubagentStatusSnapshot[];
+}
+
 /**
  * Subagent information extracted from Task tool calls
  */

--- a/webview/src/utils/subagentResult.test.ts
+++ b/webview/src/utils/subagentResult.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { ToolResultBlock } from '../types';
 import {
-  isAsyncAgentInput,
   extractResultText,
+  hasSubagentTranscript,
+  isAsyncAgentInput,
+  isSpawnAgentArgumentFailureNoise,
   parseAgentToolMeta,
   parseSpawnAgentMeta,
   readToolUseStatus,
@@ -98,6 +100,7 @@ describe('parseSpawnAgentMeta', () => {
       reasoning_effort: 'high',
     })).toEqual({
       agentPath: 'audit_ui',
+      identityLabel: 'audit_ui',
       model: 'gpt-5.6-terra',
       reasoningEffort: 'high',
     });
@@ -111,6 +114,47 @@ describe('parseSpawnAgentMeta', () => {
       agentId: 'agent-123',
       description: 'Review the bridge',
     });
+  });
+
+  it('prefers nickname and otherwise uses the final task path segment for display identity', () => {
+    expect(parseSpawnAgentMeta({ task_name: '/root/reviewer' })).toMatchObject({
+      agentPath: '/root/reviewer',
+      identityLabel: 'reviewer',
+    });
+    expect(parseSpawnAgentMeta({ task_name: '/root/reviewer', nickname: 'Hilbert' })).toMatchObject({
+      identityLabel: 'Hilbert',
+      nickname: 'Hilbert',
+    });
+  });
+});
+
+describe('isSpawnAgentArgumentFailureNoise', () => {
+  it('identifies empty historical calls with explicit argument parsing failures', () => {
+    expect(isSpawnAgentArgumentFailureNoise({}, {
+      type: 'tool_result',
+      content: 'failed to parse function arguments: EOF while parsing a value',
+    })).toBe(true);
+  });
+
+  it('keeps valid launches and unrelated runtime errors visible', () => {
+    const parseFailure = {
+      type: 'tool_result' as const,
+      content: 'failed to parse function arguments: missing field task_name',
+      is_error: true,
+    };
+    expect(isSpawnAgentArgumentFailureNoise({ task_name: 'reviewer' }, parseFailure)).toBe(false);
+    expect(isSpawnAgentArgumentFailureNoise({}, {
+      type: 'tool_result',
+      content: 'permission denied while starting agent',
+      is_error: true,
+    })).toBe(false);
+  });
+});
+
+describe('hasSubagentTranscript', () => {
+  it('distinguishes lightweight status from a loaded transcript', () => {
+    expect(hasSubagentTranscript({})).toBe(false);
+    expect(hasSubagentTranscript({ messages: [] })).toBe(true);
   });
 });
 

--- a/webview/src/utils/subagentResult.test.ts
+++ b/webview/src/utils/subagentResult.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
-  isAsyncAgentInput,
   extractResultText,
+  hasSubagentTranscript,
+  isAsyncAgentInput,
+  isSpawnAgentArgumentFailureNoise,
   parseAgentToolMeta,
   parseSpawnAgentMeta,
 } from './subagentResult';
@@ -52,6 +54,7 @@ describe('parseSpawnAgentMeta', () => {
       reasoning_effort: 'high',
     })).toEqual({
       agentPath: 'audit_ui',
+      identityLabel: 'audit_ui',
       model: 'gpt-5.6-terra',
       reasoningEffort: 'high',
     });
@@ -65,6 +68,47 @@ describe('parseSpawnAgentMeta', () => {
       agentId: 'agent-123',
       description: 'Review the bridge',
     });
+  });
+
+  it('prefers nickname and otherwise uses the final task path segment for display identity', () => {
+    expect(parseSpawnAgentMeta({ task_name: '/root/reviewer' })).toMatchObject({
+      agentPath: '/root/reviewer',
+      identityLabel: 'reviewer',
+    });
+    expect(parseSpawnAgentMeta({ task_name: '/root/reviewer', nickname: 'Hilbert' })).toMatchObject({
+      identityLabel: 'Hilbert',
+      nickname: 'Hilbert',
+    });
+  });
+});
+
+describe('isSpawnAgentArgumentFailureNoise', () => {
+  it('identifies empty historical calls with explicit argument parsing failures', () => {
+    expect(isSpawnAgentArgumentFailureNoise({}, {
+      type: 'tool_result',
+      content: 'failed to parse function arguments: EOF while parsing a value',
+    })).toBe(true);
+  });
+
+  it('keeps valid launches and unrelated runtime errors visible', () => {
+    const parseFailure = {
+      type: 'tool_result' as const,
+      content: 'failed to parse function arguments: missing field task_name',
+      is_error: true,
+    };
+    expect(isSpawnAgentArgumentFailureNoise({ task_name: 'reviewer' }, parseFailure)).toBe(false);
+    expect(isSpawnAgentArgumentFailureNoise({}, {
+      type: 'tool_result',
+      content: 'permission denied while starting agent',
+      is_error: true,
+    })).toBe(false);
+  });
+});
+
+describe('hasSubagentTranscript', () => {
+  it('distinguishes lightweight status from a loaded transcript', () => {
+    expect(hasSubagentTranscript({})).toBe(false);
+    expect(hasSubagentTranscript({ messages: [] })).toBe(true);
   });
 });
 

--- a/webview/src/utils/subagentResult.ts
+++ b/webview/src/utils/subagentResult.ts
@@ -1,4 +1,4 @@
-import type { ToolResultBlock } from '../types';
+import type { SubagentHistoryResponse, ToolResultBlock } from '../types';
 import type { GetToolResultRawFn } from '../contexts/SubagentContext';
 
 /**
@@ -97,9 +97,15 @@ export interface SpawnAgentMeta {
   agentId?: string;
   agentPath?: string;
   description?: string;
+  identityLabel?: string;
   nickname?: string;
   model?: string;
   reasoningEffort?: string;
+}
+
+function getAgentPathName(agentPath: string | undefined): string | undefined {
+  if (!agentPath) return undefined;
+  return agentPath.split(/[\\/]+/).filter(Boolean).at(-1);
 }
 
 /** Parse Codex spawn_agent launch metadata without conflating task_name with an agent UUID. */
@@ -140,8 +146,14 @@ export function parseSpawnAgentMeta(
       input.task_name,
       input.taskName,
     );
-  const description = getString(parsed?.description, input.description);
+  const inputMessage = getString(input.message);
+  const inputDescription = getString(input.description);
+  const description = getString(
+    parsed?.description,
+    inputDescription !== inputMessage ? inputDescription : undefined,
+  );
   const nickname = getString(parsed?.nickname, parsed?.name, input.nickname);
+  const identityLabel = nickname ?? getAgentPathName(agentPath);
   const model = getString(parsed?.model, input.model) ?? modelMatch?.[1];
   const reasoningEffort = getString(
       parsed?.reasoning_effort,
@@ -153,10 +165,38 @@ export function parseSpawnAgentMeta(
     ...(agentId && { agentId }),
     ...(agentPath && { agentPath }),
     ...(description && { description }),
+    ...(identityLabel && { identityLabel }),
     ...(nickname && { nickname }),
     ...(model && { model }),
     ...(reasoningEffort && { reasoningEffort }),
   };
+}
+
+/** True only when a full sidechain transcript has been loaded. */
+export function hasSubagentTranscript(history?: Pick<SubagentHistoryResponse, 'messages'>): boolean {
+  return Array.isArray(history?.messages);
+}
+
+/**
+ * Identify historical Codex noise created by an invalid spawn_agent call.
+ *
+ * The check intentionally requires both missing task identity and an explicit
+ * argument parse/validation failure. Valid launches that later fail remain
+ * visible in the StatusPanel.
+ */
+export function isSpawnAgentArgumentFailureNoise(
+  input: Record<string, unknown>,
+  result?: ToolResultBlock | null,
+): boolean {
+  const hasTaskIdentity = [input.task_name, input.taskName, input.agent_path, input.agentPath]
+    .some((value) => typeof value === 'string' && value.trim().length > 0);
+  if (hasTaskIdentity) return false;
+
+  const resultText = extractResultText(result)?.trim();
+  if (!resultText) return false;
+
+  return /failed to parse function arguments|invalid function arguments|invalid arguments for (?:tool )?spawn_agent/i.test(resultText)
+    || /missing (?:required )?(?:field|property)[^\n]*(?:task_name|taskName)/i.test(resultText);
 }
 
 /**

--- a/webview/src/utils/subagentResult.ts
+++ b/webview/src/utils/subagentResult.ts
@@ -1,4 +1,4 @@
-import type { ToolResultBlock } from '../types';
+import type { SubagentHistoryResponse, ToolResultBlock } from '../types';
 import type { GetToolResultRawFn } from '../contexts/SubagentContext';
 
 /**
@@ -45,9 +45,15 @@ export interface SpawnAgentMeta {
   agentId?: string;
   agentPath?: string;
   description?: string;
+  identityLabel?: string;
   nickname?: string;
   model?: string;
   reasoningEffort?: string;
+}
+
+function getAgentPathName(agentPath: string | undefined): string | undefined {
+  if (!agentPath) return undefined;
+  return agentPath.split(/[\\/]+/).filter(Boolean).at(-1);
 }
 
 /** Parse Codex spawn_agent launch metadata without conflating task_name with an agent UUID. */
@@ -88,8 +94,14 @@ export function parseSpawnAgentMeta(
       input.task_name,
       input.taskName,
     );
-  const description = getString(parsed?.description, input.description);
+  const inputMessage = getString(input.message);
+  const inputDescription = getString(input.description);
+  const description = getString(
+    parsed?.description,
+    inputDescription !== inputMessage ? inputDescription : undefined,
+  );
   const nickname = getString(parsed?.nickname, parsed?.name, input.nickname);
+  const identityLabel = nickname ?? getAgentPathName(agentPath);
   const model = getString(parsed?.model, input.model) ?? modelMatch?.[1];
   const reasoningEffort = getString(
       parsed?.reasoning_effort,
@@ -101,10 +113,38 @@ export function parseSpawnAgentMeta(
     ...(agentId && { agentId }),
     ...(agentPath && { agentPath }),
     ...(description && { description }),
+    ...(identityLabel && { identityLabel }),
     ...(nickname && { nickname }),
     ...(model && { model }),
     ...(reasoningEffort && { reasoningEffort }),
   };
+}
+
+/** True only when a full sidechain transcript has been loaded. */
+export function hasSubagentTranscript(history?: Pick<SubagentHistoryResponse, 'messages'>): boolean {
+  return Array.isArray(history?.messages);
+}
+
+/**
+ * Identify historical Codex noise created by an invalid spawn_agent call.
+ *
+ * The check intentionally requires both missing task identity and an explicit
+ * argument parse/validation failure. Valid launches that later fail remain
+ * visible in the StatusPanel.
+ */
+export function isSpawnAgentArgumentFailureNoise(
+  input: Record<string, unknown>,
+  result?: ToolResultBlock | null,
+): boolean {
+  const hasTaskIdentity = [input.task_name, input.taskName, input.agent_path, input.agentPath]
+    .some((value) => typeof value === 'string' && value.trim().length > 0);
+  if (hasTaskIdentity) return false;
+
+  const resultText = extractResultText(result)?.trim();
+  if (!resultText) return false;
+
+  return /failed to parse function arguments|invalid function arguments|invalid arguments for (?:tool )?spawn_agent/i.test(resultText)
+    || /missing (?:required )?(?:field|property)[^\n]*(?:task_name|taskName)/i.test(resultText);
 }
 
 /**

--- a/webview/src/utils/turnScope.test.ts
+++ b/webview/src/utils/turnScope.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { computeStatusScopeMessages, finalizeSubagentsForSettledTurn } from './turnScope';
-import type { ClaudeMessage, SubagentInfo } from '../types';
+import {
+  computeStatusScopeMessages,
+  finalizeTodosForSettledTurn,
+  selectLatestSubagentTurn,
+} from './turnScope';
+import type { ClaudeMessage, SubagentInfo, TodoItem } from '../types';
 
 const userMsg = (content: string): ClaudeMessage => ({ type: 'user', content });
 const assistantMsg = (): ClaudeMessage => ({ type: 'assistant', content: 'ok' });
@@ -48,36 +52,44 @@ const subagent = (overrides: Partial<SubagentInfo>): SubagentInfo => ({
   ...overrides,
 });
 
-describe('finalizeSubagentsForSettledTurn', () => {
-  it('does not infer async completion from a settled main turn', () => {
-    const result = finalizeSubagentsForSettledTurn([subagent({ isAsync: true })], false);
-    expect(result[0].status).toBe('running');
+describe('finalizeTodosForSettledTurn', () => {
+  const todos: TodoItem[] = [{ content: 'Implement', status: 'in_progress' }];
+
+  it('preserves Codex plan state when the main turn settles', () => {
+    expect(finalizeTodosForSettledTurn(todos, false, 'codex')).toEqual(todos);
   });
 
-  it('preserves terminal status supplied by task_notification or sidechain history', () => {
-    const result = finalizeSubagentsForSettledTurn(
-      [
-        subagent({ isAsync: true, status: 'completed' }),
-        subagent({ isAsync: true, status: 'error' }),
-      ],
-      false,
-    );
-    expect(result.map((item) => item.status)).toEqual(['completed', 'error']);
+  it('keeps the existing Claude settled-task behavior', () => {
+    expect(finalizeTodosForSettledTurn(todos, false, 'claude')).toEqual([
+      { content: 'Implement', status: 'completed' },
+    ]);
+  });
+});
+
+describe('selectLatestSubagentTurn', () => {
+  const user = (content: string): ClaudeMessage => ({ type: 'user', content });
+  const assistant = (): ClaudeMessage => ({ type: 'assistant' });
+
+  it('keeps only the most recent turn containing valid extracted subagents', () => {
+    const messages = [user('first'), assistant(), user('second'), assistant()];
+    const first = subagent({ id: 'first', messageIndex: 1 });
+    const second = subagent({ id: 'second', messageIndex: 3 });
+
+    expect(selectLatestSubagentTurn(messages, [first, second])).toEqual([second]);
   });
 
-  it('does not mutate sync extraction results', () => {
-    const running = subagent({ isAsync: false });
-    const completed = subagent({ isAsync: false, status: 'completed' });
-    const result = finalizeSubagentsForSettledTurn([running, completed], false);
-    expect(result).toEqual([running, completed]);
+  it('keeps the previous valid turn when a later turn produced no valid subagent', () => {
+    const messages = [user('first'), assistant(), user('noise-only'), assistant()];
+    const first = subagent({ id: 'first', messageIndex: 1 });
+
+    expect(selectLatestSubagentTurn(messages, [first])).toEqual([first]);
   });
 
-  it('returns the same states while streaming', () => {
-    const result = finalizeSubagentsForSettledTurn(
-      [subagent({ isAsync: false }), subagent({ isAsync: true })],
-      true,
-    );
-    expect(result[0].status).toBe('running');
-    expect(result[1].status).toBe('running');
+  it('keeps all valid subagents from the selected turn', () => {
+    const messages = [user('first'), assistant(), assistant()];
+    const first = subagent({ id: 'first', messageIndex: 1 });
+    const second = subagent({ id: 'second', messageIndex: 2 });
+
+    expect(selectLatestSubagentTurn(messages, [first, second])).toEqual([first, second]);
   });
 });

--- a/webview/src/utils/turnScope.test.ts
+++ b/webview/src/utils/turnScope.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { finalizeSubagentsForSettledTurn } from './turnScope';
-import type { SubagentInfo } from '../types';
+import {
+  finalizeTodosForSettledTurn,
+  selectLatestSubagentTurn,
+} from './turnScope';
+import type { ClaudeMessage, SubagentInfo, TodoItem } from '../types';
 
 const subagent = (overrides: Partial<SubagentInfo>): SubagentInfo => ({
   id: 'tu_1',
@@ -11,36 +14,44 @@ const subagent = (overrides: Partial<SubagentInfo>): SubagentInfo => ({
   ...overrides,
 });
 
-describe('finalizeSubagentsForSettledTurn', () => {
-  it('does not infer async completion from a settled main turn', () => {
-    const result = finalizeSubagentsForSettledTurn([subagent({ isAsync: true })], false);
-    expect(result[0].status).toBe('running');
+describe('finalizeTodosForSettledTurn', () => {
+  const todos: TodoItem[] = [{ content: 'Implement', status: 'in_progress' }];
+
+  it('preserves Codex plan state when the main turn settles', () => {
+    expect(finalizeTodosForSettledTurn(todos, false, 'codex')).toEqual(todos);
   });
 
-  it('preserves terminal status supplied by task_notification or sidechain history', () => {
-    const result = finalizeSubagentsForSettledTurn(
-      [
-        subagent({ isAsync: true, status: 'completed' }),
-        subagent({ isAsync: true, status: 'error' }),
-      ],
-      false,
-    );
-    expect(result.map((item) => item.status)).toEqual(['completed', 'error']);
+  it('keeps the existing Claude settled-task behavior', () => {
+    expect(finalizeTodosForSettledTurn(todos, false, 'claude')).toEqual([
+      { content: 'Implement', status: 'completed' },
+    ]);
+  });
+});
+
+describe('selectLatestSubagentTurn', () => {
+  const user = (content: string): ClaudeMessage => ({ type: 'user', content });
+  const assistant = (): ClaudeMessage => ({ type: 'assistant' });
+
+  it('keeps only the most recent turn containing valid extracted subagents', () => {
+    const messages = [user('first'), assistant(), user('second'), assistant()];
+    const first = subagent({ id: 'first', messageIndex: 1 });
+    const second = subagent({ id: 'second', messageIndex: 3 });
+
+    expect(selectLatestSubagentTurn(messages, [first, second])).toEqual([second]);
   });
 
-  it('does not mutate sync extraction results', () => {
-    const running = subagent({ isAsync: false });
-    const completed = subagent({ isAsync: false, status: 'completed' });
-    const result = finalizeSubagentsForSettledTurn([running, completed], false);
-    expect(result).toEqual([running, completed]);
+  it('keeps the previous valid turn when a later turn produced no valid subagent', () => {
+    const messages = [user('first'), assistant(), user('noise-only'), assistant()];
+    const first = subagent({ id: 'first', messageIndex: 1 });
+
+    expect(selectLatestSubagentTurn(messages, [first])).toEqual([first]);
   });
 
-  it('returns the same states while streaming', () => {
-    const result = finalizeSubagentsForSettledTurn(
-      [subagent({ isAsync: false }), subagent({ isAsync: true })],
-      true,
-    );
-    expect(result[0].status).toBe('running');
-    expect(result[1].status).toBe('running');
+  it('keeps all valid subagents from the selected turn', () => {
+    const messages = [user('first'), assistant(), assistant()];
+    const first = subagent({ id: 'first', messageIndex: 1 });
+    const second = subagent({ id: 'second', messageIndex: 2 });
+
+    expect(selectLatestSubagentTurn(messages, [first, second])).toEqual([first, second]);
   });
 });

--- a/webview/src/utils/turnScope.ts
+++ b/webview/src/utils/turnScope.ts
@@ -52,8 +52,42 @@ export function computeStatusScopeMessages(
   return latestTurnMessages.length > 0 && latestTurnHasToolUse ? latestTurnMessages : messages;
 }
 
-export function finalizeTodosForSettledTurn(todos: TodoItem[], isStreaming: boolean): TodoItem[] {
-  if (isStreaming) return todos;
+function findConversationTurnStartAt(messages: ClaudeMessage[], messageIndex: number): number {
+  for (let i = Math.min(messageIndex, messages.length - 1); i >= 0; i -= 1) {
+    const message = messages[i];
+    if (message.type !== 'user' || isToolResultOnlyUserMessage(message)) continue;
+    return i;
+  }
+  return -1;
+}
+
+/**
+ * Keep the most recent user turn that contains at least one extracted subagent.
+ * Invalid Codex spawn calls are filtered before this helper runs, so a later
+ * noise-only turn cannot hide the previous turn's valid agents.
+ */
+export function selectLatestSubagentTurn(
+  messages: ClaudeMessage[],
+  subagents: SubagentInfo[],
+): SubagentInfo[] {
+  if (subagents.length === 0) return [];
+
+  let latestTurnStart = Number.NEGATIVE_INFINITY;
+  const turnStarts = subagents.map((subagent) => {
+    const turnStart = findConversationTurnStartAt(messages, subagent.messageIndex);
+    latestTurnStart = Math.max(latestTurnStart, turnStart);
+    return turnStart;
+  });
+
+  return subagents.filter((_, index) => turnStarts[index] === latestTurnStart);
+}
+
+export function finalizeTodosForSettledTurn(
+  todos: TodoItem[],
+  isStreaming: boolean,
+  currentProvider: string,
+): TodoItem[] {
+  if (isStreaming || currentProvider === 'codex') return todos;
   return todos.map((todo) => (
     todo.status === 'in_progress'
       ? { ...todo, status: 'completed' }

--- a/webview/src/utils/turnScope.ts
+++ b/webview/src/utils/turnScope.ts
@@ -30,20 +30,45 @@ export function sliceLatestConversationTurn(messages: ClaudeMessage[]): ClaudeMe
   return start >= 0 ? messages.slice(start) : [];
 }
 
-export function finalizeTodosForSettledTurn(todos: TodoItem[], isStreaming: boolean): TodoItem[] {
-  if (isStreaming) return todos;
+function findConversationTurnStartAt(messages: ClaudeMessage[], messageIndex: number): number {
+  for (let i = Math.min(messageIndex, messages.length - 1); i >= 0; i -= 1) {
+    const message = messages[i];
+    if (message.type !== 'user' || isToolResultOnlyUserMessage(message)) continue;
+    return i;
+  }
+  return -1;
+}
+
+/**
+ * Keep the most recent user turn that contains at least one extracted subagent.
+ * Invalid Codex spawn calls are filtered before this helper runs, so a later
+ * noise-only turn cannot hide the previous turn's valid agents.
+ */
+export function selectLatestSubagentTurn(
+  messages: ClaudeMessage[],
+  subagents: SubagentInfo[],
+): SubagentInfo[] {
+  if (subagents.length === 0) return [];
+
+  let latestTurnStart = Number.NEGATIVE_INFINITY;
+  const turnStarts = subagents.map((subagent) => {
+    const turnStart = findConversationTurnStartAt(messages, subagent.messageIndex);
+    latestTurnStart = Math.max(latestTurnStart, turnStart);
+    return turnStart;
+  });
+
+  return subagents.filter((_, index) => turnStarts[index] === latestTurnStart);
+}
+
+export function finalizeTodosForSettledTurn(
+  todos: TodoItem[],
+  isStreaming: boolean,
+  currentProvider: string,
+): TodoItem[] {
+  if (isStreaming || currentProvider === 'codex') return todos;
   return todos.map((todo) => (
     todo.status === 'in_progress'
       ? { ...todo, status: 'completed' }
       : todo
   ));
-}
-
-export function finalizeSubagentsForSettledTurn(subagents: SubagentInfo[], _isStreaming: boolean): SubagentInfo[] {
-  // A settled main turn is not evidence that a run_in_background agent ended:
-  // the launch turn completes while the sidechain may still be running. Async
-  // agents are finalized only by task_notification or by a sidechain transcript
-  // ending in assistant/end_turn (resolved in useSubagents). Sync agents already
-  // derive their terminal state from the Agent tool_result.
-  return subagents;
 }


### PR DESCRIPTION
## Problem

After Codex subagent/history support was added, the UI still applied several Claude-specific assumptions to Codex `spawn_agent` and `update_plan` events.

The visible failures include:

1. **Subagents are missing, duplicated, or represented by parse-noise rows.** Historical malformed `spawn_agent` attempts can hide the previous valid subagent turn, while valid launch/runtime failures may disappear.
2. **Subagent titles contain transport data instead of identity.** Codex sends `task_name`, `nickname`, and an opaque `message`; the previous generic Agent renderer could expose the opaque message as a summary/prompt and fail to show a stable task identity.
3. **Reloaded sessions lose lifecycle state.** A launched agent can remain shown as running forever, or appear completed merely because the parent turn settled, even though the child sidechain is still running or already failed.
4. **Expanding details can stop at a status snapshot.** Once lightweight status data exists, the UI may assume that a full transcript was loaded and never request the actual sidechain messages.
5. **Late responses can corrupt the current session.** A status response for a previous session/provider or an older polling request can update the newly selected conversation; a late `running` response can overwrite a terminal state.
6. **Codex plans are displayed with Claude task semantics.** Pending/in-progress items can be forced to completed when the main turn settles, an empty `update_plan` cannot clear an old plan, and historical `in_progress` items keep a streaming spinner.

## Root cause

### Parent-turn completion was treated as child completion

Codex `spawn_agent` is asynchronous. The launch tool result and the end of the parent assistant turn only prove that the launch boundary settled; the authoritative state is in the child sidechain lifecycle. The previous shared settled-turn helper was correct for existing Claude task behavior but incorrect for Codex.

### History loading served two different purposes through one shape

The frontend used the same history map for both lightweight lifecycle status and a complete transcript, with no explicit way to tell them apart. The backend only exposed per-agent transcript loading, so restoring several visible agents required either expensive repeated scans or no restoration at all.

### Codex metadata was parsed through generic Agent fields

`task_name` is a path-like task identity, not an agent UUID. `message` is opaque transport content, not user-facing prompt text. Conflating those fields produced unstable lookup keys and unsafe/meaningless UI content.

### Plan normalization was provider-agnostic

The same turn-settlement normalization was used for Claude tasks and Codex plans even though Codex already sends authoritative `pending`, `in_progress`, and `completed` states.

## Why this PR is needed

PR #1556 restored stable Codex history anchors and prevented child sessions from polluting the top-level history list. This PR addresses the remaining lifecycle and rendering layer: once subagent sessions are hidden from the main history, the parent conversation still needs a bounded way to recover their state, identity, and transcript.

Loading every child transcript on every poll would be expensive and would scale with transcript size. Marking agents complete when the parent settles is cheaper but incorrect. The required design is a lightweight batched lifecycle scan, with the full transcript loaded only when the user expands an agent.

The plan fix is included because it has the same root boundary: Codex event state must remain authoritative instead of being rewritten by Claude settled-turn assumptions. The implementation keeps the provider-specific behavior isolated so Claude rendering does not regress.

## Fix

### Batched Codex lifecycle restoration

- add `load_subagent_statuses` / `onSubagentStatusesLoaded` for lightweight status snapshots;
- resolve parent activity mappings once, then scan child sidechains only for lifecycle state instead of converting full transcripts;
- cap each batch at 64 targets and use one two-second frontend poller;
- prevent concurrent status scans for the same session;
- validate session, provider, and request ID before merging a response;
- keep terminal state monotonic so a late `running` snapshot cannot replace completed/error state;
- accept the frontend `sessionId:sequence` request-ID format with a separate bounded validator.

### Transcript/identity handling

- treat a history entry as a loaded transcript only when `messages` is present;
- load the full transcript only after expansion;
- propagate resolved `agentId` and `agentPath` from status snapshots into detail lookup;
- prefer `nickname`, then the final `task_name` / `agentPath` segment for display;
- never render Codex `spawn_agent.message` in title, body, prompt, tooltip, or generic remaining fields;
- filter only calls that both lack a task identity and have an explicit argument-parse/validation failure;
- keep valid launch failures and runtime failures visible;
- show the most recent user turn containing a valid Codex subagent, so a later parse-noise-only turn cannot hide it.

### Plan rendering

- preserve authoritative Codex `pending`, `in_progress`, and `completed` states;
- let an empty Codex plan clear the previous plan;
- do not force Codex items to completed when the parent stream settles;
- retain the existing Claude settled-task behavior;
- label Codex content as a plan and Claude content as tasks;
- avoid animating historical/non-streaming `in_progress` indicators.

### Error classification

- carry the narrow historical `is_error` signal needed for failed launches;
- remove the overly broad `error ` text prefix that could classify normal explanatory output as a failed tool result.

## Compatibility and scope

- Claude task settlement behavior is intentionally unchanged;
- full child transcripts remain lazy-loaded;
- no provider credential, MCP, Skill, or AI bridge logic is modified;
- no opaque Codex transport content is exposed in the UI;
- status polling is bounded by target count and protected against slow-disk overlap.

## Testing

- targeted Java message conversion, parent/child history mapping, lifecycle scanning, request validation, error classification, and in-flight deduplication tests;
- 76 targeted Webview tests covering polling, stale-response rejection, terminal-state precedence, transcript merging, identity fallback, opaque-message filtering, turn scope, and plan semantics;
- full Java test suite;
- `checkstyleMain`;
- full Webview test suite and TypeScript test configuration check;
- Webview production build;
- `git diff --check`.