### PR TITLE
fix(bridge): clear model routing env vars in settings override to prevent model mismatch

### DIFF
--- a/ai-bridge/config/api-config.js
+++ b/ai-bridge/config/api-config.js
@@ -203,6 +203,15 @@ export function buildWebviewControlledSettingsOverride(modelId) {
     MAX_THINKING_TOKENS: '',
   };
 
+  // Clear model routing vars from settings.json so the per-request values
+  // set by setModelEnvironmentVariables() (via process.env) are the single
+  // source of truth. Without this, a stale ANTHROPIC_MODEL in settings.json
+  // overrides the webview-selected model, causing all model families to
+  // resolve to the same value (issue #1509).
+  for (const varName of MODEL_ROUTING_ENV_VARS) {
+    env[varName] = '';
+  }
+
   const normalizedModel = typeof modelId === 'string' ? modelId.trim() : '';
   if (normalizedModel) {
     env.CLAUDE_CODE_DISABLE_1M_CONTEXT = /\[1m\]$/i.test(normalizedModel) ? '' : '1';

--- a/ai-bridge/config/api-config.test.js
+++ b/ai-bridge/config/api-config.test.js
@@ -252,10 +252,23 @@ test('buildCliEnv strips stale CLI override env vars and sets host-managed for f
 });
 
 test('buildWebviewControlledSettingsOverride neutralizes Claude CLI settings env precedence', () => {
+  // Model routing vars are cleared so settings.json values cannot override
+  // the per-request process.env values set by setModelEnvironmentVariables().
+  const modelRoutingOverrides = {
+    ANTHROPIC_MODEL: '',
+    ANTHROPIC_DEFAULT_FABLE_MODEL: '',
+    ANTHROPIC_DEFAULT_OPUS_MODEL: '',
+    ANTHROPIC_DEFAULT_SONNET_MODEL: '',
+    ANTHROPIC_DEFAULT_HAIKU_MODEL: '',
+    ANTHROPIC_SMALL_FAST_MODEL: '',
+    CLAUDE_CODE_SUBAGENT_MODEL: '',
+  };
+
   assert.deepEqual(buildWebviewControlledSettingsOverride('claude-sonnet-4-6[1m]'), {
     env: {
       CLAUDE_CODE_EFFORT_LEVEL: '',
       MAX_THINKING_TOKENS: '',
+      ...modelRoutingOverrides,
       CLAUDE_CODE_DISABLE_1M_CONTEXT: '',
     },
   });
@@ -264,6 +277,7 @@ test('buildWebviewControlledSettingsOverride neutralizes Claude CLI settings env
     env: {
       CLAUDE_CODE_EFFORT_LEVEL: '',
       MAX_THINKING_TOKENS: '',
+      ...modelRoutingOverrides,
       CLAUDE_CODE_DISABLE_1M_CONTEXT: '1',
     },
   });
@@ -272,6 +286,7 @@ test('buildWebviewControlledSettingsOverride neutralizes Claude CLI settings env
     env: {
       CLAUDE_CODE_EFFORT_LEVEL: '',
       MAX_THINKING_TOKENS: '',
+      ...modelRoutingOverrides,
     },
   });
 });


### PR DESCRIPTION
# Fix: Model routing env vars in settings.json override plugin's model selection

## Problem (Issue #1509)

When a user has ANTHROPIC_MODEL (or ANTHROPIC_DEFAULT_*_MODEL) set in their `~/.claude/settings.json`, the Claude Code CLI applies it with overwrite semantics, overriding the per-request model selection made by the plugin's webview UI.

This causes **all model families** (sonnet, opus, haiku, fable) to resolve to the same ANTHROPIC_MODEL value, regardless of which model the user selected in the dropdown. The displayed model and the actually called model become inconsistent.

User reports from the issue:
- *"连ccswitch的话，只会使用ccswitch的兜底模型，但是不连ccswitch就正常了"* (When connected to cc-switch, only the fallback model is used)
- *"似乎是在claude code的setting.json配置有：ANTHROPIC_MODEL 这个配置项时，会导致所有的模型都最终指向ANTHROPIC_MODEL配置的模型"* (When settings.json has ANTHROPIC_MODEL, all models point to it)

## Root Cause

uildWebviewControlledSettingsOverride() creates a settings object passed to the SDK's query() call. It already cleared reasoning/context control vars (CLAUDE_CODE_EFFORT_LEVEL, MAX_THINKING_TOKENS, CLAUDE_CODE_DISABLE_1M_CONTEXT) as empty strings to override stale settings.json values.

However, it did **not** clear the MODEL_ROUTING_ENV_VARS (ANTHROPIC_MODEL, ANTHROPIC_DEFAULT_*_MODEL, ANTHROPIC_SMALL_FAST_MODEL, CLAUDE_CODE_SUBAGENT_MODEL). These vars were listed in WEBVIEW_CONTROLLED_ENV_VARS and set per-request in process.env by setModelEnvironmentVariables(), but the settings override did not neutralize the settings.json copies. The CLI applied the settings.json values with overwrite semantics, defeating the per-request selections.

## Fix

Iterate over MODEL_ROUTING_ENV_VARS in uildWebviewControlledSettingsOverride() and set each to an empty string, so the CLI sees them as "not set" in the settings override and falls through to the per-request process.env values set by setModelEnvironmentVariables().

This mirrors the existing pattern for reasoning control vars: empty strings in the settings override cause Claude Code's env-precedence checks to evaluate as "not set", letting the host-managed process.env values win.

## Tests

Updated the existing test 'buildWebviewControlledSettingsOverride neutralizes Claude CLI settings env precedence' to verify that all model routing vars are now included in the override. All 17 tests in pi-config.test.js pass.

Fixes #1509