### PR TITLE
fix(grok): normalize model ID to grok-4.5 instead of remapping to grok

### DIFF
--- a/ai-bridge/services/grok/grok-acp-client.js
+++ b/ai-bridge/services/grok/grok-acp-client.js
@@ -17,6 +17,7 @@ import {
   normalizeAuthMethod,
   applyGrokBaseUrlEnv,
   resolveEffectiveGrokAuth,
+  normalizeGrokModelId,
 } from './grok-utils.js';
 import { requestPermissionFromJava } from '../../permission-ipc.js';
 import { AcpTerminalHost, isTerminalMethod } from './acp-terminal-host.js';
@@ -138,13 +139,15 @@ export async function ensureSession(client, { sessionId = '', cwd = '', model = 
     }
   }
 
+  const effectiveModel = normalizeGrokModelId(model);
+
   if (!activeSessionId) {
     const newParams = {
       cwd: workCwd,
       mcpServers: [],
     };
-    if (model && model.trim()) {
-      newParams._meta = { ...(newParams._meta || {}), modelId: model.trim() };
+    if (effectiveModel) {
+      newParams._meta = { ...(newParams._meta || {}), modelId: effectiveModel };
     }
     sessionMeta = await client.request('session/new', newParams);
     activeSessionId = sessionMeta.sessionId || sessionMeta.session?.sessionId || '';
@@ -157,11 +160,11 @@ export async function ensureSession(client, { sessionId = '', cwd = '', model = 
   client.activeSessionId = activeSessionId;
 
   // Best-effort model set
-  if (model && model.trim()) {
+  if (effectiveModel) {
     try {
       await client.request('session/set_model', {
         sessionId: activeSessionId,
-        modelId: model.trim(),
+        modelId: effectiveModel,
       });
     } catch {
       // optional

--- a/ai-bridge/services/grok/grok-model-id.test.js
+++ b/ai-bridge/services/grok/grok-model-id.test.js
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeGrokModelId } from './grok-utils.js';
+
+test('normalizeGrokModelId maps sentinel values to grok-4.5', () => {
+  assert.equal(normalizeGrokModelId('grok'), 'grok-4.5');
+  assert.equal(normalizeGrokModelId('Grok'), 'grok-4.5');
+  assert.equal(normalizeGrokModelId('default'), 'grok-4.5');
+  assert.equal(normalizeGrokModelId('(default)'), 'grok-4.5');
+  assert.equal(normalizeGrokModelId(''), 'grok-4.5');
+  assert.equal(normalizeGrokModelId('   '), 'grok-4.5');
+  assert.equal(normalizeGrokModelId(null), 'grok-4.5');
+  assert.equal(normalizeGrokModelId(undefined), 'grok-4.5');
+});
+
+test('normalizeGrokModelId passes through real model ids, trimmed', () => {
+  assert.equal(normalizeGrokModelId('grok-4.5'), 'grok-4.5');
+  assert.equal(normalizeGrokModelId('  grok-3  '), 'grok-3');
+  assert.equal(normalizeGrokModelId('grok-beta'), 'grok-beta');
+});

--- a/ai-bridge/services/grok/grok-utils.js
+++ b/ai-bridge/services/grok/grok-utils.js
@@ -28,6 +28,18 @@ export function resolveGrokBinary() {
   return explicit || 'grok';
 }
 
+/**
+ * Normalize model identifier for Grok.
+ * Sentinel or fallback values like "grok", "", "default", "(default)" map to "grok-4.5".
+ */
+export function normalizeGrokModelId(modelId) {
+  const trimmed = String(modelId || '').trim();
+  if (!trimmed || trimmed.toLowerCase() === 'grok' || trimmed.toLowerCase() === 'default' || trimmed.toLowerCase() === '(default)') {
+    return 'grok-4.5';
+  }
+  return trimmed;
+}
+
 /** GROK_HOME or default ~/.grok */
 export function resolveGrokHomeDir() {
   const env = process.env.GROK_HOME;

--- a/ai-bridge/services/grok/persistent-acp-service.js
+++ b/ai-bridge/services/grok/persistent-acp-service.js
@@ -34,6 +34,7 @@ import {
   extractUsedTokens,
   extractUsageFromAcpEnvelope,
   resolveEffectiveGrokAuth,
+  normalizeGrokModelId,
 } from './grok-utils.js';
 import { requestPermissionFromJava } from '../../permission-ipc.js';
 import { AcpTerminalHost } from './acp-terminal-host.js';
@@ -77,7 +78,7 @@ function makeRuntimeKey(params) {
   const epoch = params.runtimeSessionEpoch || params.epoch || 'default';
   const sid = (params.sessionId || '').trim() || 'new';
   const cwd = (params.cwd || process.cwd()).trim();
-  const model = (params.model || '').trim();
+  const model = normalizeGrokModelId(params.model);
   const perm = normalizePermissionMode(params.permissionMode);
   // authFingerprint: presence only (never secrets)
   const authMethod = String(params.authMethod || process.env.GROK_AUTH_METHOD || 'oauth').toLowerCase();

--- a/src/main/java/com/github/claudecodegui/session/SessionSendService.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionSendService.java
@@ -397,10 +397,9 @@ public class SessionSendService {
             return null;
         }
         if ("grok".equals(provider)) {
-            // Legacy UI stored upstream API id "grok-4.5"; CLI needs profile name "grok".
-            if ("grok-4.5".equals(lower) || "grok-4".equals(lower) || "grok-4.5-build".equals(lower)) {
-                LOG.info("[Grok] Remapping upstream model id '" + trimmed + "' to config profile 'grok'");
-                return "grok";
+            if ("grok".equals(lower) || "default".equals(lower) || "(default)".equals(lower)) {
+                LOG.info("[Grok] Normalizing sentinel model id '" + trimmed + "' to default model 'grok-4.5'");
+                return "grok-4.5";
             }
         }
         return trimmed;

--- a/src/test/java/com/github/claudecodegui/session/SessionSendServiceTest.java
+++ b/src/test/java/com/github/claudecodegui/session/SessionSendServiceTest.java
@@ -55,7 +55,8 @@ public class SessionSendServiceTest {
         assertNull(SessionSendService.normalizeCliModelForProvider("kimi", "auto"));
         assertNull(SessionSendService.normalizeCliModelForProvider("opencode", "opencode-default"));
         assertEquals("kimi-k2.5", SessionSendService.normalizeCliModelForProvider("kimi", "kimi-k2.5"));
-        assertEquals("grok", SessionSendService.normalizeCliModelForProvider("grok", "grok-4.5"));
+        assertEquals("grok-4.5", SessionSendService.normalizeCliModelForProvider("grok", "grok-4.5"));
+        assertEquals("grok-4.5", SessionSendService.normalizeCliModelForProvider("grok", "grok"));
         assertNull(SessionSendService.normalizeCliModelForProvider("grok", "claude-sonnet-5"));
     }
 

--- a/webview/src/components/ChatInputBox/types.ts
+++ b/webview/src/components/ChatInputBox/types.ts
@@ -405,17 +405,32 @@ export const CODEX_MODELS: ModelInfo[] = [
  *
  * Passing `-m grok-4.5` hits official cli-chat-proxy and ignores custom base_url/api_key.
  */
-export const GROK_DEFAULT_MODEL_ID = 'grok';
+export const GROK_DEFAULT_MODEL_ID = 'grok-4.5';
 
 /**
  * Grok CLI model picker entries.
- * id = profile name for CLI `-m`; label can show the human-facing model name.
+ * id = model ID passed via ACP session/set_model or _meta.modelId.
  */
 export const GROK_MODELS: ModelInfo[] = [
   {
     id: GROK_DEFAULT_MODEL_ID,
     label: 'Grok 4.5',
     description: 'xAI Grok 4.5',
+  },
+  {
+    id: 'grok-3',
+    label: 'Grok 3',
+    description: 'xAI Grok 3',
+  },
+  {
+    id: 'grok-2',
+    label: 'Grok 2',
+    description: 'xAI Grok 2',
+  },
+  {
+    id: 'grok-beta',
+    label: 'Grok Beta',
+    description: 'xAI Grok Beta',
   },
 ];
 

--- a/webview/src/components/ChatInputBox/types.ts
+++ b/webview/src/components/ChatInputBox/types.ts
@@ -391,19 +391,16 @@ export const CODEX_MODELS: ModelInfo[] = [
 ];
 
 /**
- * Grok CLI `-m` value must be a **config profile name** from
- * `~/.grok/config.toml` (`[model."name"]`), NOT the nested `model = "grok-4.5"`
- * upstream id. Your default profile is typically:
+ * Default model id sent to the Grok ACP CLI via `session/set_model` /
+ * `_meta.modelId`. The ACP CLI only accepts real upstream model ids —
+ * sentinel values like `grok` / `default` / `(default)` are rejected with
+ * "unknown model id", so the bridge (`normalizeGrokModelId`) and the Java
+ * side (`normalizeCliModelForProvider`) normalize them to this value.
  *
- *   [models]
- *   default = "grok"
- *
- *   [model."grok"]
- *   model = "grok-4.5"
- *   base_url = "..."
- *   api_key = "..."
- *
- * Passing `-m grok-4.5` hits official cli-chat-proxy and ignores custom base_url/api_key.
+ * Note: this id goes straight to the upstream API; it does NOT resolve
+ * `~/.grok/config.toml` `[model."name"]` profiles the way the legacy
+ * `-m <profile>` path did, so custom per-profile base_url/api_key from
+ * config.toml may not apply here.
  */
 export const GROK_DEFAULT_MODEL_ID = 'grok-4.5';
 

--- a/webview/src/hooks/providers/useModelStatePersistence.test.ts
+++ b/webview/src/hooks/providers/useModelStatePersistence.test.ts
@@ -34,7 +34,7 @@ function makeOptions(overrides: Partial<UseModelStatePersistenceOptions> = {}): 
     selectedCodexModel: 'gpt-5-codex',
     claudePermissionMode: 'default' as PermissionMode,
     codexPermissionMode: 'default' as PermissionMode,
-    selectedGrokModel: 'grok',
+    selectedGrokModel: 'grok-4.5',
     selectedKimiModel: 'auto',
     selectedOpenCodeModel: 'opencode-default',
     selectedPiModel: 'auto',
@@ -287,14 +287,14 @@ describe('useModelStatePersistence — CLI provider persistence', () => {
   it('honors a backend-supplied CLI provider via __INITIAL_TAB_PROVIDER__', () => {
     const setCurrentProvider = vi.fn();
     (window as unknown as { __INITIAL_TAB_PROVIDER__?: unknown }).__INITIAL_TAB_PROVIDER__ = 'grok';
-    (window as unknown as { __INITIAL_TAB_MODEL__?: unknown }).__INITIAL_TAB_MODEL__ = 'grok';
+    (window as unknown as { __INITIAL_TAB_MODEL__?: unknown }).__INITIAL_TAB_MODEL__ = 'grok-4.5';
 
     renderHook(() => useModelStatePersistence(makeOptions({ setCurrentProvider })));
     vi.advanceTimersByTime(200);
 
     expect(setCurrentProvider).toHaveBeenCalledWith('grok');
     expect(bridgeEventsFor('set_provider')).toEqual([['set_provider', 'grok']]);
-    expect(bridgeEventsFor('set_model')).toEqual([['set_model', 'grok']]);
+    expect(bridgeEventsFor('set_model')).toEqual([['set_model', 'grok-4.5']]);
   });
 
   it('persists CLI model and permission selections in the snapshot', () => {

--- a/webview/src/hooks/providers/useModelStatePersistence.test.ts
+++ b/webview/src/hooks/providers/useModelStatePersistence.test.ts
@@ -284,6 +284,22 @@ describe('useModelStatePersistence — CLI provider persistence', () => {
     expect(bridgeEventsFor('set_model')).toEqual([['set_model', 'kimi-k3']]);
   });
 
+  it('migrates a stale sentinel grok model id to grok-4.5', () => {
+    // Versions before the ACP model-id fix persisted the profile name 'grok';
+    // the ACP CLI rejects it ("unknown model id"), so it must be upgraded.
+    const setSelectedGrokModel = vi.fn();
+    localStorage.setItem('model-selection-state', JSON.stringify({
+      provider: 'grok',
+      grokModel: 'grok',
+    }));
+
+    renderHook(() => useModelStatePersistence(makeOptions({ setSelectedGrokModel })));
+    vi.advanceTimersByTime(200);
+
+    expect(setSelectedGrokModel).toHaveBeenCalledWith('grok-4.5');
+    expect(bridgeEventsFor('set_model')).toEqual([['set_model', 'grok-4.5']]);
+  });
+
   it('honors a backend-supplied CLI provider via __INITIAL_TAB_PROVIDER__', () => {
     const setCurrentProvider = vi.fn();
     (window as unknown as { __INITIAL_TAB_PROVIDER__?: unknown }).__INITIAL_TAB_PROVIDER__ = 'grok';

--- a/webview/src/hooks/providers/useModelStatePersistence.ts
+++ b/webview/src/hooks/providers/useModelStatePersistence.ts
@@ -187,8 +187,9 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
         }
       };
       const applyGrokModel = makeCliModelApplier((id) => {
-        restoredGrokModel = id;
-        setSelectedGrokModel(id);
+        const normalized = id === 'grok' ? GROK_DEFAULT_MODEL_ID : id;
+        restoredGrokModel = normalized;
+        setSelectedGrokModel(normalized);
       });
       const applyKimiModel = makeCliModelApplier((id) => {
         restoredKimiModel = id;

--- a/webview/src/hooks/providers/useModelStatePersistence.ts
+++ b/webview/src/hooks/providers/useModelStatePersistence.ts
@@ -187,7 +187,10 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
         }
       };
       const applyGrokModel = makeCliModelApplier((id) => {
-        const normalized = id === 'grok' ? GROK_DEFAULT_MODEL_ID : id;
+        // Migrate stale sentinel ids saved by older versions — mirrors
+        // normalizeGrokModelId in ai-bridge/services/grok/grok-utils.js.
+        const sentinel = ['grok', 'default', '(default)'].includes(id.trim().toLowerCase());
+        const normalized = sentinel ? GROK_DEFAULT_MODEL_ID : id;
         restoredGrokModel = normalized;
         setSelectedGrokModel(normalized);
       });


### PR DESCRIPTION
## Summary
Fixes an issue where Grok ACP CLI returned `Couldn't set model 'grok': Invalid params: unknown model id` when initializing or switching models.

- Normalizes default/sentinel model values (`grok`, `default`) to `grok-4.5` instead of remapping `grok-4.5` to `grok`.
- Updates `GROK_DEFAULT_MODEL_ID` in frontend `types.ts` to `grok-4.5`.
- Adds model selection list for Grok in frontend (`grok-4.5`, `grok-3`, `grok-2`, `grok-beta`).
- Normalizes model ID in `ai-bridge/services/grok` (`grok-acp-client.js` & `persistent-acp-service.js`).
- Automatically migrates stale `'grok'` saved model in `useModelStatePersistence.ts`.