### PR TITLE
feat(webview): quote conversation text into the chat input

### DIFF
--- a/webview/src/components/ChatInputBox/ChatInputBox.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBox.tsx
@@ -20,6 +20,7 @@ import { ResizeHandles } from './ResizeHandles.js';
 import {
   useTextContent,
   useFileTags,
+  useQuoteTags,
   useTooltip,
   useKeyboardNavigation,
   useIMEComposition,
@@ -175,6 +176,15 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
       onCloseCompletions: closeAllCompletions,
     });
 
+    // Quote tags hook (inline quote chips)
+    const { renderQuoteTags } = useQuoteTags({ editableRef });
+
+    // Combined tag rendering: file tags first, then quote chips.
+    const renderTags = useCallback(() => {
+      renderFileTags();
+      renderQuoteTags();
+    }, [renderFileTags, renderQuoteTags]);
+
     // Tooltip hook
     const { tooltip, handleMouseOver, handleMouseLeave } = useTooltip();
 
@@ -212,8 +222,8 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
 
     // Create debounced version of renderFileTags
     const debouncedRenderFileTags = useMemo(
-      () => debounce(renderFileTags, DEBOUNCE_TIMING.FILE_TAG_RENDERING_MS),
-      [renderFileTags]
+      () => debounce(renderTags, DEBOUNCE_TIMING.FILE_TAG_RENDERING_MS),
+      [renderTags]
     );
 
     const {
@@ -357,8 +367,8 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
     }, [rawHandleCompositionEnd]);
 
     useEffect(() => {
-      setRenderFileTags(renderFileTags);
-    }, [renderFileTags, setRenderFileTags]);
+      setRenderFileTags(renderTags);
+    }, [renderTags, setRenderFileTags]);
 
     const { record: recordInputHistory, handleKeyDown: handleHistoryKeyDown } = useInputHistory({
       editableRef,
@@ -520,7 +530,7 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
       pathMappingRef,
       getTextContent,
       adjustHeight,
-      renderFileTags,
+      renderFileTags: renderTags,
       setHasContent,
       setInternalAttachments,
       onInput,
@@ -557,7 +567,8 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
       pathMappingRef,
       getTextContent,
       adjustHeight,
-      renderFileTags,
+      renderFileTags: renderTags,
+      renderQuoteTags,
       setHasContent,
       onInput,
       closeAllCompletions,

--- a/webview/src/components/ChatInputBox/hooks/index.ts
+++ b/webview/src/components/ChatInputBox/hooks/index.ts
@@ -3,6 +3,7 @@ export { useCompletionDropdown } from './useCompletionDropdown.js';
 export { useCompletionTriggerDetection } from './useCompletionTriggerDetection.js';
 export { useTextContent } from './useTextContent.js';
 export { useFileTags } from './useFileTags.js';
+export { useQuoteTags } from './useQuoteTags.js';
 export { useTooltip } from './useTooltip.js';
 export { useKeyboardNavigation } from './useKeyboardNavigation.js';
 export { useIMEComposition } from './useIMEComposition.js';

--- a/webview/src/components/ChatInputBox/hooks/useGlobalCallbacks.ts
+++ b/webview/src/components/ChatInputBox/hooks/useGlobalCallbacks.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { createTextFragment } from '../utils/selectionUtils.js';
+import { makeQuoteToken, registerQuote } from '../utils/quoteRegistry.js';
 
 interface UseGlobalCallbacksOptions {
   editableRef: React.RefObject<HTMLDivElement | null>;
@@ -7,6 +8,7 @@ interface UseGlobalCallbacksOptions {
   getTextContent: () => string;
   adjustHeight: () => void;
   renderFileTags: () => void;
+  renderQuoteTags: () => void;
   setHasContent: (hasContent: boolean) => void;
   onInput?: (content: string) => void;
   closeAllCompletions: () => void;
@@ -26,6 +28,7 @@ export function useGlobalCallbacks({
   getTextContent,
   adjustHeight,
   renderFileTags,
+  renderQuoteTags,
   setHasContent,
   onInput,
   closeAllCompletions,
@@ -250,9 +253,71 @@ export function useGlobalCallbacks({
       focusInput();
     };
 
+    // Insert an inline quote chip. Payload: JSON { text }.
+    // The chip renders a compact preview; the full Markdown blockquote is
+    // expanded from the registry only when the message is sent.
+    window.addQuotedSnippet = (payload: string) => {
+      try {
+        if (!editableRef.current) return;
+
+        let quoteText = '';
+        try {
+          const parsed = JSON.parse(payload) as { text?: unknown };
+          quoteText = typeof parsed.text === 'string' ? parsed.text : '';
+        } catch {
+          quoteText = payload;
+        }
+        if (!quoteText.trim()) return;
+
+        const token = makeQuoteToken(registerQuote(quoteText));
+
+        const selection = window.getSelection();
+        const insertAtCaret =
+          selection &&
+          selection.rangeCount > 0 &&
+          editableRef.current.contains(selection.anchorNode);
+
+        if (insertAtCaret) {
+          const range = selection.getRangeAt(0);
+          range.deleteContents();
+          const tokenNode = document.createTextNode(token);
+          range.insertNode(tokenNode);
+          range.setStartAfter(tokenNode);
+          range.collapse(true);
+          selection.removeAllRanges();
+          selection.addRange(range);
+        } else {
+          editableRef.current.focus();
+          const tokenNode = document.createTextNode(token);
+          editableRef.current.appendChild(tokenNode);
+          const range = document.createRange();
+          range.setStartAfter(tokenNode);
+          range.collapse(true);
+          const endSelection = window.getSelection();
+          endSelection?.removeAllRanges();
+          endSelection?.addRange(range);
+        }
+
+        // Turn the freshly inserted token into a chip, then sync input state.
+        renderQuoteTags();
+
+        const newText = getTextContent();
+        setHasContent(!!newText.trim());
+        adjustHeight();
+        onInput?.(newText);
+
+        requestAnimationFrame(() => {
+          editableRef.current?.focus();
+        });
+      } catch (error) {
+        console.error('[useGlobalCallbacks] addQuotedSnippet failed:', error);
+      }
+    };
+
     return () => {
       delete window.insertCodeSnippetAtCursor;
       delete window.focusChatInput;
+      delete window.addQuotedSnippet;
     };
-  }, [editableRef, getTextContent, renderFileTags, adjustHeight, onInput, setHasContent, focusInput]);
+  }, [editableRef, getTextContent, renderFileTags, renderQuoteTags, adjustHeight, onInput, setHasContent, focusInput]);
 }

--- a/webview/src/components/ChatInputBox/hooks/useQuoteTags.ts
+++ b/webview/src/components/ChatInputBox/hooks/useQuoteTags.ts
@@ -1,0 +1,112 @@
+import { useCallback, useEffect } from 'react';
+import {
+  createQuoteChipElement,
+  getQuote,
+  hasQuoteToken,
+  quoteTokenRegex,
+  removeQuote,
+} from '../utils/quoteRegistry.js';
+import {
+  getVirtualCursorPosition,
+  setVirtualCursorPosition,
+} from '../utils/virtualCursorUtils.js';
+
+interface UseQuoteTagsOptions {
+  editableRef: React.RefObject<HTMLDivElement | null>;
+}
+
+interface UseQuoteTagsReturn {
+  /** Convert any quote tokens in the input's text nodes into inline chip elements. */
+  renderQuoteTags: () => void;
+}
+
+/**
+ * useQuoteTags - Render inline quote chips from quote tokens in the input.
+ *
+ * Mirrors the file-tag mechanism: getTextContent() serializes a `.quote-tag`
+ * chip back to its compact token, and this pass rebuilds the chip from the
+ * token. The full Markdown blockquote is expanded from the registry only at
+ * send time.
+ */
+export function useQuoteTags({ editableRef }: UseQuoteTagsOptions): UseQuoteTagsReturn {
+  // Event delegation for closing quote chips (avoids per-chip listeners).
+  useEffect(() => {
+    const el = editableRef.current;
+    if (!el) return;
+
+    const onClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      const closeElement = target?.closest?.('.quote-tag-close') as HTMLElement | null;
+      if (!closeElement) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      const tag = closeElement.closest('.quote-tag') as HTMLElement | null;
+      if (!tag) return;
+      const quoteId = tag.getAttribute('data-quote-id');
+      if (quoteId) removeQuote(quoteId);
+      tag.remove();
+      // Let the input's own handler resync height/hasContent/completions.
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    };
+
+    el.addEventListener('click', onClick);
+    return () => el.removeEventListener('click', onClick);
+  }, [editableRef]);
+
+  const renderQuoteTags = useCallback(() => {
+    const el = editableRef.current;
+    if (!el) return;
+
+    // Collect text nodes that still carry a raw token, skipping already-rendered tags.
+    const tokenTextNodes: Text[] = [];
+    const walk = (node: Node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        if (hasQuoteToken(node.textContent || '')) tokenTextNodes.push(node as Text);
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        const element = node as HTMLElement;
+        if (!element.classList.contains('quote-tag') && !element.classList.contains('file-tag')) {
+          node.childNodes.forEach(walk);
+        }
+      }
+    };
+    el.childNodes.forEach(walk);
+    if (tokenTextNodes.length === 0) return;
+
+    // Chip virtual length equals token length, so the saved offset stays valid.
+    const savedOffset = getVirtualCursorPosition(el);
+
+    for (const textNode of tokenTextNodes) {
+      const text = textNode.textContent || '';
+      const regex = quoteTokenRegex();
+      const fragment = document.createDocumentFragment();
+      let lastIndex = 0;
+      let replaced = false;
+      let match: RegExpExecArray | null;
+
+      while ((match = regex.exec(text)) !== null) {
+        const quoteId = match[1];
+        const entry = getQuote(quoteId);
+        if (match.index > lastIndex) {
+          fragment.appendChild(document.createTextNode(text.slice(lastIndex, match.index)));
+        }
+        if (entry) {
+          fragment.appendChild(createQuoteChipElement(quoteId, entry));
+        }
+        lastIndex = match.index + match[0].length;
+        replaced = true;
+      }
+
+      if (!replaced) continue;
+      if (lastIndex < text.length) {
+        fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
+      }
+      textNode.parentNode?.replaceChild(fragment, textNode);
+    }
+
+    setVirtualCursorPosition(el, savedOffset);
+  }, [editableRef]);
+
+  return { renderQuoteTags };
+}

--- a/webview/src/components/ChatInputBox/hooks/useTextContent.ts
+++ b/webview/src/components/ChatInputBox/hooks/useTextContent.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef } from 'react';
 import { perfTimer } from '../../../utils/debug.js';
+import { makeQuoteToken } from '../utils/quoteRegistry.js';
 
 interface TextContentCache {
   content: string;
@@ -99,6 +100,11 @@ export function useTextContent({
           textParts.push(`@${filePath}`);
           endsWithNewline = false;
           // Don't traverse file-tag children to avoid duplicate filename and close button text
+        } else if (element.classList.contains('quote-tag')) {
+          const quoteId = element.getAttribute('data-quote-id') || '';
+          textParts.push(makeQuoteToken(quoteId));
+          endsWithNewline = false;
+          // Don't traverse quote-tag children (preview + close button are decorative)
         } else {
           // Continue traversing child nodes
           node.childNodes.forEach(walk);

--- a/webview/src/components/ChatInputBox/styles/dialogs.css
+++ b/webview/src/components/ChatInputBox/styles/dialogs.css
@@ -113,3 +113,65 @@
   background: rgba(0, 0, 0, 0.1);
 }
 
+/* Inline quote chip — mirrors the file tag with an accented left edge */
+.quote-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 6px;
+  margin: 0 2px;
+  background: var(--dropdown-bg);
+  border: 1px solid var(--input-border);
+  border-left: 2px solid var(--accent-color, #6ea8fe);
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--text-primary);
+  cursor: default;
+  user-select: none;
+  vertical-align: middle;
+}
+
+.quote-tag-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-tertiary);
+  font-size: 12px;
+}
+
+.quote-tag-text {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.85;
+}
+
+.quote-tag-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  margin-left: 2px;
+  border-radius: 2px;
+  cursor: pointer;
+  opacity: 0.6;
+  transition: opacity 0.15s, background 0.15s;
+}
+
+.quote-tag-close:hover {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+[data-theme="light"] .quote-tag {
+  background: #f3f3f3;
+  border-color: #d0d0d0;
+  color: #333;
+}
+
+[data-theme="light"] .quote-tag-close:hover {
+  background: rgba(0, 0, 0, 0.1);
+}
+

--- a/webview/src/components/ChatInputBox/utils/quoteRegistry.test.ts
+++ b/webview/src/components/ChatInputBox/utils/quoteRegistry.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  registerQuote,
+  getQuote,
+  removeQuote,
+  makeQuoteToken,
+  quoteTokenLength,
+  hasQuoteToken,
+  quotePreview,
+  createQuoteChipElement,
+  expandQuoteTokens,
+} from './quoteRegistry';
+
+describe('quoteRegistry token round-trip', () => {
+  it('registers a quote and expands its token into a Markdown blockquote', () => {
+    const id = registerQuote('line one\nline two');
+    const token = makeQuoteToken(id);
+
+    expect(hasQuoteToken(`before ${token} after`)).toBe(true);
+    expect(quoteTokenLength(id)).toBe(token.length);
+
+    const expanded = expandQuoteTokens(`ask: ${token}please`);
+    expect(expanded).toBe('ask: > line one\n> line two\nplease');
+  });
+
+  it('drops unknown tokens on expand', () => {
+    const id = registerQuote('gone');
+    const token = makeQuoteToken(id);
+    removeQuote(id);
+    expect(getQuote(id)).toBeUndefined();
+    expect(expandQuoteTokens(`x${token}y`)).toBe('xy');
+  });
+
+  it('expands multiple tokens in one pass', () => {
+    const first = makeQuoteToken(registerQuote('aaa'));
+    const second = makeQuoteToken(registerQuote('bbb'));
+    expect(expandQuoteTokens(`${first}${second}`)).toBe('> aaa\n> bbb\n');
+  });
+});
+
+describe('quotePreview', () => {
+  it('collapses whitespace and truncates long text', () => {
+    expect(quotePreview('short\n  text')).toBe('short text');
+    expect(quotePreview('x'.repeat(60), 10)).toBe(`${'x'.repeat(10)}…`);
+  });
+});
+
+describe('createQuoteChipElement', () => {
+  it('builds a non-editable chip carrying the id and a preview', () => {
+    const id = registerQuote('the quoted body');
+    const chip = createQuoteChipElement(id, { text: 'the quoted body' });
+
+    expect(chip.classList.contains('quote-tag')).toBe(true);
+    expect(chip.getAttribute('contenteditable')).toBe('false');
+    expect(chip.getAttribute('data-quote-id')).toBe(id);
+    expect(chip.querySelector('.quote-tag-text')?.textContent).toBe('the quoted body');
+    expect(chip.querySelector('.quote-tag-close')?.textContent).toBe('×');
+  });
+});

--- a/webview/src/components/ChatInputBox/utils/quoteRegistry.ts
+++ b/webview/src/components/ChatInputBox/utils/quoteRegistry.ts
@@ -1,0 +1,88 @@
+import { formatAsMarkdownQuote } from '../../../utils/quoteUtils.js';
+
+/**
+ * Inline quote chips are represented in the input's virtual text by a compact
+ * token delimited with Private Use Area characters so it can never collide with
+ * anything the user types. The heavy Markdown blockquote lives only in this
+ * registry and is expanded back into the text when the message is sent.
+ */
+const TOKEN_START = String.fromCharCode(0xe000);
+const TOKEN_END = String.fromCharCode(0xe001);
+
+export interface QuoteEntry {
+  text: string;
+}
+
+const registry = new Map<string, QuoteEntry>();
+let quoteCounter = 0;
+
+export function registerQuote(text: string): string {
+  const id = `q${(quoteCounter++).toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+  registry.set(id, { text });
+  return id;
+}
+
+export function getQuote(id: string): QuoteEntry | undefined {
+  return registry.get(id);
+}
+
+export function removeQuote(id: string): void {
+  registry.delete(id);
+}
+
+export function makeQuoteToken(id: string): string {
+  return `${TOKEN_START}${id}${TOKEN_END}`;
+}
+
+/** Virtual length of a quote token — kept in sync with makeQuoteToken for cursor math. */
+export function quoteTokenLength(id: string): number {
+  return id.length + 2;
+}
+
+/** True when the text contains at least one quote token opener. */
+export function hasQuoteToken(text: string): boolean {
+  return text.includes(TOKEN_START);
+}
+
+/** Fresh regex each call so the shared lastIndex of a /g literal never bites us. */
+export function quoteTokenRegex(): RegExp {
+  return new RegExp(`${TOKEN_START}([^${TOKEN_START}${TOKEN_END}]+)${TOKEN_END}`, 'g');
+}
+
+/** Short single-line preview shown on the chip. */
+export function quotePreview(text: string, maxLength = 40): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  return collapsed.length > maxLength ? `${collapsed.slice(0, maxLength).trimEnd()}…` : collapsed;
+}
+
+/** Build the inline chip element. Uses textContent to avoid any HTML escaping concerns. */
+export function createQuoteChipElement(id: string, entry: QuoteEntry): HTMLElement {
+  const chip = document.createElement('span');
+  chip.className = 'quote-tag has-tooltip';
+  chip.setAttribute('contenteditable', 'false');
+  chip.setAttribute('data-quote-id', id);
+  chip.setAttribute('data-tooltip', entry.text);
+
+  const icon = document.createElement('span');
+  icon.className = 'quote-tag-icon';
+  icon.textContent = '❝';
+
+  const preview = document.createElement('span');
+  preview.className = 'quote-tag-text';
+  preview.textContent = quotePreview(entry.text);
+
+  const close = document.createElement('span');
+  close.className = 'quote-tag-close';
+  close.textContent = '×';
+
+  chip.append(icon, preview, close);
+  return chip;
+}
+
+/** Replace every quote token in the given text with its full Markdown blockquote. Unknown tokens are dropped. */
+export function expandQuoteTokens(text: string): string {
+  return text.replace(quoteTokenRegex(), (_whole, id: string) => {
+    const entry = registry.get(id);
+    return entry ? formatAsMarkdownQuote(entry.text) : '';
+  });
+}

--- a/webview/src/components/ChatInputBox/utils/virtualCursorUtils.ts
+++ b/webview/src/components/ChatInputBox/utils/virtualCursorUtils.ts
@@ -16,6 +16,21 @@ function textEndsWithNewline(text: string | null): boolean {
 }
 
 /**
+ * Virtual length of an inline tag element in getTextContent() terms.
+ * File tags read as "@" + path; quote tags read as their token (id length + 2
+ * delimiters). Returns null for elements that are not inline tags.
+ */
+function inlineTagVirtualLength(element: HTMLElement): number | null {
+  if (element.classList.contains('file-tag')) {
+    return (element.getAttribute('data-file-path') || '').length + 1;
+  }
+  if (element.classList.contains('quote-tag')) {
+    return (element.getAttribute('data-quote-id') || '').length + 2;
+  }
+  return null;
+}
+
+/**
  * Get the virtual cursor position in a contenteditable element.
  *
  * "Virtual position" means the character offset in the text returned by getTextContent(),
@@ -81,11 +96,9 @@ export function getVirtualCursorPosition(element: HTMLElement): number {
               const childTag = childEl.tagName.toLowerCase();
               if (childTag === 'br') {
                 position += 1;
-              } else if (childEl.classList.contains('file-tag')) {
-                const filePath = childEl.getAttribute('data-file-path') || '';
-                position += filePath.length + 1;
               } else {
-                position += childEl.textContent?.length || 0;
+                const inlineTagLength = inlineTagVirtualLength(childEl);
+                position += inlineTagLength ?? (childEl.textContent?.length || 0);
               }
             }
           }
@@ -99,16 +112,14 @@ export function getVirtualCursorPosition(element: HTMLElement): number {
         return false;
       }
 
-      if (el.classList.contains('file-tag')) {
-        const filePath = el.getAttribute('data-file-path') || '';
-        const tagLength = filePath.length + 1;
-
+      const standaloneTagLength = inlineTagVirtualLength(el);
+      if (standaloneTagLength !== null) {
         if (el.contains(range.endContainer)) {
-          position += tagLength;
+          position += standaloneTagLength;
           found = true;
           return true;
         }
-        position += tagLength;
+        position += standaloneTagLength;
         endsWithNewline = false;
       } else {
         if (range.endContainer === el) {
@@ -122,11 +133,9 @@ export function getVirtualCursorPosition(element: HTMLElement): number {
               const childTag = childEl.tagName.toLowerCase();
               if (childTag === 'br') {
                 position += 1;
-              } else if (childEl.classList.contains('file-tag')) {
-                const filePath = childEl.getAttribute('data-file-path') || '';
-                position += filePath.length + 1;
               } else {
-                position += childEl.textContent?.length || 0;
+                const inlineTagLength = inlineTagVirtualLength(childEl);
+                position += inlineTagLength ?? (childEl.textContent?.length || 0);
               }
             }
           }
@@ -213,17 +222,15 @@ export function setVirtualCursorPosition(
         return false;
       }
 
-      if (el.classList.contains('file-tag')) {
-        const filePath = el.getAttribute('data-file-path') || '';
-        const tagLength = filePath.length + 1;
-
-        if (position + tagLength >= virtualOffset) {
-          // Target is inside file tag; place cursor after the tag
+      const standaloneTagLength = inlineTagVirtualLength(el);
+      if (standaloneTagLength !== null) {
+        if (position + standaloneTagLength >= virtualOffset) {
+          // Target is inside an inline tag; place cursor after the tag
           targetNode = el;
           targetOffset = -1; // sentinel: means "after this element"
           return true;
         }
-        position += tagLength;
+        position += standaloneTagLength;
         endsWithNewline = false;
       } else {
         for (const child of Array.from(node.childNodes)) {

--- a/webview/src/components/MessageItem/MessageItem.tsx
+++ b/webview/src/components/MessageItem/MessageItem.tsx
@@ -18,6 +18,7 @@ import {
 import { ContentBlockRenderer } from './ContentBlockRenderer';
 import { formatTime } from '../../utils/helpers';
 import { copyToClipboard } from '../../utils/copyUtils';
+import { quoteToChatInput } from '../../utils/quoteUtils';
 import { READ_TOOL_NAMES, EDIT_TOOL_NAMES, BASH_TOOL_NAMES, SEARCH_TOOL_NAMES, AGENT_TOOL_NAMES, isToolName, isNonRenderedToolUse } from '../../utils/toolConstants';
 
 export interface MessageItemProps {
@@ -91,6 +92,45 @@ const CopyButton = memo(function CopyButton({
         <CopyIcon />
       </span>
       <span className="copy-tooltip">{copySuccessText}</span>
+    </button>
+  );
+});
+
+/** Quote icon (chat bubble with a right-arrow) used by the message quote button */
+const QuoteIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M2 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v7a1 1 0 0 1-1 1H6l-3 3v-3H3a1 1 0 0 1-1-1z" fill="currentColor" fillOpacity="0.6"/>
+    <path d="M7.5 4.5l2.5 2.5-2.5 2.5M5 7h5" stroke="var(--bg-secondary)" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+);
+
+interface QuoteButtonProps {
+  className?: string;
+  isQuoted: boolean;
+  onClick: () => void;
+  quoteLabel: string;
+  quoteSuccessText: string;
+}
+
+const QuoteButton = memo(function QuoteButton({
+  className,
+  isQuoted,
+  onClick,
+  quoteLabel,
+  quoteSuccessText,
+}: QuoteButtonProps) {
+  return (
+    <button
+      type="button"
+      className={`message-copy-btn message-quote-btn${className ? ` ${className}` : ''} ${isQuoted ? 'copied' : ''}`}
+      onClick={onClick}
+      title={quoteLabel}
+      aria-label={quoteLabel}
+    >
+      <span className="copy-icon">
+        <QuoteIcon />
+      </span>
+      <span className="copy-tooltip">{quoteSuccessText}</span>
     </button>
   );
 });
@@ -356,10 +396,12 @@ export const MessageItem = memo(function MessageItem({
   detailedOutputEnabled = false,
 }: MessageItemProps): React.ReactElement {
   const [copiedMessageIndex, setCopiedMessageIndex] = useState<number | null>(null);
+  const [quotedMessageIndex, setQuotedMessageIndex] = useState<number | null>(null);
   const [showStreamingConnectHint, setShowStreamingConnectHint] = useState(false);
 
   // Track timeout to properly cleanup on unmount
   const copyTimeoutRef = useRef<number | null>(null);
+  const quoteTimeoutRef = useRef<number | null>(null);
 
   // Manage thinking expansion state locally to avoid prop drilling and unnecessary re-renders
   const [expandedThinking, setExpandedThinking] = useState<Record<number, boolean>>({});
@@ -420,12 +462,29 @@ export const MessageItem = memo(function MessageItem({
     }
   }, [hasCopyableText, markdownContent, messageIndex, copiedMessageIndex]);
 
+  const handleQuoteMessage = useCallback(() => {
+    if (!hasCopyableText) return;
+    if (!quoteToChatInput(markdownContent)) return;
+    setQuotedMessageIndex(messageIndex);
+    if (quoteTimeoutRef.current !== null) {
+      window.clearTimeout(quoteTimeoutRef.current);
+    }
+    quoteTimeoutRef.current = window.setTimeout(() => {
+      setQuotedMessageIndex(null);
+      quoteTimeoutRef.current = null;
+    }, 1500);
+  }, [hasCopyableText, markdownContent, messageIndex]);
+
   // Cleanup timeout on unmount to prevent memory leaks
   useEffect(() => {
     return () => {
       if (copyTimeoutRef.current !== null) {
         window.clearTimeout(copyTimeoutRef.current);
         copyTimeoutRef.current = null;
+      }
+      if (quoteTimeoutRef.current !== null) {
+        window.clearTimeout(quoteTimeoutRef.current);
+        quoteTimeoutRef.current = null;
       }
     };
   }, []);
@@ -724,25 +783,42 @@ export const MessageItem = memo(function MessageItem({
             {formatTime(message.timestamp)}
           </div>
           {hasCopyableText && (
-            <CopyButton
-              className="message-copy-btn-inline"
-              isCopied={copiedMessageIndex === messageIndex}
-              onClick={handleCopyMessage}
-              copyLabel={t('markdown.copyMessage')}
-              copySuccessText={t('markdown.copySuccess')}
-            />
+            <>
+              <QuoteButton
+                className="message-copy-btn-inline"
+                isQuoted={quotedMessageIndex === messageIndex}
+                onClick={handleQuoteMessage}
+                quoteLabel={t('markdown.quoteMessage', 'Quote message')}
+                quoteSuccessText={t('markdown.quoteSuccess', 'Quoted!')}
+              />
+              <CopyButton
+                className="message-copy-btn-inline"
+                isCopied={copiedMessageIndex === messageIndex}
+                onClick={handleCopyMessage}
+                copyLabel={t('markdown.copyMessage')}
+                copySuccessText={t('markdown.copySuccess')}
+              />
+            </>
           )}
         </div>
       )}
 
-      {/* Copy button for assistant messages only */}
+      {/* Copy and quote buttons for assistant messages only */}
       {message.type === 'assistant' && !isMessageStreaming && hasCopyableText && (
-        <CopyButton
-          isCopied={copiedMessageIndex === messageIndex}
-          onClick={handleCopyMessage}
-          copyLabel={t('markdown.copyMessage')}
-          copySuccessText={t('markdown.copySuccess')}
-        />
+        <>
+          <QuoteButton
+            isQuoted={quotedMessageIndex === messageIndex}
+            onClick={handleQuoteMessage}
+            quoteLabel={t('markdown.quoteMessage', 'Quote message')}
+            quoteSuccessText={t('markdown.quoteSuccess', 'Quoted!')}
+          />
+          <CopyButton
+            isCopied={copiedMessageIndex === messageIndex}
+            onClick={handleCopyMessage}
+            copyLabel={t('markdown.copyMessage')}
+            copySuccessText={t('markdown.copySuccess')}
+          />
+        </>
       )}
 
       {/* Role label for non-user/assistant messages — hidden for notification types */}

--- a/webview/src/components/MessageList.tsx
+++ b/webview/src/components/MessageList.tsx
@@ -7,6 +7,7 @@ import { MessageItem } from './MessageItem';
 import WaitingIndicator from './WaitingIndicator';
 import { ContextMenu } from './ContextMenu';
 import { useContextMenu, copySelection } from '../hooks/useContextMenu.js';
+import { quoteToChatInput } from '../utils/quoteUtils';
 import type { MessageListRevealHandle } from './ConversationSearch/types';
 import {
   DETAILED_OUTPUT_ENABLED_EVENT,
@@ -181,14 +182,33 @@ export const MessageList = memo(forwardRef<MessageListRevealHandle, MessageListP
     getDetailedOutputEnabled()
   );
 
-  // Context menu for message list (copy only, when text selected)
+  // Context menu for message list (copy + quote, when text selected)
   const ctxMenu = useContextMenu();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
   const handleMessageContextMenu = useCallback((e: React.MouseEvent) => {
     const sel = window.getSelection();
     if (sel && sel.toString().trim().length > 0) {
       ctxMenu.open(e);
     }
   }, [ctxMenu.open]);
+
+  // Hotkey (Ctrl/Cmd+Shift+Q): quote the current selection when it lives inside the message list.
+  useEffect(() => {
+    const handleQuoteHotkey = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() !== 'q' || !event.shiftKey || !(event.ctrlKey || event.metaKey)) return;
+      const sel = window.getSelection();
+      const selectedText = sel?.toString() ?? '';
+      if (!selectedText.trim()) return;
+      const anchor = sel?.anchorNode ?? null;
+      const anchorElement = anchor instanceof Element ? anchor : anchor?.parentElement ?? null;
+      if (!containerRef.current || !anchorElement || !containerRef.current.contains(anchorElement)) return;
+      event.preventDefault();
+      quoteToChatInput(selectedText);
+    };
+    window.addEventListener('keydown', handleQuoteHotkey);
+    return () => window.removeEventListener('keydown', handleQuoteHotkey);
+  }, []);
 
   // Use explicit session identity in production; keep the message boundary for isolated callers/tests.
   const previousSessionRef = useRef(currentSessionId);
@@ -322,13 +342,14 @@ export const MessageList = memo(forwardRef<MessageListRevealHandle, MessageListP
   }, [messageRenderKeySnapshot]);
 
   return (
-    <div onContextMenu={handleMessageContextMenu}>
+    <div ref={containerRef} onContextMenu={handleMessageContextMenu}>
       {ctxMenu.visible && (
         <ContextMenu
           x={ctxMenu.x}
           y={ctxMenu.y}
           onClose={ctxMenu.close}
           items={[
+            { label: t('contextMenu.quote', 'Quote'), action: () => quoteToChatInput(ctxMenu.selectedText) },
             { label: t('contextMenu.copy', 'Copy'), action: () => copySelection(ctxMenu.savedRange, ctxMenu.selectedText) },
           ]}
         />

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -261,6 +261,11 @@ interface Window {
   insertCodeSnippetAtCursor?: (selectionInfo: string) => void;
 
   /**
+   * Insert an inline quote chip. Payload: JSON { text } - registered by ChatInputBox
+   */
+  addQuotedSnippet?: (payload: string) => void;
+
+  /**
    * Focus the chat input box - registered by ChatInputBox
    */
   focusChatInput?: () => void;

--- a/webview/src/hooks/useMessageSender.ts
+++ b/webview/src/hooks/useMessageSender.ts
@@ -7,6 +7,7 @@ import {
   apply1MContextSuffix,
 } from '../components/ChatInputBox/types';
 import type { Attachment, ChatInputBoxHandle, PermissionMode, ReasoningEffort, SelectedAgent, CodexFastMode } from '../components/ChatInputBox/types';
+import { expandQuoteTokens } from '../components/ChatInputBox/utils/quoteRegistry';
 import type { ViewMode } from './useModelProviderState';
 
 /**
@@ -312,7 +313,8 @@ export function useMessageSender({
    * Execute message sending (from queue or directly)
    */
   const executeMessage = useCallback((content: string, attachments?: Attachment[]) => {
-    const text = content.replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
+    // Expand inline quote chips (tokens) into their full Markdown blockquotes.
+    const text = expandQuoteTokens(content).replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
     const hasAttachments = Array.isArray(attachments) && attachments.length > 0;
 
     if (!text && !hasAttachments) return;

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -1294,7 +1294,13 @@
   "markdown": {
     "copyCode": "Copy code",
     "copyMessage": "Copy message",
-    "copySuccess": "Copied!"
+    "copySuccess": "Copied!",
+    "quoteMessage": "Quote message",
+    "quoteSuccess": "Quoted!"
+  },
+  "contextMenu": {
+    "copy": "Copy",
+    "quote": "Quote"
   },
   "usage": {
     "checkingLabel": "Checking for tokentracker-cli…",

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -962,7 +962,13 @@
   "markdown": {
     "copyCode": "Copiar código",
     "copyMessage": "Copiar mensaje",
-    "copySuccess": "¡Copiado!"
+    "copySuccess": "¡Copiado!",
+    "quoteMessage": "Citar mensaje",
+    "quoteSuccess": "¡Citado!"
+  },
+  "contextMenu": {
+    "copy": "Copiar",
+    "quote": "Citar"
   },
   "usage": {
     "checkingLabel": "Comprobando tokentracker-cli…",

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -962,7 +962,13 @@
   "markdown": {
     "copyCode": "Copier le code",
     "copyMessage": "Copier le message",
-    "copySuccess": "Copié !"
+    "copySuccess": "Copié !",
+    "quoteMessage": "Citer le message",
+    "quoteSuccess": "Cité !"
+  },
+  "contextMenu": {
+    "copy": "Copier",
+    "quote": "Citer"
   },
   "usage": {
     "checkingLabel": "Vérification de tokentracker-cli…",

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -962,7 +962,13 @@
   "markdown": {
     "copyCode": "कोड कॉपी करें",
     "copyMessage": "संदेश कॉपी करें",
-    "copySuccess": "कॉपी हो गया"
+    "copySuccess": "कॉपी हो गया",
+    "quoteMessage": "संदेश उद्धृत करें",
+    "quoteSuccess": "उद्धृत किया गया!"
+  },
+  "contextMenu": {
+    "copy": "कॉपी करें",
+    "quote": "उद्धृत करें"
   },
   "usage": {
     "checkingLabel": "tokentracker-cli की जाँच हो रही है…",

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -967,7 +967,13 @@
   "markdown": {
     "copyCode": "コードをコピー",
     "copyMessage": "メッセージをコピー",
-    "copySuccess": "コピーされました!"
+    "copySuccess": "コピーされました!",
+    "quoteMessage": "メッセージを引用",
+    "quoteSuccess": "引用しました!"
+  },
+  "contextMenu": {
+    "copy": "コピー",
+    "quote": "引用"
   },
   "usage": {
     "checkingLabel": "tokentracker-cli を確認しています…",

--- a/webview/src/i18n/locales/ko.json
+++ b/webview/src/i18n/locales/ko.json
@@ -1078,7 +1078,13 @@
   "markdown": {
     "copyCode": "코드 복사",
     "copyMessage": "메시지 복사",
-    "copySuccess": "복사됨!"
+    "copySuccess": "복사됨!",
+    "quoteMessage": "메시지 인용",
+    "quoteSuccess": "인용됨!"
+  },
+  "contextMenu": {
+    "copy": "복사",
+    "quote": "인용"
   },
   "usage": {
     "checkingLabel": "tokentracker-cli 확인 중…",

--- a/webview/src/i18n/locales/pt-BR.json
+++ b/webview/src/i18n/locales/pt-BR.json
@@ -1132,7 +1132,13 @@
   "markdown": {
     "copyCode": "Copiar código",
     "copyMessage": "Copiar mensagem",
-    "copySuccess": "Copiado!"
+    "copySuccess": "Copiado!",
+    "quoteMessage": "Citar mensagem",
+    "quoteSuccess": "Citado!"
+  },
+  "contextMenu": {
+    "copy": "Copiar",
+    "quote": "Citar"
   },
   "usage": {
     "checkingLabel": "Verificando tokentracker-cli…",

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -989,7 +989,13 @@
   "markdown": {
     "copyCode": "Копировать код",
     "copyMessage": "Копировать сообщение",
-    "copySuccess": "Скопировано!"
+    "copySuccess": "Скопировано!",
+    "quoteMessage": "Цитировать сообщение",
+    "quoteSuccess": "Процитировано!"
+  },
+  "contextMenu": {
+    "copy": "Копировать",
+    "quote": "Цитировать"
   },
   "usage": {
     "checkingLabel": "Проверка tokentracker-cli…",

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -967,7 +967,13 @@
   "markdown": {
     "copyCode": "複製程式碼",
     "copyMessage": "複製訊息",
-    "copySuccess": "複製成功"
+    "copySuccess": "複製成功",
+    "quoteMessage": "引用訊息",
+    "quoteSuccess": "已引用！"
+  },
+  "contextMenu": {
+    "copy": "複製",
+    "quote": "引用"
   },
   "usage": {
     "checkingLabel": "正在偵測 tokentracker-cli…",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -1299,7 +1299,13 @@
   "markdown": {
     "copyCode": "复制代码",
     "copyMessage": "复制消息",
-    "copySuccess": "复制成功"
+    "copySuccess": "复制成功",
+    "quoteMessage": "引用消息",
+    "quoteSuccess": "已引用！"
+  },
+  "contextMenu": {
+    "copy": "复制",
+    "quote": "引用"
   },
   "usage": {
     "checkingLabel": "正在检测 tokentracker-cli…",

--- a/webview/src/styles/less/components/message.less
+++ b/webview/src/styles/less/components/message.less
@@ -203,6 +203,11 @@
     }
 }
 
+/* Quote button sits to the left of the absolute copy button on assistant messages */
+.message-quote-btn {
+    right: 44px;
+}
+
 /* Inline copy button for user messages (in header row) */
 .message-copy-btn-inline {
     position: relative;

--- a/webview/src/utils/quoteUtils.test.ts
+++ b/webview/src/utils/quoteUtils.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { formatAsMarkdownQuote, quoteToChatInput } from './quoteUtils';
+
+describe('formatAsMarkdownQuote', () => {
+  it('prefixes every line and adds a trailing newline', () => {
+    expect(formatAsMarkdownQuote('line1\nline2')).toBe('> line1\n> line2\n');
+  });
+
+  it('trims trailing blank lines and normalizes CRLF', () => {
+    expect(formatAsMarkdownQuote('a\r\nb\n\n')).toBe('> a\n> b\n');
+  });
+});
+
+describe('quoteToChatInput', () => {
+  afterEach(() => {
+    delete window.addQuotedSnippet;
+    delete window.focusChatInput;
+  });
+
+  it('sends the raw quote as a chip payload and focuses the input', () => {
+    const addSnippet = vi.fn();
+    const focus = vi.fn();
+    window.addQuotedSnippet = addSnippet;
+    window.focusChatInput = focus;
+
+    expect(quoteToChatInput('text')).toBe(true);
+    expect(addSnippet).toHaveBeenCalledWith(JSON.stringify({ text: 'text' }));
+    expect(focus).toHaveBeenCalled();
+  });
+
+  it('returns false for empty selections', () => {
+    window.addQuotedSnippet = vi.fn();
+    expect(quoteToChatInput('   ')).toBe(false);
+    expect(window.addQuotedSnippet).not.toHaveBeenCalled();
+  });
+});

--- a/webview/src/utils/quoteUtils.ts
+++ b/webview/src/utils/quoteUtils.ts
@@ -1,0 +1,21 @@
+const QUOTE_PREFIX = '> ';
+
+/** Turn arbitrary text into a Markdown blockquote. */
+export function formatAsMarkdownQuote(text: string): string {
+  const body = text.replace(/\r\n/g, '\n').replace(/\n+$/, '');
+  const quotedBody = body
+    .split('\n')
+    .map((line) => `${QUOTE_PREFIX}${line}`.replace(/\s+$/, ''))
+    .join('\n');
+  // Trailing newline leaves the caret on a fresh, non-quoted line for the user's question.
+  return `${quotedBody}\n`;
+}
+
+/** Insert the given selection as an inline quote chip in the chat input and focus it. Returns false when there is nothing to quote. */
+export function quoteToChatInput(text: string): boolean {
+  if (!text.trim()) return false;
+  if (!window.addQuotedSnippet) return false;
+  window.addQuotedSnippet(JSON.stringify({ text }));
+  window.focusChatInput?.();
+  return true;
+}


### PR DESCRIPTION
## Summary
- Quote selected conversation text into the chat input as a removable inline chip (like @file tags). The chip shows a short preview; the full text is expanded to a Markdown blockquote on send, so the model receives the quoted context.
- Three entry points: right-click "Quote", a Ctrl/Cmd+Shift+Q hotkey for the current selection, and a per-message quote button next to copy.
- Multiple quotes per message; chips round-trip through a compact token so they survive @file re-rendering.

## Implementation
- `quoteUtils` + a token-based quote registry (compact PUA token ⇄ full blockquote).
- `useQuoteTags` renders/removes chips; `getTextContent` and the virtual cursor learn about `.quote-tag`; `window.addQuotedSnippet` inserts a chip at the caret; tokens expand to Markdown on send.

## Test plan
- [ ] `tsc --noEmit` clean
- [ ] `vitest run` — all pass (incl. new quoteUtils / quoteRegistry tests)
- [ ] Select text in a message → Quote via menu / hotkey / button → chip appears; send → the sent message contains the blockquote
- [ ] Remove a chip via ×; mix quotes with @file mentions