### PR TITLE
fix(webview): publish restored history through OSR frame fences

### DIFF
--- a/docs/fix/first-tab-history-render-fix-2026-08-06.md
+++ b/docs/fix/first-tab-history-render-fix-2026-08-06.md
@@ -1,0 +1,295 @@
+# 首个可见 Tab 历史内容不显示：OnPaint 帧栅栏修复
+
+> 首次记录：2026-08-06
+>
+> 更新：2026-08-07
+>
+> 关联问题：#1592
+>
+> 当前状态：实现与审核已完成；R18 已通过 IDEA 2025.2 多项目、多轮重启及休眠唤醒实机验证，首个可见 Tab 稳定发布完整历史，普通 Tab 切换未再观察到布局抖动
+
+## 1. 问题表现与已确认事实
+
+IDE 启动并恢复多个 CC GUI Tab 时，首个可见 Tab 偶尔只显示 Logo、输入框等基础框架，历史区域为空或仅绘制一部分。鼠标经过只能恢复局部区域，调整窗口尺寸或切换 Tab 后再切回通常可以完整恢复。
+
+日志与实机操作共同确认：
+
+- Java 已成功读取历史并调用 `updateMessages`；
+- React state 和 DOM 已包含历史内容；
+- 切换 Tab 恢复前没有新的 history query、`updateMessages`、reload 或 recreate；
+- hover 只恢复局部，而真实 resize/Tab remap 恢复全页。
+
+因此本问题不是会话数据丢失，而是 Chromium/JCEF OSR 的完整帧没有可靠发布到 JetBrains backing image。
+
+## 2. OSR 的真实完成链路
+
+以下阶段彼此独立，不能互相替代：
+
+```text
+React DOM commit
+    ↓
+Chromium style/layout/compositor
+    ↓
+CefRenderHandler.OnPaint / onPaintWithSharedMem
+    ↓
+JetBrains 默认 OSR handler 更新 backing image
+    ↓
+Swing JBCefOsrComponent.paintComponent()
+```
+
+几个容易混淆的操作：
+
+- `requestAnimationFrame()` 只提供浏览器绘制机会，不证明 `OnPaint` 已到达；
+- `wasResized()` 只发出异步 resize 通知；相同 bounds/screen-info 会在 CEF 122 中短路，不能作为 repaint/damage API；
+- `markCompletelyDirty()`、`repaint()`、`paintImmediately()` 只能重画当前 backing image；
+- `notifyScreenInfoChanged()` 更新屏幕和缩放信息，不是内容 invalidation；
+- `onLoadEnd`、`frontend_ready` 和 history callback 都不代表首帧已经显示。
+
+## 3. 早期方案与弯路
+
+### 3.1 hide/show 与固定延迟
+
+早期方案通过隐藏/显示 native component、等待固定时间再 repaint。它会改变 native window 映射状态，却不能证明 Chromium 生成了完整帧，因而已删除。
+
+### 3.2 重新应用 bounds
+
+对 `cefBrowser.getUIComponent()` 重新应用当前 bounds 能进入 JCEF resize 链，对 windowed JCEF 有效，但 OSR 下只表示 resize 请求已发出。
+
+### 3.3 R11/R12 的 120ms + 120ms OSR 补偿
+
+旧实现按如下固定时序执行：
+
+```text
+等待 120ms
+→ setBounds + wasResized
+→ 再等待 120ms
+→ markCompletelyDirty + paintImmediately
+→ 消费 pending
+```
+
+实机已经证明该方案不充分：即使所有调用成功，`paintImmediately()` 仍可能画出旧 backing image。Timer 到期也不能作为新 OSR frame 到达的证据。
+
+### 3.4 double-rAF / zoom nudge 被误当成完成确认
+
+前端跨帧 zoom nudge 对 windowed ghosting、弹窗残影仍可作为经验性补偿，但隐藏页面的 rAF 可能暂停，timer fallback 也不表示产生了 compositor frame。因此 OSR pending 的成功不再依赖 `forceWebviewRepaint()` 回调。严格 OSR pulse 活跃期间，普通 repaint 会被模块级 coordinator 合并并延后，避免多个 zoom 写入跨帧交错。
+
+## 4. 最终设计：真实 OnPaint full-frame fence
+
+### 4.1 前端只确认 DOM commit
+
+`historyLoadComplete` 仍具备启动前 placeholder，并保留显式零消息、快照顺序和 history epoch 保护。
+
+历史消息 state 被 React 提交后，`useLayoutEffect` 发送：
+
+```text
+history_dom_committed:<historyRenderCommitEpoch>
+```
+
+该事件只表示历史 DOM 已 commit，不声称 Chromium 已栅格化，更不声称 OSR 像素已经显示。Java 暂时兼容旧的 `history_render_complete` 事件名，但新前端不再发送它。
+
+### 4.2 保留 JetBrains 默认 OSR 实现
+
+创建 browser 时，只要提供了自定义 `JBCefOSRHandlerFactory`，就无条件把它注入 builder，不能依赖插件在 build 前预判的 OSR 模式。IDEA 2025.2 Remote JCEF 会忽略 macOS 上请求的 `setOffScreenRendering(false)` 并在 builder 内部改为 OSR；若仅在预判 OSR 时注入，最终 Remote browser 会绕过 frame fence。真正的 windowed browser 不使用该字段，因此无条件注入不会改变其渲染路径。
+
+factory 先调用 JetBrains 默认 factory 创建原始 component 和 render handler，再只包装返回给 CEF 的 handler：
+
+- 不替换 `JBCefOsrComponent`；
+- 不重新实现鼠标、键盘、IME、HiDPI 或共享内存；
+- 所有未拦截方法，包括 `disposeNativeResources()`，原样委托给默认 handler；
+- windowed JCEF 不经过 OSR handler，原路径保持不变。
+
+带自定义 factory 的构建采用 fail-closed：builder 或后置配置失败时先 dispose 已创建 browser，然后拒绝创建一个没有 wrapper 的 Remote OSR fallback。只有未请求自定义 factory 的旧调用路径才允许退回默认构造器。
+
+IDEA 2024.1 与项目 2024.3 编译基线暴露默认 factory 的 API 形状不同，代码通过反射兼容 `DEFAULT` 字段与 `getInstance()` 方法。
+
+### 4.3 Remote 与经典 OSR
+
+Remote JCEF 的 `CefNativeRenderHandler` 不是所有支持版本都有。实现只按类名动态加载：
+
+- 接口存在且默认 handler 实现它时，代理同时实现 Remote 接口；
+- 接口不存在时，代理只实现经典 `CefRenderHandler`；
+- 代码没有对 `CefNativeRenderHandler` 的静态类型引用，旧 IDE 可以加载同一插件二进制。
+
+最终 Remote frame 调用默认 handler 时，把非 popup 的 `dirtyRectsCount` 改为 `0`，要求 JetBrains 从共享内存复制整幅 raster。经典 OSR 则将 dirty rect 替换为 `(0, 0, width, height)` 的整幅矩形。
+
+Popup paint 和没有 active request 的普通 frame 完全透传。
+
+### 4.4 serial、pending 与 active attempt
+
+每次 refresh request 都带完整身份：
+
+```text
+browser identity
+CefBrowser identity
+page generation
+frontend-ready epoch
+content revision（frontend shell=0，history commit epoch>0）
+request serial
+attempt id
+reason
+```
+
+状态机为：
+
+```text
+PENDING
+  ↓ 页面 showing、displayable 且尺寸有效
+WAITING_PHASE_A_APPLIED
+  ↓ 前端确认精确 token 的 phase-A mutation 已执行
+DRAINING_FIRST_FRAME
+  ↓ 第一个真实非 popup OnPaint（正常透传）
+WAITING_PHASE_B
+  ↓ Java 请求 phase B，但 final gate 继续关闭
+WAITING_PHASE_B_APPLIED
+  ↓ 前端确认精确 token 已恢复透明 sentinel
+WAITING_FINAL_FRAME
+  ↓ 第二个真实非 popup OnPaint（强制 full-frame）
+PAINT_QUEUED
+  ↓ EDT 重新校验身份与可见性并 paintImmediately()
+COMPLETED
+```
+
+同一 browser、generation、ready epoch 下，`frontend_ready` 创建 revision 0；每个新的 `historyRenderCommitEpoch` 创建更高 revision。同一或更旧 revision 无论仍在 pending、正在 active，还是已经发布，都复用现有 watermark，不生成新 serial。只有 `complete(attempt)` 能推进 `lastPublishedSerial`，lifecycle invalidation 会同时清除 pending、active 和 published watermark。
+
+`OnPaint` 本身不携带 serial 或 attempt id，因此实现不能让 B 直接覆盖正在等待帧的 A。request serial 表示一条逻辑 pending 请求；attempt id 表示该请求的某一次具体 arm。相同 serial 超时后重新 arm 也会得到不同 attempt id。当前模型同时保存：
+
+- 一个 active attempt；
+- 一个 latest pending request。
+
+A 的迟到 frame 只能推进 A；B 在 pending 中等待。A 完成时只消费 A，随后再 arm B。旧 A 永远不能清除新 B；同一 request 的旧 attempt 也不能释放、完成或取消新 attempt 的 timeout。
+
+### 4.5 第一帧 drain 与最终帧发布
+
+页面真正可见后 arm 当前 request，但 paint gate 保持关闭。Java 随即调用前端 phase A。前端在 React `#app` 外创建固定定位、2 CSS px、`pointer-events:none`、`contain:strict` 的 sentinel，并写入低透明度但非零的真实背景色。sentinel 不改变字体、布局、滚动位置，也不读取 `#app.offsetHeight`。前端确认样式 mutation 后通过 generation-gated bridge 返回精确 `token + phase + applied` ACK；只有 ACK 被当前 attempt 接受后，fence 才进入 `DRAINING_FIRST_FRAME`。ACK 前到达的自然 frame 全部透传。
+
+第一个匹配的 `OnPaint` 只作为 drain frame，仍按原 dirty rect 交给默认 handler。fence 先进入 `WAITING_PHASE_B`。Java 重新检查 browser、generation、ready epoch、serial、attempt、showing 和尺寸后进入 `WAITING_PHASE_B_APPLIED`，再调用前端 phase B 把 sentinel 恢复为 transparent。`executeJavaScript()` 只代表脚本已提交，因此不会开放 final gate；只有前端确认 Phase B mutation 已实际执行后才进入 `WAITING_FINAL_FRAME`。Phase B ACK 前的自然 frame 仍只能透传。
+
+第二个匹配 frame 才强制 full-frame 并交给默认 handler。之后在 EDT：
+
+1. 再次验证 request 身份和 native component；
+2. `markCompletelyDirty()`；
+3. `paintImmediately()`；
+4. paint 返回后只完成当前 serial + attempt id；
+5. 如果还有更新的 pending request，立即开始下一条 fence。
+
+若 A 完成或超时时 B 已 pending，Java arm B 后调用前端 `replace(A, B)`。前端在同一个 JS task 内校验 A 的精确 token，并把 sentinel 直接切换为 B 的另一个 raster variant 后发送 B 的 applied ACK；相邻 attempt 交替使用两种颜色，避免写回相同样式被 Chromium 合并。整个过程不释放普通 repaint waiter。若 B 在 ACK 前超时，取消命令同时携带 B 与其 predecessor A，避免脚本丢失后遗留永久 sentinel。只有整个 fence 队列清空后，普通 dialog/session repaint 才合并执行。
+
+### 4.6 隐藏、失效与超时
+
+如果 native child 未 showing、未 displayable、尺寸无效或窗口 iconified：
+
+- 结束 active attempt；
+- 保留 latest pending；
+- 等 `componentShown`、resize、Tab 激活或窗口恢复后重新 arm。
+
+请求创建与执行资格严格分离：新的 `frontend_ready` 即使隐藏也必须创建 pending；active/showing/displayable/size 只决定当前能否 arm。Tab 激活、component showing 和窗口恢复都只能唤醒已有 publication pending，不能生成新的内容 serial。
+
+若当前内容已经发布且没有 publication pending，OSR Tab 激活只创建一条独立的 cached-presentation 请求，对现有 JetBrains backing image 执行 `markCompletelyDirty()`、`repaint()` 和必要的 `paintImmediately()`。native child 尚未 showing 时该请求单独保留到后续 hierarchy 事件；它不会制造 Chromium damage，也不会推进或消费 publication fence。
+
+以下事件同时淘汰 pending 和 active attempt：
+
+- `frontendReady=false`；
+- page generation 改变；
+- browser recreate/replace；
+- window dispose。
+
+保留一个约 1 秒的一次性 timeout，仅用于释放没有收到 phase ACK 或 frame 的 active attempt。Phase B 请求和 Phase B ACK 后都会为同一 attempt 更新相应阶段的 timeout。timeout 所有权同时绑定 attempt 对象和具体 Runnable：迟到的 A callback 不能取消 B 的 timeout，也不能取消同一 request 新 attempt 的 timeout。
+
+释放操作会原子区分 active A 与 latest pending：
+
+- 若 pending 仍是同一个超时请求 A，不重新 arm，避免每秒循环；
+- 若期间已有更高 serial 的 B，释放 A 后立即且仅一次把执行权交给 B，避免组件已经 showing、却再也没有生命周期事件来唤醒 B；
+- timeout 本身不消费 pending，也不把 Swing repaint 当成 frame 完成。
+- 每个 attempt 只执行一组 phase A/B pulse；超时后保留 pending，但同一请求不会被 timer 自行循环重试。
+
+## 5. Windowed JCEF 与其他 repaint 场景
+
+Windowed JCEF 继续重新应用真实 native component bounds，并执行 validate/repaint 和 screen info 通知。它不经过 OSR frame fence。
+
+`forceWebviewRepaint()` 仍可用于：
+
+- windowed JCEF Tab activation 的前端 ghosting 补偿；
+- changelog/dialog 关闭残影；
+- session transition 或输入区布局变化。
+
+Remote/经典 OSR 的普通 Tab 激活不再调用 generic zoom，只呈现 cached backing image。其他 timer/rAF callback 在真正写入前仍检查 strict pulse 所有权；即使 generic repaint 先排队、OSR pulse 后开始，也会延迟到 pulse 结束。dialog 和 session transition 的 legacy zoom mutation 通过同一个模块级 coordinator，不能消费 OSR history pending。
+
+## 6. 与既有修复的关系
+
+- watchdog soft recovery 继续使用 native `reload()`，不会重新注册 `loadHTML` payload；
+- hidden Tab 不执行 bridge retry/reload/recreate 风暴；
+- generation、ready epoch 和 browser identity 继续隔离旧页面任务；
+- history callback placeholder、显式零消息和 session transition guard 均保留；
+- 本修复不改变 provider/model/context usage 逻辑。
+
+## 7. 跨版本兼容核对
+
+本机 API 核对结果：
+
+- IDEA 2024.1.1：存在 `JBCefOSRHandlerFactory` 与 builder 注入方法；不存在 `CefNativeRenderHandler`；
+- 项目 IDEA 2024.3 编译基线：默认 factory 提供 `getInstance()`；
+- IDEA 2025.2.6.2：存在 Remote `CefNativeRenderHandler` 和 `onPaintWithSharedMem()`。
+
+因此：
+
+- 2024.1/经典 OSR 使用 `onPaint(Rectangle[], ByteBuffer, ...)` full rect；
+- 2025.2 Remote OSR 使用 shared-memory callback 和 dirty count `0`；
+- macOS/Windows 若最终 browser 确实是 windowed rendering，则完全保持 windowed 路径；若 Remote JCEF 覆盖请求并创建 OSR，预装的 factory 会自动接管 OnPaint。
+
+## 8. 自动化测试约束
+
+测试必须长期锁定：
+
+- 第一帧只 drain，第二帧才允许完成；
+- Phase A/B ACK 前的自然 frame 只能透传；
+- 重复、乱序或错误 token 的 phase ACK 不能推进状态；
+- phase A/B 从不修改 `#app.style.zoom`，只改变 `#app` 外的 sentinel；
+- phase A 使用非零透明 raster，phase B 恢复 transparent，finish/cancel 后无残留节点；
+- replacement 的新 sentinel variant 必须与旧 Phase A 不同；
+- Remote 最终非 popup frame 的 dirty count 为 `0`；
+- 经典最终 frame 使用整幅矩形；
+- popup 与非 pending frame 完全透传；
+- `disposeNativeResources()` 等方法仍委托默认 handler；
+- final callback 到达前不能完成 request；
+- release/timeout 保留 pending，同一 A 不循环、更新的 B 会自动接棒；
+- 迟到 A callback 不能取消 B 或重 arm attempt 的 timeout；
+- 普通 repaint 在严格 pulse 期间合并延后；
+- 普通 repaint 先排队、pulse 后开始时，执行阶段仍必须重新检查所有权；
+- timeout handoff 通过精确 `replace(A, B)` 原子转移前端所有权；
+- 请求 windowed 但 Remote 最终强制 OSR 时仍会安装 handler factory；
+- B 不会被 active A 的完成清除；
+- generation、ready=false、browser replace 和 dispose 使旧 callback 失效；
+- hidden frontend-ready 创建 pending 但不 arm，首次显示消费同一 serial；
+- 已发布 OSR 的普通 Tab 激活不创建 serial，只执行 cached presentation；
+- timeout 后由激活重试时 serial 不变、attempt id 增加；
+- React 只在 DOM commit 后发送带 epoch 的 `history_dom_committed`，重复 epoch 不生成 serial；
+- 早到的 `historyLoadComplete` 和显式零消息仍能正确 drain。
+
+## 9. 维护约束
+
+1. 不要再用固定延时推断 OSR frame 已到达；
+2. 不要把 rAF、Timer、`wasResized()` 或 `paintImmediately()` 单独当作像素完成证明；
+3. 不要替换 JetBrains OSR component 或自行管理共享内存；
+4. 不要静态引用只存在于新 IDE 的 Remote handler 类型；
+5. 不要让新 pending request 覆盖 active attempt 的 frame 归属；
+6. 不要让 request serial 代替 attempt identity；同一请求可以被重新 arm；
+7. 不要在严格 phase A/B sentinel pulse 之间执行普通 zoom repaint；
+8. 不要把 `executeJavaScript()` 返回当成 phase mutation 已执行；必须等待精确 ACK；
+9. 不要在历史 surface 恢复中 reload 页面或重新调用 `loadHTML()`；
+10. 修改 Java 单元测试时必须维护类级和方法级目标注释。
+
+## 10. 最终验证记录与范围边界
+
+最终实机包为 `0.5-beta1-FIX-d86618bb-r18`。验证覆盖 IDEA 2025.2 下多个同时恢复的项目窗口和多个 CC GUI Tab：
+
+- 连续多轮冷启动和重启均能发布首个可见 Tab 的完整历史内容；
+- 普通 OSR Tab 切换不创建新的 publication serial，只重画已发布的 cached backing image；
+- Tab 切换期间未再观察到 app-wide zoom 造成的字体或布局抖动；
+- active attempt 仍被视为 unpublished，只有最终 full-frame `OnPaint` 转交默认 handler 并完成 Swing paint 后才推进 published watermark；
+- 个别 attempt 超时时只释放 attempt 并保留原 pending，不会消费内容版本或形成 timer 自循环；后续可见性事件使用相同 serial 和新的 attempt id 重试。
+
+休眠唤醒验证进一步覆盖了恢复边界：IDE 唤醒后 watchdog 只执行一次有界 native reload，会话恢复并下发 222 条历史消息；publication `serial=8` 的首次 `attempt=3` 在窗口尚未完全激活时超时并保留 pending，窗口激活后以相同 serial 的 `attempt=4` 成功发布最终 full frame。期间没有出现 WebView reload/recreate 风暴，也没有重新注册 `loadHTML` payload。
+
+本次唤醒同时观察到多个 Claude daemon 把系统休眠造成的 heartbeat 空洞误判为进程死亡，并集中重启。该现象不属于 JCEF surface publication 链路，已由 #1601 独立跟踪；不得为了处理 daemon 生命周期而扩大本修复的职责范围。
+
+最终代码验证包括完整 Gradle 测试、Checkstyle、前端测试、TypeScript/Vite 生产构建和 `git diff --check`。自动化测试与实机日志共同覆盖了 DOM commit、phase ACK、双帧 fence、full-frame forwarding、cached presentation、隐藏页面 pending、timeout retry 和生命周期失效等关键不变量。

--- a/src/main/java/com/github/claudecodegui/handler/WindowEventHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/WindowEventHandler.java
@@ -9,14 +9,16 @@ import com.intellij.openapi.diagnostic.Logger;
 
 /**
  * Handles window-level events from the frontend:
- * heartbeat, tab status changes, session lifecycle signals.
+ * heartbeat, tab status changes, session lifecycle signals, and DOM commit acknowledgments.
  */
 public class WindowEventHandler extends BaseMessageHandler {
 
     private static final Logger LOG = Logger.getInstance(WindowEventHandler.class);
     private static final String[] SUPPORTED_TYPES = {
         "heartbeat", "tab_loading_changed", "tab_status_changed",
-        "create_new_session", "frontend_ready", "refresh_slash_commands"
+        "create_new_session", "frontend_ready", "history_dom_committed",
+        "history_render_complete", "surface_damage_applied",
+        "refresh_slash_commands"
     };
 
     /**
@@ -28,6 +30,8 @@ public class WindowEventHandler extends BaseMessageHandler {
         void onTabStatusChanged(String status);
         void onCreateNewSession();
         void onFrontendReady();
+        void onHistoryRenderComplete(long commitEpoch);
+        void onSurfaceDamageApplied(String token, String phase, boolean applied);
         void onRefreshSlashCommands();
     }
 
@@ -55,6 +59,15 @@ public class WindowEventHandler extends BaseMessageHandler {
                 return true;
             case "frontend_ready":
                 callback.onFrontendReady();
+                return true;
+            case "history_dom_committed":
+                callback.onHistoryRenderComplete(parseHistoryCommitEpoch(content));
+                return true;
+            case "history_render_complete":
+                callback.onHistoryRenderComplete(1L);
+                return true;
+            case "surface_damage_applied":
+                handleSurfaceDamageApplied(content);
                 return true;
             case "refresh_slash_commands":
                 callback.onRefreshSlashCommands();
@@ -86,6 +99,28 @@ public class WindowEventHandler extends BaseMessageHandler {
             callback.onTabStatusChanged(statusStr);
         } catch (Exception e) {
             LOG.warn("[TabStatus] Failed to parse tab status: " + e.getMessage());
+        }
+    }
+
+    private void handleSurfaceDamageApplied(String content) {
+        try {
+            JsonObject json = new Gson().fromJson(content, JsonObject.class);
+            String token = json.has("token") ? json.get("token").getAsString() : "";
+            String phase = json.has("phase") ? json.get("phase").getAsString() : "";
+            boolean applied = json.has("applied") && json.get("applied").getAsBoolean();
+            callback.onSurfaceDamageApplied(token, phase, applied);
+        } catch (Exception e) {
+            LOG.warn("[WebviewSurface] Failed to parse damage acknowledgment: "
+                    + e.getMessage());
+        }
+    }
+
+    private long parseHistoryCommitEpoch(String content) {
+        try {
+            return Math.max(1L, Long.parseLong(content == null ? "" : content.trim()));
+        } catch (NumberFormatException e) {
+            LOG.warn("[WebviewSurface] Invalid history commit epoch: " + content);
+            return 1L;
         }
     }
 }

--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -108,6 +108,8 @@ public class ChatWindowDelegate {
         boolean isFrontendReady();
         boolean isRuntimeRecoveryPage();
         void setFrontendReady(boolean ready);
+        void onHistoryRenderComplete(long commitEpoch);
+        void onSurfaceDamageApplied(String token, String phase, boolean applied);
         void setSlashCommandsFetched(boolean fetched);
         void setFetchedSlashCommandsCount(int count);
         void persistTabSessionState();
@@ -380,6 +382,16 @@ public class ChatWindowDelegate {
                 host.getSessionLifecycleManager().createNewSession();
             }
             @Override public void onFrontendReady() { handleFrontendReady(); }
+            @Override public void onHistoryRenderComplete(long commitEpoch) {
+                host.onHistoryRenderComplete(commitEpoch);
+            }
+            @Override public void onSurfaceDamageApplied(
+                    String token,
+                    String phase,
+                    boolean applied
+            ) {
+                host.onSurfaceDamageApplied(token, phase, applied);
+            }
             @Override public void onRefreshSlashCommands() {
                 host.getSessionLifecycleManager().fetchSlashCommandsOnStartup();
             }

--- a/src/main/java/com/github/claudecodegui/ui/SurfaceFrameFence.java
+++ b/src/main/java/com/github/claudecodegui/ui/SurfaceFrameFence.java
@@ -1,0 +1,632 @@
+package com.github.claudecodegui.ui;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.ui.jcef.JBCefBrowser;
+import com.intellij.ui.jcef.JBCefOSRHandlerFactory;
+import com.intellij.util.Function;
+import org.cef.browser.CefBrowser;
+import org.cef.handler.CefRenderHandler;
+
+import javax.swing.JComponent;
+import java.awt.Rectangle;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Turns real OSR paint callbacks into a generation-aware full-frame publication fence.
+ *
+ * <p>The JetBrains component and its default render handler remain authoritative for input,
+ * HiDPI conversion, shared-memory mapping, and backing-image ownership. This class only wraps
+ * the handler returned to CEF. Paint gates remain closed until the frontend acknowledges that
+ * the matching token's DOM mutation has actually run. The first post-phase-A paint drains any
+ * frame already in flight; a post-phase-B paint is forwarded to the default handler as a
+ * full-frame update and then reported to the owning chat window for the final EDT paint.</p>
+ *
+ * <p>The optional remote-render interface is loaded by name. Older supported IDEs that do not
+ * provide it therefore create a classic {@link CefRenderHandler} proxy without linking against
+ * the missing type.</p>
+ */
+public final class SurfaceFrameFence {
+
+    private static final Logger LOG = Logger.getInstance(SurfaceFrameFence.class);
+    private static final String NATIVE_RENDER_HANDLER_CLASS =
+            "org.cef.handler.CefNativeRenderHandler";
+
+    /** State of the currently pending OSR refresh request. */
+    public enum Stage {
+        PENDING,
+        WAITING_PHASE_A_APPLIED,
+        DRAINING_FIRST_FRAME,
+        WAITING_PHASE_B,
+        WAITING_PHASE_B_APPLIED,
+        WAITING_FINAL_FRAME,
+        PAINT_QUEUED
+    }
+
+    /** Frontend viewport-damage phases acknowledged through the generation-gated bridge. */
+    public enum DamagePhase {
+        A,
+        B
+    }
+
+    /** Immutable identity of one refresh request. */
+    public static final class Request {
+        private final Object browserIdentity;
+        private final CefBrowser cefBrowser;
+        private final int pageGeneration;
+        private final long readyEpoch;
+        private final long contentRevision;
+        private final long serial;
+        private final String reason;
+
+        private Request(
+                Object browserIdentity,
+                CefBrowser cefBrowser,
+                int pageGeneration,
+                long readyEpoch,
+                long contentRevision,
+                long serial,
+                String reason
+        ) {
+            this.browserIdentity = browserIdentity;
+            this.cefBrowser = cefBrowser;
+            this.pageGeneration = pageGeneration;
+            this.readyEpoch = readyEpoch;
+            this.contentRevision = contentRevision;
+            this.serial = serial;
+            this.reason = reason;
+        }
+
+        public JBCefBrowser browser() {
+            return (JBCefBrowser) browserIdentity;
+        }
+
+        public CefBrowser cefBrowser() {
+            return cefBrowser;
+        }
+
+        public int pageGeneration() {
+            return pageGeneration;
+        }
+
+        public long readyEpoch() {
+            return readyEpoch;
+        }
+
+        public long contentRevision() {
+            return contentRevision;
+        }
+
+        public long serial() {
+            return serial;
+        }
+
+        public String reason() {
+            return reason;
+        }
+    }
+
+    /** Immutable identity of one concrete arm attempt for a logical refresh request. */
+    public static final class Attempt {
+        private final Request request;
+        private final long attemptId;
+
+        private Attempt(Request request, long attemptId) {
+            this.request = request;
+            this.attemptId = attemptId;
+        }
+
+        public JBCefBrowser browser() {
+            return request.browser();
+        }
+
+        public CefBrowser cefBrowser() {
+            return request.cefBrowser();
+        }
+
+        public int pageGeneration() {
+            return request.pageGeneration();
+        }
+
+        public long readyEpoch() {
+            return request.readyEpoch();
+        }
+
+        public long serial() {
+            return request.serial();
+        }
+
+        public String reason() {
+            return request.reason();
+        }
+
+        public long attemptId() {
+            return attemptId;
+        }
+    }
+
+    /** Receives frame milestones after the JetBrains default handler has processed the frame. */
+    public interface Listener {
+        void onFirstFrameDrained(Attempt attempt);
+
+        void onFinalFrameForwarded(Attempt attempt);
+    }
+
+    /** Result of atomically releasing an active frame attempt. */
+    public static final class ReleaseResult {
+        private static final ReleaseResult NOT_RELEASED = new ReleaseResult(false, false);
+        private final boolean released;
+        private final boolean newerPending;
+        private final AtomicBoolean handoffClaimed = new AtomicBoolean();
+
+        private ReleaseResult(boolean released, boolean newerPending) {
+            this.released = released;
+            this.newerPending = newerPending;
+        }
+
+        public boolean released() {
+            return released;
+        }
+
+        public boolean newerPending() {
+            return newerPending;
+        }
+
+        /**
+         * Runs a one-shot handoff only when a strictly newer request remained pending.
+         * The same timed-out request is deliberately not retried, preventing a timer loop.
+         */
+        public boolean handOffNewer(Runnable handoff) {
+            if (!newerPending || !handoffClaimed.compareAndSet(false, true)) {
+                return false;
+            }
+            handoff.run();
+            return true;
+        }
+    }
+
+    private enum FrameKind {
+        PASSTHROUGH,
+        DRAIN,
+        FINAL
+    }
+
+    private static final class FrameDecision {
+        private final FrameKind kind;
+        private final Attempt attempt;
+
+        private FrameDecision(FrameKind kind, Attempt attempt) {
+            this.kind = kind;
+            this.attempt = attempt;
+        }
+    }
+
+    private final Listener listener;
+    private long nextSerial;
+    private long nextAttemptId;
+    private Request pending;
+    private Attempt active;
+    private Request lastPublished;
+    private Stage stage;
+
+    public SurfaceFrameFence(Listener listener) {
+        this.listener = listener;
+    }
+
+    /**
+     * Creates a factory that preserves JetBrains' default component and handler implementation.
+     * Only the handler returned to CEF is wrapped with the frame fence.
+     */
+    public JBCefOSRHandlerFactory createHandlerFactory() {
+        JBCefOSRHandlerFactory delegateFactory = resolveDefaultFactory();
+        return new JBCefOSRHandlerFactory() {
+            @Override
+            public JComponent createComponent(boolean isTransparent) {
+                return delegateFactory.createComponent(isTransparent);
+            }
+
+            @Override
+            public CefRenderHandler createCefRenderHandler(JComponent component) {
+                CefRenderHandler delegate = delegateFactory.createCefRenderHandler(component);
+                return wrapRenderHandler(delegate, SurfaceFrameFence.this,
+                        CefRenderHandler.class.getClassLoader());
+            }
+
+            @Override
+            public Function<? super JComponent, ? extends Rectangle> createScreenBoundsProvider() {
+                return delegateFactory.createScreenBoundsProvider();
+            }
+        };
+    }
+
+    /**
+     * Requests publication for one content revision. Duplicate or older revisions owned by the
+     * same browser page reuse the latest request/published watermark instead of creating a serial.
+     */
+    public synchronized Request request(
+            JBCefBrowser browser,
+            CefBrowser cefBrowser,
+            int pageGeneration,
+            long readyEpoch,
+            long contentRevision,
+            String reason
+    ) {
+        return requestInternal(
+                browser, cefBrowser, pageGeneration, readyEpoch, contentRevision, reason);
+    }
+
+    synchronized Request requestForTest(
+            Object browserIdentity,
+            CefBrowser cefBrowser,
+            int pageGeneration,
+            long readyEpoch,
+            String reason
+    ) {
+        return requestInternal(
+                browserIdentity, cefBrowser, pageGeneration, readyEpoch, 0L, reason);
+    }
+
+    synchronized Request requestForTest(
+            Object browserIdentity,
+            CefBrowser cefBrowser,
+            int pageGeneration,
+            long readyEpoch,
+            long contentRevision,
+            String reason
+    ) {
+        return requestInternal(
+                browserIdentity, cefBrowser, pageGeneration, readyEpoch, contentRevision, reason);
+    }
+
+    private Request requestInternal(
+            Object browserIdentity,
+            CefBrowser cefBrowser,
+            int pageGeneration,
+            long readyEpoch,
+            long contentRevision,
+            String reason
+    ) {
+        if (browserIdentity == null || cefBrowser == null) {
+            return null;
+        }
+        Request latest = latestOwnedRequest(
+                browserIdentity, cefBrowser, pageGeneration, readyEpoch);
+        if (latest != null && contentRevision <= latest.contentRevision) {
+            return latest;
+        }
+        pending = new Request(
+                browserIdentity, cefBrowser, pageGeneration, readyEpoch,
+                contentRevision, ++nextSerial, reason);
+        if (active == null) {
+            stage = Stage.PENDING;
+        }
+        return pending;
+    }
+
+    /** Arms the current request while keeping all paint gates closed until the Phase-A ACK. */
+    public synchronized Attempt arm(
+            JBCefBrowser browser,
+            CefBrowser cefBrowser,
+            int pageGeneration,
+            long readyEpoch
+    ) {
+        return armInternal(browser, cefBrowser, pageGeneration, readyEpoch);
+    }
+
+    synchronized Attempt armForTest(
+            Object browserIdentity,
+            CefBrowser cefBrowser,
+            int pageGeneration,
+            long readyEpoch
+    ) {
+        return armInternal(browserIdentity, cefBrowser, pageGeneration, readyEpoch);
+    }
+
+    private Attempt armInternal(
+            Object browserIdentity,
+            CefBrowser cefBrowser,
+            int pageGeneration,
+            long readyEpoch
+    ) {
+        if (active != null
+                || !matches(pending, browserIdentity, cefBrowser, pageGeneration, readyEpoch)
+                || stage != Stage.PENDING) {
+            return null;
+        }
+        active = new Attempt(pending, ++nextAttemptId);
+        stage = Stage.WAITING_PHASE_A_APPLIED;
+        return active;
+    }
+
+    /**
+     * Releases a stalled or ineligible attempt while retaining the latest request.
+     * The result distinguishes a newer pending request from the same timed-out request,
+     * allowing the owner to hand off once without creating a timeout retry loop.
+     */
+    public synchronized ReleaseResult releaseAttempt(Attempt attempt) {
+        if (active != attempt || stage == Stage.PENDING) {
+            return ReleaseResult.NOT_RELEASED;
+        }
+        Request released = active.request;
+        active = null;
+        if (pending == null || pending.serial < released.serial) {
+            pending = released;
+        }
+        stage = Stage.PENDING;
+        return new ReleaseResult(
+                true, pending != null && pending.serial > released.serial);
+    }
+
+    /** Completes the exact final frame and advances this owner's published revision watermark. */
+    public synchronized boolean complete(Attempt attempt) {
+        if (active != attempt || stage != Stage.PAINT_QUEUED) {
+            return false;
+        }
+        Request completed = active.request;
+        active = null;
+        lastPublished = completed;
+        if (pending == completed) {
+            pending = null;
+        }
+        stage = pending == null ? null : Stage.PENDING;
+        return true;
+    }
+
+    /** Invalidates pending, in-flight, and published state for a page/browser lifecycle change. */
+    public synchronized void invalidate() {
+        pending = null;
+        active = null;
+        lastPublished = null;
+        stage = null;
+        nextSerial++;
+    }
+
+    public synchronized boolean isActive(Attempt attempt) {
+        return attempt != null && active == attempt;
+    }
+
+    /** Records that Java is about to request Phase B while keeping final paints gated. */
+    public synchronized boolean beginPhaseBApply(Attempt attempt) {
+        if (active != attempt || stage != Stage.WAITING_PHASE_B) {
+            return false;
+        }
+        stage = Stage.WAITING_PHASE_B_APPLIED;
+        return true;
+    }
+
+    /**
+     * Advances a paint gate only after the frontend confirms the exact token's mutation ran.
+     * Duplicate, stale, and out-of-order acknowledgments are rejected without changing state.
+     */
+    public synchronized boolean acknowledgePhaseApplied(
+            Attempt attempt,
+            DamagePhase phase
+    ) {
+        if (active != attempt) {
+            return false;
+        }
+        if (phase == DamagePhase.A && stage == Stage.WAITING_PHASE_A_APPLIED) {
+            stage = Stage.DRAINING_FIRST_FRAME;
+            return true;
+        }
+        if (phase == DamagePhase.B && stage == Stage.WAITING_PHASE_B_APPLIED) {
+            stage = Stage.WAITING_FINAL_FRAME;
+            return true;
+        }
+        return false;
+    }
+
+    /** Returns the exact active attempt so lifecycle invalidation can cancel frontend damage. */
+    public synchronized Attempt activeAttempt() {
+        return active;
+    }
+
+    public synchronized boolean hasPending() {
+        return pending != null;
+    }
+
+    /**
+     * Returns whether unpublished work belongs to the exact current page owner.
+     * The pending request remains installed while it is active, so this also covers an
+     * in-flight publication attempt and prevents activation from presenting stale pixels.
+     */
+    public synchronized boolean hasUnpublishedFor(
+            JBCefBrowser browser,
+            CefBrowser cefBrowser,
+            int pageGeneration,
+            long readyEpoch
+    ) {
+        return matches(pending, browser, cefBrowser, pageGeneration, readyEpoch);
+    }
+
+    synchronized long lastPublishedSerial() {
+        return lastPublished == null ? 0L : lastPublished.serial;
+    }
+
+    public synchronized String pendingReason() {
+        return pending == null ? null : pending.reason;
+    }
+
+    synchronized Stage stage() {
+        return stage;
+    }
+
+    private synchronized FrameDecision beginFrame(CefBrowser browser, boolean popup) {
+        if (popup || active == null || active.cefBrowser() != browser) {
+            return new FrameDecision(FrameKind.PASSTHROUGH, null);
+        }
+        if (stage == Stage.DRAINING_FIRST_FRAME) {
+            return new FrameDecision(FrameKind.DRAIN, active);
+        }
+        if (stage == Stage.WAITING_FINAL_FRAME || stage == Stage.PAINT_QUEUED) {
+            return new FrameDecision(FrameKind.FINAL, active);
+        }
+        return new FrameDecision(FrameKind.PASSTHROUGH, null);
+    }
+
+    private void finishFrame(FrameDecision decision) {
+        Attempt callbackAttempt = null;
+        boolean firstFrame = false;
+        synchronized (this) {
+            if (active != decision.attempt) {
+                return;
+            }
+            if (decision.kind == FrameKind.DRAIN && stage == Stage.DRAINING_FIRST_FRAME) {
+                stage = Stage.WAITING_PHASE_B;
+                callbackAttempt = active;
+                firstFrame = true;
+            } else if (decision.kind == FrameKind.FINAL && stage == Stage.WAITING_FINAL_FRAME) {
+                stage = Stage.PAINT_QUEUED;
+                callbackAttempt = active;
+            }
+        }
+        if (callbackAttempt == null) {
+            return;
+        }
+        try {
+            if (firstFrame) {
+                listener.onFirstFrameDrained(callbackAttempt);
+            } else {
+                listener.onFinalFrameForwarded(callbackAttempt);
+            }
+        } catch (RuntimeException | LinkageError e) {
+            // The default handler has already accepted the frame. A plugin-side scheduling
+            // failure must never escape back into CEF. Keep the attempt active so its owned
+            // timeout performs the normal host-side cleanup and removes the frontend sentinel.
+            LOG.warn("Failed to schedule OSR frame-fence milestone", e);
+        }
+    }
+
+    private static boolean matches(
+            Request request,
+            Object browserIdentity,
+            CefBrowser cefBrowser,
+            int pageGeneration,
+            long readyEpoch
+    ) {
+        return request != null
+                && request.browserIdentity == browserIdentity
+                && request.cefBrowser == cefBrowser
+                && request.pageGeneration == pageGeneration
+                && request.readyEpoch == readyEpoch;
+    }
+
+    private Request latestOwnedRequest(
+            Object browserIdentity,
+            CefBrowser cefBrowser,
+            int pageGeneration,
+            long readyEpoch
+    ) {
+        Request latest = null;
+        if (matches(lastPublished, browserIdentity, cefBrowser, pageGeneration, readyEpoch)) {
+            latest = lastPublished;
+        }
+        if (active != null
+                && matches(active.request, browserIdentity, cefBrowser, pageGeneration, readyEpoch)
+                && (latest == null || active.request.serial > latest.serial)) {
+            latest = active.request;
+        }
+        if (matches(pending, browserIdentity, cefBrowser, pageGeneration, readyEpoch)
+                && (latest == null || pending.serial > latest.serial)) {
+            latest = pending;
+        }
+        return latest;
+    }
+
+    static CefRenderHandler wrapRenderHandler(
+            CefRenderHandler delegate,
+            SurfaceFrameFence fence,
+            ClassLoader loader
+    ) {
+        List<Class<?>> interfaces = new ArrayList<>();
+        interfaces.add(CefRenderHandler.class);
+        Class<?> nativeInterface = resolveNativeRenderHandlerInterface(loader);
+        if (nativeInterface != null && nativeInterface.isInstance(delegate)) {
+            interfaces.add(nativeInterface);
+        }
+        InvocationHandler invocationHandler =
+                (proxy, method, args) -> invokeHandler(delegate, fence, method, args);
+        return (CefRenderHandler) Proxy.newProxyInstance(
+                loader, interfaces.toArray(new Class<?>[0]), invocationHandler);
+    }
+
+    static Class<?> resolveNativeRenderHandlerInterface(ClassLoader loader) {
+        try {
+            return Class.forName(NATIVE_RENDER_HANDLER_CLASS, false, loader);
+        } catch (ClassNotFoundException | LinkageError e) {
+            return null;
+        }
+    }
+
+    static JBCefOSRHandlerFactory resolveDefaultFactory() {
+        return (JBCefOSRHandlerFactory) resolveDefaultFactoryValue(
+                JBCefOSRHandlerFactory.class);
+    }
+
+    static Object resolveDefaultFactoryValue(Class<?> factoryClass) {
+        try {
+            // IDEA 2024.1 and 2025.2 expose DEFAULT, while the project's 2024.3
+            // compile baseline exposes getInstance(). Avoid static linkage to either shape.
+            return factoryClass
+                    .getField("DEFAULT")
+                    .get(null);
+        } catch (NoSuchFieldException e) {
+            try {
+                return factoryClass
+                        .getMethod("getInstance")
+                        .invoke(null);
+            } catch (ReflectiveOperationException | LinkageError fallbackFailure) {
+                throw new IllegalStateException(
+                        "No compatible JBCefOSRHandlerFactory default is available",
+                        fallbackFailure);
+            }
+        } catch (ReflectiveOperationException | LinkageError e) {
+            throw new IllegalStateException(
+                    "Failed to resolve the default JBCefOSRHandlerFactory", e);
+        }
+    }
+
+    private static Object invokeHandler(
+            CefRenderHandler delegate,
+            SurfaceFrameFence fence,
+            Method method,
+            Object[] originalArgs
+    ) throws Throwable {
+        Object[] args = originalArgs == null ? new Object[0] : originalArgs.clone();
+        FrameDecision decision = null;
+        String methodName = method.getName();
+        if ("onPaintWithSharedMem".equals(methodName) && args.length == 7) {
+            decision = fence.beginFrame((CefBrowser) args[0], (Boolean) args[1]);
+            if (decision.kind == FrameKind.FINAL) {
+                args[2] = 0;
+            }
+        } else if ("onPaint".equals(methodName) && args.length == 6) {
+            decision = fence.beginFrame((CefBrowser) args[0], (Boolean) args[1]);
+            if (decision.kind == FrameKind.FINAL) {
+                int width = (Integer) args[4];
+                int height = (Integer) args[5];
+                args[2] = new Rectangle[]{new Rectangle(0, 0, width, height)};
+            }
+        }
+
+        boolean delegated = false;
+        try {
+            Object result = method.invoke(delegate, args);
+            delegated = true;
+            return result;
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        } finally {
+            if (decision != null) {
+                if (delegated) {
+                    fence.finishFrame(decision);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
@@ -46,6 +46,9 @@ import java.io.File;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import java.util.function.IntPredicate;
+import java.util.function.Supplier;
 
 /**
  * Handles webview (JCEF browser) creation, configuration, error panels,
@@ -93,6 +96,7 @@ public class WebviewInitializer {
         WebviewWatchdog getWebviewWatchdog();
         boolean isFrontendReady();
         boolean hasEverBeenFrontendReady();
+        boolean isWebviewActive();
         void setFrontendReady(boolean ready);
     }
 
@@ -423,7 +427,7 @@ public class WebviewInitializer {
                             cefBrowser.executeJavaScript(consoleForward, cefBrowser.getURL(), 0);
                         }
 
-                        injectFrontendConfiguration(cefBrowser, pageGeneration);
+                        injectFrontendConfiguration(cefBrowser, currentBridges, pageGeneration);
 
                         LOG.debug("onLoadEnd completed, waiting for frontend_ready signal");
                     } catch (Exception | LinkageError e) {
@@ -529,23 +533,47 @@ public class WebviewInitializer {
             BrowserBridges currentBridges,
             int pageGeneration
     ) {
-        AtomicInteger attempts = new AtomicInteger();
-        Timer timer = new Timer(BRIDGE_INJECTION_FAST_RETRY_INTERVAL_MS, null);
-        timer.addActionListener(event -> {
-            int attempt = attempts.incrementAndGet();
-            if (host.isDisposed() || host.isFrontendReady()) {
-                currentBridges.stopBridgeInjectionTimer(timer);
+        boolean scheduled = currentBridges.startBridgeInjectionRetriesIfAbsent(
+                pageGeneration,
+                () -> shouldRunBridgeInjectionRetries(
+                        host.isDisposed(), host.isFrontendReady(), host.isWebviewActive()),
+                attempt -> injectBridgeFallback(browser, currentBridges, pageGeneration, attempt));
+        if (!scheduled) {
+            if (!host.isFrontendReady() && !host.isWebviewActive()) {
+                LOG.debug("[JCEF] Bridge injection retries paused while webview is inactive");
+            }
+            return;
+        }
+        LOG.info("[JCEF] Scheduled fallback bridge injection retries until frontend readiness");
+    }
+
+    static boolean shouldRunBridgeInjectionRetries(
+            boolean disposed,
+            boolean frontendReady,
+            boolean webviewActive
+    ) {
+        return !disposed && !frontendReady && webviewActive;
+    }
+
+    /** Resume startup bridge fallback when a previously hidden tab becomes active. */
+    public void onTabActivated() {
+        if (host.isDisposed() || host.isFrontendReady() || !host.isWebviewActive()) {
+            return;
+        }
+
+        JBCefBrowser currentBrowser;
+        BrowserBridges currentBridges;
+        int currentPageGeneration;
+        synchronized (this.bridgeLock) {
+            currentBrowser = host.getBrowser();
+            currentBridges = this.bridges;
+            if (currentBrowser == null || currentBridges == null
+                    || !currentBridges.isCurrentFor(currentBrowser)) {
                 return;
             }
-            timer.setDelay(bridgeInjectionRetryDelayMs(attempt + 1));
-            if (!injectBridgeFallback(browser, currentBridges, pageGeneration, attempt)) {
-                currentBridges.stopBridgeInjectionTimer(timer);
-            }
-        });
-        timer.setInitialDelay(BRIDGE_INJECTION_FAST_RETRY_INTERVAL_MS);
-        currentBridges.setBridgeInjectionTimer(timer);
-        LOG.info("[JCEF] Scheduled fallback bridge injection retries until frontend readiness");
-        timer.start();
+            currentPageGeneration = currentBridges.getPageGeneration();
+        }
+        scheduleBridgeInjectionRetries(currentBrowser, currentBridges, currentPageGeneration);
     }
 
     private int beginPageLoad(BrowserBridges expectedBridges, PageLoadKind pageLoadKind) {
@@ -636,7 +664,7 @@ public class WebviewInitializer {
             );
             cefBrowser.executeJavaScript(runtimeBootstrap, url, 0);
 
-            injectFrontendConfiguration(cefBrowser, pageGeneration);
+            injectFrontendConfiguration(cefBrowser, currentBridges, pageGeneration);
             if (attempt == 1) {
                 LOG.info("[JCEF] Executed first fallback bridge injection for remote-mode startup");
             }
@@ -769,7 +797,25 @@ public class WebviewInitializer {
         );
     }
 
-    private void injectFrontendConfiguration(CefBrowser cefBrowser, int pageGeneration) {
+    private void injectFrontendConfiguration(
+            CefBrowser cefBrowser,
+            BrowserBridges currentBridges,
+            int pageGeneration
+    ) {
+        String idempotentConfigurationScript = currentBridges.getOrCreateConfigurationScript(
+                pageGeneration,
+                () -> buildFrontendConfigurationScript(pageGeneration));
+        if (idempotentConfigurationScript == null) {
+            return;
+        }
+        cefBrowser.executeJavaScript(
+                guardPageScript(pageGeneration, idempotentConfigurationScript),
+                cefBrowser.getURL(),
+                0);
+        LOG.debug("[WebviewConfigSync] Frontend configuration injected");
+    }
+
+    private String buildFrontendConfigurationScript(int pageGeneration) {
         String editorFontConfig = FontConfigService.getEditorFontConfigJson();
         String uiFontConfig = FontConfigService.getResolvedUiFontConfigJson(
                 host.getHandlerContext().getSettingsService());
@@ -777,18 +823,14 @@ public class WebviewInitializer {
                 host.getHandlerContext().getSettingsService());
         String languageConfig = LanguageConfigService.getLanguageConfigJson(
                 host.getHandlerContext().getSettingsService());
-        String url = cefBrowser.getURL();
 
         String configurationScript = joinConfigurationInjections(buildConfigurationInjections(
                 editorFontConfig, uiFontConfig, codeFontConfig, languageConfig));
-        String idempotentConfigurationScript =
+        return
                 "if (window.__CCG_CONFIG_GENERATION__ !== " + pageGeneration + ") {"
                 + configurationScript
                 + "window.__CCG_CONFIG_GENERATION__ = " + pageGeneration + ";"
                 + "}";
-        cefBrowser.executeJavaScript(
-                guardPageScript(pageGeneration, idempotentConfigurationScript), url, 0);
-        LOG.debug("[WebviewConfigSync] Frontend configuration injected");
     }
 
     static String joinConfigurationInjections(List<String> injections) {
@@ -1116,7 +1158,7 @@ public class WebviewInitializer {
      * Reload the webview HTML content.
      */
     public void reloadWebview(String reason) {
-        ApplicationManager.getApplication().invokeLater(() -> {
+        runOnEventDispatchThread(() -> {
             if (host.isDisposed()) { return; }
             JBCefBrowser browser = host.getBrowser();
             if (browser == null) {
@@ -1129,11 +1171,13 @@ public class WebviewInitializer {
                 int pageGeneration;
                 synchronized (this.bridgeLock) {
                     currentBridges = this.bridges;
-                    if (currentBridges == null || !currentBridges.belongsTo(browser)) {
-                        recreateWebview(reason + "_stale_bridges");
-                        return;
-                    }
-                    pageGeneration = beginPageLoad(currentBridges, recoveryPageLoadKind());
+                    pageGeneration = currentBridges == null || !currentBridges.belongsTo(browser)
+                            ? -1
+                            : beginPageLoad(currentBridges, recoveryPageLoadKind());
+                }
+                if (pageGeneration < 0) {
+                    recreateWebview(reason + "_stale_bridges");
+                    return;
                 }
                 host.activatePageGeneration(pageGeneration);
                 host.setFrontendReady(false);
@@ -1175,7 +1219,7 @@ public class WebviewInitializer {
      * Recreate the webview from scratch (dispose old, create new).
      */
     public void recreateWebview(String reason) {
-        ApplicationManager.getApplication().invokeLater(() -> {
+        runOnEventDispatchThread(() -> {
             if (host.isDisposed()) { return; }
 
             synchronized (this.bridgeLock) {
@@ -1223,6 +1267,14 @@ public class WebviewInitializer {
         });
     }
 
+    private void runOnEventDispatchThread(Runnable action) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            action.run();
+        } else {
+            ApplicationManager.getApplication().invokeLater(action);
+        }
+    }
+
     /**
      * Release the JBCefJSQuery bridges.
      * Must be called before the owning browser is disposed so the native
@@ -1250,9 +1302,11 @@ public class WebviewInitializer {
         private final JBCefJSQuery jsQuery;
         private final JBCefJSQuery clipboardPathQuery;
         private final JBCefJSQuery hidePanelQuery;
-        private Timer bridgeInjectionTimer;
         private int pageGeneration;
         private PageLoadKind pageLoadKind = PageLoadKind.INITIAL_LOAD;
+        private final PageConfigurationCache configurationCache = new PageConfigurationCache();
+        private final BridgeInjectionTimerLifecycle bridgeRetryLifecycle =
+                new BridgeInjectionTimerLifecycle();
 
         private BrowserBridges(JBCefBrowser browser) {
             this.browser = browser;
@@ -1276,9 +1330,10 @@ public class WebviewInitializer {
         }
 
         private synchronized void beginPageLoad(int newPageGeneration, PageLoadKind newPageLoadKind) {
-            stopBridgeInjectionTimer();
             this.pageGeneration = newPageGeneration;
             this.pageLoadKind = newPageLoadKind;
+            this.configurationCache.reset(newPageGeneration);
+            this.bridgeRetryLifecycle.beginPageLoad(newPageGeneration);
         }
 
         private synchronized int getPageGeneration() {
@@ -1306,23 +1361,24 @@ public class WebviewInitializer {
             return this.belongsTo(browser) && pageGeneration == expectedPageGeneration;
         }
 
-        private synchronized void setBridgeInjectionTimer(Timer timer) {
-            stopBridgeInjectionTimer();
-            this.bridgeInjectionTimer = timer;
+        private boolean startBridgeInjectionRetriesIfAbsent(
+                int expectedPageGeneration,
+                BooleanSupplier retryAllowed,
+                IntPredicate retryAction
+        ) {
+            return this.bridgeRetryLifecycle.startIfAbsent(
+                    expectedPageGeneration, retryAllowed, retryAction);
         }
 
-        private synchronized void stopBridgeInjectionTimer() {
-            if (this.bridgeInjectionTimer != null) {
-                this.bridgeInjectionTimer.stop();
-                this.bridgeInjectionTimer = null;
-            }
+        private void stopBridgeInjectionTimer() {
+            this.bridgeRetryLifecycle.stop();
         }
 
-        private synchronized void stopBridgeInjectionTimer(Timer expectedTimer) {
-            expectedTimer.stop();
-            if (this.bridgeInjectionTimer == expectedTimer) {
-                this.bridgeInjectionTimer = null;
-            }
+        private String getOrCreateConfigurationScript(
+                int expectedPageGeneration,
+                Supplier<String> scriptBuilder
+        ) {
+            return this.configurationCache.getOrCreate(expectedPageGeneration, scriptBuilder);
         }
 
         private void dispose() {
@@ -1330,6 +1386,96 @@ public class WebviewInitializer {
             disposeQueryQuietly(this.hidePanelQuery);
             disposeQueryQuietly(this.clipboardPathQuery);
             disposeQueryQuietly(this.jsQuery);
+        }
+    }
+
+    /** Owns the single Swing retry timer associated with the current runtime page generation. */
+    static final class BridgeInjectionTimerLifecycle {
+        private int pageGeneration;
+        private Timer timer;
+
+        synchronized void beginPageLoad(int newPageGeneration) {
+            stop();
+            this.pageGeneration = newPageGeneration;
+        }
+
+        boolean startIfAbsent(
+                int expectedPageGeneration,
+                BooleanSupplier retryAllowed,
+                IntPredicate retryAction
+        ) {
+            if (!retryAllowed.getAsBoolean()) {
+                stopIfCurrentGeneration(expectedPageGeneration);
+                return false;
+            }
+
+            AtomicInteger attempts = new AtomicInteger();
+            Timer candidate = new Timer(BRIDGE_INJECTION_FAST_RETRY_INTERVAL_MS, null);
+            candidate.addActionListener(event -> {
+                int attempt = attempts.incrementAndGet();
+                if (!retryAllowed.getAsBoolean()) {
+                    stop(candidate);
+                    return;
+                }
+                candidate.setDelay(bridgeInjectionRetryDelayMs(attempt + 1));
+                if (!retryAction.test(attempt)) {
+                    stop(candidate);
+                }
+            });
+            candidate.setInitialDelay(BRIDGE_INJECTION_FAST_RETRY_INTERVAL_MS);
+
+            synchronized (this) {
+                if (this.pageGeneration != expectedPageGeneration || this.timer != null) {
+                    return false;
+                }
+                this.timer = candidate;
+            }
+            candidate.start();
+            return true;
+        }
+
+        synchronized void stop() {
+            if (this.timer != null) {
+                this.timer.stop();
+                this.timer = null;
+            }
+        }
+
+        private synchronized void stopIfCurrentGeneration(int expectedPageGeneration) {
+            if (this.pageGeneration == expectedPageGeneration) {
+                stop();
+            }
+        }
+
+        private synchronized void stop(Timer expectedTimer) {
+            expectedTimer.stop();
+            if (this.timer == expectedTimer) {
+                this.timer = null;
+            }
+        }
+
+        synchronized Timer getTimer() {
+            return this.timer;
+        }
+    }
+
+    static final class PageConfigurationCache {
+        private int pageGeneration;
+        private String configurationScript;
+
+        synchronized void reset(int newPageGeneration) {
+            this.pageGeneration = newPageGeneration;
+            this.configurationScript = null;
+        }
+
+        synchronized String getOrCreate(int expectedPageGeneration, Supplier<String> scriptBuilder) {
+            if (this.pageGeneration != expectedPageGeneration) {
+                return null;
+            }
+            if (this.configurationScript == null) {
+                this.configurationScript = scriptBuilder.get();
+            }
+            return this.configurationScript;
         }
     }
 

--- a/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
@@ -25,6 +25,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.jcef.JBCefBrowser;
+import com.intellij.ui.jcef.JBCefOSRHandlerFactory;
 import com.intellij.ui.jcef.JBCefBrowserBase;
 import com.intellij.ui.jcef.JBCefJSQuery;
 import org.cef.CefClient;
@@ -89,6 +90,7 @@ public class WebviewInitializer {
         HtmlLoader getHtmlLoader();
         HandlerContext getHandlerContext();
         JBCefBrowser getBrowser();
+        JBCefOSRHandlerFactory getOsrHandlerFactory();
         void setBrowser(JBCefBrowser browser);
         boolean isDisposed();
         void activatePageGeneration(int pageGeneration);
@@ -248,7 +250,7 @@ public class WebviewInitializer {
         }
 
         try {
-            browser = JBCefBrowserFactory.create();
+            browser = JBCefBrowserFactory.create(host.getOsrHandlerFactory());
             JBCefBrowser createdBrowser = browser;
             host.setBrowser(createdBrowser);
             host.getHandlerContext().setBrowser(createdBrowser);

--- a/src/main/java/com/github/claudecodegui/ui/WebviewWatchdog.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewWatchdog.java
@@ -10,7 +10,11 @@ import com.intellij.util.concurrency.AppExecutorUtil;
 import javax.swing.*;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.LongSupplier;
 
 /**
  * Webview render watchdog for JCEF stall/black-screen recovery.
@@ -28,17 +32,18 @@ public class WebviewWatchdog {
     private static final long STARTUP_RECOVERY_COOLDOWN_MS = 15_000L;
     private static final int MAX_STARTUP_RECOVERY_ATTEMPTS = 2;
 
-    private volatile long lastHeartbeatAtMs = System.currentTimeMillis();
-    private volatile long lastRafAtMs = System.currentTimeMillis();
+    private volatile long lastHeartbeatAtMs;
+    private volatile long lastRafAtMs;
     private volatile String lastVisibility = null;
     private volatile Boolean lastHasFocus = null;
     private volatile int stallCount = 0;
     private volatile long lastRecoveryAtMs = 0L;
     private volatile ScheduledFuture<?> watchdogFuture = null;
+    private final AtomicBoolean recoveryPending = new AtomicBoolean();
     private final AtomicInteger startupRecoveryAttempts = new AtomicInteger();
 
     private final JPanel mainPanel;
-    private final BrowserProvider browserProvider;
+    private final BooleanSupplier browserAvailableCheck;
     private final Runnable onReloadWebview;
     private final Runnable onRecreateWebview;
     private final DisposedCheck disposedCheck;
@@ -77,6 +82,8 @@ public class WebviewWatchdog {
 
     private final StreamActiveCheck streamActiveCheck;
     private final ReadyCheck readyCheck;
+    private final LongSupplier currentTimeMillis;
+    private final Consumer<Runnable> recoveryExecutor;
 
     public WebviewWatchdog(
             JPanel mainPanel,
@@ -87,13 +94,42 @@ public class WebviewWatchdog {
             StreamActiveCheck streamActiveCheck,
             ReadyCheck readyCheck
     ) {
+        this(
+                mainPanel,
+                () -> browserProvider.getBrowser() != null,
+                onReloadWebview,
+                onRecreateWebview,
+                disposedCheck,
+                streamActiveCheck,
+                readyCheck,
+                System::currentTimeMillis,
+                runnable -> ApplicationManager.getApplication().invokeLater(runnable)
+        );
+    }
+
+    WebviewWatchdog(
+            JPanel mainPanel,
+            BooleanSupplier browserAvailableCheck,
+            Runnable onReloadWebview,
+            Runnable onRecreateWebview,
+            DisposedCheck disposedCheck,
+            StreamActiveCheck streamActiveCheck,
+            ReadyCheck readyCheck,
+            LongSupplier currentTimeMillis,
+            Consumer<Runnable> recoveryExecutor
+    ) {
         this.mainPanel = mainPanel;
-        this.browserProvider = browserProvider;
+        this.browserAvailableCheck = browserAvailableCheck;
         this.onReloadWebview = onReloadWebview;
         this.onRecreateWebview = onRecreateWebview;
         this.disposedCheck = disposedCheck;
         this.streamActiveCheck = streamActiveCheck;
         this.readyCheck = readyCheck;
+        this.currentTimeMillis = currentTimeMillis;
+        this.recoveryExecutor = recoveryExecutor;
+        long now = currentTimeMillis.getAsLong();
+        this.lastHeartbeatAtMs = now;
+        this.lastRafAtMs = now;
     }
 
     /**
@@ -127,7 +163,7 @@ public class WebviewWatchdog {
      * Handle a heartbeat message from the webview.
      */
     public void handleHeartbeat(String content) {
-        long now = System.currentTimeMillis();
+        long now = currentTimeMillis.getAsLong();
         lastHeartbeatAtMs = now;
 
         if (content == null || content.isEmpty()) {
@@ -162,7 +198,7 @@ public class WebviewWatchdog {
      * Reset heartbeat timestamps (e.g., after a recovery action).
      */
     public void resetTimestamps() {
-        long now = System.currentTimeMillis();
+        long now = currentTimeMillis.getAsLong();
         lastHeartbeatAtMs = now;
         lastRafAtMs = now;
         lastVisibility = null;
@@ -180,11 +216,11 @@ public class WebviewWatchdog {
         resetRecoveryState();
     }
 
-    private void checkHealth() {
+    void checkHealth() {
         if (disposedCheck.isDisposed()) { return; }
         boolean frontendReady = readyCheck.isFrontendReady();
 
-        long now = System.currentTimeMillis();
+        long now = currentTimeMillis.getAsLong();
         long heartbeatAgeMs = now - lastHeartbeatAtMs;
         long rafAgeMs = now - lastRafAtMs;
 
@@ -212,30 +248,7 @@ public class WebviewWatchdog {
             return;
         }
 
-        if (disposedCheck.isDisposed()) { return; }
-        if (!tryAcquireRecoveryPermit(frontendReady)) { return; }
-
-        stallCount += 1;
-        String reason = "frontendReady=" + frontendReady
-                + ", heartbeatAgeMs=" + heartbeatAgeMs + ", rafAgeMs=" + rafAgeMs;
-        LOG.warn("[WebviewWatchdog] Webview appears stalled (" + stallCount + "), attempting recovery. " + reason);
-
-        lastRecoveryAtMs = now;
-        // Give the webview a grace window after initiating recovery to avoid repeated triggers.
-        lastHeartbeatAtMs = now;
-        lastRafAtMs = now;
-
-        if (stallCount <= 1) {
-            reload("watchdog_reload");
-        } else {
-            onRecreateWebview.run();
-            stallCount = 0;
-        }
-
-        if (!frontendReady && startupRecoveryAttempts.get() == MAX_STARTUP_RECOVERY_ATTEMPTS) {
-            LOG.warn("[WebviewWatchdog] Startup recovery limit reached; "
-                    + "waiting for frontend readiness or tab activation before retrying");
-        }
+        scheduleRecoveryCheck();
     }
 
     boolean tryAcquireRecoveryPermit(boolean frontendReady) {
@@ -275,22 +288,75 @@ public class WebviewWatchdog {
                                  boolean panelShowing,
                                  boolean pageVisible,
                                  boolean pageFocused) {
-        if (!frontendReady) {
-            return true;
-        }
+        // A hidden JCEF page cannot advance requestAnimationFrame or complete
+        // frontend startup reliably. Treat visibility as a lifecycle gate for
+        // both startup and runtime health checks; tab activation resets the
+        // timestamps before monitoring resumes.
         // Editor focus is independent from webview render health.
         return panelShowing && pageVisible;
     }
 
-    private void reload(String reason) {
-        ApplicationManager.getApplication().invokeLater(() -> {
-            if (disposedCheck.isDisposed()) { return; }
-            JBCefBrowser browser = browserProvider.getBrowser();
-            if (browser == null) {
-                onRecreateWebview.run();
-                return;
-            }
+    private void scheduleRecoveryCheck() {
+        if (!recoveryPending.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            recoveryExecutor.accept(() -> {
+                try {
+                    executeRecoveryIfStillRequired();
+                } finally {
+                    recoveryPending.set(false);
+                }
+            });
+        } catch (RuntimeException e) {
+            recoveryPending.set(false);
+            throw e;
+        }
+    }
+
+    private void executeRecoveryIfStillRequired() {
+        if (disposedCheck.isDisposed()) { return; }
+        boolean frontendReady = readyCheck.isFrontendReady();
+        boolean visible = lastVisibility == null || "visible".equals(lastVisibility);
+        boolean focused = lastHasFocus == null || lastHasFocus;
+        if (!shouldMonitor(frontendReady, mainPanel.isShowing(), visible, focused)) {
+            return;
+        }
+
+        long now = currentTimeMillis.getAsLong();
+        if (now - lastRecoveryAtMs < recoveryCooldownMs(frontendReady)) {
+            return;
+        }
+        long heartbeatAgeMs = now - lastHeartbeatAtMs;
+        long rafAgeMs = now - lastRafAtMs;
+        long effectiveTimeoutMs = heartbeatTimeoutMs(
+                frontendReady, streamActiveCheck.isStreamActive());
+        if (heartbeatAgeMs <= effectiveTimeoutMs && rafAgeMs <= effectiveTimeoutMs) {
+            stallCount = 0;
+            return;
+        }
+        if (!tryAcquireRecoveryPermit(frontendReady)) { return; }
+
+        stallCount += 1;
+        String reason = "frontendReady=" + frontendReady
+                + ", heartbeatAgeMs=" + heartbeatAgeMs + ", rafAgeMs=" + rafAgeMs;
+        LOG.warn("[WebviewWatchdog] Webview appears stalled (" + stallCount
+                + "), attempting recovery. " + reason);
+
+        lastRecoveryAtMs = now;
+        lastHeartbeatAtMs = now;
+        lastRafAtMs = now;
+
+        if (stallCount <= 1 && browserAvailableCheck.getAsBoolean()) {
             onReloadWebview.run();
-        });
+        } else {
+            onRecreateWebview.run();
+            stallCount = 0;
+        }
+
+        if (!frontendReady && startupRecoveryAttempts.get() == MAX_STARTUP_RECOVERY_ATTEMPTS) {
+            LOG.warn("[WebviewWatchdog] Startup recovery limit reached; "
+                    + "waiting for frontend readiness or tab activation before retrying");
+        }
     }
 }

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -25,6 +25,7 @@ import com.github.claudecodegui.settings.CodemossSettingsService;
 import com.github.claudecodegui.settings.TabStateService;
 import com.github.claudecodegui.ui.ChatWindowDelegate;
 import com.github.claudecodegui.ui.EditorContextTracker;
+import com.github.claudecodegui.ui.SurfaceFrameFence;
 import com.github.claudecodegui.ui.WebviewInitializer;
 import com.github.claudecodegui.ui.WebviewWatchdog;
 import com.github.claudecodegui.ui.detached.DetachedChatFrame;
@@ -49,8 +50,16 @@ import org.cef.browser.CefBrowser;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.awt.event.HierarchyEvent;
+import java.awt.event.HierarchyListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
 
 /**
  * Chat window instance. Coordinates UI components, session management,
@@ -59,7 +68,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class ClaudeChatWindow {
 
     private static final Logger LOG = Logger.getInstance(ClaudeChatWindow.class);
-
     private final JPanel mainPanel;
     private final ClaudeSDKBridge claudeSDKBridge;
     private final CodexSDKBridge codexSDKBridge;
@@ -92,6 +100,49 @@ public class ClaudeChatWindow {
     private volatile boolean disposed = false;
     private volatile boolean initialized = false;
     private volatile boolean frontendReady = false;
+    private final FrontendReadyTransitionTracker frontendReadyTransitions =
+            new FrontendReadyTransitionTracker();
+    private final SurfaceRefreshCoordinator surfaceRefreshCoordinator =
+            new SurfaceRefreshCoordinator();
+    private final SurfacePresentationCoordinator surfacePresentationCoordinator =
+            new SurfacePresentationCoordinator();
+    private static final int OSR_FRAME_FENCE_TIMEOUT_MS = 1000;
+    private final SurfaceFrameFence surfaceFrameFence;
+    private final Disposable surfaceRefreshAlarmDisposable =
+            Disposer.newDisposable("ccgui-osr-frame-fence-timeout");
+    private final Alarm surfaceRefreshAlarm =
+            new Alarm(Alarm.ThreadToUse.SWING_THREAD, surfaceRefreshAlarmDisposable);
+    private final SurfaceAttemptTimeoutOwner surfaceAttemptTimeoutOwner =
+            new SurfaceAttemptTimeoutOwner();
+    private final Map<SurfaceFrameFence.Attempt, SurfaceFrameFence.Attempt>
+            surfaceDamageReplacementSources = new ConcurrentHashMap<>();
+    private volatile int activePageGeneration;
+    private final HierarchyListener surfaceRefreshHierarchyListener = this::handleSurfaceRefreshHierarchyChange;
+    private final ComponentAdapter surfaceRefreshComponentListener = new ComponentAdapter() {
+        @Override
+        public void componentShown(ComponentEvent event) {
+            resumePendingSurfaceWork("component_shown");
+        }
+
+        @Override
+        public void componentResized(ComponentEvent event) {
+            resumePendingSurfaceWork("component_resized");
+        }
+    };
+    private final WindowAdapter surfaceRefreshWindowListener = new WindowAdapter() {
+        @Override
+        public void windowActivated(WindowEvent event) {
+            resumePendingSurfaceWork("window_activated");
+        }
+
+        @Override
+        public void windowDeiconified(WindowEvent event) {
+            resumePendingSurfaceWork("window_deiconified");
+        }
+    };
+    private Component observedBrowserComponent;
+    private Component observedNativeSurfaceComponent;
+    private Window observedSurfaceWindow;
     private volatile boolean hasEverBeenFrontendReady = false;
     private final PendingCodeSnippetBuffer pendingCodeSnippetBuffer = new PendingCodeSnippetBuffer();
     private volatile boolean slashCommandsFetched = false;
@@ -168,8 +219,20 @@ public class ClaudeChatWindow {
         this.settingsService = new CodemossSettingsService();
         this.htmlLoader = new HtmlLoader(getClass());
         this.mainPanel = new JPanel(new BorderLayout());
+        this.surfaceFrameFence = new SurfaceFrameFence(new SurfaceFrameFence.Listener() {
+            @Override
+            public void onFirstFrameDrained(SurfaceFrameFence.Attempt attempt) {
+                handleFirstOsrFrameDrained(attempt);
+            }
+
+            @Override
+            public void onFinalFrameForwarded(SurfaceFrameFence.Attempt attempt) {
+                handleFinalOsrFrameForwarded(attempt);
+            }
+        });
 
         this.mainPanel.setBackground(com.github.claudecodegui.util.ThemeConfigService.getBackgroundColor());
+        this.mainPanel.addHierarchyListener(surfaceRefreshHierarchyListener);
 
         this.streamCoalescer = new StreamMessageCoalescer(new StreamMessageCoalescer.JsCallbackTarget() {
             @Override
@@ -452,20 +515,27 @@ public class ClaudeChatWindow {
             }
             webviewWatchdog.markTabActivated();
             webviewInitializer.onTabActivated();
-
             JBCefBrowser currentBrowser = browser;
-            if (currentBrowser != null) {
-                try {
-                    refreshActivatedWebview(
-                            mainPanel,
-                            currentBrowser.getComponent(),
-                            currentBrowser.getCefBrowser(),
-                            currentBrowser.isOffScreenRendering(),
-                            () -> callJavaScript("window.onTabActivated")
-                    );
-                } catch (Exception | LinkageError e) {
-                    LOG.warn("Failed to refresh activated JCEF tab: " + e.getMessage(), e);
-                }
+            TabActivationSurfaceAction action = decideTabActivationSurfaceAction(
+                    currentBrowser != null,
+                    currentBrowser != null && currentBrowser.isOffScreenRendering(),
+                    hasCurrentUnpublishedPublication());
+            switch (action) {
+                case PUBLISH_PENDING:
+                    tryConsumePendingSurfaceRefresh("tab_activated");
+                    break;
+                case PRESENT_CACHED:
+                    requestCachedSurfacePresentation(currentBrowser);
+                    tryConsumeCachedSurfacePresentation("tab_activated");
+                    break;
+                case WINDOWED_REFRESH:
+                    // Windowed JCEF keeps the established activation repaint path. It does not
+                    // participate in the OSR publication fence or its sentinel pulse.
+                    requestCurrentWindowedSurfaceRefresh("tab_activated");
+                    callJavaScript("window.onTabActivated");
+                    break;
+                default:
+                    break;
             }
         };
 
@@ -473,6 +543,674 @@ public class ClaudeChatWindow {
         // JCEF child. Waiting one EDT turn is essential for empty tabs because they
         // have no later DOM update that would incidentally repaint the native surface.
         ApplicationManager.getApplication().invokeLater(repaint);
+    }
+
+    /** Selects publication, cached presentation, or the legacy windowed activation path. */
+    static TabActivationSurfaceAction decideTabActivationSurfaceAction(
+            boolean browserAvailable,
+            boolean offScreenRendering,
+            boolean publicationOutstanding
+    ) {
+        if (!browserAvailable) {
+            return TabActivationSurfaceAction.NONE;
+        }
+        if (!offScreenRendering) {
+            return TabActivationSurfaceAction.WINDOWED_REFRESH;
+        }
+        return publicationOutstanding
+                ? TabActivationSurfaceAction.PUBLISH_PENDING
+                : TabActivationSurfaceAction.PRESENT_CACHED;
+    }
+
+    private boolean refreshCurrentWebviewSurface(JBCefBrowser expectedBrowser) {
+        if (expectedBrowser == null || browser != expectedBrowser) {
+            return false;
+        }
+
+        try {
+            return refreshActivatedWebview(
+                    mainPanel,
+                    expectedBrowser.getComponent(),
+                    expectedBrowser.getCefBrowser(),
+                    expectedBrowser.isOffScreenRendering(),
+                    () -> { }
+            );
+        } catch (Exception | LinkageError e) {
+            LOG.warn("Failed to refresh active JCEF tab: " + e.getMessage(), e);
+            return false;
+        } finally {
+            if (!disposed && browser == expectedBrowser) {
+                rebindNativeSurfaceComponent(getNativeSurfaceComponent(expectedBrowser));
+            }
+        }
+    }
+
+    private void requestSurfaceRefresh(
+            JBCefBrowser expectedBrowser,
+            long readyEpoch,
+            long contentRevision,
+            String reason
+    ) {
+        if (expectedBrowser == null) {
+            return;
+        }
+        if (expectedBrowser.isOffScreenRendering()) {
+            surfaceFrameFence.request(
+                    expectedBrowser,
+                    expectedBrowser.getCefBrowser(),
+                    activePageGeneration,
+                    readyEpoch,
+                    contentRevision,
+                    reason);
+        } else {
+            surfaceRefreshCoordinator.request(expectedBrowser, readyEpoch, reason);
+        }
+    }
+
+    private void requestCurrentWindowedSurfaceRefresh(String reason) {
+        JBCefBrowser currentBrowser = browser;
+        if (disposed || !frontendReady || currentBrowser == null
+                || currentBrowser.isOffScreenRendering()) {
+            return;
+        }
+        requestSurfaceRefresh(
+                currentBrowser, frontendReadyTransitions.currentEpoch(), 0L, reason);
+        tryConsumePendingSurfaceRefresh(reason);
+    }
+
+    private void tryConsumePendingSurfaceRefresh(String trigger) {
+        tryConsumePendingSurfaceRefresh(trigger, null);
+    }
+
+    private boolean tryConsumePendingSurfaceRefresh(
+            String trigger,
+            SurfaceFrameFence.Attempt replacementSource
+    ) {
+        if (!SwingUtilities.isEventDispatchThread()) {
+            ApplicationManager.getApplication().invokeLater(
+                    () -> tryConsumePendingSurfaceRefresh(trigger, replacementSource));
+            return false;
+        }
+        if (disposed) {
+            surfaceRefreshCoordinator.invalidate();
+            cancelScheduledOsrSurfaceRefresh();
+            return false;
+        }
+
+        rebindSurfaceRefreshWindow();
+        JBCefBrowser currentBrowser = browser;
+        long currentReadyEpoch = frontendReadyTransitions.currentEpoch();
+        if (currentBrowser != null && currentBrowser.isOffScreenRendering()) {
+            return tryArmOsrSurfaceRefresh(
+                    currentBrowser, currentReadyEpoch, trigger, replacementSource);
+        }
+        String pendingReason = surfaceRefreshCoordinator.pendingReason();
+        boolean consumed = surfaceRefreshCoordinator.tryConsume(
+                currentBrowser,
+                currentReadyEpoch,
+                () -> isSurfaceRefreshEligible(currentBrowser),
+                () -> refreshCurrentWebviewSurface(currentBrowser));
+        if (consumed) {
+            LOG.info("[WebviewSurface] Consumed pending surface refresh"
+                    + ", reason=" + pendingReason
+                    + ", trigger=" + trigger
+                    + ", project=" + project.getName());
+        }
+        return consumed;
+    }
+
+    private void resumePendingSurfaceWork(String trigger) {
+        tryConsumePendingSurfaceRefresh(trigger);
+        if (!hasCurrentUnpublishedPublication()) {
+            tryConsumeCachedSurfacePresentation(trigger);
+        }
+    }
+
+    private boolean hasCurrentUnpublishedPublication() {
+        JBCefBrowser currentBrowser = browser;
+        if (currentBrowser == null) {
+            return false;
+        }
+        long readyEpoch = frontendReadyTransitions.currentEpoch();
+        if (currentBrowser.isOffScreenRendering()) {
+            try {
+                return surfaceFrameFence.hasUnpublishedFor(
+                        currentBrowser,
+                        currentBrowser.getCefBrowser(),
+                        activePageGeneration,
+                        readyEpoch);
+            } catch (Exception | LinkageError e) {
+                return false;
+            }
+        }
+        return surfaceRefreshCoordinator.hasPendingFor(currentBrowser, readyEpoch);
+    }
+
+    private void requestCachedSurfacePresentation(JBCefBrowser expectedBrowser) {
+        if (disposed || !frontendReady || expectedBrowser == null
+                || browser != expectedBrowser || !expectedBrowser.isOffScreenRendering()) {
+            return;
+        }
+        try {
+            surfacePresentationCoordinator.request(
+                    expectedBrowser,
+                    expectedBrowser.getCefBrowser(),
+                    activePageGeneration,
+                    frontendReadyTransitions.currentEpoch());
+        } catch (Exception | LinkageError e) {
+            LOG.debug("Cannot queue cached OSR presentation without a live browser", e);
+        }
+    }
+
+    private boolean tryConsumeCachedSurfacePresentation(String trigger) {
+        if (!SwingUtilities.isEventDispatchThread()) {
+            ApplicationManager.getApplication().invokeLater(
+                    () -> tryConsumeCachedSurfacePresentation(trigger));
+            return false;
+        }
+        if (disposed) {
+            surfacePresentationCoordinator.invalidate();
+            return false;
+        }
+        JBCefBrowser currentBrowser = browser;
+        if (currentBrowser == null || !currentBrowser.isOffScreenRendering()) {
+            return false;
+        }
+        CefBrowser currentCefBrowser;
+        try {
+            currentCefBrowser = currentBrowser.getCefBrowser();
+        } catch (Exception | LinkageError e) {
+            return false;
+        }
+        boolean presented = surfacePresentationCoordinator.tryConsume(
+                currentBrowser,
+                currentCefBrowser,
+                activePageGeneration,
+                frontendReadyTransitions.currentEpoch(),
+                () -> isSurfaceRefreshEligible(currentBrowser),
+                () -> forceOsrSurfacePaint(
+                        mainPanel,
+                        currentBrowser.getComponent(),
+                        getNativeSurfaceComponent(currentBrowser)));
+        if (presented) {
+            LOG.info("[WebviewSurface] Presented cached OSR surface"
+                    + ", trigger=" + trigger
+                    + ", project=" + project.getName());
+        }
+        return presented;
+    }
+
+    private boolean tryArmOsrSurfaceRefresh(
+            JBCefBrowser expectedBrowser,
+            long readyEpoch,
+            String trigger,
+            SurfaceFrameFence.Attempt replacementSource
+    ) {
+        if (!isSurfaceRefreshEligible(expectedBrowser)) {
+            return false;
+        }
+        CefBrowser cefBrowser = expectedBrowser.getCefBrowser();
+        SurfaceFrameFence.Attempt attempt = surfaceFrameFence.arm(
+                expectedBrowser,
+                cefBrowser,
+                activePageGeneration,
+                readyEpoch);
+        if (attempt == null) {
+            return false;
+        }
+        LOG.info("[WebviewSurface] Armed OSR full-frame fence"
+                + ", serial=" + attempt.serial()
+                + ", attempt=" + attempt.attemptId()
+                + ", reason=" + attempt.reason()
+                + ", trigger=" + trigger
+                + ", project=" + project.getName());
+        if (!scheduleOsrFrameFenceTimeout(attempt)) {
+            releaseOsrAttempt(attempt, "timeout_owner_conflict");
+            return false;
+        }
+        if (replacementSource == null) {
+            triggerSurfaceDamage(attempt, "phaseA");
+        } else {
+            surfaceDamageReplacementSources.put(attempt, replacementSource);
+            replaceSurfaceDamage(replacementSource, attempt);
+        }
+        return true;
+    }
+
+    private boolean isCurrentOsrSurfaceRefresh(SurfaceFrameFence.Attempt attempt) {
+        return !disposed
+                && attempt != null
+                && browser == attempt.browser()
+                && activePageGeneration == attempt.pageGeneration()
+                && frontendReadyTransitions.isCurrentReady(attempt.readyEpoch())
+                && surfaceFrameFence.isActive(attempt);
+    }
+
+    /**
+     * Advances the native paint fence only after the exact frontend token confirms its DOM
+     * mutation. This callback may arrive off the EDT, while SurfaceFrameFence serializes the
+     * state transition against CEF OnPaint callbacks.
+     */
+    private void onSurfaceDamageApplied(String token, String phaseName, boolean applied) {
+        SurfaceFrameFence.Attempt attempt = surfaceFrameFence.activeAttempt();
+        if (attempt == null || !surfaceDamageToken(attempt).equals(token)) {
+            return;
+        }
+        SurfaceFrameFence.DamagePhase phase;
+        try {
+            phase = SurfaceFrameFence.DamagePhase.valueOf(phaseName);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            return;
+        }
+        if (!applied) {
+            ApplicationManager.getApplication().invokeLater(() -> {
+                if (surfaceFrameFence.isActive(attempt)) {
+                    releaseOsrAttempt(attempt, "frontend_phase_rejected_" + phaseName);
+                }
+            });
+            return;
+        }
+        if (!surfaceFrameFence.acknowledgePhaseApplied(attempt, phase)) {
+            return;
+        }
+        if (phase == SurfaceFrameFence.DamagePhase.A) {
+            surfaceDamageReplacementSources.remove(attempt);
+        }
+        LOG.info("[WebviewSurface] Frontend applied OSR damage phase"
+                + ", phase=" + phase
+                + ", serial=" + attempt.serial()
+                + ", attempt=" + attempt.attemptId()
+                + ", project=" + project.getName());
+        if (phase == SurfaceFrameFence.DamagePhase.B) {
+            ApplicationManager.getApplication().invokeLater(() -> {
+                if (!isCurrentOsrSurfaceRefresh(attempt)) {
+                    return;
+                }
+                if (!scheduleOsrFrameFenceTimeout(attempt)) {
+                    releaseOsrAttempt(attempt, "final_timeout_owner_conflict");
+                }
+            });
+        }
+    }
+
+    private void handleFirstOsrFrameDrained(SurfaceFrameFence.Attempt attempt) {
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (!isCurrentOsrSurfaceRefresh(attempt)
+                    || !isSurfaceRefreshEligible(attempt.browser())) {
+                releaseOsrAttempt(attempt, "first_frame_ineligible");
+                return;
+            }
+            if (!surfaceFrameFence.beginPhaseBApply(attempt)) {
+                releaseOsrAttempt(attempt, "phase_b_gate_rejected");
+                return;
+            }
+            if (!scheduleOsrFrameFenceTimeout(attempt)) {
+                releaseOsrAttempt(attempt, "phase_b_timeout_owner_conflict");
+                return;
+            }
+            triggerSurfaceDamage(attempt, "phaseB");
+            LOG.info("[WebviewSurface] Drained phase-A OSR frame and requested phase-B damage"
+                    + ", serial=" + attempt.serial()
+                    + ", attempt=" + attempt.attemptId()
+                    + ", project=" + project.getName());
+        });
+    }
+
+    private void handleFinalOsrFrameForwarded(SurfaceFrameFence.Attempt attempt) {
+        ApplicationManager.getApplication().invokeLater(() -> {
+            boolean painted = false;
+            boolean completed = false;
+            boolean newerPending = false;
+            try {
+                if (!isCurrentOsrSurfaceRefresh(attempt)
+                        || !isSurfaceRefreshEligible(attempt.browser())) {
+                    return;
+                }
+                Component nativeComponent = getNativeSurfaceComponent(attempt.browser());
+                painted = forceOsrSurfacePaint(
+                        mainPanel, attempt.browser().getComponent(), nativeComponent);
+                completed = painted && surfaceFrameFence.complete(attempt);
+                if (completed) {
+                    cancelOsrTimeoutIfOwned(attempt);
+                    surfacePresentationCoordinator.invalidate();
+                    newerPending = surfaceFrameFence.hasPending();
+                    if (!newerPending) {
+                        finishSurfaceDamage(attempt);
+                    }
+                    LOG.info("[WebviewSurface] Published final OSR full frame"
+                            + ", serial=" + attempt.serial()
+                            + ", attempt=" + attempt.attemptId()
+                            + ", reason=" + attempt.reason()
+                            + ", project=" + project.getName());
+                }
+            } catch (Exception | LinkageError e) {
+                LOG.warn("Failed to publish final OSR frame: " + e.getMessage(), e);
+            } finally {
+                if (!painted && surfaceFrameFence.isActive(attempt)) {
+                    releaseOsrAttempt(attempt, "final_paint_ineligible");
+                }
+            }
+            if (completed && newerPending) {
+                boolean handedOff = tryConsumePendingSurfaceRefresh(
+                        "previous_frame_completed", attempt);
+                if (!handedOff) {
+                    finishSurfaceDamage(attempt);
+                }
+            }
+        });
+    }
+
+    private void releaseTimedOutOsrAttempt(SurfaceFrameFence.Attempt attempt) {
+        SurfaceFrameFence.ReleaseResult result =
+                surfaceFrameFence.releaseAttempt(attempt);
+        if (result.released()) {
+            LOG.info("[WebviewSurface] OSR frame fence timed out; pending retained"
+                    + ", serial=" + attempt.serial()
+                    + ", attempt=" + attempt.attemptId()
+                    + ", newerPending=" + result.newerPending()
+                    + ", project=" + project.getName());
+        }
+        handOffOrCancelSurfaceDamage(
+                result, attempt, "frame_fence_timeout_handoff");
+    }
+
+    private void releaseOsrAttempt(SurfaceFrameFence.Attempt attempt, String reason) {
+        SurfaceFrameFence.ReleaseResult result =
+                surfaceFrameFence.releaseAttempt(attempt);
+        if (result.released()) {
+            cancelOsrTimeoutIfOwned(attempt);
+            LOG.info("[WebviewSurface] Released OSR frame-fence attempt"
+                    + ", serial=" + attempt.serial()
+                    + ", attempt=" + attempt.attemptId()
+                    + ", reason=" + reason
+                    + ", project=" + project.getName());
+        }
+        handOffOrCancelSurfaceDamage(
+                result, attempt, "frame_fence_release_handoff");
+    }
+
+    private void handOffOrCancelSurfaceDamage(
+            SurfaceFrameFence.ReleaseResult result,
+            SurfaceFrameFence.Attempt releasedAttempt,
+            String trigger
+    ) {
+        if (!result.released()) {
+            return;
+        }
+        SurfaceFrameFence.Attempt frontendOwner =
+                surfaceDamageReplacementSources.remove(releasedAttempt);
+        if (frontendOwner == null) {
+            frontendOwner = releasedAttempt;
+        }
+        AtomicBoolean armed = new AtomicBoolean(false);
+        SurfaceFrameFence.Attempt replacementSource = frontendOwner;
+        boolean handoffClaimed = result.handOffNewer(() -> armed.set(
+                tryConsumePendingSurfaceRefresh(trigger, replacementSource)));
+        if (!handoffClaimed || !armed.get()) {
+            cancelSurfaceDamage(releasedAttempt, frontendOwner);
+        }
+    }
+
+    private boolean scheduleOsrFrameFenceTimeout(SurfaceFrameFence.Attempt attempt) {
+        SurfaceTimeoutTask timeoutTask = new SurfaceTimeoutTask(attempt);
+        SurfaceAttemptTimeoutOwner.InstallResult installResult =
+                surfaceAttemptTimeoutOwner.install(attempt, timeoutTask);
+        if (!installResult.accepted()) {
+            LOG.warn("Refusing to replace OSR timeout owned by another attempt"
+                    + ", serial=" + attempt.serial()
+                    + ", attempt=" + attempt.attemptId());
+            return false;
+        }
+        if (installResult.previousTask() != null) {
+            surfaceRefreshAlarm.cancelRequest(installResult.previousTask());
+        }
+        surfaceRefreshAlarm.addRequest(timeoutTask, OSR_FRAME_FENCE_TIMEOUT_MS);
+        return true;
+    }
+
+    private void cancelOsrTimeoutIfOwned(SurfaceFrameFence.Attempt attempt) {
+        Runnable timeoutTask = surfaceAttemptTimeoutOwner.remove(attempt);
+        if (timeoutTask != null) {
+            surfaceRefreshAlarm.cancelRequest(timeoutTask);
+        }
+    }
+
+    private void triggerSurfaceDamage(SurfaceFrameFence.Attempt attempt, String phase) {
+        String functionName = "phaseA".equals(phase)
+                ? "window.__ccguiSurfaceDamagePhaseA"
+                : "window.__ccguiSurfaceDamagePhaseB";
+        callSurfaceDamageFunction(functionName, attempt);
+    }
+
+    private void replaceSurfaceDamage(
+            SurfaceFrameFence.Attempt previousAttempt,
+            SurfaceFrameFence.Attempt nextAttempt
+    ) {
+        callSurfaceDamageFunction(
+                "window.__ccguiSurfaceDamageReplace",
+                nextAttempt,
+                true,
+                surfaceDamageToken(previousAttempt),
+                surfaceDamageToken(nextAttempt));
+    }
+
+    private void finishSurfaceDamage(SurfaceFrameFence.Attempt attempt) {
+        callSurfaceDamageFunction("window.__ccguiSurfaceDamageFinish", attempt);
+    }
+
+    private void cancelSurfaceDamage(SurfaceFrameFence.Attempt attempt) {
+        cancelSurfaceDamage(attempt, surfaceDamageReplacementSources.remove(attempt));
+    }
+
+    private void cancelSurfaceDamage(
+            SurfaceFrameFence.Attempt attempt,
+            SurfaceFrameFence.Attempt predecessor
+    ) {
+        String predecessorToken = predecessor == null
+                ? ""
+                : surfaceDamageToken(predecessor);
+        callSurfaceDamageFunction(
+                "window.__ccguiSurfaceDamageCancel",
+                attempt,
+                false,
+                surfaceDamageToken(attempt),
+                predecessorToken);
+    }
+
+    private void callSurfaceDamageFunction(
+            String functionName,
+            SurfaceFrameFence.Attempt attempt
+    ) {
+        callSurfaceDamageFunction(
+                functionName,
+                attempt,
+                true,
+                surfaceDamageToken(attempt));
+    }
+
+    private void callSurfaceDamageFunction(
+            String functionName,
+            SurfaceFrameFence.Attempt attempt,
+            boolean requireCurrentGeneration,
+            String... arguments
+    ) {
+        JBCefBrowser expectedBrowser = attempt.browser();
+        Runnable invocation = () -> {
+            if (disposed
+                    || browser != expectedBrowser
+                    || (requireCurrentGeneration
+                    && activePageGeneration != attempt.pageGeneration())) {
+                return;
+            }
+            try {
+                CefBrowser expectedCefBrowser = attempt.cefBrowser();
+                if (expectedBrowser.getCefBrowser() != expectedCefBrowser) {
+                    return;
+                }
+                StringBuilder argumentScript = new StringBuilder();
+                for (int index = 0; index < arguments.length; index++) {
+                    if (index > 0) {
+                        argumentScript.append(',');
+                    }
+                    argumentScript.append('\'')
+                            .append(arguments[index])
+                            .append('\'');
+                }
+                String script = "(function(){try{if(typeof " + functionName
+                        + "==='function'){" + functionName + "(" + argumentScript
+                        + ");}}catch(e){console.error('[WebviewSurface] pulse failed',e);}})();";
+                expectedCefBrowser.executeJavaScript(script, expectedCefBrowser.getURL(), 0);
+            } catch (Exception | LinkageError e) {
+                LOG.warn("Failed to execute OSR surface-damage phase", e);
+            }
+        };
+        if (SwingUtilities.isEventDispatchThread()) {
+            invocation.run();
+        } else {
+            ApplicationManager.getApplication().invokeLater(invocation);
+        }
+    }
+
+    private static String surfaceDamageToken(SurfaceFrameFence.Attempt attempt) {
+        return attempt.pageGeneration()
+                + ":" + attempt.readyEpoch()
+                + ":" + attempt.serial()
+                + ":" + attempt.attemptId();
+    }
+
+    private void cancelScheduledOsrSurfaceRefresh() {
+        SurfaceFrameFence.Attempt activeAttempt = surfaceFrameFence.activeAttempt();
+        if (activeAttempt != null) {
+            cancelSurfaceDamage(activeAttempt);
+        }
+        surfaceDamageReplacementSources.clear();
+        surfaceFrameFence.invalidate();
+        surfacePresentationCoordinator.invalidate();
+        surfaceAttemptTimeoutOwner.clear();
+        surfaceRefreshAlarm.cancelAllRequests();
+    }
+
+    private boolean isSurfaceRefreshEligible(JBCefBrowser expectedBrowser) {
+        if (disposed || expectedBrowser == null || browser != expectedBrowser || !isWebviewActive()) {
+            return false;
+        }
+        Component browserComponent = expectedBrowser.getComponent();
+        Component nativeComponent = getNativeSurfaceComponent(expectedBrowser);
+        rebindNativeSurfaceComponent(nativeComponent);
+        Window rootWindow = SwingUtilities.getWindowAncestor(mainPanel);
+        boolean rootIconified = rootWindow instanceof Frame
+                && ((((Frame) rootWindow).getExtendedState() & Frame.ICONIFIED) != 0);
+        return isSurfaceRefreshEligible(
+                mainPanel.isShowing(),
+                browserComponent.isShowing(),
+                browserComponent.isDisplayable(),
+                nativeComponent != null && nativeComponent.isShowing(),
+                nativeComponent != null && nativeComponent.isDisplayable(),
+                rootWindow != null && rootWindow.isShowing(),
+                rootIconified,
+                nativeComponent == null ? 0 : nativeComponent.getWidth(),
+                nativeComponent == null ? 0 : nativeComponent.getHeight());
+    }
+
+    static boolean isSurfaceRefreshEligible(
+            boolean mainPanelShowing,
+            boolean browserShowing,
+            boolean browserDisplayable,
+            boolean nativeSurfaceShowing,
+            boolean nativeSurfaceDisplayable,
+            boolean rootWindowShowing,
+            boolean rootWindowIconified,
+            int nativeSurfaceWidth,
+            int nativeSurfaceHeight
+    ) {
+        return mainPanelShowing
+                && browserShowing
+                && browserDisplayable
+                && nativeSurfaceShowing
+                && nativeSurfaceDisplayable
+                && rootWindowShowing
+                && !rootWindowIconified
+                && nativeSurfaceWidth > 0
+                && nativeSurfaceHeight > 0;
+    }
+
+    private void handleSurfaceRefreshHierarchyChange(HierarchyEvent event) {
+        long relevantChanges = HierarchyEvent.PARENT_CHANGED
+                | HierarchyEvent.DISPLAYABILITY_CHANGED
+                | HierarchyEvent.SHOWING_CHANGED;
+        if ((event.getChangeFlags() & relevantChanges) == 0) {
+            return;
+        }
+        rebindSurfaceRefreshWindow();
+        if (mainPanel.isShowing()) {
+            resumePendingSurfaceWork("hierarchy_showing");
+        }
+    }
+
+    private void rebindSurfaceRefreshWindow() {
+        Window nextWindow = SwingUtilities.getWindowAncestor(mainPanel);
+        if (observedSurfaceWindow == nextWindow) {
+            return;
+        }
+        if (observedSurfaceWindow != null) {
+            observedSurfaceWindow.removeWindowListener(surfaceRefreshWindowListener);
+        }
+        observedSurfaceWindow = nextWindow;
+        if (observedSurfaceWindow != null) {
+            observedSurfaceWindow.addWindowListener(surfaceRefreshWindowListener);
+        }
+    }
+
+    private void replaceBrowser(JBCefBrowser nextBrowser) {
+        if (browser == nextBrowser) {
+            return;
+        }
+        if (observedBrowserComponent != null) {
+            observedBrowserComponent.removeComponentListener(surfaceRefreshComponentListener);
+        }
+        observedBrowserComponent = null;
+        rebindNativeSurfaceComponent(null);
+        cancelScheduledOsrSurfaceRefresh();
+        surfaceRefreshCoordinator.invalidate();
+        browser = nextBrowser;
+        if (nextBrowser != null) {
+            observedBrowserComponent = nextBrowser.getComponent();
+            observedBrowserComponent.addComponentListener(surfaceRefreshComponentListener);
+            rebindNativeSurfaceComponent(getNativeSurfaceComponent(nextBrowser));
+        }
+        rebindSurfaceRefreshWindow();
+    }
+
+    private Component getNativeSurfaceComponent(JBCefBrowser expectedBrowser) {
+        if (expectedBrowser == null) {
+            return null;
+        }
+        try {
+            CefBrowser cefBrowser = expectedBrowser.getCefBrowser();
+            return cefBrowser == null ? null : cefBrowser.getUIComponent();
+        } catch (Exception | LinkageError e) {
+            LOG.debug("Native JCEF surface is not available yet: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private void rebindNativeSurfaceComponent(Component nextComponent) {
+        if (observedNativeSurfaceComponent == nextComponent) {
+            return;
+        }
+        if (observedNativeSurfaceComponent != null) {
+            if (observedNativeSurfaceComponent != observedBrowserComponent) {
+                observedNativeSurfaceComponent.removeComponentListener(surfaceRefreshComponentListener);
+            }
+            observedNativeSurfaceComponent.removeHierarchyListener(surfaceRefreshHierarchyListener);
+        }
+        observedNativeSurfaceComponent = nextComponent;
+        if (observedNativeSurfaceComponent != null) {
+            if (observedNativeSurfaceComponent != observedBrowserComponent) {
+                observedNativeSurfaceComponent.addComponentListener(surfaceRefreshComponentListener);
+            }
+            observedNativeSurfaceComponent.addHierarchyListener(surfaceRefreshHierarchyListener);
+        }
     }
 
     private boolean isSelectedContent() {
@@ -506,7 +1244,7 @@ public class ClaudeChatWindow {
         return !detachedWindowPresent || detachedWindowVisible;
     }
 
-    static void refreshActivatedWebview(
+    static boolean refreshActivatedWebview(
             JPanel mainPanel,
             JComponent browserComponent,
             CefBrowser cefBrowser,
@@ -518,31 +1256,75 @@ public class ClaudeChatWindow {
         browserComponent.revalidate();
         browserComponent.repaint();
 
+        boolean nativeRefreshPerformed = false;
         try {
-            if (offScreenRendering) {
-                int width = browserComponent.getWidth();
-                int height = browserComponent.getHeight();
-                if (width > 0 && height > 0) {
-                    cefBrowser.wasResized(width, height);
-                }
-            } else {
-                Component nativeComponent = cefBrowser.getUIComponent();
-                if (nativeComponent != null) {
-                    nativeComponent.setVisible(false);
-                    nativeComponent.invalidate();
-                    nativeComponent.setVisible(true);
-                    Container parent = nativeComponent.getParent();
-                    if (parent != null) {
-                        parent.validate();
-                        parent.repaint();
+            Component nativeComponent = cefBrowser.getUIComponent();
+            if (nativeComponent != null) {
+                Rectangle currentBounds = nativeComponent.getBounds();
+                LOG.info("[WebviewSurface] Reapplying "
+                        + (offScreenRendering ? "OSR" : "windowed")
+                        + " native bounds"
+                        + ", component=" + nativeComponent.getClass().getName()
+                        + ", showing=" + nativeComponent.isShowing()
+                        + ", displayable=" + nativeComponent.isDisplayable()
+                        + ", bounds=" + currentBounds);
+                if (nativeComponent.isShowing()
+                        && nativeComponent.isDisplayable()
+                        && currentBounds.width > 0
+                        && currentBounds.height > 0) {
+                    // Both JBCefOsrComponent and CefBrowserWr override the Swing bounds
+                    // lifecycle. Reapplying the current bounds intentionally follows the
+                    // same resize scheduling path as a real layout or window resize.
+                    nativeComponent.setBounds(currentBounds);
+                    if (offScreenRendering) {
+                        // JBCefOsrComponent normally schedules this through its
+                        // reshape() alarm. Calling it explicitly makes the bounded
+                        // recovery independent from an already-coalesced resize.
+                        cefBrowser.wasResized(0, 0);
                     }
-                    nativeComponent.repaint();
+                    nativeRefreshPerformed = true;
                 }
+                if (!nativeRefreshPerformed) {
+                    return false;
+                }
+                nativeComponent.revalidate();
+                Container parent = nativeComponent.getParent();
+                if (parent != null) {
+                    parent.validate();
+                    parent.repaint();
+                }
+                nativeComponent.repaint();
             }
             cefBrowser.notifyScreenInfoChanged();
         } finally {
             frontendRepaint.run();
         }
+        return nativeRefreshPerformed;
+    }
+
+    static boolean forceOsrSurfacePaint(
+            JPanel mainPanel,
+            JComponent browserComponent,
+            Component nativeComponent
+    ) {
+        if (!(nativeComponent instanceof JComponent)
+                || !nativeComponent.isShowing()
+                || !nativeComponent.isDisplayable()
+                || nativeComponent.getWidth() <= 0
+                || nativeComponent.getHeight() <= 0) {
+            return false;
+        }
+
+        JComponent nativeSurface = (JComponent) nativeComponent;
+        mainPanel.revalidate();
+        browserComponent.revalidate();
+        nativeSurface.revalidate();
+        RepaintManager.currentManager(nativeSurface).markCompletelyDirty(nativeSurface);
+        browserComponent.repaint();
+        nativeSurface.repaint();
+        nativeSurface.paintImmediately(
+                0, 0, nativeSurface.getWidth(), nativeSurface.getHeight());
+        return true;
     }
 
     public ClaudeSDKBridge getClaudeSDKBridge() {
@@ -701,9 +1483,11 @@ public class ClaudeChatWindow {
             return;
         }
 
-        session.loadFromServer().thenRun(() -> ApplicationManager.getApplication().invokeLater(() -> {
-            if (!disposed) {
-                callJavaScript("historyLoadComplete");
+        ClaudeSession restoringSession = session;
+        restoringSession.loadFromServer().thenRun(() -> ApplicationManager.getApplication().invokeLater(() -> {
+            if (!disposed && session == restoringSession) {
+                callJavaScript("historyLoadComplete",
+                        String.valueOf(restoringSession.getMessages().size()));
             }
         })).exceptionally(ex -> {
             LOG.warn("[TabRestore] Failed to load persisted tab history: " + ex.getMessage(), ex);
@@ -738,17 +1522,515 @@ public class ClaudeChatWindow {
     }
 
     private void updateFrontendReadyState(boolean ready) {
+        FrontendReadyTransition transition = frontendReadyTransitions.update(ready);
         frontendReady = ready;
         if (!ready) {
+            surfaceRefreshCoordinator.invalidate();
+            cancelScheduledOsrSurfaceRefresh();
             return;
         }
         hasEverBeenFrontendReady = true;
         flushPendingCodeSnippet();
         ApplicationManager.getApplication().invokeLater(() -> {
-            if (!disposed) {
-                loadRestoredHistoryIfNeeded();
-            }
+            completeFrontendReadyUiUpdate(
+                    disposed,
+                    transition.becameReady(),
+                    () -> frontendReadyTransitions.isCurrentReady(transition.epoch()),
+                    () -> requestSurfaceRefresh(
+                            browser, transition.epoch(), 0L, "frontend_ready"),
+                    this::isWebviewActive,
+                    () -> tryConsumePendingSurfaceRefresh("frontend_ready"),
+                    this::loadRestoredHistoryIfNeeded
+            );
         });
+    }
+
+    /**
+     * Starts native publication after React has committed a restored-history snapshot.
+     * The event does not claim that Chromium or OSR has painted; the OSR frame fence establishes
+     * that separately from real paint callbacks. The bridge generation gate rejects messages
+     * from obsolete pages before this method runs, while the ready epoch rejects queued stale work.
+     */
+    private void onHistoryRenderComplete(long commitEpoch) {
+        long readyEpoch = frontendReadyTransitions.currentEpoch();
+        JBCefBrowser acknowledgingBrowser = browser;
+        if (acknowledgingBrowser == null) {
+            return;
+        }
+        CefBrowser acknowledgingCefBrowser;
+        try {
+            acknowledgingCefBrowser = acknowledgingBrowser.getCefBrowser();
+        } catch (Exception | LinkageError e) {
+            LOG.debug("Ignoring history DOM acknowledgment without a live CEF browser", e);
+            return;
+        }
+        int acknowledgingGeneration = activePageGeneration;
+        ApplicationManager.getApplication().invokeLater(() -> completeHistoryRenderUiUpdate(
+                disposed,
+                () -> isHistoryRenderOwnerCurrent(
+                        acknowledgingBrowser,
+                        acknowledgingCefBrowser,
+                        acknowledgingGeneration,
+                        readyEpoch),
+                () -> {
+                    LOG.info("[WebviewSurface] Queuing native surface refresh after history DOM commit");
+                    requestSurfaceRefresh(
+                            acknowledgingBrowser,
+                            readyEpoch,
+                            Math.max(1L, commitEpoch),
+                            "history_dom_committed");
+                    tryConsumePendingSurfaceRefresh("history_dom_committed");
+                }
+        ));
+    }
+
+    private boolean isHistoryRenderOwnerCurrent(
+            JBCefBrowser acknowledgingBrowser,
+            CefBrowser acknowledgingCefBrowser,
+            int acknowledgingGeneration,
+            long readyEpoch
+    ) {
+        if (disposed || !frontendReadyTransitions.isCurrentReady(readyEpoch)) {
+            return false;
+        }
+        JBCefBrowser currentBrowser = browser;
+        CefBrowser currentCefBrowser;
+        try {
+            currentCefBrowser = currentBrowser == null ? null : currentBrowser.getCefBrowser();
+        } catch (Exception | LinkageError e) {
+            return false;
+        }
+        return historyRenderOwnerMatches(
+                acknowledgingBrowser,
+                acknowledgingCefBrowser,
+                acknowledgingGeneration,
+                currentBrowser,
+                currentCefBrowser,
+                activePageGeneration);
+    }
+
+    /** Verifies browser, native browser and page-generation ownership of a queued history ack. */
+    static boolean historyRenderOwnerMatches(
+            Object acknowledgingBrowser,
+            Object acknowledgingCefBrowser,
+            int acknowledgingGeneration,
+            Object currentBrowser,
+            Object currentCefBrowser,
+            int currentGeneration
+    ) {
+        return acknowledgingBrowser != null
+                && acknowledgingBrowser == currentBrowser
+                && acknowledgingCefBrowser != null
+                && acknowledgingCefBrowser == currentCefBrowser
+                && acknowledgingGeneration == currentGeneration;
+    }
+
+    /** Applies a history-render refresh only while the acknowledging page is still current. */
+    static void completeHistoryRenderUiUpdate(
+            boolean disposed,
+            BooleanSupplier readyTransitionStillCurrent,
+            Runnable requestRefresh
+    ) {
+        if (disposed || !readyTransitionStillCurrent.getAsBoolean()) {
+            return;
+        }
+        requestRefresh.run();
+    }
+
+    /**
+     * Applies deferred frontend-ready UI work using state re-sampled on the EDT.
+     * Only the first still-active ready transition repaints the native JCEF surface.
+     */
+    static void completeFrontendReadyUiUpdate(
+            boolean disposed,
+            boolean becameReady,
+            BooleanSupplier readyTransitionStillCurrent,
+            Runnable requestPublication,
+            BooleanSupplier webviewActive,
+            Runnable tryPublish,
+            Runnable loadRestoredHistory
+    ) {
+        if (disposed) {
+            return;
+        }
+        if (becameReady && readyTransitionStillCurrent.getAsBoolean()) {
+            requestPublication.run();
+            if (webviewActive.getAsBoolean()) {
+                tryPublish.run();
+            }
+        }
+        loadRestoredHistory.run();
+    }
+
+    /**
+     * Tracks frontend-ready transitions so deferred EDT work can reject an older page transition.
+     * Repeated reports of the same state retain the current epoch.
+     */
+    static final class FrontendReadyTransitionTracker {
+        private boolean ready;
+        private long epoch;
+
+        synchronized FrontendReadyTransition update(boolean nextReady) {
+            boolean stateChanged = ready != nextReady;
+            if (stateChanged) {
+                ready = nextReady;
+                epoch++;
+            }
+            return new FrontendReadyTransition(stateChanged && ready, epoch);
+        }
+
+        synchronized boolean isCurrentReady(long capturedEpoch) {
+            return ready && capturedEpoch == epoch;
+        }
+
+        synchronized long currentEpoch() {
+            return epoch;
+        }
+    }
+
+    /** Surface action selected when an already-created chat Tab becomes active. */
+    enum TabActivationSurfaceAction {
+        NONE,
+        PUBLISH_PENDING,
+        PRESENT_CACHED,
+        WINDOWED_REFRESH
+    }
+
+    /** Captures whether a transition became ready and the epoch that owns its deferred work. */
+    static final class FrontendReadyTransition {
+        private final boolean becameReady;
+        private final long epoch;
+
+        private FrontendReadyTransition(boolean becameReady, long epoch) {
+            this.becameReady = becameReady;
+            this.epoch = epoch;
+        }
+
+        boolean becameReady() {
+            return becameReady;
+        }
+
+        long epoch() {
+            return epoch;
+        }
+    }
+
+    /**
+     * Retains one native-surface refresh request until its browser and ready epoch can
+     * complete a valid resize. Newer page requests replace obsolete pending work.
+     */
+    static final class SurfaceRefreshCoordinator {
+        private PendingSurfaceRefresh pending;
+        private boolean refreshInProgress;
+
+        synchronized void request(Object browserIdentity, long readyEpoch, String reason) {
+            if (browserIdentity == null) {
+                return;
+            }
+            if (pending != null
+                    && pending.browserIdentity == browserIdentity
+                    && pending.readyEpoch == readyEpoch) {
+                pending = new PendingSurfaceRefresh(
+                        browserIdentity, readyEpoch, reason);
+                return;
+            }
+            pending = new PendingSurfaceRefresh(browserIdentity, readyEpoch, reason);
+        }
+
+        boolean tryConsume(
+                Object currentBrowserIdentity,
+                long currentReadyEpoch,
+                BooleanSupplier eligible,
+                BooleanSupplier refreshAction
+        ) {
+            PendingSurfaceRefresh candidate;
+            synchronized (this) {
+                if (refreshInProgress) {
+                    return false;
+                }
+                candidate = pending;
+                if (candidate == null) {
+                    return false;
+                }
+                if (candidate.browserIdentity != currentBrowserIdentity
+                        || candidate.readyEpoch != currentReadyEpoch) {
+                    pending = null;
+                    return false;
+                }
+            }
+            if (!eligible.getAsBoolean()) {
+                return false;
+            }
+            synchronized (this) {
+                if (refreshInProgress || pending != candidate) {
+                    return false;
+                }
+                refreshInProgress = true;
+            }
+
+            boolean refreshed;
+            try {
+                refreshed = refreshAction.getAsBoolean();
+            } finally {
+                synchronized (this) {
+                    refreshInProgress = false;
+                }
+            }
+            synchronized (this) {
+                if (!refreshed || pending != candidate) {
+                    return false;
+                }
+                pending = null;
+                return true;
+            }
+        }
+
+        synchronized boolean hasPending() {
+            return pending != null;
+        }
+
+        synchronized boolean hasPendingFor(Object browserIdentity, long readyEpoch) {
+            if (pending == null) {
+                return false;
+            }
+            if (pending.browserIdentity != browserIdentity
+                    || pending.readyEpoch != readyEpoch) {
+                pending = null;
+                return false;
+            }
+            return true;
+        }
+
+        synchronized boolean completeCurrent(Object browserIdentity, long readyEpoch) {
+            if (!hasPendingFor(browserIdentity, readyEpoch)) {
+                return false;
+            }
+            pending = null;
+            return true;
+        }
+
+        synchronized String pendingReason() {
+            return pending == null ? null : pending.reason;
+        }
+
+        synchronized void invalidate() {
+            pending = null;
+        }
+    }
+
+    /**
+     * Retains a lightweight request to present an already-published OSR backing image.
+     * This state is intentionally independent from content publication serials: showing a
+     * cached frame must never manufacture Chromium damage or advance SurfaceFrameFence.
+     */
+    static final class SurfacePresentationCoordinator {
+        private PendingSurfacePresentation pending;
+        private boolean presentationInProgress;
+
+        synchronized void request(
+                Object browserIdentity,
+                Object cefBrowserIdentity,
+                int pageGeneration,
+                long readyEpoch
+        ) {
+            if (browserIdentity == null || cefBrowserIdentity == null) {
+                return;
+            }
+            pending = new PendingSurfacePresentation(
+                    browserIdentity, cefBrowserIdentity, pageGeneration, readyEpoch);
+        }
+
+        boolean tryConsume(
+                Object currentBrowserIdentity,
+                Object currentCefBrowserIdentity,
+                int currentPageGeneration,
+                long currentReadyEpoch,
+                BooleanSupplier eligible,
+                BooleanSupplier presentationAction
+        ) {
+            PendingSurfacePresentation candidate;
+            synchronized (this) {
+                if (presentationInProgress) {
+                    return false;
+                }
+                candidate = pending;
+                if (candidate == null) {
+                    return false;
+                }
+                if (!candidate.matches(
+                        currentBrowserIdentity,
+                        currentCefBrowserIdentity,
+                        currentPageGeneration,
+                        currentReadyEpoch)) {
+                    pending = null;
+                    return false;
+                }
+            }
+            if (!eligible.getAsBoolean()) {
+                return false;
+            }
+            synchronized (this) {
+                if (presentationInProgress || pending != candidate) {
+                    return false;
+                }
+                presentationInProgress = true;
+            }
+
+            boolean presented;
+            try {
+                presented = presentationAction.getAsBoolean();
+            } finally {
+                synchronized (this) {
+                    presentationInProgress = false;
+                }
+            }
+            synchronized (this) {
+                if (!presented || pending != candidate) {
+                    return false;
+                }
+                pending = null;
+                return true;
+            }
+        }
+
+        synchronized boolean hasPending() {
+            return pending != null;
+        }
+
+        synchronized void invalidate() {
+            pending = null;
+        }
+    }
+
+    /**
+     * Owns exactly one timeout runnable for one concrete OSR attempt.
+     * An obsolete callback can remove only its own timeout and can never cancel a newer attempt.
+     */
+    static final class SurfaceAttemptTimeoutOwner {
+        private Object owner;
+        private Runnable task;
+
+        synchronized InstallResult install(Object expectedOwner, Runnable nextTask) {
+            if (expectedOwner == null || nextTask == null) {
+                return new InstallResult(false, null);
+            }
+            if (owner != null && owner != expectedOwner) {
+                return new InstallResult(false, null);
+            }
+            Runnable previousTask = task;
+            owner = expectedOwner;
+            task = nextTask;
+            return new InstallResult(true, previousTask);
+        }
+
+        synchronized boolean claim(Object expectedOwner, Runnable expectedTask) {
+            if (owner != expectedOwner || task != expectedTask) {
+                return false;
+            }
+            owner = null;
+            task = null;
+            return true;
+        }
+
+        synchronized Runnable remove(Object expectedOwner) {
+            if (owner != expectedOwner) {
+                return null;
+            }
+            Runnable removed = task;
+            owner = null;
+            task = null;
+            return removed;
+        }
+
+        synchronized Runnable clear() {
+            Runnable removed = task;
+            owner = null;
+            task = null;
+            return removed;
+        }
+
+        synchronized boolean isOwnedBy(Object expectedOwner, Runnable expectedTask) {
+            return owner == expectedOwner && task == expectedTask;
+        }
+
+        /** Result of installing or replacing the timeout for the same exact attempt. */
+        static final class InstallResult {
+            private final boolean accepted;
+            private final Runnable previousTask;
+
+            private InstallResult(boolean accepted, Runnable previousTask) {
+                this.accepted = accepted;
+                this.previousTask = previousTask;
+            }
+
+            boolean accepted() {
+                return accepted;
+            }
+
+            Runnable previousTask() {
+                return previousTask;
+            }
+        }
+    }
+
+    /** Timeout runnable that must atomically claim ownership before releasing its attempt. */
+    private final class SurfaceTimeoutTask implements Runnable {
+        private final SurfaceFrameFence.Attempt attempt;
+
+        private SurfaceTimeoutTask(SurfaceFrameFence.Attempt attempt) {
+            this.attempt = attempt;
+        }
+
+        @Override
+        public void run() {
+            if (surfaceAttemptTimeoutOwner.claim(attempt, this)) {
+                releaseTimedOutOsrAttempt(attempt);
+            }
+        }
+    }
+
+    /** Identifies the browser page that owns a deferred surface refresh. */
+    private static final class PendingSurfaceRefresh {
+        private final Object browserIdentity;
+        private final long readyEpoch;
+        private final String reason;
+        private PendingSurfaceRefresh(Object browserIdentity, long readyEpoch, String reason) {
+            this.browserIdentity = browserIdentity;
+            this.readyEpoch = readyEpoch;
+            this.reason = reason;
+        }
+    }
+
+    /** Identifies one cached-surface presentation without creating content publication work. */
+    private static final class PendingSurfacePresentation {
+        private final Object browserIdentity;
+        private final Object cefBrowserIdentity;
+        private final int pageGeneration;
+        private final long readyEpoch;
+
+        private PendingSurfacePresentation(
+                Object browserIdentity,
+                Object cefBrowserIdentity,
+                int pageGeneration,
+                long readyEpoch
+        ) {
+            this.browserIdentity = browserIdentity;
+            this.cefBrowserIdentity = cefBrowserIdentity;
+            this.pageGeneration = pageGeneration;
+            this.readyEpoch = readyEpoch;
+        }
+
+        private boolean matches(
+                Object currentBrowserIdentity,
+                Object currentCefBrowserIdentity,
+                int currentPageGeneration,
+                long currentReadyEpoch
+        ) {
+            return browserIdentity == currentBrowserIdentity
+                    && cefBrowserIdentity == currentCefBrowserIdentity
+                    && pageGeneration == currentPageGeneration
+                    && readyEpoch == currentReadyEpoch;
+        }
     }
 
     public void updateTabStatus(ChatWindowDelegate.TabAnswerStatus status) {
@@ -1405,6 +2687,18 @@ public class ClaudeChatWindow {
         }
         this.disposed = true;
         JBCefBrowser targetBrowser = this.browser;
+        cancelScheduledOsrSurfaceRefresh();
+        surfaceRefreshCoordinator.invalidate();
+        mainPanel.removeHierarchyListener(surfaceRefreshHierarchyListener);
+        if (observedBrowserComponent != null) {
+            observedBrowserComponent.removeComponentListener(surfaceRefreshComponentListener);
+            observedBrowserComponent = null;
+        }
+        rebindNativeSurfaceComponent(null);
+        if (observedSurfaceWindow != null) {
+            observedSurfaceWindow.removeWindowListener(surfaceRefreshWindowListener);
+            observedSurfaceWindow = null;
+        }
         this.browser = null;
         if (this.handlerContext != null) {
             this.handlerContext.setDisposed(true);
@@ -1423,6 +2717,7 @@ public class ClaudeChatWindow {
         chatWindowDelegate.dispose();
         editorContextTracker.dispose();
         streamCoalescer.dispose();
+        Disposer.dispose(surfaceRefreshAlarmDisposable);
         deferredReloadSafetyAlarm.cancelAllRequests();
         Disposer.dispose(safetyAlarmDisposable);
         if (sessionCallbackAdapter != null) {
@@ -1549,8 +2844,13 @@ public class ClaudeChatWindow {
             }
 
             @Override
+            public com.intellij.ui.jcef.JBCefOSRHandlerFactory getOsrHandlerFactory() {
+                return surfaceFrameFence.createHandlerFactory();
+            }
+
+            @Override
             public void setBrowser(JBCefBrowser b) {
-                browser = b;
+                replaceBrowser(b);
             }
 
             @Override
@@ -1560,6 +2860,11 @@ public class ClaudeChatWindow {
 
             @Override
             public void activatePageGeneration(int pageGeneration) {
+                if (activePageGeneration != pageGeneration) {
+                    surfaceRefreshCoordinator.invalidate();
+                    cancelScheduledOsrSurfaceRefresh();
+                    activePageGeneration = pageGeneration;
+                }
                 dispatchGate.activatePageGeneration(pageGeneration);
             }
 
@@ -1773,6 +3078,16 @@ public class ClaudeChatWindow {
             @Override
             public void setFrontendReady(boolean ready) {
                 updateFrontendReadyState(ready);
+            }
+
+            @Override
+            public void onHistoryRenderComplete(long commitEpoch) {
+                ClaudeChatWindow.this.onHistoryRenderComplete(commitEpoch);
+            }
+
+            @Override
+            public void onSurfaceDamageApplied(String token, String phase, boolean applied) {
+                ClaudeChatWindow.this.onSurfaceDamageApplied(token, phase, applied);
             }
 
             @Override

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -451,6 +451,7 @@ public class ClaudeChatWindow {
                 return;
             }
             webviewWatchdog.markTabActivated();
+            webviewInitializer.onTabActivated();
 
             JBCefBrowser currentBrowser = browser;
             if (currentBrowser != null) {
@@ -478,6 +479,31 @@ public class ClaudeChatWindow {
         Content content = parentContent;
         ContentManager contentManager = content == null ? null : content.getManager();
         return contentManager != null && contentManager.getSelectedContent() == content;
+    }
+
+    private boolean isWebviewActive() {
+        Content content = parentContent;
+        ContentManager contentManager = content == null ? null : content.getManager();
+        boolean managedContent = contentManager != null && contentManager.getIndexOfContent(content) >= 0;
+        boolean selectedContent = managedContent && contentManager.getSelectedContent() == content;
+        DetachedChatFrame detachedFrame = DetachedWindowManager.getDetachedFrame(project, this);
+        return resolveWebviewActive(
+                managedContent,
+                selectedContent,
+                detachedFrame != null,
+                detachedFrame != null && detachedFrame.isVisible());
+    }
+
+    static boolean resolveWebviewActive(
+            boolean managedContent,
+            boolean selectedContent,
+            boolean detachedWindowPresent,
+            boolean detachedWindowVisible
+    ) {
+        if (managedContent) {
+            return selectedContent;
+        }
+        return !detachedWindowPresent || detachedWindowVisible;
     }
 
     static void refreshActivatedWebview(
@@ -1555,6 +1581,11 @@ public class ClaudeChatWindow {
             @Override
             public boolean hasEverBeenFrontendReady() {
                 return hasEverBeenFrontendReady;
+            }
+
+            @Override
+            public boolean isWebviewActive() {
+                return ClaudeChatWindow.this.isWebviewActive();
             }
 
             @Override

--- a/src/main/java/com/github/claudecodegui/util/JBCefBrowserFactory.java
+++ b/src/main/java/com/github/claudecodegui/util/JBCefBrowserFactory.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.util.registry.Registry;
 import com.intellij.ui.jcef.JBCefBrowser;
 import com.intellij.ui.jcef.JBCefBrowserBase;
 import com.intellij.ui.jcef.JBCefBrowserBuilder;
+import com.intellij.ui.jcef.JBCefOSRHandlerFactory;
 import org.cef.browser.CefBrowser;
 import org.cef.handler.CefKeyboardHandler;
 import org.cef.handler.CefKeyboardHandlerAdapter;
@@ -18,6 +19,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 
 /**
  * JBCefBrowser factory.
@@ -66,32 +68,113 @@ public final class JBCefBrowserFactory {
      * @return a JBCefBrowser instance
      */
     public static JBCefBrowser create() {
+        return create((JBCefOSRHandlerFactory) null);
+    }
+
+    /**
+     * Create a browser with an optional OSR handler factory.
+     *
+     * <p>The factory is always attached to the builder when supplied. Remote JCEF may override a
+     * platform's requested windowed mode and create an OSR browser, so the pre-build mode is not
+     * authoritative. A genuinely windowed browser simply does not use the OSR factory.</p>
+     *
+     * @param osrHandlerFactory custom OSR factory, or {@code null} for the platform default.
+     * @return a configured JBCefBrowser instance.
+     */
+    public static JBCefBrowser create(JBCefOSRHandlerFactory osrHandlerFactory) {
         boolean isOffScreenRendering = determineOsrMode();
         boolean isDevMode = PlatformUtils.isPluginDevMode();
         LOG.info("Creating JBCefBrowser with OSR=" + isOffScreenRendering
                 + " (platform=" + getPlatformName() + ", ideaVersion=" + getIdeaMajorVersion()
                 + ", devMode=" + isDevMode + ")");
 
+        JBCefBrowser browser = null;
+        Throwable builderFailure;
         try {
-            JBCefBrowserBuilder builder = JBCefBrowser.createBuilder()
-                    .setOffScreenRendering(isOffScreenRendering)
-                    .setEnableOpenDevToolsMenuItem(isDevMode);
-                    // .setCreateImmediately(true) // Causes new tabs to permanently stall on "Checking SDK status..." - commented out; using default lazy-load mode instead
-            JBCefBrowser browser = builder.build();
+            JBCefBrowserBuilder builder = configureBuilder(
+                    JBCefBrowser.createBuilder(),
+                    isOffScreenRendering,
+                    isDevMode,
+                    osrHandlerFactory);
+            // .setCreateImmediately(true) causes new tabs to stall on "Checking SDK status".
+            browser = builder.build();
             configureKeyboardWorkaround(browser);
             configureContextMenu(browser, isDevMode);
-            LOG.info("JBCefBrowser created successfully using builder");
+            LOG.info("JBCefBrowser created successfully using builder"
+                    + ", osrFactoryInstalled=" + (osrHandlerFactory != null));
             return browser;
         } catch (Exception | LinkageError e) {
-            LOG.warn("JBCefBrowser builder failed, falling back to default constructor (missing OSR and dev-tools config)", e);
+            builderFailure = e;
+            disposeQuietly(browser);
+        }
+
+        if (osrHandlerFactory != null) {
+            LOG.error("JBCefBrowser builder failed while a required OSR handler factory was installed; "
+                    + "refusing an unwrapped Remote OSR fallback", builderFailure);
+            throw newJcefUnavailableException(builderFailure);
+        }
+
+        LOG.warn("JBCefBrowser builder failed, falling back to default constructor "
+                + "(missing OSR and dev-tools config)", builderFailure);
+        try {
+            JBCefBrowser fallbackBrowser = new JBCefBrowser();
             try {
-                JBCefBrowser browser = new JBCefBrowser();
-                configureContextMenu(browser, isDevMode);
-                configureKeyboardWorkaround(browser);
-                return browser;
-            } catch (Exception | LinkageError fallbackFailure) {
-                throw newJcefUnavailableException(fallbackFailure);
+                configureContextMenu(fallbackBrowser, isDevMode);
+                configureKeyboardWorkaround(fallbackBrowser);
+                return fallbackBrowser;
+            } catch (Exception | LinkageError configurationFailure) {
+                disposeQuietly(fallbackBrowser);
+                throw configurationFailure;
             }
+        } catch (Exception | LinkageError fallbackFailure) {
+            throw newJcefUnavailableException(fallbackFailure);
+        }
+    }
+
+    /**
+     * Applies browser-builder options while preserving a custom OSR factory even when the
+     * requested rendering mode is windowed. Remote JCEF can force OSR only during build.
+     */
+    static JBCefBrowserBuilder configureBuilder(
+            JBCefBrowserBuilder builder,
+            boolean offScreenRendering,
+            boolean devMode,
+            JBCefOSRHandlerFactory osrHandlerFactory
+    ) {
+        applyBuilderOptions(
+                offScreenRendering,
+                devMode,
+                osrHandlerFactory,
+                builder::setOffScreenRendering,
+                builder::setEnableOpenDevToolsMenuItem,
+                builder::setOSRHandlerFactory);
+        return builder;
+    }
+
+    /** Applies builder options through injectable setters so wiring is testable without JCEF. */
+    static void applyBuilderOptions(
+            boolean offScreenRendering,
+            boolean devMode,
+            JBCefOSRHandlerFactory osrHandlerFactory,
+            Consumer<Boolean> osrModeSetter,
+            Consumer<Boolean> devToolsSetter,
+            Consumer<JBCefOSRHandlerFactory> osrFactorySetter
+    ) {
+        osrModeSetter.accept(offScreenRendering);
+        devToolsSetter.accept(devMode);
+        if (osrHandlerFactory != null) {
+            osrFactorySetter.accept(osrHandlerFactory);
+        }
+    }
+
+    private static void disposeQuietly(JBCefBrowser browser) {
+        if (browser == null) {
+            return;
+        }
+        try {
+            browser.dispose();
+        } catch (Exception | LinkageError disposalFailure) {
+            LOG.warn("Failed to dispose partially configured JBCefBrowser", disposalFailure);
         }
     }
 

--- a/src/test/java/com/github/claudecodegui/handler/WindowEventHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/WindowEventHandlerTest.java
@@ -1,0 +1,80 @@
+package com.github.claudecodegui.handler;
+
+import com.github.claudecodegui.handler.core.HandlerContext;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for window-level bridge event dispatch, including the restored-history DOM commit
+ * acknowledgment used to start native JCEF frame publication and tokenized surface-damage
+ * phase acknowledgments that causally gate OSR paint handling.
+ */
+public class WindowEventHandlerTest {
+
+    /** Verifies that history_dom_committed is supported and dispatched exactly once. */
+    @Test
+    public void dispatchesHistoryDomCommittedCallback() {
+        AtomicReference<Long> historyCommitEpoch = new AtomicReference<>();
+        HandlerContext context = new HandlerContext(null, null, null, null, new NoOpJsCallback());
+        WindowEventHandler handler = new WindowEventHandler(context, new NoOpCallback() {
+            @Override
+            public void onHistoryRenderComplete(long commitEpoch) {
+                historyCommitEpoch.set(commitEpoch);
+            }
+        });
+
+        assertTrue(handler.handle("history_dom_committed", "7"));
+        assertEquals(Long.valueOf(7L), historyCommitEpoch.get());
+    }
+
+    /** Verifies that a tokenized surface phase acknowledgment is parsed without losing identity. */
+    @Test
+    public void dispatchesSurfaceDamageAppliedCallback() {
+        AtomicReference<String> observed = new AtomicReference<>();
+        HandlerContext context = new HandlerContext(null, null, null, null, new NoOpJsCallback());
+        WindowEventHandler handler = new WindowEventHandler(context, new NoOpCallback() {
+            @Override
+            public void onSurfaceDamageApplied(String token, String phase, boolean applied) {
+                observed.set(token + ":" + phase + ":" + applied);
+            }
+        });
+
+        assertTrue(handler.handle(
+                "surface_damage_applied",
+                "{\"token\":\"4:5:6:7\",\"phase\":\"B\",\"applied\":true}"));
+        assertEquals("4:5:6:7:B:true", observed.get());
+    }
+
+    /** No-op JavaScript collaborator used by the handler context in this isolated dispatch test. */
+    private static final class NoOpJsCallback implements HandlerContext.JsCallback {
+        @Override
+        public void callJavaScript(String functionName, String... args) {
+            // No JavaScript calls are expected from a window event dispatch.
+        }
+
+        @Override
+        public String escapeJs(String str) {
+            return str;
+        }
+    }
+
+    /** Callback adapter that keeps unrelated window events inert for focused event tests. */
+    private static class NoOpCallback implements WindowEventHandler.Callback {
+        @Override public void onHeartbeat(String content) { }
+        @Override public void onTabLoadingChanged(boolean loading) { }
+        @Override public void onTabStatusChanged(String status) { }
+        @Override public void onCreateNewSession() { }
+        @Override public void onFrontendReady() { }
+        @Override public void onHistoryRenderComplete(long commitEpoch) { }
+        @Override public void onSurfaceDamageApplied(
+                String token,
+                String phase,
+                boolean applied
+        ) { }
+        @Override public void onRefreshSlashCommands() { }
+    }
+}

--- a/src/test/java/com/github/claudecodegui/ui/SurfaceFrameFenceTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/SurfaceFrameFenceTest.java
@@ -1,0 +1,517 @@
+package com.github.claudecodegui.ui;
+
+import org.cef.browser.CefBrowser;
+import org.cef.handler.CefRenderHandler;
+import org.junit.Test;
+
+import java.awt.Rectangle;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the real-frame OSR fence, content-revision publication watermark, acknowledged
+ * phase-A/phase-B ordering, request/attempt isolation, full-frame forwarding, delegate
+ * preservation, and runtimes lacking the remote handler API. Paints arriving before an exact
+ * frontend acknowledgment must remain transparent.
+ */
+public class SurfaceFrameFenceTest {
+
+    /**
+     * Verifies a hidden ready page retains unpublished ownership both before and during its
+     * visible publication attempt.
+     */
+    @Test
+    public void requestRemainsUnpublishedBeforeAndDuringVisibleAttempt() {
+        SurfaceFrameFence fence = new SurfaceFrameFence(new RecordingListener());
+        CefBrowser cefBrowser = createCefBrowser();
+        Object browserIdentity = new Object();
+        SurfaceFrameFence.Request request = fence.requestForTest(
+                browserIdentity, cefBrowser, 1, 2L, 0L, "frontend_ready");
+
+        assertTrue(fence.hasPending());
+        assertNull(fence.activeAttempt());
+
+        SurfaceFrameFence.Attempt attempt = fence.armForTest(
+                browserIdentity, cefBrowser, 1, 2L);
+        assertNotNull(attempt);
+        assertEquals(request.serial(), attempt.serial());
+        assertEquals(1L, attempt.attemptId());
+        assertTrue(fence.hasPending());
+    }
+
+    /** Verifies the first classic frame drains and only the second frame becomes full-frame. */
+    @Test
+    public void classicOsrRequiresDrainFrameBeforeFullFinalFrame() {
+        RecordingListener listener = new RecordingListener();
+        SurfaceFrameFence fence = new SurfaceFrameFence(listener);
+        CefBrowser cefBrowser = createCefBrowser();
+        List<Rectangle[]> forwardedRects = new ArrayList<>();
+        CefRenderHandler delegate = createClassicDelegate(forwardedRects);
+        CefRenderHandler wrapped = SurfaceFrameFence.wrapRenderHandler(
+                delegate, fence, CefRenderHandler.class.getClassLoader());
+        Object browserIdentity = new Object();
+        fence.requestForTest(
+                browserIdentity, cefBrowser, 3, 7L, "history_dom_committed");
+
+        SurfaceFrameFence.Attempt attempt = fence.armForTest(
+                browserIdentity, cefBrowser, 3, 7L);
+        assertNotNull(attempt);
+        assertEquals(SurfaceFrameFence.Stage.WAITING_PHASE_A_APPLIED, fence.stage());
+        assertTrue(fence.acknowledgePhaseApplied(
+                attempt, SurfaceFrameFence.DamagePhase.A));
+        wrapped.onPaint(cefBrowser, false,
+                new Rectangle[]{new Rectangle(2, 3, 10, 20)}, emptyBuffer(), 800, 600);
+
+        assertEquals(1, listener.drained.size());
+        assertEquals(0, listener.finalFrames.size());
+        assertArrayEquals(
+                new Rectangle[]{new Rectangle(2, 3, 10, 20)}, forwardedRects.get(0));
+        assertFalse(fence.complete(attempt));
+        assertTrue(fence.beginPhaseBApply(attempt));
+        assertTrue(fence.acknowledgePhaseApplied(
+                attempt, SurfaceFrameFence.DamagePhase.B));
+
+        wrapped.onPaint(cefBrowser, false,
+                new Rectangle[]{new Rectangle(4, 5, 30, 40)}, emptyBuffer(), 800, 600);
+
+        assertEquals(1, listener.finalFrames.size());
+        assertArrayEquals(
+                new Rectangle[]{new Rectangle(0, 0, 800, 600)}, forwardedRects.get(1));
+        assertTrue(fence.complete(attempt));
+        assertFalse(fence.hasPending());
+    }
+
+    /** Verifies popup and non-pending paints pass through without advancing the fence. */
+    @Test
+    public void popupAndNonPendingFramesAreFullyTransparent() {
+        RecordingListener listener = new RecordingListener();
+        SurfaceFrameFence fence = new SurfaceFrameFence(listener);
+        CefBrowser cefBrowser = createCefBrowser();
+        List<Rectangle[]> forwardedRects = new ArrayList<>();
+        CefRenderHandler wrapped = SurfaceFrameFence.wrapRenderHandler(
+                createClassicDelegate(forwardedRects),
+                fence,
+                CefRenderHandler.class.getClassLoader());
+        Rectangle[] popupRects = {new Rectangle(7, 8, 9, 10)};
+
+        wrapped.onPaint(cefBrowser, false, popupRects, emptyBuffer(), 100, 80);
+        Object browserIdentity = new Object();
+        fence.requestForTest(browserIdentity, cefBrowser, 1, 2L, "test");
+        fence.armForTest(browserIdentity, cefBrowser, 1, 2L);
+        wrapped.onPaint(cefBrowser, true, popupRects, emptyBuffer(), 100, 80);
+
+        assertArrayEquals(popupRects, forwardedRects.get(0));
+        assertArrayEquals(popupRects, forwardedRects.get(1));
+        assertEquals(SurfaceFrameFence.Stage.WAITING_PHASE_A_APPLIED, fence.stage());
+        assertTrue(listener.drained.isEmpty());
+    }
+
+    /** Verifies incidental paints cannot drain or finalize before their phase ACK is accepted. */
+    @Test
+    public void framesPassThroughWhileWaitingForFrontendPhaseAcknowledgments() {
+        RecordingListener listener = new RecordingListener();
+        SurfaceFrameFence fence = new SurfaceFrameFence(listener);
+        CefBrowser cefBrowser = createCefBrowser();
+        List<Rectangle[]> forwardedRects = new ArrayList<>();
+        CefRenderHandler wrapped = SurfaceFrameFence.wrapRenderHandler(
+                createClassicDelegate(forwardedRects),
+                fence,
+                CefRenderHandler.class.getClassLoader());
+        Object browserIdentity = new Object();
+        fence.requestForTest(browserIdentity, cefBrowser, 3, 4L, "test");
+        SurfaceFrameFence.Attempt attempt = fence.armForTest(
+                browserIdentity, cefBrowser, 3, 4L);
+        Rectangle[] incidentalRects = {new Rectangle(9, 10, 11, 12)};
+
+        wrapped.onPaint(cefBrowser, false, incidentalRects, emptyBuffer(), 300, 200);
+        assertEquals(SurfaceFrameFence.Stage.WAITING_PHASE_A_APPLIED, fence.stage());
+        assertTrue(listener.drained.isEmpty());
+
+        assertTrue(fence.acknowledgePhaseApplied(
+                attempt, SurfaceFrameFence.DamagePhase.A));
+        wrapped.onPaint(cefBrowser, false, new Rectangle[0], emptyBuffer(), 300, 200);
+        wrapped.onPaint(cefBrowser, false, incidentalRects, emptyBuffer(), 300, 200);
+
+        assertEquals(SurfaceFrameFence.Stage.WAITING_PHASE_B, fence.stage());
+        assertArrayEquals(incidentalRects, forwardedRects.get(2));
+        assertTrue(listener.finalFrames.isEmpty());
+        assertTrue(fence.beginPhaseBApply(attempt));
+        wrapped.onPaint(cefBrowser, false, incidentalRects, emptyBuffer(), 300, 200);
+        assertTrue(listener.finalFrames.isEmpty());
+        assertTrue(fence.acknowledgePhaseApplied(
+                attempt, SurfaceFrameFence.DamagePhase.B));
+        wrapped.onPaint(cefBrowser, false, incidentalRects, emptyBuffer(), 300, 200);
+        assertEquals(1, listener.finalFrames.size());
+    }
+
+    /** Verifies duplicate and out-of-order phase acknowledgments cannot skip fence stages. */
+    @Test
+    public void phaseAcknowledgmentsMustMatchTheExactCurrentStage() {
+        SurfaceFrameFence fence = new SurfaceFrameFence(new RecordingListener());
+        CefBrowser cefBrowser = createCefBrowser();
+        Object browserIdentity = new Object();
+        fence.requestForTest(browserIdentity, cefBrowser, 5, 6L, "test");
+        SurfaceFrameFence.Attempt attempt = fence.armForTest(
+                browserIdentity, cefBrowser, 5, 6L);
+
+        assertFalse(fence.acknowledgePhaseApplied(
+                attempt, SurfaceFrameFence.DamagePhase.B));
+        assertEquals(SurfaceFrameFence.Stage.WAITING_PHASE_A_APPLIED, fence.stage());
+        assertTrue(fence.acknowledgePhaseApplied(
+                attempt, SurfaceFrameFence.DamagePhase.A));
+        assertFalse(fence.acknowledgePhaseApplied(
+                attempt, SurfaceFrameFence.DamagePhase.A));
+        assertEquals(SurfaceFrameFence.Stage.DRAINING_FIRST_FRAME, fence.stage());
+    }
+
+    /** Verifies a newer pending serial cannot be cleared by the older active attempt. */
+    @Test
+    public void olderActiveSerialCannotClearNewerPendingRequest() {
+        RecordingListener listener = new RecordingListener();
+        SurfaceFrameFence fence = new SurfaceFrameFence(listener);
+        CefBrowser cefBrowser = createCefBrowser();
+        CefRenderHandler wrapped = SurfaceFrameFence.wrapRenderHandler(
+                createClassicDelegate(new ArrayList<>()),
+                fence,
+                CefRenderHandler.class.getClassLoader());
+        Object browserIdentity = new Object();
+        fence.requestForTest(
+                browserIdentity, cefBrowser, 4, 5L, 0L, "frontend_ready");
+        SurfaceFrameFence.Attempt firstAttempt = fence.armForTest(
+                browserIdentity, cefBrowser, 4, 5L);
+        SurfaceFrameFence.Request second = fence.requestForTest(
+                browserIdentity, cefBrowser, 4, 5L, 1L, "history_dom_committed");
+
+        assertTrue(fence.acknowledgePhaseApplied(
+                firstAttempt, SurfaceFrameFence.DamagePhase.A));
+        wrapped.onPaint(cefBrowser, false, new Rectangle[0], emptyBuffer(), 640, 480);
+        assertTrue(fence.beginPhaseBApply(firstAttempt));
+        assertTrue(fence.acknowledgePhaseApplied(
+                firstAttempt, SurfaceFrameFence.DamagePhase.B));
+        wrapped.onPaint(cefBrowser, false, new Rectangle[0], emptyBuffer(), 640, 480);
+
+        assertTrue(fence.complete(firstAttempt));
+        assertTrue(fence.hasPending());
+        assertFalse(fence.complete(firstAttempt));
+        SurfaceFrameFence.Attempt secondAttempt = fence.armForTest(
+                browserIdentity, cefBrowser, 4, 5L);
+        assertNotNull(secondAttempt);
+        assertEquals(second.serial(), secondAttempt.serial());
+        assertTrue(fence.isActive(secondAttempt));
+    }
+
+    /**
+     * Verifies a published content revision is not requested again, while a newer history
+     * commit creates exactly one additional serial for the same browser page owner.
+     */
+    @Test
+    public void deduplicatesPublishedContentRevisionAndQueuesOnlyNewerContent() {
+        RecordingListener listener = new RecordingListener();
+        SurfaceFrameFence fence = new SurfaceFrameFence(listener);
+        CefBrowser cefBrowser = createCefBrowser();
+        CefRenderHandler wrapped = SurfaceFrameFence.wrapRenderHandler(
+                createClassicDelegate(new ArrayList<>()),
+                fence,
+                CefRenderHandler.class.getClassLoader());
+        Object browserIdentity = new Object();
+        SurfaceFrameFence.Request shell = fence.requestForTest(
+                browserIdentity, cefBrowser, 9, 10L, 0L, "frontend_ready");
+        SurfaceFrameFence.Attempt attempt = fence.armForTest(
+                browserIdentity, cefBrowser, 9, 10L);
+        assertNotNull(attempt);
+        assertTrue(fence.acknowledgePhaseApplied(
+                attempt, SurfaceFrameFence.DamagePhase.A));
+        wrapped.onPaint(cefBrowser, false, new Rectangle[0], emptyBuffer(), 640, 480);
+        assertTrue(fence.beginPhaseBApply(attempt));
+        assertTrue(fence.acknowledgePhaseApplied(
+                attempt, SurfaceFrameFence.DamagePhase.B));
+        wrapped.onPaint(cefBrowser, false, new Rectangle[0], emptyBuffer(), 640, 480);
+        assertTrue(fence.complete(attempt));
+
+        SurfaceFrameFence.Request duplicate = fence.requestForTest(
+                browserIdentity, cefBrowser, 9, 10L, 0L, "frontend_ready");
+        assertEquals(shell.serial(), duplicate.serial());
+        assertEquals(shell.serial(), fence.lastPublishedSerial());
+        assertFalse(fence.hasPending());
+
+        SurfaceFrameFence.Request history = fence.requestForTest(
+                browserIdentity, cefBrowser, 9, 10L, 1L, "history_dom_committed");
+        SurfaceFrameFence.Request duplicateHistory = fence.requestForTest(
+                browserIdentity, cefBrowser, 9, 10L, 1L, "history_dom_committed");
+        assertTrue(history.serial() > shell.serial());
+        assertEquals(history.serial(), duplicateHistory.serial());
+        assertEquals(1L, history.contentRevision());
+        assertTrue(fence.hasPending());
+    }
+
+    /** Verifies lifecycle invalidation clears the published revision watermark. */
+    @Test
+    public void invalidationAllowsTheSameContentRevisionForANewLifecycle() {
+        SurfaceFrameFence fence = new SurfaceFrameFence(new RecordingListener());
+        CefBrowser cefBrowser = createCefBrowser();
+        Object browserIdentity = new Object();
+        SurfaceFrameFence.Request first = fence.requestForTest(
+                browserIdentity, cefBrowser, 2, 3L, 0L, "frontend_ready");
+
+        fence.invalidate();
+        SurfaceFrameFence.Request afterInvalidation = fence.requestForTest(
+                browserIdentity, cefBrowser, 2, 3L, 0L, "frontend_ready");
+
+        assertTrue(afterInvalidation.serial() > first.serial());
+        assertEquals(0L, fence.lastPublishedSerial());
+        assertTrue(fence.hasPending());
+    }
+
+    /** Verifies remote shared-memory final frames force a full raster copy and preserve disposal. */
+    @Test
+    public void remoteHandlerForcesZeroDirtyCountOnlyForFinalNonPopupFrame() throws Exception {
+        ClassLoader loader = CefRenderHandler.class.getClassLoader();
+        Class<?> nativeInterface = SurfaceFrameFence.resolveNativeRenderHandlerInterface(loader);
+        assertNotNull(nativeInterface);
+        List<Integer> forwardedDirtyCounts = new ArrayList<>();
+        AtomicInteger disposeCount = new AtomicInteger();
+        Object delegate = Proxy.newProxyInstance(
+                loader,
+                new Class<?>[]{CefRenderHandler.class, nativeInterface},
+                (proxy, method, args) -> {
+                    if ("onPaintWithSharedMem".equals(method.getName())) {
+                        forwardedDirtyCounts.add((Integer) args[2]);
+                    } else if ("disposeNativeResources".equals(method.getName())) {
+                        disposeCount.incrementAndGet();
+                    }
+                    return defaultValue(method.getReturnType());
+                });
+        RecordingListener listener = new RecordingListener();
+        SurfaceFrameFence fence = new SurfaceFrameFence(listener);
+        CefRenderHandler wrapped = SurfaceFrameFence.wrapRenderHandler(
+                (CefRenderHandler) delegate, fence, loader);
+        CefBrowser cefBrowser = createCefBrowser();
+        Object browserIdentity = new Object();
+        fence.requestForTest(browserIdentity, cefBrowser, 8, 9L, "test");
+        SurfaceFrameFence.Attempt attempt = fence.armForTest(
+                browserIdentity, cefBrowser, 8, 9L);
+        assertTrue(fence.acknowledgePhaseApplied(
+                attempt, SurfaceFrameFence.DamagePhase.A));
+        Method remotePaint = nativeInterface.getMethod(
+                "onPaintWithSharedMem", CefBrowser.class, boolean.class, int.class,
+                String.class, long.class, int.class, int.class);
+
+        remotePaint.invoke(wrapped, cefBrowser, false, 4, "first", 1L, 1200, 900);
+        assertTrue(fence.beginPhaseBApply(listener.drained.get(0)));
+        assertTrue(fence.acknowledgePhaseApplied(
+                attempt, SurfaceFrameFence.DamagePhase.B));
+        remotePaint.invoke(wrapped, cefBrowser, true, 5, "popup", 2L, 1200, 900);
+        remotePaint.invoke(wrapped, cefBrowser, false, 6, "final", 3L, 1200, 900);
+        nativeInterface.getMethod("disposeNativeResources").invoke(wrapped);
+
+        assertEquals(List.of(4, 5, 0), forwardedDirtyCounts);
+        assertEquals(1, listener.drained.size());
+        assertEquals(1, listener.finalFrames.size());
+        assertEquals(1, disposeCount.get());
+    }
+
+    /** Verifies an old runtime without the remote interface resolves to the classic path. */
+    @Test
+    public void missingRemoteInterfaceDoesNotPreventClassicHandlerLoading() {
+        ClassLoader isolatedLoader = new ClassLoader(null) { };
+
+        assertNull(SurfaceFrameFence.resolveNativeRenderHandlerInterface(isolatedLoader));
+    }
+
+    /** Verifies old/new platform default-factory shapes resolve without static API linkage. */
+    @Test
+    public void resolvesBothPlatformDefaultOsrFactoryShapesReflectively() {
+        assertEquals(DefaultFieldFactory.DEFAULT,
+                SurfaceFrameFence.resolveDefaultFactoryValue(DefaultFieldFactory.class));
+        assertEquals(InstanceMethodFactory.INSTANCE,
+                SurfaceFrameFence.resolveDefaultFactoryValue(InstanceMethodFactory.class));
+    }
+
+    /** Verifies timeout-style release retains pending work and requires a fresh first frame. */
+    @Test
+    public void releasedAttemptRetainsPendingWithoutCompletingIt() {
+        SurfaceFrameFence fence = new SurfaceFrameFence(new RecordingListener());
+        CefBrowser cefBrowser = createCefBrowser();
+        Object browserIdentity = new Object();
+        fence.requestForTest(
+                browserIdentity, cefBrowser, 2, 3L, "test");
+        SurfaceFrameFence.Attempt attempt = fence.armForTest(
+                browserIdentity, cefBrowser, 2, 3L);
+
+        SurfaceFrameFence.ReleaseResult result = fence.releaseAttempt(attempt);
+        AtomicInteger handoffCount = new AtomicInteger();
+
+        assertTrue(result.released());
+        assertFalse(result.newerPending());
+        assertFalse(result.handOffNewer(handoffCount::incrementAndGet));
+        assertEquals(0, handoffCount.get());
+        assertTrue(fence.hasPending());
+        assertFalse(fence.complete(attempt));
+        assertNotNull(fence.armForTest(browserIdentity, cefBrowser, 2, 3L));
+        assertEquals(SurfaceFrameFence.Stage.WAITING_PHASE_A_APPLIED, fence.stage());
+    }
+
+    /** Verifies a timed-out request hands ownership directly to a newer pending serial once. */
+    @Test
+    public void releasedAttemptReportsNewerPendingForAutomaticHandoff() {
+        SurfaceFrameFence fence = new SurfaceFrameFence(new RecordingListener());
+        CefBrowser cefBrowser = createCefBrowser();
+        Object browserIdentity = new Object();
+        fence.requestForTest(
+                browserIdentity, cefBrowser, 2, 3L, 0L, "frontend_ready");
+        SurfaceFrameFence.Attempt firstAttempt = fence.armForTest(
+                browserIdentity, cefBrowser, 2, 3L);
+        SurfaceFrameFence.Request latest = fence.requestForTest(
+                browserIdentity, cefBrowser, 2, 3L, 1L, "history_dom_committed");
+        AtomicInteger handoffCount = new AtomicInteger();
+
+        SurfaceFrameFence.ReleaseResult result = fence.releaseAttempt(firstAttempt);
+
+        assertTrue(result.released());
+        assertTrue(result.newerPending());
+        assertTrue(result.handOffNewer(handoffCount::incrementAndGet));
+        assertFalse(result.handOffNewer(handoffCount::incrementAndGet));
+        assertEquals(1, handoffCount.get());
+        SurfaceFrameFence.Attempt armed = fence.armForTest(
+                browserIdentity, cefBrowser, 2, 3L);
+        assertNotNull(armed);
+        assertEquals(latest.serial(), armed.serial());
+    }
+
+    /** Verifies a late callback from an old arm cannot release or complete a re-armed request. */
+    @Test
+    public void attemptIdentityProtectsRearmedRequestWithSameSerial() {
+        SurfaceFrameFence fence = new SurfaceFrameFence(new RecordingListener());
+        CefBrowser cefBrowser = createCefBrowser();
+        Object browserIdentity = new Object();
+        fence.requestForTest(browserIdentity, cefBrowser, 6, 7L, "history_dom_committed");
+        SurfaceFrameFence.Attempt firstAttempt = fence.armForTest(
+                browserIdentity, cefBrowser, 6, 7L);
+
+        assertTrue(fence.releaseAttempt(firstAttempt).released());
+        SurfaceFrameFence.Attempt secondAttempt = fence.armForTest(
+                browserIdentity, cefBrowser, 6, 7L);
+
+        assertNotNull(secondAttempt);
+        assertEquals(firstAttempt.serial(), secondAttempt.serial());
+        assertFalse(firstAttempt.attemptId() == secondAttempt.attemptId());
+        assertFalse(fence.releaseAttempt(firstAttempt).released());
+        assertTrue(fence.isActive(secondAttempt));
+        assertFalse(fence.complete(firstAttempt));
+        assertTrue(fence.isActive(secondAttempt));
+    }
+
+    /** Verifies lifecycle invalidation makes queued callbacks unable to force or complete a frame. */
+    @Test
+    public void lifecycleInvalidationRejectsOldFrameCallbacks() {
+        RecordingListener listener = new RecordingListener();
+        SurfaceFrameFence fence = new SurfaceFrameFence(listener);
+        CefBrowser cefBrowser = createCefBrowser();
+        List<Rectangle[]> forwardedRects = new ArrayList<>();
+        CefRenderHandler wrapped = SurfaceFrameFence.wrapRenderHandler(
+                createClassicDelegate(forwardedRects),
+                fence,
+                CefRenderHandler.class.getClassLoader());
+        Object browserIdentity = new Object();
+        fence.requestForTest(
+                browserIdentity, cefBrowser, 10, 11L, "test");
+        SurfaceFrameFence.Attempt attempt = fence.armForTest(
+                browserIdentity, cefBrowser, 10, 11L);
+
+        assertTrue(fence.acknowledgePhaseApplied(
+                attempt, SurfaceFrameFence.DamagePhase.A));
+        wrapped.onPaint(cefBrowser, false,
+                new Rectangle[]{new Rectangle(1, 1, 5, 5)}, emptyBuffer(), 400, 300);
+        fence.invalidate();
+        wrapped.onPaint(cefBrowser, false,
+                new Rectangle[]{new Rectangle(2, 2, 6, 6)}, emptyBuffer(), 400, 300);
+
+        assertArrayEquals(
+                new Rectangle[]{new Rectangle(2, 2, 6, 6)}, forwardedRects.get(1));
+        assertFalse(fence.complete(attempt));
+        assertFalse(fence.hasPending());
+        assertEquals(1, listener.drained.size());
+        assertTrue(listener.finalFrames.isEmpty());
+    }
+
+    private static CefRenderHandler createClassicDelegate(List<Rectangle[]> forwardedRects) {
+        return (CefRenderHandler) Proxy.newProxyInstance(
+                CefRenderHandler.class.getClassLoader(),
+                new Class<?>[]{CefRenderHandler.class},
+                (proxy, method, args) -> {
+                    if ("onPaint".equals(method.getName())) {
+                        forwardedRects.add((Rectangle[]) args[2]);
+                    }
+                    return defaultValue(method.getReturnType());
+                });
+    }
+
+    private static CefBrowser createCefBrowser() {
+        return (CefBrowser) Proxy.newProxyInstance(
+                CefBrowser.class.getClassLoader(),
+                new Class<?>[]{CefBrowser.class},
+                (proxy, method, args) -> defaultValue(method.getReturnType()));
+    }
+
+    private static ByteBuffer emptyBuffer() {
+        return ByteBuffer.allocateDirect(1);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) return null;
+        if (type == boolean.class) return false;
+        if (type == byte.class) return (byte) 0;
+        if (type == short.class) return (short) 0;
+        if (type == int.class) return 0;
+        if (type == long.class) return 0L;
+        if (type == float.class) return 0F;
+        if (type == double.class) return 0D;
+        if (type == char.class) return (char) 0;
+        return null;
+    }
+
+    private static final class RecordingListener implements SurfaceFrameFence.Listener {
+        private final List<SurfaceFrameFence.Attempt> drained = new ArrayList<>();
+        private final List<SurfaceFrameFence.Attempt> finalFrames = new ArrayList<>();
+
+        @Override
+        public void onFirstFrameDrained(SurfaceFrameFence.Attempt attempt) {
+            drained.add(attempt);
+        }
+
+        @Override
+        public void onFinalFrameForwarded(SurfaceFrameFence.Attempt attempt) {
+            finalFrames.add(attempt);
+        }
+    }
+
+    /** Mimics IDE versions that expose the default OSR factory as a public field. */
+    public static final class DefaultFieldFactory {
+        public static final Object DEFAULT = new Object();
+
+        private DefaultFieldFactory() { }
+    }
+
+    /** Mimics IDE versions that expose the default OSR factory through getInstance(). */
+    public static final class InstanceMethodFactory {
+        private static final Object INSTANCE = new Object();
+
+        private InstanceMethodFactory() { }
+
+        /** Returns the singleton value through the newer/alternate API shape. */
+        public static Object getInstance() {
+            return INSTANCE;
+        }
+    }
+}

--- a/src/test/java/com/github/claudecodegui/ui/WebviewInitializerTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/WebviewInitializerTest.java
@@ -4,8 +4,11 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.cef.browser.CefBrowser;
 
+import javax.swing.Timer;
+import java.awt.event.ActionEvent;
 import java.lang.reflect.Proxy;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
@@ -52,6 +55,145 @@ public class WebviewInitializerTest {
         Assert.assertEquals(fastDelay, WebviewInitializer.bridgeInjectionRetryDelayMs(1));
         Assert.assertTrue(slowDelay > fastDelay);
         Assert.assertEquals(slowDelay, WebviewInitializer.bridgeInjectionRetryDelayMs(500));
+    }
+
+    /** Verifies that hidden tabs pause fallback work until activation and ready tabs stop it. */
+    @Test
+    public void bridgeInjectionRetriesOnlyRunForActiveUnreadyWebviews() {
+        Assert.assertFalse(WebviewInitializer.shouldRunBridgeInjectionRetries(false, false, false));
+        Assert.assertTrue(WebviewInitializer.shouldRunBridgeInjectionRetries(false, false, true));
+        Assert.assertFalse(WebviewInitializer.shouldRunBridgeInjectionRetries(false, true, true));
+        Assert.assertFalse(WebviewInitializer.shouldRunBridgeInjectionRetries(true, false, true));
+    }
+
+    /** Verifies that a hidden-tab tick clears the real timer and activation installs a replacement. */
+    @Test
+    public void hiddenBridgeTimerStopsAndActivationRestartsIt() {
+        WebviewInitializer.BridgeInjectionTimerLifecycle lifecycle =
+                new WebviewInitializer.BridgeInjectionTimerLifecycle();
+        AtomicBoolean active = new AtomicBoolean(true);
+        lifecycle.beginPageLoad(7);
+
+        try {
+            Assert.assertTrue(lifecycle.startIfAbsent(7, active::get, attempt -> true));
+            Timer initialTimer = lifecycle.getTimer();
+            Assert.assertNotNull(initialTimer);
+            Assert.assertTrue(initialTimer.isRunning());
+
+            active.set(false);
+            fireTimer(initialTimer);
+            assertNull(lifecycle.getTimer());
+
+            active.set(true);
+            Assert.assertTrue(lifecycle.startIfAbsent(7, active::get, attempt -> true));
+            Assert.assertNotSame(initialTimer, lifecycle.getTimer());
+        } finally {
+            lifecycle.stop();
+        }
+    }
+
+    /** Verifies that repeated activation cannot install a second timer for one generation. */
+    @Test
+    public void repeatedActivationKeepsSingleBridgeTimer() {
+        WebviewInitializer.BridgeInjectionTimerLifecycle lifecycle =
+                new WebviewInitializer.BridgeInjectionTimerLifecycle();
+        lifecycle.beginPageLoad(7);
+
+        try {
+            Assert.assertTrue(lifecycle.startIfAbsent(7, () -> true, attempt -> true));
+            Timer installedTimer = lifecycle.getTimer();
+            installedTimer.stop();
+
+            Assert.assertFalse(lifecycle.startIfAbsent(7, () -> true, attempt -> true));
+            Assert.assertSame(installedTimer, lifecycle.getTimer());
+        } finally {
+            lifecycle.stop();
+        }
+    }
+
+    /** Verifies that generation changes stop old timers and reject stale-page retry installation. */
+    @Test
+    public void pageGenerationInvalidatesOldBridgeTimer() {
+        WebviewInitializer.BridgeInjectionTimerLifecycle lifecycle =
+                new WebviewInitializer.BridgeInjectionTimerLifecycle();
+        AtomicBoolean oldRetryAllowed = new AtomicBoolean(true);
+        lifecycle.beginPageLoad(7);
+
+        try {
+            Assert.assertTrue(lifecycle.startIfAbsent(7, oldRetryAllowed::get, attempt -> true));
+            Timer oldTimer = lifecycle.getTimer();
+            lifecycle.beginPageLoad(8);
+
+            assertNull(lifecycle.getTimer());
+            Assert.assertFalse(oldTimer.isRunning());
+            Assert.assertFalse(lifecycle.startIfAbsent(7, () -> true, attempt -> true));
+            Assert.assertTrue(lifecycle.startIfAbsent(8, () -> true, attempt -> true));
+            Timer currentTimer = lifecycle.getTimer();
+            currentTimer.stop();
+
+            oldRetryAllowed.set(false);
+            fireTimer(oldTimer);
+            Assert.assertSame(currentTimer, lifecycle.getTimer());
+            Assert.assertFalse(lifecycle.startIfAbsent(7, () -> false, attempt -> true));
+            Assert.assertSame(currentTimer, lifecycle.getTimer());
+        } finally {
+            lifecycle.stop();
+        }
+    }
+
+    /** Verifies that ready and disposed state transitions stop the installed timer on its next tick. */
+    @Test
+    public void readyAndDisposedTransitionsStopBridgeTimer() {
+        WebviewInitializer.BridgeInjectionTimerLifecycle lifecycle =
+                new WebviewInitializer.BridgeInjectionTimerLifecycle();
+        AtomicBoolean ready = new AtomicBoolean(false);
+        AtomicBoolean disposed = new AtomicBoolean(false);
+        lifecycle.beginPageLoad(7);
+
+        try {
+            Assert.assertTrue(lifecycle.startIfAbsent(
+                    7,
+                    () -> WebviewInitializer.shouldRunBridgeInjectionRetries(
+                            disposed.get(), ready.get(), true),
+                    attempt -> true));
+            Timer readyTimer = lifecycle.getTimer();
+            readyTimer.stop();
+            ready.set(true);
+            fireTimer(readyTimer);
+            assertNull(lifecycle.getTimer());
+
+            ready.set(false);
+            Assert.assertTrue(lifecycle.startIfAbsent(
+                    7,
+                    () -> WebviewInitializer.shouldRunBridgeInjectionRetries(
+                            disposed.get(), ready.get(), true),
+                    attempt -> true));
+            Timer disposedTimer = lifecycle.getTimer();
+            disposedTimer.stop();
+            disposed.set(true);
+            fireTimer(disposedTimer);
+            assertNull(lifecycle.getTimer());
+        } finally {
+            lifecycle.stop();
+        }
+    }
+
+    /** Verifies that configuration resolution runs once per page generation and refreshes after reload. */
+    @Test
+    public void frontendConfigurationIsCachedPerPageGeneration() {
+        WebviewInitializer.PageConfigurationCache cache =
+                new WebviewInitializer.PageConfigurationCache();
+        AtomicInteger builds = new AtomicInteger();
+        cache.reset(7);
+
+        assertEquals("config-1", cache.getOrCreate(7, () -> "config-" + builds.incrementAndGet()));
+        assertEquals("config-1", cache.getOrCreate(7, () -> "config-" + builds.incrementAndGet()));
+        assertNull(cache.getOrCreate(8, () -> "config-" + builds.incrementAndGet()));
+        assertEquals(1, builds.get());
+
+        cache.reset(8);
+        assertEquals("config-2", cache.getOrCreate(8, () -> "config-" + builds.incrementAndGet()));
+        assertEquals(2, builds.get());
     }
 
     /** Verifies that bridge injection wakes the frontend startup waiter once available. */
@@ -178,5 +320,13 @@ public class WebviewInitializerTest {
         WebviewInitializer.reloadCurrentPage(cefBrowser);
 
         Assert.assertEquals(1, reloadCalls.get());
+    }
+
+    private static void fireTimer(Timer timer) {
+        Assert.assertNotNull(timer);
+        timer.stop();
+        for (java.awt.event.ActionListener listener : timer.getActionListeners()) {
+            listener.actionPerformed(new ActionEvent(timer, ActionEvent.ACTION_PERFORMED, "test"));
+        }
     }
 }

--- a/src/test/java/com/github/claudecodegui/ui/WebviewWatchdogTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/WebviewWatchdogTest.java
@@ -2,12 +2,22 @@ package com.github.claudecodegui.ui;
 
 import org.junit.Test;
 
+import javax.swing.JPanel;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Unit tests for startup/runtime watchdog timing, visibility gating, and recovery budgets.
+ */
 public class WebviewWatchdogTest {
 
+    /** Verifies that an unready frontend uses the bounded startup timeout. */
     @Test
     public void usesShortTimeoutBeforeFrontendReady() {
         long startupTimeout = WebviewWatchdog.heartbeatTimeoutMs(false, false);
@@ -16,23 +26,86 @@ public class WebviewWatchdogTest {
         assertTrue(startupTimeout < WebviewWatchdog.heartbeatTimeoutMs(true, false));
     }
 
+    /** Verifies that active streaming only extends the timeout after frontend readiness. */
     @Test
     public void extendsHeartbeatTimeoutOnlyForReadyStreamingWebview() {
         assertTrue(WebviewWatchdog.heartbeatTimeoutMs(true, true)
                 > WebviewWatchdog.heartbeatTimeoutMs(true, false));
     }
 
+    /** Verifies that startup recovery uses a shorter cooldown than runtime recovery. */
     @Test
     public void retriesStartupRecoverySoonerThanRuntimeRecovery() {
         assertTrue(WebviewWatchdog.recoveryCooldownMs(false)
                 < WebviewWatchdog.recoveryCooldownMs(true));
     }
 
+    /** Verifies that hidden unready tabs stay idle until their panel becomes visible. */
     @Test
-    public void monitorsStartupEvenWhenPanelIsHiddenOrUnfocused() {
-        assertTrue(WebviewWatchdog.shouldMonitor(false, false, false, false));
+    public void pausesStartupMonitoringWhilePanelIsHidden() {
+        assertFalse(WebviewWatchdog.shouldMonitor(false, false, false, false));
+        assertTrue(WebviewWatchdog.shouldMonitor(false, true, true, false));
     }
 
+    /** Verifies through checkHealth that hidden startup pages do not invoke recovery callbacks. */
+    @Test
+    public void hiddenHealthCheckDefersRecoveryUntilPanelIsVisible() {
+        AtomicLong now = new AtomicLong(1_000L);
+        AtomicInteger reloads = new AtomicInteger();
+        AtomicInteger recreates = new AtomicInteger();
+        ShowingPanel panel = new ShowingPanel(false);
+        WebviewWatchdog watchdog = createWatchdog(
+                panel, now, reloads, recreates, Runnable::run);
+        now.addAndGet(1_000_000L);
+
+        watchdog.checkHealth();
+        assertEquals(0, reloads.get());
+        assertEquals(0, recreates.get());
+
+        panel.setShowing(true);
+        watchdog.checkHealth();
+        assertEquals(1, reloads.get());
+        assertEquals(0, recreates.get());
+    }
+
+    /** Verifies that a cancelled recovery neither consumes budget nor advances reload to recreate. */
+    @Test
+    public void cancelledRecoveryLeavesFirstVisibleAttemptAsReload() {
+        AtomicLong now = new AtomicLong(1_000L);
+        AtomicInteger reloads = new AtomicInteger();
+        AtomicInteger recreates = new AtomicInteger();
+        AtomicInteger queuedCount = new AtomicInteger();
+        AtomicReference<Runnable> queuedRecovery = new AtomicReference<>();
+        ShowingPanel panel = new ShowingPanel(true);
+        WebviewWatchdog watchdog = createWatchdog(
+                panel, now, reloads, recreates, recovery -> {
+                    queuedCount.incrementAndGet();
+                    queuedRecovery.set(recovery);
+                });
+        now.addAndGet(1_000_000L);
+
+        watchdog.checkHealth();
+        watchdog.checkHealth();
+        assertEquals(1, queuedCount.get());
+        assertTrue(queuedRecovery.get() != null);
+        panel.setShowing(false);
+        queuedRecovery.get().run();
+
+        assertEquals(0, reloads.get());
+        assertEquals(0, recreates.get());
+
+        panel.setShowing(true);
+        watchdog.checkHealth();
+        assertEquals(2, queuedCount.get());
+        queuedRecovery.get().run();
+
+        assertEquals(1, reloads.get());
+        assertEquals(0, recreates.get());
+        assertTrue(watchdog.tryAcquireRecoveryPermit(false));
+        assertFalse(watchdog.tryAcquireRecoveryPermit(false));
+    }
+
+    /** Verifies that runtime monitoring follows render visibility rather than editor focus. */
     @Test
     public void pausesRuntimeMonitoringWhenWebviewCannotRenderVisibly() {
         assertTrue(WebviewWatchdog.shouldMonitor(true, true, true, true));
@@ -42,6 +115,7 @@ public class WebviewWatchdogTest {
         assertTrue(WebviewWatchdog.shouldMonitor(true, true, true, false));
     }
 
+    /** Verifies that repeated startup recovery cannot loop indefinitely. */
     @Test
     public void capsBackgroundStartupRecovery() {
         WebviewWatchdog watchdog = createWatchdog();
@@ -51,6 +125,7 @@ public class WebviewWatchdogTest {
         assertFalse(watchdog.tryAcquireRecoveryPermit(false));
     }
 
+    /** Verifies that frontend readiness restores a previously exhausted startup budget. */
     @Test
     public void frontendReadinessRestoresStartupRecoveryBudget() {
         WebviewWatchdog watchdog = exhaustedWatchdog();
@@ -62,6 +137,7 @@ public class WebviewWatchdogTest {
         assertFalse(watchdog.tryAcquireRecoveryPermit(false));
     }
 
+    /** Verifies that an ordinary timestamp reset does not bypass the startup retry cap. */
     @Test
     public void timestampResetDoesNotRestoreStartupRecoveryBudget() {
         WebviewWatchdog watchdog = exhaustedWatchdog();
@@ -71,6 +147,7 @@ public class WebviewWatchdogTest {
         assertFalse(watchdog.tryAcquireRecoveryPermit(false));
     }
 
+    /** Verifies that explicit tab activation grants a fresh bounded startup retry budget. */
     @Test
     public void tabActivationRestoresStartupRecoveryBudget() {
         WebviewWatchdog watchdog = exhaustedWatchdog();
@@ -82,6 +159,7 @@ public class WebviewWatchdogTest {
         assertFalse(watchdog.tryAcquireRecoveryPermit(false));
     }
 
+    /** Verifies that ready runtime pages are not constrained by the startup retry budget. */
     @Test
     public void runtimeRecoveryIsNotCappedByStartupBudget() {
         WebviewWatchdog watchdog = createWatchdog();
@@ -109,5 +187,42 @@ public class WebviewWatchdogTest {
                 () -> false,
                 () -> false
         );
+    }
+
+    private static WebviewWatchdog createWatchdog(
+            JPanel panel,
+            AtomicLong now,
+            AtomicInteger reloads,
+            AtomicInteger recreates,
+            Consumer<Runnable> recoveryExecutor
+    ) {
+        return new WebviewWatchdog(
+                panel,
+                () -> true,
+                reloads::incrementAndGet,
+                recreates::incrementAndGet,
+                () -> false,
+                () -> false,
+                () -> false,
+                now::get,
+                recoveryExecutor
+        );
+    }
+
+    private static final class ShowingPanel extends JPanel {
+        private boolean showing;
+
+        private ShowingPanel(boolean showing) {
+            this.showing = showing;
+        }
+
+        private void setShowing(boolean showing) {
+            this.showing = showing;
+        }
+
+        @Override
+        public boolean isShowing() {
+            return showing;
+        }
     }
 }

--- a/src/test/java/com/github/claudecodegui/ui/toolwindow/WebviewTabActivationTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/toolwindow/WebviewTabActivationTest.java
@@ -16,8 +16,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Unit tests for native JCEF repainting and active-state decisions during tab activation.
+ */
 public class WebviewTabActivationTest {
 
+    /** Verifies that a windowed JCEF surface is remapped and repainted when its tab activates. */
     @Test
     public void remapsWindowedNativeSurfaceForAnEmptyTab() {
         List<String> calls = new ArrayList<>();
@@ -42,6 +46,7 @@ public class WebviewTabActivationTest {
         assertTrue(frontendRepainted.get());
     }
 
+    /** Verifies that off-screen-rendered JCEF uses resize notification instead of native remapping. */
     @Test
     public void usesResizeNotificationOnlyForOsrSurface() {
         List<String> calls = new ArrayList<>();
@@ -61,6 +66,16 @@ public class WebviewTabActivationTest {
         assertTrue(nativeComponent.visibilityChanges.isEmpty());
         assertTrue(calls.contains("notifyScreenInfoChanged"));
         assertTrue(frontendRepainted.get());
+    }
+
+    /** Verifies active-state selection for managed tabs, pre-binding windows, and detached windows. */
+    @Test
+    public void resolvesManagedAndDetachedWebviewActivity() {
+        assertTrue(ClaudeChatWindow.resolveWebviewActive(true, true, false, false));
+        assertFalse(ClaudeChatWindow.resolveWebviewActive(true, false, true, true));
+        assertTrue(ClaudeChatWindow.resolveWebviewActive(false, false, false, false));
+        assertTrue(ClaudeChatWindow.resolveWebviewActive(false, false, true, true));
+        assertFalse(ClaudeChatWindow.resolveWebviewActive(false, false, true, false));
     }
 
     private static CefBrowser createCefBrowser(

--- a/src/test/java/com/github/claudecodegui/ui/toolwindow/WebviewTabActivationTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/toolwindow/WebviewTabActivationTest.java
@@ -5,67 +5,105 @@ import org.junit.Test;
 
 import javax.swing.JPanel;
 import java.awt.Component;
+import java.awt.Rectangle;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Unit tests for native JCEF repainting and active-state decisions during tab activation.
+ * Unit tests for native JCEF repainting, publication-versus-cached-presentation activation
+ * decisions, wrapper/native-child eligibility, windowed refresh ownership, and exact OSR
+ * timeout ownership across lifecycle changes.
  */
 public class WebviewTabActivationTest {
 
-    /** Verifies that a windowed JCEF surface is remapped and repainted when its tab activates. */
+    /** Verifies that a windowed JCEF surface reapplies native bounds without toggling visibility. */
     @Test
-    public void remapsWindowedNativeSurfaceForAnEmptyTab() {
+    public void reappliesWindowedNativeBoundsForAnEmptyTab() {
         List<String> calls = new ArrayList<>();
         int[][] resized = new int[1][];
         RecordingComponent nativeComponent = new RecordingComponent();
         new JPanel().add(nativeComponent);
+        nativeComponent.setBounds(10, 20, 640, 480);
         nativeComponent.startRecording();
         CefBrowser cefBrowser = createCefBrowser(nativeComponent, calls, resized);
         JPanel browserComponent = new JPanel();
         browserComponent.setSize(640, 480);
         AtomicBoolean frontendRepainted = new AtomicBoolean(false);
 
-        ClaudeChatWindow.refreshActivatedWebview(
+        assertTrue(ClaudeChatWindow.refreshActivatedWebview(
                 new JPanel(), browserComponent, cefBrowser, false,
-                () -> frontendRepainted.set(true));
+                () -> frontendRepainted.set(true)));
 
-        assertTrue(nativeComponent.invalidated);
+        assertEquals(Arrays.asList(new Rectangle(10, 20, 640, 480)), nativeComponent.boundsChanges);
         assertTrue(nativeComponent.repainted);
-        assertEquals(Arrays.asList(false, true), nativeComponent.visibilityChanges);
+        assertTrue(nativeComponent.visibilityChanges.isEmpty());
         assertFalse(calls.contains("wasResized"));
         assertTrue(calls.contains("notifyScreenInfoChanged"));
         assertTrue(frontendRepainted.get());
     }
 
-    /** Verifies that off-screen-rendered JCEF uses resize notification instead of native remapping. */
+    /** Verifies an OSR resize kick explicitly invalidates CEF without hiding its component. */
     @Test
-    public void usesResizeNotificationOnlyForOsrSurface() {
+    public void reappliesOsrNativeBoundsWithoutVisibilityRemapping() {
         List<String> calls = new ArrayList<>();
         int[][] resized = new int[1][];
         RecordingComponent nativeComponent = new RecordingComponent();
+        new JPanel().add(nativeComponent);
+        nativeComponent.setBounds(0, 0, 800, 600);
         nativeComponent.startRecording();
         CefBrowser cefBrowser = createCefBrowser(nativeComponent, calls, resized);
         JPanel browserComponent = new JPanel();
         browserComponent.setSize(800, 600);
         AtomicBoolean frontendRepainted = new AtomicBoolean(false);
 
-        ClaudeChatWindow.refreshActivatedWebview(
+        assertTrue(ClaudeChatWindow.refreshActivatedWebview(
                 new JPanel(), browserComponent, cefBrowser, true,
-                () -> frontendRepainted.set(true));
+                () -> frontendRepainted.set(true)));
 
-        assertArrayEquals(new int[]{800, 600}, resized[0]);
+        assertEquals(Arrays.asList(new Rectangle(0, 0, 800, 600)), nativeComponent.boundsChanges);
+        assertTrue(nativeComponent.repainted);
         assertTrue(nativeComponent.visibilityChanges.isEmpty());
+        assertTrue(calls.contains("wasResized"));
+        assertTrue(Arrays.equals(new int[]{0, 0}, resized[0]));
         assertTrue(calls.contains("notifyScreenInfoChanged"));
         assertTrue(frontendRepainted.get());
+    }
+
+    /** Verifies a delivered OSR full frame is synchronously painted from its backing image. */
+    @Test
+    public void forcesCompleteOsrPaintBeforeRefreshCompletion() {
+        RecordingComponent nativeComponent = new RecordingComponent();
+        new JPanel().add(nativeComponent);
+        nativeComponent.setBounds(0, 0, 800, 600);
+        nativeComponent.startRecording();
+
+        assertTrue(ClaudeChatWindow.forceOsrSurfacePaint(
+                new JPanel(), new JPanel(), nativeComponent));
+
+        assertTrue(nativeComponent.repainted);
+        assertEquals(1, nativeComponent.immediatePaintCount);
+    }
+
+    /** Verifies an unmapped OSR child cannot falsely complete the final paint stage. */
+    @Test
+    public void rejectsFinalOsrPaintForUnmappedNativeChild() {
+        RecordingComponent nativeComponent = new RecordingComponent();
+        nativeComponent.surfaceShowing = false;
+        nativeComponent.setBounds(0, 0, 800, 600);
+        nativeComponent.startRecording();
+
+        assertFalse(ClaudeChatWindow.forceOsrSurfacePaint(
+                new JPanel(), new JPanel(), nativeComponent));
+
+        assertEquals(0, nativeComponent.immediatePaintCount);
     }
 
     /** Verifies active-state selection for managed tabs, pre-binding windows, and detached windows. */
@@ -76,6 +114,474 @@ public class WebviewTabActivationTest {
         assertTrue(ClaudeChatWindow.resolveWebviewActive(false, false, false, false));
         assertTrue(ClaudeChatWindow.resolveWebviewActive(false, false, true, true));
         assertFalse(ClaudeChatWindow.resolveWebviewActive(false, false, true, false));
+    }
+
+    /** Verifies the first active ready transition requests and publishes before history restoration. */
+    @Test
+    public void repaintsActiveWebviewOnFirstFrontendReadyTransition() {
+        List<String> calls = new ArrayList<>();
+        ClaudeChatWindow.FrontendReadyTransitionTracker tracker =
+                new ClaudeChatWindow.FrontendReadyTransitionTracker();
+        ClaudeChatWindow.FrontendReadyTransition transition = tracker.update(true);
+
+        ClaudeChatWindow.completeFrontendReadyUiUpdate(
+                false,
+                transition.becameReady(),
+                () -> tracker.isCurrentReady(transition.epoch()),
+                () -> calls.add("request"),
+                () -> true,
+                () -> calls.add("publish"),
+                () -> calls.add("history")
+        );
+
+        assertEquals(Arrays.asList("request", "publish", "history"), calls);
+    }
+
+    /** Verifies an older ready task cannot repaint a newer page after a false-to-true cycle. */
+    @Test
+    public void staleReadyTaskCannotRepaintNewGeneration() {
+        AtomicInteger repaintCount = new AtomicInteger();
+        AtomicInteger historyCount = new AtomicInteger();
+        ClaudeChatWindow.FrontendReadyTransitionTracker tracker =
+                new ClaudeChatWindow.FrontendReadyTransitionTracker();
+
+        ClaudeChatWindow.FrontendReadyTransition firstReady = tracker.update(true);
+        tracker.update(false);
+        ClaudeChatWindow.FrontendReadyTransition secondReady = tracker.update(true);
+
+        ClaudeChatWindow.completeFrontendReadyUiUpdate(
+                false,
+                firstReady.becameReady(),
+                () -> tracker.isCurrentReady(firstReady.epoch()),
+                repaintCount::incrementAndGet,
+                () -> true,
+                repaintCount::incrementAndGet,
+                historyCount::incrementAndGet);
+        ClaudeChatWindow.completeFrontendReadyUiUpdate(
+                false,
+                secondReady.becameReady(),
+                () -> tracker.isCurrentReady(secondReady.epoch()),
+                () -> { },
+                () -> true,
+                repaintCount::incrementAndGet,
+                historyCount::incrementAndGet);
+
+        assertEquals(1, repaintCount.get());
+        assertEquals(2, historyCount.get());
+    }
+
+    /** Verifies a duplicate ready report neither invalidates nor duplicates the first repaint task. */
+    @Test
+    public void duplicateReadyKeepsFirstTaskEligibleWithoutSecondRepaint() {
+        AtomicInteger repaintCount = new AtomicInteger();
+        AtomicInteger historyCount = new AtomicInteger();
+        ClaudeChatWindow.FrontendReadyTransitionTracker tracker =
+                new ClaudeChatWindow.FrontendReadyTransitionTracker();
+
+        ClaudeChatWindow.FrontendReadyTransition firstReady = tracker.update(true);
+        ClaudeChatWindow.FrontendReadyTransition duplicateReady = tracker.update(true);
+
+        ClaudeChatWindow.completeFrontendReadyUiUpdate(
+                false,
+                firstReady.becameReady(),
+                () -> tracker.isCurrentReady(firstReady.epoch()),
+                () -> { },
+                () -> true,
+                repaintCount::incrementAndGet,
+                historyCount::incrementAndGet);
+        ClaudeChatWindow.completeFrontendReadyUiUpdate(
+                false,
+                duplicateReady.becameReady(),
+                () -> tracker.isCurrentReady(duplicateReady.epoch()),
+                () -> { },
+                () -> true,
+                repaintCount::incrementAndGet,
+                historyCount::incrementAndGet);
+
+        assertEquals(1, repaintCount.get());
+        assertEquals(2, historyCount.get());
+    }
+
+    /** Verifies a hidden ready page creates publication work but defers its execution. */
+    @Test
+    public void hiddenReadyTransitionRequestsButDoesNotPublish() {
+        AtomicInteger requestCount = new AtomicInteger();
+        AtomicInteger publishCount = new AtomicInteger();
+        AtomicInteger historyCount = new AtomicInteger();
+        ClaudeChatWindow.FrontendReadyTransitionTracker tracker =
+                new ClaudeChatWindow.FrontendReadyTransitionTracker();
+        ClaudeChatWindow.FrontendReadyTransition transition = tracker.update(true);
+
+        ClaudeChatWindow.completeFrontendReadyUiUpdate(
+                false,
+                transition.becameReady(),
+                () -> tracker.isCurrentReady(transition.epoch()),
+                requestCount::incrementAndGet,
+                () -> false,
+                publishCount::incrementAndGet,
+                historyCount::incrementAndGet);
+
+        assertEquals(1, requestCount.get());
+        assertEquals(0, publishCount.get());
+        assertEquals(1, historyCount.get());
+    }
+
+    /** Verifies an OSR activation presents cached pixels without creating publication work. */
+    @Test
+    public void activationConsumesOneCachedSurfacePresentation() {
+        ClaudeChatWindow.SurfacePresentationCoordinator coordinator =
+                new ClaudeChatWindow.SurfacePresentationCoordinator();
+        Object browserIdentity = new Object();
+        Object cefBrowserIdentity = new Object();
+        AtomicInteger presentationCount = new AtomicInteger();
+
+        assertFalse(coordinator.hasPending());
+        coordinator.request(browserIdentity, cefBrowserIdentity, 3, 4L);
+        assertTrue(coordinator.hasPending());
+        assertTrue(coordinator.tryConsume(
+                browserIdentity,
+                cefBrowserIdentity,
+                3,
+                4L,
+                () -> true,
+                () -> {
+                    presentationCount.incrementAndGet();
+                    return true;
+                }));
+        assertFalse(coordinator.hasPending());
+        assertEquals(1, presentationCount.get());
+    }
+
+    /** Verifies an unmapped cached surface stays pending until a later showing event. */
+    @Test
+    public void retainsCachedPresentationUntilNativeChildIsShowing() {
+        ClaudeChatWindow.SurfacePresentationCoordinator coordinator =
+                new ClaudeChatWindow.SurfacePresentationCoordinator();
+        Object browserIdentity = new Object();
+        Object cefBrowserIdentity = new Object();
+        AtomicInteger presentationCount = new AtomicInteger();
+        coordinator.request(browserIdentity, cefBrowserIdentity, 3, 4L);
+
+        assertFalse(coordinator.tryConsume(
+                browserIdentity, cefBrowserIdentity, 3, 4L,
+                () -> false,
+                () -> {
+                    presentationCount.incrementAndGet();
+                    return true;
+                }));
+        assertTrue(coordinator.hasPending());
+
+        assertTrue(coordinator.tryConsume(
+                browserIdentity, cefBrowserIdentity, 3, 4L,
+                () -> true,
+                () -> {
+                    presentationCount.incrementAndGet();
+                    return true;
+                }));
+        assertFalse(coordinator.hasPending());
+        assertEquals(1, presentationCount.get());
+    }
+
+    /**
+     * Verifies OSR activation resumes any outstanding publication, including an active attempt,
+     * or presents cached pixels only after publication completes; the generic repaint path
+     * remains restricted to windowed JCEF.
+     */
+    @Test
+    public void selectsActivationActionWithoutCreatingOsrPublicationWork() {
+        assertEquals(
+                ClaudeChatWindow.TabActivationSurfaceAction.PUBLISH_PENDING,
+                ClaudeChatWindow.decideTabActivationSurfaceAction(true, true, true));
+        assertEquals(
+                ClaudeChatWindow.TabActivationSurfaceAction.PRESENT_CACHED,
+                ClaudeChatWindow.decideTabActivationSurfaceAction(true, true, false));
+        assertEquals(
+                ClaudeChatWindow.TabActivationSurfaceAction.WINDOWED_REFRESH,
+                ClaudeChatWindow.decideTabActivationSurfaceAction(true, false, false));
+        assertEquals(
+                ClaudeChatWindow.TabActivationSurfaceAction.NONE,
+                ClaudeChatWindow.decideTabActivationSurfaceAction(false, false, false));
+    }
+
+    /** Verifies only the current browser and epoch can complete deferred pending work. */
+    @Test
+    public void completesPendingSurfaceRefreshForCurrentPageOnly() {
+        ClaudeChatWindow.SurfaceRefreshCoordinator coordinator =
+                new ClaudeChatWindow.SurfaceRefreshCoordinator();
+        Object browserIdentity = new Object();
+        coordinator.request(browserIdentity, 11L, "history_render_complete");
+
+        assertTrue(coordinator.hasPendingFor(browserIdentity, 11L));
+        assertTrue(coordinator.completeCurrent(browserIdentity, 11L));
+        assertFalse(coordinator.hasPending());
+        assertFalse(coordinator.completeCurrent(browserIdentity, 11L));
+    }
+
+    /** Verifies disposal skips active-state lookup, repaint, and restored-history work. */
+    @Test
+    public void skipsFrontendReadyUiWorkAfterDisposal() {
+        AtomicInteger activeCheckCount = new AtomicInteger();
+        AtomicInteger repaintCount = new AtomicInteger();
+        AtomicInteger historyCount = new AtomicInteger();
+
+        ClaudeChatWindow.completeFrontendReadyUiUpdate(
+                true,
+                true,
+                () -> true,
+                repaintCount::incrementAndGet,
+                () -> {
+                    activeCheckCount.incrementAndGet();
+                    return true;
+                },
+                repaintCount::incrementAndGet,
+                historyCount::incrementAndGet);
+
+        assertEquals(0, activeCheckCount.get());
+        assertEquals(0, repaintCount.get());
+        assertEquals(0, historyCount.get());
+    }
+
+    /** Verifies that a current page requests a native refresh after history rendering. */
+    @Test
+    public void requestsCurrentSurfaceAfterRestoredHistoryRendering() {
+        AtomicInteger refreshCount = new AtomicInteger();
+        ClaudeChatWindow.FrontendReadyTransitionTracker tracker =
+                new ClaudeChatWindow.FrontendReadyTransitionTracker();
+        ClaudeChatWindow.FrontendReadyTransition ready = tracker.update(true);
+
+        ClaudeChatWindow.completeHistoryRenderUiUpdate(
+                false,
+                () -> tracker.isCurrentReady(ready.epoch()),
+                refreshCount::incrementAndGet);
+
+        assertEquals(1, refreshCount.get());
+    }
+
+    /** Verifies that a history acknowledgment queued by an obsolete page cannot refresh a new page. */
+    @Test
+    public void staleHistoryRenderTaskCannotRefreshNewGeneration() {
+        AtomicInteger refreshCount = new AtomicInteger();
+        ClaudeChatWindow.FrontendReadyTransitionTracker tracker =
+                new ClaudeChatWindow.FrontendReadyTransitionTracker();
+        ClaudeChatWindow.FrontendReadyTransition oldReady = tracker.update(true);
+        tracker.update(false);
+        tracker.update(true);
+
+        ClaudeChatWindow.completeHistoryRenderUiUpdate(
+                false,
+                () -> tracker.isCurrentReady(oldReady.epoch()),
+                refreshCount::incrementAndGet);
+
+        assertEquals(0, refreshCount.get());
+    }
+
+    /** Verifies disposal short-circuits history-render native refresh requests. */
+    @Test
+    public void skipsHistoryRenderRefreshAfterDisposal() {
+        AtomicInteger refreshCount = new AtomicInteger();
+
+        ClaudeChatWindow.completeHistoryRenderUiUpdate(
+                true,
+                () -> true,
+                refreshCount::incrementAndGet);
+
+        assertEquals(0, refreshCount.get());
+    }
+
+    /** Verifies a queued history acknowledgment remains owned by the exact browser generation. */
+    @Test
+    public void historyRenderOwnerRequiresBrowserCefAndGenerationIdentity() {
+        Object browser = new Object();
+        Object cefBrowser = new Object();
+
+        assertTrue(ClaudeChatWindow.historyRenderOwnerMatches(
+                browser, cefBrowser, 4, browser, cefBrowser, 4));
+        assertFalse(ClaudeChatWindow.historyRenderOwnerMatches(
+                browser, cefBrowser, 4, new Object(), cefBrowser, 4));
+        assertFalse(ClaudeChatWindow.historyRenderOwnerMatches(
+                browser, cefBrowser, 4, browser, new Object(), 4));
+        assertFalse(ClaudeChatWindow.historyRenderOwnerMatches(
+                browser, cefBrowser, 4, browser, cefBrowser, 5));
+    }
+
+    /** Verifies a hidden surface request remains pending and is consumed exactly once when eligible. */
+    @Test
+    public void retainsHiddenSurfaceRefreshUntilItCanBeConsumed() {
+        ClaudeChatWindow.SurfaceRefreshCoordinator coordinator =
+                new ClaudeChatWindow.SurfaceRefreshCoordinator();
+        Object browserIdentity = new Object();
+        AtomicInteger refreshCount = new AtomicInteger();
+        coordinator.request(browserIdentity, 3L, "history_render_complete");
+
+        assertFalse(coordinator.tryConsume(
+                browserIdentity, 3L, () -> false,
+                () -> {
+                    refreshCount.incrementAndGet();
+                    return true;
+                }));
+        assertTrue(coordinator.hasPending());
+
+        assertTrue(coordinator.tryConsume(
+                browserIdentity, 3L, () -> true,
+                () -> {
+                    refreshCount.incrementAndGet();
+                    return true;
+                }));
+        assertFalse(coordinator.hasPending());
+        assertFalse(coordinator.tryConsume(browserIdentity, 3L, () -> true, () -> true));
+        assertEquals(1, refreshCount.get());
+    }
+
+    /** Verifies a failed native resize keeps its request pending for a later lifecycle event. */
+    @Test
+    public void retainsSurfaceRefreshWhenNativeResizeDoesNotRun() {
+        ClaudeChatWindow.SurfaceRefreshCoordinator coordinator =
+                new ClaudeChatWindow.SurfaceRefreshCoordinator();
+        Object browserIdentity = new Object();
+        coordinator.request(browserIdentity, 5L, "history_render_complete");
+
+        assertFalse(coordinator.tryConsume(browserIdentity, 5L, () -> true, () -> false));
+
+        assertTrue(coordinator.hasPending());
+    }
+
+    /** Verifies component lifecycle callbacks cannot re-enter an in-progress native refresh. */
+    @Test
+    public void preventsSurfaceRefreshReentry() {
+        ClaudeChatWindow.SurfaceRefreshCoordinator coordinator =
+                new ClaudeChatWindow.SurfaceRefreshCoordinator();
+        Object browserIdentity = new Object();
+        AtomicBoolean nestedConsumed = new AtomicBoolean(true);
+        coordinator.request(browserIdentity, 9L, "history_render_complete");
+
+        boolean consumed = coordinator.tryConsume(
+                browserIdentity,
+                9L,
+                () -> true,
+                () -> {
+                    nestedConsumed.set(coordinator.tryConsume(
+                            browserIdentity, 9L, () -> true, () -> true));
+                    return true;
+                });
+
+        assertTrue(consumed);
+        assertFalse(nestedConsumed.get());
+        assertFalse(coordinator.hasPending());
+    }
+
+    /** Verifies a request owned by an obsolete browser or ready epoch is discarded. */
+    @Test
+    public void discardsSurfaceRefreshOwnedByObsoletePage() {
+        ClaudeChatWindow.SurfaceRefreshCoordinator coordinator =
+                new ClaudeChatWindow.SurfaceRefreshCoordinator();
+        Object oldBrowser = new Object();
+        coordinator.request(oldBrowser, 7L, "history_render_complete");
+
+        assertFalse(coordinator.tryConsume(new Object(), 7L, () -> true, () -> true));
+        assertFalse(coordinator.hasPending());
+
+        coordinator.request(oldBrowser, 7L, "history_render_complete");
+        assertFalse(coordinator.tryConsume(oldBrowser, 8L, () -> true, () -> true));
+        assertFalse(coordinator.hasPending());
+    }
+
+    /** Verifies wrapper and real native-child visibility, root state, and geometry gate refresh. */
+    @Test
+    public void requiresStableVisibleGeometryForSurfaceRefresh() {
+        assertTrue(ClaudeChatWindow.isSurfaceRefreshEligible(
+                true, true, true, true, true, true, false, 800, 600));
+        assertFalse(ClaudeChatWindow.isSurfaceRefreshEligible(
+                false, true, true, true, true, true, false, 800, 600));
+        assertFalse(ClaudeChatWindow.isSurfaceRefreshEligible(
+                true, false, true, true, true, true, false, 800, 600));
+        assertFalse(ClaudeChatWindow.isSurfaceRefreshEligible(
+                true, true, false, true, true, true, false, 800, 600));
+        assertFalse(ClaudeChatWindow.isSurfaceRefreshEligible(
+                true, true, true, false, true, true, false, 800, 600));
+        assertFalse(ClaudeChatWindow.isSurfaceRefreshEligible(
+                true, true, true, true, false, true, false, 800, 600));
+        assertFalse(ClaudeChatWindow.isSurfaceRefreshEligible(
+                true, true, true, true, true, false, false, 800, 600));
+        assertFalse(ClaudeChatWindow.isSurfaceRefreshEligible(
+                true, true, true, true, true, true, true, 800, 600));
+        assertFalse(ClaudeChatWindow.isSurfaceRefreshEligible(
+                true, true, true, true, true, true, false, 0, 600));
+    }
+
+    /** Verifies an unmapped native child cannot report success or consume its pending request. */
+    @Test
+    public void retainsRefreshWhileNativeChildIsNotShowing() {
+        List<String> calls = new ArrayList<>();
+        int[][] resized = new int[1][];
+        RecordingComponent nativeComponent = new RecordingComponent();
+        nativeComponent.surfaceShowing = false;
+        nativeComponent.setBounds(0, 0, 800, 600);
+        nativeComponent.startRecording();
+        CefBrowser cefBrowser = createCefBrowser(nativeComponent, calls, resized);
+        AtomicBoolean frontendRepainted = new AtomicBoolean(false);
+
+        assertFalse(ClaudeChatWindow.refreshActivatedWebview(
+                new JPanel(), new JPanel(), cefBrowser, true,
+                () -> frontendRepainted.set(true)));
+
+        assertTrue(nativeComponent.boundsChanges.isEmpty());
+        assertFalse(calls.contains("notifyScreenInfoChanged"));
+        assertTrue(frontendRepainted.get());
+    }
+
+    /** Verifies replacing a phase-A timeout for the same attempt invalidates the older runnable. */
+    @Test
+    public void replacesTimeoutOnlyForTheSameExactAttempt() {
+        ClaudeChatWindow.SurfaceAttemptTimeoutOwner owner =
+                new ClaudeChatWindow.SurfaceAttemptTimeoutOwner();
+        Object attempt = new Object();
+        Runnable phaseATimeout = () -> { };
+        Runnable phaseBTimeout = () -> { };
+
+        ClaudeChatWindow.SurfaceAttemptTimeoutOwner.InstallResult first =
+                owner.install(attempt, phaseATimeout);
+        ClaudeChatWindow.SurfaceAttemptTimeoutOwner.InstallResult second =
+                owner.install(attempt, phaseBTimeout);
+
+        assertTrue(first.accepted());
+        assertTrue(second.accepted());
+        assertTrue(second.previousTask() == phaseATimeout);
+        assertFalse(owner.claim(attempt, phaseATimeout));
+        assertTrue(owner.claim(attempt, phaseBTimeout));
+    }
+
+    /** Verifies a late callback from A cannot cancel B after A timed out and handed off. */
+    @Test
+    public void lateAttemptCannotRemoveNewerAttemptTimeout() {
+        ClaudeChatWindow.SurfaceAttemptTimeoutOwner owner =
+                new ClaudeChatWindow.SurfaceAttemptTimeoutOwner();
+        Object attemptA = new Object();
+        Object attemptB = new Object();
+        Runnable timeoutA = () -> { };
+        Runnable timeoutB = () -> { };
+
+        assertTrue(owner.install(attemptA, timeoutA).accepted());
+        assertTrue(owner.claim(attemptA, timeoutA));
+        assertTrue(owner.install(attemptB, timeoutB).accepted());
+
+        assertTrue(owner.remove(attemptA) == null);
+        assertTrue(owner.isOwnedBy(attemptB, timeoutB));
+        assertTrue(owner.claim(attemptB, timeoutB));
+    }
+
+    /** Verifies a different active attempt cannot have its timeout replaced before release. */
+    @Test
+    public void rejectsTimeoutReplacementOwnedByAnotherAttempt() {
+        ClaudeChatWindow.SurfaceAttemptTimeoutOwner owner =
+                new ClaudeChatWindow.SurfaceAttemptTimeoutOwner();
+        Object attemptA = new Object();
+        Object attemptB = new Object();
+        Runnable timeoutA = () -> { };
+        Runnable timeoutB = () -> { };
+
+        assertTrue(owner.install(attemptA, timeoutA).accepted());
+        assertFalse(owner.install(attemptB, timeoutB).accepted());
+        assertTrue(owner.isOwnedBy(attemptA, timeoutA));
     }
 
     private static CefBrowser createCefBrowser(
@@ -114,15 +620,29 @@ public class WebviewTabActivationTest {
 
     private static class RecordingComponent extends JPanel {
         private final List<Boolean> visibilityChanges = new ArrayList<>();
+        private final List<Rectangle> boundsChanges = new ArrayList<>();
         private boolean recording;
-        private boolean invalidated;
         private boolean repainted;
+        private int immediatePaintCount;
+        private boolean surfaceShowing = true;
+        private boolean surfaceDisplayable = true;
 
         private void startRecording() {
             recording = true;
             visibilityChanges.clear();
-            invalidated = false;
+            boundsChanges.clear();
             repainted = false;
+            immediatePaintCount = 0;
+        }
+
+        @Override
+        public boolean isShowing() {
+            return surfaceShowing;
+        }
+
+        @Override
+        public boolean isDisplayable() {
+            return surfaceDisplayable;
         }
 
         @Override
@@ -134,10 +654,10 @@ public class WebviewTabActivationTest {
         }
 
         @Override
-        public void invalidate() {
-            super.invalidate();
+        public void setBounds(int x, int y, int width, int height) {
+            super.setBounds(x, y, width, height);
             if (recording) {
-                invalidated = true;
+                boundsChanges.add(new Rectangle(x, y, width, height));
             }
         }
 
@@ -146,6 +666,13 @@ public class WebviewTabActivationTest {
             super.repaint();
             if (recording) {
                 repainted = true;
+            }
+        }
+
+        @Override
+        public void paintImmediately(int x, int y, int width, int height) {
+            if (recording) {
+                immediatePaintCount++;
             }
         }
     }

--- a/src/test/java/com/github/claudecodegui/util/JBCefBrowserFactoryTest.java
+++ b/src/test/java/com/github/claudecodegui/util/JBCefBrowserFactoryTest.java
@@ -1,13 +1,19 @@
 package com.github.claudecodegui.util;
 
+import com.intellij.ui.jcef.JBCefOSRHandlerFactory;
 import org.cef.handler.CefKeyboardHandler;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * Tests browser-builder compatibility gates and keyboard/JCEF support helpers without creating a
+ * live browser process.
+ */
 public class JBCefBrowserFactoryTest {
 
+    /** Verifies control characters are suppressed outside editable fields. */
     @Test
     public void suppressesControlCharOnNonEditableField() {
         CefKeyboardHandler.CefKeyEvent event = new CefKeyboardHandler.CefKeyEvent(
@@ -24,6 +30,7 @@ public class JBCefBrowserFactoryTest {
         Assert.assertTrue(JBCefBrowserFactory.shouldSuppressProblematicCharEvent(event));
     }
 
+    /** Verifies editable fields retain control-character input for editor shortcuts. */
     @Test
     public void keepsControlCharForEditableField() {
         CefKeyboardHandler.CefKeyEvent event = new CefKeyboardHandler.CefKeyEvent(
@@ -40,6 +47,7 @@ public class JBCefBrowserFactoryTest {
         Assert.assertFalse(JBCefBrowserFactory.shouldSuppressProblematicCharEvent(event));
     }
 
+    /** Verifies non-character keyboard events bypass the control-character filter. */
     @Test
     public void keepsNonCharEvents() {
         CefKeyboardHandler.CefKeyEvent event = new CefKeyboardHandler.CefKeyEvent(
@@ -56,6 +64,7 @@ public class JBCefBrowserFactoryTest {
         Assert.assertFalse(JBCefBrowserFactory.shouldSuppressProblematicCharEvent(event));
     }
 
+    /** Verifies zero-valued characters with a control key code are also suppressed. */
     @Test
     public void suppressesZeroCharOnNonEditableFieldWhenWindowsKeyCodeIsPresent() {
         CefKeyboardHandler.CefKeyEvent event = new CefKeyboardHandler.CefKeyEvent(
@@ -72,6 +81,7 @@ public class JBCefBrowserFactoryTest {
         Assert.assertTrue(JBCefBrowserFactory.shouldSuppressProblematicCharEvent(event));
     }
 
+    /** Verifies ordinary printable characters are never suppressed. */
     @Test
     public void keepsPrintableChars() {
         CefKeyboardHandler.CefKeyEvent event = new CefKeyboardHandler.CefKeyEvent(
@@ -112,16 +122,75 @@ public class JBCefBrowserFactoryTest {
     public static class BrowserWithoutClosedApi {
     }
 
+    /** Records builder options so Remote-forced OSR wiring can be tested without JCEF startup. */
+    private static final class RecordingBuilderOptions {
+        private boolean offScreenRendering;
+        private boolean devToolsEnabled;
+        private JBCefOSRHandlerFactory osrHandlerFactory;
+
+        private void setOffScreenRendering(boolean value) {
+            offScreenRendering = value;
+        }
+
+        private void setEnableOpenDevToolsMenuItem(boolean value) {
+            devToolsEnabled = value;
+        }
+
+        private void setOSRHandlerFactory(JBCefOSRHandlerFactory value) {
+            osrHandlerFactory = value;
+        }
+    }
+
+    /** Verifies a supplied fence factory is installed even when the requested mode is windowed. */
+    @Test
+    public void installsOsrFactoryBeforeRemoteCanOverrideWindowedMode() {
+        RecordingBuilderOptions builder = new RecordingBuilderOptions();
+        JBCefOSRHandlerFactory factory = new JBCefOSRHandlerFactory() { };
+
+        JBCefBrowserFactory.applyBuilderOptions(
+                false,
+                true,
+                factory,
+                builder::setOffScreenRendering,
+                builder::setEnableOpenDevToolsMenuItem,
+                builder::setOSRHandlerFactory);
+
+        Assert.assertFalse(builder.offScreenRendering);
+        Assert.assertTrue(builder.devToolsEnabled);
+        Assert.assertSame(factory, builder.osrHandlerFactory);
+    }
+
+    /** Verifies no default factory is fabricated when callers do not request a wrapper. */
+    @Test
+    public void leavesOsrFactoryUnsetWhenNoCustomFactoryWasRequested() {
+        RecordingBuilderOptions builder = new RecordingBuilderOptions();
+
+        JBCefBrowserFactory.applyBuilderOptions(
+                true,
+                false,
+                null,
+                builder::setOffScreenRendering,
+                builder::setEnableOpenDevToolsMenuItem,
+                builder::setOSRHandlerFactory);
+
+        Assert.assertTrue(builder.offScreenRendering);
+        Assert.assertFalse(builder.devToolsEnabled);
+        Assert.assertNull(builder.osrHandlerFactory);
+    }
+
+    /** Verifies the optional browser-closed API is discovered on newer runtimes. */
     @Test
     public void findsOptionalBrowserClosedApiWhenPresent() {
         Assert.assertTrue(JBCefBrowserFactory.findIsClosedMethod(BrowserWithClosedApi.class).isPresent());
     }
 
+    /** Verifies older runtimes without the browser-closed API remain supported. */
     @Test
     public void toleratesBrowserClosedApiMissingOnOlderPlatforms() {
         Assert.assertTrue(JBCefBrowserFactory.findIsClosedMethod(BrowserWithoutClosedApi.class).isEmpty());
     }
 
+    /** Verifies pre-2026 platform builds do not require the Remote JCEF API. */
     @Test
     public void remoteApiNotRequiredOnPlatformsBefore2026() {
         Assert.assertFalse(JBCefBrowserFactory.isRemoteApiRequiredByPlatform(233));
@@ -129,6 +198,7 @@ public class JBCefBrowserFactoryTest {
         Assert.assertFalse(JBCefBrowserFactory.isRemoteApiRequiredByPlatform(253));
     }
 
+    /** Verifies 2026+ platform builds require the Remote JCEF API contract. */
     @Test
     public void remoteApiRequiredSincePlatform2026() {
         // Android Studio Quail 2026.1.1 = AI-261.x
@@ -136,16 +206,19 @@ public class JBCefBrowserFactoryTest {
         Assert.assertTrue(JBCefBrowserFactory.isRemoteApiRequiredByPlatform(262));
     }
 
+    /** Verifies a compatible JBR exposes the Remote JCEF API. */
     @Test
     public void detectsRemoteApiWhenPresent() {
         Assert.assertTrue(JBCefBrowserFactory.hasJcefRemoteApi(JcefConfigWithRemoteApi.class));
     }
 
+    /** Verifies an incompatible JBR without the Remote API is detected. */
     @Test
     public void detectsMissingRemoteApi() {
         Assert.assertFalse(JBCefBrowserFactory.hasJcefRemoteApi(JcefConfigWithoutRemoteApi.class));
     }
 
+    /** Verifies registry disablement short-circuits all deeper support probes. */
     @Test
     public void disabledRegistryShortCircuitsPlatformSupportCheck() {
         AtomicBoolean platformChecked = new AtomicBoolean(false);
@@ -165,6 +238,7 @@ public class JBCefBrowserFactoryTest {
         Assert.assertFalse(pluginChecked.get());
     }
 
+    /** Verifies a supported platform does not require Android Studio's standalone plugin. */
     @Test
     public void platformSupportDoesNotRequireStandaloneJcefPlugin() {
         AtomicBoolean pluginChecked = new AtomicBoolean(false);
@@ -183,6 +257,7 @@ public class JBCefBrowserFactoryTest {
         Assert.assertFalse(pluginChecked.get());
     }
 
+    /** Verifies Android Studio's missing standalone JCEF plugin is reported precisely. */
     @Test
     public void reportsMissingAndroidStudioJcefPlugin() {
         JBCefBrowserFactory.JcefSupportStatus status = JBCefBrowserFactory.determineJcefSupport(
@@ -195,6 +270,7 @@ public class JBCefBrowserFactoryTest {
         Assert.assertEquals(JBCefBrowserFactory.JcefSupportStatus.ANDROID_STUDIO_PLUGIN_MISSING, status);
     }
 
+    /** Verifies an outdated JBR is reported after the platform support probe succeeds. */
     @Test
     public void reportsOutdatedJbrAfterPlatformSupportCheck() {
         JBCefBrowserFactory.JcefSupportStatus status = JBCefBrowserFactory.determineJcefSupport(
@@ -207,6 +283,7 @@ public class JBCefBrowserFactoryTest {
         Assert.assertEquals(JBCefBrowserFactory.JcefSupportStatus.OUTDATED_JBR, status);
     }
 
+    /** Verifies platform-level JCEF rejection is reported as unavailable. */
     @Test
     public void reportsUnavailableWhenPlatformRejectsJcef() {
         JBCefBrowserFactory.JcefSupportStatus status = JBCefBrowserFactory.determineJcefSupport(
@@ -219,6 +296,7 @@ public class JBCefBrowserFactoryTest {
         Assert.assertEquals(JBCefBrowserFactory.JcefSupportStatus.UNAVAILABLE, status);
     }
 
+    /** Verifies compatible platform and runtime inputs produce supported status. */
     @Test
     public void reportsSupportedJcef() {
         JBCefBrowserFactory.JcefSupportStatus status = JBCefBrowserFactory.determineJcefSupport(

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -7,8 +7,15 @@ interface Window {
    */
   sendToJava?: (message: string) => void;
 
-  /** Re-rasterize the JCEF surface after its IntelliJ content tab is activated. */
+  /** Legacy windowed-JCEF repaint requested after its IntelliJ content tab is activated. */
   onTabActivated?: () => void;
+
+  /** Strict two-frame OSR damage pulse, owned by a Java frame-fence attempt token. */
+  __ccguiSurfaceDamagePhaseA?: (token: string) => boolean;
+  __ccguiSurfaceDamagePhaseB?: (token: string) => boolean;
+  __ccguiSurfaceDamageReplace?: (previousToken: string, nextToken: string) => boolean;
+  __ccguiSurfaceDamageFinish?: (token: string) => boolean;
+  __ccguiSurfaceDamageCancel?: (token: string, predecessorToken?: string) => boolean;
 
   /**
    * Get clipboard file path from Java
@@ -120,7 +127,15 @@ interface Window {
    * History load complete callback - invoked when history messages finish loading.
    * Triggers Markdown re-rendering to fix incorrect rendering on first history load.
    */
-  historyLoadComplete?: () => void;
+  historyLoadComplete?: (expectedMessageCount?: string | number) => void;
+  /** Early history completion buffered before React installs the real callback. */
+  __pendingHistoryLoadComplete?: { expectedMessageCount?: string | number };
+  /** Number of messages in the latest full backend snapshot accepted by this page. */
+  __lastAcceptedMessageCount?: number;
+  /** Restored-history snapshot size that still needs a React commit acknowledgment. */
+  __pendingHistoryRefreshMessageCount?: number;
+  /** Identifies or invalidates a commit-bound repaint when the page changes sessions first. */
+  __historySurfaceRefreshEpoch?: number;
 
   /**
    * Subagent sidechain history callback.

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { createElement, useState } from 'react';
+import { act, render, renderHook, waitFor } from '@testing-library/react';
 import { useWindowCallbacks } from './useWindowCallbacks.js';
 import type { UseWindowCallbacksOptions } from './useWindowCallbacks.js';
 import type { ClaudeMessage } from '../types/index.js';
@@ -6,7 +7,9 @@ import { forceWebviewRepaint } from '../utils/forceWebviewRepaint.js';
 
 // Mock the repaint util so we can assert the session-transition path triggers it
 // without touching the real DOM (there is no #app element under jsdom).
-vi.mock('../utils/forceWebviewRepaint.js', () => ({ forceWebviewRepaint: vi.fn() }));
+vi.mock('../utils/forceWebviewRepaint.js', () => ({
+  forceWebviewRepaint: vi.fn((_reason?: string, onRepaint?: () => void) => onRepaint?.()),
+}));
 
 /**
  * Integration tests for useWindowCallbacks — verifies the real window callback
@@ -126,6 +129,11 @@ describe('useWindowCallbacks integration', () => {
     delete window.__pendingBackendTabState;
     delete window.__pendingUsageUpdate;
     delete window.__CCGUI_RECOVERY_STATE_APPLIED__;
+    delete window.__lastAcceptedMessageCount;
+    delete window.__pendingHistoryRefreshMessageCount;
+    delete window.__pendingHistoryLoadComplete;
+    delete window.__historySurfaceRefreshEpoch;
+    vi.mocked(forceWebviewRepaint).mockClear();
     window.__dependencyStatusState = 'pending';
   });
 
@@ -250,6 +258,7 @@ describe('useWindowCallbacks integration', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     delete window.__codexHistoryPageInfo;
   });
@@ -504,6 +513,153 @@ describe('useWindowCallbacks integration', () => {
 
     // setMessages SHOULD be called
     expect(opts.setMessages).toHaveBeenCalled();
+  });
+
+  it('reports one DOM commit when restored history arrives after completion', () => {
+    const opts = createOptions();
+    vi.useFakeTimers();
+    renderHook(() => useWindowCallbacks(opts));
+
+    act(() => {
+      window.updateMessages!(JSON.stringify([]), 1);
+      window.historyLoadComplete!('1');
+    });
+
+    expect(window.__pendingHistoryRefreshMessageCount).toBe(1);
+
+    act(() => {
+      window.updateMessages!(JSON.stringify([
+        { type: 'user', content: 'restored history' },
+      ]), 2);
+    });
+
+    expect(window.__pendingHistoryRefreshMessageCount).toBeUndefined();
+    act(() => vi.runAllTimers());
+    expect(window.sendToJava).toHaveBeenCalledWith('history_dom_committed:1');
+
+    act(() => {
+      window.updateMessages!(JSON.stringify([
+        { type: 'user', content: 'normal follow-up' },
+      ]), 3);
+    });
+
+    const historyRefreshCalls = (window.sendToJava as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([payload]) => payload === 'history_dom_committed:1');
+    expect(historyRefreshCalls).toHaveLength(1);
+    vi.useRealTimers();
+  });
+
+  it('drains an early history completion only after the restored message DOM commits', async () => {
+    const restoredMessages: ClaudeMessage[] = [
+      { type: 'assistant', content: 'restored before callback registration' },
+    ];
+    window.__pendingUpdateMessages = {
+      json: JSON.stringify(restoredMessages),
+      sequence: 1,
+    };
+    window.__pendingHistoryLoadComplete = { expectedMessageCount: 1 };
+    let domTextWhenAcknowledged = '';
+    window.sendToJava = vi.fn((payload: string) => {
+      if (payload === 'history_dom_committed:1') {
+        domTextWhenAcknowledged = document.querySelector('[data-testid="history-dom"]')?.textContent ?? '';
+      }
+    });
+
+    const HistoryHarness = () => {
+      const [messages, setMessages] = useState<ClaudeMessage[]>([]);
+      useWindowCallbacks(createOptions({ setMessages }));
+      return createElement(
+        'div',
+        { 'data-testid': 'history-dom' },
+        messages.map(message => message.content).join('|'),
+      );
+    };
+
+    render(createElement(HistoryHarness));
+
+    await waitFor(() => {
+      expect(domTextWhenAcknowledged).toContain('restored before callback registration');
+    });
+    expect(window.__pendingHistoryLoadComplete).toBeUndefined();
+    expect(window.sendToJava).toHaveBeenCalledWith('history_dom_committed:1');
+  });
+
+  it('preserves an explicit zero count buffered before callback registration', async () => {
+    window.__pendingHistoryLoadComplete = { expectedMessageCount: 0 };
+    renderHook(() => useWindowCallbacks(createOptions()));
+
+    await waitFor(() => {
+      expect(window.sendToJava).toHaveBeenCalledWith('history_dom_committed:1');
+    });
+    expect(window.__pendingHistoryLoadComplete).toBeUndefined();
+    expect(window.sendToJava).toHaveBeenCalledWith('history_dom_committed:1');
+  });
+
+  it('reports a DOM commit when the restored-history snapshot arrived first', () => {
+    const opts = createOptions();
+    vi.useFakeTimers();
+    renderHook(() => useWindowCallbacks(opts));
+
+    act(() => {
+      window.updateMessages!(JSON.stringify([
+        { type: 'assistant', content: 'already restored' },
+      ]), 1);
+    });
+    act(() => {
+      window.historyLoadComplete!(1);
+    });
+
+    expect(window.__pendingHistoryRefreshMessageCount).toBeUndefined();
+    act(() => vi.runAllTimers());
+    expect(window.sendToJava).toHaveBeenCalledWith('history_dom_committed:1');
+    vi.useRealTimers();
+  });
+
+  it('keeps the restored-history refresh pending when a stale snapshot is rejected', () => {
+    const opts = createOptions();
+    vi.useFakeTimers();
+    window.__minAcceptedUpdateSequence = 5;
+    renderHook(() => useWindowCallbacks(opts));
+
+    act(() => {
+      window.historyLoadComplete!(1);
+      window.updateMessages!(JSON.stringify([
+        { type: 'assistant', content: 'stale history' },
+      ]), 4);
+    });
+
+    expect(window.__pendingHistoryRefreshMessageCount).toBe(1);
+
+    act(() => {
+      window.updateMessages!(JSON.stringify([
+        { type: 'assistant', content: 'current history' },
+      ]), 5);
+    });
+
+    expect(window.__pendingHistoryRefreshMessageCount).toBeUndefined();
+    act(() => vi.runAllTimers());
+    expect(window.sendToJava).toHaveBeenCalledWith('history_dom_committed:1');
+    vi.useRealTimers();
+  });
+
+  it('cancels a deferred restored-history refresh when the session is cleared', () => {
+    const opts = createOptions();
+    vi.useFakeTimers();
+    renderHook(() => useWindowCallbacks(opts));
+
+    act(() => {
+      window.historyLoadComplete!(1);
+      window.clearMessages!();
+      window.updateMessages!(JSON.stringify([
+        { type: 'assistant', content: 'new session' },
+      ]), 1);
+    });
+
+    act(() => vi.runAllTimers());
+    expect(window.__pendingHistoryRefreshMessageCount).toBeUndefined();
+    expect(window.sendToJava).not.toHaveBeenCalledWith('history_dom_committed:1');
+    expect(forceWebviewRepaint).toHaveBeenCalledWith('session-transition');
+    vi.useRealTimers();
   });
 
   it('buffers a Codex history page and prepends it in one ordered state update', () => {

--- a/webview/src/hooks/useWindowCallbacks.ts
+++ b/webview/src/hooks/useWindowCallbacks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { TFunction } from 'i18next';
 import type { MutableRefObject, RefObject } from 'react';
 import type { ClaudeMessage, ClaudeRawMessage, HistoryData, SubagentHistoryResponse, TaskEventMap } from '../types';
@@ -14,6 +14,7 @@ import type { AskUserQuestionRequest } from '../components/AskUserQuestionDialog
 import type { PlanApprovalRequest } from '../components/PlanApprovalDialog';
 import type { RewindRequest } from '../components/RewindDialog';
 import { registerWindowCallbacks } from './windowCallbacks/registerCallbacks';
+import { sendBridgeEvent } from '../utils/bridge';
 
 // Re-export from messageSync to avoid duplicate definition
 export { OPTIMISTIC_MESSAGE_TIME_WINDOW } from './windowCallbacks/messageSync';
@@ -126,6 +127,7 @@ export interface UseWindowCallbacksOptions {
 
 export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
   const { t } = options;
+  const [historyRenderCommitEpoch, setHistoryRenderCommitEpoch] = useState(0);
 
   // Store t in ref to avoid stale closures
   const tRef = useRef(t);
@@ -134,8 +136,20 @@ export function useWindowCallbacks(options: UseWindowCallbacksOptions): void {
   }, [t]);
 
   useEffect(() => {
-    registerWindowCallbacks(options, tRef);
+    registerWindowCallbacks(options, tRef, setHistoryRenderCommitEpoch);
     // Callbacks are registered once on mount; re-registration would cause duplicate handlers.
     // Options object reference is intentionally excluded from deps.
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // This signal means only that React committed the restored message tree. Native OSR
+  // publication is fenced separately by Java using real OnPaint callbacks.
+  useLayoutEffect(() => {
+    if (
+      historyRenderCommitEpoch > 0
+      && window.__historySurfaceRefreshEpoch === historyRenderCommitEpoch
+    ) {
+      sendBridgeEvent('history_dom_committed', String(historyRenderCommitEpoch));
+    }
+    return undefined;
+  }, [historyRenderCommitEpoch]);
 }

--- a/webview/src/hooks/windowCallbacks/registerCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks.ts
@@ -61,6 +61,7 @@ function appendSubagentHistoryChunk(transferId: string, chunk: string, isFinal: 
 export function registerWindowCallbacks(
   options: UseWindowCallbacksOptions,
   tRef: MutableRefObject<UseWindowCallbacksOptions['t']>,
+  requestHistoryRenderCommit: (refreshEpoch: number) => void,
 ): void {
   // -------------------------------------------------------------------------
   // Session transition helpers
@@ -93,7 +94,7 @@ export function registerWindowCallbacks(
   // Register callback groups
   // =========================================================================
 
-  registerMessageCallbacks(options, resetTransientUiState);
+  registerMessageCallbacks(options, resetTransientUiState, requestHistoryRenderCommit);
   registerStreamingCallbacks(options);
   registerSessionAndSdkCallbacks(options, tRef);
   registerUsageModeCallbacks(options);

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
@@ -68,6 +68,7 @@ function getStructuralRawBlockSignature(
 export function registerMessageCallbacks(
   options: UseWindowCallbacksOptions,
   resetTransientUiState: () => void,
+  requestHistoryRenderCommit: (refreshEpoch: number) => void,
 ): void {
   const {
     addToast,
@@ -172,6 +173,20 @@ export function registerMessageCallbacks(
     window.__pendingUpdateSequence = null;
   };
   window.__cancelPendingUpdateMessages = cancelPendingUpdateMessages;
+
+  const requestNativeHistoryRefresh = () => {
+    const refreshEpoch = (window.__historySurfaceRefreshEpoch ?? 0) + 1;
+    window.__historySurfaceRefreshEpoch = refreshEpoch;
+    requestHistoryRenderCommit(refreshEpoch);
+  };
+
+  const refreshRestoredHistoryIfPending = (acceptedMessageCount: number) => {
+    if (window.__pendingHistoryRefreshMessageCount !== acceptedMessageCount) {
+      return;
+    }
+    window.__pendingHistoryRefreshMessageCount = undefined;
+    requestNativeHistoryRefresh();
+  };
 
   const processUpdateMessages = (json: string, sequence: number | null = null) => {
     // Re-check the session-transition guard inside processUpdateMessages so the
@@ -415,6 +430,8 @@ export function registerMessageCallbacks(
 
         return finalizeMessageList(prev, patched);
       });
+      window.__lastAcceptedMessageCount = backendMessages.length;
+      refreshRestoredHistoryIfPending(backendMessages.length);
     } catch (error) {
       console.error('[Frontend] Failed to parse messages:', error);
     }
@@ -726,6 +743,9 @@ export function registerMessageCallbacks(
     pendingCodexHistoryPages.clear();
     window.__prependedHistoryMessageCount = 0;
     window.__messageBaseIndex = 0;
+    window.__lastAcceptedMessageCount = undefined;
+    window.__pendingHistoryRefreshMessageCount = undefined;
+    window.__historySurfaceRefreshEpoch = (window.__historySurfaceRefreshEpoch ?? 0) + 1;
     resetTransientUiState();
     closeContextUsageDialog();
     setMessages([]);
@@ -925,7 +945,7 @@ export function registerMessageCallbacks(
 
   window.codexHistoryPageRenderComplete = refreshLoadedHistoryMessages;
 
-  window.historyLoadComplete = () => {
+  window.historyLoadComplete = (expectedMessageCountArg) => {
     releaseSessionTransition();
     const pendingToast = window.__pendingSessionTransitionToast;
     if (pendingToast) {
@@ -933,7 +953,32 @@ export function registerMessageCallbacks(
       addToast(pendingToast.message, pendingToast.type);
     }
     refreshLoadedHistoryMessages();
+
+    const expectedMessageCount = typeof expectedMessageCountArg === 'number'
+      ? expectedMessageCountArg
+      : typeof expectedMessageCountArg === 'string' && expectedMessageCountArg.trim().length > 0
+        ? Number.parseInt(expectedMessageCountArg, 10)
+        : Number.NaN;
+    if (Number.isSafeInteger(expectedMessageCount) && expectedMessageCount >= 0) {
+      const emptyHistoryNeedsNoSnapshot = expectedMessageCount === 0
+        && window.__lastAcceptedMessageCount === undefined;
+      if (window.__lastAcceptedMessageCount === expectedMessageCount || emptyHistoryNeedsNoSnapshot) {
+        if (emptyHistoryNeedsNoSnapshot) {
+          window.__lastAcceptedMessageCount = 0;
+        }
+        window.__pendingHistoryRefreshMessageCount = undefined;
+        requestNativeHistoryRefresh();
+      } else {
+        window.__pendingHistoryRefreshMessageCount = expectedMessageCount;
+      }
+    }
   };
+
+  const pendingHistoryLoadComplete = window.__pendingHistoryLoadComplete;
+  if (pendingHistoryLoadComplete) {
+    window.__pendingHistoryLoadComplete = undefined;
+    window.historyLoadComplete(pendingHistoryLoadComplete.expectedMessageCount);
+  }
 
   window.addUserMessage = (content: string) => {
     if (window.__sessionTransitioning) return;

--- a/webview/src/main.tsx
+++ b/webview/src/main.tsx
@@ -17,6 +17,14 @@ import { installRuntimeProviderDispatchers } from './utils/runtimeProviderCapabi
 import { sendBridgeEvent } from './utils/bridge';
 import { debugLog } from './utils/debug';
 import { forceWebviewRepaint } from './utils/forceWebviewRepaint';
+import {
+  advanceSurfaceDamagePulse,
+  beginSurfaceDamagePulse,
+  cancelSurfaceDamagePulse,
+  finishSurfaceDamagePulse,
+  replaceSurfaceDamagePulse,
+  runAfterSurfaceDamagePulse,
+} from './utils/surfaceDamagePulse';
 import { requestDependencyStatusUntilSettled, waitForBridge } from './utils/bridgeStartup';
 import type { UiFontConfig, CodeFontConfig } from './types/uiFontConfig';
 
@@ -127,8 +135,6 @@ if (enableVConsole) {
  * a resize recalculation for components relying on window size.
  */
 function setupScaleRecovery() {
-  type CSSStyleDeclarationWithZoom = CSSStyleDeclaration & { zoom: string };
-
   const getExpectedScale = (): string => {
     const fromCss = getComputedStyle(document.documentElement).getPropertyValue('--font-scale').trim();
     if (fromCss) return fromCss;
@@ -153,41 +159,20 @@ function setupScaleRecovery() {
   const RECOVERY_COOLDOWN_MS = 1500;
 
   const forceReapply = (reason: string) => {
-    const app = document.getElementById('app') as HTMLElement | null;
     const expected = getExpectedScale();
+    const app = document.getElementById('app');
+    const computedZoom = app
+      ? (getComputedStyle(app) as CSSStyleDeclaration & { zoom?: string }).zoom
+      : '';
+    const expectedNumber = Number.parseFloat(expected);
+    const computedNumber = Number.parseFloat(computedZoom || '');
+    const needsZoomNudge = !!app
+      && Number.isFinite(expectedNumber)
+      && (!Number.isFinite(computedNumber) || Math.abs(computedNumber - expectedNumber) > 0.01);
 
     // Re-set the CSS variable to ensure width/height calc(100vw/scale) is refreshed.
     document.documentElement.style.setProperty('--font-scale', expected);
-
-    const computedZoom = app
-      ? (getComputedStyle(app) as unknown as CSSStyleDeclarationWithZoom).zoom
-      : null;
-    const computedZoomNumber = typeof computedZoom === 'string' ? parseFloat(computedZoom) : Number.NaN;
-    const expectedNumber = parseFloat(expected);
-
-    const needsZoomNudge =
-      !!app &&
-      Number.isFinite(expectedNumber) &&
-      (!Number.isFinite(computedZoomNumber) || Math.abs(computedZoomNumber - expectedNumber) > 0.01);
-
-    if (app && needsZoomNudge) {
-      const appStyle = app.style as unknown as CSSStyleDeclarationWithZoom;
-      // Toggle inline zoom to ensure Chromium/JCEF re-applies scaling after resume.
-      // Keep the final value aligned with the CSS variable.
-      appStyle.zoom = '1';
-      // Force a sync layout.
-      void app.offsetHeight;
-      appStyle.zoom = expected;
-    }
-
-    // Let components recompute layout (some rely on window resize).
-    requestAnimationFrame(() => {
-      window.dispatchEvent(new Event('resize'));
-      if (app && needsZoomNudge) {
-        const appStyle = app.style as unknown as CSSStyleDeclarationWithZoom;
-        // One more tick to reduce flakiness on macOS/JCEF.
-        appStyle.zoom = expected;
-      }
+    const completeRecovery = () => {
       debugLog('[ScaleRecovery] Applied scale recovery:', {
         reason,
         expected,
@@ -195,7 +180,19 @@ function setupScaleRecovery() {
         needsZoomNudge,
       });
       lastRecoveryAt = Date.now();
-    });
+    };
+    if (needsZoomNudge) {
+      // The shared coordinator is the sole inline-zoom writer. If an OSR pulse is
+      // active this request remains coalesced until that exact token settles.
+      forceWebviewRepaint(`scale-recovery:${reason}`, completeRecovery);
+      return;
+    }
+    const resizeOnly = () => {
+      if (runAfterSurfaceDamagePulse(resizeOnly)) return;
+      window.dispatchEvent(new Event('resize'));
+      completeRecovery();
+    };
+    requestAnimationFrame(resizeOnly);
   };
 
   const schedule = (reason: string) => {
@@ -523,6 +520,16 @@ if (typeof window !== 'undefined' && !window.updateMessages) {
   };
 }
 
+// Pre-register historyLoadComplete for fast history restores that finish before
+// React installs the real callback. Keep an object wrapper so an explicit zero
+// message count is distinguishable from no pending callback.
+if (typeof window !== 'undefined' && !window.historyLoadComplete) {
+  debugLog('[Main] Pre-registering historyLoadComplete placeholder');
+  window.historyLoadComplete = (expectedMessageCount?: string | number) => {
+    window.__pendingHistoryLoadComplete = { expectedMessageCount };
+  };
+}
+
 // Pre-register updateStatus to handle backend status text that arrives before React initializes
 if (typeof window !== 'undefined' && !window.updateStatus) {
   debugLog('[Main] Pre-registering updateStatus placeholder');
@@ -680,6 +687,11 @@ if (typeof window !== 'undefined' && !window.showPlanApprovalDialog) {
 }
 
 if (typeof window !== 'undefined') {
+  window.__ccguiSurfaceDamagePhaseA = beginSurfaceDamagePulse;
+  window.__ccguiSurfaceDamagePhaseB = advanceSurfaceDamagePulse;
+  window.__ccguiSurfaceDamageReplace = replaceSurfaceDamagePulse;
+  window.__ccguiSurfaceDamageFinish = finishSurfaceDamagePulse;
+  window.__ccguiSurfaceDamageCancel = cancelSurfaceDamagePulse;
   window.updateLinkifyCapabilities = (json: string) => {
     applyLinkifyCapabilitiesPayload(json);
   };

--- a/webview/src/utils/forceWebviewRepaint.test.ts
+++ b/webview/src/utils/forceWebviewRepaint.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { forceWebviewRepaint } from './forceWebviewRepaint';
+import {
+  advanceSurfaceDamagePulse,
+  beginSurfaceDamagePulse,
+  cancelSurfaceDamagePulse,
+  finishSurfaceDamagePulse,
+} from './surfaceDamagePulse';
 
 describe('forceWebviewRepaint', () => {
   let rafQueue: FrameRequestCallback[] = [];
@@ -19,6 +25,7 @@ describe('forceWebviewRepaint', () => {
   });
 
   afterEach(() => {
+    cancelSurfaceDamagePulse('strict-attempt');
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
@@ -42,7 +49,9 @@ describe('forceWebviewRepaint', () => {
       offsetHeight: 0,
     } as unknown as HTMLElement;
 
-    vi.spyOn(document, 'getElementById').mockReturnValue(app);
+    vi.spyOn(document, 'getElementById').mockImplementation((id) => (
+      id === 'app' ? app : document.querySelector(`#${id}`)
+    ));
     const dispatchSpy = vi.spyOn(window, 'dispatchEvent').mockReturnValue(true);
 
     forceWebviewRepaint('unit-test');
@@ -55,11 +64,29 @@ describe('forceWebviewRepaint', () => {
 
     // zoom is forced to '1' then restored to the --font-scale value, forcing
     // Chromium/JCEF to re-rasterize the whole viewport.
-    expect(zoomWrites).toEqual(['1', '1.1']);
+    expect(zoomWrites).toEqual(['1.0989', '1.1']);
     const resizeDispatched = dispatchSpy.mock.calls.some(
       ([evt]) => evt instanceof Event && evt.type === 'resize'
     );
     expect(resizeDispatched).toBe(true);
+  });
+
+  it('invokes the completion callback once after repaint instead of when scheduled', () => {
+    const app = {
+      style: { zoom: '' },
+      offsetHeight: 0,
+    } as unknown as HTMLElement;
+    const onRepaint = vi.fn();
+
+    vi.spyOn(document, 'getElementById').mockReturnValue(app);
+    forceWebviewRepaint('history-render-complete', onRepaint);
+
+    expect(onRepaint).not.toHaveBeenCalled();
+    flushRaf();
+    expect(onRepaint).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(50);
+    expect(onRepaint).toHaveBeenCalledTimes(1);
   });
 
   it('is a no-op and does not throw when #app is missing', () => {
@@ -89,7 +116,7 @@ describe('forceWebviewRepaint', () => {
     forceWebviewRepaint('tab-activated');
     vi.advanceTimersByTime(50);
 
-    expect(zoomWrites).toEqual(['1', '1.1']);
+    expect(zoomWrites).toEqual(['1.0989', '1.1']);
     expect(dispatchSpy).toHaveBeenCalledWith(expect.objectContaining({ type: 'resize' }));
   });
 
@@ -112,5 +139,63 @@ describe('forceWebviewRepaint', () => {
     flushRaf();
 
     expect(zoomWrites).toEqual(['0.999', '1', '0.999', '1']);
+  });
+
+  it('coalesces generic repaints until a strict two-frame pulse has finished', async () => {
+    fontScale = '1';
+    const zoomWrites: string[] = [];
+    const app = {
+      style: {
+        set zoom(v: string) { zoomWrites.push(v); },
+        get zoom() { return zoomWrites[zoomWrites.length - 1] ?? ''; },
+      },
+      offsetHeight: 0,
+    } as unknown as HTMLElement;
+    const firstCallback = vi.fn();
+    const secondCallback = vi.fn();
+    vi.spyOn(document, 'getElementById').mockImplementation((id) => (
+      id === 'app' ? app : document.querySelector(`#${id}`)
+    ));
+
+    expect(beginSurfaceDamagePulse('strict-attempt')).toBe(true);
+    forceWebviewRepaint('dialog-close', firstCallback);
+    forceWebviewRepaint('tab-activated', secondCallback);
+    expect(zoomWrites).toEqual([]);
+
+    expect(advanceSurfaceDamagePulse('strict-attempt')).toBe(true);
+    expect(finishSurfaceDamagePulse('strict-attempt')).toBe(true);
+    await Promise.resolve();
+    flushRaf();
+
+    expect(zoomWrites).toEqual(['0.999', '1']);
+    expect(firstCallback).toHaveBeenCalledTimes(1);
+    expect(secondCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('rechecks ownership when a pulse begins after generic repaint scheduling', async () => {
+    fontScale = '1';
+    const zoomWrites: string[] = [];
+    const app = {
+      style: {
+        set zoom(v: string) { zoomWrites.push(v); },
+        get zoom() { return zoomWrites[zoomWrites.length - 1] ?? ''; },
+      },
+      offsetHeight: 0,
+    } as unknown as HTMLElement;
+    vi.spyOn(document, 'getElementById').mockImplementation((id) => (
+      id === 'app' ? app : document.querySelector(`#${id}`)
+    ));
+
+    forceWebviewRepaint('scheduled-before-pulse');
+    expect(beginSurfaceDamagePulse('strict-attempt')).toBe(true);
+    flushRaf();
+    vi.advanceTimersByTime(50);
+
+    expect(zoomWrites).toEqual([]);
+    expect(advanceSurfaceDamagePulse('strict-attempt')).toBe(true);
+    expect(finishSurfaceDamagePulse('strict-attempt')).toBe(true);
+    await Promise.resolve();
+
+    expect(zoomWrites).toEqual(['0.999', '1']);
   });
 });

--- a/webview/src/utils/forceWebviewRepaint.ts
+++ b/webview/src/utils/forceWebviewRepaint.ts
@@ -1,55 +1,59 @@
 /**
- * forceWebviewRepaint
+ * Coalesces legacy generic JCEF ghosting recovery behind the tokenized OSR pulse.
  *
- * Clears JCEF native-rendering ghosting on macOS by forcing a full-viewport
- * re-rasterization.
- *
- * Why this is needed: on macOS JCEF runs in native (windowed) rendering mode
- * (see JBCefBrowserFactory.determineOsrMode). In that mode Chromium's compositor
- * sometimes fails to invalidate the region a compositing-layer element occupied
- * after React unmounts it or its parent reflows — leaving stale pixels (ghosting).
- * Typical culprits: position:fixed/animated overlays (the changelog dialog) and
- * input-box header content that grows/shrinks (open-source banner, attachments).
- *
- * The fix reuses the zoom-nudge technique already proven in main.tsx `forceReapply`
- * ("Toggle inline zoom to ensure Chromium/JCEF re-applies scaling"), but applies it
- * unconditionally. A timer fallback handles deprioritized/hidden JCEF surfaces where
- * requestAnimationFrame can remain suspended during tab activation.
- *
- * @param _reason optional label for debugging; intentionally unused at runtime.
+ * A request may be scheduled before a Java pulse begins, so pulse ownership is
+ * checked again inside the actual timer/rAF callback. All inline-zoom writes are
+ * delegated to surfaceDamagePulse; this module only owns scheduling and callback
+ * coalescing.
  */
-export function forceWebviewRepaint(_reason?: string): void {
-  const app = document.getElementById('app');
-  if (!app) return;
+import {
+  performGenericSurfaceDamage,
+  runAfterSurfaceDamagePulse,
+} from './surfaceDamagePulse';
 
-  const appStyle = app.style as CSSStyleDeclaration & { zoom?: string };
-  // Restore target: align with the scale main.tsx maintains via --font-scale.
-  const expectedScale = getComputedStyle(document.documentElement)
-    .getPropertyValue('--font-scale')
-    .trim();
+let repaintScheduled = false;
+let pendingCallbacks: Array<() => void> = [];
 
-  let repainted = false;
+export function forceWebviewRepaint(_reason?: string, onRepaint?: () => void): void {
+  if (onRepaint) {
+    pendingCallbacks.push(onRepaint);
+  }
+  if (repaintScheduled) return;
+  repaintScheduled = true;
+
+  let completed = false;
+  let fallbackId: number | undefined;
   const repaint = () => {
-    if (repainted) return;
-    repainted = true;
-    const restore = expectedScale || appStyle.zoom || '1';
-    const numericRestore = Number.parseFloat(restore);
-    const nudge = Number.isFinite(numericRestore) && Math.abs(numericRestore - 1) < 0.0001
-      ? '0.999'
-      : '1';
-    appStyle.zoom = nudge;
-    void app.offsetHeight;
-    appStyle.zoom = restore;
-    window.dispatchEvent(new Event('resize'));
+    if (completed) return;
+    if (runAfterSurfaceDamagePulse(repaint)) return;
+
+    const app = document.getElementById('app');
+    if (!app) {
+      completed = true;
+      repaintScheduled = false;
+      pendingCallbacks = [];
+      return;
+    }
+    const expectedScale = getComputedStyle(document.documentElement)
+      .getPropertyValue('--font-scale')
+      .trim();
+    if (!performGenericSurfaceDamage(app, expectedScale)) {
+      runAfterSurfaceDamagePulse(repaint);
+      return;
+    }
+
+    completed = true;
+    if (fallbackId !== undefined) window.clearTimeout(fallbackId);
+    repaintScheduled = false;
+    const callbacks = pendingCallbacks;
+    pendingCallbacks = [];
+    callbacks.forEach((callback) => callback());
   };
 
-  // Keep the normal double-rAF path for post-React layout, but do not rely on it:
-  // JCEF can suspend rAF while a native-rendered content tab is hidden/black.
-  const fallbackId = window.setTimeout(repaint, 50);
+  // Keep the double-rAF path for post-React layout. The timer only schedules the
+  // generic mutation; the execution-time ownership check remains authoritative.
+  fallbackId = window.setTimeout(repaint, 50);
   requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
-      window.clearTimeout(fallbackId);
-      repaint();
-    });
+    requestAnimationFrame(repaint);
   });
 }

--- a/webview/src/utils/surfaceDamagePulse.test.ts
+++ b/webview/src/utils/surfaceDamagePulse.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  advanceSurfaceDamagePulse,
+  beginSurfaceDamagePulse,
+  cancelSurfaceDamagePulse,
+  finishSurfaceDamagePulse,
+  replaceSurfaceDamagePulse,
+  runAfterSurfaceDamagePulse,
+} from './surfaceDamagePulse';
+
+describe('surfaceDamagePulse', () => {
+  const tokens = ['attempt-a', 'attempt-b'];
+  let bridgeMessages: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="app" style="zoom: 1.4"></div>';
+    bridgeMessages = vi.fn();
+    window.sendToJava = bridgeMessages;
+  });
+
+  afterEach(() => {
+    tokens.forEach((token) => cancelSurfaceDamagePulse(token));
+    document.body.innerHTML = '';
+    delete window.sendToJava;
+    vi.restoreAllMocks();
+  });
+
+  it('acknowledges sentinel mutations without changing app zoom', () => {
+    const app = document.getElementById('app') as HTMLElement;
+
+    expect(beginSurfaceDamagePulse('attempt-a')).toBe(true);
+    const sentinel = document.getElementById('ccgui-surface-damage-sentinel');
+    expect(sentinel).not.toBeNull();
+    expect(sentinel?.parentElement).toBe(document.body);
+    expect(app.contains(sentinel)).toBe(false);
+    expect(sentinel?.style.position).toBe('fixed');
+    expect(sentinel?.style.pointerEvents).toBe('none');
+    expect(sentinel?.style.contain).toBe('strict');
+    expect(sentinel?.style.backgroundColor).not.toBe('transparent');
+    expect(app.style.zoom).toBe('1.4');
+    expect(bridgeMessages).toHaveBeenLastCalledWith(
+      'surface_damage_applied:{"token":"attempt-a","phase":"A","applied":true}',
+    );
+
+    expect(advanceSurfaceDamagePulse('attempt-a')).toBe(true);
+    expect(sentinel?.style.backgroundColor).toBe('transparent');
+    expect(app.style.zoom).toBe('1.4');
+    expect(bridgeMessages).toHaveBeenLastCalledWith(
+      'surface_damage_applied:{"token":"attempt-a","phase":"B","applied":true}',
+    );
+
+    expect(finishSurfaceDamagePulse('attempt-a')).toBe(true);
+    expect(document.getElementById('ccgui-surface-damage-sentinel')).toBeNull();
+  });
+
+  it('rejects stale phase requests without mutating the active sentinel', () => {
+    expect(beginSurfaceDamagePulse('attempt-a')).toBe(true);
+    const sentinel = document.getElementById('ccgui-surface-damage-sentinel');
+    const phaseAColor = sentinel?.style.backgroundColor;
+
+    expect(advanceSurfaceDamagePulse('attempt-b')).toBe(false);
+    expect(sentinel?.style.backgroundColor).toBe(phaseAColor);
+    expect(bridgeMessages).toHaveBeenLastCalledWith(
+      'surface_damage_applied:{"token":"attempt-b","phase":"B","applied":false}',
+    );
+  });
+
+  it('removes the sentinel when a phase-A attempt is cancelled', () => {
+    expect(beginSurfaceDamagePulse('attempt-a')).toBe(true);
+
+    expect(cancelSurfaceDamagePulse('attempt-a')).toBe(true);
+    expect(document.getElementById('ccgui-surface-damage-sentinel')).toBeNull();
+    expect((document.getElementById('app') as HTMLElement).style.zoom).toBe('1.4');
+  });
+
+  it('replaces the exact owner with a different raster variant without releasing waiters', async () => {
+    const deferred = vi.fn();
+    expect(beginSurfaceDamagePulse('attempt-a')).toBe(true);
+    const sentinel = document.getElementById('ccgui-surface-damage-sentinel');
+    const firstColor = sentinel?.style.backgroundColor;
+    expect(runAfterSurfaceDamagePulse(deferred)).toBe(true);
+
+    expect(replaceSurfaceDamagePulse('attempt-a', 'attempt-b')).toBe(true);
+    await Promise.resolve();
+
+    expect(sentinel?.style.backgroundColor).not.toBe(firstColor);
+    expect(deferred).not.toHaveBeenCalled();
+    expect(bridgeMessages).toHaveBeenLastCalledWith(
+      'surface_damage_applied:{"token":"attempt-b","phase":"A","applied":true}',
+    );
+    expect(cancelSurfaceDamagePulse('attempt-b')).toBe(true);
+    await Promise.resolve();
+    expect(deferred).toHaveBeenCalledTimes(1);
+    expect(document.getElementById('ccgui-surface-damage-sentinel')).toBeNull();
+  });
+
+  it('rejects replacement when the declared predecessor does not own the sentinel', () => {
+    expect(beginSurfaceDamagePulse('attempt-a')).toBe(true);
+    const sentinel = document.getElementById('ccgui-surface-damage-sentinel');
+    const phaseAColor = sentinel?.style.backgroundColor;
+
+    expect(replaceSurfaceDamagePulse('stale-attempt', 'attempt-b')).toBe(false);
+    expect(sentinel?.style.backgroundColor).toBe(phaseAColor);
+    expect(bridgeMessages).toHaveBeenLastCalledWith(
+      'surface_damage_applied:{"token":"attempt-b","phase":"A","applied":false}',
+    );
+  });
+});

--- a/webview/src/utils/surfaceDamagePulse.ts
+++ b/webview/src/utils/surfaceDamagePulse.ts
@@ -1,0 +1,198 @@
+import { sendBridgeEvent } from './bridge';
+
+/**
+ * Coordinates strict raster-sentinel pulses and legacy generic zoom repaints.
+ *
+ * The Java OSR frame fence owns a tokenized A/B pulse. Generic repaint work can
+ * only mutate zoom while no pulse is active, and it rechecks that ownership at
+ * execution time. Each phase reports an applied acknowledgment after its DOM
+ * mutation and forced layout have run; Java never advances a paint gate merely
+ * because executeJavaScript accepted a script for asynchronous execution.
+ */
+
+type SurfaceDamagePhase = 'A' | 'B';
+
+interface ActiveSurfaceDamagePulse {
+  token: string;
+  sentinel: HTMLElement;
+  phase: SurfaceDamagePhase;
+}
+
+let activePulse: ActiveSurfaceDamagePulse | null = null;
+let nextSentinelVariant = 0;
+const settledWaiters = new Set<() => void>();
+const SENTINEL_ID = 'ccgui-surface-damage-sentinel';
+const SENTINEL_COLORS = [
+  'rgba(255, 0, 255, 0.01)',
+  'rgba(0, 255, 255, 0.01)',
+] as const;
+
+function acknowledgePhase(token: string, phase: SurfaceDamagePhase, applied: boolean): void {
+  sendBridgeEvent('surface_damage_applied', JSON.stringify({ token, phase, applied }));
+}
+
+function parseEffectiveScale(scale: string): number {
+  const parsed = Number.parseFloat(scale || '1');
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+}
+
+function relativeNudge(scale: string): string {
+  return String(parseEffectiveScale(scale) * 0.999);
+}
+
+function getOrCreateSentinel(): HTMLElement | null {
+  const existing = document.getElementById(SENTINEL_ID);
+  if (existing) return existing;
+  const parent = document.body ?? document.documentElement;
+  if (!parent) return null;
+  const sentinel = document.createElement('div');
+  sentinel.id = SENTINEL_ID;
+  sentinel.setAttribute('aria-hidden', 'true');
+  Object.assign(sentinel.style, {
+    position: 'fixed',
+    top: '0',
+    right: '0',
+    width: '2px',
+    height: '2px',
+    pointerEvents: 'none',
+    contain: 'strict',
+    zIndex: '2147483647',
+    backgroundColor: 'transparent',
+  });
+  parent.appendChild(sentinel);
+  return sentinel;
+}
+
+function applySentinelColor(sentinel: HTMLElement, color: string): boolean {
+  sentinel.style.backgroundColor = color;
+  return getComputedStyle(sentinel).backgroundColor !== '';
+}
+
+function installPhaseA(token: string, sentinel: HTMLElement): boolean {
+  const variant = nextSentinelVariant;
+  nextSentinelVariant = (nextSentinelVariant + 1) % SENTINEL_COLORS.length;
+  const applied = applySentinelColor(sentinel, SENTINEL_COLORS[variant]);
+  activePulse = { token, sentinel, phase: 'A' };
+  return applied;
+}
+
+function restoreSentinel(pulse: ActiveSurfaceDamagePulse): boolean {
+  return applySentinelColor(pulse.sentinel, 'transparent');
+}
+
+function settlePulse(): void {
+  activePulse?.sentinel.remove();
+  activePulse = null;
+  if (settledWaiters.size === 0) return;
+  const waiters = Array.from(settledWaiters);
+  settledWaiters.clear();
+  queueMicrotask(() => {
+    waiters.forEach((waiter) => waiter());
+  });
+}
+
+/** Starts phase A only when no other Java attempt owns the raster sentinel. */
+export function beginSurfaceDamagePulse(token: string): boolean {
+  if (!token) {
+    acknowledgePhase(token, 'A', false);
+    return false;
+  }
+  const sentinel = getOrCreateSentinel();
+  if (!sentinel) {
+    acknowledgePhase(token, 'A', false);
+    return false;
+  }
+
+  if (activePulse?.token === token) {
+    const applied = activePulse.phase === 'A';
+    acknowledgePhase(token, 'A', applied);
+    return applied;
+  }
+  if (activePulse) {
+    acknowledgePhase(token, 'A', false);
+    return false;
+  }
+
+  const applied = installPhaseA(token, sentinel);
+  acknowledgePhase(token, 'A', applied);
+  return applied;
+}
+
+/**
+ * Replaces one exact pulse owner with a newer Java attempt without releasing
+ * generic repaint waiters between the two owners.
+ */
+export function replaceSurfaceDamagePulse(previousToken: string, nextToken: string): boolean {
+  const pulse = activePulse;
+  if (!pulse || pulse.token !== previousToken || !nextToken) {
+    acknowledgePhase(nextToken, 'A', false);
+    return false;
+  }
+  if (previousToken === nextToken) {
+    const applied = pulse.phase === 'A';
+    acknowledgePhase(nextToken, 'A', applied);
+    return applied;
+  }
+
+  const applied = installPhaseA(nextToken, pulse.sentinel);
+  acknowledgePhase(nextToken, 'A', applied);
+  return applied;
+}
+
+/** Restores phase A and acknowledges Phase B after the mutation is applied. */
+export function advanceSurfaceDamagePulse(token: string): boolean {
+  const pulse = activePulse;
+  if (!pulse || pulse.token !== token || pulse.phase !== 'A') {
+    acknowledgePhase(token, 'B', false);
+    return false;
+  }
+  pulse.phase = 'B';
+  const applied = restoreSentinel(pulse);
+  acknowledgePhase(token, 'B', applied);
+  return applied;
+}
+
+/** Releases coordinator ownership after Java publishes the final full frame. */
+export function finishSurfaceDamagePulse(token: string): boolean {
+  const pulse = activePulse;
+  if (!pulse || pulse.token !== token || pulse.phase !== 'B') return false;
+  settlePulse();
+  return true;
+}
+
+/** Cancels either the current attempt or its exact replacement predecessor. */
+export function cancelSurfaceDamagePulse(token: string, predecessorToken?: string): boolean {
+  const pulse = activePulse;
+  if (!pulse || (pulse.token !== token && pulse.token !== predecessorToken)) return false;
+  if (pulse.phase === 'A') {
+    restoreSentinel(pulse);
+  }
+  settlePulse();
+  return true;
+}
+
+export function isSurfaceDamagePulseActive(): boolean {
+  return activePulse !== null;
+}
+
+/** Defers generic zoom work until the exact Java sentinel owner relinquishes it. */
+export function runAfterSurfaceDamagePulse(waiter: () => void): boolean {
+  if (!activePulse) return false;
+  settledWaiters.add(waiter);
+  return true;
+}
+
+/**
+ * Performs one generic zoom nudge while the coordinator is unowned.
+ * The caller must retry later when this returns false.
+ */
+export function performGenericSurfaceDamage(app: HTMLElement, restoreScale: string): boolean {
+  if (activePulse) return false;
+  const appStyle = app.style as CSSStyleDeclaration & { zoom?: string };
+  const restore = restoreScale || appStyle.zoom || '1';
+  appStyle.zoom = relativeNudge(restore);
+  void app.offsetHeight;
+  appStyle.zoom = restore;
+  window.dispatchEvent(new Event('resize'));
+  return true;
+}


### PR DESCRIPTION
## Dependency

Stacked on #1602 (`b753eb16`). Please merge/review #1602 first. Until then GitHub may show the hidden-tab lifecycle commit in this PR; after #1602 merges, this PR reduces to the single `4ab851f7` OSR publication commit.

## Problem

During multi-project startup, the first visible restored CC GUI tab could show only the logo/input shell or a partially painted history area. Java had loaded and delivered the full history, and React had committed it. Hover repaired only local regions; resizing or switching away and back restored the complete viewport without another history query, message update, reload, or browser recreation.

The missing boundary was therefore not data recovery but publication of a current full frame through:

```text
React DOM commit
  -> Chromium compositor
  -> CefRenderHandler OnPaint
  -> JetBrains OSR backing image
  -> Swing paint
```

`frontend_ready`, `onLoadEnd`, rAF, timers, same-size `wasResized()`, and `paintImmediately()` cannot individually prove that this pipeline received new pixels.

## Technical solution

### DOM commit protocol

- Buffer early `historyLoadComplete`, including explicit zero-message history.
- Emit `history_dom_committed` from `useLayoutEffect` with a monotonic content revision.
- Bind Java handling to the exact browser, CefBrowser, page generation, ready epoch, and revision.

### JetBrains-compatible OSR handler

- Wrap the default `JBCefOSRHandlerFactory`; do not replace JetBrains component, input, IME, HiDPI, shared-memory, or disposal behavior.
- Install the factory even when the requested mode is windowed because Remote JCEF can force OSR inside the builder.
- Discover `CefNativeRenderHandler` reflectively for one binary across IDEA 2023.3, 2024.1, 2024.3, and 2025.2.
- Forward the final Remote frame with dirty count `0`, and classic OSR with a full-viewport dirty rectangle.
- Preserve popup and unrelated frame behavior and fail closed instead of creating an unwrapped Remote OSR fallback.

### Content publication fence

- Track latest pending request, one active attempt, and a published watermark in `SurfaceFrameFence`.
- Separate logical request serial from retry attempt id.
- Wait for exact phase-A and phase-B frontend acknowledgments.
- Drain the first matching real `OnPaint`; only the second matching frame is forwarded as a full raster update.
- Advance the watermark only after the default handler receives the final frame and the current Swing surface is painted.
- Keep timeout ownership exact so stale frames, ACKs, timeout callbacks, and paint tasks cannot clear or cancel newer work.

### Layout-neutral damage and activation

- Use an alternating two-pixel raster sentinel outside the React root to generate the two compositor frames.
- Never mutate app zoom, font scale, scrolling, or React layout.
- Create frontend-ready revision `0` even while hidden, but arm only when the real native surface is eligible.
- Let new history revisions supersede older content.
- Tab/window activation wakes unpublished work; once published, ordinary OSR activation only presents the cached backing image and creates no new serial or Chromium damage.
- Invalidate all ownership on ready loss, generation change, browser replacement, or disposal.
- Keep the existing windowed JCEF repaint path.

The complete state machine, compatibility notes, failed approaches, and maintenance invariants are recorded in `docs/fix/first-tab-history-render-fix-2026-08-06.md`.

## Scope

Surface publication never calls `loadHTML`, reload, or recreate and does not consume watchdog recovery budget. Provider/model/context usage and session routing are unchanged. The independent daemon heartbeat burst after system sleep is tracked by #1601.

## Verification

- Full Gradle test suite and `checkstyleMain` passed after commit consolidation.
- WebView TypeScript/Vite production build passed.
- Frontend: 127 files and 1,091 tests passed, including TypeScript test checking.
- `git diff --check` passed with no generated-file pollution.
- R18 passed repeated IDEA 2025.2 multi-project restored startups without blank first tabs or visible tab-switch layout jitter.
- Sleep/wake testing retained a timed-out pending publication and successfully re-armed the same serial with a new attempt after activation, without a WebView reload/recreate storm.

Fixes #1592
