### PR TITLE
fix(bridge): flush session-query stdout before exit to stop JSON trun…

### DIFF
--- a/ai-bridge/channel-manager.js
+++ b/ai-bridge/channel-manager.js
@@ -37,6 +37,28 @@ import { handlePiCommand } from './channels/pi-channel.js';
 import { getSdkStatus, isClaudeSdkAvailable, isCodexSdkAvailable } from './utils/sdk-loader.js';
 import { injectStartupEnvVars, configureCliIdentity } from './config/api-config.js';
 
+/**
+ * Write a JSON payload to stdout and exit once the bytes are flushed.
+ *
+ * `console.log` followed by `process.exit` races the stdout buffer: for a
+ * piped stdout the underlying `process.stdout.write` is asynchronous, and
+ * `process.exit` does not wait for it to drain, truncating the JSON. Writing
+ * explicitly and exiting in the flush callback guarantees the payload reaches
+ * the OS pipe first. The timeout fallback ensures the process still terminates
+ * if the callback never fires (e.g. a broken pipe).
+ */
+function writeJsonAndExit(payload, code = 0) {
+  let exited = false;
+  const exitNow = () => {
+    if (!exited) {
+      exited = true;
+      process.exit(code);
+    }
+  };
+  process.stdout.write(JSON.stringify(payload) + '\n', 'utf8', exitNow);
+  setTimeout(exitNow, 5000);
+}
+
 // Sync proxy/TLS settings and AWS credentials from ~/.claude/settings.json
 // BEFORE any network activity, but only for explicitly authorized Local
 // settings.json / CLI Login modes. Without this, users behind corporate
@@ -67,20 +89,18 @@ console.error('[DIAG-ENTRY] Args:', args);
 // Error handling
 process.on('uncaughtException', (error) => {
   console.error('[UNCAUGHT_ERROR]', error.message);
-  console.log(JSON.stringify({
+  writeJsonAndExit({
     success: false,
     error: error.message
-  }));
-  process.exit(1);
+  }, 1);
 });
 
 process.on('unhandledRejection', (reason) => {
   console.error('[UNHANDLED_REJECTION]', reason);
-  console.log(JSON.stringify({
+  writeJsonAndExit({
     success: false,
     error: String(reason)
-  }));
-  process.exit(1);
+  }, 1);
 });
 
 /**
@@ -114,11 +134,7 @@ async function handleSystemCommand(command, args, stdinData) {
       break;
 
     default:
-      console.log(JSON.stringify({
-        success: false,
-        error: 'Unknown system command: ' + command
-      }));
-      process.exit(1);
+      throw new Error('Unknown system command: ' + command);
   }
 }
 
@@ -140,21 +156,21 @@ const providerHandlers = {
     console.error('[DIAG-EXEC] Validating provider...');
     if (!provider || !providerHandlers[provider]) {
       console.error('Invalid provider. Use "claude", "codex", "grok", "kimi", "opencode", "pi", or "system"');
-      console.log(JSON.stringify({
+      writeJsonAndExit({
         success: false,
         error: 'Invalid provider: ' + provider
-      }));
-      process.exit(1);
+      }, 1);
+      return;
     }
 
     // Validate command
     if (!command) {
       console.error('No command specified');
-      console.log(JSON.stringify({
+      writeJsonAndExit({
         success: false,
         error: 'No command specified'
-      }));
-      process.exit(1);
+      }, 1);
+      return;
     }
 
     // Read stdin data
@@ -184,10 +200,9 @@ const providerHandlers = {
 
   } catch (error) {
     console.error('[COMMAND_ERROR]', error.message);
-    console.log(JSON.stringify({
+    writeJsonAndExit({
       success: false,
       error: error.message
-    }));
-    process.exit(1);
+    }, 1);
   }
 })();

--- a/ai-bridge/services/claude/session-service.js
+++ b/ai-bridge/services/claude/session-service.js
@@ -11,6 +11,25 @@ import { createInterface } from 'readline';
 import { getClaudeProjectSessionFilePath } from '../../utils/path-utils.js';
 
 /**
+ * Write a JSON payload as a single stdout line and await the flush.
+ *
+ * `console.log` is fire-and-forget: for a piped stdout the underlying
+ * `process.stdout.write` is asynchronous, and a large payload (the full
+ * session history returned by getSession easily exceeds the libuv
+ * high-water mark) gets queued in an internal buffer. Once the handler
+ * returns, channel-manager.js sets `process.exitCode` and lets the process
+ * exit naturally -- which can race ahead of the buffer draining and
+ * truncate the JSON mid-stream, surfacing as `MalformedJsonException` on
+ * the Java side. Awaiting the write callback guarantees the bytes reach
+ * the OS pipe before the process is allowed to exit.
+ */
+function writeJsonResponse(payload) {
+  return new Promise((resolve) => {
+    process.stdout.write(JSON.stringify(payload) + '\n', 'utf8', resolve);
+  });
+}
+
+/**
  * Append a message to the JSONL history file.
  * Adds necessary metadata fields to ensure compatibility with the history reader.
  */
@@ -91,10 +110,10 @@ export async function getSessionMessages(sessionId, cwd = null) {
     const sessionFile = resolveSessionFile(sessionId, cwd);
 
     if (!existsSync(sessionFile)) {
-      console.log(JSON.stringify({
+      await writeJsonResponse({
         success: true,
         messages: []
-      }));
+      });
       return;
     }
 
@@ -112,17 +131,17 @@ export async function getSessionMessages(sessionId, cwd = null) {
       })
       .filter(msg => msg !== null);
 
-    console.log(JSON.stringify({
+    await writeJsonResponse({
       success: true,
       messages
-    }));
+    });
 
   } catch (error) {
     console.error('[GET_SESSION_ERROR]', error.message);
-    console.log(JSON.stringify({
+    await writeJsonResponse({
       success: false,
       error: error.message
-    }));
+    });
   }
 }
 
@@ -131,10 +150,10 @@ export async function getLatestUserMessage(sessionId, cwd = null) {
     const sessionFile = resolveSessionFile(sessionId, cwd);
 
     if (!existsSync(sessionFile)) {
-      console.log(JSON.stringify({
+      await writeJsonResponse({
         success: true,
         message: null
-      }));
+      });
       return;
     }
 
@@ -164,16 +183,16 @@ export async function getLatestUserMessage(sessionId, cwd = null) {
       }
     }
 
-    console.log(JSON.stringify({
+    await writeJsonResponse({
       success: true,
       message: latestUserMessage
-    }));
+    });
   } catch (error) {
     console.error('[GET_LATEST_USER_ERROR]', error.message);
-    console.log(JSON.stringify({
+    await writeJsonResponse({
       success: false,
       error: error.message
-    }));
+    });
   }
 }
 

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSessionQueryService.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSessionQueryService.java
@@ -184,6 +184,17 @@ class ClaudeSessionQueryService {
             throw new RuntimeException("Failed to extract JSON from Node.js output");
         }
 
+        // A well-formed JSON object must end with '}'. If it doesn't, the Node child
+        // exited before its stdout buffer fully drained (a known race for large
+        // getSession payloads) and the JSON was truncated mid-stream. Log the lengths
+        // so the failure is diagnosable instead of leaving only a cryptic Gson error.
+        // extractLastJsonLine already trims its return value, so no trim is needed here
+        // (avoiding an O(n) copy of the multi-megabyte payload on every getSession).
+        if (!jsonStr.endsWith("}")) {
+            log.warn("[" + logPrefix + "] Extracted JSON appears truncated: jsonLength="
+                    + jsonStr.length() + ", rawOutputLength=" + outputStr.length());
+        }
+
         if (log.isDebugEnabled()) {
             log.debug("[" + logPrefix + "] Extracted JSON: "
                     + (jsonStr.length() > 500 ? jsonStr.substring(0, 500) + "..." : jsonStr));


### PR DESCRIPTION
…cation

Loading large Claude sessions intermittently failed with MalformedJsonException (Unterminated object at $.messages[N].cwd).

Root cause: session-service.js wrote the full session payload via console.log(JSON.stringify(...)), which is fire-and-forget on a piped stdout. For payloads exceeding the libuv high-water mark, the bytes are queued in an internal buffer and flushed asynchronously. channel-manager.js then set process.exitCode and let the process exit naturally, which can race ahead of the buffer draining and truncate the JSON mid-stream. ClaudeSessionQueryService.extractLastJsonLine's fallback branch passed the truncated fragment straight to Gson.

Fix by writing payloads through process.stdout.write and awaiting the flush callback so the bytes reach the OS pipe before the process is allowed to exit:
- session-service.js: add writeJsonResponse() that awaits the write callback; replace the 6 console.log(JSON.stringify(...)) sites in getSessionMessages/getLatestUserMessage.
- channel-manager.js: add writeJsonAndExit() that writes and exits in the flush callback (with a 5s timeout fallback), and migrate the 6 error-exit paths off console.log + process.exit. handleSystemCommand's default branch now throws so the main catch handles it uniformly.

Also add a defensive length log in ClaudeSessionQueryService when the extracted JSON does not end with '}', so a future truncation surfaces a diagnosable warning instead of a cryptic Gson error.

Verified against a 4.5MB / 1995-message session: getSession and getLatestUserMessage now return complete, parseable JSON.