### PR TITLE
fix(webview): land anchor-dot scroll on target in one click under CSS zoom

### DIFF
--- a/webview/src/components/MessageAnchorRail.tsx
+++ b/webview/src/components/MessageAnchorRail.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ClaudeMessage } from '../types';
+import { getLogicalOffsetTop } from '../utils/viewport';
 
 interface AnchorItem {
   id: string;
@@ -122,10 +123,12 @@ export const MessageAnchorRail = memo(function MessageAnchorRail({
     const container = containerRef.current;
     if (!node || !container) return;
 
-    const containerRect = container.getBoundingClientRect();
-    const nodeRect = node.getBoundingClientRect();
+    // getLogicalOffsetTop returns the layout-space delta (zoom-compensated),
+    // so it matches scrollTop/clientHeight units. The raw getBoundingClientRect
+    // delta is zoom-scaled under #app CSS zoom != 1, which made the target land
+    // short and converge only over repeated clicks.
     const targetTop =
-      container.scrollTop + (nodeRect.top - containerRect.top) - container.clientHeight * 0.28;
+      container.scrollTop + getLogicalOffsetTop(node, container) - container.clientHeight * 0.28;
 
     container.scrollTo({
       top: Math.max(0, targetTop),

--- a/webview/src/utils/viewport.test.ts
+++ b/webview/src/utils/viewport.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getLogicalOffsetTop } from './viewport';
+
+describe('getLogicalOffsetTop', () => {
+  let appEl: HTMLElement;
+  let originalInnerHeight: number;
+
+  beforeEach(() => {
+    appEl = document.createElement('div');
+    originalInnerHeight = window.innerHeight;
+    vi.spyOn(document, 'getElementById').mockImplementation(
+      (id: string) => (id === 'app' ? appEl : null) as HTMLElement | null,
+    );
+    vi.spyOn(appEl, 'getBoundingClientRect');
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: originalInnerHeight,
+    });
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  const setAppRect = (height: number) => {
+    vi.mocked(appEl.getBoundingClientRect).mockReturnValue({
+      height,
+      width: 800,
+      top: 0,
+      left: 0,
+      right: 800,
+      bottom: height,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+  };
+
+  const setZoom = (zoom: string) => {
+    vi.stubGlobal(
+      'getComputedStyle',
+      () => ({ zoom }) as unknown as CSSStyleDeclaration,
+    );
+  };
+
+  const makeEl = (top: number) => {
+    const el = document.createElement('div');
+    vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+      top,
+      height: 0,
+      width: 0,
+      left: 0,
+      right: 0,
+      bottom: top,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+    return el;
+  };
+
+  it('returns the raw delta when zoom is 1 (no #app zoom)', () => {
+    setZoom('1');
+    setAppRect(1000);
+    const node = makeEl(200);
+    const container = makeEl(50);
+    // 200 - 50 = 150, no compensation
+    expect(getLogicalOffsetTop(node, container)).toBe(150);
+  });
+
+  it('divides the delta by zoom on newer JCEF (appRect.height == innerHeight)', () => {
+    // The user's case: 90% zoom, newer variant where gBCR returns zoomed values.
+    setZoom('0.9');
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 1000,
+    });
+    setAppRect(1000); // == innerHeight -> newer variant
+    const node = makeEl(200);
+    const container = makeEl(50);
+    // raw delta 150 is zoom-scaled; /0.9 = 166.66... (the true layout delta)
+    expect(getLogicalOffsetTop(node, container)).toBeCloseTo(166.667, 2);
+  });
+
+  it('returns the raw delta on older JCEF (appRect.height != innerHeight)', () => {
+    // Older builds return unzoomed layout values: appRect.height = innerHeight / zoom.
+    setZoom('0.9');
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      writable: true,
+      value: 1000,
+    });
+    setAppRect(1111); // 1000 / 0.9 ~ 1111, != innerHeight -> older variant
+    const node = makeEl(200);
+    const container = makeEl(50);
+    expect(getLogicalOffsetTop(node, container)).toBe(150);
+  });
+});

--- a/webview/src/utils/viewport.ts
+++ b/webview/src/utils/viewport.ts
@@ -7,9 +7,9 @@
  *
  * Also provides a `fixedPosDivisor` to compensate for CSS zoom on position:fixed elements.
  * Different Chromium/JCEF versions handle zoom differently:
- *   - Older: getBoundingClientRect() returns unzoomed CSS values, fixed positioning also unzoomed → consistent, no fix needed.
- *   - Newer: getBoundingClientRect() returns zoomed viewport values, but fixed positioning values are scaled by zoom → needs compensation.
- * Detection: if appRect.height ≈ window.innerHeight while zoom ≠ 1, we're in the "zoomed" variant.
+ *   - Older: getBoundingClientRect() returns unzoomed CSS values, fixed positioning also unzoomed -> consistent, no fix needed.
+ *   - Newer: getBoundingClientRect() returns zoomed viewport values, but fixed positioning values are scaled by zoom -> needs compensation.
+ * Detection: if appRect.height ~ window.innerHeight while zoom != 1, we're in the "zoomed" variant.
  *
  * @returns Viewport dimensions, offsets, and fixedPosDivisor for zoom compensation
  */
@@ -22,17 +22,47 @@ export function getAppViewport(): {
 } {
   const appEl = document.getElementById('app');
   const appRect = appEl?.getBoundingClientRect();
-  const zoomFactor = appEl ? parseFloat(getComputedStyle(appEl).zoom) || 1 : 1;
+  const { zoom, gBCRisZoomed } = getZoomState(appEl, appRect);
   const height = appRect?.height ?? window.innerHeight;
-  // When zoom ≠ 1 and appRect.height matches window.innerHeight,
-  // the browser returns zoomed values from getBoundingClientRect but
-  // also scales position:fixed values by zoom, causing double-scaling.
-  const needsCompensation = zoomFactor !== 1 && Math.abs(height - window.innerHeight) < 2;
   return {
     width: appRect?.width ?? window.innerWidth,
     height,
     top: appRect?.top ?? 0,
     left: appRect?.left ?? 0,
-    fixedPosDivisor: needsCompensation ? zoomFactor : 1,
+    fixedPosDivisor: gBCRisZoomed ? zoom : 1,
   };
+}
+
+/**
+ * Internal: detect #app CSS zoom and whether getBoundingClientRect returns
+ * zoom-scaled viewport values (newer Chromium/JCEF) or unzoomed layout
+ * values (older builds). See getAppViewport for the detection rationale.
+ */
+function getZoomState(
+  appEl: HTMLElement | null,
+  appRect: DOMRect | undefined,
+): { zoom: number; gBCRisZoomed: boolean } {
+  const zoom = appEl ? parseFloat(getComputedStyle(appEl).zoom) || 1 : 1;
+  if (zoom === 1) return { zoom: 1, gBCRisZoomed: false };
+  const height = appRect?.height ?? window.innerHeight;
+  return { zoom, gBCRisZoomed: Math.abs(height - window.innerHeight) < 2 };
+}
+
+/**
+ * Logical (layout-space) top offset of `node` relative to the top edge of
+ * `container`'s viewport. Use this instead of
+ * `node.getBoundingClientRect().top - container.getBoundingClientRect().top`
+ * whenever the delta is combined with `scrollTop`/`clientHeight`, which are
+ * layout-space values: under #app CSS zoom != 1 on newer Chromium/JCEF,
+ * getBoundingClientRect returns zoom-scaled viewport values, so the raw delta
+ * is in the wrong unit. A scroll target computed from the raw delta lands
+ * short by (1 - zoom) * remainingDistance on every click, converging only
+ * over repeated clicks.
+ */
+export function getLogicalOffsetTop(node: HTMLElement, container: HTMLElement): number {
+  const rawDelta = node.getBoundingClientRect().top - container.getBoundingClientRect().top;
+  const appEl = document.getElementById('app');
+  const appRect = appEl?.getBoundingClientRect();
+  const { zoom, gBCRisZoomed } = getZoomState(appEl, appRect);
+  return gBCRisZoomed ? rawDelta / zoom : rawDelta;
 }


### PR DESCRIPTION
scrollToAnchor mixed zoom-scaled getBoundingClientRect deltas with layout-space scrollTop/clientHeight, so the computed target fell short by (1 - zoom) * remainingDistance on every click and only converged after 3-4 tries. Add getLogicalOffsetTop to divide the delta by the #app zoom factor on newer JCEF (where gBCR returns zoomed viewport values), unifying the unit so a single click lands on target. Zoom=1 and older-variant behavior is unchanged.