### PR TITLE
修复 @file 引用在含空格文件名下的路径截断，并优化引用链接的展示样式

### DIFF
--- a/webview/src/components/CollapsibleTextBlock.test.ts
+++ b/webview/src/components/CollapsibleTextBlock.test.ts
@@ -87,6 +87,25 @@ describe('convertAtFileRefsToLinks', () => {
     expect(result).toContain('中查看');
   });
 
+  it('preserves spaces inside CJK filenames', () => {
+    const result = convertAtFileRefsToLinks(
+      '@D:\\workspace\\hello-agents\\docs\\chapter6\\第六章 框架开发实践.md'
+    );
+    // 空格后的 "框架开发实践.md" 以 .md 结尾，属于路径片段，不应截断
+    expect(result).toContain(
+      '<a class="file-link" data-linkify="file" href="D:\\workspace\\hello-agents\\docs\\chapter6\\第六章%20框架开发实践.md" title="D:\\workspace\\hello-agents\\docs\\chapter6\\第六章 框架开发实践.md">@第六章 框架开发实践.md</a>'
+    );
+  });
+
+  it('preserves spaces inside CJK filenames with line number', () => {
+    const result = convertAtFileRefsToLinks(
+      '@D:\\workspace\\hello-agents\\docs\\chapter6\\第六章 框架开发实践.md#L10-20'
+    );
+    expect(result).toContain(
+      '<a class="file-link" data-linkify="file" href="D:\\workspace\\hello-agents\\docs\\chapter6\\第六章%20框架开发实践.md:10-20" title="D:\\workspace\\hello-agents\\docs\\chapter6\\第六章 框架开发实践.md">@第六章 框架开发实践.md#L10-20</a>'
+    );
+  });
+
   // ── 路径含 # 但不匹配行号 ─────────────────────────
 
   it('does not split on # inside path when not #L format (C# files)', () => {

--- a/webview/src/components/CollapsibleTextBlock.tsx
+++ b/webview/src/components/CollapsibleTextBlock.tsx
@@ -35,13 +35,28 @@ function escapeHtml(text: string): string {
  * display-only.
  */
 /**
+ * Whether a word following a space could be a continuation of a file path.
+ * Accepts segments that contain a path separator (`\` or `/`), or that end
+ * with a file extension — the latter covers filenames containing spaces
+ * such as "第六章 框架开发实践.md". A trailing `#L10-20` line marker is
+ * stripped first so the extension is still visible.
+ */
+function looksLikePathSegment(segment: string): boolean {
+  const withoutLineMarker = segment.replace(/#L\d+(?:-\d+)?$/, '');
+  return (
+    /[\\/]/.test(withoutLineMarker) || // contains a path separator (dir / absolute segment)
+    /\.[A-Za-z0-9]{1,10}$/.test(withoutLineMarker) // ends with a file extension (filename with spaces)
+  );
+}
+
+/**
  * Extract a file path starting after `@` at position `start` in `text`.
  * Returns `[fullMatch, filePath, lineStart?, lineEnd?]` or null.
  *
  * Scans forward character-by-character, allowing spaces inside the path
  * when the next word segment looks like a path continuation (contains
- * a path separator: `\` or `/`).  A trailing `#L10-20` line marker is
- * parsed into separate line-start / line-end groups.
+ * a path separator or a file extension).  A trailing `#L10-20` line marker
+ * is parsed into separate line-start / line-end groups.
  */
 function extractAtFilePath(
   text: string,
@@ -66,7 +81,7 @@ function extractAtFilePath(
         peekRemainder[0] !== '\n' &&
         peekRemainder[0] !== '\r' &&
         peekRemainder[0] !== '@' &&
-        /[\\/]/.test(peekRemainder.split(/\s/)[0])
+        looksLikePathSegment(peekRemainder.split(/\s/)[0])
       ) {
         endPos++; // space is inside the path
         continue;


### PR DESCRIPTION
### 背景

用户消息中的 `@file` 引用（file tag）在发送后会转换为可点击的链接。此前存在两个问题：

1. **含空格的文件名被截断**：路径 `D:\...\第六章 框架开发实践.md` 中，空格后的 `框架开发实践.md` 因不含路径分隔符被误判为路径终点，链接只生成到 `第六章`。
2. **链接样式缺失**：`CollapsibleTextBlock` 渲染的 `a.file-link` 链接此前与普通文本视觉无区分，也没有完整路径提示。

### 变更内容

**修复含空格文件名截断**（`CollapsibleTextBlock.tsx`）
- 新增 `looksLikePathSegment()`：空格后的下一词只要**包含路径分隔符**或**以文件扩展名结尾**，即视为路径片段继续扫描
- 判断前先剥离 `#L10-20` 行号后缀，避免行号挡住扩展名匹配
- 该规则同时适用于 `useFileTags.ts` 中 file tag 的路径终止判断（同步修正注释）

**优化引用链接样式**（`message.less`）
- `.plain-text-content a.file-link` 继承气泡文字颜色、点线式下划线、手型指针及悬停高亮效果
- 链接增加 `title` 属性，悬停显示完整原始路径

**测试**（`CollapsibleTextBlock.test.ts`）
- 新增：含空格的中文文件名（`第六章 框架开发实践.md`）完整匹配、含空格+行号场景