### PR TITLE
feat(grok): add dynamic model discovery via listModels API

### DIFF
--- a/ai-bridge/channels/grok-channel.js
+++ b/ai-bridge/channels/grok-channel.js
@@ -4,6 +4,7 @@
  */
 
 import { sendMessage as grokSendMessage } from '../services/grok/message-service.js';
+import { listModels as grokListModels } from '../services/grok/models-service.js';
 import {
   getGrokReasoningSupportedModels,
   buildGrokContextUsagePayload,
@@ -45,6 +46,11 @@ export async function handleGrokCommand(command, args, stdinData) {
       break;
     }
 
+    case 'listModels': {
+      grokListModels();
+      break;
+    }
+
     case 'getContextUsage': {
       // One-shot path: synthesize from Java-supplied used/max when present.
       const payload = buildGrokContextUsagePayload({
@@ -83,5 +89,5 @@ export async function handleGrokCommand(command, args, stdinData) {
 }
 
 export function getGrokCommandList() {
-  return ['send', 'getContextUsage', 'getUsage', 'getReasoningSupportedModels'];
+  return ['send', 'listModels', 'getContextUsage', 'getUsage', 'getReasoningSupportedModels'];
 }

--- a/ai-bridge/services/grok/models-service.js
+++ b/ai-bridge/services/grok/models-service.js
@@ -1,0 +1,117 @@
+/**
+ * Discover Grok models from ~/.grok/models_cache.json and ~/.grok/config.toml.
+ * Grok CLI auto-fetches API models to models_cache.json and allows custom profiles in config.toml.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+function resolveGrokDir() {
+  const env = process.env.GROK_HOME;
+  if (env && String(env).trim()) return String(env).trim();
+  return join(homedir(), '.grok');
+}
+
+export function parseModelsCacheJson(jsonText) {
+  const models = [];
+  const seen = new Set();
+  try {
+    const data = JSON.parse(jsonText);
+    const modelsObj = data?.models || (typeof data === 'object' && !Array.isArray(data) ? data : null);
+    if (modelsObj && typeof modelsObj === 'object') {
+      for (const [id, entry] of Object.entries(modelsObj)) {
+        if (!id || seen.has(id)) continue;
+        const info = entry?.info || entry || {};
+        if (info.hidden === true) continue;
+        seen.add(id);
+        models.push({
+          id,
+          label: info.name || info.id || id,
+          description: info.description || info.model || id,
+        });
+      }
+    }
+  } catch {
+    // Ignore JSON parse errors
+  }
+  return { models, seen };
+}
+
+export function parseGrokProfilesFromToml(tomlText, seenSet = new Set()) {
+  const models = [];
+  let defaultModel = null;
+  const src = String(tomlText || '');
+
+  const defaultMatch = src.match(/^\s*default\s*=\s*"([^"]+)"/m);
+  if (defaultMatch) {
+    defaultModel = defaultMatch[1].trim();
+  }
+
+  const sectionRe = /\[model\.(?:"([^"]+)"|([a-zA-Z0-9_-]+))\]([\s\S]*?)(?=\n\[|\s*$)/g;
+  let match;
+  while ((match = sectionRe.exec(src)) !== null) {
+    const id = (match[1] || match[2] || '').trim();
+    if (!id || seenSet.has(id)) continue;
+    seenSet.add(id);
+    const body = match[3] || '';
+    const nestedModel = body.match(/^\s*model\s*=\s*"([^"]+)"/m);
+    models.push({
+      id,
+      label: id,
+      description: nestedModel ? nestedModel[1].trim() : id,
+    });
+  }
+
+  return { models, defaultModel };
+}
+
+export function listModels() {
+  const grokDir = resolveGrokDir();
+  const cachePath = join(grokDir, 'models_cache.json');
+  const configPath = join(grokDir, 'config.toml');
+
+  let allModels = [];
+  const seen = new Set();
+  let defaultModel = 'grok-4.5';
+
+  if (existsSync(cachePath)) {
+    try {
+      const raw = readFileSync(cachePath, 'utf8');
+      const { models: cacheModels, seen: cacheSeen } = parseModelsCacheJson(raw);
+      allModels.push(...cacheModels);
+      cacheSeen.forEach((id) => seen.add(id));
+    } catch (e) {
+      console.error('[Grok Models] Failed to read models_cache.json:', e?.message || e);
+    }
+  }
+
+  if (existsSync(configPath)) {
+    try {
+      const raw = readFileSync(configPath, 'utf8');
+      const { models: profileModels, defaultModel: def } = parseGrokProfilesFromToml(raw, seen);
+      allModels.push(...profileModels);
+      if (def) defaultModel = def;
+    } catch (e) {
+      console.error('[Grok Models] Failed to read config.toml:', e?.message || e);
+    }
+  }
+
+  if (allModels.length === 0) {
+    allModels = [
+      { id: 'grok-4.5', label: 'Grok 4.5', description: "SpaceXAI's new frontier model" },
+      { id: 'grok-3', label: 'Grok 3', description: 'xAI Grok 3' },
+      { id: 'grok-2', label: 'Grok 2', description: 'xAI Grok 2' },
+      { id: 'grok-beta', label: 'Grok Beta', description: 'xAI Grok Beta' },
+    ];
+  }
+
+  const payload = {
+    success: true,
+    models: allModels,
+    defaultModel,
+  };
+
+  console.log(JSON.stringify(payload));
+  return payload;
+}

--- a/ai-bridge/services/grok/models-service.js
+++ b/ai-bridge/services/grok/models-service.js
@@ -22,13 +22,16 @@ export function parseModelsCacheJson(jsonText) {
     if (modelsObj && typeof modelsObj === 'object') {
       for (const [id, entry] of Object.entries(modelsObj)) {
         if (!id || seen.has(id)) continue;
-        const info = entry?.info || entry || {};
-        if (info.hidden === true) continue;
+        // Skip scalar metadata keys (e.g. `fetched_at`) that appear in
+        // root-map layouts without a `models` wrapper.
+        if (!entry || typeof entry !== 'object') continue;
+        const raw = entry.info && typeof entry.info === 'object' ? entry.info : entry;
+        if (raw.hidden === true) continue;
         seen.add(id);
         models.push({
           id,
-          label: info.name || info.id || id,
-          description: info.description || info.model || id,
+          label: raw.name || raw.id || id,
+          description: raw.description || raw.model || id,
         });
       }
     }
@@ -43,6 +46,8 @@ export function parseGrokProfilesFromToml(tomlText, seenSet = new Set()) {
   let defaultModel = null;
   const src = String(tomlText || '');
 
+  // Grok keeps `default` inside the `[models]` section (not at TOML top level),
+  // so this intentionally matches anywhere in the file, first occurrence wins.
   const defaultMatch = src.match(/^\s*default\s*=\s*"([^"]+)"/m);
   if (defaultMatch) {
     defaultModel = defaultMatch[1].trim();
@@ -98,6 +103,8 @@ export function listModels() {
   }
 
   if (allModels.length === 0) {
+    // Last-resort static list, used only when neither the CLI's models cache
+    // nor config.toml profiles exist (e.g. grok CLI never ran).
     allModels = [
       { id: 'grok-4.5', label: 'Grok 4.5', description: "SpaceXAI's new frontier model" },
       { id: 'grok-3', label: 'Grok 3', description: 'xAI Grok 3' },

--- a/ai-bridge/services/grok/models-service.test.js
+++ b/ai-bridge/services/grok/models-service.test.js
@@ -39,6 +39,20 @@ test('parseModelsCacheJson extracts models from models_cache.json payload', () =
   assert.ok(seen.has('grok-3'));
 });
 
+test('parseModelsCacheJson skips scalar metadata keys in root-map layout', () => {
+  const json = JSON.stringify({
+    fetched_at: '2026-08-09T12:04:19Z',
+    'grok-4.5': {
+      id: 'grok-4.5',
+      name: 'Grok 4.5',
+    },
+  });
+
+  const { models } = parseModelsCacheJson(json);
+  assert.equal(models.length, 1);
+  assert.deepEqual(models[0], { id: 'grok-4.5', label: 'Grok 4.5', description: 'grok-4.5' });
+});
+
 test('parseGrokProfilesFromToml extracts custom profiles from config.toml', () => {
   const toml = `
 [models]

--- a/ai-bridge/services/grok/models-service.test.js
+++ b/ai-bridge/services/grok/models-service.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseModelsCacheJson, parseGrokProfilesFromToml } from './models-service.js';
+
+test('parseModelsCacheJson extracts models from models_cache.json payload', () => {
+  const json = JSON.stringify({
+    fetched_at: '2026-08-09T12:04:19Z',
+    models: {
+      'grok-4.5': {
+        info: {
+          id: 'grok-4.5',
+          name: 'Grok 4.5',
+          description: "SpaceXAI's new frontier model",
+        },
+      },
+      'grok-3': {
+        info: {
+          id: 'grok-3',
+          name: 'Grok 3',
+          description: 'Grok 3 reasoning model',
+          hidden: false,
+        },
+      },
+      'hidden-model': {
+        info: {
+          id: 'hidden-model',
+          name: 'Hidden Model',
+          hidden: true,
+        },
+      },
+    },
+  });
+
+  const { models, seen } = parseModelsCacheJson(json);
+  assert.equal(models.length, 2);
+  assert.deepEqual(models[0], { id: 'grok-4.5', label: 'Grok 4.5', description: "SpaceXAI's new frontier model" });
+  assert.deepEqual(models[1], { id: 'grok-3', label: 'Grok 3', description: 'Grok 3 reasoning model' });
+  assert.ok(seen.has('grok-4.5'));
+  assert.ok(seen.has('grok-3'));
+});
+
+test('parseGrokProfilesFromToml extracts custom profiles from config.toml', () => {
+  const toml = `
+[models]
+default = "grok-custom"
+
+[model."grok-custom"]
+model = "grok-4.5"
+base_url = "https://example.com/v1"
+`;
+
+  const { models, defaultModel } = parseGrokProfilesFromToml(toml);
+  assert.equal(defaultModel, 'grok-custom');
+  assert.equal(models.length, 1);
+  assert.deepEqual(models[0], { id: 'grok-custom', label: 'grok-custom', description: 'grok-4.5' });
+});

--- a/src/main/java/com/github/claudecodegui/handler/CliModelsHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/CliModelsHandler.java
@@ -59,7 +59,7 @@ public class CliModelsHandler extends BaseMessageHandler {
             return false;
         }
         String provider = content != null ? content.trim().toLowerCase(Locale.ROOT) : "";
-        if (!"opencode".equals(provider) && !"kimi".equals(provider) && !"pi".equals(provider) && !"codex".equals(provider)) {
+        if (!"opencode".equals(provider) && !"kimi".equals(provider) && !"pi".equals(provider) && !"codex".equals(provider) && !"grok".equals(provider)) {
             pushError(provider, "Unsupported CLI provider for model list: " + provider);
             return true;
         }

--- a/webview/src/hooks/providers/useCliModels.test.ts
+++ b/webview/src/hooks/providers/useCliModels.test.ts
@@ -32,9 +32,13 @@ describe('useCliModels', () => {
     expect(sendBridgeEventMock).toHaveBeenCalledWith('get_cli_models', 'codex');
   });
 
-  it('does not fetch for claude or grok', () => {
-    renderHook(() => useCliModels('claude'));
+  it('fetches the grok catalog when the grok provider is active', () => {
     renderHook(() => useCliModels('grok'));
+    expect(sendBridgeEventMock).toHaveBeenCalledWith('get_cli_models', 'grok');
+  });
+
+  it('does not fetch for claude', () => {
+    renderHook(() => useCliModels('claude'));
     expect(sendBridgeEventMock).not.toHaveBeenCalled();
   });
 

--- a/webview/src/hooks/providers/useCliModels.ts
+++ b/webview/src/hooks/providers/useCliModels.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { sendBridgeEvent } from '../../utils/bridge';
 import type { ModelInfo } from '../../components/ChatInputBox/types';
-import { CODEX_MODELS, KIMI_MODELS, OPENCODE_MODELS, PI_MODELS } from '../../components/ChatInputBox/types';
+import { CODEX_MODELS, GROK_MODELS, KIMI_MODELS, OPENCODE_MODELS, PI_MODELS } from '../../components/ChatInputBox/types';
 import { isCliOnlyProvider } from './cliProviders';
 import { subscribeActiveCodexProvider } from '../../utils/runtimeProviderCapabilities';
 
@@ -11,6 +11,7 @@ type CliModelsByProvider = Record<string, ModelInfo[]>;
 const CLI_MODELS_TIMEOUT_MS = 15_000;
 
 function fallbackModels(providerId: string): ModelInfo[] {
+  if (providerId === 'grok') return GROK_MODELS;
   if (providerId === 'kimi') return KIMI_MODELS;
   if (providerId === 'opencode') return OPENCODE_MODELS;
   if (providerId === 'pi') return PI_MODELS;
@@ -22,11 +23,10 @@ function fallbackModels(providerId: string): ModelInfo[] {
  * Providers whose model list is discovered dynamically via `get_cli_models`.
  * Codex is included even though it is not a CLI-only provider: its list comes
  * from ~/.codex/config.toml + model_catalog_json, same as the codex CLI picker.
- * Grok is excluded (static profile list).
  */
 function supportsDynamicModels(providerId: string): boolean {
   if (providerId === 'codex') return true;
-  return isCliOnlyProvider(providerId) && providerId !== 'grok';
+  return isCliOnlyProvider(providerId);
 }
 
 function normalizeModels(raw: unknown): ModelInfo[] {


### PR DESCRIPTION
## Summary
Adds dynamic model discovery for the Grok CLI provider via `listModels` / `get_cli_models:grok`.

### Key Changes
1. **`models-service.js`**: Discovers models from `~/.grok/models_cache.json` (auto-fetched by Grok CLI from the API) and custom profiles in `~/.grok/config.toml`.
2. **`grok-channel.js`**: Implements the `listModels` command for the Grok bridge channel.
3. **`CliModelsHandler.java`**: Adds `"grok"` to supported providers for `get_cli_models`.
4. **`useCliModels.ts`**: Enables dynamic model fetching and fallback list for Grok in the frontend model selector.
5. **Tests**: Added unit test suite `models-service.test.js` verifying cache parsing and profile extraction.