### PR TITLE
fix(daemon): probe idle processes safely after system resume

### DIFF
--- a/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,8 @@ public class DaemonBridge {
     private static final long HEARTBEAT_INTERVAL_MS = 15_000;
     private static final long HEARTBEAT_TIMEOUT_MS = 45_000; // 3 missed heartbeats = dead
     private static final long ACTIVE_REQUEST_HEARTBEAT_TIMEOUT_MS = 180_000;
+    private static final long HEARTBEAT_PROBE_TIMEOUT_MS = HEARTBEAT_INTERVAL_MS * 2;
+    private static final long HEARTBEAT_SCHEDULER_GAP_MS = HEARTBEAT_INTERVAL_MS + 5_000;
     private static final int MAX_RESTART_ATTEMPTS = 3;
     private static final long RESTART_WINDOW_MS = 30_000; // Reset restart counter after this period of stability
     private static final int STDERR_RING_CAPACITY = 40;
@@ -50,28 +53,22 @@ public class DaemonBridge {
     private final NodeDetector nodeDetector;
     private final BridgeDirectoryResolver directoryResolver;
     private final EnvironmentConfigurator envConfigurator;
-    // Daemon process state
-    private volatile Process daemonProcess;
-    private volatile BufferedWriter daemonStdin;
-    private volatile Thread readerThread;
-    private volatile Thread heartbeatThread;
-    private final AtomicBoolean isRunning = new AtomicBoolean(false);
-    private final AtomicBoolean sdkPreloaded = new AtomicBoolean(false);
+    private final TimeSource timeSource;
+    private final DaemonProcessLauncher processLauncher;
+    private final DaemonLifecycleHooks lifecycleHooks;
+    private final long heartbeatIntervalMs;
+    // Daemon process state. Every asynchronous callback is scoped to one context.
+    private volatile DaemonGenerationContext daemonContext;
+    private final AtomicLong daemonGenerationCounter = new AtomicLong(0);
+    // Guarded by startLock. Explicit stop intent always outranks auto-restart.
+    private boolean restartInProgress;
+    private boolean desiredRunning;
+    private long stopEpoch;
+    private final AtomicLong startAttemptCounter = new AtomicLong(0);
+    private StartAttempt activeStartAttempt;
     private final AtomicLong requestIdCounter = new AtomicLong(0);
-    private volatile CountDownLatch readyLatch = new CountDownLatch(1);
     private final AtomicInteger restartAttempts = new AtomicInteger(0);
-    private final AtomicLong lastSuccessfulStart = new AtomicLong(0);
-    private final AtomicLong lastHeartbeatResponse = new AtomicLong(0);
-    private final AtomicLong lastDaemonActivity = new AtomicLong(0);
-    private final AtomicInteger activeRequestCount = new AtomicInteger(0);
-    /** True while {@link #start()} is blocked waiting for the daemon "ready" event. */
-    private final AtomicBoolean awaitingReady = new AtomicBoolean(false);
-    private final Deque<String> recentStderrLines = new ArrayDeque<>();
-    private final Object stderrRingLock = new Object();
     private final Object startLock = new Object();
-
-    // Pending request handlers: requestId -> handler
-    private final ConcurrentHashMap<String, RequestHandler> pendingRequests = new ConcurrentHashMap<>();
 
     // Lifecycle listener
     private volatile DaemonLifecycleListener lifecycleListener;
@@ -85,9 +82,54 @@ public class DaemonBridge {
             BridgeDirectoryResolver directoryResolver,
             EnvironmentConfigurator envConfigurator
     ) {
+        this(nodeDetector, directoryResolver, envConfigurator, TimeSource.system());
+    }
+
+    DaemonBridge(
+            NodeDetector nodeDetector,
+            BridgeDirectoryResolver directoryResolver,
+            EnvironmentConfigurator envConfigurator,
+            TimeSource timeSource
+    ) {
+        this(nodeDetector, directoryResolver, envConfigurator, timeSource, null, null);
+    }
+
+    DaemonBridge(
+            NodeDetector nodeDetector,
+            BridgeDirectoryResolver directoryResolver,
+            EnvironmentConfigurator envConfigurator,
+            TimeSource timeSource,
+            DaemonProcessLauncher processLauncher,
+            DaemonLifecycleHooks lifecycleHooks
+    ) {
+        this(
+                nodeDetector,
+                directoryResolver,
+                envConfigurator,
+                timeSource,
+                processLauncher,
+                lifecycleHooks,
+                HEARTBEAT_INTERVAL_MS);
+    }
+
+    DaemonBridge(
+            NodeDetector nodeDetector,
+            BridgeDirectoryResolver directoryResolver,
+            EnvironmentConfigurator envConfigurator,
+            TimeSource timeSource,
+            DaemonProcessLauncher processLauncher,
+            DaemonLifecycleHooks lifecycleHooks,
+            long heartbeatIntervalMs
+    ) {
         this.nodeDetector = nodeDetector;
         this.directoryResolver = directoryResolver;
         this.envConfigurator = envConfigurator;
+        this.timeSource = timeSource;
+        this.processLauncher = processLauncher != null
+                ? processLauncher : this::launchConfiguredDaemon;
+        this.lifecycleHooks = lifecycleHooks != null
+                ? lifecycleHooks : DaemonLifecycleHooks.NO_OP;
+        this.heartbeatIntervalMs = heartbeatIntervalMs;
     }
 
     // =========================================================================
@@ -101,117 +143,220 @@ public class DaemonBridge {
      * @return true if daemon started successfully
      */
     public boolean start() {
+        StartAttempt attempt;
+        boolean ownsAttempt;
         synchronized (startLock) {
-            if (isRunning.get()) {
-                LOG.info("[DaemonBridge] Daemon already running");
-                return true;
-            }
-
-            LOG.info("[DaemonBridge] Starting daemon process...");
-            CountDownLatch latch = new CountDownLatch(1);
-            readyLatch = latch;
-
-            try {
-                File bridgeDir = directoryResolver.findSdkDir();
-                if (bridgeDir == null) {
-                    LOG.error("[DaemonBridge] Bridge directory not found");
+            if (activeStartAttempt != null) {
+                attempt = activeStartAttempt;
+                ownsAttempt = false;
+            } else {
+                DaemonGenerationContext existingContext = daemonContext;
+                if (existingContext != null && existingContext.isActive()) {
+                    if (existingContext.isStartupPublished()
+                            && existingContext.process.isAlive()) {
+                        LOG.info("[DaemonBridge] Daemon already running");
+                        return true;
+                    }
+                    LOG.info("[DaemonBridge] Existing daemon generation still owns lifecycle "
+                            + "cleanup; refusing to replace generation="
+                            + existingContext.generation);
                     return false;
                 }
-
-                File daemonScript = new File(bridgeDir, DAEMON_SCRIPT);
-                if (!daemonScript.exists()) {
-                    LOG.error("[DaemonBridge] daemon.js not found at: " + daemonScript.getAbsolutePath());
+                if (restartInProgress) {
+                    LOG.info("[DaemonBridge] Daemon restart cleanup is still in progress");
                     return false;
                 }
-
-                String nodePath = nodeDetector.findNodeExecutable();
-                if (nodePath == null) {
-                    LOG.error("[DaemonBridge] Node.js not found");
-                    return false;
-                }
-
-                List<String> daemonCmd = NodeDetector.buildNodeScriptCommand(
-                        nodePath, daemonScript.getAbsolutePath());
-                ProcessBuilder pb = new ProcessBuilder(daemonCmd);
-                pb.directory(bridgeDir);
-
-                // Configure environment
-                Map<String, String> env = pb.environment();
-                envConfigurator.updateProcessEnvironment(pb, nodePath);
-
-                // Pass through user-configured Claude Code CLI override (if any).
-                // Picked up by ai-bridge to set SDK option `pathToClaudeCodeExecutable`.
-                String claudeCliPath = PropertiesComponent.getInstance()
-                        .getValue(ClaudeCliPathHandler.CLAUDE_CLI_PATH_PROPERTY_KEY);
-                if (claudeCliPath != null && !claudeCliPath.trim().isEmpty()) {
-                    env.put("CLAUDE_CODE_PATH", claudeCliPath.trim());
-                    LOG.info("[DaemonBridge] Using custom Claude CLI: " + claudeCliPath.trim());
-                }
-
-                // Keep stderr separate for debugging
-                pb.redirectErrorStream(false);
-
-                daemonProcess = pb.start();
-                isRunning.set(true);
-                lastSuccessfulStart.set(System.currentTimeMillis());
-                markDaemonActivity();
-
-                LOG.info("[DaemonBridge] Daemon process started, PID: " + daemonProcess.pid()
-                        + ", cmd: " + String.join(" ", daemonCmd)
-                        + ", cwd: " + bridgeDir.getAbsolutePath());
-
-                awaitingReady.set(true);
-                synchronized (stderrRingLock) {
-                    recentStderrLines.clear();
-                }
-
-                // Setup stdin writer
-                daemonStdin = new BufferedWriter(
-                        new OutputStreamWriter(daemonProcess.getOutputStream(), StandardCharsets.UTF_8));
-
-                // Start stdout reader thread
-                startReaderThread();
-
-                // Start stderr reader thread (for debugging)
-                startStderrReaderThread();
-
-                // Wait for "ready" event, but fail fast if process exits early.
-                boolean ready = false;
-                long deadline = System.currentTimeMillis() + DAEMON_START_TIMEOUT_MS;
-                while (System.currentTimeMillis() < deadline) {
-                    if (latch.await(200, TimeUnit.MILLISECONDS)) {
-                        ready = true;
-                        break;
-                    }
-                    if (daemonProcess == null || !daemonProcess.isAlive() || !isRunning.get()) {
-                        logDaemonStartupFailure("exited_before_ready");
-                        isRunning.set(false);
-                        return false;
-                    }
-                }
-                if (!ready) {
-                    LOG.warn("[DaemonBridge] Daemon did not signal ready within timeout");
-                    if (daemonProcess == null || !daemonProcess.isAlive() || !isRunning.get()) {
-                        logDaemonStartupFailure("not_alive_after_ready_timeout");
-                        isRunning.set(false);
-                        return false;
-                    }
-                }
-
-                // Start heartbeat thread
-                startHeartbeatThread();
-
-                LOG.info("[DaemonBridge] Daemon is ready. SDK preloaded: " + sdkPreloaded.get());
-                return true;
-
-            } catch (Exception e) {
-                LOG.error("[DaemonBridge] Failed to start daemon", e);
-                isRunning.set(false);
-                return false;
-            } finally {
-                awaitingReady.set(false);
+                desiredRunning = true;
+                attempt = reserveStartAttemptLocked();
+                ownsAttempt = true;
             }
         }
+        return ownsAttempt ? executeStartAttempt(attempt) : attempt.awaitResult();
+    }
+
+    private StartAttempt reserveStartAttemptLocked() {
+        StartAttempt attempt = new StartAttempt(
+                startAttemptCounter.incrementAndGet(), stopEpoch);
+        activeStartAttempt = attempt;
+        return attempt;
+    }
+
+    private boolean executeStartAttempt(StartAttempt attempt) {
+        DaemonGenerationContext startedContext = null;
+        Process startedProcess = null;
+        try {
+            synchronized (startLock) {
+                if (!isStartAttemptCurrentLocked(attempt)) {
+                    attempt.complete(false);
+                    return false;
+                }
+            }
+
+            startedProcess = processLauncher.launch();
+            BufferedWriter startedStdin = new BufferedWriter(
+                    new OutputStreamWriter(startedProcess.getOutputStream(), StandardCharsets.UTF_8));
+            long startedGeneration = daemonGenerationCounter.incrementAndGet();
+            long startedWallTime = timeSource.currentTimeMillis();
+            long startedNanos = timeSource.nanoTime();
+            startedContext = new DaemonGenerationContext(
+                    startedProcess,
+                    startedStdin,
+                    startedGeneration,
+                    startedWallTime,
+                    startedNanos);
+
+            synchronized (startLock) {
+                if (!isStartAttemptCurrentLocked(attempt)) {
+                    startedContext.stop();
+                    destroyProcess(startedProcess);
+                    attempt.complete(false);
+                    return false;
+                }
+                daemonContext = startedContext;
+                attempt.context = startedContext;
+            }
+
+            LOG.info("[DaemonBridge] Daemon process started, PID: " + startedProcess.pid()
+                    + ", generation=" + startedGeneration
+                    + ", startAttempt=" + attempt.id);
+
+            startReaderThread(startedContext);
+            startStderrReaderThread(startedContext);
+
+            boolean ready = awaitDaemonReady(attempt, startedContext);
+            if (!ready) {
+                String failurePhase = startedProcess.isAlive()
+                        ? "ready_timeout" : "exited_before_ready";
+                logDaemonStartupFailure(startedContext, failurePhase);
+                LOG.warn("[DaemonBridge] Daemon failed to signal ready for startAttempt="
+                        + attempt.id);
+                failStartAttempt(attempt, startedContext, startedProcess);
+                return false;
+            }
+
+            startHeartbeatThread(startedContext);
+            synchronized (startLock) {
+                if (!isStartAttemptCurrentLocked(attempt)
+                        || daemonContext != startedContext
+                        || !startedContext.isActive()
+                        || !startedProcess.isAlive()) {
+                    failStartAttemptLocked(attempt, startedContext);
+                    destroyProcess(startedProcess);
+                    return false;
+                }
+                startedContext.publishStartup();
+                activeStartAttempt = null;
+                attempt.complete(true);
+            }
+
+            LOG.info("[DaemonBridge] Daemon is ready. SDK preloaded: "
+                    + startedContext.sdkPreloaded.get());
+            return true;
+        } catch (Exception e) {
+            LOG.error("[DaemonBridge] Failed to start daemon", e);
+            failStartAttempt(attempt, startedContext, startedProcess);
+            return false;
+        }
+    }
+
+    private boolean awaitDaemonReady(
+            StartAttempt attempt,
+            DaemonGenerationContext context
+    ) throws InterruptedException {
+        long startWaitNanos = timeSource.nanoTime();
+        while (elapsedMillis(timeSource.nanoTime(), startWaitNanos)
+                < DAEMON_START_TIMEOUT_MS) {
+            if (context.readyLatch.await(200, TimeUnit.MILLISECONDS)) {
+                return context.isActive() && context.process.isAlive();
+            }
+            synchronized (startLock) {
+                if (!isStartAttemptCurrentLocked(attempt)
+                        || daemonContext != context
+                        || !context.isActive()
+                        || !context.process.isAlive()) {
+                    return false;
+                }
+            }
+        }
+        return false;
+    }
+
+    private void failStartAttempt(
+            StartAttempt attempt,
+            DaemonGenerationContext context,
+            Process process
+    ) {
+        synchronized (startLock) {
+            failStartAttemptLocked(attempt, context);
+        }
+        destroyProcess(process);
+    }
+
+    private void failStartAttemptLocked(
+            StartAttempt attempt,
+            DaemonGenerationContext context
+    ) {
+        if (context != null && !context.isStartupPublished()) {
+            context.stop();
+        }
+        if (activeStartAttempt == attempt) {
+            activeStartAttempt = null;
+            if (stopEpoch == attempt.stopEpoch) {
+                desiredRunning = false;
+            }
+        }
+        attempt.complete(false);
+    }
+
+    private boolean isStartAttemptCurrentLocked(StartAttempt attempt) {
+        return desiredRunning
+                && stopEpoch == attempt.stopEpoch
+                && activeStartAttempt == attempt
+                && !attempt.isCancelled();
+    }
+
+    private static void destroyProcess(Process process) {
+        if (process != null && process.isAlive()) {
+            process.destroyForcibly();
+        }
+    }
+
+    private Process launchConfiguredDaemon() throws IOException {
+        File bridgeDir = directoryResolver.findSdkDir();
+        if (bridgeDir == null) {
+            throw new IOException("Bridge directory not found");
+        }
+
+        File daemonScript = new File(bridgeDir, DAEMON_SCRIPT);
+        if (!daemonScript.exists()) {
+            throw new IOException("daemon.js not found at: " + daemonScript.getAbsolutePath());
+        }
+
+        String nodePath = nodeDetector.findNodeExecutable();
+        if (nodePath == null) {
+            throw new IOException("Node.js not found");
+        }
+
+        List<String> daemonCmd = NodeDetector.buildNodeScriptCommand(
+                nodePath, daemonScript.getAbsolutePath());
+        ProcessBuilder processBuilder = new ProcessBuilder(daemonCmd);
+        processBuilder.directory(bridgeDir);
+        envConfigurator.updateProcessEnvironment(processBuilder, nodePath);
+
+        Map<String, String> environment = processBuilder.environment();
+        String claudeCliPath = PropertiesComponent.getInstance()
+                .getValue(ClaudeCliPathHandler.CLAUDE_CLI_PATH_PROPERTY_KEY);
+        if (claudeCliPath != null && !claudeCliPath.trim().isEmpty()) {
+            environment.put("CLAUDE_CODE_PATH", claudeCliPath.trim());
+            LOG.info("[DaemonBridge] Using custom Claude CLI: " + claudeCliPath.trim());
+        }
+
+        processBuilder.redirectErrorStream(false);
+        Process process = processBuilder.start();
+        LOG.info("[DaemonBridge] Daemon process launched, PID: " + process.pid()
+                + ", cmd: " + String.join(" ", daemonCmd)
+                + ", cwd: " + bridgeDir.getAbsolutePath());
+        return process;
     }
 
     /**
@@ -219,26 +364,38 @@ public class DaemonBridge {
      */
     public void stop() {
         LOG.info("[DaemonBridge] Stopping daemon...");
-        isRunning.set(false);
+        DaemonGenerationContext context;
+        synchronized (startLock) {
+            desiredRunning = false;
+            stopEpoch++;
+            StartAttempt startAttempt = activeStartAttempt;
+            activeStartAttempt = null;
+            if (startAttempt != null) {
+                startAttempt.cancel();
+            }
+            context = daemonContext;
+            if (context != null) {
+                context.stop();
+            }
+        }
+        if (context == null) {
+            return;
+        }
 
         // Cancel all pending requests
-        for (Map.Entry<String, RequestHandler> entry : pendingRequests.entrySet()) {
-            entry.getValue().onError("Daemon stopped");
+        for (RequestHandler handler : context.drainRequests()) {
+            handler.onError("Daemon stopped");
         }
-        pendingRequests.clear();
-        activeRequestCount.set(0);
 
         // Send shutdown command before closing stdin (allows daemon to flush)
         try {
-            if (daemonStdin != null) {
-                JsonObject shutdown = new JsonObject();
-                shutdown.addProperty("id", "shutdown");
-                shutdown.addProperty("method", "shutdown");
-                synchronized (daemonStdin) {
-                    daemonStdin.write(shutdown.toString());
-                    daemonStdin.newLine();
-                    daemonStdin.flush();
-                }
+            JsonObject shutdown = new JsonObject();
+            shutdown.addProperty("id", "shutdown");
+            shutdown.addProperty("method", "shutdown");
+            synchronized (context.stdin) {
+                context.stdin.write(shutdown.toString());
+                context.stdin.newLine();
+                context.stdin.flush();
             }
         } catch (IOException e) {
             LOG.debug("[DaemonBridge] Error sending shutdown command: " + e.getMessage());
@@ -246,36 +403,34 @@ public class DaemonBridge {
 
         // Close stdin (triggers daemon shutdown if command wasn't received)
         try {
-            if (daemonStdin != null) {
-                daemonStdin.close();
-            }
+            context.stdin.close();
         } catch (IOException e) {
             LOG.debug("[DaemonBridge] Error closing stdin: " + e.getMessage());
         }
 
         // Kill process if still alive and wait for termination
-        if (daemonProcess != null && daemonProcess.isAlive()) {
-            daemonProcess.destroyForcibly();
+        if (context.process.isAlive()) {
+            context.process.destroyForcibly();
             try {
-                daemonProcess.waitFor(3, TimeUnit.SECONDS);
+                context.process.waitFor(3, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
         }
 
         // Interrupt and join threads
-        if (readerThread != null) {
-            readerThread.interrupt();
+        if (context.readerThread != null && context.readerThread != Thread.currentThread()) {
+            context.readerThread.interrupt();
             try {
-                readerThread.join(2000);
+                context.readerThread.join(2000);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
         }
-        if (heartbeatThread != null) {
-            heartbeatThread.interrupt();
+        if (context.heartbeatThread != null && context.heartbeatThread != Thread.currentThread()) {
+            context.heartbeatThread.interrupt();
             try {
-                heartbeatThread.join(2000);
+                context.heartbeatThread.join(2000);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
@@ -290,16 +445,17 @@ public class DaemonBridge {
      * Also completes all pending request futures so Java-side blocking calls unblock.
      */
     public void sendAbort() {
+        DaemonGenerationContext context = daemonContext;
         // Send abort command to daemon so it stops the active SDK query
         try {
-            if (daemonStdin != null && isRunning.get()) {
+            if (context != null && context.isActive()) {
                 JsonObject abort = new JsonObject();
                 abort.addProperty("id", "abort-" + System.currentTimeMillis());
                 abort.addProperty("method", "abort");
-                synchronized (daemonStdin) {
-                    daemonStdin.write(abort.toString());
-                    daemonStdin.newLine();
-                    daemonStdin.flush();
+                synchronized (context.stdin) {
+                    context.stdin.write(abort.toString());
+                    context.stdin.newLine();
+                    context.stdin.flush();
                 }
                 LOG.info("[DaemonBridge] Sent abort command");
             }
@@ -311,18 +467,20 @@ public class DaemonBridge {
         // Use onComplete(false) instead of onError() so that user-initiated aborts
         // are treated as a normal (unsuccessful) completion rather than an error,
         // matching the graceful handling that Codex uses.
-        for (Map.Entry<String, RequestHandler> entry : pendingRequests.entrySet()) {
-            entry.getValue().onAbort();
+        if (context != null) {
+            for (RequestHandler handler : context.drainRequests()) {
+                handler.onAbort();
+            }
         }
-        pendingRequests.clear();
-        activeRequestCount.set(0);
     }
 
     /**
      * Check if the daemon is running and healthy.
      */
     public boolean isAlive() {
-        return isRunning.get() && daemonProcess != null && daemonProcess.isAlive();
+        DaemonGenerationContext context = daemonContext;
+        return context != null && context.isStartupPublished()
+                && context.isActive() && context.process.isAlive();
     }
 
     /**
@@ -331,7 +489,8 @@ public class DaemonBridge {
      * this reference — always go through stop() to keep state consistent.
      */
     public Process getDaemonProcessForInspection() {
-        return daemonProcess;
+        DaemonGenerationContext context = daemonContext;
+        return context != null ? context.process : null;
     }
 
     /**
@@ -339,7 +498,8 @@ public class DaemonBridge {
      * Used by the management panel to indicate daemon load.
      */
     public int getActiveRequestCount() {
-        return activeRequestCount.get();
+        DaemonGenerationContext context = daemonContext;
+        return context != null ? context.activeRequestCount.get() : 0;
     }
 
     /**
@@ -376,25 +536,25 @@ public class DaemonBridge {
             f.completeExceptionally(new IOException("Daemon not running"));
             return f;
         }
+        DaemonGenerationContext context = daemonContext;
+        if (context == null || !context.isActive() || !context.process.isAlive()) {
+            CompletableFuture<Boolean> f = new CompletableFuture<>();
+            f.completeExceptionally(new IOException("Daemon generation changed before request"));
+            return f;
+        }
 
         String requestId = String.valueOf(requestIdCounter.incrementAndGet());
         CompletableFuture<Boolean> future = new CompletableFuture<>();
         boolean countsAsActiveRequest = !"heartbeat".equals(method) && !"status".equals(method);
 
         RequestHandler handler = new RequestHandler(callback, future);
-        pendingRequests.put(requestId, handler);
-        if (countsAsActiveRequest) {
-            activeRequestCount.incrementAndGet();
+        if (!context.registerRequest(requestId, handler, countsAsActiveRequest, timeSource)) {
+            future.completeExceptionally(new IOException("Daemon generation is no longer active"));
+            return future;
         }
-        markDaemonActivity();
 
         // Ensure cleanup when future completes (e.g., via timeout or cancellation)
-        future.whenComplete((result, ex) -> {
-            pendingRequests.remove(requestId);
-            if (countsAsActiveRequest) {
-                activeRequestCount.updateAndGet(current -> Math.max(0, current - 1));
-            }
-        });
+        future.whenComplete((result, ex) -> context.removeRequest(requestId));
 
         // Build request JSON
         JsonObject request = new JsonObject();
@@ -403,14 +563,17 @@ public class DaemonBridge {
         request.add("params", params);
 
         try {
-            synchronized (daemonStdin) {
-                daemonStdin.write(request.toString());
-                daemonStdin.newLine();
-                daemonStdin.flush();
+            synchronized (context.stdin) {
+                if (!context.isActive()) {
+                    throw new IOException("Daemon generation changed before write");
+                }
+                context.stdin.write(request.toString());
+                context.stdin.newLine();
+                context.stdin.flush();
             }
             LOG.info("[DaemonBridge] Sent request " + requestId + ": " + method);
         } catch (IOException e) {
-            pendingRequests.remove(requestId);
+            context.removeRequest(requestId);
             future.completeExceptionally(e);
             LOG.error("[DaemonBridge] Failed to send request: " + e.getMessage());
         }
@@ -422,34 +585,41 @@ public class DaemonBridge {
     // Reader Threads
     // =========================================================================
 
-    private void startReaderThread() {
-        readerThread = new Thread(() -> {
+    private void startReaderThread(DaemonGenerationContext context) {
+        context.readerThread = new Thread(() -> {
             try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(daemonProcess.getInputStream(), StandardCharsets.UTF_8))) {
+                    new InputStreamReader(context.process.getInputStream(), StandardCharsets.UTF_8))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
-                    handleDaemonOutput(line);
+                    if (!isCurrentDaemon(context) || !context.isActive()) {
+                        break;
+                    }
+                    handleDaemonOutput(line, context);
                 }
             } catch (IOException e) {
-                if (isRunning.get()) {
+                if (isCurrentDaemon(context) && context.isActive()) {
                     LOG.error("[DaemonBridge] Reader thread error: " + e.getMessage());
                 }
             } finally {
-                handleDaemonDeath();
+                handleDaemonDeath(context, null);
             }
         }, "DaemonBridge-Reader");
-        readerThread.setDaemon(true);
-        readerThread.start();
+        context.readerThread.setDaemon(true);
+        context.readerThread.start();
     }
 
-    private void startStderrReaderThread() {
+    private void startStderrReaderThread(DaemonGenerationContext context) {
         Thread stderrThread = new Thread(() -> {
             try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(daemonProcess.getErrorStream(), StandardCharsets.UTF_8))) {
+                    new InputStreamReader(context.process.getErrorStream(), StandardCharsets.UTF_8))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
-                    appendStderrLine(line);
-                    LOG.debug("[DaemonBridge:stderr] " + line);
+                    if (!shouldRecordStderrLine(daemonContext, context)) {
+                        break;
+                    }
+                    context.appendStderrLine(line);
+                    LOG.debug("[DaemonBridge:stderr] generation="
+                            + context.generation + " " + line);
                 }
             } catch (IOException e) {
                 // Expected on shutdown
@@ -459,59 +629,88 @@ public class DaemonBridge {
         stderrThread.start();
     }
 
-    private void startHeartbeatThread() {
-        // Initialize heartbeat baseline so the first check doesn't trigger timeout
-        long now = System.currentTimeMillis();
-        lastHeartbeatResponse.set(now);
-        lastDaemonActivity.set(now);
+    private void startHeartbeatThread(DaemonGenerationContext context) {
+        IdleHeartbeatProbeState heartbeatProbeState = new IdleHeartbeatProbeState();
+        heartbeatProbeState.reset(timeSource.currentTimeMillis());
 
-        heartbeatThread = new Thread(() -> {
-            while (isRunning.get()) {
+        context.heartbeatThread = new Thread(() -> {
+            while (context.isActive() && isCurrentDaemon(context)) {
                 try {
-                    Thread.sleep(HEARTBEAT_INTERVAL_MS);
-                    if (!isAlive()) { break; }
-
-                    // Check if daemon is unresponsive (no heartbeat response for too long)
-                    long currentTime = System.currentTimeMillis();
-                    long heartbeatAgeMs = currentTime - lastHeartbeatResponse.get();
-                    long activityAgeMs = currentTime - lastDaemonActivity.get();
-                    int activeRequests = activeRequestCount.get();
-                    if (shouldTreatAsUnresponsive(heartbeatAgeMs, activityAgeMs, activeRequests)) {
-                        LOG.warn("[DaemonBridge] Daemon unresponsive (heartbeatAgeMs=" + heartbeatAgeMs
-                                + ", activityAgeMs=" + activityAgeMs
-                                + ", activeRequests=" + activeRequests + "), treating as dead");
-                        handleDaemonDeath();
+                    Thread.sleep(heartbeatIntervalMs);
+                    lifecycleHooks.beforeHeartbeatCheck(context.generation);
+                    if (!context.isActive() || !isCurrentDaemon(context)) {
+                        break;
+                    }
+                    if (!context.process.isAlive()) {
+                        handleDaemonDeath(context, null);
                         break;
                     }
 
-                    // Send heartbeat
+                    HeartbeatObservation observation =
+                            context.captureHeartbeatObservation(timeSource);
+                    int activeRequests = observation.activeRequestCount;
+                    HeartbeatDecision decision = heartbeatProbeState.evaluate(observation);
+                    if (decision == HeartbeatDecision.DECLARE_DEAD) {
+                        String probeDetail = activeRequests <= 0
+                                ? " after heartbeat probe" : " with active request";
+                        LOG.warn("[DaemonBridge] Daemon unresponsive" + probeDetail
+                                + " (activeRequests=" + activeRequests
+                                + ", generation=" + context.generation + "), treating as dead");
+                        DeathHandlingResult result = handleDaemonDeath(context, observation);
+                        if (shouldContinueHeartbeatAfterDeath(result)) {
+                            continue;
+                        }
+                        break;
+                    }
+                    if (decision == HeartbeatDecision.WAIT_FOR_PROBE) {
+                        continue;
+                    }
+                    if (decision == HeartbeatDecision.SEND_PROBE) {
+                        LOG.info("[DaemonBridge] Daemon heartbeat is stale; sending a resume-safe probe"
+                                + " before restart (activeRequests=" + activeRequests
+                                + ", generation=" + context.generation + ")");
+                    }
+
+                    // Send the regular heartbeat, or the one bounded liveness probe.
                     JsonObject hb = new JsonObject();
-                    hb.addProperty("id", "hb-" + System.currentTimeMillis());
+                    hb.addProperty("id", "hb-" + timeSource.currentTimeMillis());
                     hb.addProperty("method", "heartbeat");
-                    synchronized (daemonStdin) {
-                        daemonStdin.write(hb.toString());
-                        daemonStdin.newLine();
-                        daemonStdin.flush();
+                    synchronized (context.stdin) {
+                        if (!isCurrentDaemon(context) || !context.isActive()) {
+                            break;
+                        }
+                        context.stdin.write(hb.toString());
+                        context.stdin.newLine();
+                        context.stdin.flush();
                     }
                 } catch (InterruptedException e) {
                     break;
                 } catch (IOException e) {
                     LOG.warn("[DaemonBridge] Heartbeat failed: " + e.getMessage());
-                    handleDaemonDeath();
+                    handleDaemonDeath(context, null);
                     break;
                 }
             }
         }, "DaemonBridge-Heartbeat");
-        heartbeatThread.setDaemon(true);
-        heartbeatThread.start();
+        context.heartbeatThread.setDaemon(true);
+        context.heartbeatThread.start();
     }
 
     // =========================================================================
     // Output Parsing
     // =========================================================================
 
-    private void handleDaemonOutput(String jsonLine) {
-        markDaemonActivity();
+    private void handleDaemonOutput(String jsonLine, DaemonGenerationContext context) {
+        synchronized (context) {
+            if (!isCurrentDaemon(context) || !context.isActive()) {
+                return;
+            }
+            handleActiveDaemonOutput(jsonLine, context);
+        }
+    }
+
+    private void handleActiveDaemonOutput(String jsonLine, DaemonGenerationContext context) {
+        context.heartbeatTimestamps.markActivity(timeSource);
         // Skip non-JSON lines (SDK debug output, permission logs, etc.)
         String trimmed = jsonLine.trim();
         if (trimmed.isEmpty() || trimmed.charAt(0) != '{') {
@@ -529,14 +728,13 @@ public class DaemonBridge {
                 String type = obj.get("type").getAsString();
 
                 if ("daemon".equals(type)) {
-                    handleDaemonEvent(obj);
+                    handleDaemonEvent(obj, context);
                     return;
                 }
 
                 if ("heartbeat".equals(type)) {
                     // Heartbeat response — daemon is alive
-                    lastHeartbeatResponse.set(System.currentTimeMillis());
-                    markDaemonActivity();
+                    context.markHeartbeat(timeSource);
                     return;
                 }
 
@@ -553,7 +751,7 @@ public class DaemonBridge {
             // Skip heartbeat responses
             if (id.startsWith("hb-")) { return; }
 
-            RequestHandler handler = pendingRequests.get(id);
+            RequestHandler handler = context.getRequestHandler(id);
             if (handler == null) {
                 LOG.debug("[DaemonBridge] No handler for request " + id);
                 return;
@@ -566,7 +764,7 @@ public class DaemonBridge {
                     handler.onError(obj.get("error").getAsString());
                 }
                 handler.onComplete(success);
-                pendingRequests.remove(id);
+                context.removeRequest(id);
                 return;
             }
 
@@ -586,29 +784,27 @@ public class DaemonBridge {
         }
     }
 
-    private void handleDaemonEvent(JsonObject obj) {
+    private void handleDaemonEvent(JsonObject obj, DaemonGenerationContext context) {
         String event = obj.has("event") ? obj.get("event").getAsString() : "unknown";
         LOG.info("[DaemonBridge] Daemon event: " + event);
 
         switch (event) {
             case "ready":
-                if (obj.has("sdkPreloaded")) {
-                    sdkPreloaded.set(obj.get("sdkPreloaded").getAsBoolean());
-                }
-                readyLatch.countDown();
-                if (lifecycleListener != null) {
+                boolean preloaded = obj.has("sdkPreloaded")
+                        && obj.get("sdkPreloaded").getAsBoolean();
+                if (context.signalReady(preloaded) && lifecycleListener != null) {
                     lifecycleListener.onDaemonReady();
                 }
                 break;
 
             case "startup_failed": {
                 String startupError = obj.has("error") ? obj.get("error").getAsString() : "unknown";
-                LOG.error("[DaemonBridge] Daemon reported startup_failed: " + startupError);
+                LOG.warn("[DaemonBridge] Daemon reported startup_failed: " + startupError);
                 break;
             }
 
             case "sdk_loaded":
-                sdkPreloaded.set(true);
+                context.markSdkPreloaded();
                 LOG.info("[DaemonBridge] SDK pre-loaded successfully");
                 break;
 
@@ -707,60 +903,126 @@ public class DaemonBridge {
     // Daemon Death & Auto-Restart
     // =========================================================================
 
-    private void handleDaemonDeath() {
-        if (!isRunning.compareAndSet(true, false)) { return; }
+    private DeathHandlingResult handleDaemonDeath(
+            DaemonGenerationContext context,
+            HeartbeatObservation timeoutObservation
+    ) {
+        List<RequestHandler> failedHandlers;
+        long claimedStopEpoch;
+        synchronized (context) {
+            if (timeoutObservation != null
+                    && !context.matchesTimeoutObservation(timeoutObservation)) {
+                LOG.info("[DaemonBridge] Cancelling stale heartbeat timeout for generation="
+                        + context.generation + " because daemon progress advanced");
+                return DeathHandlingResult.CANCELLED;
+            }
+            synchronized (startLock) {
+                if (!isCurrentDaemon(context) || !context.isActive() || !desiredRunning
+                        || restartInProgress) {
+                    LOG.debug("[DaemonBridge] Ignoring stale death signal for generation="
+                            + context.generation);
+                    return DeathHandlingResult.STALE_GENERATION;
+                }
+                restartInProgress = true;
+                claimedStopEpoch = stopEpoch;
+                context.claimDeath();
+            }
+            failedHandlers = context.drainRequests();
+        }
 
-        LOG.warn("[DaemonBridge] Daemon process died");
+        LOG.warn("[DaemonBridge] Daemon process died, generation=" + context.generation);
 
-        // Forcefully kill the old process if still alive (e.g., heartbeat timeout)
-        Process oldProcess = daemonProcess;
-        if (oldProcess != null && oldProcess.isAlive()) {
+        // Kill only the process whose generation was atomically claimed.
+        if (context.process.isAlive()) {
             LOG.info("[DaemonBridge] Forcefully killing unresponsive daemon process (PID: "
-                    + oldProcess.pid() + ")");
-            oldProcess.destroyForcibly();
+                    + context.process.pid() + ", generation=" + context.generation + ")");
+            context.process.destroyForcibly();
             try {
-                oldProcess.waitFor(2, TimeUnit.SECONDS);
+                context.process.waitFor(2, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
         }
 
-        // Fail all pending requests
-        for (Map.Entry<String, RequestHandler> entry : pendingRequests.entrySet()) {
-            entry.getValue().onError("Daemon process died unexpectedly");
+        // The old generation is already detached, so callbacks cannot remove B's requests.
+        for (RequestHandler handler : failedHandlers) {
+            try {
+                handler.onError("Daemon process died unexpectedly");
+            } catch (RuntimeException e) {
+                LOG.warn("[DaemonBridge] Request callback failed during daemon cleanup", e);
+            }
         }
-        pendingRequests.clear();
-        activeRequestCount.set(0);
 
-        // Notify listener
         if (lifecycleListener != null) {
-            lifecycleListener.onDaemonDied();
+            try {
+                lifecycleListener.onDaemonDied();
+            } catch (RuntimeException e) {
+                LOG.warn("[DaemonBridge] Lifecycle listener failed during daemon cleanup", e);
+            }
         }
 
-        // Auto-restart if within limit.
-        // If the daemon ran stably for RESTART_WINDOW_MS before dying, reset the
-        // counter so transient failures don't exhaust attempts permanently.
-        long uptime = System.currentTimeMillis() - lastSuccessfulStart.get();
+        // Stability intentionally includes suspended time on every platform.
+        long uptime = elapsedWallMillis(
+                timeSource.currentTimeMillis(), context.startedAtWallTimeMs);
         if (uptime > RESTART_WINDOW_MS) {
             restartAttempts.set(0);
         }
 
-        if (awaitingReady.get()) {
-            LOG.warn("[DaemonBridge] Daemon died during startup wait; skipping auto-restart"
-                    + " (coordinator will fall back to per-process mode). "
-                    + formatRecentStderrTail());
-            return;
+        Thread oldHeartbeat = context.heartbeatThread;
+        if (oldHeartbeat != null && oldHeartbeat != Thread.currentThread()) {
+            oldHeartbeat.interrupt();
+        }
+
+        if (!context.isStartupPublished()) {
+            synchronized (startLock) {
+                restartInProgress = false;
+                StartAttempt startAttempt = activeStartAttempt;
+                if (startAttempt != null && startAttempt.context == context) {
+                    activeStartAttempt = null;
+                    if (stopEpoch == startAttempt.stopEpoch) {
+                        desiredRunning = false;
+                    }
+                    startAttempt.complete(false);
+                }
+            }
+            LOG.info("[DaemonBridge] Initial daemon exited before ready; "
+                    + "background restart is disabled until the owner calls start() again. "
+                    + context.formatRecentStderrTail());
+            return DeathHandlingResult.CLAIMED;
         }
 
         int attempts = restartAttempts.incrementAndGet();
-        if (attempts <= MAX_RESTART_ATTEMPTS) {
-            LOG.info("[DaemonBridge] Attempting restart (" + attempts + "/" + MAX_RESTART_ATTEMPTS
-                    + ", last uptime=" + uptime + "ms)");
-            start();
-        } else {
-            LOG.error("[DaemonBridge] Max restart attempts reached (" + attempts
-                    + " within " + RESTART_WINDOW_MS + "ms window). Daemon will not be restarted.");
+        lifecycleHooks.beforeAutoRestartCheck(context.generation);
+        StartAttempt restartAttempt = null;
+        synchronized (startLock) {
+            restartInProgress = false;
+            boolean stillDesired = desiredRunning
+                    && stopEpoch == claimedStopEpoch
+                    && daemonContext == context
+                    && !context.isStopped();
+            if (shouldAutoRestart(
+                    desiredRunning,
+                    stopEpoch,
+                    claimedStopEpoch,
+                    daemonContext,
+                    context,
+                    attempts)) {
+                LOG.info("[DaemonBridge] Attempting restart (" + attempts + "/"
+                        + MAX_RESTART_ATTEMPTS + ", last uptime=" + uptime + "ms)");
+                restartAttempt = reserveStartAttemptLocked();
+            } else if (!stillDesired) {
+                LOG.info("[DaemonBridge] Automatic restart cancelled by newer lifecycle intent");
+            } else {
+                LOG.error("[DaemonBridge] Max restart attempts reached (" + attempts
+                        + " within " + RESTART_WINDOW_MS
+                        + "ms window). Daemon will not be restarted.");
+            }
         }
+        lifecycleHooks.afterAutoRestartCheck(context.generation);
+        if (restartAttempt != null) {
+            executeStartAttempt(restartAttempt);
+        }
+        return DeathHandlingResult.CLAIMED;
     }
 
     // =========================================================================
@@ -791,52 +1053,31 @@ public class DaemonBridge {
     }
 
     public boolean isSdkPreloaded() {
-        return sdkPreloaded.get();
+        DaemonGenerationContext context = daemonContext;
+        return context != null && context.sdkPreloaded.get();
     }
 
-    private void appendStderrLine(String line) {
-        if (line == null) { return; }
-        synchronized (stderrRingLock) {
-            recentStderrLines.addLast(line);
-            while (recentStderrLines.size() > STDERR_RING_CAPACITY) {
-                recentStderrLines.removeFirst();
-            }
-        }
-    }
-
-    private String formatRecentStderrTail() {
-        synchronized (stderrRingLock) {
-            if (recentStderrLines.isEmpty()) {
-                return "stderr=(empty)";
-            }
-            return "stderrTail=" + String.join(" | ", recentStderrLines);
-        }
-    }
-
-    private void logDaemonStartupFailure(String phase) {
+    private void logDaemonStartupFailure(
+            DaemonGenerationContext context,
+            String phase
+    ) {
         int exitCode = Integer.MIN_VALUE;
-        Process process = daemonProcess;
+        Process process = context != null ? context.process : null;
         if (process != null) {
             try {
                 if (!process.isAlive()) {
                     exitCode = process.exitValue();
-                } else {
-                    boolean finished = process.waitFor(500, TimeUnit.MILLISECONDS);
-                    if (finished) {
-                        exitCode = process.exitValue();
-                    }
                 }
             } catch (IllegalThreadStateException stillRunning) {
                 exitCode = Integer.MIN_VALUE;
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
             }
         }
         String exitLabel = exitCode == Integer.MIN_VALUE ? "unknown" : String.valueOf(exitCode);
-        LOG.error("[DaemonBridge] Daemon exited before signaling ready"
+        LOG.warn("[DaemonBridge] Daemon exited before signaling ready"
                 + " (phase=" + phase
                 + ", exitCode=" + exitLabel
-                + ", " + formatRecentStderrTail() + ")");
+                + ", " + (context != null
+                        ? context.formatRecentStderrTail() : "stderr=(unavailable)") + ")");
     }
 
     static boolean shouldTreatAsUnresponsive(long heartbeatAgeMs, long activityAgeMs, int activeRequestCount) {
@@ -847,8 +1088,480 @@ public class DaemonBridge {
         return livenessAgeMs > ACTIVE_REQUEST_HEARTBEAT_TIMEOUT_MS;
     }
 
-    private void markDaemonActivity() {
-        lastDaemonActivity.set(System.currentTimeMillis());
+    static boolean shouldRecordStderrLine(
+            DaemonGenerationContext currentContext,
+            DaemonGenerationContext sourceContext
+    ) {
+        return sourceContext != null
+                && currentContext == sourceContext
+                && sourceContext.isActive();
+    }
+
+    static boolean shouldAutoRestart(
+            boolean desiredRunning,
+            long currentStopEpoch,
+            long claimedStopEpoch,
+            DaemonGenerationContext currentContext,
+            DaemonGenerationContext claimedContext,
+            int attempts
+    ) {
+        return desiredRunning
+                && currentStopEpoch == claimedStopEpoch
+                && currentContext == claimedContext
+                && !claimedContext.isStopped()
+                && attempts <= MAX_RESTART_ATTEMPTS;
+    }
+
+    enum HeartbeatDecision {
+        HEALTHY,
+        SEND_PROBE,
+        WAIT_FOR_PROBE,
+        DECLARE_DEAD
+    }
+
+    enum DeathHandlingResult {
+        CLAIMED,
+        CANCELLED,
+        STALE_GENERATION
+    }
+
+    static boolean shouldContinueHeartbeatAfterDeath(DeathHandlingResult result) {
+        return result == DeathHandlingResult.CANCELLED;
+    }
+
+    /**
+     * Applies probe-first recovery only to idle daemons. Active requests keep
+     * the established timeout semantics until request-level resume progress can
+     * be identified independently from daemon heartbeat traffic.
+     */
+    static final class IdleHeartbeatProbeState {
+        private long lastCheckWallTimeMs = -1;
+        private long probeStartedAtNanos;
+        private long probeHeartbeatVersion;
+        private boolean probeActive;
+
+        synchronized HeartbeatDecision evaluate(HeartbeatObservation observation) {
+            long nowWallTimeMs = observation.nowWallTimeMs;
+            long nowNanos = observation.nowNanos;
+            int activeRequestCount = observation.activeRequestCount;
+            boolean schedulerDiscontinuity = lastCheckWallTimeMs >= 0
+                    && (nowWallTimeMs < lastCheckWallTimeMs
+                    || nowWallTimeMs - lastCheckWallTimeMs > HEARTBEAT_SCHEDULER_GAP_MS);
+            lastCheckWallTimeMs = nowWallTimeMs;
+
+            // Keep the pre-existing active-request behavior. A heartbeat probe
+            // alone cannot prove that a suspended SDK/network operation resumed.
+            if (activeRequestCount > 0) {
+                probeActive = false;
+                return shouldTreatAsUnresponsive(
+                        observation.heartbeatWallAgeMs,
+                        observation.activityWallAgeMs,
+                        activeRequestCount)
+                        ? HeartbeatDecision.DECLARE_DEAD : HeartbeatDecision.HEALTHY;
+            }
+
+            // On every platform a wall-clock scheduler gap arms an idle probe,
+            // regardless of whether that platform's nanoTime advances in suspend.
+            if (schedulerDiscontinuity) {
+                startProbe(nowNanos, observation.heartbeatVersion);
+                return HeartbeatDecision.SEND_PROBE;
+            }
+
+            if (probeActive) {
+                if (observation.heartbeatVersion != probeHeartbeatVersion) {
+                    probeActive = false;
+                    return HeartbeatDecision.HEALTHY;
+                }
+                if (elapsedMillis(nowNanos, probeStartedAtNanos)
+                        < HEARTBEAT_PROBE_TIMEOUT_MS) {
+                    return HeartbeatDecision.WAIT_FOR_PROBE;
+                }
+                return HeartbeatDecision.DECLARE_DEAD;
+            }
+
+            if (!shouldTreatAsUnresponsive(
+                    observation.heartbeatMonotonicAgeMs,
+                    observation.activityMonotonicAgeMs,
+                    0)) {
+                return HeartbeatDecision.HEALTHY;
+            }
+
+            startProbe(nowNanos, observation.heartbeatVersion);
+            return HeartbeatDecision.SEND_PROBE;
+        }
+
+        synchronized void reset(long nowWallTimeMs) {
+            lastCheckWallTimeMs = nowWallTimeMs;
+            probeActive = false;
+        }
+
+        private void startProbe(long nowNanos, long heartbeatVersion) {
+            probeStartedAtNanos = nowNanos;
+            probeHeartbeatVersion = heartbeatVersion;
+            probeActive = true;
+        }
+    }
+
+    /** Stores both clocks so liveness policy is deterministic across suspend semantics. */
+    static final class HeartbeatTimestamps {
+        private long lastHeartbeatWallTimeMs;
+        private long lastHeartbeatNanos;
+        private long lastActivityWallTimeMs;
+        private long lastActivityNanos;
+        private long heartbeatVersion;
+        private long activityVersion;
+
+        HeartbeatTimestamps(long wallTimeMs, long nanos) {
+            lastHeartbeatWallTimeMs = wallTimeMs;
+            lastHeartbeatNanos = nanos;
+            lastActivityWallTimeMs = wallTimeMs;
+            lastActivityNanos = nanos;
+        }
+
+        synchronized void markHeartbeat(TimeSource timeSource) {
+            long wallTimeMs = timeSource.currentTimeMillis();
+            long nanos = timeSource.nanoTime();
+            lastHeartbeatWallTimeMs = wallTimeMs;
+            lastHeartbeatNanos = nanos;
+            lastActivityWallTimeMs = wallTimeMs;
+            lastActivityNanos = nanos;
+            heartbeatVersion++;
+            activityVersion++;
+        }
+
+        synchronized void markActivity(TimeSource timeSource) {
+            lastActivityWallTimeMs = timeSource.currentTimeMillis();
+            lastActivityNanos = timeSource.nanoTime();
+            activityVersion++;
+        }
+
+        synchronized HeartbeatObservation snapshot(
+                TimeSource timeSource,
+                int activeRequestCount
+        ) {
+            long nowWallTimeMs = timeSource.currentTimeMillis();
+            long nowNanos = timeSource.nanoTime();
+            return new HeartbeatObservation(
+                    nowWallTimeMs,
+                    nowNanos,
+                    elapsedWallMillis(nowWallTimeMs, lastHeartbeatWallTimeMs),
+                    elapsedWallMillis(nowWallTimeMs, lastActivityWallTimeMs),
+                    elapsedMillis(nowNanos, lastHeartbeatNanos),
+                    elapsedMillis(nowNanos, lastActivityNanos),
+                    heartbeatVersion,
+                    activityVersion,
+                    activeRequestCount);
+        }
+
+        synchronized boolean matches(HeartbeatObservation observation) {
+            return heartbeatVersion == observation.heartbeatVersion
+                    && activityVersion == observation.activityVersion;
+        }
+    }
+
+    /** Immutable timeout observation revalidated immediately before claiming daemon death. */
+    static final class HeartbeatObservation {
+        private final long nowWallTimeMs;
+        private final long nowNanos;
+        private final long heartbeatWallAgeMs;
+        private final long activityWallAgeMs;
+        private final long heartbeatMonotonicAgeMs;
+        private final long activityMonotonicAgeMs;
+        private final long heartbeatVersion;
+        private final long activityVersion;
+        private final int activeRequestCount;
+
+        HeartbeatObservation(
+                long nowWallTimeMs,
+                long nowNanos,
+                long heartbeatWallAgeMs,
+                long activityWallAgeMs,
+                long heartbeatMonotonicAgeMs,
+                long activityMonotonicAgeMs,
+                long heartbeatVersion,
+                long activityVersion,
+                int activeRequestCount
+        ) {
+            this.nowWallTimeMs = nowWallTimeMs;
+            this.nowNanos = nowNanos;
+            this.heartbeatWallAgeMs = heartbeatWallAgeMs;
+            this.activityWallAgeMs = activityWallAgeMs;
+            this.heartbeatMonotonicAgeMs = heartbeatMonotonicAgeMs;
+            this.activityMonotonicAgeMs = activityMonotonicAgeMs;
+            this.heartbeatVersion = heartbeatVersion;
+            this.activityVersion = activityVersion;
+            this.activeRequestCount = activeRequestCount;
+        }
+    }
+
+    enum DaemonGenerationState {
+        ACTIVE,
+        DEATH_CLAIMED,
+        STOPPED
+    }
+
+    /** Owns all mutable state that must never cross a daemon generation boundary. */
+    static final class DaemonGenerationContext {
+        private final Process process;
+        private final BufferedWriter stdin;
+        private final long generation;
+        private final long startedAtWallTimeMs;
+        private final CountDownLatch readyLatch = new CountDownLatch(1);
+        private final AtomicBoolean sdkPreloaded = new AtomicBoolean(false);
+        private final AtomicInteger activeRequestCount = new AtomicInteger(0);
+        private final ConcurrentHashMap<String, PendingRequest> pendingRequests =
+                new ConcurrentHashMap<>();
+        private final Deque<String> recentStderrLines = new ArrayDeque<>();
+        private final HeartbeatTimestamps heartbeatTimestamps;
+        private volatile DaemonGenerationState state = DaemonGenerationState.ACTIVE;
+        private volatile boolean startupPublished;
+        private volatile Thread readerThread;
+        private volatile Thread heartbeatThread;
+
+        DaemonGenerationContext(
+                Process process,
+                BufferedWriter stdin,
+                long generation,
+                long startedWallTimeMs,
+                long startedAtNanos
+        ) {
+            this.process = process;
+            this.stdin = stdin;
+            this.generation = generation;
+            this.startedAtWallTimeMs = startedWallTimeMs;
+            this.heartbeatTimestamps = new HeartbeatTimestamps(
+                    startedWallTimeMs, startedAtNanos);
+        }
+
+        boolean isActive() {
+            return state == DaemonGenerationState.ACTIVE;
+        }
+
+        boolean isStopped() {
+            return state == DaemonGenerationState.STOPPED;
+        }
+
+        void publishStartup() {
+            startupPublished = true;
+        }
+
+        boolean isStartupPublished() {
+            return startupPublished;
+        }
+
+        synchronized void claimDeath() {
+            if (state == DaemonGenerationState.ACTIVE) {
+                state = DaemonGenerationState.DEATH_CLAIMED;
+            }
+        }
+
+        void stop() {
+            state = DaemonGenerationState.STOPPED;
+        }
+
+        synchronized boolean signalReady(boolean preloaded) {
+            if (!isActive()) {
+                return false;
+            }
+            sdkPreloaded.set(preloaded);
+            readyLatch.countDown();
+            return true;
+        }
+
+        synchronized boolean markSdkPreloaded() {
+            if (!isActive()) {
+                return false;
+            }
+            sdkPreloaded.set(true);
+            return true;
+        }
+
+        long readySignalsRemaining() {
+            return readyLatch.getCount();
+        }
+
+        boolean isSdkPreloaded() {
+            return sdkPreloaded.get();
+        }
+
+        synchronized void appendStderrLine(String line) {
+            if (line == null) { return; }
+            recentStderrLines.addLast(line);
+            while (recentStderrLines.size() > STDERR_RING_CAPACITY) {
+                recentStderrLines.removeFirst();
+            }
+        }
+
+        synchronized String formatRecentStderrTail() {
+            if (recentStderrLines.isEmpty()) {
+                return "stderr=(empty)";
+            }
+            return "stderrTail=" + String.join(" | ", recentStderrLines);
+        }
+
+        synchronized HeartbeatObservation captureHeartbeatObservation(TimeSource timeSource) {
+            return heartbeatTimestamps.snapshot(timeSource, activeRequestCount.get());
+        }
+
+        synchronized void markHeartbeat(TimeSource timeSource) {
+            if (isActive()) {
+                heartbeatTimestamps.markHeartbeat(timeSource);
+            }
+        }
+
+        synchronized boolean matchesTimeoutObservation(HeartbeatObservation observation) {
+            return heartbeatTimestamps.matches(observation)
+                    && activeRequestCount.get() == observation.activeRequestCount;
+        }
+
+        synchronized boolean registerRequest(
+                String id,
+                RequestHandler handler,
+                boolean countsAsActiveRequest,
+                TimeSource timeSource
+        ) {
+            if (!isActive()) {
+                return false;
+            }
+            pendingRequests.put(id, new PendingRequest(handler, countsAsActiveRequest));
+            if (countsAsActiveRequest) {
+                activeRequestCount.incrementAndGet();
+            }
+            heartbeatTimestamps.markActivity(timeSource);
+            return true;
+        }
+
+        synchronized RequestHandler getRequestHandler(String id) {
+            PendingRequest request = pendingRequests.get(id);
+            return request != null ? request.handler : null;
+        }
+
+        synchronized void removeRequest(String id) {
+            PendingRequest removed = pendingRequests.remove(id);
+            if (removed != null && removed.countsAsActiveRequest) {
+                activeRequestCount.updateAndGet(current -> Math.max(0, current - 1));
+            }
+        }
+
+        synchronized List<RequestHandler> drainRequests() {
+            List<RequestHandler> handlers = new ArrayList<>();
+            for (PendingRequest request : pendingRequests.values()) {
+                handlers.add(request.handler);
+            }
+            pendingRequests.clear();
+            activeRequestCount.set(0);
+            return handlers;
+        }
+    }
+
+    private static final class PendingRequest {
+        private final RequestHandler handler;
+        private final boolean countsAsActiveRequest;
+
+        private PendingRequest(RequestHandler handler, boolean countsAsActiveRequest) {
+            this.handler = handler;
+            this.countsAsActiveRequest = countsAsActiveRequest;
+        }
+    }
+
+    /** A cancellable owner for one process launch and ready wait. */
+    private static final class StartAttempt {
+        private final long id;
+        private final long stopEpoch;
+        private final CountDownLatch completion = new CountDownLatch(1);
+        private final AtomicBoolean completed = new AtomicBoolean(false);
+        private volatile boolean cancelled;
+        private volatile boolean result;
+        private volatile DaemonGenerationContext context;
+
+        private StartAttempt(long id, long stopEpoch) {
+            this.id = id;
+            this.stopEpoch = stopEpoch;
+        }
+
+        private void cancel() {
+            cancelled = true;
+            complete(false);
+        }
+
+        private boolean isCancelled() {
+            return cancelled;
+        }
+
+        private void complete(boolean success) {
+            if (completed.compareAndSet(false, true)) {
+                result = success;
+                completion.countDown();
+            }
+        }
+
+        private boolean awaitResult() {
+            try {
+                completion.await();
+                return result;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface DaemonProcessLauncher {
+        Process launch() throws IOException;
+    }
+
+    interface DaemonLifecycleHooks {
+        DaemonLifecycleHooks NO_OP = new DaemonLifecycleHooks() { };
+
+        default void beforeAutoRestartCheck(long generation) {
+            // No-op in production.
+        }
+
+        default void afterAutoRestartCheck(long generation) {
+            // No-op in production.
+        }
+
+        default void beforeHeartbeatCheck(long generation) {
+            // No-op in production.
+        }
+    }
+
+    interface TimeSource {
+        long currentTimeMillis();
+        long nanoTime();
+
+        static TimeSource system() {
+            return SystemTimeSource.INSTANCE;
+        }
+    }
+
+    private enum SystemTimeSource implements TimeSource {
+        INSTANCE;
+
+        @Override
+        public long currentTimeMillis() {
+            return System.currentTimeMillis();
+        }
+
+        @Override
+        public long nanoTime() {
+            return System.nanoTime();
+        }
+    }
+
+    private boolean isCurrentDaemon(DaemonGenerationContext context) {
+        return daemonContext == context;
+    }
+
+    private static long elapsedMillis(long nowNanos, long startedAtNanos) {
+        long elapsedNanos = nowNanos - startedAtNanos;
+        return elapsedNanos <= 0 ? 0 : TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
+    }
+
+    private static long elapsedWallMillis(long nowWallTimeMs, long startedWallTimeMs) {
+        long elapsedMs = nowWallTimeMs - startedWallTimeMs;
+        return Math.max(0, elapsedMs);
     }
 
     // =========================================================================
@@ -893,7 +1606,7 @@ public class DaemonBridge {
     /**
      * Internal handler that wraps callback + future for a pending request.
      */
-    private static class RequestHandler {
+    static class RequestHandler {
         final DaemonOutputCallback callback;
         final CompletableFuture<Boolean> future;
 

--- a/src/test/java/com/github/claudecodegui/provider/common/DaemonBridgeTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/common/DaemonBridgeTest.java
@@ -1,10 +1,31 @@
 package com.github.claudecodegui.provider.common;
 
+import com.google.gson.JsonObject;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Verifies cross-platform daemon heartbeat/probe timing, generation-scoped
+ * ownership including stderr eligibility, and cancellable start/stop lifecycle
+ * transitions.
+ */
 public class DaemonBridgeTest {
 
     // HEARTBEAT_TIMEOUT_MS = 45_000; just over threshold triggers unresponsive
@@ -14,16 +35,19 @@ public class DaemonBridgeTest {
     // Recent activity within threshold
     private static final long RECENT_ACTIVITY = 5_000;
 
+    /** Verifies that an idle daemon beyond the base timeout is considered stale. */
     @Test
     public void staleHeartbeatWithoutActiveRequestsIsUnresponsive() {
         assertTrue(DaemonBridge.shouldTreatAsUnresponsive(JUST_OVER_HEARTBEAT_THRESHOLD, JUST_OVER_HEARTBEAT_THRESHOLD, 0));
     }
 
+    /** Verifies that recent request output keeps an active daemon alive. */
     @Test
     public void activeRequestWithRecentOutputGetsGraceWindow() {
         assertFalse(DaemonBridge.shouldTreatAsUnresponsive(JUST_OVER_HEARTBEAT_THRESHOLD, RECENT_ACTIVITY, 1));
     }
 
+    /** Verifies that an active daemon is eventually stale when all activity stops. */
     @Test
     public void activeRequestWithNoRecentOutputEventuallyTimesOut() {
         assertTrue(DaemonBridge.shouldTreatAsUnresponsive(OVER_ACTIVE_REQUEST_THRESHOLD, OVER_ACTIVE_REQUEST_THRESHOLD, 1));
@@ -43,11 +67,726 @@ public class DaemonBridgeTest {
      * Documents the exact restart-storm scenario from issue #1512: a stale
      * heartbeat age (left over from the previous dead process) combined with
      * a fresh activity age and no active requests IS treated as unresponsive.
-     * The fix prevents this stale value from ever reaching the check by
-     * resetting lastHeartbeatResponse when a new process is spawned.
+     * A generation context prevents this stale combination from crossing a
+     * restart by owning and initializing both heartbeat clocks independently.
      */
     @Test
     public void staleHeartbeatWithFreshActivityIsUnresponsive() {
         assertTrue(DaemonBridge.shouldTreatAsUnresponsive(297_132, 149, 0));
+    }
+
+    /**
+     * Verifies a stderr reader records only for the current active generation,
+     * rejecting both a replaced generation and a generation that has stopped.
+     */
+    @Test
+    public void stderrReaderRejectsStoppedAndReplacedGenerations() {
+        DaemonBridge.DaemonGenerationContext sourceContext = newContext(1);
+        DaemonBridge.DaemonGenerationContext replacementContext = newContext(2);
+
+        assertTrue(DaemonBridge.shouldRecordStderrLine(sourceContext, sourceContext));
+        assertFalse(DaemonBridge.shouldRecordStderrLine(replacementContext, sourceContext));
+
+        sourceContext.stop();
+        assertFalse(DaemonBridge.shouldRecordStderrLine(sourceContext, sourceContext));
+    }
+
+    /** Verifies that the first stale observation sends a probe instead of killing the daemon. */
+    @Test
+    public void firstStaleObservationRequestsHeartbeatProbe() {
+        MutableTimeSource timeSource = new MutableTimeSource(46_000, nanos(46_000));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(30_000);
+
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies idle wake probes immediately when nanoTime pauses during suspend. */
+    @Test
+    public void idleWakeWithPausedMonotonicClockStillSendsProbe() {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(0);
+
+        timeSource.set(300_000, nanos(15_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+
+        timeSource.set(305_000, nanos(20_000));
+        timestamps.markHeartbeat(timeSource);
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.HEALTHY,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies idle wake has the same probe policy when nanoTime includes suspend. */
+    @Test
+    public void idleWakeWithAdvancingMonotonicClockAlsoSendsProbe() {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(0);
+
+        timeSource.set(300_000, nanos(300_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies a wake probe cannot succeed without a response when nanoTime paused. */
+    @Test
+    public void pausedMonotonicWakeWithoutResponseExpiresProbe() {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(0);
+
+        timeSource.set(300_000, nanos(15_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+        timeSource.set(315_000, nanos(30_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.WAIT_FOR_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+        timeSource.set(330_000, nanos(45_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.DECLARE_DEAD,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies a wake probe also expires without a response when nanoTime advanced. */
+    @Test
+    public void advancingMonotonicWakeWithoutResponseExpiresProbe() {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(0);
+
+        timeSource.set(300_000, nanos(300_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+        timeSource.set(315_000, nanos(315_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.WAIT_FOR_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+        timeSource.set(330_000, nanos(330_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.DECLARE_DEAD,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies active requests use wall age consistently when nanoTime pauses in sleep. */
+    @Test
+    public void activeRequestAfterSystemSleepKeepsExistingTimeoutSemantics() {
+        MutableTimeSource timeSource = new MutableTimeSource(300_000, nanos(15_000));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(0);
+
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.DECLARE_DEAD,
+                evaluate(state, timeSource, timestamps, 1));
+
+        timeSource.set(305_000, nanos(20_000));
+        timestamps.markHeartbeat(timeSource);
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.HEALTHY,
+                evaluate(state, timeSource, timestamps, 1));
+    }
+
+    /** Verifies active suspend timeout is identical when nanoTime includes the sleep. */
+    @Test
+    public void activeRequestWithAdvancingMonotonicClockUsesSameWallTimeout() {
+        MutableTimeSource timeSource = new MutableTimeSource(300_000, nanos(300_000));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(0);
+
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.DECLARE_DEAD,
+                evaluate(state, timeSource, timestamps, 1));
+    }
+
+    /** Verifies that a stale daemon is declared dead only after the bounded probe expires. */
+    @Test
+    public void unansweredProbeEventuallyDeclaresDaemonDead() {
+        MutableTimeSource timeSource = new MutableTimeSource(46_000, nanos(46_000));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(30_000);
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+
+        timeSource.set(61_000, nanos(61_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.WAIT_FOR_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+        timeSource.set(76_000, nanos(76_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.DECLARE_DEAD,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies that a heartbeat response clears the outstanding probe state. */
+    @Test
+    public void heartbeatResponseClearsOutstandingProbe() {
+        MutableTimeSource timeSource = new MutableTimeSource(46_000, nanos(46_000));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(30_000);
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+
+        timeSource.set(51_000, nanos(51_000));
+        timestamps.markHeartbeat(timeSource);
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.HEALTHY,
+                evaluate(state, timeSource, timestamps, 0));
+        timeSource.set(97_000, nanos(97_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /**
+     * Verifies that a sleep-sized scheduler gap replaces an old probe instead
+     * of treating its elapsed wall-clock time as a failed liveness check.
+     */
+    @Test
+    public void schedulerGapRearmsProbeWithoutKillingHealthyDaemon() {
+        MutableTimeSource timeSource = new MutableTimeSource(46_000, nanos(46_000));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(30_000);
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+
+        timeSource.set(346_000, nanos(51_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+        timeSource.set(351_000, nanos(56_000));
+        timestamps.markHeartbeat(timeSource);
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.HEALTHY,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies a wall-clock rollback rearms the idle probe without expiring it. */
+    @Test
+    public void wallClockRollbackRearmsProbeUsingMonotonicDeadline() {
+        MutableTimeSource timeSource = new MutableTimeSource(25_000, nanos(46_000));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(10_000);
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+
+        timeSource.set(5_000, nanos(61_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies a negative nanoTime value can still own an active probe deadline. */
+    @Test
+    public void negativeMonotonicValueDoesNotCollideWithProbeState() {
+        MutableTimeSource timeSource = new MutableTimeSource(46_000, -nanos(1_000));
+        DaemonBridge.HeartbeatTimestamps timestamps =
+                new DaemonBridge.HeartbeatTimestamps(0, -nanos(50_000));
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(30_000);
+
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+        timeSource.set(61_000, nanos(14_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.WAIT_FOR_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies a death claim revokes all subsequent output eligibility for its generation. */
+    @Test
+    public void claimedGenerationCannotBecomeActiveAgain() {
+        DaemonBridge.DaemonGenerationContext context = newContext(1);
+
+        assertTrue(context.isActive());
+        context.claimDeath();
+        assertFalse(context.isActive());
+    }
+
+    /** Verifies a late ready event cannot release or mutate the replacement generation. */
+    @Test
+    public void claimedGenerationRejectsLateReadyForReplacement() {
+        DaemonBridge.DaemonGenerationContext claimed = newContext(1);
+        DaemonBridge.DaemonGenerationContext replacement = newContext(2);
+        claimed.claimDeath();
+
+        assertFalse(claimed.signalReady(true));
+        assertEquals(1, claimed.readySignalsRemaining());
+        assertEquals(1, replacement.readySignalsRemaining());
+        assertFalse(replacement.isSdkPreloaded());
+    }
+
+    /** Verifies cleanup of one generation cannot remove a replacement request. */
+    @Test
+    public void generationScopedRequestCleanupCannotClearReplacementRequests() {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        DaemonBridge.DaemonGenerationContext claimed = newContext(1);
+        DaemonBridge.DaemonGenerationContext replacement = newContext(2);
+        DaemonBridge.RequestHandler oldHandler = newRequestHandler();
+        DaemonBridge.RequestHandler newHandler = newRequestHandler();
+
+        assertTrue(claimed.registerRequest("old", oldHandler, true, timeSource));
+        claimed.claimDeath();
+        assertEquals(1, claimed.drainRequests().size());
+        assertFalse(claimed.registerRequest("late", oldHandler, true, timeSource));
+
+        assertTrue(replacement.registerRequest("new", newHandler, true, timeSource));
+        assertTrue(claimed.drainRequests().isEmpty());
+        assertSame(newHandler, replacement.getRequestHandler("new"));
+    }
+
+    /** Verifies a heartbeat arriving after timeout observation cancels the death claim. */
+    @Test
+    public void heartbeatProgressInvalidatesPendingTimeoutObservation() {
+        MutableTimeSource timeSource = new MutableTimeSource(300_000, nanos(300_000));
+        DaemonBridge.DaemonGenerationContext context = newContext(1);
+        DaemonBridge.HeartbeatObservation observation =
+                context.captureHeartbeatObservation(timeSource);
+
+        assertTrue(context.matchesTimeoutObservation(observation));
+        timeSource.set(301_000, nanos(301_000));
+        context.markHeartbeat(timeSource);
+        assertFalse(context.matchesTimeoutObservation(observation));
+        assertTrue(context.isActive());
+    }
+
+    /** Verifies a cancelled timeout keeps the heartbeat watchdog loop running. */
+    @Test
+    public void cancelledTimeoutContinuesHeartbeatMonitoring() {
+        assertTrue(DaemonBridge.shouldContinueHeartbeatAfterDeath(
+                DaemonBridge.DeathHandlingResult.CANCELLED));
+        assertFalse(DaemonBridge.shouldContinueHeartbeatAfterDeath(
+                DaemonBridge.DeathHandlingResult.CLAIMED));
+        assertFalse(DaemonBridge.shouldContinueHeartbeatAfterDeath(
+                DaemonBridge.DeathHandlingResult.STALE_GENERATION));
+    }
+
+    /** Verifies a later explicit stop epoch vetoes an already prepared auto-restart. */
+    @Test
+    public void explicitStopEpochCancelsPreparedAutomaticRestart() {
+        DaemonBridge.DaemonGenerationContext claimed = newContext(1);
+        claimed.claimDeath();
+
+        assertTrue(DaemonBridge.shouldAutoRestart(
+                true, 4, 4, claimed, claimed, 1));
+        assertFalse(DaemonBridge.shouldAutoRestart(
+                false, 5, 4, claimed, claimed, 1));
+        assertFalse(DaemonBridge.shouldAutoRestart(
+                true, 5, 4, claimed, claimed, 1));
+    }
+
+    /** Verifies a concurrent explicit stop prevents the claimed daemon from launching B. */
+    @Test
+    public void stopDuringDeathCleanupPreventsAutomaticReplacementProcess() throws Exception {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        ControlledProcess firstProcess = new ControlledProcess(101);
+        ControlledProcess replacementProcess = new ControlledProcess(102);
+        firstProcess.emitReady();
+        replacementProcess.emitReady();
+        AtomicInteger launchCount = new AtomicInteger();
+        CountDownLatch beforeRestartCheck = new CountDownLatch(1);
+        CountDownLatch allowRestartCheck = new CountDownLatch(1);
+        CountDownLatch restartCheckFinished = new CountDownLatch(1);
+        DaemonBridge.DaemonLifecycleHooks hooks = new DaemonBridge.DaemonLifecycleHooks() {
+            @Override
+            public void beforeAutoRestartCheck(long generation) {
+                beforeRestartCheck.countDown();
+                await(allowRestartCheck);
+            }
+
+            @Override
+            public void afterAutoRestartCheck(long generation) {
+                restartCheckFinished.countDown();
+            }
+        };
+        DaemonBridge bridge = new DaemonBridge(
+                null,
+                null,
+                null,
+                timeSource,
+                () -> launchCount.getAndIncrement() == 0 ? firstProcess : replacementProcess,
+                hooks);
+
+        assertTrue(bridge.start());
+        firstProcess.exit();
+        assertTrue(beforeRestartCheck.await(2, TimeUnit.SECONDS));
+
+        Thread stopThread = new Thread(bridge::stop, "DaemonBridgeTest-Stop");
+        stopThread.start();
+        assertTrue(firstProcess.stdinFlushed.await(2, TimeUnit.SECONDS));
+        allowRestartCheck.countDown();
+        stopThread.join(2_000);
+
+        assertTrue(restartCheckFinished.await(2, TimeUnit.SECONDS));
+        assertEquals(1, launchCount.get());
+        assertFalse(replacementProcess.wasDestroyed());
+        assertFalse(bridge.isAlive());
+    }
+
+    /**
+     * Verifies a published dead generation retains the lifecycle slot and the
+     * watchdog claims it even while the stdout reader remains blocked.
+     */
+    @Test
+    public void deadPublishedGenerationIsNotOverwrittenBeforeReaderCleanup() throws Exception {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        ControlledProcess firstProcess = new ControlledProcess(151);
+        ControlledProcess replacementProcess = new ControlledProcess(152);
+        firstProcess.emitReady();
+        replacementProcess.emitReady();
+        AtomicInteger launchCount = new AtomicInteger();
+        CountDownLatch replacementLaunch = new CountDownLatch(1);
+        CountDownLatch heartbeatCheckReached = new CountDownLatch(1);
+        CountDownLatch allowHeartbeatCheck = new CountDownLatch(1);
+        DaemonBridge.DaemonLifecycleHooks hooks = new DaemonBridge.DaemonLifecycleHooks() {
+            @Override
+            public void beforeHeartbeatCheck(long generation) {
+                if (generation == 1) {
+                    heartbeatCheckReached.countDown();
+                    await(allowHeartbeatCheck);
+                }
+            }
+        };
+        DaemonBridge bridge = new DaemonBridge(
+                null,
+                null,
+                null,
+                timeSource,
+                () -> {
+                    if (launchCount.getAndIncrement() == 0) {
+                        return firstProcess;
+                    }
+                    replacementLaunch.countDown();
+                    return replacementProcess;
+                },
+                hooks,
+                5);
+
+        assertTrue(bridge.start());
+        assertTrue(heartbeatCheckReached.await(2, TimeUnit.SECONDS));
+        CompletableFuture<Boolean> oldFuture = bridge.sendCommand(
+                "claude.send", new JsonObject(), new NoOpDaemonOutputCallback());
+        firstProcess.markDeadWithoutClosingOutput();
+
+        assertFalse(bridge.start());
+        assertEquals(1, launchCount.get());
+        assertFalse(oldFuture.isDone());
+
+        allowHeartbeatCheck.countDown();
+        assertTrue(replacementLaunch.await(2, TimeUnit.SECONDS));
+        assertTrue(oldFuture.handle((value, error) -> error != null)
+                .get(2, TimeUnit.SECONDS));
+        assertTrue(bridge.start());
+        assertEquals(2, launchCount.get());
+        assertTrue(bridge.isAlive());
+        firstProcess.closeOutput();
+        bridge.stop();
+    }
+
+    /**
+     * Verifies a daemon that exits before its initial ready signal cannot start
+     * an ownerless replacement after {@link DaemonBridge#start()} returns false.
+     */
+    @Test
+    public void readyFailureDoesNotLaunchBackgroundReplacement() throws Exception {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        ControlledProcess failedProcess = new ControlledProcess(201);
+        ControlledProcess replacementProcess = new ControlledProcess(202);
+        failedProcess.exit();
+        replacementProcess.emitReady();
+        AtomicInteger launchCount = new AtomicInteger();
+        CountDownLatch replacementLaunch = new CountDownLatch(1);
+        DaemonBridge bridge = new DaemonBridge(
+                null,
+                null,
+                null,
+                timeSource,
+                () -> {
+                    if (launchCount.getAndIncrement() == 0) {
+                        return failedProcess;
+                    }
+                    replacementLaunch.countDown();
+                    return replacementProcess;
+                },
+                null);
+
+        assertFalse(bridge.start());
+        assertFalse(replacementLaunch.await(500, TimeUnit.MILLISECONDS));
+        assertEquals(1, launchCount.get());
+        assertFalse(bridge.isAlive());
+        assertFalse(replacementProcess.wasDestroyed());
+    }
+
+    /**
+     * Verifies stop can cancel a daemon waiting for ready without waiting for
+     * the full daemon startup timeout or leaving the launched process alive.
+     */
+    @Test
+    public void stopCancelsStartingDaemonWithoutWaitingForReadyTimeout() throws Exception {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        ControlledProcess startingProcess = new ControlledProcess(301);
+        CountDownLatch processLaunchEntered = new CountDownLatch(1);
+        AtomicBoolean startResult = new AtomicBoolean(true);
+        DaemonBridge bridge = new DaemonBridge(
+                null,
+                null,
+                null,
+                timeSource,
+                () -> {
+                    processLaunchEntered.countDown();
+                    return startingProcess;
+                },
+                null);
+        Thread startThread = new Thread(
+                () -> startResult.set(bridge.start()), "DaemonBridgeTest-Start");
+        startThread.start();
+        assertTrue(processLaunchEntered.await(2, TimeUnit.SECONDS));
+
+        Thread stopThread = new Thread(bridge::stop, "DaemonBridgeTest-StopStarting");
+        stopThread.start();
+        stopThread.join(2_000);
+        startThread.join(2_000);
+
+        assertFalse("stop() must not wait for the 30-second ready timeout", stopThread.isAlive());
+        assertFalse("start() must observe the cancelled attempt", startThread.isAlive());
+        assertFalse(startResult.get());
+        assertTrue(startingProcess.wasDestroyed());
+        assertFalse(bridge.isAlive());
+    }
+
+    private static DaemonBridge.HeartbeatTimestamps timestampsAtZero() {
+        return new DaemonBridge.HeartbeatTimestamps(0, nanos(0));
+    }
+
+    private static DaemonBridge.HeartbeatDecision evaluate(
+            DaemonBridge.IdleHeartbeatProbeState state,
+            DaemonBridge.TimeSource timeSource,
+            DaemonBridge.HeartbeatTimestamps timestamps,
+            int activeRequestCount
+    ) {
+        return state.evaluate(timestamps.snapshot(timeSource, activeRequestCount));
+    }
+
+    private static DaemonBridge.DaemonGenerationContext newContext(long generation) {
+        StubProcess process = new StubProcess();
+        return new DaemonBridge.DaemonGenerationContext(
+                process,
+                new java.io.BufferedWriter(new java.io.OutputStreamWriter(process.getOutputStream())),
+                generation,
+                0,
+                nanos(0));
+    }
+
+    private static DaemonBridge.RequestHandler newRequestHandler() {
+        return new DaemonBridge.RequestHandler(
+                new NoOpDaemonOutputCallback(), new CompletableFuture<>());
+    }
+
+    private static long nanos(long millis) {
+        return TimeUnit.MILLISECONDS.toNanos(millis);
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await(2, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /** Mutable dual clock used to reproduce platform-specific suspend behavior. */
+    private static final class MutableTimeSource implements DaemonBridge.TimeSource {
+        private long wallTimeMs;
+        private long nanoTime;
+
+        private MutableTimeSource(long wallTimeMs, long nanoTime) {
+            set(wallTimeMs, nanoTime);
+        }
+
+        private void set(long wallTimeMs, long nanoTime) {
+            this.wallTimeMs = wallTimeMs;
+            this.nanoTime = nanoTime;
+        }
+
+        @Override
+        public long currentTimeMillis() {
+            return wallTimeMs;
+        }
+
+        @Override
+        public long nanoTime() {
+            return nanoTime;
+        }
+    }
+
+    /** No-op callback used to test request ownership without invoking provider logic. */
+    private static final class NoOpDaemonOutputCallback implements DaemonBridge.DaemonOutputCallback {
+        @Override
+        public void onLine(String line) {
+            // No-op.
+        }
+
+        @Override
+        public void onStderr(String text) {
+            // No-op.
+        }
+
+        @Override
+        public void onError(String error) {
+            // No-op.
+        }
+
+        @Override
+        public void onComplete(boolean success) {
+            // No-op.
+        }
+    }
+
+    /** Minimal process identity used to test generation ownership without starting an OS process. */
+    private static final class StubProcess extends Process {
+        @Override
+        public OutputStream getOutputStream() {
+            return new ByteArrayOutputStream();
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+
+        @Override
+        public int waitFor() {
+            return 0;
+        }
+
+        @Override
+        public int exitValue() {
+            return 0;
+        }
+
+        @Override
+        public void destroy() {
+            // No-op test process.
+        }
+    }
+
+    /** Controllable process used to drive the real reader/death/stop lifecycle deterministically. */
+    private static final class ControlledProcess extends Process {
+        private final long processId;
+        private final PipedInputStream stdout = new PipedInputStream();
+        private final PipedOutputStream stdoutWriter;
+        private final AtomicBoolean alive = new AtomicBoolean(true);
+        private final AtomicBoolean destroyed = new AtomicBoolean(false);
+        private final CountDownLatch stdinFlushed = new CountDownLatch(1);
+        private final OutputStream stdin = new ByteArrayOutputStream() {
+            @Override
+            public void flush() {
+                stdinFlushed.countDown();
+            }
+        };
+
+        private ControlledProcess(long processId) throws java.io.IOException {
+            this.processId = processId;
+            this.stdoutWriter = new PipedOutputStream(stdout);
+        }
+
+        private void emitReady() throws java.io.IOException {
+            stdoutWriter.write(("{\"type\":\"daemon\",\"event\":\"ready\","
+                    + "\"sdkPreloaded\":true}\n").getBytes(StandardCharsets.UTF_8));
+            stdoutWriter.flush();
+        }
+
+        private void exit() throws java.io.IOException {
+            markDeadWithoutClosingOutput();
+            closeOutput();
+        }
+
+        private void markDeadWithoutClosingOutput() {
+            alive.set(false);
+        }
+
+        private void closeOutput() throws java.io.IOException {
+            stdoutWriter.close();
+        }
+
+        private boolean wasDestroyed() {
+            return destroyed.get();
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return stdin;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return stdout;
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+
+        @Override
+        public int waitFor() {
+            return 0;
+        }
+
+        @Override
+        public int exitValue() {
+            return 0;
+        }
+
+        @Override
+        public void destroy() {
+            destroyed.set(true);
+            alive.set(false);
+        }
+
+        @Override
+        public Process destroyForcibly() {
+            destroy();
+            return this;
+        }
+
+        @Override
+        public boolean isAlive() {
+            return alive.get();
+        }
+
+        @Override
+        public long pid() {
+            return processId;
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes the daemon restart storm reported in #1601. Idle daemons are no longer killed immediately after a system suspend/resume scheduling gap. They first receive one bounded heartbeat probe; the existing daemon is reused when it responds, and is restarted only when the probe expires without a real heartbeat response.

The change also makes daemon lifecycle state generation-scoped. This refactor is necessary for correctness: adding only a probe timer would leave races where a death decision for daemon A can kill or mutate replacement B, an explicit stop can lose to an already prepared restart, or A's pending requests can be orphaned when B is installed.

Refs #1601. This PR intentionally does not auto-close the issue so the owner can decide when runtime validation is sufficient.

## Problem

Before this change, suspend time was interpreted as daemon execution time:

```text
system suspend
  -> heartbeat thread is not scheduled
  -> wall-clock heartbeat age jumps after resume
  -> watchdog immediately declares the daemon dead
  -> every restored chat window restarts its own daemon
  -> coordinated restart storm
```

Three observations make this more than a one-line timeout change:

1. A stale heartbeat can mean system suspension rather than a dead daemon.
2. `Process.isAlive()`, stdout EOF, heartbeat timeout, and request output are observed by different threads and can arrive in any order.
3. A replacement process must not become current until the previous generation has lost output authority and its pending requests have been detached.

## What changed

### 1. Probe-first recovery for idle daemons

- An idle heartbeat timeout or suspend-sized scheduler gap arms one bounded heartbeat probe instead of immediately killing the process.
- A probe succeeds only when `heartbeatVersion` advances after it was armed.
- Ordinary output, a young monotonic heartbeat age, or an old timestamp cannot incorrectly complete the probe.
- A new scheduler discontinuity replaces the previous probe and binds a new version/deadline.
- If no heartbeat response arrives within 30 seconds, the existing kill/restart path runs.

### 2. Clear dual-clock responsibilities

- Wall clock detects suspend-sized scheduler gaps, time jumps, and rollbacks.
- `System.nanoTime()` measures probe deadlines and normal elapsed time.
- Active SDK requests retain the existing 180-second wall-time timeout.

This avoids depending on a platform-specific assumption about whether the monotonic clock advances during sleep.

### 3. Generation-scoped daemon ownership

Each `DaemonGenerationContext` owns its own:

- `Process` and stdin writer;
- ready latch and SDK preload state;
- heartbeat/activity timestamps and versions;
- pending requests and active-request count;
- reader and heartbeat threads;
- lifecycle state.

The lifecycle is monotonic:

```text
ACTIVE -> DEATH_CLAIMED
ACTIVE -> STOPPED
```

Once a generation leaves `ACTIVE`, late ready events, heartbeat responses, output, and request completions from daemon A cannot mutate daemon B.

### 4. Cancellable start/stop lifecycle

- `desiredRunning` and `stopEpoch` represent bridge-level lifecycle intent.
- Every launch is owned by one cancellable `StartAttempt`.
- Process creation and the ready wait occur outside `startLock`, so `stop()` is not blocked by the 30-second startup timeout.
- Concurrent `start()` callers wait for the same attempt result instead of launching duplicate processes or using independent guessed deadlines.
- Explicit stop cancels an in-flight attempt and always overrides a prepared automatic restart.
- A generation that exits before it has successfully published ready is not eligible for background auto-restart, preventing ownerless Node processes after `start()` returns false.

### 5. Atomic death claim and restart

- Reader EOF, heartbeat timeout, dead-process observation, and stdin failure share the same generation-scoped death handler.
- Only one thread can claim an `ACTIVE` generation.
- Pending handlers are atomically detached from A before replacement startup.
- User callbacks run outside lifecycle locks, preventing callback re-entry from clearing B's requests or deadlocking startup.
- Automatic restart revalidates current generation, stop epoch, desired-running intent, and restart budget.
- Timeout observations are revalidated immediately before death claim; if heartbeat or request progress advanced, the timeout is cancelled and the watchdog continues running.

### 6. Dead process recovery no longer depends on stdout EOF

The watchdog now treats `process.isAlive() == false` as hard death and participates in the same death claim. This matters when a descendant process temporarily keeps an inherited stdout pipe open: pending futures are still completed, the generation slot is released, and replacement startup can proceed without waiting forever for reader EOF.

## Behavior changes

| Scenario | Before | After |
|---|---|---|
| Idle daemon after suspend/resume | Could be killed immediately | Receives a bounded probe first |
| Probe receives heartbeat | No probe state | Existing daemon is retained |
| Probe receives no response | Timeout could trigger immediate restart | Restart occurs after the 30-second deadline |
| Late output from daemon A | Could mutate shared/global state | Rejected by generation ownership |
| A dies while stdout remains open | Could occupy the lifecycle slot indefinitely | Watchdog claims A within one heartbeat cycle |
| Concurrent `start()` calls | Could race or observe inconsistent startup | Share one `StartAttempt` result |
| `stop()` during ready wait | Could wait behind the startup lock | Cancels the attempt immediately |
| A cleanup races with B requests | Could clear B-owned state | Request maps are generation-scoped |
| Active SDK request | 180-second wall-time behavior | Unchanged |

## Cross-platform compatibility

The implementation explicitly covers both common suspend clock behaviors:

- macOS/Linux-style behavior where the monotonic source may pause during suspend;
- Windows-style behavior where the monotonic source may advance across standby/hibernate.

Wall time is used only to identify scheduler discontinuities and to preserve the existing active-request policy. Probe expiration is monotonic, and probe success requires a heartbeat version change. Unit tests model both "wall advances / nano pauses" and "wall and nano both advance" paths, including unanswered probes.

No platform-specific APIs were added. The daemon protocol and `daemon.js` are unchanged.

## Why the refactor is necessary

Although the production diff is larger than a timer adjustment, it remains limited to `DaemonBridge.java`. The added structure falls into three necessary categories:

1. **Business fix:** idle probe, scheduler-gap handling, and heartbeat-version acknowledgment.
2. **Concurrency correctness:** generation context, atomic death claim, stop epoch, and shared start attempts.
3. **Deterministic verification:** injectable clocks/process factory/lifecycle hooks and a package-private heartbeat interval used only by tests.

Without the generation and lifecycle boundaries, a probe-first policy would introduce or preserve races involving stale callbacks, duplicate replacement processes, stop/restart inversion, and leaked pending requests.

## Scope and expected trade-offs

- Production heartbeat interval remains 15 seconds.
- Idle probe deadline is 30 seconds.
- No new loop thread is introduced; the existing heartbeat watchdog is reused.
- The one-daemon-per-window architecture is unchanged.
- No project-level daemon sharing is introduced.
- A live but temporarily silent idle daemon may restart up to one probe deadline later; this is the intended trade-off that avoids false kills.
- A hard-dead process whose reader has not observed EOF is recovered within at most one heartbeat cycle.
- Recovery of an SDK network request that was active during suspend is not included. Active-request resume grace requires request-progress semantics and should remain separate from daemon liveness.

## Suggested review focus

Please review the following invariants in particular:

1. At most one daemon generation is current.
2. At most one `StartAttempt` is active.
3. Only an `ACTIVE` generation can accept output or register requests.
4. `DEATH_CLAIMED` and `STOPPED` generations can never become active again.
5. Only a successfully ready-published generation may auto-restart.
6. Explicit `stop()` always wins over automatic restart.
7. A probe succeeds only after `heartbeatVersion` advances.
8. User callbacks never execute under lifecycle locks.
9. Cleanup for A can never access B's request map, ready latch, heartbeat state, or stdin.
10. A published dead generation retains ownership until its requests are detached; B cannot overwrite it early.

## Verification

- `DaemonBridgeTest`: 27/27 passed.
- Full Gradle test suite passed.
- `checkstyleMain --rerun-tasks` passed.
- `git diff --check` passed.
- Tests cover both suspend clock models, unanswered probes, stale timeout cancellation, reader/watchdog death races, dead process with stdout held open, generation isolation, stop/restart races, ready-before-exit failure, and concurrent start waiters.
- Java test class-level and method-level documentation is present.

