### PR TITLE
fix(usage): bill turn cost with provider-mapped model instead of Claude slot id

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/provider/ModelProviderHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/provider/ModelProviderHandler.java
@@ -320,7 +320,7 @@ public class ModelProviderHandler {
         return baseModel;
     }
 
-    static String resolveConfiguredClaudeModel(String baseModel, JsonObject env) {
+    public static String resolveConfiguredClaudeModel(String baseModel, JsonObject env) {
         if (baseModel == null || baseModel.isEmpty() || env == null) {
             return baseModel;
         }

--- a/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
@@ -2,8 +2,10 @@ package com.github.claudecodegui.session;
 
 import com.github.claudecodegui.session.ClaudeSession.Message;
 import com.github.claudecodegui.handler.SettingsHandler;
+import com.github.claudecodegui.handler.provider.ModelProviderHandler;
 import com.github.claudecodegui.notifications.ClaudeNotifier;
 import com.github.claudecodegui.provider.common.MessageCallback;
+import com.github.claudecodegui.settings.CodemossSettingsService;
 import com.github.claudecodegui.provider.common.SDKResult;
 import com.github.claudecodegui.util.TokenUsageUtils;
 import com.github.claudecodegui.util.UsageCostCalculator;
@@ -30,6 +32,7 @@ public class ClaudeMessageHandler implements MessageCallback {
     private final MessageMerger messageMerger;
     private final ReplayDeduplicator replayDedup = new ReplayDeduplicator();
     private final Gson gson;
+    private final CodemossSettingsService settingsService;
 
     // Content accumulator for the current assistant message
     private final StringBuilder assistantContent = new StringBuilder();
@@ -66,12 +69,30 @@ public class ClaudeMessageHandler implements MessageCallback {
             MessageMerger messageMerger,
             Gson gson
     ) {
+        this(project, state, callbackHandler, messageParser, messageMerger, gson, null);
+    }
+
+    /**
+     * Constructor with an injectable settings service. The service is used to resolve the
+     * model actually billed for a turn (slot ID → provider-mapped real ID); tests inject a
+     * fake so pricing never depends on the developer's real config file.
+     */
+    ClaudeMessageHandler(
+            Project project,
+            SessionState state,
+            CallbackHandler callbackHandler,
+            MessageParser messageParser,
+            MessageMerger messageMerger,
+            Gson gson,
+            CodemossSettingsService settingsService
+    ) {
         this.project = project;
         this.state = state;
         this.callbackHandler = callbackHandler;
         this.messageParser = messageParser;
         this.messageMerger = messageMerger;
         this.gson = gson;
+        this.settingsService = settingsService != null ? settingsService : new CodemossSettingsService();
     }
 
     /**
@@ -592,6 +613,27 @@ public class ClaudeMessageHandler implements MessageCallback {
     }
 
     /**
+     * Resolve the model that should be billed for this turn.
+     *
+     * <p>The chat UI selects Claude slot IDs (e.g. {@code claude-sonnet-4-6[1m]}), which the
+     * active provider's env maps to real model IDs (e.g. {@code deepseek-v4-flash}) before the
+     * request reaches the API. Pricing must use the real ID — otherwise a custom price configured
+     * for the mapped model is never matched and the turn is billed at built-in Claude rates
+     * (same resolution used for the context limit at {@link ModelProviderHandler}).
+     */
+    private String resolvePricingModel(String model) {
+        try {
+            JsonObject claudeSettings = settingsService.readClaudeSettings();
+            if (claudeSettings != null && claudeSettings.has("env") && claudeSettings.get("env").isJsonObject()) {
+                return ModelProviderHandler.resolveConfiguredClaudeModel(model, claudeSettings.getAsJsonObject("env"));
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to resolve pricing model: " + e.getMessage());
+        }
+        return model;
+    }
+
+    /**
      * Handle the result message as a fallback for non-streaming mode.
      * In streaming mode, usage is updated via handleUsage() from [USAGE] tags.
      * In non-streaming mode, [USAGE] tags may not be emitted, so result.usage
@@ -613,7 +655,7 @@ public class ClaudeMessageHandler implements MessageCallback {
                 // for the status bar and must keep its semantics.
                 JsonObject turnUsage = resultJson.getAsJsonObject("usage");
                 currentAssistantMessage.raw.add("turnUsage", turnUsage.deepCopy());
-                Double turnCostUsd = UsageCostCalculator.calculateTurnCostUsd(state.getProvider(), turnUsage, state.getModel());
+                Double turnCostUsd = UsageCostCalculator.calculateTurnCostUsd(state.getProvider(), turnUsage, resolvePricingModel(state.getModel()));
                 if (turnCostUsd != null) {
                     currentAssistantMessage.raw.addProperty("turnCostUsd", turnCostUsd);
                 }

--- a/src/test/java/com/github/claudecodegui/session/ClaudeMessageHandlerResultUsageTest.java
+++ b/src/test/java/com/github/claudecodegui/session/ClaudeMessageHandlerResultUsageTest.java
@@ -1,6 +1,8 @@
 package com.github.claudecodegui.session;
 
+import com.github.claudecodegui.provider.CustomPricingProvider;
 import com.github.claudecodegui.session.ClaudeSession.Message;
+import com.github.claudecodegui.settings.CodemossSettingsService;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -8,8 +10,11 @@ import com.google.gson.JsonObject;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -45,14 +50,27 @@ public class ClaudeMessageHandlerResultUsageTest {
         callback = new RecordingCallback();
         callbackHandler.setCallback(callback);
 
+        // No env mappings: pricing must stay on the built-in table, and must never read
+        // the developer's real ~/.codemoss/config.json.
         handler = new ClaudeMessageHandler(
                 null,
                 state,
                 callbackHandler,
                 messageParser,
                 messageMerger,
-                gson
+                gson,
+                fakeSettings("{}")
         );
+    }
+
+    /** Fake settings service returning a fixed claude settings JSON. */
+    private static CodemossSettingsService fakeSettings(String settingsJson) {
+        return new CodemossSettingsService() {
+            @Override
+            public JsonObject readClaudeSettings() throws IOException {
+                return new Gson().fromJson(settingsJson, JsonObject.class);
+            }
+        };
     }
 
     @Test
@@ -79,6 +97,40 @@ public class ClaudeMessageHandlerResultUsageTest {
         JsonObject messageUsage = msg.raw.getAsJsonObject("message").getAsJsonObject("usage");
         assertEquals(37, messageUsage.get("input_tokens").getAsInt());
         assertEquals(353, messageUsage.get("output_tokens").getAsInt());
+    }
+
+    @Test
+    public void billsTurnWithProviderMappedModelInsteadOfClaudeSlotId() throws Exception {
+        Path config = Files.createTempFile("pricing-test", ".json");
+        Files.writeString(config, "{\"customModelPricing\":{\"claude\":{\"deepseek-v4-flash\":{"
+                + "\"inputCostPer1M\":1.0,\"outputCostPer1M\":2.0,\"cacheReadCostPer1M\":0.02}}}}");
+        CustomPricingProvider.setInstanceForTests(CustomPricingProvider.createForTests(config));
+        try {
+            // Session selected the claude-sonnet-4-6 slot, but the provider env maps it to
+            // deepseek-v4-flash (as in ~/.codemoss config). The turn must be billed at the
+            // custom deepseek rate, NOT the built-in sonnet rate.
+            handler = new ClaudeMessageHandler(
+                    null,
+                    state,
+                    new CallbackHandler(),
+                    new MessageParser(),
+                    new MessageMerger(),
+                    new GsonBuilder().create(),
+                    fakeSettings("{\"env\":{\"ANTHROPIC_DEFAULT_SONNET_MODEL\":\"deepseek-v4-flash\"}}")
+            );
+
+            Message msg = newAssistantMessageWithUsage(37, 353);
+            setCurrentAssistantMessage(msg);
+            invokeHandleResult("{\"type\":\"result\",\"subtype\":\"success\",\"usage\":{"
+                    + "\"input_tokens\":1200,\"cache_creation_input_tokens\":4096,"
+                    + "\"cache_read_input_tokens\":363100,\"output_tokens\":4560}}");
+
+            // 1200*1 + 363100*0.02 + 4560*2 per 1M = 0.0012 + 0.007262 + 0.00912
+            assertEquals(0.017582, msg.raw.get("turnCostUsd").getAsDouble(), 0.000001);
+        } finally {
+            CustomPricingProvider.setInstanceForTests(null);
+            Files.deleteIfExists(config);
+        }
     }
 
     @Test

--- a/src/test/java/com/github/claudecodegui/util/UsageCostCalculatorTest.java
+++ b/src/test/java/com/github/claudecodegui/util/UsageCostCalculatorTest.java
@@ -1,7 +1,11 @@
 package com.github.claudecodegui.util;
 
+import com.github.claudecodegui.provider.CustomPricingProvider;
 import com.google.gson.JsonObject;
 import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -60,6 +64,33 @@ public class UsageCostCalculatorTest {
         // Bare "gpt-5.6" is aliased to gpt-5.6-sol, matching CodexPricingTable.
         double aliasCost = UsageCostCalculator.calculateTurnCostUsd("codex", usage, "gpt-5.6");
         assertEquals(0.032195, aliasCost, 0.0000001);
+    }
+
+    @Test
+    public void pricesMappedCustomModelUsingConfiguredRates() throws Exception {
+        Path config = Files.createTempFile("pricing-test", ".json");
+        Files.writeString(config, "{\"customModelPricing\":{\"claude\":{\"deepseek-v4-flash\":{"
+                + "\"inputCostPer1M\":1.0,\"outputCostPer1M\":2.0,\"cacheReadCostPer1M\":0.02}}}}");
+        CustomPricingProvider.setInstanceForTests(CustomPricingProvider.createForTests(config));
+        try {
+            // Turn from the real-world deepseek-v4-flash session:
+            // 1.2M input (95% cache-hit => 62K uncached + 1178K read), 11.1K output.
+            JsonObject usage = new JsonObject();
+            usage.addProperty("input_tokens", 62000);
+            usage.addProperty("cache_creation_input_tokens", 0);
+            usage.addProperty("cache_read_input_tokens", 1178000);
+            usage.addProperty("output_tokens", 11100);
+
+            // Model arrives as the Claude slot ID with the 1m suffix; pricing lookup must
+            // resolve it to the configured base model (mapping done by ModelProviderHandler).
+            double cost = UsageCostCalculator.calculateTurnCostUsd("claude", usage, "deepseek-v4-flash[1m]");
+
+            // 0.062 * 1 + 1.178 * 0.02 + 0.0111 * 2 = 0.10776
+            assertEquals(0.10776, cost, 0.00001);
+        } finally {
+            CustomPricingProvider.setInstanceForTests(null);
+            Files.deleteIfExists(config);
+        }
     }
 
     @Test


### PR DESCRIPTION
Problem
The per-turn cost shown in the message footer was consistently wrong when using custom providers (e.g. DeepSeek via ANTHROPIC_BASE_URL). A turn that should have cost $0.11 displayed $0.706.

Root cause: the footer cost was computed with state.getModel(), which holds the Claude slot ID selected in the chat UI (e.g. claude-sonnet-4-6[1m]). The active provider's env maps that slot to the real model (ANTHROPIC_DEFAULT_SONNET_MODEL=deepseek-v4-flash) before the API call — but the billing path never applied this mapping. As a result, every turn was priced against the built-in Claude rate table (sonnet $3/$15/$0.30, haiku $1/$5/$0.10) instead of the user-configured custom price for the mapped model:

Sonnet slot → $0.706 (built-in sonnet rates)
Haiku slot → $0.648 (built-in haiku rates)
Expected with custom deepseek-v4-flash pricing → ≈ $0.11
The context-limit path already resolved the mapped model (ModelProviderHandler), only billing was missed.

Fix
ClaudeMessageHandler now resolves the billed model through ModelProviderHandler.resolveConfiguredClaudeModel (slot ID → provider-mapped real ID, via readClaudeSettings().env) before calling UsageCostCalculator, matching the resolution used for context limits.
resolveConfiguredClaudeModel made public to be shared across packages.
ClaudeMessageHandler constructor now accepts an injectable CodemossSettingsService so tests never read the developer's real ~/.codemoss/config.json.
Tests
UsageCostCalculatorTest — new case: deepseek-v4-flash[1m] billed at custom rates ($0.10776 for a 1.2M-input / 95% cache-hit turn).
ClaudeMessageHandlerResultUsageTest — new end-to-end case: sonnet slot + env mapping → billed at custom deepseek rates, not built-in sonnet; existing cases now use a fake settings service.
Notes
Only new turns are billed correctly; already-stored turnCostUsd on historical messages is not recomputed on replay.
A related config-side caveat: the cache-hit price must be configured under cacheReadCostPer1M (cache-read); cacheWriteCostPer1M (cache-write) only bills cache_creation_input_tokens.