### PR TITLE
feat(codex-pet): enable the settings tab

### DIFF
--- a/webview/src/components/settings/index.tsx
+++ b/webview/src/components/settings/index.tsx
@@ -73,9 +73,8 @@ const SettingsView = ({
   const { t } = useTranslation();
   const isCodexMode = currentProvider === 'codex';
   // Codex mode: align with Claude capabilities for settings tabs.
-  // The Codex pet entry is temporarily disabled (grayed out, not clickable).
   const disabledTabs = useMemo<SettingsTab[]>(
-    () => ['pet'],
+    () => [],
     []
   );
 


### PR DESCRIPTION
## Summary

- enable the existing Pet settings tab for Codex now that the scoped Codex Pet integration is available
- remove the stale disabled-tab entry without changing Pet behavior for Claude

## Testing

- full Webview test suite and TypeScript test configuration check
- Webview production build
- `git diff --check`