### PR TITLE
fix(dependency): parse nested versions array from npm >=12

### DIFF
--- a/src/main/java/com/github/claudecodegui/dependency/DependencyManager.java
+++ b/src/main/java/com/github/claudecodegui/dependency/DependencyManager.java
@@ -876,7 +876,7 @@ public class DependencyManager {
      *
      * @return negative if v1 < v2, 0 if equal, positive if v1 > v2
      */
-    private int compareVersions(String v1, String v2) {
+    static int compareVersions(String v1, String v2) {
         if (v1 == null || v2 == null) {
             return 0;
         }
@@ -944,7 +944,7 @@ public class DependencyManager {
         return packages;
     }
 
-    private List<String> parseVersionList(String rawJson) {
+    static List<String> parseVersionList(String rawJson) {
         List<String> versions = new ArrayList<>();
 
         try {
@@ -953,7 +953,21 @@ public class DependencyManager {
                 return versions;
             }
 
-            for (com.google.gson.JsonElement item : element.getAsJsonArray()) {
+            // npm >= 9 wraps the version list in an extra array layer
+            // (`[["0.0.4", ..., "0.3.221"]]`), while older npm emits a flat array
+            // (`["0.0.4", ..., "0.3.221"]`). Unwrap leading array-of-array layers so
+            // both shapes reach the same primitive-version leaves; otherwise every
+            // element is itself an array, `isJsonPrimitive()` is false, and the whole
+            // list is silently dropped (causing the misleading "remote versions
+            // unavailable" fallback).
+            com.google.gson.JsonArray array = element.getAsJsonArray();
+            while (!array.isEmpty()
+                    && array.get(0).isJsonArray()
+                    && array.size() == 1) {
+                array = array.get(0).getAsJsonArray();
+            }
+
+            for (com.google.gson.JsonElement item : array) {
                 if (!item.isJsonPrimitive()) {
                     continue;
                 }
@@ -975,7 +989,7 @@ public class DependencyManager {
     /**
      * Parses a single segment of a version string.
      */
-    private int parseVersionPart(String part) {
+    private static int parseVersionPart(String part) {
         // Strip non-numeric suffixes (e.g. -beta, -alpha)
         Pattern pattern = Pattern.compile("^(\\d+)");
         Matcher matcher = pattern.matcher(part);


### PR DESCRIPTION
npm 12 wraps `versions --json` output in an extra array layer (`[["0.0.4", ..., "0.3.221"]]`), while older npm emits a flat array. The previous parser checked the outer element was an array but then expected each child to be a primitive version string; on npm 9+ every child is an inner array, so `isJsonPrimitive()` was false and all versions were silently dropped. The SDK version dropdown then fell back to built-in versions and showed the misleading "remote versions unavailable" banner, even though the single-value latest-version lookup succeeded.

Unwrap leading array-of-array layers before iterating, so both shapes reach the same primitive leaves. Also make `compareVersions` and `parseVersionPart` static (pure helpers) to enable unit testing of `parseVersionList`.

<img width="739" height="139" alt="image" src="https://github.com/user-attachments/assets/138750ad-812e-4a0e-ac39-064309ced965" />
<img width="678" height="128" alt="image" src="https://github.com/user-attachments/assets/4bc8f37f-521b-4587-a775-f2772f04b7a1" />
<img width="786" height="153" alt="image" src="https://github.com/user-attachments/assets/7e93ffe9-7cae-4eec-b8c6-d366e15d312f" />


related to: https://github.com/zhukunpenglinyutong/jetbrains-cc-gui/issues/1449