### PR TITLE
fix: 同步 settings.json 模型映射到子代理 env，修复 opus/haiku fallback 到错误模型

### DIFF
--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -203,6 +203,21 @@ async function buildRequestContext(params, withAttachments, overrides = {}) {
   const modelId = params.model || null;
   const { sdkModelName, resolvedModelId } = resolveRequestModelState(modelId, settings?.env);
   setModelEnvironmentVariables(resolvedModelId, modelId);
+  // Fix: 同步 settings.json 中配置的所有模型层级映射到进程环境，
+  // 否则 opus/haiku/fable 子代理请求时对应 env 为空，会 fallback 到错误的模型。
+  for (const key of [
+    'ANTHROPIC_DEFAULT_OPUS_MODEL',
+    'ANTHROPIC_DEFAULT_HAIKU_MODEL',
+    'ANTHROPIC_DEFAULT_FABLE_MODEL',
+    'ANTHROPIC_DEFAULT_SONNET_MODEL',
+    'CLAUDE_CODE_SUBAGENT_MODEL',
+  ]) {
+    const value = settings?.env?.[key];
+    if (value) {
+      process.env[key] = String(value).trim();
+    }
+  }
+
 
   const permissionMode = normalizePermissionMode(params.permissionMode);
   const streamingEnabled = resolveStreamingEnabled(params, settings);


### PR DESCRIPTION
## 问题

主模型为 sonnet/flash 层级（如 `deepseek-v4-flash`）时，`setModelEnvironmentVariables` 只会设置 `ANTHROPIC_MODEL` 和 `ANTHROPIC_DEFAULT_SONNET_MODEL`，**不会设置 `ANTHROPIC_DEFAULT_OPUS_MODEL` 等其他层级**。

当 Claude Code SDK 发起 opus/haiku/fable 子代理请求（例如 superpowers 的 review 流程指定 `model=opus`）时，对应 env 变量为空，会 fallback 到**插件内置供应商预设**的模型，忽略用户 settings.json 中配置的模型映射。

## 复现

- Provider: DeepSeek（`api.deepseek.com/anthropic`）
- settings.json: `ANTHROPIC_DEFAULT_OPUS_MODEL = "deepseek-v4-flash[1m]"`
- 主模型: `deepseek-v4-flash[1m]`（sonnet 层级）
- 触发 opus 子代理 → 实际请求 `deepseek-v4-pro`，而非 settings.json 配置的 flash

内置 DeepSeek 预设（`claude-chat.html`）把 opus/sonnet 映射到 `deepseek-v4-pro[1m]`，因此空 env 时子代理全部落到 pro。

## 修复

在 `buildRequestContext` 每轮请求时，将 settings.json 中配置的所有模型层级映射（OPUS/HAIKU/FABLE/SONNET/SUBAGENT）同步到进程环境，确保 SDK 子代理使用用户配置的模型，而不是 fallback 到供应商预设。

## 验证

- 修改前：opus 子代理实际请求 `deepseek-v4-pro`
- 修改后：opus 子代理实际请求 `deepseek-v4-flash`

## 影响范围

所有使用 settings.json 配置模型映射的用户；不改变现有行为（只是把用户已配置但未生效的映射真正传给 SDK）。
