### PR TITLE
fix(webview): pause hidden tab recovery loops

### DIFF
--- a/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
@@ -46,6 +46,9 @@ import java.io.File;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import java.util.function.IntPredicate;
+import java.util.function.Supplier;
 
 /**
  * Handles webview (JCEF browser) creation, configuration, error panels,
@@ -93,6 +96,7 @@ public class WebviewInitializer {
         WebviewWatchdog getWebviewWatchdog();
         boolean isFrontendReady();
         boolean hasEverBeenFrontendReady();
+        boolean isWebviewActive();
         void setFrontendReady(boolean ready);
     }
 
@@ -423,7 +427,7 @@ public class WebviewInitializer {
                             cefBrowser.executeJavaScript(consoleForward, cefBrowser.getURL(), 0);
                         }
 
-                        injectFrontendConfiguration(cefBrowser, pageGeneration);
+                        injectFrontendConfiguration(cefBrowser, currentBridges, pageGeneration);
 
                         LOG.debug("onLoadEnd completed, waiting for frontend_ready signal");
                     } catch (Exception | LinkageError e) {
@@ -529,23 +533,47 @@ public class WebviewInitializer {
             BrowserBridges currentBridges,
             int pageGeneration
     ) {
-        AtomicInteger attempts = new AtomicInteger();
-        Timer timer = new Timer(BRIDGE_INJECTION_FAST_RETRY_INTERVAL_MS, null);
-        timer.addActionListener(event -> {
-            int attempt = attempts.incrementAndGet();
-            if (host.isDisposed() || host.isFrontendReady()) {
-                currentBridges.stopBridgeInjectionTimer(timer);
+        boolean scheduled = currentBridges.startBridgeInjectionRetriesIfAbsent(
+                pageGeneration,
+                () -> shouldRunBridgeInjectionRetries(
+                        host.isDisposed(), host.isFrontendReady(), host.isWebviewActive()),
+                attempt -> injectBridgeFallback(browser, currentBridges, pageGeneration, attempt));
+        if (!scheduled) {
+            if (!host.isFrontendReady() && !host.isWebviewActive()) {
+                LOG.debug("[JCEF] Bridge injection retries paused while webview is inactive");
+            }
+            return;
+        }
+        LOG.info("[JCEF] Scheduled fallback bridge injection retries until frontend readiness");
+    }
+
+    static boolean shouldRunBridgeInjectionRetries(
+            boolean disposed,
+            boolean frontendReady,
+            boolean webviewActive
+    ) {
+        return !disposed && !frontendReady && webviewActive;
+    }
+
+    /** Resume startup bridge fallback when a previously hidden tab becomes active. */
+    public void onTabActivated() {
+        if (host.isDisposed() || host.isFrontendReady() || !host.isWebviewActive()) {
+            return;
+        }
+
+        JBCefBrowser currentBrowser;
+        BrowserBridges currentBridges;
+        int currentPageGeneration;
+        synchronized (this.bridgeLock) {
+            currentBrowser = host.getBrowser();
+            currentBridges = this.bridges;
+            if (currentBrowser == null || currentBridges == null
+                    || !currentBridges.isCurrentFor(currentBrowser)) {
                 return;
             }
-            timer.setDelay(bridgeInjectionRetryDelayMs(attempt + 1));
-            if (!injectBridgeFallback(browser, currentBridges, pageGeneration, attempt)) {
-                currentBridges.stopBridgeInjectionTimer(timer);
-            }
-        });
-        timer.setInitialDelay(BRIDGE_INJECTION_FAST_RETRY_INTERVAL_MS);
-        currentBridges.setBridgeInjectionTimer(timer);
-        LOG.info("[JCEF] Scheduled fallback bridge injection retries until frontend readiness");
-        timer.start();
+            currentPageGeneration = currentBridges.getPageGeneration();
+        }
+        scheduleBridgeInjectionRetries(currentBrowser, currentBridges, currentPageGeneration);
     }
 
     private int beginPageLoad(BrowserBridges expectedBridges, PageLoadKind pageLoadKind) {
@@ -636,7 +664,7 @@ public class WebviewInitializer {
             );
             cefBrowser.executeJavaScript(runtimeBootstrap, url, 0);
 
-            injectFrontendConfiguration(cefBrowser, pageGeneration);
+            injectFrontendConfiguration(cefBrowser, currentBridges, pageGeneration);
             if (attempt == 1) {
                 LOG.info("[JCEF] Executed first fallback bridge injection for remote-mode startup");
             }
@@ -769,7 +797,25 @@ public class WebviewInitializer {
         );
     }
 
-    private void injectFrontendConfiguration(CefBrowser cefBrowser, int pageGeneration) {
+    private void injectFrontendConfiguration(
+            CefBrowser cefBrowser,
+            BrowserBridges currentBridges,
+            int pageGeneration
+    ) {
+        String idempotentConfigurationScript = currentBridges.getOrCreateConfigurationScript(
+                pageGeneration,
+                () -> buildFrontendConfigurationScript(pageGeneration));
+        if (idempotentConfigurationScript == null) {
+            return;
+        }
+        cefBrowser.executeJavaScript(
+                guardPageScript(pageGeneration, idempotentConfigurationScript),
+                cefBrowser.getURL(),
+                0);
+        LOG.debug("[WebviewConfigSync] Frontend configuration injected");
+    }
+
+    private String buildFrontendConfigurationScript(int pageGeneration) {
         String editorFontConfig = FontConfigService.getEditorFontConfigJson();
         String uiFontConfig = FontConfigService.getResolvedUiFontConfigJson(
                 host.getHandlerContext().getSettingsService());
@@ -777,18 +823,14 @@ public class WebviewInitializer {
                 host.getHandlerContext().getSettingsService());
         String languageConfig = LanguageConfigService.getLanguageConfigJson(
                 host.getHandlerContext().getSettingsService());
-        String url = cefBrowser.getURL();
 
         String configurationScript = joinConfigurationInjections(buildConfigurationInjections(
                 editorFontConfig, uiFontConfig, codeFontConfig, languageConfig));
-        String idempotentConfigurationScript =
+        return
                 "if (window.__CCG_CONFIG_GENERATION__ !== " + pageGeneration + ") {"
                 + configurationScript
                 + "window.__CCG_CONFIG_GENERATION__ = " + pageGeneration + ";"
                 + "}";
-        cefBrowser.executeJavaScript(
-                guardPageScript(pageGeneration, idempotentConfigurationScript), url, 0);
-        LOG.debug("[WebviewConfigSync] Frontend configuration injected");
     }
 
     static String joinConfigurationInjections(List<String> injections) {
@@ -1116,7 +1158,7 @@ public class WebviewInitializer {
      * Reload the webview HTML content.
      */
     public void reloadWebview(String reason) {
-        ApplicationManager.getApplication().invokeLater(() -> {
+        runOnEventDispatchThread(() -> {
             if (host.isDisposed()) { return; }
             JBCefBrowser browser = host.getBrowser();
             if (browser == null) {
@@ -1129,11 +1171,13 @@ public class WebviewInitializer {
                 int pageGeneration;
                 synchronized (this.bridgeLock) {
                     currentBridges = this.bridges;
-                    if (currentBridges == null || !currentBridges.belongsTo(browser)) {
-                        recreateWebview(reason + "_stale_bridges");
-                        return;
-                    }
-                    pageGeneration = beginPageLoad(currentBridges, recoveryPageLoadKind());
+                    pageGeneration = currentBridges == null || !currentBridges.belongsTo(browser)
+                            ? -1
+                            : beginPageLoad(currentBridges, recoveryPageLoadKind());
+                }
+                if (pageGeneration < 0) {
+                    recreateWebview(reason + "_stale_bridges");
+                    return;
                 }
                 host.activatePageGeneration(pageGeneration);
                 host.setFrontendReady(false);
@@ -1175,7 +1219,7 @@ public class WebviewInitializer {
      * Recreate the webview from scratch (dispose old, create new).
      */
     public void recreateWebview(String reason) {
-        ApplicationManager.getApplication().invokeLater(() -> {
+        runOnEventDispatchThread(() -> {
             if (host.isDisposed()) { return; }
 
             synchronized (this.bridgeLock) {
@@ -1223,6 +1267,14 @@ public class WebviewInitializer {
         });
     }
 
+    private void runOnEventDispatchThread(Runnable action) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            action.run();
+        } else {
+            ApplicationManager.getApplication().invokeLater(action);
+        }
+    }
+
     /**
      * Release the JBCefJSQuery bridges.
      * Must be called before the owning browser is disposed so the native
@@ -1250,9 +1302,11 @@ public class WebviewInitializer {
         private final JBCefJSQuery jsQuery;
         private final JBCefJSQuery clipboardPathQuery;
         private final JBCefJSQuery hidePanelQuery;
-        private Timer bridgeInjectionTimer;
         private int pageGeneration;
         private PageLoadKind pageLoadKind = PageLoadKind.INITIAL_LOAD;
+        private final PageConfigurationCache configurationCache = new PageConfigurationCache();
+        private final BridgeInjectionTimerLifecycle bridgeRetryLifecycle =
+                new BridgeInjectionTimerLifecycle();
 
         private BrowserBridges(JBCefBrowser browser) {
             this.browser = browser;
@@ -1276,9 +1330,10 @@ public class WebviewInitializer {
         }
 
         private synchronized void beginPageLoad(int newPageGeneration, PageLoadKind newPageLoadKind) {
-            stopBridgeInjectionTimer();
             this.pageGeneration = newPageGeneration;
             this.pageLoadKind = newPageLoadKind;
+            this.configurationCache.reset(newPageGeneration);
+            this.bridgeRetryLifecycle.beginPageLoad(newPageGeneration);
         }
 
         private synchronized int getPageGeneration() {
@@ -1306,23 +1361,24 @@ public class WebviewInitializer {
             return this.belongsTo(browser) && pageGeneration == expectedPageGeneration;
         }
 
-        private synchronized void setBridgeInjectionTimer(Timer timer) {
-            stopBridgeInjectionTimer();
-            this.bridgeInjectionTimer = timer;
+        private boolean startBridgeInjectionRetriesIfAbsent(
+                int expectedPageGeneration,
+                BooleanSupplier retryAllowed,
+                IntPredicate retryAction
+        ) {
+            return this.bridgeRetryLifecycle.startIfAbsent(
+                    expectedPageGeneration, retryAllowed, retryAction);
         }
 
-        private synchronized void stopBridgeInjectionTimer() {
-            if (this.bridgeInjectionTimer != null) {
-                this.bridgeInjectionTimer.stop();
-                this.bridgeInjectionTimer = null;
-            }
+        private void stopBridgeInjectionTimer() {
+            this.bridgeRetryLifecycle.stop();
         }
 
-        private synchronized void stopBridgeInjectionTimer(Timer expectedTimer) {
-            expectedTimer.stop();
-            if (this.bridgeInjectionTimer == expectedTimer) {
-                this.bridgeInjectionTimer = null;
-            }
+        private String getOrCreateConfigurationScript(
+                int expectedPageGeneration,
+                Supplier<String> scriptBuilder
+        ) {
+            return this.configurationCache.getOrCreate(expectedPageGeneration, scriptBuilder);
         }
 
         private void dispose() {
@@ -1330,6 +1386,96 @@ public class WebviewInitializer {
             disposeQueryQuietly(this.hidePanelQuery);
             disposeQueryQuietly(this.clipboardPathQuery);
             disposeQueryQuietly(this.jsQuery);
+        }
+    }
+
+    /** Owns the single Swing retry timer associated with the current runtime page generation. */
+    static final class BridgeInjectionTimerLifecycle {
+        private int pageGeneration;
+        private Timer timer;
+
+        synchronized void beginPageLoad(int newPageGeneration) {
+            stop();
+            this.pageGeneration = newPageGeneration;
+        }
+
+        boolean startIfAbsent(
+                int expectedPageGeneration,
+                BooleanSupplier retryAllowed,
+                IntPredicate retryAction
+        ) {
+            if (!retryAllowed.getAsBoolean()) {
+                stopIfCurrentGeneration(expectedPageGeneration);
+                return false;
+            }
+
+            AtomicInteger attempts = new AtomicInteger();
+            Timer candidate = new Timer(BRIDGE_INJECTION_FAST_RETRY_INTERVAL_MS, null);
+            candidate.addActionListener(event -> {
+                int attempt = attempts.incrementAndGet();
+                if (!retryAllowed.getAsBoolean()) {
+                    stop(candidate);
+                    return;
+                }
+                candidate.setDelay(bridgeInjectionRetryDelayMs(attempt + 1));
+                if (!retryAction.test(attempt)) {
+                    stop(candidate);
+                }
+            });
+            candidate.setInitialDelay(BRIDGE_INJECTION_FAST_RETRY_INTERVAL_MS);
+
+            synchronized (this) {
+                if (this.pageGeneration != expectedPageGeneration || this.timer != null) {
+                    return false;
+                }
+                this.timer = candidate;
+            }
+            candidate.start();
+            return true;
+        }
+
+        synchronized void stop() {
+            if (this.timer != null) {
+                this.timer.stop();
+                this.timer = null;
+            }
+        }
+
+        private synchronized void stopIfCurrentGeneration(int expectedPageGeneration) {
+            if (this.pageGeneration == expectedPageGeneration) {
+                stop();
+            }
+        }
+
+        private synchronized void stop(Timer expectedTimer) {
+            expectedTimer.stop();
+            if (this.timer == expectedTimer) {
+                this.timer = null;
+            }
+        }
+
+        synchronized Timer getTimer() {
+            return this.timer;
+        }
+    }
+
+    static final class PageConfigurationCache {
+        private int pageGeneration;
+        private String configurationScript;
+
+        synchronized void reset(int newPageGeneration) {
+            this.pageGeneration = newPageGeneration;
+            this.configurationScript = null;
+        }
+
+        synchronized String getOrCreate(int expectedPageGeneration, Supplier<String> scriptBuilder) {
+            if (this.pageGeneration != expectedPageGeneration) {
+                return null;
+            }
+            if (this.configurationScript == null) {
+                this.configurationScript = scriptBuilder.get();
+            }
+            return this.configurationScript;
         }
     }
 

--- a/src/main/java/com/github/claudecodegui/ui/WebviewWatchdog.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewWatchdog.java
@@ -10,7 +10,11 @@ import com.intellij.util.concurrency.AppExecutorUtil;
 import javax.swing.*;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.LongSupplier;
 
 /**
  * Webview render watchdog for JCEF stall/black-screen recovery.
@@ -28,17 +32,18 @@ public class WebviewWatchdog {
     private static final long STARTUP_RECOVERY_COOLDOWN_MS = 15_000L;
     private static final int MAX_STARTUP_RECOVERY_ATTEMPTS = 2;
 
-    private volatile long lastHeartbeatAtMs = System.currentTimeMillis();
-    private volatile long lastRafAtMs = System.currentTimeMillis();
+    private volatile long lastHeartbeatAtMs;
+    private volatile long lastRafAtMs;
     private volatile String lastVisibility = null;
     private volatile Boolean lastHasFocus = null;
     private volatile int stallCount = 0;
     private volatile long lastRecoveryAtMs = 0L;
     private volatile ScheduledFuture<?> watchdogFuture = null;
+    private final AtomicBoolean recoveryPending = new AtomicBoolean();
     private final AtomicInteger startupRecoveryAttempts = new AtomicInteger();
 
     private final JPanel mainPanel;
-    private final BrowserProvider browserProvider;
+    private final BooleanSupplier browserAvailableCheck;
     private final Runnable onReloadWebview;
     private final Runnable onRecreateWebview;
     private final DisposedCheck disposedCheck;
@@ -77,6 +82,8 @@ public class WebviewWatchdog {
 
     private final StreamActiveCheck streamActiveCheck;
     private final ReadyCheck readyCheck;
+    private final LongSupplier currentTimeMillis;
+    private final Consumer<Runnable> recoveryExecutor;
 
     public WebviewWatchdog(
             JPanel mainPanel,
@@ -87,13 +94,42 @@ public class WebviewWatchdog {
             StreamActiveCheck streamActiveCheck,
             ReadyCheck readyCheck
     ) {
+        this(
+                mainPanel,
+                () -> browserProvider.getBrowser() != null,
+                onReloadWebview,
+                onRecreateWebview,
+                disposedCheck,
+                streamActiveCheck,
+                readyCheck,
+                System::currentTimeMillis,
+                runnable -> ApplicationManager.getApplication().invokeLater(runnable)
+        );
+    }
+
+    WebviewWatchdog(
+            JPanel mainPanel,
+            BooleanSupplier browserAvailableCheck,
+            Runnable onReloadWebview,
+            Runnable onRecreateWebview,
+            DisposedCheck disposedCheck,
+            StreamActiveCheck streamActiveCheck,
+            ReadyCheck readyCheck,
+            LongSupplier currentTimeMillis,
+            Consumer<Runnable> recoveryExecutor
+    ) {
         this.mainPanel = mainPanel;
-        this.browserProvider = browserProvider;
+        this.browserAvailableCheck = browserAvailableCheck;
         this.onReloadWebview = onReloadWebview;
         this.onRecreateWebview = onRecreateWebview;
         this.disposedCheck = disposedCheck;
         this.streamActiveCheck = streamActiveCheck;
         this.readyCheck = readyCheck;
+        this.currentTimeMillis = currentTimeMillis;
+        this.recoveryExecutor = recoveryExecutor;
+        long now = currentTimeMillis.getAsLong();
+        this.lastHeartbeatAtMs = now;
+        this.lastRafAtMs = now;
     }
 
     /**
@@ -127,7 +163,7 @@ public class WebviewWatchdog {
      * Handle a heartbeat message from the webview.
      */
     public void handleHeartbeat(String content) {
-        long now = System.currentTimeMillis();
+        long now = currentTimeMillis.getAsLong();
         lastHeartbeatAtMs = now;
 
         if (content == null || content.isEmpty()) {
@@ -162,7 +198,7 @@ public class WebviewWatchdog {
      * Reset heartbeat timestamps (e.g., after a recovery action).
      */
     public void resetTimestamps() {
-        long now = System.currentTimeMillis();
+        long now = currentTimeMillis.getAsLong();
         lastHeartbeatAtMs = now;
         lastRafAtMs = now;
         lastVisibility = null;
@@ -180,11 +216,11 @@ public class WebviewWatchdog {
         resetRecoveryState();
     }
 
-    private void checkHealth() {
+    void checkHealth() {
         if (disposedCheck.isDisposed()) { return; }
         boolean frontendReady = readyCheck.isFrontendReady();
 
-        long now = System.currentTimeMillis();
+        long now = currentTimeMillis.getAsLong();
         long heartbeatAgeMs = now - lastHeartbeatAtMs;
         long rafAgeMs = now - lastRafAtMs;
 
@@ -212,30 +248,7 @@ public class WebviewWatchdog {
             return;
         }
 
-        if (disposedCheck.isDisposed()) { return; }
-        if (!tryAcquireRecoveryPermit(frontendReady)) { return; }
-
-        stallCount += 1;
-        String reason = "frontendReady=" + frontendReady
-                + ", heartbeatAgeMs=" + heartbeatAgeMs + ", rafAgeMs=" + rafAgeMs;
-        LOG.warn("[WebviewWatchdog] Webview appears stalled (" + stallCount + "), attempting recovery. " + reason);
-
-        lastRecoveryAtMs = now;
-        // Give the webview a grace window after initiating recovery to avoid repeated triggers.
-        lastHeartbeatAtMs = now;
-        lastRafAtMs = now;
-
-        if (stallCount <= 1) {
-            reload("watchdog_reload");
-        } else {
-            onRecreateWebview.run();
-            stallCount = 0;
-        }
-
-        if (!frontendReady && startupRecoveryAttempts.get() == MAX_STARTUP_RECOVERY_ATTEMPTS) {
-            LOG.warn("[WebviewWatchdog] Startup recovery limit reached; "
-                    + "waiting for frontend readiness or tab activation before retrying");
-        }
+        scheduleRecoveryCheck();
     }
 
     boolean tryAcquireRecoveryPermit(boolean frontendReady) {
@@ -275,22 +288,75 @@ public class WebviewWatchdog {
                                  boolean panelShowing,
                                  boolean pageVisible,
                                  boolean pageFocused) {
-        if (!frontendReady) {
-            return true;
-        }
+        // A hidden JCEF page cannot advance requestAnimationFrame or complete
+        // frontend startup reliably. Treat visibility as a lifecycle gate for
+        // both startup and runtime health checks; tab activation resets the
+        // timestamps before monitoring resumes.
         // Editor focus is independent from webview render health.
         return panelShowing && pageVisible;
     }
 
-    private void reload(String reason) {
-        ApplicationManager.getApplication().invokeLater(() -> {
-            if (disposedCheck.isDisposed()) { return; }
-            JBCefBrowser browser = browserProvider.getBrowser();
-            if (browser == null) {
-                onRecreateWebview.run();
-                return;
-            }
+    private void scheduleRecoveryCheck() {
+        if (!recoveryPending.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            recoveryExecutor.accept(() -> {
+                try {
+                    executeRecoveryIfStillRequired();
+                } finally {
+                    recoveryPending.set(false);
+                }
+            });
+        } catch (RuntimeException e) {
+            recoveryPending.set(false);
+            throw e;
+        }
+    }
+
+    private void executeRecoveryIfStillRequired() {
+        if (disposedCheck.isDisposed()) { return; }
+        boolean frontendReady = readyCheck.isFrontendReady();
+        boolean visible = lastVisibility == null || "visible".equals(lastVisibility);
+        boolean focused = lastHasFocus == null || lastHasFocus;
+        if (!shouldMonitor(frontendReady, mainPanel.isShowing(), visible, focused)) {
+            return;
+        }
+
+        long now = currentTimeMillis.getAsLong();
+        if (now - lastRecoveryAtMs < recoveryCooldownMs(frontendReady)) {
+            return;
+        }
+        long heartbeatAgeMs = now - lastHeartbeatAtMs;
+        long rafAgeMs = now - lastRafAtMs;
+        long effectiveTimeoutMs = heartbeatTimeoutMs(
+                frontendReady, streamActiveCheck.isStreamActive());
+        if (heartbeatAgeMs <= effectiveTimeoutMs && rafAgeMs <= effectiveTimeoutMs) {
+            stallCount = 0;
+            return;
+        }
+        if (!tryAcquireRecoveryPermit(frontendReady)) { return; }
+
+        stallCount += 1;
+        String reason = "frontendReady=" + frontendReady
+                + ", heartbeatAgeMs=" + heartbeatAgeMs + ", rafAgeMs=" + rafAgeMs;
+        LOG.warn("[WebviewWatchdog] Webview appears stalled (" + stallCount
+                + "), attempting recovery. " + reason);
+
+        lastRecoveryAtMs = now;
+        lastHeartbeatAtMs = now;
+        lastRafAtMs = now;
+
+        if (stallCount <= 1 && browserAvailableCheck.getAsBoolean()) {
             onReloadWebview.run();
-        });
+        } else {
+            onRecreateWebview.run();
+            stallCount = 0;
+        }
+
+        if (!frontendReady && startupRecoveryAttempts.get() == MAX_STARTUP_RECOVERY_ATTEMPTS) {
+            LOG.warn("[WebviewWatchdog] Startup recovery limit reached; "
+                    + "waiting for frontend readiness or tab activation before retrying");
+        }
     }
 }

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -451,6 +451,7 @@ public class ClaudeChatWindow {
                 return;
             }
             webviewWatchdog.markTabActivated();
+            webviewInitializer.onTabActivated();
 
             JBCefBrowser currentBrowser = browser;
             if (currentBrowser != null) {
@@ -478,6 +479,31 @@ public class ClaudeChatWindow {
         Content content = parentContent;
         ContentManager contentManager = content == null ? null : content.getManager();
         return contentManager != null && contentManager.getSelectedContent() == content;
+    }
+
+    private boolean isWebviewActive() {
+        Content content = parentContent;
+        ContentManager contentManager = content == null ? null : content.getManager();
+        boolean managedContent = contentManager != null && contentManager.getIndexOfContent(content) >= 0;
+        boolean selectedContent = managedContent && contentManager.getSelectedContent() == content;
+        DetachedChatFrame detachedFrame = DetachedWindowManager.getDetachedFrame(project, this);
+        return resolveWebviewActive(
+                managedContent,
+                selectedContent,
+                detachedFrame != null,
+                detachedFrame != null && detachedFrame.isVisible());
+    }
+
+    static boolean resolveWebviewActive(
+            boolean managedContent,
+            boolean selectedContent,
+            boolean detachedWindowPresent,
+            boolean detachedWindowVisible
+    ) {
+        if (managedContent) {
+            return selectedContent;
+        }
+        return !detachedWindowPresent || detachedWindowVisible;
     }
 
     static void refreshActivatedWebview(
@@ -1555,6 +1581,11 @@ public class ClaudeChatWindow {
             @Override
             public boolean hasEverBeenFrontendReady() {
                 return hasEverBeenFrontendReady;
+            }
+
+            @Override
+            public boolean isWebviewActive() {
+                return ClaudeChatWindow.this.isWebviewActive();
             }
 
             @Override

--- a/src/test/java/com/github/claudecodegui/ui/WebviewInitializerTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/WebviewInitializerTest.java
@@ -4,8 +4,11 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.cef.browser.CefBrowser;
 
+import javax.swing.Timer;
+import java.awt.event.ActionEvent;
 import java.lang.reflect.Proxy;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
@@ -52,6 +55,145 @@ public class WebviewInitializerTest {
         Assert.assertEquals(fastDelay, WebviewInitializer.bridgeInjectionRetryDelayMs(1));
         Assert.assertTrue(slowDelay > fastDelay);
         Assert.assertEquals(slowDelay, WebviewInitializer.bridgeInjectionRetryDelayMs(500));
+    }
+
+    /** Verifies that hidden tabs pause fallback work until activation and ready tabs stop it. */
+    @Test
+    public void bridgeInjectionRetriesOnlyRunForActiveUnreadyWebviews() {
+        Assert.assertFalse(WebviewInitializer.shouldRunBridgeInjectionRetries(false, false, false));
+        Assert.assertTrue(WebviewInitializer.shouldRunBridgeInjectionRetries(false, false, true));
+        Assert.assertFalse(WebviewInitializer.shouldRunBridgeInjectionRetries(false, true, true));
+        Assert.assertFalse(WebviewInitializer.shouldRunBridgeInjectionRetries(true, false, true));
+    }
+
+    /** Verifies that a hidden-tab tick clears the real timer and activation installs a replacement. */
+    @Test
+    public void hiddenBridgeTimerStopsAndActivationRestartsIt() {
+        WebviewInitializer.BridgeInjectionTimerLifecycle lifecycle =
+                new WebviewInitializer.BridgeInjectionTimerLifecycle();
+        AtomicBoolean active = new AtomicBoolean(true);
+        lifecycle.beginPageLoad(7);
+
+        try {
+            Assert.assertTrue(lifecycle.startIfAbsent(7, active::get, attempt -> true));
+            Timer initialTimer = lifecycle.getTimer();
+            Assert.assertNotNull(initialTimer);
+            Assert.assertTrue(initialTimer.isRunning());
+
+            active.set(false);
+            fireTimer(initialTimer);
+            assertNull(lifecycle.getTimer());
+
+            active.set(true);
+            Assert.assertTrue(lifecycle.startIfAbsent(7, active::get, attempt -> true));
+            Assert.assertNotSame(initialTimer, lifecycle.getTimer());
+        } finally {
+            lifecycle.stop();
+        }
+    }
+
+    /** Verifies that repeated activation cannot install a second timer for one generation. */
+    @Test
+    public void repeatedActivationKeepsSingleBridgeTimer() {
+        WebviewInitializer.BridgeInjectionTimerLifecycle lifecycle =
+                new WebviewInitializer.BridgeInjectionTimerLifecycle();
+        lifecycle.beginPageLoad(7);
+
+        try {
+            Assert.assertTrue(lifecycle.startIfAbsent(7, () -> true, attempt -> true));
+            Timer installedTimer = lifecycle.getTimer();
+            installedTimer.stop();
+
+            Assert.assertFalse(lifecycle.startIfAbsent(7, () -> true, attempt -> true));
+            Assert.assertSame(installedTimer, lifecycle.getTimer());
+        } finally {
+            lifecycle.stop();
+        }
+    }
+
+    /** Verifies that generation changes stop old timers and reject stale-page retry installation. */
+    @Test
+    public void pageGenerationInvalidatesOldBridgeTimer() {
+        WebviewInitializer.BridgeInjectionTimerLifecycle lifecycle =
+                new WebviewInitializer.BridgeInjectionTimerLifecycle();
+        AtomicBoolean oldRetryAllowed = new AtomicBoolean(true);
+        lifecycle.beginPageLoad(7);
+
+        try {
+            Assert.assertTrue(lifecycle.startIfAbsent(7, oldRetryAllowed::get, attempt -> true));
+            Timer oldTimer = lifecycle.getTimer();
+            lifecycle.beginPageLoad(8);
+
+            assertNull(lifecycle.getTimer());
+            Assert.assertFalse(oldTimer.isRunning());
+            Assert.assertFalse(lifecycle.startIfAbsent(7, () -> true, attempt -> true));
+            Assert.assertTrue(lifecycle.startIfAbsent(8, () -> true, attempt -> true));
+            Timer currentTimer = lifecycle.getTimer();
+            currentTimer.stop();
+
+            oldRetryAllowed.set(false);
+            fireTimer(oldTimer);
+            Assert.assertSame(currentTimer, lifecycle.getTimer());
+            Assert.assertFalse(lifecycle.startIfAbsent(7, () -> false, attempt -> true));
+            Assert.assertSame(currentTimer, lifecycle.getTimer());
+        } finally {
+            lifecycle.stop();
+        }
+    }
+
+    /** Verifies that ready and disposed state transitions stop the installed timer on its next tick. */
+    @Test
+    public void readyAndDisposedTransitionsStopBridgeTimer() {
+        WebviewInitializer.BridgeInjectionTimerLifecycle lifecycle =
+                new WebviewInitializer.BridgeInjectionTimerLifecycle();
+        AtomicBoolean ready = new AtomicBoolean(false);
+        AtomicBoolean disposed = new AtomicBoolean(false);
+        lifecycle.beginPageLoad(7);
+
+        try {
+            Assert.assertTrue(lifecycle.startIfAbsent(
+                    7,
+                    () -> WebviewInitializer.shouldRunBridgeInjectionRetries(
+                            disposed.get(), ready.get(), true),
+                    attempt -> true));
+            Timer readyTimer = lifecycle.getTimer();
+            readyTimer.stop();
+            ready.set(true);
+            fireTimer(readyTimer);
+            assertNull(lifecycle.getTimer());
+
+            ready.set(false);
+            Assert.assertTrue(lifecycle.startIfAbsent(
+                    7,
+                    () -> WebviewInitializer.shouldRunBridgeInjectionRetries(
+                            disposed.get(), ready.get(), true),
+                    attempt -> true));
+            Timer disposedTimer = lifecycle.getTimer();
+            disposedTimer.stop();
+            disposed.set(true);
+            fireTimer(disposedTimer);
+            assertNull(lifecycle.getTimer());
+        } finally {
+            lifecycle.stop();
+        }
+    }
+
+    /** Verifies that configuration resolution runs once per page generation and refreshes after reload. */
+    @Test
+    public void frontendConfigurationIsCachedPerPageGeneration() {
+        WebviewInitializer.PageConfigurationCache cache =
+                new WebviewInitializer.PageConfigurationCache();
+        AtomicInteger builds = new AtomicInteger();
+        cache.reset(7);
+
+        assertEquals("config-1", cache.getOrCreate(7, () -> "config-" + builds.incrementAndGet()));
+        assertEquals("config-1", cache.getOrCreate(7, () -> "config-" + builds.incrementAndGet()));
+        assertNull(cache.getOrCreate(8, () -> "config-" + builds.incrementAndGet()));
+        assertEquals(1, builds.get());
+
+        cache.reset(8);
+        assertEquals("config-2", cache.getOrCreate(8, () -> "config-" + builds.incrementAndGet()));
+        assertEquals(2, builds.get());
     }
 
     /** Verifies that bridge injection wakes the frontend startup waiter once available. */
@@ -178,5 +320,13 @@ public class WebviewInitializerTest {
         WebviewInitializer.reloadCurrentPage(cefBrowser);
 
         Assert.assertEquals(1, reloadCalls.get());
+    }
+
+    private static void fireTimer(Timer timer) {
+        Assert.assertNotNull(timer);
+        timer.stop();
+        for (java.awt.event.ActionListener listener : timer.getActionListeners()) {
+            listener.actionPerformed(new ActionEvent(timer, ActionEvent.ACTION_PERFORMED, "test"));
+        }
     }
 }

--- a/src/test/java/com/github/claudecodegui/ui/WebviewWatchdogTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/WebviewWatchdogTest.java
@@ -2,12 +2,22 @@ package com.github.claudecodegui.ui;
 
 import org.junit.Test;
 
+import javax.swing.JPanel;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Unit tests for startup/runtime watchdog timing, visibility gating, and recovery budgets.
+ */
 public class WebviewWatchdogTest {
 
+    /** Verifies that an unready frontend uses the bounded startup timeout. */
     @Test
     public void usesShortTimeoutBeforeFrontendReady() {
         long startupTimeout = WebviewWatchdog.heartbeatTimeoutMs(false, false);
@@ -16,23 +26,86 @@ public class WebviewWatchdogTest {
         assertTrue(startupTimeout < WebviewWatchdog.heartbeatTimeoutMs(true, false));
     }
 
+    /** Verifies that active streaming only extends the timeout after frontend readiness. */
     @Test
     public void extendsHeartbeatTimeoutOnlyForReadyStreamingWebview() {
         assertTrue(WebviewWatchdog.heartbeatTimeoutMs(true, true)
                 > WebviewWatchdog.heartbeatTimeoutMs(true, false));
     }
 
+    /** Verifies that startup recovery uses a shorter cooldown than runtime recovery. */
     @Test
     public void retriesStartupRecoverySoonerThanRuntimeRecovery() {
         assertTrue(WebviewWatchdog.recoveryCooldownMs(false)
                 < WebviewWatchdog.recoveryCooldownMs(true));
     }
 
+    /** Verifies that hidden unready tabs stay idle until their panel becomes visible. */
     @Test
-    public void monitorsStartupEvenWhenPanelIsHiddenOrUnfocused() {
-        assertTrue(WebviewWatchdog.shouldMonitor(false, false, false, false));
+    public void pausesStartupMonitoringWhilePanelIsHidden() {
+        assertFalse(WebviewWatchdog.shouldMonitor(false, false, false, false));
+        assertTrue(WebviewWatchdog.shouldMonitor(false, true, true, false));
     }
 
+    /** Verifies through checkHealth that hidden startup pages do not invoke recovery callbacks. */
+    @Test
+    public void hiddenHealthCheckDefersRecoveryUntilPanelIsVisible() {
+        AtomicLong now = new AtomicLong(1_000L);
+        AtomicInteger reloads = new AtomicInteger();
+        AtomicInteger recreates = new AtomicInteger();
+        ShowingPanel panel = new ShowingPanel(false);
+        WebviewWatchdog watchdog = createWatchdog(
+                panel, now, reloads, recreates, Runnable::run);
+        now.addAndGet(1_000_000L);
+
+        watchdog.checkHealth();
+        assertEquals(0, reloads.get());
+        assertEquals(0, recreates.get());
+
+        panel.setShowing(true);
+        watchdog.checkHealth();
+        assertEquals(1, reloads.get());
+        assertEquals(0, recreates.get());
+    }
+
+    /** Verifies that a cancelled recovery neither consumes budget nor advances reload to recreate. */
+    @Test
+    public void cancelledRecoveryLeavesFirstVisibleAttemptAsReload() {
+        AtomicLong now = new AtomicLong(1_000L);
+        AtomicInteger reloads = new AtomicInteger();
+        AtomicInteger recreates = new AtomicInteger();
+        AtomicInteger queuedCount = new AtomicInteger();
+        AtomicReference<Runnable> queuedRecovery = new AtomicReference<>();
+        ShowingPanel panel = new ShowingPanel(true);
+        WebviewWatchdog watchdog = createWatchdog(
+                panel, now, reloads, recreates, recovery -> {
+                    queuedCount.incrementAndGet();
+                    queuedRecovery.set(recovery);
+                });
+        now.addAndGet(1_000_000L);
+
+        watchdog.checkHealth();
+        watchdog.checkHealth();
+        assertEquals(1, queuedCount.get());
+        assertTrue(queuedRecovery.get() != null);
+        panel.setShowing(false);
+        queuedRecovery.get().run();
+
+        assertEquals(0, reloads.get());
+        assertEquals(0, recreates.get());
+
+        panel.setShowing(true);
+        watchdog.checkHealth();
+        assertEquals(2, queuedCount.get());
+        queuedRecovery.get().run();
+
+        assertEquals(1, reloads.get());
+        assertEquals(0, recreates.get());
+        assertTrue(watchdog.tryAcquireRecoveryPermit(false));
+        assertFalse(watchdog.tryAcquireRecoveryPermit(false));
+    }
+
+    /** Verifies that runtime monitoring follows render visibility rather than editor focus. */
     @Test
     public void pausesRuntimeMonitoringWhenWebviewCannotRenderVisibly() {
         assertTrue(WebviewWatchdog.shouldMonitor(true, true, true, true));
@@ -42,6 +115,7 @@ public class WebviewWatchdogTest {
         assertTrue(WebviewWatchdog.shouldMonitor(true, true, true, false));
     }
 
+    /** Verifies that repeated startup recovery cannot loop indefinitely. */
     @Test
     public void capsBackgroundStartupRecovery() {
         WebviewWatchdog watchdog = createWatchdog();
@@ -51,6 +125,7 @@ public class WebviewWatchdogTest {
         assertFalse(watchdog.tryAcquireRecoveryPermit(false));
     }
 
+    /** Verifies that frontend readiness restores a previously exhausted startup budget. */
     @Test
     public void frontendReadinessRestoresStartupRecoveryBudget() {
         WebviewWatchdog watchdog = exhaustedWatchdog();
@@ -62,6 +137,7 @@ public class WebviewWatchdogTest {
         assertFalse(watchdog.tryAcquireRecoveryPermit(false));
     }
 
+    /** Verifies that an ordinary timestamp reset does not bypass the startup retry cap. */
     @Test
     public void timestampResetDoesNotRestoreStartupRecoveryBudget() {
         WebviewWatchdog watchdog = exhaustedWatchdog();
@@ -71,6 +147,7 @@ public class WebviewWatchdogTest {
         assertFalse(watchdog.tryAcquireRecoveryPermit(false));
     }
 
+    /** Verifies that explicit tab activation grants a fresh bounded startup retry budget. */
     @Test
     public void tabActivationRestoresStartupRecoveryBudget() {
         WebviewWatchdog watchdog = exhaustedWatchdog();
@@ -82,6 +159,7 @@ public class WebviewWatchdogTest {
         assertFalse(watchdog.tryAcquireRecoveryPermit(false));
     }
 
+    /** Verifies that ready runtime pages are not constrained by the startup retry budget. */
     @Test
     public void runtimeRecoveryIsNotCappedByStartupBudget() {
         WebviewWatchdog watchdog = createWatchdog();
@@ -109,5 +187,42 @@ public class WebviewWatchdogTest {
                 () -> false,
                 () -> false
         );
+    }
+
+    private static WebviewWatchdog createWatchdog(
+            JPanel panel,
+            AtomicLong now,
+            AtomicInteger reloads,
+            AtomicInteger recreates,
+            Consumer<Runnable> recoveryExecutor
+    ) {
+        return new WebviewWatchdog(
+                panel,
+                () -> true,
+                reloads::incrementAndGet,
+                recreates::incrementAndGet,
+                () -> false,
+                () -> false,
+                () -> false,
+                now::get,
+                recoveryExecutor
+        );
+    }
+
+    private static final class ShowingPanel extends JPanel {
+        private boolean showing;
+
+        private ShowingPanel(boolean showing) {
+            this.showing = showing;
+        }
+
+        private void setShowing(boolean showing) {
+            this.showing = showing;
+        }
+
+        @Override
+        public boolean isShowing() {
+            return showing;
+        }
     }
 }

--- a/src/test/java/com/github/claudecodegui/ui/toolwindow/WebviewTabActivationTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/toolwindow/WebviewTabActivationTest.java
@@ -16,8 +16,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Unit tests for native JCEF repainting and active-state decisions during tab activation.
+ */
 public class WebviewTabActivationTest {
 
+    /** Verifies that a windowed JCEF surface is remapped and repainted when its tab activates. */
     @Test
     public void remapsWindowedNativeSurfaceForAnEmptyTab() {
         List<String> calls = new ArrayList<>();
@@ -42,6 +46,7 @@ public class WebviewTabActivationTest {
         assertTrue(frontendRepainted.get());
     }
 
+    /** Verifies that off-screen-rendered JCEF uses resize notification instead of native remapping. */
     @Test
     public void usesResizeNotificationOnlyForOsrSurface() {
         List<String> calls = new ArrayList<>();
@@ -61,6 +66,16 @@ public class WebviewTabActivationTest {
         assertTrue(nativeComponent.visibilityChanges.isEmpty());
         assertTrue(calls.contains("notifyScreenInfoChanged"));
         assertTrue(frontendRepainted.get());
+    }
+
+    /** Verifies active-state selection for managed tabs, pre-binding windows, and detached windows. */
+    @Test
+    public void resolvesManagedAndDetachedWebviewActivity() {
+        assertTrue(ClaudeChatWindow.resolveWebviewActive(true, true, false, false));
+        assertFalse(ClaudeChatWindow.resolveWebviewActive(true, false, true, true));
+        assertTrue(ClaudeChatWindow.resolveWebviewActive(false, false, false, false));
+        assertTrue(ClaudeChatWindow.resolveWebviewActive(false, false, true, true));
+        assertFalse(ClaudeChatWindow.resolveWebviewActive(false, false, true, false));
     }
 
     private static CefBrowser createCefBrowser(


### PR DESCRIPTION
## Summary

Fix the hidden-tab bridge retry and watchdog recovery storm observed when IDEA restores many projects and saved CC GUI tabs at startup.

In the measured reproduction, 7 projects restored 21 chat tabs while 14 hidden tabs could not reliably mount React or report `frontend_ready`. Those hidden pages performed 42 Codemoss configuration reads per second, repeated bridge injection, and bounded reload/recreate attempts until every tab was manually activated.

## Technical changes

- Gate bridge fallback injection on the current page being active and unready.
- Stop the installed Swing timer when a tab becomes inactive and resume exactly one timer for the current page generation on activation.
- Make stale queued timer events identity-safe so an old generation cannot clear a newer timer.
- Gate watchdog startup and runtime monitoring on panel/page visibility.
- Reserve only a `recoveryPending` token before the EDT recovery task performs its final eligibility check.
- Commit startup permits, stall count, cooldown, and heartbeat timestamps only after disposal, visibility, readiness, streaming timeout, cooldown, and heartbeat age are revalidated.
- Keep watchdog recovery to a single EDT queue boundary and perform reload/recreate immediately when already on EDT.
- Move stale-bridge recreation outside `bridgeLock` so JCEF teardown or reconstruction never runs while holding that lock.
- Cache the complete frontend configuration script once per runtime page generation and invalidate it from `beginPageLoad()`.

Cancelled or hidden recovery work therefore consumes no startup budget and cannot advance the next visible recovery from reload to recreate.

## Compatibility and scope

This preserves eager JCEF and daemon creation, Remote JCEF fallback, native reload memory-leak recovery, generation guards, and frontend recovery ownership. Lazy browser creation, daemon sharing, first-tab OSR frame publication, and the sleep-related daemon heartbeat issue remain separate work.

## Verification

- 33 focused Java tests passed.
- Full Gradle test suite passed.
- `checkstyleMain` passed.
- Java compilation and TypeScript/Vite production build passed.
- `git diff --check` passed.
- Multi-project runtime verification confirmed hidden tabs no longer sustain configuration reads or recovery activity while inactive.

Fixes #1587
