### PR TITLE
fix: retry dropped stream end notifications

### DIFF
--- a/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
@@ -40,8 +40,12 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
     private volatile boolean active = true;
     /** Lock making deactivate() atomic with onMessageUpdate()'s active-check-then-enqueue. */
     private final Object lifecycleLock = new Object();
-    /** Guards against duplicate onStreamEnd delivery from dual-path dispatch. */
-    private volatile boolean streamEndSignalSent = false;
+    /** Tracks whether the ordered flush path dispatched its frontend signal. */
+    private volatile boolean streamEndPrimaryDispatched = false;
+    /** Guards the host lifecycle callback while allowing an idempotent frontend retry. */
+    private volatile boolean streamEndLifecycleCompleted = false;
+    /** Identifies the active stream so a late callback cannot end the next turn. */
+    private volatile long streamGeneration = 0L;
 
     public SessionCallbackAdapter(
             StreamMessageCoalescer streamCoalescer,
@@ -225,6 +229,7 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         // Cancel any stale fallback alarm from the previous turn to prevent
         // it from firing during the new turn's streaming phase.
         streamEndFallbackAlarm.cancelAllRequests();
+        streamGeneration++;
         contentDeltaThrottler.reset();
         thinkingDeltaThrottler.reset();
         streamCoalescer.onStreamStart();
@@ -243,11 +248,12 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         if (isInactive()) {
             return;
         }
-        // Reset the signal guard so this turn's dual-path dispatch can proceed.
-        // Thread-safety: this runs on the process reader thread; the callbacks that
-        // read/write streamEndSignalSent all run on EDT (via invokeLater or Alarm).
-        // The reset happens-before flush() schedules any callbacks, so no race exists.
-        streamEndSignalSent = false;
+        // Reset the dispatch guards so this turn's dual-path delivery can proceed.
+        // Thread-safety: this reset runs on the process reader thread before flush()
+        // schedules callbacks; subsequent dispatch state access happens on EDT.
+        streamEndPrimaryDispatched = false;
+        streamEndLifecycleCompleted = false;
+        final long endingStreamGeneration = streamGeneration;
 
         // Each step is wrapped in safeRun so that a failure in one step
         // (e.g., flushNow throwing due to a disposed throttler, or JCEF
@@ -271,47 +277,62 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         // The frontend's onStreamEnd is idempotent (per-turn guard), so receiving
         // both signals is harmless — only the first takes effect.
 
-        // Primary: ordered delivery via flush callback
+        // Primary: ordered delivery via flush callback. Do not cancel the delayed
+        // retry here: JCEF dispatch is asynchronous and can drop this call without
+        // throwing, so a successful Java invocation is not a frontend acknowledgement.
         streamCoalescer.flush(sequence -> {
-            if (streamEndSignalSent) {
+            if (isInactive() || streamGeneration != endingStreamGeneration) {
                 return;
             }
-            streamEndSignalSent = true;
-            streamEndFallbackAlarm.cancelAllRequests();
-            sendStreamEndToFrontend(sequence);
+            streamEndPrimaryDispatched = true;
+            sendStreamEndSignalToFrontend(sequence);
+            completeStreamEndLifecycle();
         });
 
-        // Fallback: independent delivery after timeout
+        // Fallback: always retry the idempotent frontend signal after the timeout.
+        // If the primary callback never runs, this path also completes host cleanup.
         streamEndFallbackAlarm.cancelAllRequests();
         streamEndFallbackAlarm.addRequest(() -> {
-            if (streamEndSignalSent || isInactive()) {
+            if (isInactive() || streamGeneration != endingStreamGeneration) {
                 return;
             }
-            streamEndSignalSent = true;
-            LOG.warn("Stream end signal delivered via fallback (primary flush callback did not fire within 300ms)");
-            sendStreamEndToFrontend(-1);
+            if (streamEndPrimaryDispatched) {
+                LOG.debug("Retrying stream end signal after primary dispatch");
+            } else {
+                LOG.warn("Stream end signal delivered via fallback (primary flush callback did not fire within 300ms)");
+            }
+            sendStreamEndSignalToFrontend(-1);
+            completeStreamEndLifecycle();
         }, 300);
     }
 
     /**
-     * Send the onStreamEnd signal and associated cleanup to the frontend.
-     * Called from either the primary (flush callback) or fallback (Alarm) path.
+     * Send the idempotent onStreamEnd signal and loading cleanup to the frontend.
+     * Called from both the primary (flush callback) and fallback (Alarm) paths.
      *
      * @param sequence the flush sequence number, or -1 if fired from fallback
      */
-    private void sendStreamEndToFrontend(long sequence) {
+    private void sendStreamEndSignalToFrontend(long sequence) {
         if (isInactive()) {
-            LOG.debug("Skipping sendStreamEndToFrontend — adapter deactivated (sequence=" + sequence + ")");
+            LOG.debug("Skipping stream end signal - adapter deactivated (sequence=" + sequence + ")");
             return;
         }
         safeRun("callJavaScript(onStreamEnd)", () ->
                 jsTarget.callJavaScript("onStreamEnd", String.valueOf(sequence)));
         safeRun("callJavaScript(showLoading, false)", () ->
                 jsTarget.callJavaScript("showLoading", "false"));
+        LOG.debug("Stream ended - notified frontend (sequence=" + sequence + ")");
+    }
+
+    /** Complete host-side stream cleanup exactly once for this turn. */
+    private void completeStreamEndLifecycle() {
+        if (streamEndLifecycleCompleted) {
+            return;
+        }
+        streamEndLifecycleCompleted = true;
         if (streamEndCallback != null) {
             safeRun("streamEndCallback", streamEndCallback);
         }
-        LOG.debug("Stream ended - notified frontend (sequence=" + sequence + ")");
     }
 
     private static void safeRun(String label, Runnable action) {

--- a/src/test/java/com/github/claudecodegui/session/SessionCallbackAdapterStreamEndTest.java
+++ b/src/test/java/com/github/claudecodegui/session/SessionCallbackAdapterStreamEndTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongConsumer;
 
@@ -18,9 +19,7 @@ import static org.junit.Assert.*;
  */
 public class SessionCallbackAdapterStreamEndTest {
 
-    /**
-     * Records callJavaScript invocations for assertion.
-     */
+    /** Records callJavaScript invocations for assertion. */
     private static final class RecordingJsTarget implements SessionCallbackAdapter.JsTarget {
         final List<String> calls = new ArrayList<>();
 
@@ -40,52 +39,89 @@ public class SessionCallbackAdapterStreamEndTest {
      * IntelliJ Alarm/invokeLater.
      */
     private static final class DualPathSimulator {
-        private volatile boolean streamEndSignalSent = false;
+        private volatile boolean streamEndPrimaryDispatched = false;
+        private volatile boolean streamEndLifecycleCompleted = false;
+        private volatile long streamGeneration = 0L;
+        private long endingStreamGeneration = 0L;
         private final RecordingJsTarget jsTarget;
+        private final Runnable streamEndCallback;
 
-        DualPathSimulator(RecordingJsTarget jsTarget) {
+        DualPathSimulator(RecordingJsTarget jsTarget, Runnable streamEndCallback) {
             this.jsTarget = jsTarget;
+            this.streamEndCallback = streamEndCallback;
         }
 
         /** Simulate the flush callback path (primary). */
         void simulateFlushCallback(long sequence) {
-            if (streamEndSignalSent) {
+            if (streamGeneration != endingStreamGeneration) {
                 return;
             }
-            streamEndSignalSent = true;
-            jsTarget.callJavaScript("onStreamEnd", String.valueOf(sequence));
-            jsTarget.callJavaScript("showLoading", "false");
+            streamEndPrimaryDispatched = true;
+            sendStreamEndSignal(sequence);
+            completeStreamEndLifecycle();
         }
 
         /** Simulate the fallback alarm path. */
         void simulateFallback() {
-            if (streamEndSignalSent) {
+            if (streamGeneration != endingStreamGeneration) {
                 return;
             }
-            streamEndSignalSent = true;
-            jsTarget.callJavaScript("onStreamEnd", String.valueOf(-1));
+            sendStreamEndSignal(-1);
+            completeStreamEndLifecycle();
+        }
+
+        private void sendStreamEndSignal(long sequence) {
+            jsTarget.callJavaScript("onStreamEnd", String.valueOf(sequence));
             jsTarget.callJavaScript("showLoading", "false");
+        }
+
+        private void completeStreamEndLifecycle() {
+            if (streamEndLifecycleCompleted) {
+                return;
+            }
+            streamEndLifecycleCompleted = true;
+            streamEndCallback.run();
         }
 
         /** Reset for a new onStreamEnd call. */
         void reset() {
-            streamEndSignalSent = false;
+            streamEndPrimaryDispatched = false;
+            streamEndLifecycleCompleted = false;
+            endingStreamGeneration = streamGeneration;
         }
 
-        boolean isStreamEndSent() {
-            return streamEndSignalSent;
+        void simulateStreamStart() {
+            streamGeneration++;
         }
+
+        boolean isPrimaryDispatched() {
+            return streamEndPrimaryDispatched;
+        }
+
+        boolean isLifecycleCompleted() {
+            return streamEndLifecycleCompleted;
+        }
+    }
+
+    private static DualPathSimulator createSimulator(
+            RecordingJsTarget jsTarget,
+            AtomicInteger lifecycleCompletions
+    ) {
+        return new DualPathSimulator(jsTarget, lifecycleCompletions::incrementAndGet);
     }
 
     @Test
     public void primaryPathSendsStreamEndWithSequence() {
         RecordingJsTarget jsTarget = new RecordingJsTarget();
-        DualPathSimulator sim = new DualPathSimulator(jsTarget);
+        AtomicInteger lifecycleCompletions = new AtomicInteger();
+        DualPathSimulator sim = createSimulator(jsTarget, lifecycleCompletions);
 
         sim.reset();
         sim.simulateFlushCallback(42);
 
-        assertTrue(sim.isStreamEndSent());
+        assertTrue(sim.isPrimaryDispatched());
+        assertTrue(sim.isLifecycleCompleted());
+        assertEquals(1, lifecycleCompletions.get());
         assertEquals(2, jsTarget.calls.size());
         assertEquals("onStreamEnd:42", jsTarget.calls.get(0));
         assertEquals("showLoading:false", jsTarget.calls.get(1));
@@ -94,63 +130,93 @@ public class SessionCallbackAdapterStreamEndTest {
     @Test
     public void fallbackPathSendsStreamEndWithNegativeSequence() {
         RecordingJsTarget jsTarget = new RecordingJsTarget();
-        DualPathSimulator sim = new DualPathSimulator(jsTarget);
+        AtomicInteger lifecycleCompletions = new AtomicInteger();
+        DualPathSimulator sim = createSimulator(jsTarget, lifecycleCompletions);
 
         sim.reset();
         sim.simulateFallback();
 
-        assertTrue(sim.isStreamEndSent());
+        assertFalse(sim.isPrimaryDispatched());
+        assertTrue(sim.isLifecycleCompleted());
+        assertEquals(1, lifecycleCompletions.get());
         assertEquals(2, jsTarget.calls.size());
         assertEquals("onStreamEnd:-1", jsTarget.calls.get(0));
         assertEquals("showLoading:false", jsTarget.calls.get(1));
     }
 
     @Test
-    public void primaryPathBlocksFallback() {
+    public void fallbackRetriesFrontendAfterPrimaryWithoutRepeatingLifecycle() {
         RecordingJsTarget jsTarget = new RecordingJsTarget();
-        DualPathSimulator sim = new DualPathSimulator(jsTarget);
+        AtomicInteger lifecycleCompletions = new AtomicInteger();
+        DualPathSimulator sim = createSimulator(jsTarget, lifecycleCompletions);
 
         sim.reset();
-        // Primary fires first
         sim.simulateFlushCallback(42);
-        // Fallback fires after — should be no-op
         sim.simulateFallback();
 
-        assertEquals(2, jsTarget.calls.size()); // Only primary's calls
+        assertEquals(4, jsTarget.calls.size());
         assertEquals("onStreamEnd:42", jsTarget.calls.get(0));
+        assertEquals("showLoading:false", jsTarget.calls.get(1));
+        assertEquals("onStreamEnd:-1", jsTarget.calls.get(2));
+        assertEquals("showLoading:false", jsTarget.calls.get(3));
+        assertEquals(1, lifecycleCompletions.get());
     }
 
     @Test
-    public void fallbackBlocksPrimary() {
+    public void latePrimaryRetriesFrontendAfterFallbackWithoutRepeatingLifecycle() {
         RecordingJsTarget jsTarget = new RecordingJsTarget();
-        DualPathSimulator sim = new DualPathSimulator(jsTarget);
+        AtomicInteger lifecycleCompletions = new AtomicInteger();
+        DualPathSimulator sim = createSimulator(jsTarget, lifecycleCompletions);
 
         sim.reset();
-        // Fallback fires first (primary flush failed)
         sim.simulateFallback();
-        // Primary fires late — should be no-op
         sim.simulateFlushCallback(42);
 
-        assertEquals(2, jsTarget.calls.size()); // Only fallback's calls
+        assertEquals(4, jsTarget.calls.size());
         assertEquals("onStreamEnd:-1", jsTarget.calls.get(0));
+        assertEquals("showLoading:false", jsTarget.calls.get(1));
+        assertEquals("onStreamEnd:42", jsTarget.calls.get(2));
+        assertEquals("showLoading:false", jsTarget.calls.get(3));
+        assertEquals(1, lifecycleCompletions.get());
+    }
+
+    @Test
+    public void latePrimaryDoesNotEndNextStream() {
+        RecordingJsTarget jsTarget = new RecordingJsTarget();
+        AtomicInteger lifecycleCompletions = new AtomicInteger();
+        DualPathSimulator sim = createSimulator(jsTarget, lifecycleCompletions);
+
+        sim.reset();
+        sim.simulateFallback();
+        sim.simulateStreamStart();
+        sim.simulateFlushCallback(42);
+
+        assertEquals(2, jsTarget.calls.size());
+        assertEquals("onStreamEnd:-1", jsTarget.calls.get(0));
+        assertEquals("showLoading:false", jsTarget.calls.get(1));
+        assertEquals(1, lifecycleCompletions.get());
     }
 
     @Test
     public void resetAllowsNextTurn() {
         RecordingJsTarget jsTarget = new RecordingJsTarget();
-        DualPathSimulator sim = new DualPathSimulator(jsTarget);
+        AtomicInteger lifecycleCompletions = new AtomicInteger();
+        DualPathSimulator sim = createSimulator(jsTarget, lifecycleCompletions);
 
-        // First turn
+        sim.simulateStreamStart();
         sim.reset();
         sim.simulateFlushCallback(10);
         assertEquals(2, jsTarget.calls.size());
+        assertEquals(1, lifecycleCompletions.get());
 
-        // Second turn — reset allows new delivery
+        sim.simulateStreamStart();
         sim.reset();
-        assertFalse(sim.isStreamEndSent());
+        assertFalse(sim.isPrimaryDispatched());
+        assertFalse(sim.isLifecycleCompleted());
         sim.simulateFlushCallback(20);
         assertEquals(4, jsTarget.calls.size());
         assertEquals("onStreamEnd:20", jsTarget.calls.get(2));
+        assertEquals(2, lifecycleCompletions.get());
     }
 
     /**
@@ -162,8 +228,6 @@ public class SessionCallbackAdapterStreamEndTest {
     public void flushCallbackPassesSequenceToOnStreamEnd() {
         RecordingJsTarget jsTarget = new RecordingJsTarget();
 
-        // Simulate what happens when flush(callback) is called:
-        // The callback receives the sequence from the coalescer.
         final AtomicLong capturedSequence = new AtomicLong(-999);
         LongConsumer flushCallback = seq -> {
             capturedSequence.set(seq);
@@ -177,4 +241,3 @@ public class SessionCallbackAdapterStreamEndTest {
         assertEquals("onStreamEnd:77", jsTarget.calls.get(0));
     }
 }
-


### PR DESCRIPTION
## Summary

- retry the idempotent frontend stream-end notification after 300ms
- complete host-side stream lifecycle cleanup exactly once
- prevent delayed callbacks from ending a newer streaming turn
- update regression tests for both callback orderings

## Root cause

The primary Java-to-JCEF dispatch was treated as successful as soon as
`callJavaScript` returned. JCEF dispatch is asynchronous and can silently drop
the call without throwing, while the primary path immediately cancelled the
fallback. The frontend could therefore remain permanently in the streaming
state even though the backend turn had completed.

## Testing

- GitHub Actions: Tests
- GitHub Actions: Build Plugin