### PR TITLE
feat(gemini): Antigravity CLI (agy) provider support

### DIFF
--- a/ai-bridge/channel-manager.js
+++ b/ai-bridge/channel-manager.js
@@ -34,6 +34,7 @@ import { handleGrokCommand } from './channels/grok-channel.js';
 import { handleKimiCommand } from './channels/kimi-channel.js';
 import { handleOpenCodeCommand } from './channels/opencode-channel.js';
 import { handlePiCommand } from './channels/pi-channel.js';
+import { handleGeminiCommand } from './channels/gemini-channel.js';
 import { getSdkStatus, isClaudeSdkAvailable, isCodexSdkAvailable } from './utils/sdk-loader.js';
 import { injectStartupEnvVars, configureCliIdentity } from './config/api-config.js';
 
@@ -145,6 +146,7 @@ const providerHandlers = {
   kimi: handleKimiCommand,
   opencode: handleOpenCodeCommand,
   pi: handlePiCommand,
+  gemini: handleGeminiCommand,
   system: handleSystemCommand
 };
 
@@ -154,8 +156,8 @@ const providerHandlers = {
   try {
     // Validate provider
     console.error('[DIAG-EXEC] Validating provider...');
-    if (!provider || !providerHandlers[provider]) {
-      console.error('Invalid provider. Use "claude", "codex", "grok", "kimi", "opencode", "pi", or "system"');
+    if (!providerHandlers[provider]) {
+      console.error('Invalid provider. Use "claude", "codex", "grok", "kimi", "opencode", "pi", "gemini", or "system"');
       writeJsonAndExit({
         success: false,
         error: 'Invalid provider: ' + provider

--- a/ai-bridge/channels/gemini-channel.js
+++ b/ai-bridge/channels/gemini-channel.js
@@ -1,0 +1,91 @@
+/**
+ * Gemini / Antigravity CLI channel command handler.
+ * Provider id in the plugin UI: "gemini"
+ * Transport: agy headless stream-json (not ACP, not Claude SDK).
+ */
+
+import { sendMessage as geminiSendMessage } from '../services/gemini/message-service.js';
+import {
+  isAgyAvailable,
+  buildAgyModelsCatalog,
+  buildGeminiContextUsagePayload,
+  resolveAgyBinary,
+} from '../services/gemini/agy-utils.js';
+
+export async function handleGeminiCommand(command, args, stdinData) {
+  switch (command) {
+    case 'send': {
+      if (stdinData && (stdinData.message !== undefined || stdinData.prompt !== undefined)) {
+        const options = {
+          message: stdinData.message ?? stdinData.prompt ?? '',
+          sessionId: stdinData.sessionId || '',
+          cwd: stdinData.cwd || '',
+          permissionMode: stdinData.permissionMode || '',
+          model: stdinData.model || '',
+          attachments: stdinData.attachments || [],
+          openedFiles: stdinData.openedFiles ?? null,
+          agentPrompt: stdinData.agentPrompt || '',
+          streaming: stdinData.streaming !== undefined ? stdinData.streaming : true,
+          reasoningEffort: stdinData.reasoningEffort || '',
+          agent: stdinData.agent || '',
+          printTimeout: stdinData.printTimeout || '',
+        };
+        await geminiSendMessage(options);
+      } else {
+        await geminiSendMessage(args[0], args[1], args[2], args[3], args[4]);
+      }
+      break;
+    }
+
+    case 'getContextUsage': {
+      const payload = buildGeminiContextUsagePayload({
+        usedTokens: stdinData?.usedTokens ?? 0,
+        maxTokens: stdinData?.maxTokens ?? 200_000,
+        model: stdinData?.model || '',
+      });
+      console.log(JSON.stringify(payload));
+      break;
+    }
+
+    case 'getUsage': {
+      console.log(JSON.stringify({
+        success: true,
+        data: {
+          unavailable: true,
+          message:
+            'Antigravity CLI billing/quota is available via `agy` TUI (/usage, /credits). '
+            + 'Per-turn token usage is streamed on [USAGE] during chat.',
+          source: 'channel-fallback',
+        },
+      }));
+      break;
+    }
+
+    case 'listModels': {
+      const catalog = buildAgyModelsCatalog();
+      console.log(JSON.stringify({
+        success: true,
+        models: catalog.models,
+        families: catalog.families,
+        binary: catalog.binary || resolveAgyBinary() || '',
+      }));
+      break;
+    }
+
+    case 'checkCli': {
+      console.log(JSON.stringify({
+        success: true,
+        available: isAgyAvailable(),
+        binary: resolveAgyBinary() || '',
+      }));
+      break;
+    }
+
+    default:
+      throw new Error(`Unknown Gemini/agy command: ${command}`);
+  }
+}
+
+export function getGeminiCommandList() {
+  return ['send', 'getContextUsage', 'getUsage', 'listModels', 'checkCli'];
+}

--- a/ai-bridge/daemon.js
+++ b/ai-bridge/daemon.js
@@ -29,6 +29,7 @@ import { createInterface } from 'readline';
 import { handleClaudeCommand } from './channels/claude-channel.js';
 import { handleCodexCommand } from './channels/codex-channel.js';
 import { handleGrokCommand } from './channels/grok-channel.js';
+import { handleGeminiCommand } from './channels/gemini-channel.js';
 import { loadClaudeSdk, isClaudeSdkAvailable } from './utils/sdk-loader.js';
 import {
   sendMessagePersistent,
@@ -503,6 +504,9 @@ async function processRequest(request) {
           break;
         case 'grok':
           await handleGrokCommand(command, [], stdinData);
+          break;
+        case 'gemini':
+          await handleGeminiCommand(command, [], stdinData);
           break;
         default:
           throw new Error(`Unknown provider: ${provider}`);

--- a/ai-bridge/services/claude/mcp-status/stdio-tools-getter.test.js
+++ b/ai-bridge/services/claude/mcp-status/stdio-tools-getter.test.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { realpathSync } from 'node:fs';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -50,7 +51,7 @@ lines.on('line', (line) => {
 
     assert.equal(result.error, null);
     assert.equal(result.tools.length, 1);
-    assert.equal(path.resolve(result.tools[0].description), path.resolve(workingDirectory));
+    assert.equal(realpathSync(result.tools[0].description), realpathSync(workingDirectory));
   } finally {
     await rm(workingDirectory, {
       recursive: true,

--- a/ai-bridge/services/gemini/agy-event-normalizer.js
+++ b/ai-bridge/services/gemini/agy-event-normalizer.js
@@ -1,0 +1,327 @@
+/**
+ * Normalize Antigravity CLI stream-json NDJSON events → Claude-compatible bridge tags.
+ *
+ * Official headless events (https://antigravity.google/docs/cli/headless):
+ *   init → step_update* → result
+ *
+ * Tags match Grok/Claude Java parsers:
+ *   [MESSAGE_START] [STREAM_START] [CONTENT_DELTA] [MESSAGE] [TOOL_RESULT]
+ *   [USAGE] [SESSION_ID] [STREAM_END] [MESSAGE_END] [SEND_ERROR]
+ */
+
+import { normalizeUsageToSnakeCase, extractAgyContextTokens } from './agy-utils.js';
+
+export class AgyEventNormalizer {
+  constructor({ log = console.log, error = console.error } = {}) {
+    this.log = log;
+    this.error = error;
+    this.assistantText = '';
+    this.streamStarted = false;
+    this.messageStarted = false;
+    this.streamEnded = false;
+    this.messageEnded = false;
+    this.conversationId = null;
+    this.lastUsage = null;
+    /** Peak context tokens seen this turn (ignore tiny checkpoint regressions). */
+    this.peakContextTokens = 0;
+    this.emittedToolKeys = new Set();
+    this.emittedToolUses = new Set();
+    this.emittedToolResults = new Set();
+    this._terminalError = null;
+    this._terminalStatus = null;
+  }
+
+  begin() {
+    this.lastUsage = null;
+    this.peakContextTokens = 0;
+    this.assistantText = '';
+    this.emittedToolKeys = new Set();
+    this.emittedToolUses = new Set();
+    this.emittedToolResults = new Set();
+    this._terminalError = null;
+    this._terminalStatus = null;
+    this.streamEnded = false;
+    this.messageEnded = false;
+    this._emit('[MESSAGE_START]');
+    this.messageStarted = true;
+    this._emit('[STREAM_START]');
+    this.streamStarted = true;
+  }
+
+  /**
+   * @param {object} eventObj parsed NDJSON line from agy stream-json
+   */
+  handleStreamEvent(eventObj) {
+    if (!eventObj || typeof eventObj !== 'object') return;
+    const event = eventObj.event;
+
+    if (event === 'init') {
+      const cid = eventObj.conversation_id || eventObj.init?.conversation_id;
+      if (cid) {
+        this.conversationId = cid;
+        this._emit(`[SESSION_ID] ${cid}`);
+      }
+      return;
+    }
+
+    if (event === 'step_update') {
+      this._handleStepUpdate(eventObj.step_update || {});
+      return;
+    }
+
+    if (event === 'result') {
+      this._handleResult(eventObj.result || eventObj);
+      return;
+    }
+  }
+
+  _handleStepUpdate(step) {
+    if (!step || typeof step !== 'object') return;
+
+    if (step.conversation_id && !this.conversationId) {
+      this.conversationId = step.conversation_id;
+      this._emit(`[SESSION_ID] ${this.conversationId}`);
+    }
+
+    const usage = normalizeUsageToSnakeCase(step.usage);
+    if (usage) {
+      this._maybeEmitUsage(usage, { authoritative: false });
+    }
+
+    const stepType = String(step.step_type || '').toLowerCase();
+    const state = String(step.state || '').toUpperCase();
+
+    if (stepType === 'agent_response' || stepType === 'planner_response') {
+      const delta = step.text_delta;
+      if (delta != null && String(delta).length > 0) {
+        const text = String(delta);
+        this.assistantText += text;
+        this._emit(`[CONTENT_DELTA] ${JSON.stringify(text)}`);
+      }
+    }
+
+    if (stepType === 'thinking' || stepType === 'agent_thought' || step.thinking_delta) {
+      const t = step.thinking_delta ?? step.text_delta;
+      if (t != null && String(t).length > 0) {
+        this._emit(`[THINKING_DELTA] ${JSON.stringify(String(t))}`);
+      }
+    }
+
+    // Handle planner_response / agent_response tool_calls array if present
+    if (Array.isArray(step.tool_calls) && step.tool_calls.length > 0) {
+      step.tool_calls.forEach((call, idx) => {
+        const toolName = call.name || 'tool';
+        const params = call.args || call.parameters || {};
+        const callId = `agy-tool-${step.step_index ?? 'x'}-${idx}`;
+        this._emitToolUse(callId, toolName, params);
+      });
+    }
+
+    if (stepType === 'tool' || step.tool_info || step.tool_name) {
+      this._emitTool(step);
+    }
+
+    if (step.subagent_info && state === 'DONE') {
+      try {
+        const info = step.subagent_info;
+        const names = Array.isArray(info.subagents)
+          ? info.subagents.map((s) => s.type_name || s.role || 'subagent').join(', ')
+          : 'subagent';
+        this._emit(`[TOOL_RESULT] ${JSON.stringify({
+          type: 'tool_result',
+          tool_use_id: `subagent-${step.step_index ?? 'x'}`,
+          content: `Subagent: ${names}`,
+          is_error: false,
+          _meta: { kind: 'subagent', subagent_info: info },
+        })}`);
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  _emitToolUse(toolCallId, name, params) {
+    if (this.emittedToolUses.has(toolCallId)) return;
+    this.emittedToolUses.add(toolCallId);
+
+    const toolUseMsg = {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: toolCallId,
+            name: name || 'tool',
+            input: typeof params === 'object' && params !== null ? params : { value: params },
+          },
+        ],
+      },
+    };
+    this._emit(`[MESSAGE] ${JSON.stringify(toolUseMsg)}`);
+    this._emit('[BLOCK_RESET]');
+  }
+
+  _emitTool(step) {
+    const info = step.tool_info || {};
+    const name = info.name || step.tool_name || 'tool';
+    const params = info.parameters || step.parameters || {};
+    const state = String(step.state || '').toUpperCase();
+    const stepIndex = step.step_index ?? 'x';
+    const toolCallId = `agy-tool-${stepIndex}`;
+
+    // Always emit tool_use card to UI on first sight / ACTIVE state
+    this._emitToolUse(toolCallId, name, params);
+
+    const output = info.output != null ? String(info.output) : '';
+    const err = info.error;
+    const isError = !!(err && (err.message || err.type));
+
+    // Emit tool_result when tool completes or has output/error
+    const isDone = state === 'DONE' || output || isError;
+    if (isDone && !this.emittedToolResults.has(toolCallId)) {
+      this.emittedToolResults.add(toolCallId);
+
+      let summary = '';
+      try {
+        const cmd = params.CommandLine || params.command || params.path || params.Path || '';
+        summary = cmd ? `${name}: ${cmd}` : name;
+      } catch {
+        summary = name;
+      }
+
+      const body = isError
+        ? `${summary}\nError: ${err.message || err.type || 'tool error'}`
+        : (output ? `${summary}\n${output}`.slice(0, 8000) : summary);
+
+      this._emit(`[TOOL_RESULT] ${JSON.stringify({
+        type: 'tool_result',
+        tool_use_id: toolCallId,
+        content: body,
+        is_error: isError,
+        _meta: {
+          tool_name: name,
+          parameters: params,
+          step_index: step.step_index,
+          state,
+        },
+      })}`);
+    }
+  }
+
+  _handleResult(result) {
+    if (!result || typeof result !== 'object') return;
+
+    if (result.conversation_id && this.conversationId !== result.conversation_id) {
+      this.conversationId = result.conversation_id;
+      this._emit(`[SESSION_ID] ${this.conversationId}`);
+    }
+
+    const usage = normalizeUsageToSnakeCase(result.usage);
+    if (usage) {
+      // Final result usage is authoritative for the turn (includes all steps).
+      this._maybeEmitUsage(usage, { authoritative: true });
+    }
+
+    const responseText = result.response != null ? String(result.response) : '';
+    if (responseText && !this.assistantText) {
+      this.assistantText = responseText;
+      this._emit(`[CONTENT_DELTA] ${JSON.stringify(responseText)}`);
+    } else if (responseText && responseText.length > this.assistantText.length) {
+      const already = this.assistantText;
+      if (!responseText.startsWith(already)) {
+        this.assistantText = responseText;
+      }
+    }
+
+    const status = String(result.status || '').toUpperCase();
+    if (status && status !== 'SUCCESS' && status !== 'RUNNING') {
+      if (status === 'ERROR' || status === 'INVALID') {
+        const errMsg = result.error || `agy run status=${status}`;
+        this._terminalError = errMsg;
+        this._terminalStatus = status;
+      }
+    }
+  }
+
+  /**
+   * Emit [USAGE] for the status bar.
+   * Intermediate step usage (esp. tiny checkpoint rows) must not replace a larger
+   * peak — agy often ends with checkpoint usage ~100 tokens after a 20k+ response step.
+   */
+  _maybeEmitUsage(usage, { authoritative = false } = {}) {
+    if (!usage) return;
+    const ctx = extractAgyContextTokens(usage);
+    if (!authoritative && ctx > 0 && ctx < this.peakContextTokens) {
+      return;
+    }
+    if (ctx > this.peakContextTokens) {
+      this.peakContextTokens = ctx;
+    }
+    this.lastUsage = usage;
+    this._emit(`[USAGE] ${JSON.stringify(usage)}`);
+  }
+
+  finishSuccess(conversationId, resultText) {
+    const finalId = conversationId || this.conversationId || `agy-${Date.now()}`;
+    if (!this.conversationId) {
+      this._emit(`[SESSION_ID] ${finalId}`);
+    }
+
+    const text = (resultText != null && String(resultText).length > 0)
+      ? String(resultText)
+      : this.assistantText;
+
+    if (this.lastUsage) {
+      this._emit(`[USAGE] ${JSON.stringify(this.lastUsage)}`);
+    }
+
+    const assistantMessage = {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: text || '' }],
+        ...(this.lastUsage ? { usage: this.lastUsage } : {}),
+      },
+    };
+    this._emit(`[MESSAGE] ${JSON.stringify(assistantMessage)}`);
+    this._emitStreamEndOnce();
+    this._emitMessageEndOnce();
+
+    this.log(JSON.stringify({
+      success: true,
+      sessionId: finalId,
+      result: text,
+    }));
+  }
+
+  finishError(error) {
+    const message = error?.message || String(error || 'Unknown error');
+    this._emit(`[SEND_ERROR] ${JSON.stringify({ error: message })}`);
+    this._emitStreamEndOnce();
+    this._emitMessageEndOnce();
+    this.log(JSON.stringify({
+      success: false,
+      error: message,
+      sessionId: this.conversationId || '',
+    }));
+  }
+
+  _emitStreamEndOnce() {
+    if (!this.streamEnded) {
+      this._emit('[STREAM_END]');
+      this.streamEnded = true;
+    }
+  }
+
+  _emitMessageEndOnce() {
+    if (!this.messageEnded) {
+      this._emit('[MESSAGE_END]');
+      this.messageEnded = true;
+    }
+  }
+
+  _emit(line) {
+    this.log(line);
+  }
+}

--- a/ai-bridge/services/gemini/agy-event-normalizer.test.js
+++ b/ai-bridge/services/gemini/agy-event-normalizer.test.js
@@ -1,0 +1,235 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { AgyEventNormalizer } from './agy-event-normalizer.js';
+
+function collect() {
+  const lines = [];
+  const n = new AgyEventNormalizer({
+    log: (line) => lines.push(String(line)),
+    error: () => {},
+  });
+  return { n, lines };
+}
+
+test('normalizer emits session id, deltas, tools, usage, success envelope', () => {
+  const { n, lines } = collect();
+  n.begin();
+  n.handleStreamEvent({
+    event: 'init',
+    conversation_id: 'conv-abc',
+    init: { cwd: '/tmp', tools: ['run_command'], permission_mode: 'request-review' },
+  });
+  n.handleStreamEvent({
+    event: 'step_update',
+    step_update: {
+      conversation_id: 'conv-abc',
+      step_index: 2,
+      state: 'ACTIVE',
+      step_type: 'agent_response',
+      text_delta: 'Hello ',
+    },
+  });
+  n.handleStreamEvent({
+    event: 'step_update',
+    step_update: {
+      conversation_id: 'conv-abc',
+      step_index: 2,
+      state: 'DONE',
+      step_type: 'agent_response',
+      text_delta: 'world',
+      usage: { input_tokens: 100, output_tokens: 10, thinking_tokens: 0, cache_read_tokens: 0, total_tokens: 110 },
+    },
+  });
+  n.handleStreamEvent({
+    event: 'step_update',
+    step_update: {
+      step_index: 4,
+      state: 'DONE',
+      step_type: 'tool',
+      tool_name: 'run_command',
+      tool_info: {
+        name: 'run_command',
+        parameters: { CommandLine: 'echo hi' },
+        output: 'hi\n',
+      },
+    },
+  });
+  n.handleStreamEvent({
+    event: 'result',
+    result: {
+      conversation_id: 'conv-abc',
+      status: 'SUCCESS',
+      response: 'Hello world',
+      usage: { input_tokens: 100, output_tokens: 10, thinking_tokens: 0, cache_read_tokens: 0, total_tokens: 110 },
+    },
+  });
+  n.finishSuccess('conv-abc', 'Hello world');
+
+  assert.ok(lines.some((l) => l.startsWith('[MESSAGE_START]')));
+  assert.ok(lines.some((l) => l.startsWith('[STREAM_START]')));
+  assert.ok(lines.some((l) => l === '[SESSION_ID] conv-abc'));
+  assert.ok(lines.some((l) => l.startsWith('[CONTENT_DELTA]') && l.includes('Hello')));
+  assert.ok(lines.some((l) => l.startsWith('[CONTENT_DELTA]') && l.includes('world')));
+  assert.ok(lines.some((l) => l.startsWith('[TOOL_RESULT]') && l.includes('run_command')));
+  assert.ok(lines.some((l) => l.startsWith('[USAGE]')));
+  assert.ok(lines.some((l) => l.startsWith('[MESSAGE]')));
+  assert.ok(lines.some((l) => l.startsWith('[STREAM_END]')));
+  assert.ok(lines.some((l) => l.startsWith('[MESSAGE_END]')));
+  const ok = lines.find((l) => l.startsWith('{') && l.includes('"success"'));
+  assert.ok(ok);
+  const env = JSON.parse(ok);
+  assert.equal(env.success, true);
+  assert.equal(env.sessionId, 'conv-abc');
+  assert.equal(env.result, 'Hello world');
+});
+
+test('finishError emits SEND_ERROR', () => {
+  const { n, lines } = collect();
+  n.begin();
+  n.finishError(new Error('authentication required'));
+  assert.ok(lines.some((l) => l.startsWith('[SEND_ERROR]') && l.includes('authentication required')));
+  const env = JSON.parse(lines.find((l) => l.startsWith('{') && l.includes('"success"')));
+  assert.equal(env.success, false);
+});
+
+test('normalizer emits thinking deltas', () => {
+  const { n, lines } = collect();
+  n.begin();
+  n.handleStreamEvent({
+    event: 'step_update',
+    step_update: {
+      step_index: 1,
+      state: 'ACTIVE',
+      step_type: 'thinking',
+      thinking_delta: 'pondering',
+    },
+  });
+  assert.ok(lines.some((l) => l.startsWith('[THINKING_DELTA]') && l.includes('pondering')));
+});
+
+test('result without streamed text emits content delta from response', () => {
+  const { n, lines } = collect();
+  n.begin();
+  n.handleStreamEvent({
+    event: 'result',
+    result: {
+      conversation_id: 'c1',
+      status: 'SUCCESS',
+      response: 'final only',
+      usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+    },
+  });
+  n.finishSuccess('c1', 'final only');
+  assert.ok(lines.some((l) => l.startsWith('[CONTENT_DELTA]') && l.includes('final only')));
+  assert.equal(n.assistantText, 'final only');
+  assert.equal(n.conversationId, 'c1');
+});
+
+test('result ERROR status records terminal error', () => {
+  const { n } = collect();
+  n.begin();
+  n.handleStreamEvent({
+    event: 'result',
+    result: {
+      conversation_id: 'c-err',
+      status: 'ERROR',
+      error: 'auth failed',
+      response: '',
+    },
+  });
+  assert.equal(n._terminalError, 'auth failed');
+});
+
+test('checkpoint usage smaller than peak is not emitted', () => {
+  const { n, lines } = collect();
+  n.begin();
+  n.handleStreamEvent({
+    event: 'step_update',
+    step_update: {
+      step_type: 'agent_response',
+      state: 'DONE',
+      text_delta: '2',
+      usage: { input_tokens: 27793, output_tokens: 18, total_tokens: 27811 },
+    },
+  });
+  n.handleStreamEvent({
+    event: 'step_update',
+    step_update: {
+      step_type: 'checkpoint',
+      state: 'DONE',
+      usage: { input_tokens: 96, output_tokens: 3, total_tokens: 99 },
+    },
+  });
+  const usageLines = lines.filter((l) => l.startsWith('[USAGE]'));
+  assert.equal(usageLines.length, 1);
+  assert.ok(usageLines[0].includes('"input_tokens":27793'));
+  assert.ok(usageLines[0].includes('"cache_read_input_tokens"'));
+});
+
+test('result usage is always emitted even if smaller', () => {
+  const { n, lines } = collect();
+  n.begin();
+  n.handleStreamEvent({
+    event: 'step_update',
+    step_update: {
+      step_type: 'agent_response',
+      state: 'DONE',
+      usage: { input_tokens: 5000, output_tokens: 1, total_tokens: 5001 },
+    },
+  });
+  n.handleStreamEvent({
+    event: 'result',
+    result: {
+      conversation_id: 'c',
+      status: 'SUCCESS',
+      response: 'ok',
+      usage: { input_tokens: 4000, output_tokens: 2, total_tokens: 4002 },
+    },
+  });
+  const usageLines = lines.filter((l) => l.startsWith('[USAGE]'));
+  assert.ok(usageLines.length >= 2);
+  assert.ok(usageLines[usageLines.length - 1].includes('"input_tokens":4000'));
+});
+
+test('finishSuccess is idempotent for stream/message end tags', () => {
+  const { n, lines } = collect();
+  n.begin();
+  n.finishSuccess('id', 'text');
+  n.finishSuccess('id', 'text');
+  assert.equal(lines.filter((l) => l === '[STREAM_END]').length, 1);
+  assert.equal(lines.filter((l) => l === '[MESSAGE_END]').length, 1);
+});
+
+test('ignores null/unknown events', () => {
+  const { n, lines } = collect();
+  n.begin();
+  const before = lines.length;
+  n.handleStreamEvent(null);
+  n.handleStreamEvent({ event: 'unknown_thing' });
+  assert.equal(lines.length, before);
+});
+
+test('emits tool_use message and BLOCK_RESET when tool step update arrives', () => {
+  const { n, lines } = collect();
+  n.begin();
+  n.handleStreamEvent({
+    event: 'step_update',
+    step_update: {
+      step_index: 3,
+      state: 'ACTIVE',
+      step_type: 'tool',
+      tool_name: 'view_file',
+      tool_info: {
+        name: 'view_file',
+        parameters: { AbsolutePath: '/foo/bar.txt' },
+      },
+    },
+  });
+
+  const toolUseLine = lines.find((l) => l.startsWith('[MESSAGE]') && l.includes('"tool_use"'));
+  assert.ok(toolUseLine, 'tool_use message should be emitted on ACTIVE tool step');
+  assert.ok(toolUseLine.includes('view_file'));
+  assert.ok(toolUseLine.includes('/foo/bar.txt'));
+  assert.ok(lines.includes('[BLOCK_RESET]'), 'BLOCK_RESET should be emitted for tool step');
+});
+

--- a/ai-bridge/services/gemini/agy-runner.js
+++ b/ai-bridge/services/gemini/agy-runner.js
@@ -1,0 +1,242 @@
+/**
+ * Spawn Antigravity CLI headless turn and parse stream-json NDJSON from stdout.
+ */
+
+import { spawn } from 'node:child_process';
+import readline from 'node:readline';
+import {
+  resolveAgyBinary,
+  buildAgyArgs,
+  buildAgyEnv,
+  resolveAgySpawnModel,
+} from './agy-utils.js';
+import { selectWorkingDirectory, isUnsafeWorkingDirectory } from '../../utils/path-utils.js';
+
+/**
+ * Run one agy headless turn.
+ *
+ * @param {object} options
+ * @param {(obj: object) => void} options.onEvent - parsed NDJSON event
+ * @param {(chunk: string) => void} [options.onStderr]
+ * @returns {Promise<{ conversationId: string, status: string, response: string, usage: object|null, error: string|null, exitCode: number }>}
+ */
+export function runAgyTurn(options = {}) {
+  const {
+    message = '',
+    sessionId = '',
+    cwd = '',
+    model = '',
+    reasoningEffort = '',
+    agent = '',
+    permissionMode = '',
+    printTimeout = '',
+    addDirs = [],
+    env: envOverride = null,
+    onEvent = () => {},
+    onStderr = () => {},
+  } = options;
+
+  const bin = resolveAgyBinary();
+  if (!bin) {
+    return Promise.reject(new Error(
+      'Antigravity CLI (agy) not found. Install from https://antigravity.google/docs/cli/install '
+      + 'or set AGY_PATH / GEMINI_CLI_PATH to the agy binary.'
+    ));
+  }
+
+  // Resolve family base (gemini-3.6-flash) → full catalog slug (…-medium).
+  // Never pass a separate --effort: bare slugs like claude-sonnet-4-6 reject it,
+  // and effort-required families are selected via the full --model slug.
+  const resolved = resolveAgySpawnModel(model, reasoningEffort);
+  const modelStr = resolved.model;
+  // Guard against plugin/ai-bridge/~/.gemini paths becoming workspaceDirs.
+  const workCwd = selectWorkingDirectory(cwd);
+
+  const effectiveAddDirs = Array.isArray(addDirs) ? [...addDirs] : [];
+  if (workCwd && !isUnsafeWorkingDirectory(workCwd) && !effectiveAddDirs.includes(workCwd)) {
+    effectiveAddDirs.push(workCwd);
+  }
+
+  const args = buildAgyArgs({
+    message,
+    conversationId: sessionId,
+    model: modelStr,
+    effort: '',
+    agent,
+    permissionMode,
+    printTimeout,
+    addDirs: effectiveAddDirs,
+  });
+
+  const env = buildAgyEnv(envOverride || process.env);
+
+  // Avoid logging full prompt body (-p value)
+  const safeArgs = args.map((a, i) => (i > 0 && args[i - 1] === '-p' ? '<prompt>' : a));
+  console.error('[AGY] spawn', bin, safeArgs.join(' '), 'cwd=' + workCwd);
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let conversationId = sessionId || '';
+    let status = '';
+    let response = '';
+    let usage = null;
+    let resultError = null;
+    let stderrBuf = '';
+
+    const child = spawn(bin, args, {
+      cwd: workCwd,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: process.platform !== 'win32',
+      windowsHide: true,
+    });
+
+    const cleanupChild = () => {
+      killProcessGroup(child);
+    };
+    process.on('exit', cleanupChild);
+    process.on('SIGTERM', () => { cleanupChild(); process.exit(0); });
+    process.on('SIGINT', () => { cleanupChild(); process.exit(0); });
+
+    const timeoutMs = options.turnTimeoutMs != null
+      ? Number(options.turnTimeoutMs)
+      : 15 * 60 * 1000; // 15-minute default watchdog
+
+    let timeoutTimer = null;
+    if (timeoutMs > 0) {
+      timeoutTimer = setTimeout(() => {
+        if (settled) return;
+        console.error(`[AGY] Watchdog timeout after ${Math.round(timeoutMs / 1000)}s — terminating process group ${child.pid}`);
+        settled = true;
+        killProcessGroup(child);
+        rl.close();
+        reject(new Error(
+          `Antigravity CLI (agy) turn timed out after ${Math.round(timeoutMs / 60000)} minutes.`
+          + ' If running a long background task (like starting an emulator), run it in background with output redirected (e.g. `nohup emulator @nexus > /dev/null 2>&1 &`).'
+        ));
+      }, timeoutMs);
+    }
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    const rl = readline.createInterface({ input: child.stdout, crlfDelay: Infinity });
+
+    rl.on('line', (line) => {
+      const trimmed = String(line || '').trim();
+      if (!trimmed) return;
+      if (!trimmed.startsWith('{')) {
+        console.error('[AGY-STDOUT-NONJSON]', trimmed.slice(0, 200));
+        return;
+      }
+      let obj;
+      try {
+        obj = JSON.parse(trimmed);
+      } catch {
+        console.error('[AGY-STDOUT-PARSE]', trimmed.slice(0, 200));
+        return;
+      }
+
+      try {
+        onEvent(obj);
+      } catch (e) {
+        console.error('[AGY-ONEVENT]', e?.message || e);
+      }
+
+      if (obj.event === 'init' && obj.conversation_id) {
+        conversationId = obj.conversation_id;
+      }
+      if (obj.event === 'result' && obj.result) {
+        const r = obj.result;
+        conversationId = r.conversation_id || conversationId;
+        status = r.status || status;
+        response = r.response != null ? String(r.response) : response;
+        usage = r.usage || usage;
+        if (r.error) resultError = String(r.error);
+      }
+      if (!obj.event && obj.conversation_id && obj.status) {
+        conversationId = obj.conversation_id;
+        status = obj.status;
+        response = obj.response != null ? String(obj.response) : response;
+        usage = obj.usage || usage;
+        if (obj.error) resultError = String(obj.error);
+        onEvent({ event: 'result', result: obj });
+      }
+    });
+
+    child.stderr.on('data', (buf) => {
+      const s = buf.toString('utf8');
+      stderrBuf += s;
+      onStderr(s);
+    });
+
+    child.on('error', (err) => {
+      if (settled) return;
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      settled = true;
+      killProcessGroup(child);
+      reject(err);
+    });
+
+    child.on('close', (code) => {
+      if (settled) return;
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      settled = true;
+      rl.close();
+      process.removeListener('exit', cleanupChild);
+
+      const exitCode = code == null ? 1 : code;
+      const st = String(status || '').toUpperCase();
+
+      if (exitCode !== 0 && (!st || st === 'ERROR' || st === 'INVALID')) {
+        const stderrSnippet = String(stderrBuf || '').trim();
+        const errText = resultError
+          || extractAuthHint(stderrBuf)
+          || (stderrSnippet ? `agy stderr: ${stderrSnippet}` : null)
+          || `agy exited with code ${exitCode}`;
+        if (!response && !conversationId) {
+          reject(new Error(errText));
+          return;
+        }
+      }
+
+      resolve({
+        conversationId,
+        status: st || (exitCode === 0 ? 'SUCCESS' : 'ERROR'),
+        response,
+        usage,
+        error: resultError,
+        exitCode,
+      });
+    });
+  });
+}
+
+/**
+ * Terminate an agy child process and its process group.
+ * @param {import('node:child_process').ChildProcess} child
+ */
+export function killProcessGroup(child) {
+  if (!child || child.killed) return;
+  try {
+    if (process.platform !== 'win32' && child.pid) {
+      process.kill(-child.pid, 'SIGKILL');
+    } else {
+      child.kill('SIGKILL');
+    }
+  } catch {
+    try {
+      child.kill('SIGKILL');
+    } catch {}
+  }
+}
+
+function extractAuthHint(stderrText) {
+  const s = String(stderrText || '');
+  if (/authentication required/i.test(s)) {
+    return 'Antigravity CLI authentication required. Run `agy` once in a terminal and complete Google Sign-In, then retry.';
+  }
+  if (/not recognized as a known model/i.test(s)) {
+    return s.trim().slice(0, 500);
+  }
+  const lines = s.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  return lines.length ? lines.slice(-5).join('\n').slice(0, 500) : '';
+}

--- a/ai-bridge/services/gemini/agy-runner.test.js
+++ b/ai-bridge/services/gemini/agy-runner.test.js
@@ -1,0 +1,149 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync, chmodSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runAgyTurn } from './agy-runner.js';
+
+function makeFakeAgy(scriptBody) {
+  const dir = mkdtempSync(join(tmpdir(), 'agy-fake-'));
+  const bin = join(dir, 'agy-fake');
+  writeFileSync(bin, scriptBody, { encoding: 'utf8' });
+  chmodSync(bin, 0o755);
+  return { dir, bin };
+}
+
+test('runAgyTurn parses NDJSON stream and returns SUCCESS', async () => {
+  const { dir, bin } = makeFakeAgy(`#!/usr/bin/env node
+const events = [
+  { event: 'init', conversation_id: 'conv-1' },
+  { event: 'step_update', step_update: { step_type: 'agent_response', text_delta: 'hi', state: 'DONE' } },
+  { event: 'result', result: { conversation_id: 'conv-1', status: 'SUCCESS', response: 'hi', usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } } },
+];
+for (const e of events) console.log(JSON.stringify(e));
+process.exit(0);
+`);
+  const prev = process.env.AGY_PATH;
+  process.env.AGY_PATH = bin;
+  try {
+    const events = [];
+    const turn = await runAgyTurn({
+      message: 'hello',
+      onEvent: (e) => events.push(e),
+    });
+    assert.equal(turn.conversationId, 'conv-1');
+    assert.equal(turn.status, 'SUCCESS');
+    assert.equal(turn.response, 'hi');
+    assert.equal(turn.exitCode, 0);
+    assert.ok(events.some((e) => e.event === 'init'));
+    assert.ok(events.some((e) => e.event === 'result'));
+  } finally {
+    if (prev === undefined) delete process.env.AGY_PATH;
+    else process.env.AGY_PATH = prev;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runAgyTurn rejects when binary missing', async () => {
+  const prev = process.env.AGY_PATH;
+  const prevG = process.env.GEMINI_CLI_PATH;
+  const prevA = process.env.AGY_CLI_PATH;
+  const prevPath = process.env.PATH;
+  process.env.AGY_PATH = '/nonexistent/agy-binary-xyz';
+  process.env.GEMINI_CLI_PATH = '';
+  process.env.AGY_CLI_PATH = '';
+  process.env.PATH = '';
+  try {
+    await assert.rejects(
+      () => runAgyTurn({ message: 'x' }),
+      /not found/i,
+    );
+  } finally {
+    if (prev === undefined) delete process.env.AGY_PATH;
+    else process.env.AGY_PATH = prev;
+    if (prevG === undefined) delete process.env.GEMINI_CLI_PATH;
+    else process.env.GEMINI_CLI_PATH = prevG;
+    if (prevA === undefined) delete process.env.AGY_CLI_PATH;
+    else process.env.AGY_CLI_PATH = prevA;
+    process.env.PATH = prevPath;
+  }
+});
+
+test('runAgyTurn rejects hard failure with no partial output', async () => {
+  const { dir, bin } = makeFakeAgy(`#!/usr/bin/env node
+console.error('authentication required');
+process.exit(2);
+`);
+  const prev = process.env.AGY_PATH;
+  process.env.AGY_PATH = bin;
+  try {
+    await assert.rejects(
+      () => runAgyTurn({ message: 'x' }),
+      /authentication required|exited with code/i,
+    );
+  } finally {
+    if (prev === undefined) delete process.env.AGY_PATH;
+    else process.env.AGY_PATH = prev;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runAgyTurn never passes --effort (effort is in model slug only)', async () => {
+  const { dir, bin } = makeFakeAgy(`#!/usr/bin/env node
+const fs = require('fs');
+fs.writeFileSync(process.env.AGY_ARGV_LOG, JSON.stringify(process.argv.slice(2)));
+console.log(JSON.stringify({ event: 'result', result: { conversation_id: 'c', status: 'SUCCESS', response: 'ok' } }));
+process.exit(0);
+`);
+  const prev = process.env.AGY_PATH;
+  const logPath = join(dir, 'argv.json');
+  process.env.AGY_PATH = bin;
+  process.env.AGY_ARGV_LOG = logPath;
+  try {
+    await runAgyTurn({
+      message: 'hi',
+      model: 'claude-sonnet-4-6',
+      reasoningEffort: '',
+    });
+    const { readFileSync } = await import('node:fs');
+    const argv = JSON.parse(readFileSync(logPath, 'utf8'));
+    assert.ok(argv.includes('--model'));
+    assert.ok(argv.includes('claude-sonnet-4-6'));
+    assert.ok(!argv.includes('--effort'), 'must not pass --effort, got: ' + argv.join(' '));
+  } finally {
+    if (prev === undefined) delete process.env.AGY_PATH;
+    else process.env.AGY_PATH = prev;
+    delete process.env.AGY_ARGV_LOG;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runAgyTurn upgrades bare gemini family to full effort slug', async () => {
+  const { dir, bin } = makeFakeAgy(`#!/usr/bin/env node
+const fs = require('fs');
+fs.writeFileSync(process.env.AGY_ARGV_LOG, JSON.stringify(process.argv.slice(2)));
+console.log(JSON.stringify({ event: 'result', result: { conversation_id: 'c', status: 'SUCCESS', response: 'ok' } }));
+process.exit(0);
+`);
+  const prev = process.env.AGY_PATH;
+  const logPath = join(dir, 'argv-flash.json');
+  process.env.AGY_PATH = bin;
+  process.env.AGY_ARGV_LOG = logPath;
+  try {
+    await runAgyTurn({
+      message: 'hi',
+      model: 'gemini-3.6-flash',
+      reasoningEffort: '',
+    });
+    const { readFileSync } = await import('node:fs');
+    const argv = JSON.parse(readFileSync(logPath, 'utf8'));
+    assert.ok(argv.includes('--model'));
+    assert.ok(argv.includes('gemini-3.6-flash-medium'), 'got: ' + argv.join(' '));
+    assert.ok(!argv.includes('--effort'), 'must not pass --effort, got: ' + argv.join(' '));
+  } finally {
+    if (prev === undefined) delete process.env.AGY_PATH;
+    else process.env.AGY_PATH = prev;
+    delete process.env.AGY_ARGV_LOG;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/ai-bridge/services/gemini/agy-utils.js
+++ b/ai-bridge/services/gemini/agy-utils.js
@@ -1,0 +1,619 @@
+/**
+ * Antigravity CLI (agy) helpers for the Gemini provider bridge.
+ * Docs: https://antigravity.google/docs/cli/headless
+ */
+
+import { existsSync, accessSync, constants as fsConstants } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, delimiter, dirname } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const DEFAULT_MAX_TOKENS = 200_000;
+
+export function getAgyHome() {
+  return process.env.AGY_HOME
+    || process.env.ANTIGRAVITY_CLI_HOME
+    || join(homedir(), '.gemini', 'antigravity-cli');
+}
+
+/**
+ * Resolve agy binary.
+ * ONLY the user-facing `agy` binary is allowed — never `agy.real`
+ * (internal install artifact; forbidden).
+ * Prefer AGY_PATH / GEMINI_CLI_PATH (if they point at `agy`), then
+ * ~/.local/bin/agy, ~/.gemini/antigravity-cli/bin/agy, PATH.
+ */
+function isForbiddenAgyName(path) {
+  const norm = String(path || '').replace(/\\/g, '/');
+  return /(^|\/)agy\.real$/i.test(norm);
+}
+
+function isExecutableBinary(path) {
+  if (!path || isForbiddenAgyName(path) || !existsSync(path)) return false;
+  try {
+    accessSync(path, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function resolveAgyBinary() {
+  // Explicit override:
+  // - agy.real is FORBIDDEN: ignore and fall through to discover `agy`
+  // - any other path: honor strictly (null if missing) so misconfig fails loudly
+  const explicit = (process.env.AGY_PATH || process.env.GEMINI_CLI_PATH || process.env.AGY_CLI_PATH || '').trim();
+  if (explicit) {
+    if (!isForbiddenAgyName(explicit)) {
+      return isExecutableBinary(explicit) ? explicit : null;
+    }
+    // fall through — never invoke agy.real
+  }
+
+  const candidates = [];
+  const home = homedir();
+  const agyHome = getAgyHome();
+  candidates.push(
+    join(home, '.local', 'bin', 'agy'),
+    join(agyHome, 'bin', 'agy'),
+    join(home, 'bin', 'agy'),
+    '/usr/local/bin/agy',
+    '/opt/homebrew/bin/agy',
+  );
+
+  const pathEnv = process.env.PATH || '';
+  for (const dir of pathEnv.split(delimiter)) {
+    if (!dir) continue;
+    candidates.push(join(dir, 'agy'));
+  }
+
+  const seen = new Set();
+  for (const c of candidates) {
+    if (!c || seen.has(c) || isForbiddenAgyName(c)) continue;
+    seen.add(c);
+    if (isExecutableBinary(c)) return c;
+  }
+  return null;
+}
+
+export function isAgyAvailable() {
+  return !!resolveAgyBinary();
+}
+
+/**
+ * Map unified plugin permission modes onto agy CLI flags.
+ * Headless has no interactive Ask UI — default is soft-deny for Ask tools.
+ *
+ * @returns {{ skipPermissions: boolean, modeFlag: string, sandbox: boolean }}
+ */
+export function mapPermissionMode(permissionMode) {
+  const m = String(permissionMode || 'default').trim().toLowerCase();
+  const out = { skipPermissions: false, modeFlag: '', sandbox: false };
+
+  if (m === 'plan') {
+    out.modeFlag = 'plan';
+  } else if (m === 'acceptedits' || m === 'accept-edits' || m === 'accept_edits') {
+    out.modeFlag = 'accept-edits';
+  }
+
+  if (
+    m === 'bypasspermissions'
+    || m === 'bypass'
+    || m === 'yolo'
+    || m === 'dontask'
+    || m === 'dont_ask'
+    || m === 'auto'
+    || m === 'always-proceed'
+    || m === 'always_proceed'
+  ) {
+    out.skipPermissions = true;
+  }
+
+  if (m === 'sandbox') {
+    out.sandbox = true;
+  }
+
+  return out;
+}
+
+/**
+ * Build argv for one headless turn.
+ */
+export function buildAgyArgs(options = {}) {
+  const {
+    message = '',
+    conversationId = '',
+    model = '',
+    effort = '',
+    agent = '',
+    permissionMode = '',
+    continueRecent = false,
+    printTimeout = '',
+    addDirs = [],
+  } = options;
+
+  const perm = mapPermissionMode(permissionMode);
+  const args = [
+    '-p', String(message ?? ''),
+    '--output-format', 'stream-json',
+  ];
+
+  if (conversationId && String(conversationId).trim()) {
+    args.push('--conversation', String(conversationId).trim());
+  } else if (continueRecent) {
+    args.push('--continue');
+  }
+
+  if (model && String(model).trim()) {
+    args.push('--model', String(model).trim());
+  }
+  if (effort && String(effort).trim()) {
+    args.push('--effort', String(effort).trim().toLowerCase());
+  }
+  if (agent && String(agent).trim()) {
+    args.push('--agent', String(agent).trim());
+  }
+  if (perm.modeFlag) {
+    args.push('--mode', perm.modeFlag);
+  }
+  if (perm.skipPermissions) {
+    args.push('--dangerously-skip-permissions');
+  }
+  if (perm.sandbox) {
+    args.push('--sandbox');
+  }
+  if (printTimeout && String(printTimeout).trim()) {
+    args.push('--print-timeout', String(printTimeout).trim());
+  }
+
+  if (Array.isArray(addDirs)) {
+    for (const d of addDirs) {
+      if (d && String(d).trim()) {
+        args.push('--add-dir', String(d).trim());
+      }
+    }
+  }
+
+  return args;
+}
+
+export function buildAgyEnv(baseEnv = process.env) {
+  const env = { ...(baseEnv || process.env) };
+  env.CI = '1';
+  env.NO_COLOR = '1';
+  env.TERM = 'dumb';
+
+  const resolved = resolveAgyBinary();
+  if (!env.AGY_PATH && resolved) {
+    env.AGY_PATH = resolved;
+  }
+
+  // Ensure PATH contains all standard binary directories (homebrew, local/bin, node, agy)
+  const home = homedir();
+  const agyHome = getAgyHome();
+  const extraPaths = [
+    join(home, '.local', 'bin'),
+    join(agyHome, 'bin'),
+    join(agyHome, 'bin', 'sys'),
+    join(home, 'bin'),
+    '/usr/local/bin',
+    '/opt/homebrew/bin',
+  ];
+  if (resolved) {
+    extraPaths.push(dirname(resolved));
+  }
+  if (process.execPath) {
+    extraPaths.push(dirname(process.execPath));
+  }
+
+  const currentPath = env.PATH || '';
+  const currentDirs = new Set(currentPath.split(delimiter).filter(Boolean));
+  for (const p of extraPaths) {
+    if (p && !currentDirs.has(p) && existsSync(p)) {
+      currentDirs.add(p);
+    }
+  }
+  env.PATH = Array.from(currentDirs).join(delimiter);
+
+  return env;
+}
+
+/** Effort suffixes baked into agy model slugs (longest first). */
+export const AGY_EFFORT_SUFFIXES = ['thinking', 'max', 'xhigh', 'medium', 'high', 'low'];
+
+/**
+ * Parse one `agy models` line: "id   Human Label (Effort)".
+ * @returns {{ id: string, label: string } | null}
+ */
+export function parseAgyModelLine(line) {
+  const raw = String(line || '').trim();
+  if (!raw || raw.startsWith('Usage') || raw.startsWith('CLI') || raw.startsWith('Flags')) {
+    return null;
+  }
+  const m = raw.match(/^(\S+)\s+(.*)$/);
+  if (m) {
+    const id = m[1].trim();
+    const label = m[2].trim() || id;
+    if (!id) return null;
+    return { id, label };
+  }
+  // id-only line
+  if (/^\S+$/.test(raw)) {
+    return { id: raw, label: raw };
+  }
+  return null;
+}
+
+/**
+ * Parse full `agy models` stdout into [{ id, label }, ...].
+ */
+export function parseAgyModelsOutput(text) {
+  const out = String(text || '');
+  const entries = [];
+  const seen = new Set();
+  for (const line of out.split(/\r?\n/)) {
+    const parsed = parseAgyModelLine(line);
+    if (!parsed || seen.has(parsed.id)) continue;
+    seen.add(parsed.id);
+    entries.push(parsed);
+  }
+  return entries;
+}
+
+/**
+ * Split an agy model slug into base family + effort suffix.
+ * e.g. gemini-3.6-flash-high → { baseId, effort: 'high' }
+ *      claude-opus-4-6-thinking → { baseId: 'claude-opus-4-6', effort: 'thinking' }
+ *      claude-sonnet-4-6 → { baseId: 'claude-sonnet-4-6', effort: '' }
+ */
+export function splitAgyModelId(modelId) {
+  const id = String(modelId || '').trim();
+  if (!id) return { baseId: '', effort: '' };
+  for (const effort of AGY_EFFORT_SUFFIXES) {
+    const suffix = `-${effort}`;
+    if (id.endsWith(suffix) && id.length > suffix.length) {
+      return { baseId: id.slice(0, -suffix.length), effort };
+    }
+  }
+
+  // Handle custom model variants like -latest, -preview, -exp, -20240229 for ANY model
+  const match = id.match(/-(latest|preview|exp|\d{8})$/i);
+  if (match && id.length > match[0].length) {
+    return { baseId: id.slice(0, -match[0].length), effort: match[1] };
+  }
+
+  return { baseId: id, effort: '' };
+}
+
+/**
+ * Compose full agy model slug from family base + effort.
+ * If effort is empty, returns baseId. If baseId already ends with an effort, replaces it.
+ */
+export function composeAgyModelId(baseId, effort) {
+  const base = String(baseId || '').trim();
+  if (!base) return '';
+  const { baseId: stripped } = splitAgyModelId(base);
+  const family = stripped || base;
+  const e = String(effort || '').trim().toLowerCase();
+  if (!e) return family;
+  return `${family}-${e}`;
+}
+
+/**
+ * Resolve what to pass to agy spawn: full catalog slug preferred.
+ *
+ * agy rejects bare family ids that require effort:
+ *   --model gemini-3.6-flash  → needs --effort or full slug …-medium
+ * and rejects --effort on bare single-slug models:
+ *   --model claude-sonnet-4-6 --effort medium  → invalid
+ *
+ * Strategy: always prefer a full model id with effort in the slug. Never rely
+ * on a separate --effort flag for spawn (caller should pass effort: '').
+ * Fast path — no `agy models` spawn (optional catalog can refine if provided).
+ *
+ * @param {string} model family id or full slug
+ * @param {string} [effort] preferred effort when model is a family base
+ * @param {Array<{id:string,label?:string,defaultModelId?:string,defaultEffort?:string,efforts?:Array}>} [catalogOrFamilies]
+ * @returns {{ model: string, effort: string }}
+ */
+export function resolveAgySpawnModel(model, effort = '', catalogOrFamilies = null) {
+  const raw = String(model || '').trim();
+  if (!raw) {
+    return { model: '', effort: '' };
+  }
+
+  const { baseId, effort: embedded } = splitAgyModelId(raw);
+  // Already a full effort slug (gemini-3.6-flash-medium, claude-opus-4-6-thinking)
+  if (embedded) {
+    return { model: raw, effort: '' };
+  }
+
+  const wantEffort = String(effort || '').trim().toLowerCase();
+
+  // Optional catalog/families for precise defaultModelId
+  if (Array.isArray(catalogOrFamilies) && catalogOrFamilies.length > 0) {
+    const looksLikeFamilies = catalogOrFamilies.some(
+      (e) => e && (Array.isArray(e.efforts) || e.defaultModelId),
+    );
+    const families = looksLikeFamilies
+      ? catalogOrFamilies
+      : groupAgyModelFamilies(catalogOrFamilies);
+    const fam = families.find((f) => f && (f.id === raw || f.id === baseId));
+    if (fam) {
+      const match =
+        (wantEffort && fam.efforts?.find((e) => e.id === wantEffort))
+        || fam.efforts?.find((e) => e.id === fam.defaultEffort)
+        || fam.efforts?.find((e) => e.id === 'medium')
+        || fam.efforts?.find((e) => e.id === 'high')
+        || fam.efforts?.[0];
+      if (match?.modelId) {
+        return { model: match.modelId, effort: '' };
+      }
+      if (fam.defaultModelId) {
+        return { model: fam.defaultModelId, effort: '' };
+      }
+    }
+    // Exact flat catalog id (e.g. claude-sonnet-4-6)
+    const exact = catalogOrFamilies.find((e) => e && e.id === raw);
+    if (exact?.id) {
+      return { model: exact.id, effort: '' };
+    }
+  }
+
+  const isGeminiOrGpt = /^gemini-/i.test(raw) || /^gpt-oss-/i.test(raw);
+  const isClaude = /opus-|sonnet-|haiku-|^claude-/i.test(raw);
+  const isCustomSuffix = wantEffort === 'thinking' || /^(latest|preview|exp|\d{8})$/i.test(wantEffort);
+
+  if (wantEffort && (isGeminiOrGpt || (isClaude && isCustomSuffix))) {
+    return { model: composeAgyModelId(raw, wantEffort), effort: '' };
+  }
+
+  // Gemini flash/pro bare family always needs a default effort tier
+  if (/^gemini-/i.test(raw)) {
+    return { model: `${raw}-medium`, effort: '' };
+  }
+
+  // gpt-oss bare family → medium slug
+  if (/^gpt-oss-/i.test(raw)) {
+    return { model: `${raw}-medium`, effort: '' };
+  }
+
+  // Bare single-slug models (claude-sonnet-4-6): pass as-is — never attach --effort
+  // or invent -medium (agy rejects both for these ids).
+  return { model: raw, effort: '' };
+}
+
+/**
+ * Strip trailing " (High|Medium|Low|Thinking)" style effort from display labels.
+ */
+export function stripEffortFromLabel(label) {
+  const s = String(label || '').trim();
+  if (!s) return s;
+  return s
+    .replace(/\s*\((?:Very\s+)?(?:High|Medium|Low|XHigh|Max|Thinking)\)\s*$/i, '')
+    .trim() || s;
+}
+
+/**
+ * Group flat agy catalog into UI families with subordinate effort options.
+ * @param {Array<{id:string,label:string}>} entries
+ * @returns {Array<{id:string,label:string,description:string,efforts:Array<{id:string,label:string,modelId:string}>,defaultEffort:string,defaultModelId:string}>}
+ */
+export function groupAgyModelFamilies(entries) {
+  const list = Array.isArray(entries) ? entries : [];
+  /** @type {Map<string, { id: string, label: string, efforts: Array<{id:string,label:string,modelId:string}>, order: number }>} */
+  const families = new Map();
+  let order = 0;
+
+  for (const entry of list) {
+    if (!entry || !entry.id) continue;
+    const { baseId, effort } = splitAgyModelId(entry.id);
+    const familyId = baseId || entry.id;
+    let fam = families.get(familyId);
+    if (!fam) {
+      fam = {
+        id: familyId,
+        label: stripEffortFromLabel(entry.label) || familyId,
+        efforts: [],
+        order: order++,
+      };
+      families.set(familyId, fam);
+    } else if (effort) {
+      // Prefer non-effort label when we already have a bare entry, else strip
+      const stripped = stripEffortFromLabel(entry.label);
+      if (stripped && stripped.length < fam.label.length) {
+        fam.label = stripped;
+      }
+    } else if (entry.label) {
+      fam.label = stripEffortFromLabel(entry.label) || fam.label;
+    }
+
+    if (effort) {
+      if (!fam.efforts.some((e) => e.id === effort)) {
+        fam.efforts.push({
+          id: effort,
+          label: effortLabel(effort),
+          modelId: entry.id,
+        });
+      }
+    } else {
+      // Bare slug (no effort suffix) — treat as sole "default" option
+      if (!fam.efforts.some((e) => e.modelId === entry.id)) {
+        fam.efforts.push({
+          id: '',
+          label: 'Default',
+          modelId: entry.id,
+        });
+      }
+    }
+  }
+
+  const EFFORT_RANK = { low: 1, medium: 2, high: 3, xhigh: 4, max: 5, thinking: 6, '': 0 };
+  const result = [];
+  for (const fam of [...families.values()].sort((a, b) => a.order - b.order)) {
+    fam.efforts.sort((a, b) => (EFFORT_RANK[a.id] ?? 50) - (EFFORT_RANK[b.id] ?? 50));
+    const defaultEffort =
+      fam.efforts.find((e) => e.id === 'medium')?.id
+      ?? fam.efforts.find((e) => e.id === 'high')?.id
+      ?? fam.efforts.find((e) => e.id === 'thinking')?.id
+      ?? fam.efforts[0]?.id
+      ?? '';
+    const defaultModelId =
+      fam.efforts.find((e) => e.id === defaultEffort)?.modelId
+      ?? fam.efforts[0]?.modelId
+      ?? fam.id;
+    result.push({
+      id: fam.id,
+      label: fam.label,
+      description: fam.efforts.length > 1
+        ? `${fam.efforts.length} effort levels`
+        : (fam.efforts[0]?.label || ''),
+      efforts: fam.efforts,
+      defaultEffort,
+      defaultModelId,
+    });
+  }
+  return result;
+}
+
+function effortLabel(effort) {
+  const e = String(effort || '').toLowerCase();
+  if (e === 'low') return 'Low';
+  if (e === 'medium') return 'Medium';
+  if (e === 'high') return 'High';
+  if (e === 'xhigh') return 'XHigh';
+  if (e === 'max') return 'Max';
+  if (e === 'thinking') return 'Thinking';
+  if (!e) return 'Default';
+  return e.charAt(0).toUpperCase() + e.slice(1);
+}
+
+/**
+ * List models via `agy models` (id + human label per line).
+ * @returns {Array<{id:string,label:string}>}
+ */
+export function listAgyModels() {
+  const bin = resolveAgyBinary();
+  if (!bin) return [];
+  try {
+    const r = spawnSync(bin, ['models'], {
+      encoding: 'utf8',
+      timeout: 15_000,
+      env: buildAgyEnv(),
+    });
+    return parseAgyModelsOutput(String(r.stdout || ''));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Full catalog for the plugin UI: flat models + grouped families.
+ */
+export function buildAgyModelsCatalog() {
+  const models = listAgyModels();
+  const families = groupAgyModelFamilies(models);
+  return {
+    models,
+    families,
+    binary: resolveAgyBinary() || '',
+  };
+}
+
+export function normalizeUsageToSnakeCase(usage) {
+  if (!usage || typeof usage !== 'object') return null;
+  const input = num(usage.input_tokens ?? usage.inputTokens);
+  const output = num(usage.output_tokens ?? usage.outputTokens);
+  const thinking = num(usage.thinking_tokens ?? usage.thinkingTokens);
+  // agy uses cache_read_tokens; Claude/webview status bar expects cache_read_input_tokens
+  const cacheRead = num(
+    usage.cache_read_input_tokens
+    ?? usage.cacheReadInputTokens
+    ?? usage.cache_read_tokens
+    ?? usage.cacheReadTokens
+    ?? usage.cached_input_tokens
+    ?? usage.cachedInputTokens,
+  );
+  const cacheCreation = num(
+    usage.cache_creation_input_tokens
+    ?? usage.cacheCreationInputTokens
+    ?? usage.cache_write_tokens
+    ?? usage.cacheWriteTokens,
+  );
+  const total = num(usage.total_tokens ?? usage.totalTokens)
+    || (input + output + thinking);
+  if (input === 0 && output === 0 && thinking === 0 && total === 0 && cacheRead === 0 && cacheCreation === 0) {
+    return null;
+  }
+  // Context occupancy for the status ring is input + cache (not total/output).
+  // Emit both agy and Claude field names so Java TokenUsageUtils can read either.
+  return {
+    input_tokens: input,
+    output_tokens: output,
+    thinking_tokens: thinking,
+    cache_read_tokens: cacheRead,
+    cache_read_input_tokens: cacheRead,
+    cache_creation_input_tokens: cacheCreation,
+    total_tokens: total,
+  };
+}
+
+/**
+ * Context-window occupancy (status bar / context %).
+ * Prefer input (+ cache); never use total_tokens (includes output) as context fill.
+ */
+export function extractAgyContextTokens(usage) {
+  const u = usage && typeof usage === 'object' && !Array.isArray(usage)
+    ? usage
+    : null;
+  if (!u) return 0;
+  const normalized = normalizeUsageToSnakeCase(u) || u;
+  const input = num(normalized.input_tokens ?? normalized.inputTokens);
+  const cacheRead = num(
+    normalized.cache_read_input_tokens
+    ?? normalized.cache_read_tokens
+    ?? normalized.cacheReadTokens,
+  );
+  const cacheCreation = num(
+    normalized.cache_creation_input_tokens
+    ?? normalized.cacheCreationInputTokens,
+  );
+  const total = num(normalized.total_tokens ?? normalized.totalTokens);
+  const sum = input + cacheRead + cacheCreation;
+  if (total > 0 && sum > total) {
+    return Math.max(input, cacheRead + cacheCreation);
+  }
+  return sum;
+}
+
+function num(v) {
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+export function buildGeminiContextUsagePayload({ usedTokens = 0, maxTokens = DEFAULT_MAX_TOKENS, model = '' } = {}) {
+  const used = Math.max(0, Number(usedTokens) || 0);
+  const max = Math.max(1, Number(maxTokens) || DEFAULT_MAX_TOKENS);
+  const percentage = Math.min(100, Math.round((used / max) * 1000) / 10);
+  return {
+    success: true,
+    data: {
+      usedTokens: used,
+      maxTokens: max,
+      percentage,
+      model: model || '',
+      source: 'gemini-bridge',
+    },
+  };
+}
+
+export function buildErrorPayload(error, extras = {}) {
+  const message = error?.message || String(error || 'Unknown error');
+  return {
+    success: false,
+    error: message,
+    ...extras,
+  };
+}
+
+export { DEFAULT_MAX_TOKENS };

--- a/ai-bridge/services/gemini/agy-utils.test.js
+++ b/ai-bridge/services/gemini/agy-utils.test.js
@@ -1,0 +1,333 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildAgyArgs,
+  mapPermissionMode,
+  normalizeUsageToSnakeCase,
+  extractAgyContextTokens,
+  buildGeminiContextUsagePayload,
+  buildErrorPayload,
+  buildAgyEnv,
+  resolveAgyBinary,
+  parseAgyModelLine,
+  parseAgyModelsOutput,
+  splitAgyModelId,
+  composeAgyModelId,
+  resolveAgySpawnModel,
+  groupAgyModelFamilies,
+  stripEffortFromLabel,
+} from './agy-utils.js';
+
+test('resolveAgyBinary honors explicit AGY_PATH without fallback', () => {
+  const prev = process.env.AGY_PATH;
+  const prevG = process.env.GEMINI_CLI_PATH;
+  const prevA = process.env.AGY_CLI_PATH;
+  process.env.AGY_PATH = '/nonexistent/agy-binary-xyz';
+  process.env.GEMINI_CLI_PATH = '';
+  process.env.AGY_CLI_PATH = '';
+  try {
+    assert.equal(resolveAgyBinary(), null);
+  } finally {
+    if (prev === undefined) delete process.env.AGY_PATH;
+    else process.env.AGY_PATH = prev;
+    if (prevG === undefined) delete process.env.GEMINI_CLI_PATH;
+    else process.env.GEMINI_CLI_PATH = prevG;
+    if (prevA === undefined) delete process.env.AGY_CLI_PATH;
+    else process.env.AGY_CLI_PATH = prevA;
+  }
+});
+
+test('resolveAgyBinary never returns agy.real even if AGY_PATH points at it', () => {
+  const prev = process.env.AGY_PATH;
+  const prevG = process.env.GEMINI_CLI_PATH;
+  const prevA = process.env.AGY_CLI_PATH;
+  process.env.AGY_PATH = '/Users/nobody/.local/bin/agy.real';
+  process.env.GEMINI_CLI_PATH = '';
+  process.env.AGY_CLI_PATH = '';
+  try {
+    const resolved = resolveAgyBinary();
+    if (resolved) {
+      assert.ok(!/agy\.real$/i.test(resolved), `must not resolve agy.real, got ${resolved}`);
+    }
+  } finally {
+    if (prev === undefined) delete process.env.AGY_PATH;
+    else process.env.AGY_PATH = prev;
+    if (prevG === undefined) delete process.env.GEMINI_CLI_PATH;
+    else process.env.GEMINI_CLI_PATH = prevG;
+    if (prevA === undefined) delete process.env.AGY_CLI_PATH;
+    else process.env.AGY_CLI_PATH = prevA;
+  }
+});
+
+test('mapPermissionMode default does not skip permissions', () => {
+  const m = mapPermissionMode('default');
+  assert.equal(m.skipPermissions, false);
+  assert.equal(m.modeFlag, '');
+  assert.equal(m.sandbox, false);
+});
+
+test('mapPermissionMode bypass/yolo/dontAsk/auto skips permissions', () => {
+  assert.equal(mapPermissionMode('bypassPermissions').skipPermissions, true);
+  assert.equal(mapPermissionMode('bypass').skipPermissions, true);
+  assert.equal(mapPermissionMode('yolo').skipPermissions, true);
+  assert.equal(mapPermissionMode('dontAsk').skipPermissions, true);
+  assert.equal(mapPermissionMode('dont_ask').skipPermissions, true);
+  assert.equal(mapPermissionMode('auto').skipPermissions, true);
+  assert.equal(mapPermissionMode('always-proceed').skipPermissions, true);
+});
+
+test('mapPermissionMode plan and accept-edits set mode flags', () => {
+  assert.equal(mapPermissionMode('plan').modeFlag, 'plan');
+  assert.equal(mapPermissionMode('acceptEdits').modeFlag, 'accept-edits');
+  assert.equal(mapPermissionMode('accept-edits').modeFlag, 'accept-edits');
+  assert.equal(mapPermissionMode('accept_edits').modeFlag, 'accept-edits');
+});
+
+test('mapPermissionMode sandbox sets sandbox flag', () => {
+  assert.equal(mapPermissionMode('sandbox').sandbox, true);
+  assert.equal(mapPermissionMode('sandbox').skipPermissions, false);
+});
+
+test('buildAgyArgs includes stream-json and conversation resume', () => {
+  const args = buildAgyArgs({
+    message: 'hello',
+    conversationId: 'cid-1',
+    model: 'gemini-3.5-flash-medium',
+    effort: 'high',
+    permissionMode: 'bypassPermissions',
+  });
+  assert.ok(args.includes('-p'));
+  assert.ok(args.includes('hello'));
+  assert.ok(args.includes('--output-format'));
+  assert.ok(args.includes('stream-json'));
+  assert.ok(args.includes('--conversation'));
+  assert.ok(args.includes('cid-1'));
+  assert.ok(args.includes('--model'));
+  assert.ok(args.includes('gemini-3.5-flash-medium'));
+  assert.ok(args.includes('--effort'));
+  assert.ok(args.includes('high'));
+  assert.ok(args.includes('--dangerously-skip-permissions'));
+  assert.ok(!args.includes('--continue'));
+});
+
+test('buildAgyArgs uses --continue when no conversation id', () => {
+  const args = buildAgyArgs({
+    message: 'hi',
+    continueRecent: true,
+  });
+  assert.ok(args.includes('--continue'));
+  assert.ok(!args.includes('--conversation'));
+});
+
+test('buildAgyArgs plan mode and add-dir and agent and print-timeout', () => {
+  const args = buildAgyArgs({
+    message: 'x',
+    permissionMode: 'plan',
+    agent: 'explorer',
+    printTimeout: '30s',
+    addDirs: ['/tmp/a', '', '/tmp/b'],
+  });
+  assert.ok(args.includes('--mode'));
+  assert.ok(args.includes('plan'));
+  assert.ok(args.includes('--agent'));
+  assert.ok(args.includes('explorer'));
+  assert.ok(args.includes('--print-timeout'));
+  assert.ok(args.includes('30s'));
+  assert.ok(args.includes('--add-dir'));
+  assert.ok(args.includes('/tmp/a'));
+  assert.ok(args.includes('/tmp/b'));
+});
+
+test('buildAgyArgs effort is lowercased', () => {
+  const args = buildAgyArgs({ message: 'm', effort: 'HIGH' });
+  const i = args.indexOf('--effort');
+  assert.ok(i >= 0);
+  assert.equal(args[i + 1], 'high');
+});
+
+test('normalizeUsageToSnakeCase maps fields and camelCase', () => {
+  const u = normalizeUsageToSnakeCase({
+    input_tokens: 10,
+    output_tokens: 5,
+    thinking_tokens: 2,
+    cache_read_tokens: 3,
+    total_tokens: 17,
+  });
+  assert.deepEqual(u, {
+    input_tokens: 10,
+    output_tokens: 5,
+    thinking_tokens: 2,
+    cache_read_tokens: 3,
+    cache_read_input_tokens: 3,
+    cache_creation_input_tokens: 0,
+    total_tokens: 17,
+  });
+
+  const camel = normalizeUsageToSnakeCase({
+    inputTokens: 1,
+    outputTokens: 2,
+    thinkingTokens: 3,
+  });
+  assert.equal(camel.input_tokens, 1);
+  assert.equal(camel.output_tokens, 2);
+  assert.equal(camel.thinking_tokens, 3);
+  assert.equal(camel.total_tokens, 6);
+});
+
+test('normalizeUsageToSnakeCase returns null for empty usage', () => {
+  assert.equal(normalizeUsageToSnakeCase(null), null);
+  assert.equal(normalizeUsageToSnakeCase({}), null);
+  assert.equal(normalizeUsageToSnakeCase({ input_tokens: 0, output_tokens: 0 }), null);
+});
+
+test('extractAgyContextTokens uses input+cache not total/output', () => {
+  assert.equal(extractAgyContextTokens({
+    input_tokens: 27793,
+    output_tokens: 18,
+    total_tokens: 27811,
+  }), 27793);
+  assert.equal(extractAgyContextTokens({
+    input_tokens: 100,
+    cache_read_tokens: 50,
+    cache_creation_input_tokens: 25,
+    output_tokens: 999,
+    total_tokens: 1174,
+  }), 175);
+  assert.equal(extractAgyContextTokens(null), 0);
+});
+
+test('resolveAgySpawnModel upgrades bare gemini family to effort slug', () => {
+  assert.deepEqual(resolveAgySpawnModel('gemini-3.6-flash', ''), {
+    model: 'gemini-3.6-flash-medium',
+    effort: '',
+  });
+  assert.deepEqual(resolveAgySpawnModel('gemini-3.6-flash', 'high'), {
+    model: 'gemini-3.6-flash-high',
+    effort: '',
+  });
+  assert.deepEqual(resolveAgySpawnModel('gemini-3.6-flash-low', 'high'), {
+    model: 'gemini-3.6-flash-low',
+    effort: '',
+  });
+  // Bare Claude models must never get a fake -medium suffix or --effort
+  assert.deepEqual(resolveAgySpawnModel('claude-sonnet-4-6', 'medium'), {
+    model: 'claude-sonnet-4-6',
+    effort: '',
+  });
+  assert.deepEqual(resolveAgySpawnModel('claude-sonnet-4-6', ''), {
+    model: 'claude-sonnet-4-6',
+    effort: '',
+  });
+  assert.deepEqual(resolveAgySpawnModel('claude-opus-4-6', 'thinking'), {
+    model: 'claude-opus-4-6-thinking',
+    effort: '',
+  });
+});
+
+test('buildGeminiContextUsagePayload percentage', () => {
+  const p = buildGeminiContextUsagePayload({ usedTokens: 50, maxTokens: 200, model: 'm' });
+  assert.equal(p.success, true);
+  assert.equal(p.data.percentage, 25);
+  assert.equal(p.data.model, 'm');
+  assert.equal(p.data.source, 'gemini-bridge');
+});
+
+test('buildGeminiContextUsagePayload clamps percentage at 100', () => {
+  const p = buildGeminiContextUsagePayload({ usedTokens: 9999, maxTokens: 100 });
+  assert.equal(p.data.percentage, 100);
+});
+
+test('buildErrorPayload extracts message', () => {
+  const p = buildErrorPayload(new Error('boom'), { code: 1 });
+  assert.equal(p.success, false);
+  assert.equal(p.error, 'boom');
+  assert.equal(p.code, 1);
+});
+
+test('buildAgyEnv sets non-interactive defaults', () => {
+  const env = buildAgyEnv({ PATH: '/bin', HOME: '/tmp' });
+  assert.equal(env.CI, '1');
+  assert.equal(env.NO_COLOR, '1');
+  assert.equal(env.TERM, 'dumb');
+});
+
+test('parseAgyModelLine reads id and label', () => {
+  const p = parseAgyModelLine('gemini-3.6-flash-high     Gemini 3.6 Flash (High)');
+  assert.deepEqual(p, { id: 'gemini-3.6-flash-high', label: 'Gemini 3.6 Flash (High)' });
+  assert.equal(parseAgyModelLine('Usage of agy'), null);
+  assert.deepEqual(parseAgyModelLine('claude-sonnet-4-6'), {
+    id: 'claude-sonnet-4-6',
+    label: 'claude-sonnet-4-6',
+  });
+});
+
+test('groupAgyModelFamilies nests effort under family base', () => {
+  const sample = `
+gemini-3.6-flash-high     Gemini 3.6 Flash (High)
+gemini-3.6-flash-medium   Gemini 3.6 Flash (Medium)
+gemini-3.6-flash-low      Gemini 3.6 Flash (Low)
+gemini-3.5-flash-high     Gemini 3.5 Flash (High)
+gemini-3.5-flash-medium   Gemini 3.5 Flash (Medium)
+gemini-3.5-flash-low      Gemini 3.5 Flash (Low)
+gemini-3.1-pro-high       Gemini 3.1 Pro (High)
+gemini-3.1-pro-low        Gemini 3.1 Pro (Low)
+claude-sonnet-4-6         Claude Sonnet 4.6 (Thinking)
+claude-opus-4-6-thinking  Claude Opus 4.6 (Thinking)
+gpt-oss-120b-medium       GPT-OSS 120B (Medium)
+`.trim();
+  const entries = parseAgyModelsOutput(sample);
+  const families = groupAgyModelFamilies(entries);
+
+  // Gemini 3.6 Flash
+  const flash36 = families.find((f) => f.id === 'gemini-3.6-flash');
+  assert.ok(flash36);
+  assert.equal(flash36.label, 'Gemini 3.6 Flash');
+  assert.deepEqual(flash36.efforts.map((e) => e.id), ['low', 'medium', 'high']);
+  assert.equal(flash36.defaultEffort, 'medium');
+
+  // Gemini 3.5 Flash
+  const flash35 = families.find((f) => f.id === 'gemini-3.5-flash');
+  assert.ok(flash35);
+  assert.equal(flash35.label, 'Gemini 3.5 Flash');
+  assert.deepEqual(flash35.efforts.map((e) => e.id), ['low', 'medium', 'high']);
+  assert.equal(flash35.defaultEffort, 'medium');
+
+  // Gemini 3.1 Pro
+  const pro31 = families.find((f) => f.id === 'gemini-3.1-pro');
+  assert.ok(pro31);
+  assert.equal(pro31.label, 'Gemini 3.1 Pro');
+  assert.deepEqual(pro31.efforts.map((e) => e.id), ['low', 'high']);
+  assert.equal(pro31.defaultEffort, 'high'); // high since no medium
+
+  // Claude Sonnet 4.6
+  const sonnet = families.find((f) => f.id === 'claude-sonnet-4-6');
+  assert.ok(sonnet);
+  assert.equal(sonnet.label, 'Claude Sonnet 4.6');
+  assert.equal(sonnet.efforts.length, 1);
+  assert.equal(sonnet.efforts[0].id, '');
+  assert.equal(sonnet.efforts[0].modelId, 'claude-sonnet-4-6');
+  assert.equal(sonnet.defaultEffort, '');
+
+  // Claude Opus 4.6
+  const opus = families.find((f) => f.id === 'claude-opus-4-6');
+  assert.ok(opus);
+  assert.equal(opus.label, 'Claude Opus 4.6');
+  assert.deepEqual(opus.efforts.map((e) => e.id), ['thinking']);
+  assert.equal(opus.defaultEffort, 'thinking');
+
+  // GPT-OSS 120B
+  const gpt = families.find((f) => f.id === 'gpt-oss-120b');
+  assert.ok(gpt);
+  assert.equal(gpt.label, 'GPT-OSS 120B');
+  assert.deepEqual(gpt.efforts.map((e) => e.id), ['medium']);
+  assert.equal(gpt.defaultEffort, 'medium');
+});
+
+test('split/compose agy model ids', () => {
+  assert.deepEqual(splitAgyModelId('gemini-3.5-flash-high'), {
+    baseId: 'gemini-3.5-flash',
+    effort: 'high',
+  });
+  assert.equal(composeAgyModelId('gemini-3.5-flash', 'low'), 'gemini-3.5-flash-low');
+  assert.equal(stripEffortFromLabel('Gemini 3.6 Flash (High)'), 'Gemini 3.6 Flash');
+});

--- a/ai-bridge/services/gemini/message-service.js
+++ b/ai-bridge/services/gemini/message-service.js
@@ -1,0 +1,115 @@
+/**
+ * Gemini / Antigravity CLI message service.
+ * Claude-shaped stdin contract; headless agy stream-json transport.
+ */
+
+import { runAgyTurn } from './agy-runner.js';
+import { AgyEventNormalizer } from './agy-event-normalizer.js';
+import { buildErrorPayload, isAgyAvailable, resolveAgyBinary } from './agy-utils.js';
+import { selectWorkingDirectory } from '../../utils/path-utils.js';
+
+/**
+ * @param {object|string} messageOrOptions Claude-shaped options bag or plain message
+ */
+export async function sendMessage(messageOrOptions, sessionId = '', cwd = '', permissionMode = '', model = '') {
+  const opts =
+    messageOrOptions && typeof messageOrOptions === 'object' && !Array.isArray(messageOrOptions)
+      ? messageOrOptions
+      : {
+          message: messageOrOptions,
+          sessionId,
+          cwd,
+          permissionMode,
+          model,
+        };
+
+  const {
+    message = '',
+    sessionId: sid = '',
+    cwd: workCwd = '',
+    permissionMode: perm = '',
+    model: modelId = '',
+    agentPrompt = '',
+    reasoningEffort = '',
+    agent = '',
+    printTimeout = '',
+  } = opts;
+
+  const normalizer = new AgyEventNormalizer({
+    log: (...args) => console.log(...args),
+    error: (...args) => console.error(...args),
+  });
+
+  try {
+    if (!isAgyAvailable()) {
+      throw new Error(
+        'Antigravity CLI (agy) not found. Install: https://antigravity.google/docs/cli/install '
+        + 'or set AGY_PATH to the binary.'
+      );
+    }
+
+    const guardedCwd = selectWorkingDirectory(workCwd);
+
+    console.error('[DEBUG] Gemini/agy sendMessage:', {
+      bin: resolveAgyBinary(),
+      hasSessionId: !!sid,
+      cwd: guardedCwd || '(current)',
+      model: modelId || '(default)',
+      permissionMode: perm || '(default)',
+      reasoningEffort: reasoningEffort || '(none)',
+      hasAgentPrompt: !!agentPrompt,
+    });
+
+    normalizer.begin();
+
+    // Optional agent role preamble (agy has no separate system prompt flag in headless)
+    let finalMessage = String(message ?? '').trim();
+    if (agentPrompt && String(agentPrompt).trim()) {
+      finalMessage = finalMessage
+        ? `${finalMessage}\n\n## Agent Role and Instructions\n\n${agentPrompt}`
+        : `## Agent Role and Instructions\n\n${agentPrompt}`;
+    }
+
+    if (!finalMessage.trim()) {
+      if (Array.isArray(opts.attachments) && opts.attachments.length > 0) {
+        finalMessage = 'Please analyze the attached content.';
+      } else {
+        finalMessage = 'Continue';
+      }
+    }
+
+    const turn = await runAgyTurn({
+      message: finalMessage,
+      sessionId: sid,
+      cwd: guardedCwd,
+      model: modelId,
+      reasoningEffort,
+      agent,
+      permissionMode: perm,
+      printTimeout,
+      onEvent: (obj) => normalizer.handleStreamEvent(obj),
+      onStderr: (chunk) => {
+        const s = String(chunk || '').trim();
+        if (s) console.error('[AGY]', s.slice(0, 500));
+      },
+    });
+
+    const st = String(turn.status || '').toUpperCase();
+    const text = turn.response || normalizer.assistantText || '';
+
+    if (st && st !== 'SUCCESS' && !text) {
+      throw new Error(turn.error || `agy status=${st}`);
+    }
+
+    if (st && st !== 'SUCCESS' && text) {
+      console.error('[AGY] terminal status', st, turn.error || '');
+    }
+
+    normalizer.finishSuccess(turn.conversationId || sid, text);
+  } catch (error) {
+    console.error('[DEBUG] Gemini/agy error:', error?.message || error);
+    normalizer.finishError(error);
+  }
+}
+
+export { buildErrorPayload };

--- a/ai-bridge/utils/cli-path.js
+++ b/ai-bridge/utils/cli-path.js
@@ -6,12 +6,22 @@
  * 2. PATH lookup (`which` / `where`)
  * 3. Common home install candidates
  * 4. Bare binary name fallback
+ *
+ * Windows note: npm global installs create three shims (`pi`, `pi.cmd`, `pi.ps1`).
+ * `where pi` often lists the extensionless bash wrapper first. Node's
+ * `spawn()` cannot CreateProcess that file (ENOENT). Prefer `.cmd` / `.exe`
+ * and shell-spawn `.cmd`/`.bat` (see `isWindowsCmdShim`).
  */
 
 import { existsSync } from 'fs';
 import { homedir } from 'os';
-import { join } from 'path';
-import { execSync } from 'child_process';
+import { join, isAbsolute } from 'path';
+import { execFileSync, execSync } from 'child_process';
+
+/** Extensions Node can CreateProcess on Windows (with shell for .cmd/.bat). */
+const WINDOWS_SPAWNABLE_EXT = /\.(cmd|bat|exe)$/i;
+/** Prefer real PE binaries, then cmd shims, over extensionless npm wrappers. */
+const WINDOWS_SPAWNABLE_PRIORITY = ['.exe', '.cmd', '.bat'];
 
 /**
  * Windows npm global installs only ship a `.cmd` / `.bat` shim (no `.exe`),
@@ -21,6 +31,61 @@ import { execSync } from 'child_process';
  */
 export function isWindowsCmdShim(bin) {
   return process.platform === 'win32' && /\.(cmd|bat)$/i.test(String(bin || ''));
+}
+
+/**
+ * Pick the best match from `where` output lines on Windows.
+ * Prefer `.exe` / `.cmd` / `.bat` over extensionless npm bash shims.
+ *
+ * @param {string[]|null|undefined} matches
+ * @returns {string|null}
+ */
+export function selectWindowsWhereMatch(matches) {
+  const lines = (Array.isArray(matches) ? matches : [])
+    .map((line) => String(line || '').trim())
+    .filter(Boolean);
+  if (lines.length === 0) return null;
+
+  for (const ext of WINDOWS_SPAWNABLE_PRIORITY) {
+    const hit = lines.find((line) => line.toLowerCase().endsWith(ext));
+    if (hit) return hit;
+  }
+  return lines[0];
+}
+
+/**
+ * If `bin` is an absolute/relative path without a spawnable Windows extension
+ * and a sibling `.exe`/`.cmd`/`.bat` exists, return that sibling.
+ *
+ * Bare names (`pi`) are left unchanged so PATH+PATHEXT still apply at spawn.
+ *
+ * @param {string} bin
+ * @param {(path: string) => boolean} [existsFn]
+ * @param {boolean} [forceWindows] - test hook; defaults to process.platform === 'win32'
+ * @returns {string}
+ */
+export function resolveWindowsSpawnableBin(
+  bin,
+  existsFn = pathExists,
+  forceWindows = process.platform === 'win32',
+) {
+  if (!forceWindows || typeof bin !== 'string') return bin;
+  const trimmed = bin.trim();
+  if (!trimmed) return bin;
+  if (WINDOWS_SPAWNABLE_EXT.test(trimmed)) return trimmed;
+
+  // Bare command names: let PATHEXT / shell resolve; do not invent a path.
+  const looksLikePath = isAbsolute(trimmed)
+    || trimmed.includes('/')
+    || trimmed.includes('\\')
+    || /^[A-Za-z]:/.test(trimmed);
+  if (!looksLikePath) return trimmed;
+
+  for (const ext of WINDOWS_SPAWNABLE_PRIORITY) {
+    const candidate = `${trimmed}${ext}`;
+    if (existsFn(candidate)) return candidate;
+  }
+  return trimmed;
 }
 
 function firstNonEmpty(...values) {
@@ -43,8 +108,32 @@ function pathExists(candidate) {
 
 function whichOnPath(binaryName) {
   try {
-    const command = process.platform === 'win32' ? `where ${binaryName}` : `which ${binaryName}`;
-    const output = execSync(command, {
+    if (process.platform === 'win32') {
+      // Prefer execFile so the binary name is not re-parsed by a shell.
+      // `where` lists every PATHEXT match; the extensionless npm shim is often first
+      // and cannot be spawned — selectWindowsWhereMatch prefers .cmd/.exe.
+      let output;
+      try {
+        output = execFileSync('where.exe', [binaryName], {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+          env: process.env,
+          windowsHide: true,
+        });
+      } catch {
+        // Fallback for systems where where.exe is not on PATH of the IDE process.
+        output = execSync(`where ${binaryName}`, {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+          env: process.env,
+          windowsHide: true,
+        });
+      }
+      const lines = String(output || '').split(/\r?\n/);
+      return selectWindowsWhereMatch(lines);
+    }
+
+    const output = execFileSync('which', [binaryName], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
       env: process.env,
@@ -76,12 +165,12 @@ export function resolveCliPath({ binaryName, envKeys = [], homeCandidates = [] }
 
   const envOverride = firstNonEmpty(...envKeys.map((key) => process.env[key]));
   if (envOverride) {
-    return envOverride;
+    return resolveWindowsSpawnableBin(envOverride);
   }
 
-  // `where <name>` (no extension) honors PATHEXT, so it finds `.cmd` shims.
+  // `where <name>` (no extension) honors PATHEXT; we then prefer .cmd/.exe.
   const fromPath = whichOnPath(binaryName);
-  if (fromPath) return fromPath;
+  if (fromPath) return resolveWindowsSpawnableBin(fromPath);
 
   const home = homedir();
   for (const template of homeCandidates) {
@@ -90,7 +179,7 @@ export function resolveCliPath({ binaryName, envKeys = [], homeCandidates = [] }
         .replace('{home}', home)
         .replace('{bin}', exeName)
         .replace('{name}', binaryName);
-      if (pathExists(resolved)) return resolved;
+      if (pathExists(resolved)) return resolveWindowsSpawnableBin(resolved);
     }
   }
 

--- a/ai-bridge/utils/cli-path.test.js
+++ b/ai-bridge/utils/cli-path.test.js
@@ -1,0 +1,107 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isWindowsCmdShim,
+  selectWindowsWhereMatch,
+  resolveWindowsSpawnableBin,
+} from './cli-path.js';
+
+test('isWindowsCmdShim detects .cmd/.bat only on win32-style paths', () => {
+  // Function gates on process.platform; we only assert the regex half via
+  // known Windows-like paths when running on Windows, and always assert
+  // non-matching extensions return false on any platform.
+  assert.equal(isWindowsCmdShim('opencode.exe'), false);
+  assert.equal(isWindowsCmdShim('pi'), false);
+  assert.equal(isWindowsCmdShim('C:\\Users\\a\\AppData\\Roaming\\npm\\pi'), false);
+  if (process.platform === 'win32') {
+    assert.equal(isWindowsCmdShim('C:\\Users\\a\\AppData\\Roaming\\npm\\pi.cmd'), true);
+    assert.equal(isWindowsCmdShim('opencode.bat'), true);
+  } else {
+    // Non-Windows: always false even for .cmd paths
+    assert.equal(isWindowsCmdShim('C:\\Users\\a\\AppData\\Roaming\\npm\\pi.cmd'), false);
+  }
+});
+
+test('selectWindowsWhereMatch prefers .cmd over extensionless npm shim', () => {
+  const chosen = selectWindowsWhereMatch([
+    'C:\\Users\\83429\\AppData\\Roaming\\npm\\pi',
+    'C:\\Users\\83429\\AppData\\Roaming\\npm\\pi.cmd',
+  ]);
+  assert.equal(chosen, 'C:\\Users\\83429\\AppData\\Roaming\\npm\\pi.cmd');
+});
+
+test('selectWindowsWhereMatch prefers .exe when present', () => {
+  const chosen = selectWindowsWhereMatch([
+    'D:\\develop\\node-v24.13.1-win-x64\\opencode',
+    'D:\\develop\\node-v24.13.1-win-x64\\opencode.exe',
+  ]);
+  assert.equal(chosen, 'D:\\develop\\node-v24.13.1-win-x64\\opencode.exe');
+});
+
+test('selectWindowsWhereMatch prefers .cmd over .ps1-only noise and keeps first good match', () => {
+  const chosen = selectWindowsWhereMatch([
+    'D:\\software\\nvm4w\\nodejs\\opencode',
+    'D:\\software\\nvm4w\\nodejs\\opencode.ps1',
+    'D:\\software\\nvm4w\\nodejs\\opencode.cmd',
+  ]);
+  assert.equal(chosen, 'D:\\software\\nvm4w\\nodejs\\opencode.cmd');
+});
+
+test('selectWindowsWhereMatch falls back to first line when no spawnable extension', () => {
+  const chosen = selectWindowsWhereMatch([
+    'C:\\tools\\pi',
+    'C:\\other\\pi',
+  ]);
+  assert.equal(chosen, 'C:\\tools\\pi');
+});
+
+test('selectWindowsWhereMatch ignores blanks', () => {
+  assert.equal(selectWindowsWhereMatch(['', '  ', 'C:\\x\\pi.cmd']), 'C:\\x\\pi.cmd');
+  assert.equal(selectWindowsWhereMatch([]), null);
+  assert.equal(selectWindowsWhereMatch(null), null);
+});
+
+test('resolveWindowsSpawnableBin upgrades extensionless path when sibling .cmd exists', () => {
+  const exists = (p) => p === 'C:\\Users\\a\\AppData\\Roaming\\npm\\pi.cmd';
+  const resolved = resolveWindowsSpawnableBin(
+    'C:\\Users\\a\\AppData\\Roaming\\npm\\pi',
+    exists,
+    true, // force Windows behavior for cross-platform unit tests
+  );
+  assert.equal(resolved, 'C:\\Users\\a\\AppData\\Roaming\\npm\\pi.cmd');
+});
+
+test('resolveWindowsSpawnableBin prefers .exe over .cmd when both exist', () => {
+  const exists = (p) =>
+    p === 'D:\\node\\opencode.cmd' || p === 'D:\\node\\opencode.exe';
+  const resolved = resolveWindowsSpawnableBin('D:\\node\\opencode', exists, true);
+  assert.equal(resolved, 'D:\\node\\opencode.exe');
+});
+
+test('resolveWindowsSpawnableBin leaves .cmd paths unchanged', () => {
+  const resolved = resolveWindowsSpawnableBin(
+    'C:\\npm\\pi.cmd',
+    () => false,
+    true,
+  );
+  assert.equal(resolved, 'C:\\npm\\pi.cmd');
+});
+
+test('resolveWindowsSpawnableBin leaves bare names unchanged', () => {
+  // Bare names rely on PATHEXT at spawn time; do not invent a path.
+  const resolved = resolveWindowsSpawnableBin('pi', () => true, true);
+  assert.equal(resolved, 'pi');
+});
+
+test('resolveWindowsSpawnableBin no-ops when forceWindows is false', () => {
+  const exists = (p) => p === '/home/u/.local/bin/pi.cmd';
+  const resolved = resolveWindowsSpawnableBin('/home/u/.local/bin/pi', exists, false);
+  assert.equal(resolved, '/home/u/.local/bin/pi');
+});
+
+test('resolveWindowsSpawnableBin handles paths with spaces', () => {
+  const base = 'C:\\Program Files\\nodejs\\opencode';
+  const exists = (p) => p === `${base}.cmd`;
+  const resolved = resolveWindowsSpawnableBin(base, exists, true);
+  assert.equal(resolved, `${base}.cmd`);
+});

--- a/ai-bridge/utils/path-utils.js
+++ b/ai-bridge/utils/path-utils.js
@@ -240,6 +240,40 @@ export function isBridgeDirectory(pathValue) {
 }
 
 /**
+ * Paths that must never become agy workspaceDirs / process cwd.
+ * Plugin install trees, ai-bridge, and ~/.gemini were observed as wrong
+ * workspace roots and inflate tool context with unrelated trees.
+ * @param {string} pathValue
+ * @returns {boolean}
+ */
+export function isUnsafeWorkingDirectory(pathValue) {
+  if (!pathValue || typeof pathValue !== 'string') return true;
+  const trimmed = pathValue.trim();
+  if (!trimmed || trimmed === 'undefined' || trimmed === 'null') return true;
+
+  if (isBridgeDirectory(trimmed)) return true;
+
+  const n = normalizePathForComparison(trimmed);
+  if (!n) return true;
+
+  // JetBrains plugin / config trees (embedded ai-bridge).
+  if (n.includes('/application support/jetbrains/')) return true;
+  if (n.includes('/plugins/idea-claude-code-gui')) return true;
+  if (n.includes('/.local/share/jetbrains/')) return true;
+
+  // Standalone or nested ai-bridge directory.
+  if (n.endsWith('/ai-bridge') || n.includes('/ai-bridge/')) return true;
+
+  // Antigravity CLI home — wrong workspaceDirs=[~/.gemini] in production logs.
+  if (n.endsWith('/.gemini') || n.includes('/.gemini/')) return true;
+  if (n.endsWith('/.gemini/antigravity-cli') || n.includes('/.gemini/antigravity-cli/')) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
  * Intelligently select the working directory.
  * @param {string} requestedCwd - The requested working directory
  * @returns {string} The selected working directory
@@ -270,8 +304,9 @@ export function selectWorkingDirectory(requestedCwd) {
     // so an empty requestedCwd + missing IDEA_PROJECT_PATH would otherwise land
     // here and make the SDK persist sessions under
     // ~/.claude/projects/<sanitized-bridge-dir>/, hiding every project's history.
-    if (isBridgeDirectory(normalized)) {
-      console.log('[DEBUG] Skipping ai-bridge directory candidate:', normalized);
+    // Also reject JetBrains plugin trees and ~/.gemini (agy workspaceDirs bugs).
+    if (isUnsafeWorkingDirectory(normalized)) {
+      console.log('[DEBUG] Skipping unsafe working-directory candidate:', normalized);
       continue;
     }
 
@@ -293,11 +328,11 @@ export function selectWorkingDirectory(requestedCwd) {
   }
 
   console.log('[DEBUG] selectWorkingDirectory fallback triggered');
-  // Guard: reject the bridge dir even from IDEA_PROJECT_PATH (e.g. when the user
+  // Guard: reject unsafe dirs even from IDEA_PROJECT_PATH (e.g. when the user
   // is developing the bridge itself). The home dir is always a safe fallback.
   const fallback = envProjectPath || getRealHomeDir();
-  if (isBridgeDirectory(fallback)) {
-    console.log('[DEBUG] Fallback env path is bridge dir, using home dir instead');
+  if (isUnsafeWorkingDirectory(fallback)) {
+    console.log('[DEBUG] Fallback env path is unsafe, using home dir instead');
     return getRealHomeDir();
   }
   return fallback;

--- a/ai-bridge/utils/path-utils.test.js
+++ b/ai-bridge/utils/path-utils.test.js
@@ -1,12 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'fs';
-import { resolve, dirname } from 'path';
+import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { homedir } from 'os';
 import {
   selectWorkingDirectory,
   isBridgeDirectory,
+  isUnsafeWorkingDirectory,
   normalizePathForComparison,
   getClaudeProjectKey,
   getClaudeProjectSessionFilePath,
@@ -77,6 +78,24 @@ test('selectWorkingDirectory returns a valid requested cwd unchanged', () => {
   withoutProjectEnv(() => {
     const home = homedir();
     assert.ok(samePath(selectWorkingDirectory(home), resolve(home)));
+  });
+});
+
+test('isUnsafeWorkingDirectory rejects plugin and gemini homes', () => {
+  assert.equal(
+    isUnsafeWorkingDirectory('/Users/x/Library/Application Support/JetBrains/IntelliJIdea2026.2/plugins/idea-claude-code-gui/ai-bridge'),
+    true,
+  );
+  assert.equal(isUnsafeWorkingDirectory('/Users/x/.gemini'), true);
+  assert.equal(isUnsafeWorkingDirectory('/Users/x/.gemini/antigravity-cli'), true);
+  assert.equal(isUnsafeWorkingDirectory('/path/to/normal/project'), false);
+});
+
+test('selectWorkingDirectory skips ~/.gemini candidate', () => {
+  withoutProjectEnv(() => {
+    const home = homedir();
+    const result = selectWorkingDirectory(join(home, '.gemini'));
+    assert.ok(!samePath(result, join(home, '.gemini')), `expected non-gemini cwd, got ${result}`);
   });
 });
 

--- a/ai-bridge/utils/stdin-utils.js
+++ b/ai-bridge/utils/stdin-utils.js
@@ -9,6 +9,7 @@ const STDIN_ENV_BY_PROVIDER = {
   kimi: 'KIMI_USE_STDIN',
   opencode: 'OPENCODE_USE_STDIN',
   pi: 'PI_USE_STDIN',
+  gemini: 'GEMINI_USE_STDIN',
 };
 
 /**

--- a/docs/agy/AGY-CLI-INTEGRATION-SPEC.md
+++ b/docs/agy/AGY-CLI-INTEGRATION-SPEC.md
@@ -1,0 +1,61 @@
+# Antigravity CLI (agy) → plugin provider `gemini`
+
+## Goal
+
+First-class provider id **`gemini`** in jetbrains-cc-gui, backed by **Antigravity CLI** headless NDJSON (`agy -p … --output-format stream-json`), not Claude Agent SDK and not ACP.
+
+## Transport
+
+```
+UI provider=gemini
+  → SessionSendService.sendToGemini
+  → GeminiSDKBridge.sendMessage (one-shot channel-manager)
+  → node channel-manager.js gemini send  (stdin JSON, GEMINI_USE_STDIN=true)
+  → services/gemini/message-service.js
+  → agy-runner.js spawn: agy -p <msg> --output-format stream-json [--conversation id] …
+  → agy-event-normalizer.js → Claude-compatible stdout tags
+  → GeminiMessageHandler → webview
+```
+
+## Multi-turn
+
+`conversation_id` from agy `init` / `result` is stored as plugin `sessionId` and passed back as `--conversation` on later turns.
+
+### Session reset
+
+Clear `sessionId` (no `--conversation` on the next turn) when:
+
+- the user starts a new chat tab session (`createNewSession` already sets id to null)
+- Gemini **model** changes (including effort slug changes) — resume of a multi-model fat history is what produced ~2M context on a 128k model
+- **provider** switches (Claude/Codex/Gemini ids are not interchangeable)
+
+### cwd / workspaceDirs guard
+
+agy uses process cwd as `workspaceDirs`. Never spawn with:
+
+- JetBrains plugin / Application Support trees
+- embedded or standalone `ai-bridge`
+- `~/.gemini` / antigravity-cli home
+
+Java `PathUtils.guardWorkingDirectory` + Node `selectWorkingDirectory` / `isUnsafeWorkingDirectory` enforce this; `runAgyTurn` always resolves cwd through `selectWorkingDirectory`.
+
+## Permissions
+
+Headless has no Ask UI. Default: soft-deny. Plugin modes map via `mapPermissionMode`:
+
+| Plugin mode | agy |
+|-------------|-----|
+| plan | `--mode plan` |
+| acceptEdits | `--mode accept-edits` |
+| bypass / yolo / dontAsk | `--dangerously-skip-permissions` |
+| sandbox | `--sandbox` |
+
+## Auth
+
+User runs `agy` once in a terminal (Google Sign-In). Binary resolution: `AGY_PATH` / `GEMINI_CLI_PATH`, then common install paths, then `PATH`.
+
+## Out of scope (v1)
+
+- On-disk history browser for agy conversations
+- Interactive permission dialogs for agy tools
+- Persistent daemon ACP session (one-shot per turn is enough)

--- a/src/main/java/com/github/claudecodegui/cli/CliStatusDetector.java
+++ b/src/main/java/com/github/claudecodegui/cli/CliStatusDetector.java
@@ -135,6 +135,11 @@ public final class CliStatusDetector {
             return dirs;
         }
         switch (tool) {
+            case AGY:
+                dirs.add(join(home, ".gemini", "antigravity-cli", "bin"));
+                dirs.add(join(home, ".antigravity", "bin"));
+                dirs.add(join(home, ".local", "bin"));
+                break;
             case GROK:
                 dirs.add(join(home, ".grok", "bin"));
                 dirs.add(join(home, ".local", "bin"));
@@ -176,6 +181,7 @@ public final class CliStatusDetector {
 
     private static String[] envKeysFor(CliToolId tool) {
         return switch (tool) {
+            case AGY -> new String[]{"AGY_BIN", "AGY_PATH", "AGY_CLI_PATH", "GEMINI_CLI_PATH", "ANTIGRAVITY_BIN"};
             case GROK -> new String[]{"GROK_BIN", "GROK_PATH", "GROK_CLI_PATH"};
             case KIMI -> new String[]{"KIMI_BIN", "KIMI_PATH", "KIMI_CLI_PATH", "KIMI_CODE_BIN"};
             case OPENCODE -> new String[]{"OPENCODE_BIN", "OPENCODE_PATH", "OPENCODE_CLI_PATH"};
@@ -232,6 +238,10 @@ public final class CliStatusDetector {
 
     /**
      * When the candidate is a bare name, try to resolve an absolute path via which/where.
+     *
+     * <p>On Windows, {@code where} often lists the extensionless npm bash shim first
+     * (e.g. {@code ...\npm\pi}) before the spawnable {@code .cmd}/{@code .exe}. Prefer
+     * spawnable extensions so the displayed path matches what the Node bridge can run.
      */
     private static String resolveWhichLike(String candidate) {
         if (candidate == null || candidate.isBlank()) {
@@ -239,7 +249,7 @@ public final class CliStatusDetector {
         }
         File asFile = new File(candidate);
         if (asFile.isAbsolute() && asFile.isFile()) {
-            return asFile.getAbsolutePath();
+            return preferWindowsSpawnable(asFile.getAbsolutePath());
         }
         try {
             List<String> command = PlatformUtils.isWindows()
@@ -247,19 +257,71 @@ public final class CliStatusDetector {
                     : List.of("which", candidate);
             ProcessResult result = run(command);
             if (result.exitCode == 0 && result.stdout != null) {
-                String first = result.stdout.lines()
+                List<String> lines = result.stdout.lines()
                         .map(String::trim)
                         .filter(line -> !line.isEmpty())
-                        .findFirst()
-                        .orElse(null);
-                if (first != null) {
-                    return first;
+                        .toList();
+                String best = selectWindowsWhereMatch(lines);
+                if (best != null) {
+                    return preferWindowsSpawnable(best);
                 }
             }
         } catch (Exception e) {
             LOG.debug("[CliStatusDetector] which/where failed for " + candidate + ": " + e.getMessage());
         }
-        return candidate;
+        return preferWindowsSpawnable(candidate);
+    }
+
+    /**
+     * Prefer {@code .exe}/{@code .cmd}/{@code .bat} entries from {@code where} output.
+     * Non-Windows: first line.
+     */
+    static String selectWindowsWhereMatch(List<String> lines) {
+        if (lines == null || lines.isEmpty()) {
+            return null;
+        }
+        if (PlatformUtils.isWindows()) {
+            for (String ext : new String[]{".exe", ".cmd", ".bat"}) {
+                for (String line : lines) {
+                    if (line != null && line.length() > ext.length()
+                            && line.regionMatches(true, line.length() - ext.length(), ext, 0, ext.length())) {
+                        return line;
+                    }
+                }
+            }
+        }
+        return lines.get(0);
+    }
+
+    /**
+     * If path has no spawnable Windows extension but a sibling {@code .exe}/{@code .cmd}/{@code .bat}
+     * exists, return that sibling. Bare names and non-Windows are unchanged.
+     */
+    static String preferWindowsSpawnable(String path) {
+        if (!PlatformUtils.isWindows() || path == null || path.isBlank()) {
+            return path;
+        }
+        String trimmed = path.trim();
+        String lower = trimmed.toLowerCase();
+        if (lower.endsWith(".exe") || lower.endsWith(".cmd") || lower.endsWith(".bat")) {
+            return trimmed;
+        }
+        // Bare names rely on PATH+PATHEXT at probe time.
+        File file = new File(trimmed);
+        boolean looksLikePath = file.isAbsolute()
+                || trimmed.indexOf('/') >= 0
+                || trimmed.indexOf('\\') >= 0
+                || (trimmed.length() >= 2 && trimmed.charAt(1) == ':');
+        if (!looksLikePath) {
+            return trimmed;
+        }
+        for (String ext : new String[]{".exe", ".cmd", ".bat"}) {
+            File sibling = new File(trimmed + ext);
+            if (sibling.isFile()) {
+                return sibling.getAbsolutePath();
+            }
+        }
+        return trimmed;
     }
 
     private static ProcessResult run(List<String> command) {
@@ -315,6 +377,8 @@ public final class CliStatusDetector {
         String current = env.getOrDefault(pathKey, env.getOrDefault("PATH", ""));
         String sep = PlatformUtils.isWindows() ? ";" : ":";
         List<String> extras = List.of(
+                join(home, ".gemini", "antigravity-cli", "bin"),
+                join(home, ".antigravity", "bin"),
                 join(home, ".kimi-code", "bin"),
                 join(home, ".kimi", "bin"),
                 join(home, ".opencode", "bin"),

--- a/src/main/java/com/github/claudecodegui/cli/CliToolId.java
+++ b/src/main/java/com/github/claudecodegui/cli/CliToolId.java
@@ -4,6 +4,7 @@ package com.github.claudecodegui.cli;
  * Supported headless CLI tools shown in Settings → Provider Management → CLI.
  */
 public enum CliToolId {
+    AGY("agy", "Antigravity CLI (Gemini)", "agy"),
     GROK("grok", "Grok CLI", "grok"),
     KIMI("kimi", "Kimi CLI", "kimi"),
     OPENCODE("opencode", "OpenCode", "opencode"),
@@ -36,6 +37,9 @@ public enum CliToolId {
             return null;
         }
         String normalized = raw.trim().toLowerCase();
+        if ("gemini".equals(normalized)) {
+            return AGY;
+        }
         for (CliToolId tool : values()) {
             if (tool.id.equals(normalized)) {
                 return tool;

--- a/src/main/java/com/github/claudecodegui/dependency/DependencyManager.java
+++ b/src/main/java/com/github/claudecodegui/dependency/DependencyManager.java
@@ -103,6 +103,10 @@ public class DependencyManager {
      * Checks whether an SDK is installed.
      */
     public boolean isInstalled(String sdkId) {
+        if ("gemini-cli".equals(sdkId)) {
+            return com.github.claudecodegui.cli.CliStatusDetector.detect(com.github.claudecodegui.cli.CliToolId.AGY).isInstalled();
+        }
+
         SdkDefinition sdk = SdkDefinition.fromId(sdkId);
         if (sdk == null) {
             return false;
@@ -170,6 +174,11 @@ public class DependencyManager {
      * Returns the installed version.
      */
     public String getInstalledVersion(String sdkId) {
+        if ("gemini-cli".equals(sdkId)) {
+            com.github.claudecodegui.cli.CliToolStatus status = com.github.claudecodegui.cli.CliStatusDetector.detect(com.github.claudecodegui.cli.CliToolId.AGY);
+            return status.getVersion() != null ? status.getVersion() : (status.isInstalled() ? "installed" : null);
+        }
+
         SdkDefinition sdk = SdkDefinition.fromId(sdkId);
         if (sdk == null || !isInstalled(sdkId)) {
             return null;

--- a/src/main/java/com/github/claudecodegui/dependency/SdkDefinition.java
+++ b/src/main/java/com/github/claudecodegui/dependency/SdkDefinition.java
@@ -35,6 +35,21 @@ public enum SdkDefinition {
         Arrays.asList("0.117.0", "0.116.0", "0.115.0"),
         "Codex AI 提供商所需。",
         null // minRequiredVersion — no enforced minimum
+    ),
+
+    /**
+     * Gemini uses Antigravity CLI ({@code agy}) headless stream-json — not an npm SDK.
+     * Install externally; path via AGY_PATH / GEMINI_CLI_PATH or PATH.
+     */
+    GEMINI_CLI(
+        "gemini-cli",
+        "Antigravity CLI (Gemini)",
+        "agy-cli-binary",
+        "latest",
+        Collections.emptyList(),
+        Collections.emptyList(),
+        "Gemini provider requires Antigravity CLI (agy). Install from https://antigravity.google/docs/cli/install and sign in once via agy.",
+        null
     );
 
     private final String id;
@@ -137,6 +152,8 @@ public enum SdkDefinition {
             return CLAUDE_SDK;
         } else if ("codex".equalsIgnoreCase(provider)) {
             return CODEX_SDK;
+        } else if ("gemini".equalsIgnoreCase(provider)) {
+            return GEMINI_CLI;
         }
         return null;
     }

--- a/src/main/java/com/github/claudecodegui/handler/CliModelsHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/CliModelsHandler.java
@@ -59,7 +59,7 @@ public class CliModelsHandler extends BaseMessageHandler {
             return false;
         }
         String provider = content != null ? content.trim().toLowerCase(Locale.ROOT) : "";
-        if (!"opencode".equals(provider) && !"kimi".equals(provider) && !"pi".equals(provider) && !"codex".equals(provider) && !"grok".equals(provider)) {
+        if (!"opencode".equals(provider) && !"kimi".equals(provider) && !"pi".equals(provider) && !"codex".equals(provider) && !"gemini".equals(provider) && !"grok".equals(provider)) {
             pushError(provider, "Unsupported CLI provider for model list: " + provider);
             return true;
         }

--- a/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
@@ -28,6 +28,10 @@ public class SettingsHandler extends BaseMessageHandler {
     private final NodePathHandler nodePathHandler;
     private final ClaudeCliPathHandler claudeCliPathHandler;
     private final ProjectConfigHandler projectConfigHandler;
+    // Handle for the theme-change callback registered with ThemeConfigService.
+    // Kept so it can be cleanly unregistered when the owning window is disposed,
+    // preventing notifications to disposed webviews (issue #1586).
+    private ThemeConfigService.RegisteredCallback themeCallbackHandle;
     private final CodexSubscriptionQuotaHandler codexSubscriptionQuotaHandler;
     private final TokenTrackerHandler tokenTrackerHandler;
 
@@ -38,6 +42,7 @@ public class SettingsHandler extends BaseMessageHandler {
         "set_provider",
         "set_reasoning_effort",
         "set_codex_fast_mode",
+        "get_gemini_models",
         "get_node_path",
         "set_node_path",
         "get_claude_cli_path",
@@ -124,13 +129,27 @@ public class SettingsHandler extends BaseMessageHandler {
 
     /**
      * Register theme change listener.
+     * Uses the multi-callback API so that every open ClaudeChatWindow receives
+     * theme change notifications. The returned handle is stored for clean
+     * unregistration in {@link #dispose()}.
      */
     private void registerThemeChangeListener() {
-        ThemeConfigService.registerThemeChangeListener(themeConfig -> {
+        themeCallbackHandle = ThemeConfigService.registerThemeChangeListener(themeConfig -> {
             ApplicationManager.getApplication().invokeLater(() -> {
                 callJavaScript("window.onIdeThemeChanged", escapeJs(themeConfig.toString()));
             });
-        });
+        }, true);
+    }
+
+    /**
+     * Unregister the theme change callback to prevent notifications to a disposed webview.
+     * Should be called when the owning ClaudeChatWindow is disposed.
+     */
+    public void dispose() {
+        if (themeCallbackHandle != null) {
+            ThemeConfigService.unregisterThemeChangeListener(themeCallbackHandle);
+            themeCallbackHandle = null;
+        }
     }
 
     @Override
@@ -160,6 +179,9 @@ public class SettingsHandler extends BaseMessageHandler {
                 return true;
             case "set_codex_fast_mode":
                 modelProviderHandler.handleSetCodexFastMode(content);
+                return true;
+            case "get_gemini_models":
+                modelProviderHandler.handleGetGeminiModels(content);
                 return true;
             // Node path
             case "get_node_path":

--- a/src/main/java/com/github/claudecodegui/handler/core/HandlerContext.java
+++ b/src/main/java/com/github/claudecodegui/handler/core/HandlerContext.java
@@ -3,6 +3,7 @@ package com.github.claudecodegui.handler.core;
 import com.github.claudecodegui.session.ClaudeSession;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.provider.gemini.GeminiSDKBridge;
 import com.github.claudecodegui.settings.CodemossSettingsService;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
@@ -23,6 +24,7 @@ public class HandlerContext {
     private final Project project;
     private final ClaudeSDKBridge claudeSDKBridge;
     private final CodexSDKBridge codexSDKBridge;
+    private final GeminiSDKBridge geminiSDKBridge;
     private final CodemossSettingsService settingsService;
     private final JsCallback jsCallback;
     private final BooleanSupplier activeContentSupplier;
@@ -51,7 +53,7 @@ public class HandlerContext {
             CodemossSettingsService settingsService,
             JsCallback jsCallback
     ) {
-        this(project, claudeSDKBridge, codexSDKBridge, settingsService, jsCallback, () -> true, () -> null);
+        this(project, claudeSDKBridge, codexSDKBridge, null, settingsService, jsCallback, () -> true, () -> null);
     }
 
     public HandlerContext(
@@ -63,9 +65,24 @@ public class HandlerContext {
             BooleanSupplier activeContentSupplier,
             Supplier<String> contentTitleSupplier
     ) {
+        this(project, claudeSDKBridge, codexSDKBridge, null, settingsService, jsCallback,
+                activeContentSupplier, contentTitleSupplier);
+    }
+
+    public HandlerContext(
+            Project project,
+            ClaudeSDKBridge claudeSDKBridge,
+            CodexSDKBridge codexSDKBridge,
+            GeminiSDKBridge geminiSDKBridge,
+            CodemossSettingsService settingsService,
+            JsCallback jsCallback,
+            BooleanSupplier activeContentSupplier,
+            Supplier<String> contentTitleSupplier
+    ) {
         this.project = project;
         this.claudeSDKBridge = claudeSDKBridge;
         this.codexSDKBridge = codexSDKBridge;
+        this.geminiSDKBridge = geminiSDKBridge;
         this.settingsService = settingsService;
         this.jsCallback = jsCallback;
         this.activeContentSupplier = activeContentSupplier == null ? () -> true : activeContentSupplier;
@@ -83,6 +100,10 @@ public class HandlerContext {
 
     public CodexSDKBridge getCodexSDKBridge() {
         return codexSDKBridge;
+    }
+
+    public GeminiSDKBridge getGeminiSDKBridge() {
+        return geminiSDKBridge;
     }
 
     public CodemossSettingsService getSettingsService() {

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryDeleteService.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryDeleteService.java
@@ -233,6 +233,9 @@ class HistoryDeleteService {
         if ("grok".equals(currentProvider)) {
             return new DeleteResult(deleteGrokSession(sessionId), 0);
         }
+        if ("gemini".equals(currentProvider)) {
+            return new DeleteResult(deleteGeminiSession(sessionId), 0);
+        }
 
         String rawPath = context.resolveEffectiveWorkingDirectory();
         String nodePath = NodeDetector.getInstance().getCachedNodePath();
@@ -256,6 +259,16 @@ class HistoryDeleteService {
         LOG.info("[HistoryHandler] Delete Grok session " + sessionId + ": " + (deleted ? "ok" : "not found"));
         return deleted;
     }
+
+    private boolean deleteGeminiSession(String sessionId) throws java.io.IOException {
+        com.github.claudecodegui.provider.gemini.GeminiHistoryReader reader =
+                new com.github.claudecodegui.provider.gemini.GeminiHistoryReader();
+        boolean deleted = reader.deleteSession(sessionId);
+        LOG.info("[HistoryHandler] Delete Gemini session " + sessionId + ": " + (deleted ? "ok" : "not found"));
+        return deleted;
+    }
+
+
 
     private boolean deleteCodexSession(String sessionId) throws java.io.IOException {
         return deleteCodexSessions(Collections.singleton(sessionId)).deletedSessionIds.contains(sessionId);

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryExportService.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryExportService.java
@@ -5,7 +5,11 @@ import com.github.claudecodegui.handler.core.HandlerContext;
 
 import com.github.claudecodegui.provider.claude.ClaudeHistoryReader;
 import com.github.claudecodegui.provider.codex.CodexHistoryReader;
+import com.github.claudecodegui.provider.grok.GrokHistoryReader;
+
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.intellij.openapi.application.ApplicationManager;
@@ -13,6 +17,7 @@ import com.intellij.openapi.diagnostic.Logger;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -23,6 +28,7 @@ class HistoryExportService {
     private static final Logger LOG = Logger.getInstance(HistoryExportService.class);
 
     private final HandlerContext context;
+    private final Gson gson = new Gson();
 
     HistoryExportService(HandlerContext context) {
         this.context = context;
@@ -38,9 +44,17 @@ class HistoryExportService {
 
             try {
                 // Parse JSON from frontend to extract sessionId and title
-                JsonObject exportRequest = new Gson().fromJson(content, JsonObject.class);
+                JsonObject exportRequest = gson.fromJson(content, JsonObject.class);
                 String sessionId = exportRequest.get("sessionId").getAsString();
                 String title = exportRequest.get("title").getAsString();
+                // Prefer provider embedded in the export request (history row) when present.
+                String provider = currentProvider;
+                if (exportRequest.has("provider") && !exportRequest.get("provider").isJsonNull()) {
+                    String fromRequest = exportRequest.get("provider").getAsString();
+                    if (fromRequest != null && !fromRequest.trim().isEmpty()) {
+                        provider = fromRequest.trim();
+                    }
+                }
 
                 String rawPath = context.resolveEffectiveWorkingDirectory();
                 String nodePath = NodeDetector.getInstance().getCachedNodePath();
@@ -52,27 +66,18 @@ class HistoryExportService {
                 LOG.info("[HistoryHandler] SessionId: " + sessionId);
                 LOG.info("[HistoryHandler] Title: " + title);
                 LOG.info("[HistoryHandler] ProjectPath: " + projectPath);
-                LOG.info("[HistoryHandler] CurrentProvider: " + currentProvider);
+                LOG.info("[HistoryHandler] CurrentProvider: " + provider);
 
-                // Choose a different reader based on the provider
-                String messagesJson;
-                if ("codex".equals(currentProvider)) {
-                    LOG.info("[HistoryHandler] 使用 CodexHistoryReader 读取 Codex 会话消息");
-                    CodexHistoryReader codexReader = new CodexHistoryReader();
-                    messagesJson = codexReader.getSessionMessagesAsJson(sessionId);
-                } else {
-                    LOG.info("[HistoryHandler] 使用 ClaudeHistoryReader 读取 Claude 会话消息");
-                    ClaudeHistoryReader historyReader = new ClaudeHistoryReader();
-                    messagesJson = historyReader.getSessionMessagesAsJson(projectPath, sessionId);
-                }
+                JsonElement messagesElement = loadMessagesForExport(provider, sessionId, projectPath);
 
                 // Wrap messages into an object containing sessionId and title
                 JsonObject exportData = new JsonObject();
                 exportData.addProperty("sessionId", sessionId);
                 exportData.addProperty("title", title);
-                exportData.add("messages", JsonParser.parseString(messagesJson));
+                exportData.addProperty("provider", provider != null ? provider : "claude");
+                exportData.add("messages", messagesElement);
 
-                String wrappedJson = new Gson().toJson(exportData);
+                String wrappedJson = gson.toJson(exportData);
 
                 LOG.info("[HistoryHandler] 读取到会话消息，准备注入到前端");
 
@@ -114,5 +119,43 @@ class HistoryExportService {
                 });
             }
         });
+    }
+
+    private JsonElement loadMessagesForExport(String provider, String sessionId, String projectPath)
+            throws Exception {
+        if ("codex".equals(provider)) {
+            LOG.info("[HistoryHandler] 使用 CodexHistoryReader 读取 Codex 会话消息");
+            CodexHistoryReader codexReader = new CodexHistoryReader();
+            String messagesJson = codexReader.getSessionMessagesAsJson(sessionId);
+            return JsonParser.parseString(messagesJson != null ? messagesJson : "[]");
+        }
+        if ("grok".equals(provider)) {
+            LOG.info("[HistoryHandler] 使用 GrokHistoryReader 导出 Grok 会话");
+            return toJsonArray(new GrokHistoryReader().getSessionMessages(sessionId, projectPath));
+        }
+        if ("gemini".equals(provider)) {
+            LOG.info("[HistoryHandler] 使用 GeminiHistoryReader 读取 Gemini 会话消息");
+            com.github.claudecodegui.provider.gemini.GeminiHistoryReader geminiReader =
+                    new com.github.claudecodegui.provider.gemini.GeminiHistoryReader();
+            String messagesJson = geminiReader.getSessionMessagesAsJson(sessionId);
+            return JsonParser.parseString(messagesJson != null ? messagesJson : "[]");
+        }
+        LOG.info("[HistoryHandler] 使用 ClaudeHistoryReader 读取 Claude 会话消息");
+        ClaudeHistoryReader historyReader = new ClaudeHistoryReader();
+        String messagesJson = historyReader.getSessionMessagesAsJson(projectPath, sessionId);
+        return JsonParser.parseString(messagesJson != null ? messagesJson : "[]");
+    }
+
+    private JsonElement toJsonArray(List<JsonObject> messages) {
+        if (messages == null || messages.isEmpty()) {
+            return new JsonArray();
+        }
+        JsonArray array = new JsonArray();
+        for (JsonObject message : messages) {
+            if (message != null) {
+                array.add(message);
+            }
+        }
+        return array;
     }
 }

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryHandler.java
@@ -31,7 +31,10 @@ public class HistoryHandler extends BaseMessageHandler {
 
     // Session load callback interface
     public interface SessionLoadCallback {
-        void onLoadSession(String sessionId, String projectPath, String provider);
+        /**
+         * @param model optional model id from the history row; null/blank keeps previous UI model
+         */
+        void onLoadSession(String sessionId, String projectPath, String provider, String model);
     }
 
     private SessionLoadCallback sessionLoadCallback;

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryLoadService.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryLoadService.java
@@ -8,6 +8,7 @@ import com.github.claudecodegui.cache.SessionIndexCache;
 import com.github.claudecodegui.cache.SessionIndexManager;
 import com.github.claudecodegui.provider.claude.ClaudeHistoryReader;
 import com.github.claudecodegui.provider.codex.CodexHistoryReader;
+import com.github.claudecodegui.provider.gemini.GeminiHistoryReader;
 import com.github.claudecodegui.provider.grok.GrokHistoryReader;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -69,10 +70,11 @@ class HistoryLoadService {
                     GrokHistoryReader grokReader = new GrokHistoryReader();
                     historyJson = grokReader.getSessionsForProjectAsJson(projectPath);
                     LOG.info("[HistoryHandler] GrokHistoryReader 返回的 JSON 长度: " + historyJson.length());
-                } else if ("kimi".equals(provider) || "opencode".equals(provider) || "pi".equals(provider)) {
-                    // History disk readers are deferred; live multi-turn uses sessionId resume.
-                    LOG.info("[HistoryHandler] " + provider + " history list not implemented yet; returning empty");
-                    historyJson = "{\"success\":true,\"sessions\":[],\"provider\":\"" + provider + "\"}";
+                } else if ("gemini".equals(provider)) {
+                    LOG.info("[HistoryHandler] 使用 GeminiHistoryReader 读取 Gemini 会话 (项目: " + projectPath + ")");
+                    GeminiHistoryReader geminiReader = new GeminiHistoryReader();
+                    historyJson = geminiReader.getSessionsForProjectAsJson(projectPath);
+                    LOG.info("[HistoryHandler] GeminiHistoryReader 返回的 JSON 长度: " + historyJson.length());
                 } else {
                     // Default: use ClaudeHistoryReader to read Claude sessions
                     LOG.info("[HistoryHandler] 使用 ClaudeHistoryReader 读取 Claude 会话");
@@ -153,8 +155,6 @@ class HistoryLoadService {
             } else if ("grok".equals(provider)) {
                 // Grok history is read live from disk; no dedicated index cache yet.
                 LOG.info("[HistoryHandler] Grok deep search: reloading from ~/.grok/sessions");
-            } else if ("kimi".equals(provider) || "opencode".equals(provider) || "pi".equals(provider)) {
-                LOG.info("[HistoryHandler] " + provider + " deep search: no disk index yet");
             } else if (projectPath != null) {
                 SessionIndexCache.getInstance().clearProject(projectPath);
                 SessionIndexManager.getInstance().clearProjectIndex("claude", projectPath);

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
@@ -65,6 +65,7 @@ public class HistoryMessageInjector {
         sessionLoadGeneration.incrementAndGet();
         String provider = currentProvider;
         String resolvedSessionId = sessionId;
+        String model = null;
 
         try {
             JsonObject payload = new Gson().fromJson(sessionId, JsonObject.class);
@@ -74,6 +75,12 @@ public class HistoryMessageInjector {
                 }
                 if (payload.has("provider") && !payload.get("provider").isJsonNull()) {
                     provider = payload.get("provider").getAsString();
+                }
+                if (payload.has("model") && !payload.get("model").isJsonNull()) {
+                    String m = payload.get("model").getAsString();
+                    if (m != null && !m.trim().isEmpty()) {
+                        model = m.trim();
+                    }
                 }
             }
         } catch (Exception ignored) {
@@ -89,15 +96,16 @@ public class HistoryMessageInjector {
             return;
         }
         LOG.info("[HistoryHandler] Loading history session: " + resolvedSessionId
-                + " from project: " + projectPath + ", provider: " + provider);
+                + " from project: " + projectPath + ", provider: " + provider
+                + (model != null ? ", model: " + model : ""));
 
         if ("codex".equals(provider)) {
             // Codex session: read session info and restore session state
-            loadCodexSession(resolvedSessionId);
+            loadCodexSession(resolvedSessionId, model);
         } else {
-            // Claude session: use existing callback mechanism
+            // Claude / CLI providers: use existing callback mechanism
             if (sessionLoadCallback != null) {
-                sessionLoadCallback.onLoadSession(resolvedSessionId, projectPath, provider);
+                sessionLoadCallback.onLoadSession(resolvedSessionId, projectPath, provider, model);
             } else {
                 LOG.warn("[HistoryHandler] WARNING: No session load callback set");
                 notifyHistoryLoadComplete();
@@ -110,6 +118,10 @@ public class HistoryMessageInjector {
      * Reads session messages directly and injects them into the frontend, while restoring session state.
      */
     void loadCodexSession(String sessionId) {
+        loadCodexSession(sessionId, null);
+    }
+
+    void loadCodexSession(String sessionId, String model) {
         long generation = sessionLoadGeneration.incrementAndGet();
         CompletableFuture.runAsync(() -> {
             LOG.info("[HistoryHandler] ========== 开始加载 Codex 会话 ==========");
@@ -127,6 +139,9 @@ public class HistoryMessageInjector {
                 String cwd = page.cwd;
 
                 context.getSession().setSessionInfo(threadIdToUse, cwd);
+                if (model != null && !model.isBlank()) {
+                    context.getSession().setModel(model.trim());
+                }
                 restoreCodexFrontendMessagesToSessionState(context.getSession().getState(), page.messages);
                 pushRestoredCodexUsage();
                 LOG.info("[HistoryHandler] 恢复 Codex 会话状态: threadId=" + threadIdToUse + " (from sessionId=" + sessionId + "), cwd=" + cwd);

--- a/src/main/java/com/github/claudecodegui/handler/provider/ModelProviderHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/provider/ModelProviderHandler.java
@@ -75,6 +75,29 @@ public class ModelProviderHandler {
         MODEL_CONTEXT_LIMITS.put("grok-4.5", 500_000);
         MODEL_CONTEXT_LIMITS.put("grok-4", 500_000);
         MODEL_CONTEXT_LIMITS.put("grok-build", 500_000);
+
+        // Gemini / Antigravity models
+        MODEL_CONTEXT_LIMITS.put("gemini", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("gemini-2.5-pro", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("gemini-2.5-flash", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("gemini-3-pro", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("gemini-3.5-flash", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("gemini-3.5-flash-high", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("gemini-3.5-flash-medium", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("gemini-3.5-flash-low", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("gemini-3.6-flash", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("gemini-3.6-flash-high", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("gemini-3.6-flash-medium", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("gemini-3.6-flash-low", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("gemini-3.1-pro", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("gemini-3.1-pro-high", 1_000_000);
+        MODEL_CONTEXT_LIMITS.put("gemini-3.1-pro-low", 1_000_000);
+
+        MODEL_CONTEXT_LIMITS.put("claude-sonnet-4-6", 200_000);
+        MODEL_CONTEXT_LIMITS.put("claude-opus-4-6", 200_000);
+        MODEL_CONTEXT_LIMITS.put("claude-opus-4-6-thinking", 200_000);
+
+        MODEL_CONTEXT_LIMITS.put("gpt-oss-120b", 128_000);
     }
 
     private final HandlerContext context;
@@ -100,6 +123,7 @@ public class ModelProviderHandler {
                 }
             }
 
+            String provider = context.getCurrentProvider();
             String previousModel = resolveCurrentSessionModel(context);
             boolean modelChanged = isActualModelSwitch(previousModel, model);
             LOG.info("[ModelProviderHandler] Setting model to: " + model
@@ -112,6 +136,14 @@ public class ModelProviderHandler {
                     TokenUsageUtils.clearContextUsageFromSessionMessages(
                             context.getSession().getMessages());
                 }
+                // agy resumes the full conversation blob via --conversation. Switching
+                // models (or effort slugs) inside one fat multi-model history is what
+                // blew context to ~2M tokens. Start a fresh conversation instead.
+                if (shouldResetGeminiSessionOnModelChange(provider, previousModel, model)) {
+                    context.getSession().clearSessionId();
+                    LOG.info("[ModelProviderHandler] Cleared Gemini conversation id after model change: "
+                            + previousModel + " -> " + model);
+                }
                 LOG.info("[ModelProviderHandler] Updated session model to canonical ID: " + model);
             }
 
@@ -123,10 +155,12 @@ public class ModelProviderHandler {
                 com.github.claudecodegui.notifications.ClaudeNotifier.setModel(context.getProject(), model);
             }
 
-            String provider = context.getCurrentProvider();
             boolean isCodex = "codex".equalsIgnoreCase(provider);
-            String resolvedModelForUsage = isCodex ? model : resolveConfiguredClaudeModelFromSettings(model);
-            int newMaxTokens = isCodex
+            boolean isGemini = "gemini".equalsIgnoreCase(provider);
+            String resolvedModelForUsage = isCodex || isGemini
+                    ? model
+                    : resolveConfiguredClaudeModelFromSettings(model);
+            int newMaxTokens = (isCodex || isGemini)
                     ? getModelContextLimit(provider, model)
                     : getModelContextLimit(resolvedModelForUsage);
             LOG.info("[ModelProviderHandler] Model context limit: " + newMaxTokens
@@ -180,6 +214,14 @@ public class ModelProviderHandler {
                 if (providerChanged) {
                     TokenUsageUtils.clearContextUsageFromSessionMessages(
                             context.getSession().getMessages());
+                }
+                // Provider session ids are not interchangeable (Claude UUID vs Codex
+                // thread vs agy conversation). Drop the previous id on a real switch
+                // so the next send cannot resume a foreign conversation.
+                if (shouldClearSessionOnProviderSwitch(previousProvider, provider)) {
+                    context.getSession().clearSessionId();
+                    LOG.info("[ModelProviderHandler] Cleared session id after provider switch: "
+                            + previousProvider + " -> " + provider);
                 }
             }
 
@@ -241,6 +283,36 @@ public class ModelProviderHandler {
                 && !previousProvider.isEmpty()
                 && !newProvider.isEmpty()
                 && !previousProvider.equals(newProvider);
+    }
+
+    /**
+     * Gemini/agy only: clear {@code --conversation} resume when the selected model
+     * slug actually changes. Reaffirmations of the same model keep the session.
+     */
+    static boolean shouldResetGeminiSessionOnModelChange(String provider, String previousModel, String newModel) {
+        if (provider == null || !"gemini".equalsIgnoreCase(provider.trim())) {
+            return false;
+        }
+        if (newModel == null || newModel.trim().isEmpty()) {
+            return false;
+        }
+        String prev = previousModel != null ? previousModel.trim() : "";
+        String next = newModel.trim();
+        return !prev.isEmpty() && !prev.equals(next);
+    }
+
+    /**
+     * True when the tab moves between distinct non-empty providers (not a
+     * reaffirmation of the same provider, and not empty init races).
+     */
+    static boolean shouldClearSessionOnProviderSwitch(String previousProvider, String newProvider) {
+        if (previousProvider == null || previousProvider.trim().isEmpty()) {
+            return false;
+        }
+        if (newProvider == null || newProvider.trim().isEmpty()) {
+            return false;
+        }
+        return !previousProvider.trim().equalsIgnoreCase(newProvider.trim());
     }
 
     /**
@@ -344,6 +416,55 @@ public class ModelProviderHandler {
             }
         } catch (Exception e) {
             LOG.error("[ModelProviderHandler] Failed to set Codex fast mode: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Fetch live Gemini/agy model catalog and push to webview via
+     * {@code window.updateGeminiModels}.
+     */
+    public void handleGetGeminiModels(String content) {
+        try {
+            if (context.getGeminiSDKBridge() == null) {
+                LOG.warn("[ModelProviderHandler] get_gemini_models: GeminiSDKBridge unavailable");
+                pushGeminiModelsError("Gemini bridge unavailable");
+                return;
+            }
+            context.getGeminiSDKBridge().listModels()
+                    .thenAccept(result -> ApplicationManager.getApplication().invokeLater(() -> {
+                        try {
+                            if (result == null) {
+                                pushGeminiModelsError("Empty listModels response");
+                                return;
+                            }
+                            String json = gson.toJson(result);
+                            context.callJavaScript("window.updateGeminiModels", context.escapeJs(json));
+                        } catch (Exception e) {
+                            LOG.error("[ModelProviderHandler] Failed to push gemini models: " + e.getMessage(), e);
+                            pushGeminiModelsError(e.getMessage());
+                        }
+                    }))
+                    .exceptionally(ex -> {
+                        LOG.error("[ModelProviderHandler] listModels failed: " + ex.getMessage(), ex);
+                        ApplicationManager.getApplication().invokeLater(() ->
+                                pushGeminiModelsError(ex.getMessage()));
+                        return null;
+                    });
+        } catch (Exception e) {
+            LOG.error("[ModelProviderHandler] get_gemini_models failed: " + e.getMessage(), e);
+            pushGeminiModelsError(e.getMessage());
+        }
+    }
+
+    private void pushGeminiModelsError(String message) {
+        try {
+            JsonObject err = new JsonObject();
+            err.addProperty("success", false);
+            err.add("models", new com.google.gson.JsonArray());
+            err.add("families", new com.google.gson.JsonArray());
+            err.addProperty("error", message != null ? message : "unknown");
+            context.callJavaScript("window.updateGeminiModels", context.escapeJs(gson.toJson(err)));
+        } catch (Exception ignored) {
         }
     }
 
@@ -452,8 +573,10 @@ public class ModelProviderHandler {
             return 200_000;
         }
 
+        String normalized = stripAgyEffortSuffix(model.trim());
+
         java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("\\s*\\[([0-9.]+)([kKmM])\\]\\s*$");
-        java.util.regex.Matcher matcher = pattern.matcher(model);
+        java.util.regex.Matcher matcher = pattern.matcher(normalized);
 
         if (matcher.find()) {
             try {
@@ -470,7 +593,63 @@ public class ModelProviderHandler {
             }
         }
 
-        return MODEL_CONTEXT_LIMITS.getOrDefault(model, 200_000);
+        Integer exact = MODEL_CONTEXT_LIMITS.get(normalized);
+        if (exact != null) {
+            return exact;
+        }
+        // Also try original (in case map has full slug keys)
+        exact = MODEL_CONTEXT_LIMITS.get(model);
+        if (exact != null) {
+            return exact;
+        }
+
+        // Longest-prefix match for family slugs (gemini-3.6-flash-medium → gemini-3.6-flash).
+        // Require key length >= 6 so short keys like "o1" / "gpt-4" cannot steal longer ids.
+        String bestKey = null;
+        for (String key : MODEL_CONTEXT_LIMITS.keySet()) {
+            if (key == null || key.length() < 6) {
+                continue;
+            }
+            if (normalized.equals(key)
+                    || normalized.startsWith(key + "-")
+                    || normalized.startsWith(key + "[")
+                    || model.startsWith(key + "-")
+                    || model.startsWith(key + "[")) {
+                if (bestKey == null || key.length() > bestKey.length()) {
+                    bestKey = key;
+                }
+            }
+        }
+        if (bestKey != null) {
+            return MODEL_CONTEXT_LIMITS.get(bestKey);
+        }
+
+        // Provider-ish defaults by id prefix (agy multi-model catalog)
+        if (normalized.startsWith("gemini")) {
+            return 1_000_000;
+        }
+        if (normalized.startsWith("claude")) {
+            return 200_000;
+        }
+        if (normalized.startsWith("gpt-oss")) {
+            return 128_000;
+        }
+
+        return 200_000;
+    }
+
+    /** Strip trailing agy effort suffix (-low|-medium|-high|-xhigh|-thinking). */
+    static String stripAgyEffortSuffix(String modelId) {
+        if (modelId == null || modelId.isEmpty()) {
+            return modelId;
+        }
+        String[] suffixes = { "-thinking", "-xhigh", "-medium", "-high", "-low" };
+        for (String suffix : suffixes) {
+            if (modelId.endsWith(suffix) && modelId.length() > suffix.length()) {
+                return modelId.substring(0, modelId.length() - suffix.length());
+            }
+        }
+        return modelId;
     }
 
     public static int getModelContextLimit(String provider, String model) {

--- a/src/main/java/com/github/claudecodegui/handler/provider/gemini/GeminiPlanUsageHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/provider/gemini/GeminiPlanUsageHandler.java
@@ -1,0 +1,49 @@
+package com.github.claudecodegui.handler.provider.gemini;
+
+import com.github.claudecodegui.handler.core.BaseMessageHandler;
+import com.github.claudecodegui.handler.core.HandlerContext;
+import com.github.claudecodegui.provider.gemini.GeminiPlanUsageService;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.application.ApplicationManager;
+
+public class GeminiPlanUsageHandler extends BaseMessageHandler {
+
+    private static final String[] SUPPORTED_TYPES = {
+            "get_gemini_plan_usage"
+    };
+
+    public GeminiPlanUsageHandler(HandlerContext context) {
+        super(context);
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return SUPPORTED_TYPES;
+    }
+
+    @Override
+    public boolean handle(String type, String content) {
+        if ("get_gemini_plan_usage".equals(type)) {
+            ApplicationManager.getApplication().executeOnPooledThread(() -> {
+                try {
+                    JsonObject usage = GeminiPlanUsageService.resolvePlanUsagePayload();
+                    if (usage != null) {
+                        context.callJavaScript("window.updateGeminiPlanUsage", context.escapeJs(usage.toString()));
+                    } else {
+                        // Send empty/error state
+                        JsonObject error = new JsonObject();
+                        error.addProperty("error", true);
+                        context.callJavaScript("window.updateGeminiPlanUsage", context.escapeJs(error.toString()));
+                    }
+                } catch (Exception e) {
+                    JsonObject error = new JsonObject();
+                    error.addProperty("error", true);
+                    error.addProperty("message", e.getMessage());
+                    context.callJavaScript("window.updateGeminiPlanUsage", context.escapeJs(error.toString()));
+                }
+            });
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,8 @@ public class DaemonBridge {
     private static final long HEARTBEAT_INTERVAL_MS = 15_000;
     private static final long HEARTBEAT_TIMEOUT_MS = 45_000; // 3 missed heartbeats = dead
     private static final long ACTIVE_REQUEST_HEARTBEAT_TIMEOUT_MS = 180_000;
+    private static final long HEARTBEAT_PROBE_TIMEOUT_MS = HEARTBEAT_INTERVAL_MS * 2;
+    private static final long HEARTBEAT_SCHEDULER_GAP_MS = HEARTBEAT_INTERVAL_MS + 5_000;
     private static final int MAX_RESTART_ATTEMPTS = 3;
     private static final long RESTART_WINDOW_MS = 30_000; // Reset restart counter after this period of stability
     private static final int STDERR_RING_CAPACITY = 40;
@@ -50,28 +53,22 @@ public class DaemonBridge {
     private final NodeDetector nodeDetector;
     private final BridgeDirectoryResolver directoryResolver;
     private final EnvironmentConfigurator envConfigurator;
-    // Daemon process state
-    private volatile Process daemonProcess;
-    private volatile BufferedWriter daemonStdin;
-    private volatile Thread readerThread;
-    private volatile Thread heartbeatThread;
-    private final AtomicBoolean isRunning = new AtomicBoolean(false);
-    private final AtomicBoolean sdkPreloaded = new AtomicBoolean(false);
+    private final TimeSource timeSource;
+    private final DaemonProcessLauncher processLauncher;
+    private final DaemonLifecycleHooks lifecycleHooks;
+    private final long heartbeatIntervalMs;
+    // Daemon process state. Every asynchronous callback is scoped to one context.
+    private volatile DaemonGenerationContext daemonContext;
+    private final AtomicLong daemonGenerationCounter = new AtomicLong(0);
+    // Guarded by startLock. Explicit stop intent always outranks auto-restart.
+    private boolean restartInProgress;
+    private boolean desiredRunning;
+    private long stopEpoch;
+    private final AtomicLong startAttemptCounter = new AtomicLong(0);
+    private StartAttempt activeStartAttempt;
     private final AtomicLong requestIdCounter = new AtomicLong(0);
-    private volatile CountDownLatch readyLatch = new CountDownLatch(1);
     private final AtomicInteger restartAttempts = new AtomicInteger(0);
-    private final AtomicLong lastSuccessfulStart = new AtomicLong(0);
-    private final AtomicLong lastHeartbeatResponse = new AtomicLong(0);
-    private final AtomicLong lastDaemonActivity = new AtomicLong(0);
-    private final AtomicInteger activeRequestCount = new AtomicInteger(0);
-    /** True while {@link #start()} is blocked waiting for the daemon "ready" event. */
-    private final AtomicBoolean awaitingReady = new AtomicBoolean(false);
-    private final Deque<String> recentStderrLines = new ArrayDeque<>();
-    private final Object stderrRingLock = new Object();
     private final Object startLock = new Object();
-
-    // Pending request handlers: requestId -> handler
-    private final ConcurrentHashMap<String, RequestHandler> pendingRequests = new ConcurrentHashMap<>();
 
     // Lifecycle listener
     private volatile DaemonLifecycleListener lifecycleListener;
@@ -85,9 +82,54 @@ public class DaemonBridge {
             BridgeDirectoryResolver directoryResolver,
             EnvironmentConfigurator envConfigurator
     ) {
+        this(nodeDetector, directoryResolver, envConfigurator, TimeSource.system());
+    }
+
+    DaemonBridge(
+            NodeDetector nodeDetector,
+            BridgeDirectoryResolver directoryResolver,
+            EnvironmentConfigurator envConfigurator,
+            TimeSource timeSource
+    ) {
+        this(nodeDetector, directoryResolver, envConfigurator, timeSource, null, null);
+    }
+
+    DaemonBridge(
+            NodeDetector nodeDetector,
+            BridgeDirectoryResolver directoryResolver,
+            EnvironmentConfigurator envConfigurator,
+            TimeSource timeSource,
+            DaemonProcessLauncher processLauncher,
+            DaemonLifecycleHooks lifecycleHooks
+    ) {
+        this(
+                nodeDetector,
+                directoryResolver,
+                envConfigurator,
+                timeSource,
+                processLauncher,
+                lifecycleHooks,
+                HEARTBEAT_INTERVAL_MS);
+    }
+
+    DaemonBridge(
+            NodeDetector nodeDetector,
+            BridgeDirectoryResolver directoryResolver,
+            EnvironmentConfigurator envConfigurator,
+            TimeSource timeSource,
+            DaemonProcessLauncher processLauncher,
+            DaemonLifecycleHooks lifecycleHooks,
+            long heartbeatIntervalMs
+    ) {
         this.nodeDetector = nodeDetector;
         this.directoryResolver = directoryResolver;
         this.envConfigurator = envConfigurator;
+        this.timeSource = timeSource;
+        this.processLauncher = processLauncher != null
+                ? processLauncher : this::launchConfiguredDaemon;
+        this.lifecycleHooks = lifecycleHooks != null
+                ? lifecycleHooks : DaemonLifecycleHooks.NO_OP;
+        this.heartbeatIntervalMs = heartbeatIntervalMs;
     }
 
     // =========================================================================
@@ -101,117 +143,220 @@ public class DaemonBridge {
      * @return true if daemon started successfully
      */
     public boolean start() {
+        StartAttempt attempt;
+        boolean ownsAttempt;
         synchronized (startLock) {
-            if (isRunning.get()) {
-                LOG.info("[DaemonBridge] Daemon already running");
-                return true;
-            }
-
-            LOG.info("[DaemonBridge] Starting daemon process...");
-            CountDownLatch latch = new CountDownLatch(1);
-            readyLatch = latch;
-
-            try {
-                File bridgeDir = directoryResolver.findSdkDir();
-                if (bridgeDir == null) {
-                    LOG.error("[DaemonBridge] Bridge directory not found");
+            if (activeStartAttempt != null) {
+                attempt = activeStartAttempt;
+                ownsAttempt = false;
+            } else {
+                DaemonGenerationContext existingContext = daemonContext;
+                if (existingContext != null && existingContext.isActive()) {
+                    if (existingContext.isStartupPublished()
+                            && existingContext.process.isAlive()) {
+                        LOG.info("[DaemonBridge] Daemon already running");
+                        return true;
+                    }
+                    LOG.info("[DaemonBridge] Existing daemon generation still owns lifecycle "
+                            + "cleanup; refusing to replace generation="
+                            + existingContext.generation);
                     return false;
                 }
-
-                File daemonScript = new File(bridgeDir, DAEMON_SCRIPT);
-                if (!daemonScript.exists()) {
-                    LOG.error("[DaemonBridge] daemon.js not found at: " + daemonScript.getAbsolutePath());
+                if (restartInProgress) {
+                    LOG.info("[DaemonBridge] Daemon restart cleanup is still in progress");
                     return false;
                 }
-
-                String nodePath = nodeDetector.findNodeExecutable();
-                if (nodePath == null) {
-                    LOG.error("[DaemonBridge] Node.js not found");
-                    return false;
-                }
-
-                List<String> daemonCmd = NodeDetector.buildNodeScriptCommand(
-                        nodePath, daemonScript.getAbsolutePath());
-                ProcessBuilder pb = new ProcessBuilder(daemonCmd);
-                pb.directory(bridgeDir);
-
-                // Configure environment
-                Map<String, String> env = pb.environment();
-                envConfigurator.updateProcessEnvironment(pb, nodePath);
-
-                // Pass through user-configured Claude Code CLI override (if any).
-                // Picked up by ai-bridge to set SDK option `pathToClaudeCodeExecutable`.
-                String claudeCliPath = PropertiesComponent.getInstance()
-                        .getValue(ClaudeCliPathHandler.CLAUDE_CLI_PATH_PROPERTY_KEY);
-                if (claudeCliPath != null && !claudeCliPath.trim().isEmpty()) {
-                    env.put("CLAUDE_CODE_PATH", claudeCliPath.trim());
-                    LOG.info("[DaemonBridge] Using custom Claude CLI: " + claudeCliPath.trim());
-                }
-
-                // Keep stderr separate for debugging
-                pb.redirectErrorStream(false);
-
-                daemonProcess = pb.start();
-                isRunning.set(true);
-                lastSuccessfulStart.set(System.currentTimeMillis());
-                markDaemonActivity();
-
-                LOG.info("[DaemonBridge] Daemon process started, PID: " + daemonProcess.pid()
-                        + ", cmd: " + String.join(" ", daemonCmd)
-                        + ", cwd: " + bridgeDir.getAbsolutePath());
-
-                awaitingReady.set(true);
-                synchronized (stderrRingLock) {
-                    recentStderrLines.clear();
-                }
-
-                // Setup stdin writer
-                daemonStdin = new BufferedWriter(
-                        new OutputStreamWriter(daemonProcess.getOutputStream(), StandardCharsets.UTF_8));
-
-                // Start stdout reader thread
-                startReaderThread();
-
-                // Start stderr reader thread (for debugging)
-                startStderrReaderThread();
-
-                // Wait for "ready" event, but fail fast if process exits early.
-                boolean ready = false;
-                long deadline = System.currentTimeMillis() + DAEMON_START_TIMEOUT_MS;
-                while (System.currentTimeMillis() < deadline) {
-                    if (latch.await(200, TimeUnit.MILLISECONDS)) {
-                        ready = true;
-                        break;
-                    }
-                    if (daemonProcess == null || !daemonProcess.isAlive() || !isRunning.get()) {
-                        logDaemonStartupFailure("exited_before_ready");
-                        isRunning.set(false);
-                        return false;
-                    }
-                }
-                if (!ready) {
-                    LOG.warn("[DaemonBridge] Daemon did not signal ready within timeout");
-                    if (daemonProcess == null || !daemonProcess.isAlive() || !isRunning.get()) {
-                        logDaemonStartupFailure("not_alive_after_ready_timeout");
-                        isRunning.set(false);
-                        return false;
-                    }
-                }
-
-                // Start heartbeat thread
-                startHeartbeatThread();
-
-                LOG.info("[DaemonBridge] Daemon is ready. SDK preloaded: " + sdkPreloaded.get());
-                return true;
-
-            } catch (Exception e) {
-                LOG.error("[DaemonBridge] Failed to start daemon", e);
-                isRunning.set(false);
-                return false;
-            } finally {
-                awaitingReady.set(false);
+                desiredRunning = true;
+                attempt = reserveStartAttemptLocked();
+                ownsAttempt = true;
             }
         }
+        return ownsAttempt ? executeStartAttempt(attempt) : attempt.awaitResult();
+    }
+
+    private StartAttempt reserveStartAttemptLocked() {
+        StartAttempt attempt = new StartAttempt(
+                startAttemptCounter.incrementAndGet(), stopEpoch);
+        activeStartAttempt = attempt;
+        return attempt;
+    }
+
+    private boolean executeStartAttempt(StartAttempt attempt) {
+        DaemonGenerationContext startedContext = null;
+        Process startedProcess = null;
+        try {
+            synchronized (startLock) {
+                if (!isStartAttemptCurrentLocked(attempt)) {
+                    attempt.complete(false);
+                    return false;
+                }
+            }
+
+            startedProcess = processLauncher.launch();
+            BufferedWriter startedStdin = new BufferedWriter(
+                    new OutputStreamWriter(startedProcess.getOutputStream(), StandardCharsets.UTF_8));
+            long startedGeneration = daemonGenerationCounter.incrementAndGet();
+            long startedWallTime = timeSource.currentTimeMillis();
+            long startedNanos = timeSource.nanoTime();
+            startedContext = new DaemonGenerationContext(
+                    startedProcess,
+                    startedStdin,
+                    startedGeneration,
+                    startedWallTime,
+                    startedNanos);
+
+            synchronized (startLock) {
+                if (!isStartAttemptCurrentLocked(attempt)) {
+                    startedContext.stop();
+                    destroyProcess(startedProcess);
+                    attempt.complete(false);
+                    return false;
+                }
+                daemonContext = startedContext;
+                attempt.context = startedContext;
+            }
+
+            LOG.info("[DaemonBridge] Daemon process started, PID: " + startedProcess.pid()
+                    + ", generation=" + startedGeneration
+                    + ", startAttempt=" + attempt.id);
+
+            startReaderThread(startedContext);
+            startStderrReaderThread(startedContext);
+
+            boolean ready = awaitDaemonReady(attempt, startedContext);
+            if (!ready) {
+                String failurePhase = startedProcess.isAlive()
+                        ? "ready_timeout" : "exited_before_ready";
+                logDaemonStartupFailure(startedContext, failurePhase);
+                LOG.warn("[DaemonBridge] Daemon failed to signal ready for startAttempt="
+                        + attempt.id);
+                failStartAttempt(attempt, startedContext, startedProcess);
+                return false;
+            }
+
+            startHeartbeatThread(startedContext);
+            synchronized (startLock) {
+                if (!isStartAttemptCurrentLocked(attempt)
+                        || daemonContext != startedContext
+                        || !startedContext.isActive()
+                        || !startedProcess.isAlive()) {
+                    failStartAttemptLocked(attempt, startedContext);
+                    destroyProcess(startedProcess);
+                    return false;
+                }
+                startedContext.publishStartup();
+                activeStartAttempt = null;
+                attempt.complete(true);
+            }
+
+            LOG.info("[DaemonBridge] Daemon is ready. SDK preloaded: "
+                    + startedContext.sdkPreloaded.get());
+            return true;
+        } catch (Exception e) {
+            LOG.error("[DaemonBridge] Failed to start daemon", e);
+            failStartAttempt(attempt, startedContext, startedProcess);
+            return false;
+        }
+    }
+
+    private boolean awaitDaemonReady(
+            StartAttempt attempt,
+            DaemonGenerationContext context
+    ) throws InterruptedException {
+        long startWaitNanos = timeSource.nanoTime();
+        while (elapsedMillis(timeSource.nanoTime(), startWaitNanos)
+                < DAEMON_START_TIMEOUT_MS) {
+            if (context.readyLatch.await(200, TimeUnit.MILLISECONDS)) {
+                return context.isActive() && context.process.isAlive();
+            }
+            synchronized (startLock) {
+                if (!isStartAttemptCurrentLocked(attempt)
+                        || daemonContext != context
+                        || !context.isActive()
+                        || !context.process.isAlive()) {
+                    return false;
+                }
+            }
+        }
+        return false;
+    }
+
+    private void failStartAttempt(
+            StartAttempt attempt,
+            DaemonGenerationContext context,
+            Process process
+    ) {
+        synchronized (startLock) {
+            failStartAttemptLocked(attempt, context);
+        }
+        destroyProcess(process);
+    }
+
+    private void failStartAttemptLocked(
+            StartAttempt attempt,
+            DaemonGenerationContext context
+    ) {
+        if (context != null && !context.isStartupPublished()) {
+            context.stop();
+        }
+        if (activeStartAttempt == attempt) {
+            activeStartAttempt = null;
+            if (stopEpoch == attempt.stopEpoch) {
+                desiredRunning = false;
+            }
+        }
+        attempt.complete(false);
+    }
+
+    private boolean isStartAttemptCurrentLocked(StartAttempt attempt) {
+        return desiredRunning
+                && stopEpoch == attempt.stopEpoch
+                && activeStartAttempt == attempt
+                && !attempt.isCancelled();
+    }
+
+    private static void destroyProcess(Process process) {
+        if (process != null && process.isAlive()) {
+            process.destroyForcibly();
+        }
+    }
+
+    private Process launchConfiguredDaemon() throws IOException {
+        File bridgeDir = directoryResolver.findSdkDir();
+        if (bridgeDir == null) {
+            throw new IOException("Bridge directory not found");
+        }
+
+        File daemonScript = new File(bridgeDir, DAEMON_SCRIPT);
+        if (!daemonScript.exists()) {
+            throw new IOException("daemon.js not found at: " + daemonScript.getAbsolutePath());
+        }
+
+        String nodePath = nodeDetector.findNodeExecutable();
+        if (nodePath == null) {
+            throw new IOException("Node.js not found");
+        }
+
+        List<String> daemonCmd = NodeDetector.buildNodeScriptCommand(
+                nodePath, daemonScript.getAbsolutePath());
+        ProcessBuilder processBuilder = new ProcessBuilder(daemonCmd);
+        processBuilder.directory(bridgeDir);
+        envConfigurator.updateProcessEnvironment(processBuilder, nodePath);
+
+        Map<String, String> environment = processBuilder.environment();
+        String claudeCliPath = PropertiesComponent.getInstance()
+                .getValue(ClaudeCliPathHandler.CLAUDE_CLI_PATH_PROPERTY_KEY);
+        if (claudeCliPath != null && !claudeCliPath.trim().isEmpty()) {
+            environment.put("CLAUDE_CODE_PATH", claudeCliPath.trim());
+            LOG.info("[DaemonBridge] Using custom Claude CLI: " + claudeCliPath.trim());
+        }
+
+        processBuilder.redirectErrorStream(false);
+        Process process = processBuilder.start();
+        LOG.info("[DaemonBridge] Daemon process launched, PID: " + process.pid()
+                + ", cmd: " + String.join(" ", daemonCmd)
+                + ", cwd: " + bridgeDir.getAbsolutePath());
+        return process;
     }
 
     /**
@@ -219,26 +364,38 @@ public class DaemonBridge {
      */
     public void stop() {
         LOG.info("[DaemonBridge] Stopping daemon...");
-        isRunning.set(false);
+        DaemonGenerationContext context;
+        synchronized (startLock) {
+            desiredRunning = false;
+            stopEpoch++;
+            StartAttempt startAttempt = activeStartAttempt;
+            activeStartAttempt = null;
+            if (startAttempt != null) {
+                startAttempt.cancel();
+            }
+            context = daemonContext;
+            if (context != null) {
+                context.stop();
+            }
+        }
+        if (context == null) {
+            return;
+        }
 
         // Cancel all pending requests
-        for (Map.Entry<String, RequestHandler> entry : pendingRequests.entrySet()) {
-            entry.getValue().onError("Daemon stopped");
+        for (RequestHandler handler : context.drainRequests()) {
+            handler.onError("Daemon stopped");
         }
-        pendingRequests.clear();
-        activeRequestCount.set(0);
 
         // Send shutdown command before closing stdin (allows daemon to flush)
         try {
-            if (daemonStdin != null) {
-                JsonObject shutdown = new JsonObject();
-                shutdown.addProperty("id", "shutdown");
-                shutdown.addProperty("method", "shutdown");
-                synchronized (daemonStdin) {
-                    daemonStdin.write(shutdown.toString());
-                    daemonStdin.newLine();
-                    daemonStdin.flush();
-                }
+            JsonObject shutdown = new JsonObject();
+            shutdown.addProperty("id", "shutdown");
+            shutdown.addProperty("method", "shutdown");
+            synchronized (context.stdin) {
+                context.stdin.write(shutdown.toString());
+                context.stdin.newLine();
+                context.stdin.flush();
             }
         } catch (IOException e) {
             LOG.debug("[DaemonBridge] Error sending shutdown command: " + e.getMessage());
@@ -246,36 +403,34 @@ public class DaemonBridge {
 
         // Close stdin (triggers daemon shutdown if command wasn't received)
         try {
-            if (daemonStdin != null) {
-                daemonStdin.close();
-            }
+            context.stdin.close();
         } catch (IOException e) {
             LOG.debug("[DaemonBridge] Error closing stdin: " + e.getMessage());
         }
 
         // Kill process if still alive and wait for termination
-        if (daemonProcess != null && daemonProcess.isAlive()) {
-            daemonProcess.destroyForcibly();
+        if (context.process.isAlive()) {
+            context.process.destroyForcibly();
             try {
-                daemonProcess.waitFor(3, TimeUnit.SECONDS);
+                context.process.waitFor(3, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
         }
 
         // Interrupt and join threads
-        if (readerThread != null) {
-            readerThread.interrupt();
+        if (context.readerThread != null && context.readerThread != Thread.currentThread()) {
+            context.readerThread.interrupt();
             try {
-                readerThread.join(2000);
+                context.readerThread.join(2000);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
         }
-        if (heartbeatThread != null) {
-            heartbeatThread.interrupt();
+        if (context.heartbeatThread != null && context.heartbeatThread != Thread.currentThread()) {
+            context.heartbeatThread.interrupt();
             try {
-                heartbeatThread.join(2000);
+                context.heartbeatThread.join(2000);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
@@ -290,16 +445,17 @@ public class DaemonBridge {
      * Also completes all pending request futures so Java-side blocking calls unblock.
      */
     public void sendAbort() {
+        DaemonGenerationContext context = daemonContext;
         // Send abort command to daemon so it stops the active SDK query
         try {
-            if (daemonStdin != null && isRunning.get()) {
+            if (context != null && context.isActive()) {
                 JsonObject abort = new JsonObject();
                 abort.addProperty("id", "abort-" + System.currentTimeMillis());
                 abort.addProperty("method", "abort");
-                synchronized (daemonStdin) {
-                    daemonStdin.write(abort.toString());
-                    daemonStdin.newLine();
-                    daemonStdin.flush();
+                synchronized (context.stdin) {
+                    context.stdin.write(abort.toString());
+                    context.stdin.newLine();
+                    context.stdin.flush();
                 }
                 LOG.info("[DaemonBridge] Sent abort command");
             }
@@ -311,18 +467,20 @@ public class DaemonBridge {
         // Use onComplete(false) instead of onError() so that user-initiated aborts
         // are treated as a normal (unsuccessful) completion rather than an error,
         // matching the graceful handling that Codex uses.
-        for (Map.Entry<String, RequestHandler> entry : pendingRequests.entrySet()) {
-            entry.getValue().onAbort();
+        if (context != null) {
+            for (RequestHandler handler : context.drainRequests()) {
+                handler.onAbort();
+            }
         }
-        pendingRequests.clear();
-        activeRequestCount.set(0);
     }
 
     /**
      * Check if the daemon is running and healthy.
      */
     public boolean isAlive() {
-        return isRunning.get() && daemonProcess != null && daemonProcess.isAlive();
+        DaemonGenerationContext context = daemonContext;
+        return context != null && context.isStartupPublished()
+                && context.isActive() && context.process.isAlive();
     }
 
     /**
@@ -331,7 +489,8 @@ public class DaemonBridge {
      * this reference — always go through stop() to keep state consistent.
      */
     public Process getDaemonProcessForInspection() {
-        return daemonProcess;
+        DaemonGenerationContext context = daemonContext;
+        return context != null ? context.process : null;
     }
 
     /**
@@ -339,7 +498,8 @@ public class DaemonBridge {
      * Used by the management panel to indicate daemon load.
      */
     public int getActiveRequestCount() {
-        return activeRequestCount.get();
+        DaemonGenerationContext context = daemonContext;
+        return context != null ? context.activeRequestCount.get() : 0;
     }
 
     /**
@@ -376,25 +536,25 @@ public class DaemonBridge {
             f.completeExceptionally(new IOException("Daemon not running"));
             return f;
         }
+        DaemonGenerationContext context = daemonContext;
+        if (context == null || !context.isActive() || !context.process.isAlive()) {
+            CompletableFuture<Boolean> f = new CompletableFuture<>();
+            f.completeExceptionally(new IOException("Daemon generation changed before request"));
+            return f;
+        }
 
         String requestId = String.valueOf(requestIdCounter.incrementAndGet());
         CompletableFuture<Boolean> future = new CompletableFuture<>();
         boolean countsAsActiveRequest = !"heartbeat".equals(method) && !"status".equals(method);
 
         RequestHandler handler = new RequestHandler(callback, future);
-        pendingRequests.put(requestId, handler);
-        if (countsAsActiveRequest) {
-            activeRequestCount.incrementAndGet();
+        if (!context.registerRequest(requestId, handler, countsAsActiveRequest, timeSource)) {
+            future.completeExceptionally(new IOException("Daemon generation is no longer active"));
+            return future;
         }
-        markDaemonActivity();
 
         // Ensure cleanup when future completes (e.g., via timeout or cancellation)
-        future.whenComplete((result, ex) -> {
-            pendingRequests.remove(requestId);
-            if (countsAsActiveRequest) {
-                activeRequestCount.updateAndGet(current -> Math.max(0, current - 1));
-            }
-        });
+        future.whenComplete((result, ex) -> context.removeRequest(requestId));
 
         // Build request JSON
         JsonObject request = new JsonObject();
@@ -403,14 +563,17 @@ public class DaemonBridge {
         request.add("params", params);
 
         try {
-            synchronized (daemonStdin) {
-                daemonStdin.write(request.toString());
-                daemonStdin.newLine();
-                daemonStdin.flush();
+            synchronized (context.stdin) {
+                if (!context.isActive()) {
+                    throw new IOException("Daemon generation changed before write");
+                }
+                context.stdin.write(request.toString());
+                context.stdin.newLine();
+                context.stdin.flush();
             }
             LOG.info("[DaemonBridge] Sent request " + requestId + ": " + method);
         } catch (IOException e) {
-            pendingRequests.remove(requestId);
+            context.removeRequest(requestId);
             future.completeExceptionally(e);
             LOG.error("[DaemonBridge] Failed to send request: " + e.getMessage());
         }
@@ -422,34 +585,41 @@ public class DaemonBridge {
     // Reader Threads
     // =========================================================================
 
-    private void startReaderThread() {
-        readerThread = new Thread(() -> {
+    private void startReaderThread(DaemonGenerationContext context) {
+        context.readerThread = new Thread(() -> {
             try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(daemonProcess.getInputStream(), StandardCharsets.UTF_8))) {
+                    new InputStreamReader(context.process.getInputStream(), StandardCharsets.UTF_8))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
-                    handleDaemonOutput(line);
+                    if (!isCurrentDaemon(context) || !context.isActive()) {
+                        break;
+                    }
+                    handleDaemonOutput(line, context);
                 }
             } catch (IOException e) {
-                if (isRunning.get()) {
+                if (isCurrentDaemon(context) && context.isActive()) {
                     LOG.error("[DaemonBridge] Reader thread error: " + e.getMessage());
                 }
             } finally {
-                handleDaemonDeath();
+                handleDaemonDeath(context, null);
             }
         }, "DaemonBridge-Reader");
-        readerThread.setDaemon(true);
-        readerThread.start();
+        context.readerThread.setDaemon(true);
+        context.readerThread.start();
     }
 
-    private void startStderrReaderThread() {
+    private void startStderrReaderThread(DaemonGenerationContext context) {
         Thread stderrThread = new Thread(() -> {
             try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(daemonProcess.getErrorStream(), StandardCharsets.UTF_8))) {
+                    new InputStreamReader(context.process.getErrorStream(), StandardCharsets.UTF_8))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
-                    appendStderrLine(line);
-                    LOG.debug("[DaemonBridge:stderr] " + line);
+                    if (!shouldRecordStderrLine(daemonContext, context)) {
+                        break;
+                    }
+                    context.appendStderrLine(line);
+                    LOG.debug("[DaemonBridge:stderr] generation="
+                            + context.generation + " " + line);
                 }
             } catch (IOException e) {
                 // Expected on shutdown
@@ -459,59 +629,88 @@ public class DaemonBridge {
         stderrThread.start();
     }
 
-    private void startHeartbeatThread() {
-        // Initialize heartbeat baseline so the first check doesn't trigger timeout
-        long now = System.currentTimeMillis();
-        lastHeartbeatResponse.set(now);
-        lastDaemonActivity.set(now);
+    private void startHeartbeatThread(DaemonGenerationContext context) {
+        IdleHeartbeatProbeState heartbeatProbeState = new IdleHeartbeatProbeState();
+        heartbeatProbeState.reset(timeSource.currentTimeMillis());
 
-        heartbeatThread = new Thread(() -> {
-            while (isRunning.get()) {
+        context.heartbeatThread = new Thread(() -> {
+            while (context.isActive() && isCurrentDaemon(context)) {
                 try {
-                    Thread.sleep(HEARTBEAT_INTERVAL_MS);
-                    if (!isAlive()) { break; }
-
-                    // Check if daemon is unresponsive (no heartbeat response for too long)
-                    long currentTime = System.currentTimeMillis();
-                    long heartbeatAgeMs = currentTime - lastHeartbeatResponse.get();
-                    long activityAgeMs = currentTime - lastDaemonActivity.get();
-                    int activeRequests = activeRequestCount.get();
-                    if (shouldTreatAsUnresponsive(heartbeatAgeMs, activityAgeMs, activeRequests)) {
-                        LOG.warn("[DaemonBridge] Daemon unresponsive (heartbeatAgeMs=" + heartbeatAgeMs
-                                + ", activityAgeMs=" + activityAgeMs
-                                + ", activeRequests=" + activeRequests + "), treating as dead");
-                        handleDaemonDeath();
+                    Thread.sleep(heartbeatIntervalMs);
+                    lifecycleHooks.beforeHeartbeatCheck(context.generation);
+                    if (!context.isActive() || !isCurrentDaemon(context)) {
+                        break;
+                    }
+                    if (!context.process.isAlive()) {
+                        handleDaemonDeath(context, null);
                         break;
                     }
 
-                    // Send heartbeat
+                    HeartbeatObservation observation =
+                            context.captureHeartbeatObservation(timeSource);
+                    int activeRequests = observation.activeRequestCount;
+                    HeartbeatDecision decision = heartbeatProbeState.evaluate(observation);
+                    if (decision == HeartbeatDecision.DECLARE_DEAD) {
+                        String probeDetail = activeRequests <= 0
+                                ? " after heartbeat probe" : " with active request";
+                        LOG.warn("[DaemonBridge] Daemon unresponsive" + probeDetail
+                                + " (activeRequests=" + activeRequests
+                                + ", generation=" + context.generation + "), treating as dead");
+                        DeathHandlingResult result = handleDaemonDeath(context, observation);
+                        if (shouldContinueHeartbeatAfterDeath(result)) {
+                            continue;
+                        }
+                        break;
+                    }
+                    if (decision == HeartbeatDecision.WAIT_FOR_PROBE) {
+                        continue;
+                    }
+                    if (decision == HeartbeatDecision.SEND_PROBE) {
+                        LOG.info("[DaemonBridge] Daemon heartbeat is stale; sending a resume-safe probe"
+                                + " before restart (activeRequests=" + activeRequests
+                                + ", generation=" + context.generation + ")");
+                    }
+
+                    // Send the regular heartbeat, or the one bounded liveness probe.
                     JsonObject hb = new JsonObject();
-                    hb.addProperty("id", "hb-" + System.currentTimeMillis());
+                    hb.addProperty("id", "hb-" + timeSource.currentTimeMillis());
                     hb.addProperty("method", "heartbeat");
-                    synchronized (daemonStdin) {
-                        daemonStdin.write(hb.toString());
-                        daemonStdin.newLine();
-                        daemonStdin.flush();
+                    synchronized (context.stdin) {
+                        if (!isCurrentDaemon(context) || !context.isActive()) {
+                            break;
+                        }
+                        context.stdin.write(hb.toString());
+                        context.stdin.newLine();
+                        context.stdin.flush();
                     }
                 } catch (InterruptedException e) {
                     break;
                 } catch (IOException e) {
                     LOG.warn("[DaemonBridge] Heartbeat failed: " + e.getMessage());
-                    handleDaemonDeath();
+                    handleDaemonDeath(context, null);
                     break;
                 }
             }
         }, "DaemonBridge-Heartbeat");
-        heartbeatThread.setDaemon(true);
-        heartbeatThread.start();
+        context.heartbeatThread.setDaemon(true);
+        context.heartbeatThread.start();
     }
 
     // =========================================================================
     // Output Parsing
     // =========================================================================
 
-    private void handleDaemonOutput(String jsonLine) {
-        markDaemonActivity();
+    private void handleDaemonOutput(String jsonLine, DaemonGenerationContext context) {
+        synchronized (context) {
+            if (!isCurrentDaemon(context) || !context.isActive()) {
+                return;
+            }
+            handleActiveDaemonOutput(jsonLine, context);
+        }
+    }
+
+    private void handleActiveDaemonOutput(String jsonLine, DaemonGenerationContext context) {
+        context.heartbeatTimestamps.markActivity(timeSource);
         // Skip non-JSON lines (SDK debug output, permission logs, etc.)
         String trimmed = jsonLine.trim();
         if (trimmed.isEmpty() || trimmed.charAt(0) != '{') {
@@ -529,14 +728,13 @@ public class DaemonBridge {
                 String type = obj.get("type").getAsString();
 
                 if ("daemon".equals(type)) {
-                    handleDaemonEvent(obj);
+                    handleDaemonEvent(obj, context);
                     return;
                 }
 
                 if ("heartbeat".equals(type)) {
                     // Heartbeat response — daemon is alive
-                    lastHeartbeatResponse.set(System.currentTimeMillis());
-                    markDaemonActivity();
+                    context.markHeartbeat(timeSource);
                     return;
                 }
 
@@ -553,7 +751,7 @@ public class DaemonBridge {
             // Skip heartbeat responses
             if (id.startsWith("hb-")) { return; }
 
-            RequestHandler handler = pendingRequests.get(id);
+            RequestHandler handler = context.getRequestHandler(id);
             if (handler == null) {
                 LOG.debug("[DaemonBridge] No handler for request " + id);
                 return;
@@ -566,7 +764,7 @@ public class DaemonBridge {
                     handler.onError(obj.get("error").getAsString());
                 }
                 handler.onComplete(success);
-                pendingRequests.remove(id);
+                context.removeRequest(id);
                 return;
             }
 
@@ -586,29 +784,27 @@ public class DaemonBridge {
         }
     }
 
-    private void handleDaemonEvent(JsonObject obj) {
+    private void handleDaemonEvent(JsonObject obj, DaemonGenerationContext context) {
         String event = obj.has("event") ? obj.get("event").getAsString() : "unknown";
         LOG.info("[DaemonBridge] Daemon event: " + event);
 
         switch (event) {
             case "ready":
-                if (obj.has("sdkPreloaded")) {
-                    sdkPreloaded.set(obj.get("sdkPreloaded").getAsBoolean());
-                }
-                readyLatch.countDown();
-                if (lifecycleListener != null) {
+                boolean preloaded = obj.has("sdkPreloaded")
+                        && obj.get("sdkPreloaded").getAsBoolean();
+                if (context.signalReady(preloaded) && lifecycleListener != null) {
                     lifecycleListener.onDaemonReady();
                 }
                 break;
 
             case "startup_failed": {
                 String startupError = obj.has("error") ? obj.get("error").getAsString() : "unknown";
-                LOG.error("[DaemonBridge] Daemon reported startup_failed: " + startupError);
+                LOG.warn("[DaemonBridge] Daemon reported startup_failed: " + startupError);
                 break;
             }
 
             case "sdk_loaded":
-                sdkPreloaded.set(true);
+                context.markSdkPreloaded();
                 LOG.info("[DaemonBridge] SDK pre-loaded successfully");
                 break;
 
@@ -707,60 +903,126 @@ public class DaemonBridge {
     // Daemon Death & Auto-Restart
     // =========================================================================
 
-    private void handleDaemonDeath() {
-        if (!isRunning.compareAndSet(true, false)) { return; }
+    private DeathHandlingResult handleDaemonDeath(
+            DaemonGenerationContext context,
+            HeartbeatObservation timeoutObservation
+    ) {
+        List<RequestHandler> failedHandlers;
+        long claimedStopEpoch;
+        synchronized (context) {
+            if (timeoutObservation != null
+                    && !context.matchesTimeoutObservation(timeoutObservation)) {
+                LOG.info("[DaemonBridge] Cancelling stale heartbeat timeout for generation="
+                        + context.generation + " because daemon progress advanced");
+                return DeathHandlingResult.CANCELLED;
+            }
+            synchronized (startLock) {
+                if (!isCurrentDaemon(context) || !context.isActive() || !desiredRunning
+                        || restartInProgress) {
+                    LOG.debug("[DaemonBridge] Ignoring stale death signal for generation="
+                            + context.generation);
+                    return DeathHandlingResult.STALE_GENERATION;
+                }
+                restartInProgress = true;
+                claimedStopEpoch = stopEpoch;
+                context.claimDeath();
+            }
+            failedHandlers = context.drainRequests();
+        }
 
-        LOG.warn("[DaemonBridge] Daemon process died");
+        LOG.warn("[DaemonBridge] Daemon process died, generation=" + context.generation);
 
-        // Forcefully kill the old process if still alive (e.g., heartbeat timeout)
-        Process oldProcess = daemonProcess;
-        if (oldProcess != null && oldProcess.isAlive()) {
+        // Kill only the process whose generation was atomically claimed.
+        if (context.process.isAlive()) {
             LOG.info("[DaemonBridge] Forcefully killing unresponsive daemon process (PID: "
-                    + oldProcess.pid() + ")");
-            oldProcess.destroyForcibly();
+                    + context.process.pid() + ", generation=" + context.generation + ")");
+            context.process.destroyForcibly();
             try {
-                oldProcess.waitFor(2, TimeUnit.SECONDS);
+                context.process.waitFor(2, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
         }
 
-        // Fail all pending requests
-        for (Map.Entry<String, RequestHandler> entry : pendingRequests.entrySet()) {
-            entry.getValue().onError("Daemon process died unexpectedly");
+        // The old generation is already detached, so callbacks cannot remove B's requests.
+        for (RequestHandler handler : failedHandlers) {
+            try {
+                handler.onError("Daemon process died unexpectedly");
+            } catch (RuntimeException e) {
+                LOG.warn("[DaemonBridge] Request callback failed during daemon cleanup", e);
+            }
         }
-        pendingRequests.clear();
-        activeRequestCount.set(0);
 
-        // Notify listener
         if (lifecycleListener != null) {
-            lifecycleListener.onDaemonDied();
+            try {
+                lifecycleListener.onDaemonDied();
+            } catch (RuntimeException e) {
+                LOG.warn("[DaemonBridge] Lifecycle listener failed during daemon cleanup", e);
+            }
         }
 
-        // Auto-restart if within limit.
-        // If the daemon ran stably for RESTART_WINDOW_MS before dying, reset the
-        // counter so transient failures don't exhaust attempts permanently.
-        long uptime = System.currentTimeMillis() - lastSuccessfulStart.get();
+        // Stability intentionally includes suspended time on every platform.
+        long uptime = elapsedWallMillis(
+                timeSource.currentTimeMillis(), context.startedAtWallTimeMs);
         if (uptime > RESTART_WINDOW_MS) {
             restartAttempts.set(0);
         }
 
-        if (awaitingReady.get()) {
-            LOG.warn("[DaemonBridge] Daemon died during startup wait; skipping auto-restart"
-                    + " (coordinator will fall back to per-process mode). "
-                    + formatRecentStderrTail());
-            return;
+        Thread oldHeartbeat = context.heartbeatThread;
+        if (oldHeartbeat != null && oldHeartbeat != Thread.currentThread()) {
+            oldHeartbeat.interrupt();
+        }
+
+        if (!context.isStartupPublished()) {
+            synchronized (startLock) {
+                restartInProgress = false;
+                StartAttempt startAttempt = activeStartAttempt;
+                if (startAttempt != null && startAttempt.context == context) {
+                    activeStartAttempt = null;
+                    if (stopEpoch == startAttempt.stopEpoch) {
+                        desiredRunning = false;
+                    }
+                    startAttempt.complete(false);
+                }
+            }
+            LOG.info("[DaemonBridge] Initial daemon exited before ready; "
+                    + "background restart is disabled until the owner calls start() again. "
+                    + context.formatRecentStderrTail());
+            return DeathHandlingResult.CLAIMED;
         }
 
         int attempts = restartAttempts.incrementAndGet();
-        if (attempts <= MAX_RESTART_ATTEMPTS) {
-            LOG.info("[DaemonBridge] Attempting restart (" + attempts + "/" + MAX_RESTART_ATTEMPTS
-                    + ", last uptime=" + uptime + "ms)");
-            start();
-        } else {
-            LOG.error("[DaemonBridge] Max restart attempts reached (" + attempts
-                    + " within " + RESTART_WINDOW_MS + "ms window). Daemon will not be restarted.");
+        lifecycleHooks.beforeAutoRestartCheck(context.generation);
+        StartAttempt restartAttempt = null;
+        synchronized (startLock) {
+            restartInProgress = false;
+            boolean stillDesired = desiredRunning
+                    && stopEpoch == claimedStopEpoch
+                    && daemonContext == context
+                    && !context.isStopped();
+            if (shouldAutoRestart(
+                    desiredRunning,
+                    stopEpoch,
+                    claimedStopEpoch,
+                    daemonContext,
+                    context,
+                    attempts)) {
+                LOG.info("[DaemonBridge] Attempting restart (" + attempts + "/"
+                        + MAX_RESTART_ATTEMPTS + ", last uptime=" + uptime + "ms)");
+                restartAttempt = reserveStartAttemptLocked();
+            } else if (!stillDesired) {
+                LOG.info("[DaemonBridge] Automatic restart cancelled by newer lifecycle intent");
+            } else {
+                LOG.error("[DaemonBridge] Max restart attempts reached (" + attempts
+                        + " within " + RESTART_WINDOW_MS
+                        + "ms window). Daemon will not be restarted.");
+            }
         }
+        lifecycleHooks.afterAutoRestartCheck(context.generation);
+        if (restartAttempt != null) {
+            executeStartAttempt(restartAttempt);
+        }
+        return DeathHandlingResult.CLAIMED;
     }
 
     // =========================================================================
@@ -791,52 +1053,31 @@ public class DaemonBridge {
     }
 
     public boolean isSdkPreloaded() {
-        return sdkPreloaded.get();
+        DaemonGenerationContext context = daemonContext;
+        return context != null && context.sdkPreloaded.get();
     }
 
-    private void appendStderrLine(String line) {
-        if (line == null) { return; }
-        synchronized (stderrRingLock) {
-            recentStderrLines.addLast(line);
-            while (recentStderrLines.size() > STDERR_RING_CAPACITY) {
-                recentStderrLines.removeFirst();
-            }
-        }
-    }
-
-    private String formatRecentStderrTail() {
-        synchronized (stderrRingLock) {
-            if (recentStderrLines.isEmpty()) {
-                return "stderr=(empty)";
-            }
-            return "stderrTail=" + String.join(" | ", recentStderrLines);
-        }
-    }
-
-    private void logDaemonStartupFailure(String phase) {
+    private void logDaemonStartupFailure(
+            DaemonGenerationContext context,
+            String phase
+    ) {
         int exitCode = Integer.MIN_VALUE;
-        Process process = daemonProcess;
+        Process process = context != null ? context.process : null;
         if (process != null) {
             try {
                 if (!process.isAlive()) {
                     exitCode = process.exitValue();
-                } else {
-                    boolean finished = process.waitFor(500, TimeUnit.MILLISECONDS);
-                    if (finished) {
-                        exitCode = process.exitValue();
-                    }
                 }
             } catch (IllegalThreadStateException stillRunning) {
                 exitCode = Integer.MIN_VALUE;
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
             }
         }
         String exitLabel = exitCode == Integer.MIN_VALUE ? "unknown" : String.valueOf(exitCode);
-        LOG.error("[DaemonBridge] Daemon exited before signaling ready"
+        LOG.warn("[DaemonBridge] Daemon exited before signaling ready"
                 + " (phase=" + phase
                 + ", exitCode=" + exitLabel
-                + ", " + formatRecentStderrTail() + ")");
+                + ", " + (context != null
+                        ? context.formatRecentStderrTail() : "stderr=(unavailable)") + ")");
     }
 
     static boolean shouldTreatAsUnresponsive(long heartbeatAgeMs, long activityAgeMs, int activeRequestCount) {
@@ -847,8 +1088,480 @@ public class DaemonBridge {
         return livenessAgeMs > ACTIVE_REQUEST_HEARTBEAT_TIMEOUT_MS;
     }
 
-    private void markDaemonActivity() {
-        lastDaemonActivity.set(System.currentTimeMillis());
+    static boolean shouldRecordStderrLine(
+            DaemonGenerationContext currentContext,
+            DaemonGenerationContext sourceContext
+    ) {
+        return sourceContext != null
+                && currentContext == sourceContext
+                && sourceContext.isActive();
+    }
+
+    static boolean shouldAutoRestart(
+            boolean desiredRunning,
+            long currentStopEpoch,
+            long claimedStopEpoch,
+            DaemonGenerationContext currentContext,
+            DaemonGenerationContext claimedContext,
+            int attempts
+    ) {
+        return desiredRunning
+                && currentStopEpoch == claimedStopEpoch
+                && currentContext == claimedContext
+                && !claimedContext.isStopped()
+                && attempts <= MAX_RESTART_ATTEMPTS;
+    }
+
+    enum HeartbeatDecision {
+        HEALTHY,
+        SEND_PROBE,
+        WAIT_FOR_PROBE,
+        DECLARE_DEAD
+    }
+
+    enum DeathHandlingResult {
+        CLAIMED,
+        CANCELLED,
+        STALE_GENERATION
+    }
+
+    static boolean shouldContinueHeartbeatAfterDeath(DeathHandlingResult result) {
+        return result == DeathHandlingResult.CANCELLED;
+    }
+
+    /**
+     * Applies probe-first recovery only to idle daemons. Active requests keep
+     * the established timeout semantics until request-level resume progress can
+     * be identified independently from daemon heartbeat traffic.
+     */
+    static final class IdleHeartbeatProbeState {
+        private long lastCheckWallTimeMs = -1;
+        private long probeStartedAtNanos;
+        private long probeHeartbeatVersion;
+        private boolean probeActive;
+
+        synchronized HeartbeatDecision evaluate(HeartbeatObservation observation) {
+            long nowWallTimeMs = observation.nowWallTimeMs;
+            long nowNanos = observation.nowNanos;
+            int activeRequestCount = observation.activeRequestCount;
+            boolean schedulerDiscontinuity = lastCheckWallTimeMs >= 0
+                    && (nowWallTimeMs < lastCheckWallTimeMs
+                    || nowWallTimeMs - lastCheckWallTimeMs > HEARTBEAT_SCHEDULER_GAP_MS);
+            lastCheckWallTimeMs = nowWallTimeMs;
+
+            // Keep the pre-existing active-request behavior. A heartbeat probe
+            // alone cannot prove that a suspended SDK/network operation resumed.
+            if (activeRequestCount > 0) {
+                probeActive = false;
+                return shouldTreatAsUnresponsive(
+                        observation.heartbeatWallAgeMs,
+                        observation.activityWallAgeMs,
+                        activeRequestCount)
+                        ? HeartbeatDecision.DECLARE_DEAD : HeartbeatDecision.HEALTHY;
+            }
+
+            // On every platform a wall-clock scheduler gap arms an idle probe,
+            // regardless of whether that platform's nanoTime advances in suspend.
+            if (schedulerDiscontinuity) {
+                startProbe(nowNanos, observation.heartbeatVersion);
+                return HeartbeatDecision.SEND_PROBE;
+            }
+
+            if (probeActive) {
+                if (observation.heartbeatVersion != probeHeartbeatVersion) {
+                    probeActive = false;
+                    return HeartbeatDecision.HEALTHY;
+                }
+                if (elapsedMillis(nowNanos, probeStartedAtNanos)
+                        < HEARTBEAT_PROBE_TIMEOUT_MS) {
+                    return HeartbeatDecision.WAIT_FOR_PROBE;
+                }
+                return HeartbeatDecision.DECLARE_DEAD;
+            }
+
+            if (!shouldTreatAsUnresponsive(
+                    observation.heartbeatMonotonicAgeMs,
+                    observation.activityMonotonicAgeMs,
+                    0)) {
+                return HeartbeatDecision.HEALTHY;
+            }
+
+            startProbe(nowNanos, observation.heartbeatVersion);
+            return HeartbeatDecision.SEND_PROBE;
+        }
+
+        synchronized void reset(long nowWallTimeMs) {
+            lastCheckWallTimeMs = nowWallTimeMs;
+            probeActive = false;
+        }
+
+        private void startProbe(long nowNanos, long heartbeatVersion) {
+            probeStartedAtNanos = nowNanos;
+            probeHeartbeatVersion = heartbeatVersion;
+            probeActive = true;
+        }
+    }
+
+    /** Stores both clocks so liveness policy is deterministic across suspend semantics. */
+    static final class HeartbeatTimestamps {
+        private long lastHeartbeatWallTimeMs;
+        private long lastHeartbeatNanos;
+        private long lastActivityWallTimeMs;
+        private long lastActivityNanos;
+        private long heartbeatVersion;
+        private long activityVersion;
+
+        HeartbeatTimestamps(long wallTimeMs, long nanos) {
+            lastHeartbeatWallTimeMs = wallTimeMs;
+            lastHeartbeatNanos = nanos;
+            lastActivityWallTimeMs = wallTimeMs;
+            lastActivityNanos = nanos;
+        }
+
+        synchronized void markHeartbeat(TimeSource timeSource) {
+            long wallTimeMs = timeSource.currentTimeMillis();
+            long nanos = timeSource.nanoTime();
+            lastHeartbeatWallTimeMs = wallTimeMs;
+            lastHeartbeatNanos = nanos;
+            lastActivityWallTimeMs = wallTimeMs;
+            lastActivityNanos = nanos;
+            heartbeatVersion++;
+            activityVersion++;
+        }
+
+        synchronized void markActivity(TimeSource timeSource) {
+            lastActivityWallTimeMs = timeSource.currentTimeMillis();
+            lastActivityNanos = timeSource.nanoTime();
+            activityVersion++;
+        }
+
+        synchronized HeartbeatObservation snapshot(
+                TimeSource timeSource,
+                int activeRequestCount
+        ) {
+            long nowWallTimeMs = timeSource.currentTimeMillis();
+            long nowNanos = timeSource.nanoTime();
+            return new HeartbeatObservation(
+                    nowWallTimeMs,
+                    nowNanos,
+                    elapsedWallMillis(nowWallTimeMs, lastHeartbeatWallTimeMs),
+                    elapsedWallMillis(nowWallTimeMs, lastActivityWallTimeMs),
+                    elapsedMillis(nowNanos, lastHeartbeatNanos),
+                    elapsedMillis(nowNanos, lastActivityNanos),
+                    heartbeatVersion,
+                    activityVersion,
+                    activeRequestCount);
+        }
+
+        synchronized boolean matches(HeartbeatObservation observation) {
+            return heartbeatVersion == observation.heartbeatVersion
+                    && activityVersion == observation.activityVersion;
+        }
+    }
+
+    /** Immutable timeout observation revalidated immediately before claiming daemon death. */
+    static final class HeartbeatObservation {
+        private final long nowWallTimeMs;
+        private final long nowNanos;
+        private final long heartbeatWallAgeMs;
+        private final long activityWallAgeMs;
+        private final long heartbeatMonotonicAgeMs;
+        private final long activityMonotonicAgeMs;
+        private final long heartbeatVersion;
+        private final long activityVersion;
+        private final int activeRequestCount;
+
+        HeartbeatObservation(
+                long nowWallTimeMs,
+                long nowNanos,
+                long heartbeatWallAgeMs,
+                long activityWallAgeMs,
+                long heartbeatMonotonicAgeMs,
+                long activityMonotonicAgeMs,
+                long heartbeatVersion,
+                long activityVersion,
+                int activeRequestCount
+        ) {
+            this.nowWallTimeMs = nowWallTimeMs;
+            this.nowNanos = nowNanos;
+            this.heartbeatWallAgeMs = heartbeatWallAgeMs;
+            this.activityWallAgeMs = activityWallAgeMs;
+            this.heartbeatMonotonicAgeMs = heartbeatMonotonicAgeMs;
+            this.activityMonotonicAgeMs = activityMonotonicAgeMs;
+            this.heartbeatVersion = heartbeatVersion;
+            this.activityVersion = activityVersion;
+            this.activeRequestCount = activeRequestCount;
+        }
+    }
+
+    enum DaemonGenerationState {
+        ACTIVE,
+        DEATH_CLAIMED,
+        STOPPED
+    }
+
+    /** Owns all mutable state that must never cross a daemon generation boundary. */
+    static final class DaemonGenerationContext {
+        private final Process process;
+        private final BufferedWriter stdin;
+        private final long generation;
+        private final long startedAtWallTimeMs;
+        private final CountDownLatch readyLatch = new CountDownLatch(1);
+        private final AtomicBoolean sdkPreloaded = new AtomicBoolean(false);
+        private final AtomicInteger activeRequestCount = new AtomicInteger(0);
+        private final ConcurrentHashMap<String, PendingRequest> pendingRequests =
+                new ConcurrentHashMap<>();
+        private final Deque<String> recentStderrLines = new ArrayDeque<>();
+        private final HeartbeatTimestamps heartbeatTimestamps;
+        private volatile DaemonGenerationState state = DaemonGenerationState.ACTIVE;
+        private volatile boolean startupPublished;
+        private volatile Thread readerThread;
+        private volatile Thread heartbeatThread;
+
+        DaemonGenerationContext(
+                Process process,
+                BufferedWriter stdin,
+                long generation,
+                long startedWallTimeMs,
+                long startedAtNanos
+        ) {
+            this.process = process;
+            this.stdin = stdin;
+            this.generation = generation;
+            this.startedAtWallTimeMs = startedWallTimeMs;
+            this.heartbeatTimestamps = new HeartbeatTimestamps(
+                    startedWallTimeMs, startedAtNanos);
+        }
+
+        boolean isActive() {
+            return state == DaemonGenerationState.ACTIVE;
+        }
+
+        boolean isStopped() {
+            return state == DaemonGenerationState.STOPPED;
+        }
+
+        void publishStartup() {
+            startupPublished = true;
+        }
+
+        boolean isStartupPublished() {
+            return startupPublished;
+        }
+
+        synchronized void claimDeath() {
+            if (state == DaemonGenerationState.ACTIVE) {
+                state = DaemonGenerationState.DEATH_CLAIMED;
+            }
+        }
+
+        void stop() {
+            state = DaemonGenerationState.STOPPED;
+        }
+
+        synchronized boolean signalReady(boolean preloaded) {
+            if (!isActive()) {
+                return false;
+            }
+            sdkPreloaded.set(preloaded);
+            readyLatch.countDown();
+            return true;
+        }
+
+        synchronized boolean markSdkPreloaded() {
+            if (!isActive()) {
+                return false;
+            }
+            sdkPreloaded.set(true);
+            return true;
+        }
+
+        long readySignalsRemaining() {
+            return readyLatch.getCount();
+        }
+
+        boolean isSdkPreloaded() {
+            return sdkPreloaded.get();
+        }
+
+        synchronized void appendStderrLine(String line) {
+            if (line == null) { return; }
+            recentStderrLines.addLast(line);
+            while (recentStderrLines.size() > STDERR_RING_CAPACITY) {
+                recentStderrLines.removeFirst();
+            }
+        }
+
+        synchronized String formatRecentStderrTail() {
+            if (recentStderrLines.isEmpty()) {
+                return "stderr=(empty)";
+            }
+            return "stderrTail=" + String.join(" | ", recentStderrLines);
+        }
+
+        synchronized HeartbeatObservation captureHeartbeatObservation(TimeSource timeSource) {
+            return heartbeatTimestamps.snapshot(timeSource, activeRequestCount.get());
+        }
+
+        synchronized void markHeartbeat(TimeSource timeSource) {
+            if (isActive()) {
+                heartbeatTimestamps.markHeartbeat(timeSource);
+            }
+        }
+
+        synchronized boolean matchesTimeoutObservation(HeartbeatObservation observation) {
+            return heartbeatTimestamps.matches(observation)
+                    && activeRequestCount.get() == observation.activeRequestCount;
+        }
+
+        synchronized boolean registerRequest(
+                String id,
+                RequestHandler handler,
+                boolean countsAsActiveRequest,
+                TimeSource timeSource
+        ) {
+            if (!isActive()) {
+                return false;
+            }
+            pendingRequests.put(id, new PendingRequest(handler, countsAsActiveRequest));
+            if (countsAsActiveRequest) {
+                activeRequestCount.incrementAndGet();
+            }
+            heartbeatTimestamps.markActivity(timeSource);
+            return true;
+        }
+
+        synchronized RequestHandler getRequestHandler(String id) {
+            PendingRequest request = pendingRequests.get(id);
+            return request != null ? request.handler : null;
+        }
+
+        synchronized void removeRequest(String id) {
+            PendingRequest removed = pendingRequests.remove(id);
+            if (removed != null && removed.countsAsActiveRequest) {
+                activeRequestCount.updateAndGet(current -> Math.max(0, current - 1));
+            }
+        }
+
+        synchronized List<RequestHandler> drainRequests() {
+            List<RequestHandler> handlers = new ArrayList<>();
+            for (PendingRequest request : pendingRequests.values()) {
+                handlers.add(request.handler);
+            }
+            pendingRequests.clear();
+            activeRequestCount.set(0);
+            return handlers;
+        }
+    }
+
+    private static final class PendingRequest {
+        private final RequestHandler handler;
+        private final boolean countsAsActiveRequest;
+
+        private PendingRequest(RequestHandler handler, boolean countsAsActiveRequest) {
+            this.handler = handler;
+            this.countsAsActiveRequest = countsAsActiveRequest;
+        }
+    }
+
+    /** A cancellable owner for one process launch and ready wait. */
+    private static final class StartAttempt {
+        private final long id;
+        private final long stopEpoch;
+        private final CountDownLatch completion = new CountDownLatch(1);
+        private final AtomicBoolean completed = new AtomicBoolean(false);
+        private volatile boolean cancelled;
+        private volatile boolean result;
+        private volatile DaemonGenerationContext context;
+
+        private StartAttempt(long id, long stopEpoch) {
+            this.id = id;
+            this.stopEpoch = stopEpoch;
+        }
+
+        private void cancel() {
+            cancelled = true;
+            complete(false);
+        }
+
+        private boolean isCancelled() {
+            return cancelled;
+        }
+
+        private void complete(boolean success) {
+            if (completed.compareAndSet(false, true)) {
+                result = success;
+                completion.countDown();
+            }
+        }
+
+        private boolean awaitResult() {
+            try {
+                completion.await();
+                return result;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface DaemonProcessLauncher {
+        Process launch() throws IOException;
+    }
+
+    interface DaemonLifecycleHooks {
+        DaemonLifecycleHooks NO_OP = new DaemonLifecycleHooks() { };
+
+        default void beforeAutoRestartCheck(long generation) {
+            // No-op in production.
+        }
+
+        default void afterAutoRestartCheck(long generation) {
+            // No-op in production.
+        }
+
+        default void beforeHeartbeatCheck(long generation) {
+            // No-op in production.
+        }
+    }
+
+    interface TimeSource {
+        long currentTimeMillis();
+        long nanoTime();
+
+        static TimeSource system() {
+            return SystemTimeSource.INSTANCE;
+        }
+    }
+
+    private enum SystemTimeSource implements TimeSource {
+        INSTANCE;
+
+        @Override
+        public long currentTimeMillis() {
+            return System.currentTimeMillis();
+        }
+
+        @Override
+        public long nanoTime() {
+            return System.nanoTime();
+        }
+    }
+
+    private boolean isCurrentDaemon(DaemonGenerationContext context) {
+        return daemonContext == context;
+    }
+
+    private static long elapsedMillis(long nowNanos, long startedAtNanos) {
+        long elapsedNanos = nowNanos - startedAtNanos;
+        return elapsedNanos <= 0 ? 0 : TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
+    }
+
+    private static long elapsedWallMillis(long nowWallTimeMs, long startedWallTimeMs) {
+        long elapsedMs = nowWallTimeMs - startedWallTimeMs;
+        return Math.max(0, elapsedMs);
     }
 
     // =========================================================================
@@ -893,7 +1606,7 @@ public class DaemonBridge {
     /**
      * Internal handler that wraps callback + future for a pending request.
      */
-    private static class RequestHandler {
+    static class RequestHandler {
         final DaemonOutputCallback callback;
         final CompletableFuture<Boolean> future;
 

--- a/src/main/java/com/github/claudecodegui/provider/common/HistoryPathMatcher.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/HistoryPathMatcher.java
@@ -1,0 +1,63 @@
+package com.github.claudecodegui.provider.common;
+
+import java.util.Locale;
+
+/**
+ * Shared cwd matching for history readers (Claude CLI providers, Grok, OpenCode, …).
+ *
+ * <p>Rules (case-insensitive after normalize):
+ * <ul>
+ *   <li>Exact match after {@code \}→{@code /} and trailing-slash strip</li>
+ *   <li>macOS {@code /tmp} ↔ {@code /private/tmp}</li>
+ *   <li>Parent / child directory (either direction) so sessions under a subfolder
+ *       still appear when browsing the project root, and vice versa</li>
+ * </ul>
+ */
+public final class HistoryPathMatcher {
+
+    private HistoryPathMatcher() {
+    }
+
+    public static String normalize(String path) {
+        if (path == null) {
+            return "";
+        }
+        String p = path.trim().replace('\\', '/');
+        if (p.length() >= 2 && p.charAt(1) == ':') {
+            p = Character.toLowerCase(p.charAt(0)) + p.substring(1);
+        }
+        while (p.endsWith("/") && p.length() > 1) {
+            p = p.substring(0, p.length() - 1);
+        }
+        return p;
+    }
+
+    public static boolean matches(String sessionCwd, String projectPath) {
+        if (sessionCwd == null || projectPath == null) {
+            return false;
+        }
+        String a = normalize(sessionCwd).toLowerCase(Locale.ROOT);
+        String b = normalize(projectPath).toLowerCase(Locale.ROOT);
+        if (a.isEmpty() || b.isEmpty()) {
+            return false;
+        }
+        if (a.equals(b)) {
+            return true;
+        }
+        // macOS /tmp vs /private/tmp
+        String a2 = stripPrivatePrefix(a);
+        String b2 = stripPrivatePrefix(b);
+        if (a2.equals(b2)) {
+            return true;
+        }
+        return a.startsWith(b + "/") || b.startsWith(a + "/")
+                || a2.startsWith(b2 + "/") || b2.startsWith(a2 + "/");
+    }
+
+    private static String stripPrivatePrefix(String path) {
+        if (path.startsWith("/private/")) {
+            return path.substring("/private".length());
+        }
+        return path;
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/gemini/GeminiHistoryReader.java
+++ b/src/main/java/com/github/claudecodegui/provider/gemini/GeminiHistoryReader.java
@@ -1,0 +1,505 @@
+package com.github.claudecodegui.provider.gemini;
+
+import com.github.claudecodegui.bridge.NodeDetector;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Reads Gemini CLI (Antigravity CLI) session history from
+ * {@code ~/.gemini/antigravity-cli/brain/<sessionId>/.system_generated/logs/transcript.jsonl}
+ * and {@code ~/.gemini/antigravity-cli/history.jsonl}.
+ */
+public class GeminiHistoryReader {
+
+    private static final Logger LOG = Logger.getInstance(GeminiHistoryReader.class);
+    private static final int MAX_TITLE_CHARS = 80;
+    private static final Pattern USER_REQUEST_PATTERN = Pattern.compile("<USER_REQUEST>\\s*(.*?)\\s*</USER_REQUEST>", Pattern.DOTALL);
+
+    private final Gson gson;
+    private final Path brainRoot;
+    private final Path historyFile;
+
+    public GeminiHistoryReader() {
+        this(defaultBrainRoot(), defaultHistoryFile(), new Gson());
+    }
+
+    public GeminiHistoryReader(Path brainRoot, Path historyFile, Gson gson) {
+        this.brainRoot = brainRoot;
+        this.historyFile = historyFile;
+        this.gson = gson;
+    }
+
+    private static Path defaultBrainRoot() {
+        String home = NodeDetector.resolveHomeForFileOps();
+        String geminiHome = System.getenv("GEMINI_CLI_HOME");
+        if (geminiHome == null || geminiHome.trim().isEmpty()) {
+            geminiHome = System.getenv("ANTIGRAVITY_HOME");
+        }
+        if (geminiHome != null && !geminiHome.trim().isEmpty()) {
+            return Paths.get(geminiHome.trim(), "brain");
+        }
+        return Paths.get(home, ".gemini", "antigravity-cli", "brain");
+    }
+
+    private static Path defaultHistoryFile() {
+        String home = NodeDetector.resolveHomeForFileOps();
+        String geminiHome = System.getenv("GEMINI_CLI_HOME");
+        if (geminiHome == null || geminiHome.trim().isEmpty()) {
+            geminiHome = System.getenv("ANTIGRAVITY_HOME");
+        }
+        if (geminiHome != null && !geminiHome.trim().isEmpty()) {
+            return Paths.get(geminiHome.trim(), "history.jsonl");
+        }
+        return Paths.get(home, ".gemini", "antigravity-cli", "history.jsonl");
+    }
+
+    public static class SessionInfo {
+        public String sessionId;
+        public String title;
+        public int messageCount;
+        public long lastTimestamp;
+        public long firstTimestamp;
+        public String cwd;
+        public long fileSize;
+        public String provider = "gemini";
+    }
+
+    /**
+     * List sessions for a project path as JSON expected by HistoryView frontend.
+     */
+    public String getSessionsForProjectAsJson(String projectPath) {
+        try {
+            List<SessionInfo> sessions = listSessionsForProject(projectPath);
+            Map<String, Object> result = new HashMap<>();
+            result.put("success", true);
+            result.put("sessions", sessions);
+            result.put("sessionCount", sessions.size());
+            int totalMessages = sessions.stream().mapToInt(s -> s.messageCount).sum();
+            result.put("total", totalMessages);
+            return gson.toJson(result);
+        } catch (Exception e) {
+            LOG.error("[GeminiHistoryReader] Failed to list sessions: " + e.getMessage(), e);
+            Map<String, Object> error = new HashMap<>();
+            error.put("success", false);
+            error.put("error", "Failed to read Gemini sessions: " + e.getMessage());
+            return gson.toJson(error);
+        }
+    }
+
+    public List<SessionInfo> listSessionsForProject(String projectPath) throws IOException {
+        List<SessionInfo> all = listAllSessions();
+        if (projectPath == null || projectPath.trim().isEmpty()) {
+            return all;
+        }
+        String normalizedProject = normalizePath(projectPath);
+        List<SessionInfo> filtered = new ArrayList<>();
+        for (SessionInfo session : all) {
+            if (session.cwd == null) {
+                // Include session if workspace path is unknown/not recorded to avoid hiding session
+                filtered.add(session);
+                continue;
+            }
+            String sessionCwd = normalizePath(session.cwd);
+            if (pathsMatch(sessionCwd, normalizedProject)) {
+                filtered.add(session);
+            }
+        }
+        filtered.sort(Comparator.comparingLong((SessionInfo s) -> s.lastTimestamp).reversed());
+        return filtered;
+    }
+
+    public List<SessionInfo> listAllSessions() throws IOException {
+        List<SessionInfo> sessions = new ArrayList<>();
+        if (!Files.isDirectory(brainRoot)) {
+            LOG.info("[GeminiHistoryReader] Brain root missing: " + brainRoot);
+            return sessions;
+        }
+
+        Map<String, String> workspaceMap = readHistoryWorkspaceMap();
+
+        try (DirectoryStream<Path> sessionDirs = Files.newDirectoryStream(brainRoot)) {
+            for (Path sessionDir : sessionDirs) {
+                if (!Files.isDirectory(sessionDir)) {
+                    continue;
+                }
+                String name = sessionDir.getFileName().toString();
+                if (name.startsWith(".") || name.contains("..")) {
+                    continue;
+                }
+                SessionInfo info = readSessionSummary(sessionDir, workspaceMap.get(name));
+                if (info != null) {
+                    sessions.add(info);
+                }
+            }
+        }
+        sessions.sort(Comparator.comparingLong((SessionInfo s) -> s.lastTimestamp).reversed());
+        return sessions;
+    }
+
+    private Map<String, String> readHistoryWorkspaceMap() {
+        Map<String, String> map = new HashMap<>();
+        if (historyFile == null || !Files.isRegularFile(historyFile)) {
+            return map;
+        }
+        try (BufferedReader reader = Files.newBufferedReader(historyFile, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (line.isEmpty() || !line.startsWith("{")) {
+                    continue;
+                }
+                try {
+                    JsonObject obj = JsonParser.parseString(line).getAsJsonObject();
+                    if (obj.has("conversationId") && !obj.get("conversationId").isJsonNull()
+                            && obj.has("workspace") && !obj.get("workspace").isJsonNull()) {
+                        String cid = obj.get("conversationId").getAsString().trim();
+                        String ws = obj.get("workspace").getAsString().trim();
+                        if (!cid.isEmpty() && !ws.isEmpty()) {
+                            map.put(cid, ws);
+                        }
+                    }
+                } catch (Exception ignored) {
+                }
+            }
+        } catch (Exception e) {
+            LOG.debug("[GeminiHistoryReader] Error reading history.jsonl: " + e.getMessage());
+        }
+        return map;
+    }
+
+    private SessionInfo readSessionSummary(Path sessionDir, String historyCwd) {
+        String sessionId = sessionDir.getFileName().toString();
+        Path transcriptPath = sessionDir.resolve(".system_generated").resolve("logs").resolve("transcript.jsonl");
+        if (!Files.isRegularFile(transcriptPath)) {
+            transcriptPath = sessionDir.resolve(".system_generated").resolve("logs").resolve("transcript_full.jsonl");
+        }
+        if (!Files.isRegularFile(transcriptPath)) {
+            return null;
+        }
+
+        SessionInfo info = new SessionInfo();
+        info.sessionId = sessionId;
+        info.cwd = historyCwd;
+        info.provider = "gemini";
+
+        long mtime = fileMtimeMillis(transcriptPath);
+        String title = null;
+        int messageCount = 0;
+        long firstTime = 0L;
+
+        try {
+            info.fileSize = Files.size(transcriptPath);
+            try (BufferedReader reader = Files.newBufferedReader(transcriptPath, StandardCharsets.UTF_8)) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    line = line.trim();
+                    if (line.isEmpty() || !line.startsWith("{")) {
+                        continue;
+                    }
+                    try {
+                        JsonObject obj = JsonParser.parseString(line).getAsJsonObject();
+                        String type = obj.has("type") && !obj.get("type").isJsonNull() ? obj.get("type").getAsString() : "";
+                        String content = obj.has("content") && !obj.get("content").isJsonNull() ? obj.get("content").getAsString() : "";
+
+                        if ("USER_INPUT".equals(type) || "PLANNER_RESPONSE".equals(type)) {
+                            messageCount++;
+                        }
+
+                        if (firstTime == 0L && obj.has("created_at") && !obj.get("created_at").isJsonNull()) {
+                            firstTime = parseIso8601Millis(obj.get("created_at").getAsString());
+                        }
+
+                        if (title == null && "USER_INPUT".equals(type) && !content.trim().isEmpty()) {
+                            title = extractTitleFromContent(content);
+                        }
+
+                        if (info.cwd == null && !content.isEmpty()) {
+                            info.cwd = extractCwdFromContent(content);
+                        }
+                    } catch (Exception ignored) {
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.debug("[GeminiHistoryReader] Error reading transcript for " + sessionId + ": " + e.getMessage());
+        }
+
+        if (title == null || title.trim().isEmpty()) {
+            title = "Gemini session " + sessionId.substring(0, Math.min(8, sessionId.length()));
+        }
+
+        info.title = truncate(title.trim(), MAX_TITLE_CHARS);
+        info.messageCount = Math.max(messageCount, 0);
+        info.firstTimestamp = firstTime > 0 ? firstTime : mtime;
+        info.lastTimestamp = mtime > 0 ? mtime : (firstTime > 0 ? firstTime : System.currentTimeMillis());
+
+        return info;
+    }
+
+    private String extractTitleFromContent(String content) {
+        Matcher matcher = USER_REQUEST_PATTERN.matcher(content);
+        if (matcher.find()) {
+            String req = matcher.group(1).trim();
+            if (!req.isEmpty()) {
+                return req;
+            }
+        }
+        // Remove XML-like tags if user request tag is not matched
+        String clean = content.replaceAll("<[^>]+>", "").trim();
+        return clean.isEmpty() ? content.trim() : clean;
+    }
+
+    public List<JsonObject> getSessionMessages(String sessionId, String cwd) throws IOException {
+        Path sessionDir = brainRoot.resolve(sessionId);
+        if (!Files.isDirectory(sessionDir)) {
+            LOG.warn("[GeminiHistoryReader] Session dir not found for id=" + sessionId);
+            return List.of();
+        }
+        Path transcriptPath = sessionDir.resolve(".system_generated").resolve("logs").resolve("transcript.jsonl");
+        if (!Files.isRegularFile(transcriptPath)) {
+            transcriptPath = sessionDir.resolve(".system_generated").resolve("logs").resolve("transcript_full.jsonl");
+        }
+        if (!Files.isRegularFile(transcriptPath)) {
+            return List.of();
+        }
+        return parseTranscriptToMessages(transcriptPath);
+    }
+
+    public String getSessionMessagesAsJson(String sessionId) {
+        try {
+            List<JsonObject> messages = getSessionMessages(sessionId, null);
+            return gson.toJson(messages);
+        } catch (Exception e) {
+            LOG.error("[GeminiHistoryReader] Failed to get session messages as JSON: " + e.getMessage(), e);
+            return "[]";
+        }
+    }
+
+    List<JsonObject> parseTranscriptToMessages(Path transcriptPath) throws IOException {
+        List<JsonObject> messages = new ArrayList<>();
+        try (BufferedReader reader = Files.newBufferedReader(transcriptPath, StandardCharsets.UTF_8)) {
+            String line;
+            int counter = 0;
+            String lastToolCallId = null;
+
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (line.isEmpty() || !line.startsWith("{")) {
+                    continue;
+                }
+                JsonObject obj;
+                try {
+                    obj = JsonParser.parseString(line).getAsJsonObject();
+                } catch (Exception e) {
+                    continue;
+                }
+                String type = obj.has("type") && !obj.get("type").isJsonNull() ? obj.get("type").getAsString() : "";
+                int stepIndex = obj.has("step_index") && obj.get("step_index").isJsonPrimitive() ? obj.get("step_index").getAsInt() : (++counter);
+
+                if ("USER_INPUT".equals(type)) {
+                    String rawContent = obj.has("content") && !obj.get("content").isJsonNull() ? obj.get("content").getAsString() : "";
+                    String userText = extractTitleFromContent(rawContent);
+                    if (!userText.isBlank()) {
+                        messages.add(buildUserTextMessage(userText, "gemini-user-" + stepIndex));
+                    }
+                } else if ("PLANNER_RESPONSE".equals(type)) {
+                    if (obj.has("content") && !obj.get("content").isJsonNull()) {
+                        String assistantText = obj.get("content").getAsString();
+                        if (!assistantText.isBlank()) {
+                            messages.add(buildAssistantTextMessage(assistantText, "gemini-assistant-" + stepIndex));
+                        }
+                    }
+                    if (obj.has("tool_calls") && obj.get("tool_calls").isJsonArray()) {
+                        com.google.gson.JsonArray toolCalls = obj.getAsJsonArray("tool_calls");
+                        for (int i = 0; i < toolCalls.size(); i++) {
+                            com.google.gson.JsonElement el = toolCalls.get(i);
+                            if (!el.isJsonObject()) {
+                                continue;
+                            }
+                            JsonObject call = el.getAsJsonObject();
+                            String toolName = call.has("name") && !call.get("name").isJsonNull() ? call.get("name").getAsString() : "tool";
+                            JsonObject input = call.has("args") && call.get("args").isJsonObject() ? call.getAsJsonObject("args") : new JsonObject();
+                            String callId = "gemini-tool-" + stepIndex + "-" + i;
+                            lastToolCallId = callId;
+                            messages.add(buildToolUseMessage(callId, toolName, input));
+                        }
+                    }
+                } else if (!"USER_INPUT".equals(type) && !"PLANNER_RESPONSE".equals(type) && !"CHECKPOINT".equals(type) && !"CONVERSATION_HISTORY".equals(type)) {
+                    // Tool output or system event
+                    if (obj.has("content") && !obj.get("content").isJsonNull()) {
+                        String toolOutput = obj.get("content").getAsString();
+                        if (!toolOutput.isBlank()) {
+                            String callId = lastToolCallId != null ? lastToolCallId : "gemini-tool-" + stepIndex;
+                            messages.add(buildToolResultMessage(callId, truncate(toolOutput, 20_000)));
+                        }
+                    }
+                }
+            }
+        }
+        return messages;
+    }
+
+    private static JsonObject buildUserTextMessage(String text, String uuid) {
+        JsonObject root = new JsonObject();
+        root.addProperty("type", "user");
+        root.addProperty("uuid", uuid);
+        JsonObject message = new JsonObject();
+        message.addProperty("role", "user");
+        com.google.gson.JsonArray content = new com.google.gson.JsonArray();
+        JsonObject block = new JsonObject();
+        block.addProperty("type", "text");
+        block.addProperty("text", text);
+        content.add(block);
+        message.add("content", content);
+        root.add("message", message);
+        return root;
+    }
+
+    private static JsonObject buildAssistantTextMessage(String text, String uuid) {
+        JsonObject root = new JsonObject();
+        root.addProperty("type", "assistant");
+        root.addProperty("uuid", uuid);
+        JsonObject message = new JsonObject();
+        message.addProperty("role", "assistant");
+        com.google.gson.JsonArray content = new com.google.gson.JsonArray();
+        JsonObject block = new JsonObject();
+        block.addProperty("type", "text");
+        block.addProperty("text", text);
+        content.add(block);
+        message.add("content", content);
+        root.add("message", message);
+        return root;
+    }
+
+    private static JsonObject buildToolUseMessage(String id, String name, JsonObject input) {
+        JsonObject root = new JsonObject();
+        root.addProperty("type", "assistant");
+        JsonObject message = new JsonObject();
+        message.addProperty("role", "assistant");
+        com.google.gson.JsonArray content = new com.google.gson.JsonArray();
+        JsonObject block = new JsonObject();
+        block.addProperty("type", "tool_use");
+        block.addProperty("id", id);
+        block.addProperty("name", name);
+        block.add("input", input != null ? input : new JsonObject());
+        content.add(block);
+        message.add("content", content);
+        root.add("message", message);
+        return root;
+    }
+
+    private static JsonObject buildToolResultMessage(String toolUseId, String contentText) {
+        JsonObject root = new JsonObject();
+        root.addProperty("type", "user");
+        JsonObject message = new JsonObject();
+        message.addProperty("role", "user");
+        com.google.gson.JsonArray content = new com.google.gson.JsonArray();
+        JsonObject block = new JsonObject();
+        block.addProperty("type", "tool_result");
+        block.addProperty("tool_use_id", toolUseId);
+        block.addProperty("is_error", false);
+        block.addProperty("content", contentText);
+        content.add(block);
+        message.add("content", content);
+        root.add("message", message);
+        return root;
+    }
+
+    private String extractCwdFromContent(String content) {
+        if (!content.contains("<user_information>") && !content.contains("active workspaces")) {
+            return null;
+        }
+        String[] lines = content.split("\n");
+        for (String l : lines) {
+            if (l.contains(" -> ") && l.trim().startsWith("/")) {
+                String candidate = l.split(" -> ")[0].trim();
+                if (candidate.startsWith("/")) {
+                    return candidate;
+                }
+            }
+        }
+        return null;
+    }
+
+    public boolean deleteSession(String sessionId) throws IOException {
+        if (sessionId == null || sessionId.trim().isEmpty() || sessionId.contains("..") || sessionId.contains("/") || sessionId.contains("\\")) {
+            return false;
+        }
+        Path targetDir = brainRoot.resolve(sessionId);
+        if (!Files.isDirectory(targetDir)) {
+            return false;
+        }
+        deleteRecursively(targetDir);
+        return !Files.exists(targetDir);
+    }
+
+    private void deleteRecursively(Path path) throws IOException {
+        if (Files.isDirectory(path)) {
+            try (DirectoryStream<Path> entries = Files.newDirectoryStream(path)) {
+                for (Path entry : entries) {
+                    deleteRecursively(entry);
+                }
+            }
+        }
+        Files.deleteIfExists(path);
+    }
+
+    private static long fileMtimeMillis(Path path) {
+        try {
+            return Files.getLastModifiedTime(path).toMillis();
+        } catch (IOException e) {
+            return 0L;
+        }
+    }
+
+    private static long parseIso8601Millis(String str) {
+        try {
+            return java.time.Instant.parse(str).toEpochMilli();
+        } catch (Exception e) {
+            return 0L;
+        }
+    }
+
+    private static String truncate(String str, int maxLen) {
+        if (str == null) {
+            return "";
+        }
+        if (str.length() <= maxLen) {
+            return str;
+        }
+        return str.substring(0, maxLen) + "...";
+    }
+
+    private static String normalizePath(String path) {
+        if (path == null) {
+            return "";
+        }
+        String p = path.replace('\\', '/').trim();
+        while (p.endsWith("/") && p.length() > 1) {
+            p = p.substring(0, p.length() - 1);
+        }
+        return p.toLowerCase(Locale.ROOT);
+    }
+
+    private static boolean pathsMatch(String p1, String p2) {
+        return p1.equals(p2) || p1.startsWith(p2 + "/") || p2.startsWith(p1 + "/");
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/gemini/GeminiPlanUsageService.java
+++ b/src/main/java/com/github/claudecodegui/provider/gemini/GeminiPlanUsageService.java
@@ -1,0 +1,648 @@
+package com.github.claudecodegui.provider.gemini;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.github.claudecodegui.util.PlatformUtils;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+/**
+ * Token-free Gemini / Antigravity account quota for ContextBar.
+ *
+ * <p>Spawns a short-lived {@code agy} TUI process with a temporary statusLine hook.
+ * agy authenticates itself; the plugin never reads keychain or OAuth tokens.
+ * Statusline JSON {@code quota} map is normalized into the same capacity shape
+ * used by Grok/Claude plan-usage UI ({@code capacity_pct} + {@code windows[]}).
+ */
+public final class GeminiPlanUsageService {
+
+    private static final Logger LOG = Logger.getInstance(GeminiPlanUsageService.class);
+    private static final Gson GSON = new Gson();
+
+    private static final long DEFAULT_TIMEOUT_MS = 40_000L;
+    private static final long CACHE_TTL_MS = 90_000L;
+
+    private static final AtomicReference<CacheEntry> CACHE = new AtomicReference<>();
+
+    private GeminiPlanUsageService() {
+    }
+
+    /**
+     * Resolve plan-usage payload. Uses a short in-memory cache to avoid spawning agy
+     * on every 2-minute poll when the previous snapshot is still fresh.
+     */
+    public static JsonObject resolvePlanUsagePayload() {
+        CacheEntry cached = CACHE.get();
+        long now = System.currentTimeMillis();
+        if (cached != null && now - cached.atMs < CACHE_TTL_MS && cached.payload != null) {
+            JsonObject copy = cached.payload.deepCopy();
+            copy.addProperty("cached", true);
+            return copy;
+        }
+        JsonObject fresh = fetchViaStatusline(DEFAULT_TIMEOUT_MS);
+        if (fresh != null && isPresent(fresh)) {
+            CACHE.set(new CacheEntry(now, fresh));
+            return fresh.deepCopy();
+        }
+        if (cached != null && cached.payload != null && isPresent(cached.payload)) {
+            JsonObject copy = cached.payload.deepCopy();
+            copy.addProperty("cached", true);
+            copy.addProperty("stale", true);
+            return copy;
+        }
+        if (fresh != null) {
+            return fresh;
+        }
+        return unavailable("Usage unavailable");
+    }
+
+    /**
+     * Normalize statusline quota buckets into capacity shape.
+     *
+     * <p>Antigravity exposes two billing families (same as TUI /usage):
+     * <ul>
+     *   <li>{@code gemini} — "Gemini Models"</li>
+     *   <li>{@code third_party} — "Claude and GPT models" (bucket ids {@code 3p-*})</li>
+     * </ul>
+     * Each family carries only {@code 5h}/{@code 7d} windows so the ContextBar switcher
+     * matches Claude (period only). The webview picks a family from the selected model.
+     */
+    static JsonObject normalizeQuotaMap(JsonObject quota, String email) {
+        if (quota == null || quota.entrySet().isEmpty()) {
+            return unavailable("No quota in statusline payload");
+        }
+
+        Map<String, List<Window>> byFamily = new LinkedHashMap<>();
+        byFamily.put("gemini", new ArrayList<>());
+        byFamily.put("third_party", new ArrayList<>());
+
+        for (Map.Entry<String, JsonElement> e : quota.entrySet()) {
+            if (e.getValue() == null || !e.getValue().isJsonObject()) {
+                continue;
+            }
+            JsonObject q = e.getValue().getAsJsonObject();
+            Double remaining = asDouble(q, "remaining_fraction", "remainingFraction");
+            if (remaining == null || !Double.isFinite(remaining)) {
+                continue;
+            }
+            double usedPct = clampPct((1.0 - remaining) * 100.0);
+            String resetAt = asString(q, "reset_time", "resetTime");
+            String bucketId = e.getKey();
+            String periodType = periodTypeFromBucketId(bucketId);
+            String family = familyFromBucketId(bucketId);
+            String windowId = windowIdFromPeriod(periodType);
+            if (windowId == null) {
+                continue;
+            }
+            byFamily.computeIfAbsent(family, k -> new ArrayList<>())
+                    .add(new Window(windowId, usedPct, resetAt, periodType));
+        }
+
+        // Collapse duplicate period keys within a family (keep first = sorted later)
+        JsonObject families = new JsonObject();
+        JsonObject defaultFamily = null;
+        for (Map.Entry<String, List<Window>> fe : byFamily.entrySet()) {
+            List<Window> list = fe.getValue();
+            if (list.isEmpty()) {
+                continue;
+            }
+            list.sort(Comparator.comparingInt(w -> windowRank(w.periodType)));
+            Map<String, Window> unique = new LinkedHashMap<>();
+            for (Window w : list) {
+                unique.putIfAbsent(w.id, w);
+            }
+            List<Window> ordered = new ArrayList<>(unique.values());
+            JsonObject fam = familyPayload(ordered);
+            families.add(fe.getKey(), fam);
+            if (defaultFamily == null && "gemini".equals(fe.getKey())) {
+                defaultFamily = fam;
+            }
+            if (defaultFamily == null) {
+                defaultFamily = fam;
+            }
+        }
+        if (families.size() == 0 || defaultFamily == null) {
+            return unavailable("Quota buckets empty");
+        }
+
+        // Top-level mirrors default (gemini) family so parseCapacityPayload works
+        // without model context; webview re-binds via families + selected model.
+        JsonObject out = defaultFamily.deepCopy();
+        out.addProperty("ok", true);
+        out.addProperty("present", true);
+        out.addProperty("provider", "gemini");
+        out.addProperty("source", "agy-statusline");
+        out.addProperty("default_family", families.has("gemini") ? "gemini" : families.entrySet().iterator().next().getKey());
+        out.add("families", families);
+        if (email != null && !email.isBlank()) {
+            out.addProperty("worker_id", email.trim());
+        }
+        return out;
+    }
+
+    private static JsonObject familyPayload(List<Window> ordered) {
+        Window primary = pickPrimary(ordered);
+        JsonObject fam = new JsonObject();
+        fam.addProperty("capacity_pct", primary.usedPct);
+        if (primary.resetAt != null) {
+            fam.addProperty("reset_at", primary.resetAt);
+        }
+        fam.addProperty("period_type", primary.periodType);
+        JsonArray arr = new JsonArray();
+        for (Window w : ordered) {
+            JsonObject o = new JsonObject();
+            o.addProperty("id", w.id);
+            o.addProperty("used_pct", w.usedPct);
+            if (w.resetAt != null) {
+                o.addProperty("reset_at", w.resetAt);
+            }
+            o.addProperty("period_type", w.periodType);
+            arr.add(o);
+        }
+        fam.add("windows", arr);
+        return fam;
+    }
+
+    private static Window pickPrimary(List<Window> windows) {
+        for (Window w : windows) {
+            if ("5h".equals(w.periodType) || "5h".equals(w.id)) {
+                return w;
+            }
+        }
+        return windows.get(0);
+    }
+
+    /** gemini-* → gemini; 3p-* / claude / gpt → third_party. */
+    static String familyFromBucketId(String id) {
+        String s = id == null ? "" : id.toLowerCase(Locale.ROOT);
+        if (s.contains("3p") || s.contains("claude") || s.contains("gpt") || s.contains("opus") || s.contains("sonnet")) {
+            return "third_party";
+        }
+        return "gemini";
+    }
+
+    /** Only 5h / 7d are shown in the bar switcher (Claude-style). */
+    private static String windowIdFromPeriod(String periodType) {
+        if ("5h".equals(periodType)) {
+            return "5h";
+        }
+        if ("7d".equals(periodType) || "weekly".equals(periodType)) {
+            return "7d";
+        }
+        return null;
+    }
+
+    private static int windowRank(String periodType) {
+        if ("5h".equals(periodType)) {
+            return 0;
+        }
+        if ("7d".equals(periodType) || "weekly".equals(periodType)) {
+            return 1;
+        }
+        return 2;
+    }
+
+    private static String periodTypeFromBucketId(String id) {
+        String s = id == null ? "" : id.toLowerCase(Locale.ROOT);
+        if (s.contains("5h") || s.contains("five")) {
+            return "5h";
+        }
+        if (s.contains("week") || s.contains("7d")) {
+            return "7d";
+        }
+        if (s.contains("month")) {
+            return "monthly";
+        }
+        return s.isEmpty() ? "limit" : s;
+    }
+
+    private static JsonObject fetchViaStatusline(long timeoutMs) {
+        String agy = resolveAgyBinary();
+        if (agy == null) {
+            return unavailable("agy CLI not found");
+        }
+
+        Path workDir = null;
+        Path settingsPath = null;
+        Path backupPath = null;
+        Path hookPath = null;
+        Path dumpPath = null;
+        Process process = null;
+        boolean restored = false;
+        try {
+            workDir = Files.createTempDirectory("agy-plan-usage-");
+            Path cliDir = Paths.get(PlatformUtils.getHomeDirectory(), ".gemini", "antigravity-cli");
+            Files.createDirectories(cliDir);
+            settingsPath = cliDir.resolve("settings.json");
+            backupPath = cliDir.resolve("settings.json.bak-plan-usage-plugin");
+            hookPath = workDir.resolve("statusline-hook.sh");
+            dumpPath = workDir.resolve("last.json");
+
+            writeHookScript(hookPath, dumpPath);
+
+            JsonObject prevSettings = readJsonObject(settingsPath);
+            if (Files.exists(settingsPath)) {
+                Files.copy(settingsPath, backupPath);
+            }
+            JsonObject next = prevSettings != null ? prevSettings.deepCopy() : new JsonObject();
+            JsonObject statusLine = new JsonObject();
+            statusLine.addProperty("type", "command");
+            statusLine.addProperty("command", hookPath.toAbsolutePath().toString());
+            statusLine.addProperty("enabled", true);
+            next.add("statusLine", statusLine);
+            // Ensure /tmp-like work dirs are trusted if list exists
+            writeJson(settingsPath, next);
+
+            // TUI statusline only runs with a PTY. Prefer macOS/BSD `script`.
+            ProcessBuilder pb = buildAgyProcess(agy, workDir);
+            pb.redirectErrorStream(true);
+            mapEnv(pb);
+            process = pb.start();
+
+            // Drain stdout so PTY-less process does not block on pipe fill
+            Process proc = process;
+            Thread drainer = new Thread(() -> drainQuietly(proc), "agy-plan-usage-drain");
+            drainer.setDaemon(true);
+            drainer.start();
+
+            long deadline = System.currentTimeMillis() + timeoutMs;
+            JsonObject payload = null;
+            while (System.currentTimeMillis() < deadline) {
+                payload = tryReadDump(dumpPath);
+                if (payload != null && payload.has("quota") && payload.get("quota").isJsonObject()
+                        && payload.getAsJsonObject("quota").size() > 0) {
+                    break;
+                }
+                if (!process.isAlive()) {
+                    break;
+                }
+                try {
+                    Thread.sleep(250L);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+
+            // best-effort quit
+            try {
+                if (process.isAlive()) {
+                    try (Writer w = new OutputStreamWriter(process.getOutputStream(), StandardCharsets.UTF_8)) {
+                        w.write("/quit\n");
+                        w.flush();
+                    } catch (Exception ignored) {
+                    }
+                    process.waitFor(2, TimeUnit.SECONDS);
+                    if (process.isAlive()) {
+                        process.descendants().forEach(ProcessHandle::destroyForcibly);
+                        process.destroyForcibly();
+                    }
+                }
+            } catch (Exception ignored) {
+            }
+
+            restoreSettings(settingsPath, backupPath);
+            restored = true;
+
+            if (payload == null || !payload.has("quota") || !payload.get("quota").isJsonObject()) {
+                return unavailable("agy statusline did not report quota (login required?)");
+            }
+            String email = payload.has("email") && payload.get("email").isJsonPrimitive()
+                    ? payload.get("email").getAsString()
+                    : null;
+            return normalizeQuotaMap(payload.getAsJsonObject("quota"), email);
+        } catch (Exception e) {
+            LOG.warn("[GeminiPlanUsageService] statusline capture failed: " + e.getMessage());
+            return unavailable("Usage unavailable: " + e.getMessage());
+        } finally {
+            if (!restored && settingsPath != null && backupPath != null) {
+                try {
+                    restoreSettings(settingsPath, backupPath);
+                } catch (Exception ignored) {
+                }
+            }
+            if (process != null && process.isAlive()) {
+                try {
+                    process.descendants().forEach(ProcessHandle::destroyForcibly);
+                } catch (Exception ignored) {
+                }
+                process.destroyForcibly();
+            }
+            // leave workDir for debug if dump failed? clean always
+            if (workDir != null) {
+                deleteRecursiveQuietly(workDir);
+            }
+            if (backupPath != null) {
+                try {
+                    Files.deleteIfExists(backupPath);
+                } catch (Exception ignored) {
+                }
+            }
+        }
+    }
+
+    private static ProcessBuilder buildAgyProcess(String agy, Path workDir) {
+        String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+        List<String> cmd = new ArrayList<>();
+        if (os.contains("mac") || os.contains("darwin") || os.contains("bsd")) {
+            // script -q /dev/null <cmd>  → allocate pseudo-TTY
+            cmd.add("script");
+            cmd.add("-q");
+            cmd.add("/dev/null");
+            cmd.add(agy);
+            cmd.add("--model");
+            cmd.add("gemini-3.5-flash-low");
+        } else if (os.contains("linux")) {
+            cmd.add("script");
+            cmd.add("-q");
+            cmd.add("-c");
+            cmd.add(agy + " --model gemini-3.5-flash-low");
+            cmd.add("/dev/null");
+        } else {
+            cmd.add(agy);
+            cmd.add("--model");
+            cmd.add("gemini-3.5-flash-low");
+        }
+        ProcessBuilder pb = new ProcessBuilder(cmd);
+        pb.directory(workDir.toFile());
+        return pb;
+    }
+
+    private static void mapEnv(ProcessBuilder pb) {
+        Map<String, String> env = pb.environment();
+        env.put("TERM", "xterm-256color");
+        env.put("COLORTERM", "truecolor");
+        env.put("CI", "1");
+        env.putIfAbsent("NO_COLOR", "1");
+    }
+
+    private static void writeHookScript(Path hookPath, Path dumpPath) throws IOException {
+        // Dump stdin JSON; emit short stdout for TUI.
+        String body = "#!/bin/sh\n"
+                + "payload=$(cat)\n"
+                + "printf '%s\\n' \"$payload\" > '" + dumpPath.toAbsolutePath() + "'\n";
+        Files.writeString(hookPath, body, StandardCharsets.UTF_8);
+        hookPath.toFile().setExecutable(true);
+    }
+
+    private static JsonObject tryReadDump(Path dumpPath) {
+        try {
+            if (!Files.isRegularFile(dumpPath) || Files.size(dumpPath) < 2) {
+                return null;
+            }
+            String raw = Files.readString(dumpPath, StandardCharsets.UTF_8).trim();
+            if (raw.isEmpty()) {
+                return null;
+            }
+            JsonElement el = JsonParser.parseString(raw);
+            return el.isJsonObject() ? el.getAsJsonObject() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static void restoreSettings(Path settingsPath, Path backupPath) throws IOException {
+        if (backupPath != null && Files.exists(backupPath)) {
+            Files.copy(backupPath, settingsPath, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            Files.deleteIfExists(backupPath);
+            return;
+        }
+        // No backup: strip statusLine we may have added
+        if (settingsPath != null && Files.exists(settingsPath)) {
+            JsonObject cur = readJsonObject(settingsPath);
+            if (cur != null && cur.has("statusLine")) {
+                cur.remove("statusLine");
+                writeJson(settingsPath, cur);
+            }
+        }
+    }
+
+    private static JsonObject readJsonObject(Path path) {
+        try {
+            if (path == null || !Files.isRegularFile(path)) {
+                return null;
+            }
+            String raw = Files.readString(path, StandardCharsets.UTF_8).trim();
+            if (raw.isEmpty()) {
+                return null;
+            }
+            JsonElement el = JsonParser.parseString(raw);
+            return el.isJsonObject() ? el.getAsJsonObject() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static void writeJson(Path path, JsonObject obj) throws IOException {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, GSON.toJson(obj), StandardCharsets.UTF_8);
+    }
+
+    private static void drainQuietly(Process proc) {
+        try (BufferedReader r = new BufferedReader(
+                new InputStreamReader(proc.getInputStream(), StandardCharsets.UTF_8))) {
+            // Also try writing /quit after a few seconds via stdin if available
+            Thread quitter = new Thread(() -> {
+                try {
+                    Thread.sleep(12_000L);
+                    if (proc.isAlive()) {
+                        try (Writer w = new OutputStreamWriter(proc.getOutputStream(), StandardCharsets.UTF_8)) {
+                            w.write("/quit\n");
+                            w.flush();
+                        } catch (Exception ignored) {
+                        }
+                    }
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+            }, "agy-plan-usage-quit");
+            quitter.setDaemon(true);
+            quitter.start();
+            while (r.readLine() != null) {
+                // discard
+            }
+        } catch (Exception ignored) {
+        }
+    }
+
+    private static void deleteRecursiveQuietly(Path root) {
+        try {
+            if (!Files.exists(root)) {
+                return;
+            }
+            Files.walk(root)
+                    .sorted(Comparator.reverseOrder())
+                    .forEach(p -> {
+                        try {
+                            Files.deleteIfExists(p);
+                        } catch (Exception ignored) {
+                        }
+                    });
+        } catch (Exception ignored) {
+        }
+    }
+
+    /**
+     * Same discovery rules as {@link com.github.claudecodegui.dependency.DependencyManager}:
+     * only {@code agy}, never {@code agy.real}.
+     */
+    static String resolveAgyBinary() {
+        String[] envKeys = {"AGY_PATH", "GEMINI_CLI_PATH", "AGY_CLI_PATH"};
+        for (String key : envKeys) {
+            String v = System.getenv(key);
+            if (v != null && !v.trim().isEmpty()) {
+                String path = v.trim();
+                if (isForbiddenAgyBinaryName(path)) {
+                    break;
+                }
+                Path p = Paths.get(path);
+                if (Files.isExecutable(p)) {
+                    return p.toAbsolutePath().toString();
+                }
+                return null;
+            }
+        }
+        String home = PlatformUtils.getHomeDirectory();
+        String[] candidates = {
+                home + "/.local/bin/agy",
+                home + "/.gemini/antigravity-cli/bin/agy",
+                home + "/bin/agy",
+                "/usr/local/bin/agy",
+                "/opt/homebrew/bin/agy",
+        };
+        for (String c : candidates) {
+            try {
+                if (isForbiddenAgyBinaryName(c)) {
+                    continue;
+                }
+                Path p = Paths.get(c);
+                if (Files.isExecutable(p)) {
+                    return p.toAbsolutePath().toString();
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        String pathEnv = System.getenv("PATH");
+        if (pathEnv != null) {
+            for (String dir : pathEnv.split(Pattern.quote(java.io.File.pathSeparator))) {
+                if (dir == null || dir.isEmpty()) {
+                    continue;
+                }
+                try {
+                    Path p = Paths.get(dir, "agy");
+                    if (isForbiddenAgyBinaryName(p.toString())) {
+                        continue;
+                    }
+                    if (Files.isExecutable(p)) {
+                        return p.toAbsolutePath().toString();
+                    }
+                } catch (Exception ignored) {
+                }
+            }
+        }
+        return null;
+    }
+
+    private static boolean isForbiddenAgyBinaryName(String path) {
+        if (path == null || path.isEmpty()) {
+            return false;
+        }
+        String norm = path.replace('\\', '/');
+        int slash = norm.lastIndexOf('/');
+        String base = slash >= 0 ? norm.substring(slash + 1) : norm;
+        return "agy.real".equalsIgnoreCase(base);
+    }
+
+    private static JsonObject unavailable(String message) {
+        JsonObject o = new JsonObject();
+        o.addProperty("ok", true);
+        o.addProperty("present", false);
+        o.addProperty("message", message != null ? message : "Usage unavailable");
+        o.addProperty("provider", "gemini");
+        o.addProperty("source", "plugin");
+        return o;
+    }
+
+    private static boolean isPresent(JsonObject o) {
+        return o != null
+                && o.has("present")
+                && o.get("present").isJsonPrimitive()
+                && o.get("present").getAsBoolean();
+    }
+
+    private static Double asDouble(JsonObject o, String... keys) {
+        for (String k : keys) {
+            if (o.has(k) && o.get(k).isJsonPrimitive()) {
+                try {
+                    return o.get(k).getAsDouble();
+                } catch (Exception ignored) {
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String asString(JsonObject o, String... keys) {
+        for (String k : keys) {
+            if (o.has(k) && o.get(k).isJsonPrimitive()) {
+                try {
+                    return o.get(k).getAsString();
+                } catch (Exception ignored) {
+                }
+            }
+        }
+        return null;
+    }
+
+    private static double clampPct(double v) {
+        if (!Double.isFinite(v)) {
+            return 0;
+        }
+        return Math.max(0, Math.min(100, v));
+    }
+
+    private static final class CacheEntry {
+        final long atMs;
+        final JsonObject payload;
+
+        CacheEntry(long atMs, JsonObject payload) {
+            this.atMs = atMs;
+            this.payload = payload;
+        }
+    }
+
+    private static final class Window {
+        final String id;
+        final double usedPct;
+        final String resetAt;
+        final String periodType;
+
+        Window(String id, double usedPct, String resetAt, String periodType) {
+            this.id = id;
+            this.usedPct = usedPct;
+            this.resetAt = resetAt;
+            this.periodType = periodType;
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/gemini/GeminiSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/gemini/GeminiSDKBridge.java
@@ -1,0 +1,501 @@
+package com.github.claudecodegui.provider.gemini;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import com.github.claudecodegui.bridge.NodeDetector;
+import com.github.claudecodegui.provider.common.BaseSDKBridge;
+import com.github.claudecodegui.provider.common.MessageCallback;
+import com.github.claudecodegui.provider.common.SDKResult;
+import com.github.claudecodegui.session.ClaudeSession;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Gemini / Antigravity CLI bridge.
+ *
+ * Transport is one-shot channel-manager → agy headless stream-json (not ACP).
+ * Java contract mirrors Claude send shape so
+ * {@link com.github.claudecodegui.session.SessionSendService} can route uniformly.
+ */
+public class GeminiSDKBridge extends BaseSDKBridge {
+
+    /** Last observed token total from [USAGE] for /context synthesis. */
+    private final AtomicInteger lastUsedTokens = new AtomicInteger(0);
+    private volatile String lastUsageModel = "";
+
+    public GeminiSDKBridge() {
+        super(GeminiSDKBridge.class);
+    }
+
+    @Override
+    protected String getProviderName() {
+        return "gemini";
+    }
+
+    @Override
+    protected void configureProviderEnv(Map<String, String> env, String stdinJson) {
+        env.put("GEMINI_USE_STDIN", "true");
+        env.put("CI", "1");
+        // Optional path overrides from host environment are already on process env.
+        // Prefer not to invent auth keys — agy uses Google Sign-In on first TUI run.
+    }
+
+    @Override
+    protected void processOutputLine(
+            String line,
+            MessageCallback callback,
+            SDKResult result,
+            StringBuilder assistantContent,
+            AtomicBoolean hadSendError,
+            AtomicReference<String> lastNodeError
+    ) {
+        if (line.contains("[DEBUG]") || line.startsWith("[AGY]") || line.startsWith("[DIAG-")) {
+            LOG.debug("[Gemini] " + line);
+            return;
+        }
+
+        if (line.startsWith("[STDIN_ERROR]")
+                || line.startsWith("[STDIN_PARSE_ERROR]")
+                || line.startsWith("[COMMAND_ERROR]")
+                || line.startsWith("[UNCAUGHT_ERROR]")
+                || line.startsWith("[UNHANDLED_REJECTION]")) {
+            lastNodeError.set(line);
+        }
+
+        if (line.startsWith("[MESSAGE_START]")) {
+            callback.onMessage("message_start", "");
+            return;
+        }
+        if (line.startsWith("[MESSAGE_END]")) {
+            callback.onMessage("message_end", "");
+            return;
+        }
+        if (line.startsWith("[STREAM_START]")) {
+            callback.onMessage("stream_start", "");
+            return;
+        }
+        if (line.startsWith("[STREAM_END]")) {
+            callback.onMessage("stream_end", "");
+            return;
+        }
+        if (line.startsWith("[BLOCK_RESET]")) {
+            callback.onMessage("block_reset", "");
+            return;
+        }
+        if (line.startsWith("[SESSION_ID]")) {
+            String id = line.substring("[SESSION_ID]".length()).trim();
+            if (!id.isEmpty()) {
+                callback.onMessage("session_id", id);
+            }
+            return;
+        }
+        if (line.startsWith("[MESSAGE]")) {
+            String jsonStr = line.substring("[MESSAGE]".length()).trim();
+            try {
+                JsonObject msg = gson.fromJson(jsonStr, JsonObject.class);
+                if (msg != null) {
+                    result.messages.add(msg);
+                    String msgType = msg.has("type") && !msg.get("type").isJsonNull()
+                            ? msg.get("type").getAsString()
+                            : "assistant";
+                    callback.onMessage(msgType, jsonStr);
+
+                    if ("assistant".equals(msgType)) {
+                        String text = extractAssistantText(msg);
+                        if (text != null && !text.isEmpty() && assistantContent.indexOf(text) < 0) {
+                            if (text.length() >= assistantContent.length()) {
+                                assistantContent.setLength(0);
+                                assistantContent.append(text);
+                            }
+                        }
+                    }
+                }
+            } catch (Exception ignored) {
+            }
+            return;
+        }
+        if (line.startsWith("[CONTENT_DELTA]")) {
+            String delta = decodeJsonStringPayload(line.substring("[CONTENT_DELTA]".length()));
+            assistantContent.append(delta);
+            callback.onMessage("content_delta", delta);
+            return;
+        }
+        if (line.startsWith("[CONTENT]")) {
+            String content = line.substring("[CONTENT]".length()).trim();
+            assistantContent.append(content);
+            callback.onMessage("content", content);
+            return;
+        }
+        if (line.startsWith("[THINKING_DELTA]")) {
+            String delta = decodeJsonStringPayload(line.substring("[THINKING_DELTA]".length()));
+            callback.onMessage("thinking_delta", delta);
+            return;
+        }
+        if (line.startsWith("[THINKING]")) {
+            callback.onMessage("thinking", line.substring("[THINKING]".length()).trim());
+            return;
+        }
+        if (line.startsWith("[TOOL_RESULT]")) {
+            callback.onMessage("tool_result", line.substring("[TOOL_RESULT]".length()).trim());
+            return;
+        }
+        if (line.startsWith("[USAGE]")) {
+            String usageJson = line.substring("[USAGE]".length()).trim();
+            try {
+                JsonObject usage = gson.fromJson(usageJson, JsonObject.class);
+                int used = extractUsedTokens(usage);
+                // Keep peak context this process lifetime for /context synthesis;
+                // small checkpoint rows must not wipe a larger peak.
+                if (used > lastUsedTokens.get()) {
+                    lastUsedTokens.set(used);
+                }
+            } catch (Exception ignored) {
+            }
+            callback.onMessage("usage", usageJson);
+            return;
+        }
+        if (line.startsWith("[SEND_ERROR]")) {
+            String jsonStr = line.substring("[SEND_ERROR]".length()).trim();
+            String errorMessage = jsonStr;
+            try {
+                JsonObject obj = gson.fromJson(jsonStr, JsonObject.class);
+                if (obj != null && obj.has("error")) {
+                    errorMessage = obj.get("error").getAsString();
+                }
+            } catch (Exception ignored) {
+            }
+            hadSendError.set(true);
+            result.success = false;
+            result.error = errorMessage;
+            callback.onError(errorMessage);
+            return;
+        }
+
+        if (line.startsWith("{") && line.contains("\"success\"")) {
+            try {
+                JsonObject obj = gson.fromJson(line, JsonObject.class);
+                if (obj != null && obj.has("success") && !obj.get("success").getAsBoolean()) {
+                    String err = obj.has("error") ? obj.get("error").getAsString() : line;
+                    hadSendError.set(true);
+                    result.success = false;
+                    result.error = err;
+                    callback.onError(err);
+                } else if (obj != null && obj.has("sessionId") && !obj.get("sessionId").isJsonNull()) {
+                    String sid = obj.get("sessionId").getAsString();
+                    if (sid != null && !sid.isEmpty()) {
+                        callback.onMessage("session_id", sid);
+                    }
+                }
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    /**
+     * Context occupancy for the status ring: input (+ cache), never total/output.
+     * Matches {@link com.github.claudecodegui.util.TokenUsageUtils#extractContextTokens}.
+     */
+    private static int extractUsedTokens(JsonObject usage) {
+        return com.github.claudecodegui.util.TokenUsageUtils.extractContextTokens(usage, "gemini");
+    }
+
+    private String decodeJsonStringPayload(String rawPayload) {
+        String jsonStr = rawPayload.startsWith(" ") ? rawPayload.substring(1) : rawPayload;
+        try {
+            String decoded = gson.fromJson(jsonStr, String.class);
+            return decoded != null ? decoded : "";
+        } catch (Exception e) {
+            return jsonStr;
+        }
+    }
+
+    private String extractAssistantText(JsonObject msg) {
+        if (msg == null || !msg.has("message")) {
+            return null;
+        }
+        try {
+            JsonObject message = msg.getAsJsonObject("message");
+            if (message == null || !message.has("content")) {
+                return null;
+            }
+            com.google.gson.JsonElement contentEl = message.get("content");
+            if (contentEl.isJsonArray()) {
+                StringBuilder sb = new StringBuilder();
+                for (com.google.gson.JsonElement el : contentEl.getAsJsonArray()) {
+                    if (el.isJsonObject()) {
+                        JsonObject block = el.getAsJsonObject();
+                        if (block.has("text")) {
+                            sb.append(block.get("text").getAsString());
+                        }
+                    }
+                }
+                return sb.toString();
+            } else if (contentEl.isJsonPrimitive()) {
+                return contentEl.getAsString();
+            }
+        } catch (Exception ignored) {
+        }
+        return null;
+    }
+
+    /**
+     * Full Claude-shaped send entry (preferred). One-shot channel-manager only —
+     * agy does not keep a persistent ACP session in the plugin process.
+     */
+    public CompletableFuture<SDKResult> sendMessage(
+            String channelId,
+            String message,
+            String sessionId,
+            String runtimeSessionEpoch,
+            String cwd,
+            List<ClaudeSession.Attachment> attachments,
+            String permissionMode,
+            String model,
+            JsonObject openedFiles,
+            String agentPrompt,
+            Boolean streaming,
+            boolean disableThinking,
+            String reasoningEffort,
+            MessageCallback callback
+    ) {
+        String normalizedCwd = normalizeCwdForNode(cwd);
+
+        if (model != null && !model.isEmpty()) {
+            lastUsageModel = model;
+        }
+
+        JsonObject stdinInput = buildStdinPayload(
+                message, sessionId, runtimeSessionEpoch, normalizedCwd, attachments,
+                permissionMode, model, openedFiles, agentPrompt, streaming, disableThinking, reasoningEffort
+        );
+        String stdinJson = gson.toJson(stdinInput);
+        List<String> command = buildBaseCommand("send");
+        LOG.info("[Gemini] sendMessage sessionId=" + (sessionId != null ? sessionId : "(new)")
+                + ", epoch=" + (runtimeSessionEpoch != null ? runtimeSessionEpoch : "(none)")
+                + ", model=" + (model != null ? model : "(default)"));
+
+        return executeStreamingCommand(channelId, command, stdinJson, normalizedCwd, callback);
+    }
+
+    /**
+     * Compatibility overload used by older call sites.
+     */
+    public CompletableFuture<SDKResult> sendMessage(
+            String channelId,
+            String message,
+            String sessionId,
+            String cwd,
+            List<ClaudeSession.Attachment> attachments,
+            String permissionMode,
+            String model,
+            String agentPrompt,
+            MessageCallback callback
+    ) {
+        return sendMessage(
+                channelId,
+                message,
+                sessionId,
+                null,
+                cwd,
+                attachments,
+                permissionMode,
+                model,
+                null,
+                agentPrompt,
+                true,
+                false,
+                null,
+                callback
+        );
+    }
+
+    private String normalizeCwdForNode(String cwd) {
+        if (cwd == null || cwd.isEmpty()) {
+            return cwd;
+        }
+        String nodePath = nodeDetector.getCachedNodePath();
+        boolean isWsl = nodePath != null && NodeDetector.isWslPath(nodePath);
+        return isWsl ? NodeDetector.convertToWslPath(cwd) : cwd;
+    }
+
+    private JsonObject buildStdinPayload(
+            String message,
+            String sessionId,
+            String runtimeSessionEpoch,
+            String cwd,
+            List<ClaudeSession.Attachment> attachments,
+            String permissionMode,
+            String model,
+            JsonObject openedFiles,
+            String agentPrompt,
+            Boolean streaming,
+            boolean disableThinking,
+            String reasoningEffort
+    ) {
+        JsonObject stdinInput = new JsonObject();
+        stdinInput.addProperty("message", message != null ? message : "");
+        stdinInput.addProperty("sessionId", sessionId != null ? sessionId : "");
+        if (runtimeSessionEpoch != null && !runtimeSessionEpoch.isEmpty()) {
+            stdinInput.addProperty("runtimeSessionEpoch", runtimeSessionEpoch);
+        }
+        stdinInput.addProperty("cwd", cwd != null ? cwd : "");
+        stdinInput.addProperty("permissionMode", permissionMode != null ? permissionMode : "");
+        stdinInput.addProperty("model", model != null ? model : "");
+        stdinInput.addProperty("agentPrompt", agentPrompt != null ? agentPrompt : "");
+        stdinInput.addProperty("streaming", streaming == null || streaming);
+        stdinInput.addProperty("disableThinking", disableThinking);
+        if (reasoningEffort != null && !reasoningEffort.isEmpty()) {
+            stdinInput.addProperty("reasoningEffort", reasoningEffort);
+        }
+        if (openedFiles != null) {
+            stdinInput.add("openedFiles", openedFiles);
+        }
+        if (attachments != null && !attachments.isEmpty()) {
+            JsonArray attArr = new JsonArray();
+            for (ClaudeSession.Attachment a : attachments) {
+                JsonObject o = new JsonObject();
+                o.addProperty("fileName", a.fileName);
+                o.addProperty("mediaType", a.mediaType);
+                o.addProperty("data", a.data);
+                attArr.add(o);
+            }
+            stdinInput.add("attachments", attArr);
+        }
+        return stdinInput;
+    }
+
+    /**
+     * Fetch live model catalog from {@code agy models} via channel-manager listModels.
+     * Returns JSON: {@code { success, models:[{id,label}], families:[...], binary }}.
+     */
+    public CompletableFuture<JsonObject> listModels() {
+        return CompletableFuture.supplyAsync(() -> {
+            JsonObject fallback = new JsonObject();
+            fallback.addProperty("success", false);
+            fallback.add("models", new JsonArray());
+            fallback.add("families", new JsonArray());
+            fallback.addProperty("binary", "");
+            fallback.addProperty("error", "listModels failed");
+
+            try {
+                List<String> command = buildBaseCommand("listModels");
+                if (command.isEmpty()) {
+                    fallback.addProperty("error", "channel-manager command unavailable");
+                    return fallback;
+                }
+
+                File bridgeDir = getDirectoryResolver().findSdkDir();
+                if (bridgeDir == null) {
+                    fallback.addProperty("error", "Bridge directory not ready");
+                    return fallback;
+                }
+
+                ProcessBuilder pb = new ProcessBuilder(command);
+                pb.directory(bridgeDir);
+                Map<String, String> env = pb.environment();
+                envConfigurator.configureTempDir(env, processManager.prepareClaudeTempDir());
+                configureProviderEnv(env, "{}");
+                String node = nodeDetector.findNodeExecutable();
+                envConfigurator.updateProcessEnvironment(pb, node);
+                pb.redirectErrorStream(true);
+
+                Process process = pb.start();
+                // listModels needs no stdin payload
+                try {
+                    process.getOutputStream().close();
+                } catch (Exception ignored) {
+                }
+
+                StringBuilder out = new StringBuilder();
+                try (java.io.BufferedReader reader = new java.io.BufferedReader(
+                        new java.io.InputStreamReader(process.getInputStream(), java.nio.charset.StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        out.append(line).append('\n');
+                    }
+                }
+                boolean finished = process.waitFor(20, java.util.concurrent.TimeUnit.SECONDS);
+                if (!finished) {
+                    process.destroyForcibly();
+                    fallback.addProperty("error", "listModels timed out");
+                    return fallback;
+                }
+
+                JsonObject parsed = extractLastJsonObject(out.toString());
+                if (parsed != null && parsed.has("success")) {
+                    return parsed;
+                }
+                fallback.addProperty("error", "No listModels JSON in output");
+                fallback.addProperty("raw", out.length() > 500 ? out.substring(0, 500) : out.toString());
+                return fallback;
+            } catch (Exception e) {
+                LOG.warn("[Gemini] listModels failed: " + e.getMessage());
+                fallback.addProperty("error", e.getMessage() != null ? e.getMessage() : "listModels exception");
+                return fallback;
+            }
+        });
+    }
+
+    private JsonObject extractLastJsonObject(String text) {
+        if (text == null || text.isBlank()) {
+            return null;
+        }
+        String[] lines = text.split("\\R");
+        for (int i = lines.length - 1; i >= 0; i--) {
+            String line = lines[i].trim();
+            if (line.isEmpty() || !line.startsWith("{")) {
+                continue;
+            }
+            try {
+                return gson.fromJson(line, JsonObject.class);
+            } catch (Exception ignored) {
+                // try previous line
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Best-effort context usage from last [USAGE] tags (agy has no live /context RPC).
+     * Signature matches Claude bridge for ContextHandler routing.
+     */
+    public CompletableFuture<JsonObject> getContextUsage(String sessionId, String cwd, String model) {
+        int used = lastUsedTokens.get();
+        String m = model != null && !model.isEmpty() ? model : lastUsageModel;
+        int max = com.github.claudecodegui.handler.provider.ModelProviderHandler
+                .getModelContextLimit("gemini", m != null ? m : "");
+        if (max <= 0) {
+            max = 200_000;
+        }
+        JsonObject data = new JsonObject();
+        data.addProperty("usedTokens", used);
+        data.addProperty("maxTokens", max);
+        data.addProperty("percentage", used <= 0 ? 0 : Math.min(100.0, Math.round(used * 1000.0 / max) / 10.0));
+        data.addProperty("model", m != null ? m : "");
+        data.addProperty("source", "gemini-bridge");
+        JsonObject result = new JsonObject();
+        result.addProperty("success", true);
+        result.add("data", data);
+        return CompletableFuture.completedFuture(result);
+    }
+
+    /**
+     * Reads persisted session messages from Gemini/Antigravity CLI transcript.
+     */
+    public List<JsonObject> getSessionMessages(String sessionId, String cwd) {
+        try {
+            return new GeminiHistoryReader().getSessionMessages(sessionId, cwd);
+        } catch (Exception e) {
+            LOG.warn("[GeminiSDKBridge] Failed to get session messages for " + sessionId + ": " + e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/service/NodeProcessRegistry.java
+++ b/src/main/java/com/github/claudecodegui/service/NodeProcessRegistry.java
@@ -3,6 +3,7 @@ package com.github.claudecodegui.service;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
 import com.github.claudecodegui.provider.common.DaemonBridge;
+import com.github.claudecodegui.provider.gemini.GeminiSDKBridge;
 import com.github.claudecodegui.ui.toolwindow.ClaudeChatWindow;
 import com.github.claudecodegui.ui.toolwindow.ClaudeSDKToolWindow;
 import com.github.claudecodegui.util.PlatformUtils;
@@ -104,6 +105,7 @@ public final class NodeProcessRegistry implements Disposable {
 
             // -- DAEMON entries from ClaudeSDKBridge --
             ClaudeSDKBridge claudeBridge = safeClaudeBridge(window);
+            GeminiSDKBridge geminiBridge = safeGeminiBridge(window);
             if (claudeBridge != null) {
                 DaemonBridge daemon = claudeBridge.getCurrentDaemonBridgeForInspection();
                 if (daemon != null && daemon.isAlive()) {
@@ -170,6 +172,35 @@ public final class NodeProcessRegistry implements Disposable {
             if (codexBridge != null) {
                 Map<String, Process> codexChannels = codexBridge.getProcessManager().getActiveChannelSnapshot();
                 for (Map.Entry<String, Process> entry : codexChannels.entrySet()) {
+                    Process p = entry.getValue();
+                    if (p == null || !p.isAlive()) {
+                        continue;
+                    }
+                    long pid = p.pid();
+                    knownPids.add(pid);
+                    ProcessHandle.Info info = safeInfo(p);
+                    long startedAt = info != null
+                            ? info.startInstant().map(Instant::toEpochMilli).orElse(-1L)
+                            : -1L;
+                    result.add(NodeProcessInfo.builder()
+                            .kind(NodeProcessInfo.Kind.CHANNEL)
+                            .provider(tabProvider)
+                            .pid(pid)
+                            .alive(true)
+                            .startedAtMs(startedAt)
+                            .uptimeMs(startedAt > 0 ? Math.max(0, now - startedAt) : 0L)
+                            .command(extractCommand(info))
+                            .channelId(entry.getKey())
+                            .sessionId(sessionId)
+                            .tabName(tabName)
+                            .build());
+                }
+            }
+
+            // -- CHANNEL entries from geminiBridge.processManager (per-message processes) --
+            if (geminiBridge != null) {
+                Map<String, Process> geminiChannels = geminiBridge.getProcessManager().getActiveChannelSnapshot();
+                for (Map.Entry<String, Process> entry : geminiChannels.entrySet()) {
                     Process p = entry.getValue();
                     if (p == null || !p.isAlive()) {
                         continue;
@@ -445,6 +476,14 @@ public final class NodeProcessRegistry implements Disposable {
     private static @Nullable ClaudeSDKBridge safeClaudeBridge(ClaudeChatWindow window) {
         try {
             return window != null ? window.getClaudeSDKBridge() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static @Nullable GeminiSDKBridge safeGeminiBridge(ClaudeChatWindow window) {
+        try {
+            return window != null ? window.getGeminiSDKBridge() : null;
         } catch (Exception e) {
             return null;
         }

--- a/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
@@ -5,6 +5,7 @@ import com.github.claudecodegui.permission.PermissionRequest;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
 import com.github.claudecodegui.provider.common.MarkerCliBridge;
+import com.github.claudecodegui.provider.gemini.GeminiSDKBridge;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
@@ -55,6 +56,7 @@ public class ClaudeSession {
     // SDK bridges
     private final ClaudeSDKBridge claudeSDKBridge;
     private final CodexSDKBridge codexSDKBridge;
+    private final GeminiSDKBridge geminiSDKBridge;
 
     // Permission manager
     private final PermissionManager permissionManager = new PermissionManager();
@@ -157,9 +159,20 @@ public class ClaudeSession {
             CodexSDKBridge codexSDKBridge,
             Map<String, MarkerCliBridge> cliBridges
     ) {
+        this(project, claudeSDKBridge, codexSDKBridge, cliBridges, null);
+    }
+
+    public ClaudeSession(
+            Project project,
+            ClaudeSDKBridge claudeSDKBridge,
+            CodexSDKBridge codexSDKBridge,
+            Map<String, MarkerCliBridge> cliBridges,
+            GeminiSDKBridge geminiSDKBridge
+    ) {
         this.project = project;
         this.claudeSDKBridge = claudeSDKBridge;
         this.codexSDKBridge = codexSDKBridge;
+        this.geminiSDKBridge = geminiSDKBridge;
 
         // Initialize managers
         this.state = new com.github.claudecodegui.session.SessionState();
@@ -168,7 +181,7 @@ public class ClaudeSession {
         this.contextCollector = new com.github.claudecodegui.session.EditorContextCollector(project);
         this.callbackFacade = new SessionCallbackFacade(project);
         this.contextService = new SessionContextService(project, MAX_FILE_SIZE_BYTES);
-        this.providerRouter = new SessionProviderRouter(claudeSDKBridge, codexSDKBridge, cliBridges);
+        this.providerRouter = new SessionProviderRouter(claudeSDKBridge, codexSDKBridge, cliBridges, geminiSDKBridge);
         this.sendService = new SessionSendService(
                 project,
                 state,
@@ -179,7 +192,8 @@ public class ClaudeSession {
                 claudeSDKBridge,
                 codexSDKBridge,
                 cliBridges,
-                contextService
+                contextService,
+                geminiSDKBridge
         );
         this.messageOrchestrator = new SessionMessageOrchestrator(
                 project,
@@ -266,6 +280,10 @@ public class ClaudeSession {
         } else {
             state.setCwd(null);
         }
+    }
+
+    public void clearSessionId() {
+        setSessionInfo(null, getCwd());
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/session/GeminiMessageHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/GeminiMessageHandler.java
@@ -1,0 +1,679 @@
+package com.github.claudecodegui.session;
+
+import com.github.claudecodegui.handler.SettingsHandler;
+import com.github.claudecodegui.notifications.ClaudeNotifier;
+import com.github.claudecodegui.provider.common.MessageCallback;
+import com.github.claudecodegui.provider.common.SDKResult;
+import com.github.claudecodegui.session.ClaudeSession.Message;
+import com.github.claudecodegui.util.TokenUsageUtils;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+
+import java.util.List;
+
+/**
+ * Gemini/agy message callback handler (Claude-template protocol surface).
+ *
+ * Grows toward ClaudeMessageHandler event types without reusing Claude-specific
+ * Anthropic assumptions wholesale (handler strategy A).
+ *
+ * Protocol tags from ai-bridge agy stream-json normalizer:
+ *   message_start / message_end / stream_start / stream_end / block_reset
+ *   content_delta / content / thinking / thinking_delta
+ *   assistant / user / result / session_id / tool_result / usage
+ */
+public class GeminiMessageHandler implements MessageCallback {
+    private static final Logger LOG = Logger.getInstance(GeminiMessageHandler.class);
+
+    private final SessionState state;
+    private final CallbackHandler callbackHandler;
+    private final Project project;
+    private final Gson gson = new Gson();
+
+    private final StringBuilder assistantContent = new StringBuilder();
+    private Message currentAssistantMessage = null;
+    /** Peak context tokens this stream (ignore tiny agy checkpoint regressions). */
+    private int peakContextTokens = 0;
+    /**
+     * Assistant bubble owned by the active stream. After {@code stream_start} we only
+     * attach content to this message — never to a completed previous-turn assistant
+     * (which would silently glue two answers together when the send-time user message
+     * is missing from state).
+     */
+    private Message assistantMessageForCurrentStream = null;
+
+    private boolean isStreaming = false;
+    private boolean streamEndedThisTurn = false;
+    private boolean isThinking = false;
+
+    public GeminiMessageHandler(SessionState state, CallbackHandler callbackHandler) {
+        this(state, callbackHandler, null);
+    }
+
+    public GeminiMessageHandler(SessionState state, CallbackHandler callbackHandler, Project project) {
+        this.state = state;
+        this.callbackHandler = callbackHandler;
+        this.project = project;
+    }
+
+    @Override
+    public void onMessage(String type, String content) {
+        LOG.debug("GeminiMessageHandler.onMessage: type=" + type);
+
+        switch (type) {
+            case "assistant":
+            case "message":
+                handleAssistantMessage(content);
+                break;
+            case "user":
+                handleUserMessage(content);
+                break;
+            case "result":
+                handleResultMessage(content);
+                break;
+            case "session_id":
+            case "thread_id":
+                handleSessionId(content);
+                break;
+            case "stream_start":
+                handleStreamStart();
+                break;
+            case "stream_end":
+                handleStreamEnd();
+                break;
+            case "block_reset":
+                handleBlockReset();
+                break;
+            case "content_delta":
+            case "content":
+                handleContentDelta(content);
+                break;
+            case "thinking":
+                handleThinking();
+                break;
+            case "thinking_delta":
+                handleThinkingDelta(content);
+                break;
+            case "tool_result":
+                handleToolResult(content);
+                break;
+            case "usage":
+                handleUsage(content);
+                break;
+            case "status":
+                if (content != null && !content.trim().isEmpty()) {
+                    callbackHandler.notifyStatusMessage(content);
+                }
+                break;
+            case "message_start":
+                // lifecycle marker; stream_start drives UI
+                break;
+            case "message_end":
+                handleMessageEnd();
+                break;
+            default:
+                LOG.debug("GeminiMessageHandler: Unhandled message type: " + type);
+        }
+    }
+
+    @Override
+    public void onError(String error) {
+        boolean wasStreaming = isStreaming;
+        isStreaming = false;
+        streamEndedThisTurn = false;
+        if (isThinking) {
+            isThinking = false;
+            callbackHandler.notifyThinkingStatusChanged(false);
+        }
+        state.setError(error);
+        state.setBusy(false);
+        state.setLoading(false);
+
+        Message errorMessage = new Message(Message.Type.ERROR, error);
+        state.addMessage(errorMessage);
+
+        // Always end stream so tool cards / loading state finalize
+        callbackHandler.notifyStreamEnd();
+        callbackHandler.notifyMessageUpdate(state.getMessages());
+        resetStreamingAccumulator();
+        callbackHandler.notifyStateChange(state.isBusy(), state.isLoading(), state.getError());
+    }
+
+    @Override
+    public void onComplete(SDKResult result) {
+        boolean streamEndedBeforeComplete = streamEndedThisTurn;
+        boolean wasStreaming = isStreaming;
+
+        isStreaming = false;
+        streamEndedThisTurn = false;
+        if (isThinking) {
+            isThinking = false;
+            callbackHandler.notifyThinkingStatusChanged(false);
+        }
+        state.setBusy(false);
+        state.setLoading(false);
+        state.updateLastModifiedTime();
+
+        if (wasStreaming && !streamEndedBeforeComplete) {
+            LOG.warn("Gemini onComplete called without prior stream_end; forcing stream cleanup");
+            callbackHandler.notifyMessageUpdate(state.getMessages());
+            callbackHandler.notifyStreamEnd();
+        }
+
+        resetStreamingAccumulator();
+        callbackHandler.notifyStateChange(state.isBusy(), state.isLoading(), state.getError());
+    }
+
+    // ===== Private handlers =====
+
+    private void handleAssistantMessage(String jsonContent) {
+        try {
+            JsonObject msgJson = gson.fromJson(jsonContent, JsonObject.class);
+            if (msgJson == null) {
+                return;
+            }
+
+            // tool_use blocks: keep raw structure for UI tool cards
+            boolean hasToolUse = hasToolUseBlocks(msgJson);
+
+            Message parsed = parseAssistantMessage(msgJson);
+            if (parsed == null) {
+                return;
+            }
+
+            Message target = resolveAssistantMessageForStream();
+            // Merge raw when possible (preserve existing tool_use blocks)
+            if (target.raw != null && (hasToolUse || hasToolUseBlocks(target.raw))) {
+                target.raw = mergeAssistantRaw(target.raw, msgJson);
+            } else {
+                target.raw = parsed.raw;
+            }
+            if (parsed.content != null && !parsed.content.isEmpty()) {
+                if (!isStreaming || parsed.content.length() >= assistantContent.length()) {
+                    target.content = parsed.content;
+                    assistantContent.setLength(0);
+                    assistantContent.append(parsed.content);
+                }
+            }
+            // Structural changes (tool_use) must refresh UI even during streaming
+            callbackHandler.notifyMessageUpdate(state.getMessages());
+        } catch (Exception e) {
+            LOG.warn("Failed to parse Gemini assistant message: " + e.getMessage());
+        }
+    }
+
+    private void handleUserMessage(String jsonContent) {
+        try {
+            JsonObject msgJson = gson.fromJson(jsonContent, JsonObject.class);
+            if (msgJson == null) {
+                return;
+            }
+
+            if (hasToolResult(msgJson)) {
+                Message toolResultMessage = new Message(Message.Type.USER, "[tool_result]", msgJson);
+                state.addMessage(toolResultMessage);
+                callbackHandler.notifyMessageUpdate(state.getMessages());
+                return;
+            }
+
+            // Live user text is owned by SessionSendService at send-time. ACP/user echoes
+            // must NOT addMessage again — that re-appends the user's first message after
+            // the assistant and glues turns in the UI. Mirror Claude: patch existing only.
+            String userText = extractText(msgJson);
+            if (userText == null || userText.isEmpty()) {
+                LOG.debug("Gemini user message has no text; skipping");
+                return;
+            }
+
+            List<Message> messages = state.getMessagesReference();
+            for (int i = messages.size() - 1; i >= 0; i--) {
+                Message msg = messages.get(i);
+                if (msg.type != Message.Type.USER) {
+                    continue;
+                }
+                if (userText.equals(msg.content)) {
+                    if (msg.raw == null) {
+                        msg.raw = msgJson;
+                    }
+                    LOG.debug("Gemini user message matched existing send-time bubble; not duplicating");
+                    callbackHandler.notifyMessageUpdate(state.getMessages());
+                    return;
+                }
+            }
+            // No matching send-time bubble (edge path). Still avoid inventing a trailing
+            // user after an assistant mid-conversation — the webview optimistic path
+            // owns display until SessionSendService persists the message.
+            LOG.debug("Gemini user message with no matching state entry; not adding to avoid duplicate bubble");
+        } catch (Exception e) {
+            LOG.warn("Failed to parse Gemini user message: " + e.getMessage());
+        }
+    }
+
+    private void handleResultMessage(String jsonContent) {
+        if (jsonContent == null || !jsonContent.startsWith("{")) {
+            return;
+        }
+        try {
+            JsonObject resultJson = gson.fromJson(jsonContent, JsonObject.class);
+            if (resultJson == null) {
+                return;
+            }
+            if (resultJson.has("usage") && resultJson.get("usage").isJsonObject()) {
+                JsonObject usage = resultJson.getAsJsonObject("usage");
+                if (currentAssistantMessage != null) {
+                    if (currentAssistantMessage.raw == null) {
+                        currentAssistantMessage.raw = new JsonObject();
+                    }
+                    // Per-turn display (MessageItem) reads turnUsage; status bar uses context extract.
+                    currentAssistantMessage.raw.add("turnUsage", usage.deepCopy());
+                    ensureAssistantRaw();
+                    JsonObject message = currentAssistantMessage.raw.has("message")
+                            && currentAssistantMessage.raw.get("message").isJsonObject()
+                            ? currentAssistantMessage.raw.getAsJsonObject("message")
+                            : new JsonObject();
+                    message.add("usage", usage.deepCopy());
+                    currentAssistantMessage.raw.add("message", message);
+                }
+                // Final result is authoritative for the turn context occupancy.
+                applyContextUsage(usage, true);
+                callbackHandler.notifyMessageUpdate(state.getMessages());
+            }
+        } catch (Exception e) {
+            LOG.debug("Gemini result parse skipped: " + e.getMessage());
+        }
+    }
+
+    private void handleSessionId(String id) {
+        if (id != null && !id.trim().isEmpty()) {
+            state.setSessionId(id.trim());
+            callbackHandler.notifySessionIdReceived(id.trim());
+            LOG.info("Captured Gemini session ID: " + id.trim());
+        }
+    }
+
+    private void handleStreamStart() {
+        isStreaming = true;
+        streamEndedThisTurn = false;
+        peakContextTokens = 0;
+        resetStreamingAccumulator();
+        callbackHandler.notifyStreamStart();
+    }
+
+    private void handleStreamEnd() {
+        streamEndedThisTurn = true;
+        isStreaming = false;
+        if (isThinking) {
+            isThinking = false;
+            callbackHandler.notifyThinkingStatusChanged(false);
+        }
+        callbackHandler.notifyMessageUpdate(state.getMessages());
+        callbackHandler.notifyStreamEnd();
+        state.setBusy(false);
+        state.setLoading(false);
+        state.updateLastModifiedTime();
+        callbackHandler.notifyStateChange(state.isBusy(), state.isLoading(), state.getError());
+    }
+
+    private void handleBlockReset() {
+        // New structural segment after tools — clear delta accumulator for next text block
+        assistantContent.setLength(0);
+        currentAssistantMessage = null;
+        try {
+            callbackHandler.notifyBlockReset();
+        } catch (Exception e) {
+            LOG.debug("notifyBlockReset not available or failed: " + e.getMessage());
+        }
+    }
+
+    private void handleContentDelta(String content) {
+        if (content == null || content.isEmpty()) {
+            return;
+        }
+        if (isThinking) {
+            isThinking = false;
+            callbackHandler.notifyThinkingStatusChanged(false);
+        }
+        assistantContent.append(content);
+
+        Message target = resolveAssistantMessageForStream();
+        target.content = assistantContent.toString();
+        callbackHandler.notifyContentDelta(content);
+        if (!isStreaming) {
+            callbackHandler.notifyMessageUpdate(state.getMessages());
+        }
+    }
+
+    private void handleThinking() {
+        if (!isThinking) {
+            isThinking = true;
+            callbackHandler.notifyThinkingStatusChanged(true);
+        }
+    }
+
+    private void handleThinkingDelta(String content) {
+        if (content == null || content.isEmpty()) {
+            return;
+        }
+        if (!isThinking) {
+            isThinking = true;
+            callbackHandler.notifyThinkingStatusChanged(true);
+        }
+        ensureAssistantRaw();
+        appendThinkingToRaw(content);
+        try {
+            callbackHandler.notifyThinkingDelta(content);
+        } catch (Exception e) {
+            LOG.debug("notifyThinkingDelta failed: " + e.getMessage());
+        }
+        callbackHandler.notifyMessageUpdate(state.getMessages());
+    }
+
+    private void handleToolResult(String content) {
+        if (content == null || !content.startsWith("{")) {
+            return;
+        }
+        try {
+            JsonObject toolResultBlock = gson.fromJson(content, JsonObject.class);
+            String toolUseId = toolResultBlock.has("tool_use_id")
+                    ? toolResultBlock.get("tool_use_id").getAsString()
+                    : null;
+            if (toolUseId == null) {
+                return;
+            }
+
+            JsonArray contentArray = new JsonArray();
+            contentArray.add(toolResultBlock);
+            JsonObject messageObj = new JsonObject();
+            messageObj.add("content", contentArray);
+            JsonObject rawUser = new JsonObject();
+            rawUser.addProperty("type", "user");
+            rawUser.add("message", messageObj);
+
+            Message toolResultMessage = new Message(Message.Type.USER, "[tool_result]", rawUser);
+            state.addMessage(toolResultMessage);
+            callbackHandler.notifyMessageUpdate(state.getMessages());
+        } catch (Exception e) {
+            LOG.warn("Failed to parse Gemini tool_result: " + e.getMessage());
+        }
+    }
+
+    private void handleUsage(String content) {
+        if (content == null || content.isEmpty()) {
+            return;
+        }
+        try {
+            JsonObject usage = gson.fromJson(content, JsonObject.class);
+            if (usage == null) {
+                return;
+            }
+            // Intermediate step usage (agy checkpoint rows are tiny) must not replace a larger peak.
+            if (!applyContextUsage(usage, false)) {
+                return;
+            }
+            ensureAssistantRaw();
+            JsonObject message = currentAssistantMessage.raw.has("message")
+                    && currentAssistantMessage.raw.get("message").isJsonObject()
+                    ? currentAssistantMessage.raw.getAsJsonObject("message")
+                    : new JsonObject();
+            message.add("usage", usage);
+            currentAssistantMessage.raw.add("message", message);
+            callbackHandler.notifyMessageUpdate(state.getMessages());
+        } catch (Exception e) {
+            LOG.debug("Gemini usage parse skipped: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Push context occupancy to the status bar.
+     * Uses input (+ cache) only — never total_tokens (includes output).
+     *
+     * @param authoritative when true, always apply (final result); when false, ignore regressions
+     * @return true if applied
+     */
+    private boolean applyContextUsage(JsonObject usage, boolean authoritative) {
+        if (usage == null) {
+            return false;
+        }
+        int used = TokenUsageUtils.extractContextTokens(usage, "gemini");
+        if (used <= 0) {
+            return false;
+        }
+        if (!authoritative && used < peakContextTokens) {
+            return false;
+        }
+        if (used > peakContextTokens) {
+            peakContextTokens = used;
+        }
+        int maxTokens = SettingsHandler.getModelContextLimit(state.getProvider(), state.getModel());
+        int effectiveUsed = maxTokens > 0 ? Math.min(used, maxTokens) : used;
+        if (project != null) {
+            ClaudeNotifier.setTokenUsage(project, effectiveUsed, maxTokens);
+        }
+        callbackHandler.notifyUsageUpdate(effectiveUsed, maxTokens);
+        return true;
+    }
+
+    private void handleMessageEnd() {
+        if (isThinking) {
+            isThinking = false;
+            callbackHandler.notifyThinkingStatusChanged(false);
+        }
+    }
+
+    private Message parseAssistantMessage(JsonObject msg) {
+        String text = extractText(msg);
+        Message m = new Message(Message.Type.ASSISTANT, text != null ? text : "");
+        m.raw = msg;
+        return m;
+    }
+
+    private String extractText(JsonObject msg) {
+        if (msg == null) {
+            return "";
+        }
+        try {
+            if (msg.has("message") && msg.get("message").isJsonObject()) {
+                JsonObject message = msg.getAsJsonObject("message");
+                if (message.has("content")) {
+                    com.google.gson.JsonElement c = message.get("content");
+                    if (c.isJsonArray()) {
+                        StringBuilder sb = new StringBuilder();
+                        for (com.google.gson.JsonElement el : c.getAsJsonArray()) {
+                            if (el.isJsonObject()) {
+                                JsonObject b = el.getAsJsonObject();
+                                if (b.has("text")) {
+                                    sb.append(b.get("text").getAsString());
+                                }
+                            }
+                        }
+                        return sb.toString();
+                    } else if (c.isJsonPrimitive()) {
+                        return c.getAsString();
+                    }
+                }
+            }
+            if (msg.has("content") && msg.get("content").isJsonPrimitive()) {
+                return msg.get("content").getAsString();
+            }
+        } catch (Exception ignored) {
+        }
+        return "";
+    }
+
+    private boolean hasToolUseBlocks(JsonObject msg) {
+        try {
+            if (msg != null && msg.has("message") && msg.get("message").isJsonObject()) {
+                JsonObject message = msg.getAsJsonObject("message");
+                if (message.has("content") && message.get("content").isJsonArray()) {
+                    for (com.google.gson.JsonElement el : message.getAsJsonArray("content")) {
+                        if (el.isJsonObject() && el.getAsJsonObject().has("type")) {
+                            if ("tool_use".equals(el.getAsJsonObject().get("type").getAsString())) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception ignored) {
+        }
+        return false;
+    }
+
+    private boolean hasToolResult(JsonObject msg) {
+        try {
+            if (msg != null && msg.has("message") && msg.get("message").isJsonObject()) {
+                JsonObject message = msg.getAsJsonObject("message");
+                if (message.has("content") && message.get("content").isJsonArray()) {
+                    for (com.google.gson.JsonElement el : message.getAsJsonArray("content")) {
+                        if (el.isJsonObject() && el.getAsJsonObject().has("type")) {
+                            if ("tool_result".equals(el.getAsJsonObject().get("type").getAsString())) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception ignored) {
+        }
+        return false;
+    }
+
+    private JsonObject mergeAssistantRaw(JsonObject previous, JsonObject incoming) {
+        // Merge content blocks from incoming into previous without duplicating tool_use blocks
+        try {
+            JsonObject prevMsg = previous.has("message") && previous.get("message").isJsonObject()
+                    ? previous.getAsJsonObject("message")
+                    : new JsonObject();
+            JsonArray prevContent = prevMsg.has("content") && prevMsg.get("content").isJsonArray()
+                    ? prevMsg.getAsJsonArray("content")
+                    : new JsonArray();
+
+            if (incoming.has("message") && incoming.get("message").isJsonObject()) {
+                JsonObject inMsg = incoming.getAsJsonObject("message");
+                if (inMsg.has("content") && inMsg.get("content").isJsonArray()) {
+                    for (com.google.gson.JsonElement el : inMsg.getAsJsonArray("content")) {
+                        if (!el.isJsonObject()) {
+                            continue;
+                        }
+                        JsonObject incomingBlock = el.getAsJsonObject();
+                        String type = incomingBlock.has("type") ? incomingBlock.get("type").getAsString() : "";
+                        String id = incomingBlock.has("id") ? incomingBlock.get("id").getAsString() : "";
+
+                        if ("tool_use".equals(type)) {
+                            boolean exists = false;
+                            if (!id.isEmpty()) {
+                                for (com.google.gson.JsonElement prevEl : prevContent) {
+                                    if (prevEl.isJsonObject()) {
+                                        JsonObject p = prevEl.getAsJsonObject();
+                                        if ("tool_use".equals(p.has("type") ? p.get("type").getAsString() : "")
+                                                && id.equals(p.has("id") ? p.get("id").getAsString() : "")) {
+                                            exists = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            if (!exists) {
+                                prevContent.add(incomingBlock.deepCopy());
+                            }
+                        } else if ("text".equals(type)) {
+                            boolean textBlockFound = false;
+                            for (com.google.gson.JsonElement prevEl : prevContent) {
+                                if (prevEl.isJsonObject() && "text".equals(prevEl.getAsJsonObject().has("type") ? prevEl.getAsJsonObject().get("type").getAsString() : "")) {
+                                    if (incomingBlock.has("text")) {
+                                        prevEl.getAsJsonObject().addProperty("text", incomingBlock.get("text").getAsString());
+                                    }
+                                    textBlockFound = true;
+                                    break;
+                                }
+                            }
+                            if (!textBlockFound) {
+                                prevContent.add(incomingBlock.deepCopy());
+                            }
+                        } else {
+                            prevContent.add(incomingBlock.deepCopy());
+                        }
+                    }
+                }
+            }
+            prevMsg.add("content", prevContent);
+            previous.add("message", prevMsg);
+            return previous;
+        } catch (Exception e) {
+            return incoming;
+        }
+    }
+
+    private void ensureAssistantRaw() {
+        Message target = resolveAssistantMessageForStream();
+        if (target.raw == null) {
+            JsonObject raw = new JsonObject();
+            raw.addProperty("type", "assistant");
+            JsonObject messageObj = new JsonObject();
+            messageObj.add("content", new JsonArray());
+            raw.add("message", messageObj);
+            target.raw = raw;
+        }
+    }
+
+    /**
+     * Resolve the assistant bubble for the current stream. Always creates a new
+     * message on the first call after {@code stream_start} instead of reusing a
+     * completed previous-turn assistant (see {@link #assistantMessageForCurrentStream}).
+     */
+    private Message resolveAssistantMessageForStream() {
+        if (currentAssistantMessage != null) {
+            return currentAssistantMessage;
+        }
+        if (assistantMessageForCurrentStream != null) {
+            currentAssistantMessage = assistantMessageForCurrentStream;
+            return currentAssistantMessage;
+        }
+        Message created = new Message(Message.Type.ASSISTANT, assistantContent.toString());
+        state.addMessage(created);
+        currentAssistantMessage = created;
+        assistantMessageForCurrentStream = created;
+        return created;
+    }
+
+    private void appendThinkingToRaw(String delta) {
+        ensureAssistantRaw();
+        JsonObject raw = currentAssistantMessage.raw;
+        JsonObject message = raw.has("message") && raw.get("message").isJsonObject()
+                ? raw.getAsJsonObject("message")
+                : new JsonObject();
+        JsonArray content = message.has("content") && message.get("content").isJsonArray()
+                ? message.getAsJsonArray("content")
+                : new JsonArray();
+
+        JsonObject thinkingBlock = null;
+        for (int i = content.size() - 1; i >= 0; i--) {
+            com.google.gson.JsonElement el = content.get(i);
+            if (el.isJsonObject() && el.getAsJsonObject().has("type")
+                    && "thinking".equals(el.getAsJsonObject().get("type").getAsString())) {
+                thinkingBlock = el.getAsJsonObject();
+                break;
+            }
+        }
+        if (thinkingBlock == null) {
+            thinkingBlock = new JsonObject();
+            thinkingBlock.addProperty("type", "thinking");
+            thinkingBlock.addProperty("thinking", delta);
+            content.add(thinkingBlock);
+        } else {
+            String prev = thinkingBlock.has("thinking") ? thinkingBlock.get("thinking").getAsString() : "";
+            thinkingBlock.addProperty("thinking", prev + delta);
+        }
+        message.add("content", content);
+        raw.add("message", message);
+    }
+
+    private void resetStreamingAccumulator() {
+        assistantContent.setLength(0);
+        currentAssistantMessage = null;
+        assistantMessageForCurrentStream = null;
+    }
+}

--- a/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
@@ -41,6 +41,8 @@ public class SessionLifecycleManager {
 
         CodexSDKBridge getCodexSDKBridge();
 
+        com.github.claudecodegui.provider.gemini.GeminiSDKBridge getGeminiSDKBridge();
+
         Map<String, MarkerCliBridge> getCliBridges();
 
         ClaudeSession getSession();
@@ -197,13 +199,22 @@ public class SessionLifecycleManager {
      * Load a history session by ID.
      */
     public void loadHistorySession(String sessionId, String projectPath) {
-        loadHistorySession(sessionId, projectPath, null);
+        loadHistorySession(sessionId, projectPath, null, null);
     }
 
     /**
      * Load a history session by ID and provider.
      */
     public void loadHistorySession(String sessionId, String projectPath, String provider) {
+        loadHistorySession(sessionId, projectPath, provider, null);
+    }
+
+    /**
+     * Load a history session by ID, provider, and optional model from the history row.
+     *
+     * @param model when non-blank, restores that model instead of keeping the previous UI selection
+     */
+    public void loadHistorySession(String sessionId, String projectPath, String provider, String model) {
         LOG.info("Loading history session: " + sessionId + " from project: " + projectPath);
 
         ClaudeSession oldSession = host.getSession();
@@ -224,8 +235,10 @@ public class SessionLifecycleManager {
             previousProvider = defaultSession.getProvider();
             previousModel = defaultSession.getModel();
         }
+        String modelToRestore = (model != null && !model.trim().isEmpty()) ? model.trim() : previousModel;
         LOG.info("Preserving session state when loading history: mode=" + previousPermissionMode
-                         + ", provider=" + previousProvider + ", model=" + previousModel);
+                         + ", provider=" + previousProvider + ", model=" + modelToRestore
+                         + (model != null && !model.trim().isEmpty() ? " (from history)" : " (previous)"));
 
         host.invalidateSessionCallbacks();
         long clearBarrierSeq = host.getStreamCoalescer().resetStreamState();
@@ -248,12 +261,13 @@ public class SessionLifecycleManager {
                     host.getProject(),
                     host.getClaudeSDKBridge(),
                     host.getCodexSDKBridge(),
-                    host.getCliBridges());
+                    host.getCliBridges(),
+                    host.getGeminiSDKBridge());
             newSession.setPermissionMode(previousPermissionMode);
             newSession.setProvider(provider != null && !provider.trim().isEmpty() ? provider : previousProvider);
-            newSession.setModel(previousModel);
+            newSession.setModel(modelToRestore);
             LOG.info("Restored session state to loaded session: mode=" + previousPermissionMode
-                             + ", provider=" + newSession.getProvider() + ", model=" + previousModel);
+                             + ", provider=" + newSession.getProvider() + ", model=" + modelToRestore);
 
             host.setSession(newSession);
             host.getHandlerContext().setSession(newSession);
@@ -264,7 +278,9 @@ public class SessionLifecycleManager {
             newSession.setSessionInfo(sessionId, workingDir);
 
             // Prewarm daemon runtime for the historical session so /context and first message are fast
-            host.getClaudeSDKBridge().prewarmDaemonAsync(workingDir, newSession.getRuntimeSessionEpoch(), sessionId);
+            if ("claude".equals(newSession.getProvider())) {
+                host.getClaudeSDKBridge().prewarmDaemonAsync(workingDir, newSession.getRuntimeSessionEpoch(), sessionId);
+            }
 
             newSession.loadFromServer().thenRun(() -> ApplicationManager.getApplication().invokeLater(() -> {
                 host.callJavaScript("historyLoadComplete");
@@ -414,7 +430,8 @@ public class SessionLifecycleManager {
                 host.getProject(),
                 host.getClaudeSDKBridge(),
                 host.getCodexSDKBridge(),
-                host.getCliBridges());
+                host.getCliBridges(),
+                host.getGeminiSDKBridge());
     }
 
     private void completeNewSessionBootstrap(ClaudeSession newSession, String workingDirectory, String successLogPrefix) {
@@ -426,7 +443,9 @@ public class SessionLifecycleManager {
 
         newSession.setSessionInfo(null, workingDirectory);
         LOG.info(successLogPrefix + workingDirectory + ", epoch=" + newSession.getRuntimeSessionEpoch());
-        host.getClaudeSDKBridge().prewarmDaemonAsync(workingDirectory, newSession.getRuntimeSessionEpoch());
+        if ("claude".equals(newSession.getProvider())) {
+            host.getClaudeSDKBridge().prewarmDaemonAsync(workingDirectory, newSession.getRuntimeSessionEpoch());
+        }
         fetchSlashCommandsOnStartup();
 
         ApplicationManager.getApplication().invokeLater(() -> {

--- a/src/main/java/com/github/claudecodegui/session/SessionProviderRouter.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionProviderRouter.java
@@ -2,6 +2,7 @@ package com.github.claudecodegui.session;
 
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.provider.gemini.GeminiSDKBridge;
 import com.github.claudecodegui.provider.common.MarkerCliBridge;
 import com.google.gson.JsonObject;
 
@@ -33,6 +34,7 @@ public class SessionProviderRouter {
 
     private final ClaudeSDKBridge claudeSDKBridge;
     private final CodexSDKBridge codexSDKBridge;
+    private final GeminiSDKBridge geminiSDKBridge;
     private final Map<String, MarkerCliBridge> cliBridges;
 
     public SessionProviderRouter(
@@ -40,8 +42,18 @@ public class SessionProviderRouter {
             CodexSDKBridge codexSDKBridge,
             Map<String, MarkerCliBridge> cliBridges
     ) {
+        this(claudeSDKBridge, codexSDKBridge, cliBridges, null);
+    }
+
+    public SessionProviderRouter(
+            ClaudeSDKBridge claudeSDKBridge,
+            CodexSDKBridge codexSDKBridge,
+            Map<String, MarkerCliBridge> cliBridges,
+            GeminiSDKBridge geminiSDKBridge
+    ) {
         this.claudeSDKBridge = claudeSDKBridge;
         this.codexSDKBridge = codexSDKBridge;
+        this.geminiSDKBridge = geminiSDKBridge;
         this.cliBridges = cliBridges != null
                 ? Collections.unmodifiableMap(new LinkedHashMap<>(cliBridges))
                 : Collections.emptyMap();
@@ -67,6 +79,8 @@ public class SessionProviderRouter {
     public JsonObject launchChannel(String provider, String channelId, String sessionId, String cwd) {
         if ("codex".equals(provider)) {
             return codexSDKBridge.launchChannel(channelId, sessionId, cwd);
+        } else if ("gemini".equals(provider) && geminiSDKBridge != null) {
+            return geminiSDKBridge.launchChannel(channelId, sessionId, cwd);
         }
         MarkerCliBridge bridge = cli(provider);
         if (bridge != null) {
@@ -78,6 +92,9 @@ public class SessionProviderRouter {
     public void interruptChannel(String provider, String channelId) {
         if ("codex".equals(provider)) {
             codexSDKBridge.interruptChannel(channelId);
+            return;
+        } else if ("gemini".equals(provider) && geminiSDKBridge != null) {
+            geminiSDKBridge.interruptChannel(channelId);
             return;
         }
         MarkerCliBridge bridge = cli(provider);
@@ -91,6 +108,8 @@ public class SessionProviderRouter {
     public List<JsonObject> getSessionMessages(String provider, String sessionId, String cwd) {
         if ("codex".equals(provider)) {
             return codexSDKBridge.getSessionMessages(sessionId, cwd);
+        } else if ("gemini".equals(provider) && geminiSDKBridge != null) {
+            return geminiSDKBridge.getSessionMessages(sessionId, cwd);
         }
         MarkerCliBridge bridge = cli(provider);
         if (bridge != null) {

--- a/src/main/java/com/github/claudecodegui/session/SessionSendService.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionSendService.java
@@ -6,6 +6,7 @@ import com.github.claudecodegui.settings.CodexSettingsManager;
 import com.github.claudecodegui.notifications.ClaudeNotifier;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.provider.gemini.GeminiSDKBridge;
 import com.github.claudecodegui.provider.common.MarkerCliBridge;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -33,6 +34,7 @@ public class SessionSendService {
     private final Gson gson;
     private final ClaudeSDKBridge claudeSDKBridge;
     private final CodexSDKBridge codexSDKBridge;
+    private final GeminiSDKBridge geminiSDKBridge;
     private final Map<String, MarkerCliBridge> cliBridges;
     private final SessionContextService contextService;
 
@@ -48,6 +50,22 @@ public class SessionSendService {
             Map<String, MarkerCliBridge> cliBridges,
             SessionContextService contextService
     ) {
+        this(project, state, callbackFacade, messageParser, messageMerger, gson, claudeSDKBridge, codexSDKBridge, cliBridges, contextService, null);
+    }
+
+    public SessionSendService(
+            Project project,
+            SessionState state,
+            SessionCallbackFacade callbackFacade,
+            MessageParser messageParser,
+            MessageMerger messageMerger,
+            Gson gson,
+            ClaudeSDKBridge claudeSDKBridge,
+            CodexSDKBridge codexSDKBridge,
+            Map<String, MarkerCliBridge> cliBridges,
+            SessionContextService contextService,
+            GeminiSDKBridge geminiSDKBridge
+    ) {
         this.project = project;
         this.state = state;
         this.callbackFacade = callbackFacade;
@@ -58,6 +76,7 @@ public class SessionSendService {
         this.codexSDKBridge = codexSDKBridge;
         this.cliBridges = cliBridges != null ? cliBridges : Collections.emptyMap();
         this.contextService = contextService;
+        this.geminiSDKBridge = geminiSDKBridge;
     }
 
     public void prepareContextCollector(EditorContextCollector contextCollector) {
@@ -138,6 +157,19 @@ public class SessionSendService {
                     effectivePermissionMode,
                     normalizedRequestedEffort,
                     effectiveCodexServiceTier
+            );
+        }
+
+        if ("gemini".equals(currentProvider) && geminiSDKBridge != null) {
+            return sendToGemini(
+                    channelId,
+                    input,
+                    attachments,
+                    openedFilesJson,
+                    agentPrompt,
+                    fileTagPaths,
+                    effectivePermissionMode,
+                    normalizedRequestedEffort
             );
         }
 
@@ -305,6 +337,63 @@ public class SessionSendService {
         ).thenApply(result -> null);
     }
 
+    private CompletableFuture<Void> sendToGemini(
+            String channelId,
+            String input,
+            List<ClaudeSession.Attachment> attachments,
+            JsonObject openedFilesJson,
+            String agentPrompt,
+            List<String> fileTagPaths,
+            String effectivePermissionMode,
+            String requestedReasoningEffort
+    ) {
+        if (geminiSDKBridge == null) {
+            LOG.error("[Lifecycle] sendToGemini called but GeminiSDKBridge is null");
+            callbackFacade.notifyStateChange(false, false, "Gemini bridge not available");
+            return CompletableFuture.completedFuture(null);
+        }
+        GeminiMessageHandler handler = new GeminiMessageHandler(state, callbackFacade.getCallbackHandler(), project);
+        Boolean streaming = readStreamingEnabled();
+        final String runtimeSessionEpoch = state.getRuntimeSessionEpoch();
+        final String currentModel = state.getModel();
+        String effort = requestedReasoningEffort;
+        if (effort == null) {
+            effort = state.getReasoningEffort();
+        }
+        String projectBase = project != null ? project.getBasePath() : null;
+        String guardedCwd = com.github.claudecodegui.util.PathUtils.guardWorkingDirectory(
+                state.getCwd(), projectBase);
+        if (guardedCwd == null) {
+            guardedCwd = state.getCwd();
+        } else if (state.getCwd() == null || !guardedCwd.equals(state.getCwd())) {
+            LOG.warn("[Lifecycle] sendToGemini cwd guard: " + state.getCwd() + " -> " + guardedCwd);
+            state.setCwd(guardedCwd);
+        }
+        LOG.info("[Lifecycle] sendToGemini model=" + currentModel
+                + ", sessionId=" + (state.getSessionId() != null ? state.getSessionId() : "(new)")
+                + ", cwd=" + guardedCwd);
+
+        String contextAppend = contextService.buildCodexContextAppend(openedFilesJson, fileTagPaths);
+        String finalInput = (input != null ? input : "") + contextAppend;
+
+        return geminiSDKBridge.sendMessage(
+                channelId,
+                finalInput,
+                state.getSessionId(),
+                runtimeSessionEpoch,
+                guardedCwd,
+                attachments,
+                effectivePermissionMode,
+                currentModel,
+                openedFilesJson,
+                agentPrompt,
+                streaming,
+                false,
+                effort,
+                handler
+        ).thenApply(result -> null);
+    }
+
     private CompletableFuture<Void> sendToCliProvider(
             String provider,
             String channelId,
@@ -337,9 +426,18 @@ public class SessionSendService {
         );
         String modelForCli = normalizeCliModelForProvider(provider, state.getModel());
 
+        String projectBase = project != null ? project.getBasePath() : null;
+        String guardedCwd = com.github.claudecodegui.util.PathUtils.guardWorkingDirectory(
+                state.getCwd(), projectBase);
+        if (guardedCwd == null) {
+            guardedCwd = state.getCwd();
+        } else if (state.getCwd() == null || !guardedCwd.equals(state.getCwd())) {
+            state.setCwd(guardedCwd);
+        }
+
         LOG.info("[Lifecycle] sendToCli provider=" + provider
                 + " sessionId=" + (state.getSessionId() != null ? state.getSessionId() : "(new)")
-                + ", cwd=" + state.getCwd()
+                + ", cwd=" + guardedCwd
                 + ", modelRaw=" + state.getModel()
                 + ", modelCli=" + (modelForCli != null ? modelForCli : "(config-default)")
                 + ", effort=" + effort);
@@ -348,7 +446,7 @@ public class SessionSendService {
                 channelId,
                 finalInput,
                 state.getSessionId(),
-                state.getCwd(),
+                guardedCwd,
                 modelForCli != null ? modelForCli : "",
                 effort,
                 handler
@@ -397,10 +495,9 @@ public class SessionSendService {
             return null;
         }
         if ("grok".equals(provider)) {
-            // Legacy UI stored upstream API id "grok-4.5"; CLI needs profile name "grok".
-            if ("grok-4.5".equals(lower) || "grok-4".equals(lower) || "grok-4.5-build".equals(lower)) {
-                LOG.info("[Grok] Remapping upstream model id '" + trimmed + "' to config profile 'grok'");
-                return "grok";
+            if ("grok".equals(lower) || "default".equals(lower) || "(default)".equals(lower)) {
+                LOG.info("[Grok] Normalizing sentinel model id '" + trimmed + "' to default model 'grok-4.5'");
+                return "grok-4.5";
             }
         }
         return trimmed;

--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -82,6 +82,7 @@ public class ChatWindowDelegate {
         Project getProject();
         ClaudeSDKBridge getClaudeSDKBridge();
         CodexSDKBridge getCodexSDKBridge();
+        com.github.claudecodegui.provider.gemini.GeminiSDKBridge getGeminiSDKBridge();
         Map<String, MarkerCliBridge> getCliBridges();
         ClaudeSession getSession();
         CodemossSettingsService getSettingsService();
@@ -130,6 +131,8 @@ public class ChatWindowDelegate {
     private ScheduledFuture<?> statusResetTask;
     private volatile String pendingQuickFixPrompt = null;
     private volatile MessageCallback pendingQuickFixCallback = null;
+    // Reference to the SettingsHandler for clean theme-callback unregistration on dispose.
+    private com.github.claudecodegui.handler.SettingsHandler settingsHandler;
 
     public ChatWindowDelegate(DelegateHost host) {
         this.host = host;
@@ -316,6 +319,7 @@ public class ChatWindowDelegate {
                 project,
                 claudeSDKBridge,
                 codexSDKBridge,
+                host.getGeminiSDKBridge(),
                 settingsService,
                 jsCallback,
                 host::isActiveContent,
@@ -343,7 +347,8 @@ public class ChatWindowDelegate {
         messageDispatcher.registerHandler(new CodexPetHandler(handlerContext));
         messageDispatcher.registerHandler(new SkillHandler(handlerContext));
         messageDispatcher.registerHandler(new FileHandler(handlerContext));
-        messageDispatcher.registerHandler(new SettingsHandler(handlerContext));
+        this.settingsHandler = new SettingsHandler(handlerContext);
+        messageDispatcher.registerHandler(this.settingsHandler);
         messageDispatcher.registerHandler(new SessionHandler(handlerContext));
         messageDispatcher.registerHandler(new ContextHandler(handlerContext));
         messageDispatcher.registerHandler(new FileExportHandler(handlerContext));
@@ -403,7 +408,7 @@ public class ChatWindowDelegate {
         messageDispatcher.registerHandler(permissionHandler);
 
         HistoryHandler historyHandler = new HistoryHandler(handlerContext);
-        historyHandler.setSessionLoadCallback((sessionId, projectPath, provider) -> {
+        historyHandler.setSessionLoadCallback((sessionId, projectPath, provider, model) -> {
             ClaudeSession current = host.getSession();
             boolean sameSession = current != null
                     && sessionId != null
@@ -414,9 +419,12 @@ public class ChatWindowDelegate {
                 // Re-opening the very session already active: soft-reload its transcript
                 // instead of interrupting the in-flight turn.
                 LOG.info("[HistoryHandler] Same-session resume, soft-reloading transcript: " + sessionId);
+                if (model != null && !model.trim().isEmpty()) {
+                    current.setModel(model.trim());
+                }
                 host.reloadActiveSessionMessages();
             } else {
-                host.getSessionLifecycleManager().loadHistorySession(sessionId, projectPath, provider);
+                host.getSessionLifecycleManager().loadHistorySession(sessionId, projectPath, provider, model);
             }
         });
         host.setHistoryHandler(historyHandler);
@@ -751,6 +759,13 @@ public class ChatWindowDelegate {
             statusResetTask.cancel(false);
             statusResetTask = null;
             LOG.debug("[TabStatus] Cancelled pending status reset task");
+        }
+        // Unregister the theme-change callback to prevent notifications to the disposed webview.
+        // This fixes the "Cannot call JS function window.onIdeThemeChanged: disposed=true" warning
+        // and ensures stale sessions don't interfere with theme updates for remaining windows.
+        if (settingsHandler != null) {
+            settingsHandler.dispose();
+            settingsHandler = null;
         }
     }
 }

--- a/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
@@ -235,9 +235,15 @@ public class WebviewInitializer {
         // Prewarm daemon in background so first user message starts faster.
         // Bind the warm runtime to the current logical session epoch so future new-session
         // transitions cannot accidentally reuse stale anonymous runtime ownership.
-        claudeSDKBridge.prewarmDaemonAsync(host.getProject().getBasePath(), host.getHandlerContext().getSession() != null
-                ? host.getHandlerContext().getSession().getRuntimeSessionEpoch()
-                : null);
+        com.github.claudecodegui.session.ClaudeSession currentSession = host.getHandlerContext().getSession();
+        if (currentSession != null) {
+            if ("claude".equals(currentSession.getProvider())) {
+                claudeSDKBridge.prewarmDaemonAsync(host.getProject().getBasePath(), currentSession.getRuntimeSessionEpoch());
+            }
+        } else {
+            // Default to prewarming Claude if no session exists yet (e.g., first startup before session is loaded)
+            claudeSDKBridge.prewarmDaemonAsync(host.getProject().getBasePath(), null);
+        }
 
         // Check JCEF support before creating browser. Keep the precise status
         // so the fallback panel can distinguish a disabled registry flag from

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -32,6 +32,7 @@ import com.github.claudecodegui.ui.detached.DetachedChatFrame;
 import com.github.claudecodegui.ui.detached.DetachedWindowManager;
 import com.github.claudecodegui.util.HtmlLoader;
 import com.github.claudecodegui.util.JsUtils;
+import com.github.claudecodegui.util.ThemeConfigService;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -61,6 +62,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 
+import com.github.claudecodegui.provider.gemini.GeminiSDKBridge;
+
 /**
  * Chat window instance. Coordinates UI components, session management,
  * and message dispatching. One instance per tab.
@@ -71,6 +74,7 @@ public class ClaudeChatWindow {
     private final JPanel mainPanel;
     private final ClaudeSDKBridge claudeSDKBridge;
     private final CodexSDKBridge codexSDKBridge;
+    private final GeminiSDKBridge geminiSDKBridge;
     private final Map<String, MarkerCliBridge> cliBridges;
     private final GrokCliBridge grokCliBridge;
     private final KimiCliBridge kimiCliBridge;
@@ -152,6 +156,11 @@ public class ClaudeChatWindow {
     private DaemonBridge.DaemonEventListener titleEventListener;
     private volatile int fetchedSlashCommandsCount = 0;
 
+    // Theme-change callback handle for updating Swing component backgrounds (mainPanel, browser).
+    // Separate from the SettingsHandler's JS-notification callback: this one ensures the Java-side
+    // Swing containers repaint with the new theme color, not just the webview's CSS.
+    private ThemeConfigService.RegisteredCallback swingThemeCallbackHandle;
+
     // Coalesces session_updated reloads. SessionState's message list is not
     // thread-safe and loadFromServer() runs async, so concurrent background-task
     // completions must not reload at the same time. Guarded by sessionReloadLock.
@@ -210,6 +219,7 @@ public class ClaudeChatWindow {
         this.project = project;
         this.claudeSDKBridge = new ClaudeSDKBridge();
         this.codexSDKBridge = new CodexSDKBridge();
+        this.geminiSDKBridge = new GeminiSDKBridge();
         this.grokCliBridge = new GrokCliBridge();
         this.kimiCliBridge = new KimiCliBridge();
         this.openCodeCliBridge = new OpenCodeCliBridge();
@@ -271,7 +281,7 @@ public class ClaudeChatWindow {
                 () -> frontendReady
         );
 
-        this.session = new ClaudeSession(project, claudeSDKBridge, codexSDKBridge, cliBridges);
+        this.session = new ClaudeSession(project, claudeSDKBridge, codexSDKBridge, cliBridges, geminiSDKBridge);
 
         this.chatWindowDelegate = new ChatWindowDelegate(createDelegateHost());
         chatWindowDelegate.loadPermissionModeFromSettings();
@@ -295,6 +305,11 @@ public class ClaudeChatWindow {
             @Override
             public CodexSDKBridge getCodexSDKBridge() {
                 return codexSDKBridge;
+            }
+
+            @Override
+            public GeminiSDKBridge getGeminiSDKBridge() {
+                return geminiSDKBridge;
             }
 
             @Override
@@ -390,6 +405,32 @@ public class ClaudeChatWindow {
             }
         });
         editorContextTracker.registerListeners();
+
+        // Register a Swing-level theme change callback to update the background color of
+        // mainPanel and the browser component when the IDE theme changes. This ensures
+        // Java-side containers repaint with the correct color, complementing the webview's
+        // CSS theme update (handled by SettingsHandler). Fixes issue #1586.
+        swingThemeCallbackHandle = ThemeConfigService.registerThemeChangeListener(themeConfig -> {
+            ApplicationManager.getApplication().invokeLater(() -> {
+                if (disposed) {
+                    return;
+                }
+                Color bgColor = ThemeConfigService.getBackgroundColor();
+                mainPanel.setBackground(bgColor);
+                JBCefBrowser currentBrowser = browser;
+                if (currentBrowser != null) {
+                    try {
+                        java.awt.Component browserComp = currentBrowser.getComponent();
+                        if (browserComp != null) {
+                            browserComp.setBackground(bgColor);
+                        }
+                    } catch (Exception | LinkageError e) {
+                        LOG.debug("Failed to update browser component background on theme change: " + e.getMessage());
+                    }
+                }
+                mainPanel.repaint();
+            });
+        }, true);
 
         this.webviewInitializer = new WebviewInitializer(createWebviewHost());
 
@@ -1329,6 +1370,10 @@ public class ClaudeChatWindow {
 
     public ClaudeSDKBridge getClaudeSDKBridge() {
         return claudeSDKBridge;
+    }
+
+    public GeminiSDKBridge getGeminiSDKBridge() {
+        return geminiSDKBridge;
     }
 
     public CodexSDKBridge getCodexSDKBridge() {
@@ -2717,6 +2762,12 @@ public class ClaudeChatWindow {
         chatWindowDelegate.dispose();
         editorContextTracker.dispose();
         streamCoalescer.dispose();
+        // Unregister the Swing-level theme change callback to prevent background updates
+        // on a disposed panel. The SettingsHandler's callback is cleaned up via chatWindowDelegate.dispose().
+        if (swingThemeCallbackHandle != null) {
+            ThemeConfigService.unregisterThemeChangeListener(swingThemeCallbackHandle);
+            swingThemeCallbackHandle = null;
+        }
         Disposer.dispose(surfaceRefreshAlarmDisposable);
         deferredReloadSafetyAlarm.cancelAllRequests();
         Disposer.dispose(safetyAlarmDisposable);
@@ -2948,6 +2999,11 @@ public class ClaudeChatWindow {
             @Override
             public CodexSDKBridge getCodexSDKBridge() {
                 return codexSDKBridge;
+            }
+
+            @Override
+            public GeminiSDKBridge getGeminiSDKBridge() {
+                return geminiSDKBridge;
             }
 
             @Override

--- a/src/main/java/com/github/claudecodegui/util/PathUtils.java
+++ b/src/main/java/com/github/claudecodegui/util/PathUtils.java
@@ -338,6 +338,79 @@ public class PathUtils {
         return false;
     }
 
+    /**
+     * Paths that must never be used as the agent working directory / agy
+     * {@code workspaceDirs}. Observed failures used plugin install dirs, the
+     * embedded ai-bridge tree, or {@code ~/.gemini} when cwd fell through.
+     *
+     * @param path candidate working directory
+     * @return true when the path is empty or clearly not a user project root
+     */
+    public static boolean isUnsafeWorkingDirectory(String path) {
+        if (path == null || path.trim().isEmpty()) {
+            return true;
+        }
+        String normalized = normalizeToUnix(path.trim()).toLowerCase();
+        if (normalized.isEmpty() || "undefined".equals(normalized) || "null".equals(normalized)) {
+            return true;
+        }
+        // JetBrains plugin install / config trees (embedded ai-bridge lives here).
+        if (normalized.contains("/application support/jetbrains/")) {
+            return true;
+        }
+        if (normalized.contains("/plugins/idea-claude-code-gui")) {
+            return true;
+        }
+        if (normalized.contains("/.local/share/jetbrains/")) {
+            return true;
+        }
+        // Standalone ai-bridge checkout used as process.cwd() by the daemon.
+        if (normalized.endsWith("/ai-bridge") || normalized.contains("/ai-bridge/")) {
+            return true;
+        }
+        // Antigravity CLI default home — was seen as workspaceDirs=[~/.gemini].
+        if (normalized.endsWith("/.gemini") || normalized.contains("/.gemini/")) {
+            return true;
+        }
+        if (normalized.endsWith("/.gemini/antigravity-cli")
+                || normalized.contains("/.gemini/antigravity-cli/")) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Prefer {@code requested} when it is a safe existing directory; otherwise
+     * fall back to {@code projectBasePath} when that is safe. Returns the first
+     * usable path, or {@code null} when neither is acceptable.
+     */
+    public static String guardWorkingDirectory(String requested, String projectBasePath) {
+        String primary = firstSafeExistingDirectory(requested);
+        if (primary != null) {
+            return primary;
+        }
+        String fallback = firstSafeExistingDirectory(projectBasePath);
+        if (fallback != null) {
+            return fallback;
+        }
+        return null;
+    }
+
+    private static String firstSafeExistingDirectory(String path) {
+        if (path == null || path.trim().isEmpty() || isUnsafeWorkingDirectory(path)) {
+            return null;
+        }
+        String normalized = normalizeAbsolute(path.trim());
+        if (normalized == null || normalized.isEmpty() || isUnsafeWorkingDirectory(normalized)) {
+            return null;
+        }
+        File dir = new File(normalized);
+        if (!dir.isDirectory()) {
+            return null;
+        }
+        return normalized;
+    }
+
     // ==================== Path Validation ====================
 
     /**

--- a/src/main/java/com/github/claudecodegui/util/ThemeConfigService.java
+++ b/src/main/java/com/github/claudecodegui/util/ThemeConfigService.java
@@ -9,6 +9,8 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 
 import java.awt.Color;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * IDE theme configuration service.
@@ -31,9 +33,37 @@ public class ThemeConfigService {
     public static final Color LIGHT_BG_COLOR = Color.WHITE;             // #ffffff
     public static final String DARK_BG_HEX = "#1e1e1e";
     public static final String LIGHT_BG_HEX = "#ffffff";
-    private static ThemeChangeCallback themeChangeCallback = null;
     private static Boolean lastKnownIsDark = null; // Cache the last known theme state for deduplication
-    private static boolean listenerRegistered = false;
+    // Written from window-registration threads, read from the LafManager/EDT thread.
+    private static volatile boolean listenerRegistered = false;
+
+    // Multi-callback support: each ClaudeChatWindow registers its own callback so that
+    // theme changes are delivered to every open session, not just the last one registered.
+    // CopyOnWriteArraySet ensures safe iteration on the LafManager thread without explicit locking.
+    private static final CopyOnWriteArraySet<RegisteredCallback> themeChangeCallbacks = new CopyOnWriteArraySet<>();
+    private static final AtomicLong callbackIdSeq = new AtomicLong(0);
+
+    // Slot for callbacks registered via the legacy no-handle overload. Each legacy call
+    // replaces the previous slot (preserving the original "update on project reopen"
+    // semantics) so repeated registrations never accumulate duplicates in the set.
+    private static volatile RegisteredCallback legacySlot = null;
+
+    /**
+     * Opaque handle returned by {@link #registerThemeChangeListener(ThemeChangeCallback, boolean)}
+     * for later unregistration via {@link #unregisterThemeChangeListener(RegisteredCallback)}.
+     */
+    public static final class RegisteredCallback {
+        private final long id;
+        private final ThemeChangeCallback callback;
+
+        RegisteredCallback(long id, ThemeChangeCallback callback) {
+            this.id = id;
+            this.callback = callback;
+        }
+
+        long getId() { return id; }
+        ThemeChangeCallback getCallback() { return callback; }
+    }
 
     /**
      * Callback interface for theme changes.
@@ -43,26 +73,97 @@ public class ThemeConfigService {
     }
 
     /**
-     * Register a theme change listener.
-     * Uses LafManagerListener to listen for all Look and Feel changes.
+     * Register a theme change listener (backward-compatible no-handle overload).
      *
-     * The listener fires in these situations:
-     * - User manually switches theme (View - Appearance - Theme)
-     * - IDE follows OS theme changes (Settings - Sync with OS enabled)
-     * - Toggling Sync with OS causes an actual theme change
-     * - Installing or switching to a custom theme
+     * <p>Each call <em>replaces</em> the previous no-handle registration, preserving the
+     * original single-callback semantics (e.g. a project reopen re-registers without
+     * accumulating duplicates). New callers should prefer
+     * {@link #registerThemeChangeListener(ThemeChangeCallback, boolean)} which returns a
+     * handle that can be used for clean unregistration on dispose.
      *
-     * Notes:
-     * - The listener is registered once (Application level) and remains active for the IDE's lifetime
-     * - Each call updates the callback, supporting project close/reopen scenarios
+     * @param callback the callback to invoke on theme change
      */
     public static void registerThemeChangeListener(ThemeChangeCallback callback) {
-        // Always update the callback to support project reopen scenarios
-        // Even if listenerRegistered is true, the callback needs updating after project reopen
-        themeChangeCallback = callback;
-        LOG.info("[ThemeConfig] Theme change callback updated");
+        ensureListenerRegistered();
+
+        RegisteredCallback slot = new RegisteredCallback(callbackIdSeq.incrementAndGet(), callback);
+        RegisteredCallback prev = legacySlot;
+        legacySlot = slot;
+        if (prev != null) {
+            themeChangeCallbacks.remove(prev);
+        }
+        if (callback != null) {
+            themeChangeCallbacks.add(slot);
+        }
+        LOG.info("[ThemeConfig] Legacy (no-handle) theme change callback updated");
+    }
+
+    /**
+     * Register a theme change listener and return a handle for later unregistration.
+     *
+     * <p>Each {@link com.github.claudecodegui.ui.toolwindow.ClaudeChatWindow ClaudeChatWindow}
+     * registers its own callback so that theme changes are delivered to <em>every</em> open
+     * session, not just the last one registered. The returned handle should be passed to
+     * {@link #unregisterThemeChangeListener(RegisteredCallback)} when the window is disposed
+     * to prevent notifications to disposed webviews.
+     *
+     * <p>The listener is registered once at the Application level and remains active for the
+     * IDE's lifetime. Multiple callbacks can coexist and are all notified on each theme change.
+     *
+     * @param callback the callback to invoke on theme change
+     * @param returnHandle if {@code true}, returns a {@link RegisteredCallback} handle for
+     *                     later unregistration; if {@code false}, behaves like the legacy
+     *                     no-handle overload and returns {@code null}
+     * @return a handle for unregistration, or {@code null} if {@code returnHandle} is false
+     */
+    public static RegisteredCallback registerThemeChangeListener(ThemeChangeCallback callback, boolean returnHandle) {
+        if (!returnHandle) {
+            registerThemeChangeListener(callback);
+            return null;
+        }
 
         // Register the listener only once (Application level)
+        ensureListenerRegistered();
+
+        RegisteredCallback handle = null;
+        if (callback != null) {
+            handle = new RegisteredCallback(callbackIdSeq.incrementAndGet(), callback);
+            themeChangeCallbacks.add(handle);
+            LOG.info("[ThemeConfig] Multi-callback registered (id=" + handle.getId()
+                    + ", total=" + themeChangeCallbacks.size() + ")");
+        }
+
+        return handle;
+    }
+
+    /**
+     * Unregister a previously registered theme change callback.
+     *
+     * <p>Should be called when a {@link com.github.claudecodegui.ui.toolwindow.ClaudeChatWindow}
+     * is disposed, so that theme changes no longer attempt to call JavaScript on a disposed
+     * webview (which logs the warning "Cannot call JS function window.onIdeThemeChanged: disposed=true").
+     *
+     * @param handle the handle returned by {@link #registerThemeChangeListener(ThemeChangeCallback, boolean)}
+     */
+    public static void unregisterThemeChangeListener(RegisteredCallback handle) {
+        if (handle == null) {
+            return;
+        }
+        boolean removed = themeChangeCallbacks.remove(handle);
+        if (removed) {
+            LOG.info("[ThemeConfig] Multi-callback unregistered (id=" + handle.getId()
+                    + ", remaining=" + themeChangeCallbacks.size() + ")");
+            // Clear the legacy slot if the removed handle is the current legacy registration
+            if (handle == legacySlot) {
+                legacySlot = null;
+            }
+        }
+    }
+
+    /**
+     * Ensure the LafManagerListener is registered exactly once at the Application level.
+     */
+    private static void ensureListenerRegistered() {
         if (listenerRegistered) {
             LOG.debug("[ThemeConfig] Listener already registered, callback updated");
             return;
@@ -95,12 +196,12 @@ public class ThemeConfigService {
     }
 
     /**
-     * Notify the frontend of a theme change.
+     * Notify all registered callbacks of a theme change.
      * Only sends a notification when the theme actually changes, avoiding duplicate notifications and unnecessary UI updates.
      */
     private static void notifyThemeChange() {
-        if (themeChangeCallback == null) {
-            LOG.warn("[ThemeConfig] Theme callback is null, cannot notify");
+        if (themeChangeCallbacks.isEmpty()) {
+            LOG.warn("[ThemeConfig] No theme callbacks registered, cannot notify");
             return;
         }
 
@@ -116,8 +217,17 @@ public class ThemeConfigService {
 
             // Update cache and notify
             lastKnownIsDark = currentIsDark;
-            LOG.info("[ThemeConfig] Theme changed to: " + (currentIsDark ? "DARK" : "LIGHT") + ", notifying webview");
-            themeChangeCallback.onThemeChanged(config);
+            LOG.info("[ThemeConfig] Theme changed to: " + (currentIsDark ? "DARK" : "LIGHT")
+                    + ", notifying " + themeChangeCallbacks.size() + " webview(s)");
+
+            // Notify all registered callbacks (one per open ClaudeChatWindow)
+            for (RegisteredCallback rc : themeChangeCallbacks) {
+                try {
+                    rc.getCallback().onThemeChanged(config);
+                } catch (Exception e) {
+                    LOG.warn("[ThemeConfig] Failed to notify callback id=" + rc.getId() + ": " + e.getMessage(), e);
+                }
+            }
         } catch (Exception e) {
             LOG.error("[ThemeConfig] Failed to notify theme change: " + e.getMessage(), e);
         }

--- a/src/main/java/com/github/claudecodegui/util/TokenUsageUtils.java
+++ b/src/main/java/com/github/claudecodegui/util/TokenUsageUtils.java
@@ -29,7 +29,7 @@ public final class TokenUsageUtils {
             return 0;
         }
         int input = usage.has("input_tokens") ? usage.get("input_tokens").getAsInt() : 0;
-        if ("codex".equals(provider)) {
+        if ("codex".equals(provider) || "gemini".equals(provider)) {
             return input;
         }
         int cacheCreation = usage.has("cache_creation_input_tokens")

--- a/src/test/java/com/github/claudecodegui/cli/CliToolIdTest.java
+++ b/src/test/java/com/github/claudecodegui/cli/CliToolIdTest.java
@@ -10,6 +10,8 @@ public class CliToolIdTest {
 
     @Test
     public void fromId_acceptsKnownTools() {
+        assertEquals(CliToolId.AGY, CliToolId.fromId("agy"));
+        assertEquals(CliToolId.AGY, CliToolId.fromId("gemini"));
         assertEquals(CliToolId.GROK, CliToolId.fromId("grok"));
         assertEquals(CliToolId.KIMI, CliToolId.fromId("KIMI"));
         assertEquals(CliToolId.OPENCODE, CliToolId.fromId(" opencode "));
@@ -25,6 +27,7 @@ public class CliToolIdTest {
 
     @Test
     public void binaryNames_matchExpected() {
+        assertEquals("agy", CliToolId.AGY.getBinaryName());
         assertEquals("grok", CliToolId.GROK.getBinaryName());
         assertEquals("kimi", CliToolId.KIMI.getBinaryName());
         assertEquals("opencode", CliToolId.OPENCODE.getBinaryName());

--- a/src/test/java/com/github/claudecodegui/dependency/SdkDefinitionGeminiTest.java
+++ b/src/test/java/com/github/claudecodegui/dependency/SdkDefinitionGeminiTest.java
@@ -1,0 +1,36 @@
+package com.github.claudecodegui.dependency;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class SdkDefinitionGeminiTest {
+
+    @Test
+    public void fromProviderMapsGemini() {
+        assertEquals(SdkDefinition.GEMINI_CLI, SdkDefinition.fromProvider("gemini"));
+        assertEquals(SdkDefinition.GEMINI_CLI, SdkDefinition.fromProvider("GEMINI"));
+        assertEquals(SdkDefinition.CLAUDE_SDK, SdkDefinition.fromProvider("claude"));
+        assertEquals(SdkDefinition.CODEX_SDK, SdkDefinition.fromProvider("codex"));
+        assertNull(SdkDefinition.fromProvider("unknown"));
+    }
+
+    @Test
+    public void fromIdMapsGeminiCli() {
+        assertEquals(SdkDefinition.GEMINI_CLI, SdkDefinition.fromId("gemini-cli"));
+        assertNull(SdkDefinition.fromId("nope"));
+    }
+
+    @Test
+    public void geminiCliIsExternalBinaryMarker() {
+        assertEquals("gemini-cli", SdkDefinition.GEMINI_CLI.getId());
+        assertEquals("agy-cli-binary", SdkDefinition.GEMINI_CLI.getNpmPackage());
+        assertNull(SdkDefinition.GEMINI_CLI.getMinRequiredVersion());
+        assertTrue(SdkDefinition.GEMINI_CLI.getDisplayName().toLowerCase().contains("antigravity")
+                || SdkDefinition.GEMINI_CLI.getDisplayName().toLowerCase().contains("gemini"));
+        assertNotNull(SdkDefinition.GEMINI_CLI.getDescription());
+    }
+}

--- a/src/test/java/com/github/claudecodegui/handler/history/HistoryMessageInjectorTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/history/HistoryMessageInjectorTest.java
@@ -34,7 +34,7 @@ public class HistoryMessageInjectorTest {
         injector.handleLoadSession(
                 "{\"sessionId\":\"hist-codex\",\"provider\":\"codex\"}",
                 "claude",
-                (sessionId, projectPath, provider) -> callbackInvoked[0] = true
+                (sessionId, projectPath, provider, model) -> callbackInvoked[0] = true
         );
 
         assertEquals("hist-codex", injector.loadedCodexSessionId);
@@ -44,15 +44,16 @@ public class HistoryMessageInjectorTest {
     @Test
     public void handleLoadSessionUsesPayloadProviderForClaudeEvenWhenCurrentProviderIsCodex() {
         RecordingHistoryMessageInjector injector = new RecordingHistoryMessageInjector(createContext("D:/project/demo"));
-        String[] callbackArgs = new String[3];
+        String[] callbackArgs = new String[4];
 
         injector.handleLoadSession(
-                "{\"sessionId\":\"hist-claude\",\"provider\":\"claude\"}",
+                "{\"sessionId\":\"hist-claude\",\"provider\":\"claude\",\"model\":\"claude-sonnet-4-6\"}",
                 "codex",
-                (sessionId, projectPath, provider) -> {
+                (sessionId, projectPath, provider, model) -> {
                     callbackArgs[0] = sessionId;
                     callbackArgs[1] = projectPath;
                     callbackArgs[2] = provider;
+                    callbackArgs[3] = model;
                 }
         );
 
@@ -60,6 +61,7 @@ public class HistoryMessageInjectorTest {
         assertEquals("hist-claude", callbackArgs[0]);
         assertEquals("D:/project/demo", callbackArgs[1]);
         assertEquals("claude", callbackArgs[2]);
+        assertEquals("claude-sonnet-4-6", callbackArgs[3]);
     }
 
     @Test
@@ -70,7 +72,7 @@ public class HistoryMessageInjectorTest {
         injector.handleLoadSession(
                 "{\"sessionId\":\"hist-codex\",\"provider\":\"codex\"}",
                 "claude",
-                (sessionId, projectPath, provider) -> callbackInvoked[0] = true
+                (sessionId, projectPath, provider, model) -> callbackInvoked[0] = true
         );
 
         assertNull(injector.loadedCodexSessionId);
@@ -831,6 +833,11 @@ public class HistoryMessageInjectorTest {
 
         @Override
         void loadCodexSession(String sessionId) {
+            loadCodexSession(sessionId, null);
+        }
+
+        @Override
+        void loadCodexSession(String sessionId, String model) {
             this.loadedCodexSessionId = sessionId;
         }
 

--- a/src/test/java/com/github/claudecodegui/handler/provider/ModelProviderHandlerGeminiTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/provider/ModelProviderHandlerGeminiTest.java
@@ -1,0 +1,79 @@
+package com.github.claudecodegui.handler.provider;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ModelProviderHandlerGeminiTest {
+
+    @Test
+    public void geminiCatalogModelsHaveOneMillionContext() {
+        assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("gemini-3.5-flash-medium"));
+        assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("gemini-3.6-flash-high"));
+        assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("gemini-3.1-pro-high"));
+        assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("gemini-3.1-pro-low"));
+    }
+
+    @Test
+    public void genericGeminiFallbackIsOneMillion() {
+        assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("gemini"));
+        assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("gemini-unknown-future-model"));
+    }
+
+    @Test
+    public void agyClaudeCatalogModelsKeepTwoHundredK() {
+        assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-sonnet-4-6"));
+        assertEquals(200_000, ModelProviderHandler.getModelContextLimit("claude-opus-4-6-thinking"));
+    }
+
+    @Test
+    public void effortSuffixDoesNotChangeContextLimit() {
+        assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("gemini-3.6-flash-medium"));
+        assertEquals(1_000_000, ModelProviderHandler.getModelContextLimit("gemini-3.6-flash"));
+        assertEquals(128_000, ModelProviderHandler.getModelContextLimit("gpt-oss-120b-medium"));
+        assertEquals(128_000, ModelProviderHandler.getModelContextLimit("gpt-oss-120b"));
+    }
+
+    @Test
+    public void switchingFromClaudeToGeminiShutsDownDaemon() {
+        assertTrue(ModelProviderHandler.shouldShutdownClaudeDaemonOnProviderSwitch("claude", "gemini"));
+    }
+
+    @Test
+    public void geminiModelChangeResetsSession() {
+        assertTrue(ModelProviderHandler.shouldResetGeminiSessionOnModelChange(
+                "gemini", "gemini-3.5-flash-low", "gemini-3.6-flash-medium"));
+    }
+
+    @Test
+    public void geminiSameModelDoesNotResetSession() {
+        assertTrue(!ModelProviderHandler.shouldResetGeminiSessionOnModelChange(
+                "gemini", "gemini-3.6-flash-medium", "gemini-3.6-flash-medium"));
+    }
+
+    @Test
+    public void nonGeminiModelChangeDoesNotResetSession() {
+        assertTrue(!ModelProviderHandler.shouldResetGeminiSessionOnModelChange(
+                "claude", "claude-sonnet-4-6", "claude-opus-4-6-thinking"));
+        assertTrue(!ModelProviderHandler.shouldResetGeminiSessionOnModelChange(
+                "codex", "gpt-5.2", "gpt-5.3"));
+    }
+
+    @Test
+    public void emptyPreviousGeminiModelDoesNotReset() {
+        assertTrue(!ModelProviderHandler.shouldResetGeminiSessionOnModelChange(
+                "gemini", null, "gemini-3.6-flash-medium"));
+        assertTrue(!ModelProviderHandler.shouldResetGeminiSessionOnModelChange(
+                "gemini", "", "gemini-3.6-flash-medium"));
+    }
+
+    @Test
+    public void providerSwitchClearsSession() {
+        assertTrue(ModelProviderHandler.shouldClearSessionOnProviderSwitch("claude", "gemini"));
+        assertTrue(ModelProviderHandler.shouldClearSessionOnProviderSwitch("gemini", "codex"));
+        assertTrue(!ModelProviderHandler.shouldClearSessionOnProviderSwitch("gemini", "gemini"));
+        assertTrue(!ModelProviderHandler.shouldClearSessionOnProviderSwitch(null, "gemini"));
+        assertTrue(!ModelProviderHandler.shouldClearSessionOnProviderSwitch("gemini", ""));
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/common/DaemonBridgeTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/common/DaemonBridgeTest.java
@@ -1,10 +1,31 @@
 package com.github.claudecodegui.provider.common;
 
+import com.google.gson.JsonObject;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Verifies cross-platform daemon heartbeat/probe timing, generation-scoped
+ * ownership including stderr eligibility, and cancellable start/stop lifecycle
+ * transitions.
+ */
 public class DaemonBridgeTest {
 
     // HEARTBEAT_TIMEOUT_MS = 45_000; just over threshold triggers unresponsive
@@ -14,16 +35,19 @@ public class DaemonBridgeTest {
     // Recent activity within threshold
     private static final long RECENT_ACTIVITY = 5_000;
 
+    /** Verifies that an idle daemon beyond the base timeout is considered stale. */
     @Test
     public void staleHeartbeatWithoutActiveRequestsIsUnresponsive() {
         assertTrue(DaemonBridge.shouldTreatAsUnresponsive(JUST_OVER_HEARTBEAT_THRESHOLD, JUST_OVER_HEARTBEAT_THRESHOLD, 0));
     }
 
+    /** Verifies that recent request output keeps an active daemon alive. */
     @Test
     public void activeRequestWithRecentOutputGetsGraceWindow() {
         assertFalse(DaemonBridge.shouldTreatAsUnresponsive(JUST_OVER_HEARTBEAT_THRESHOLD, RECENT_ACTIVITY, 1));
     }
 
+    /** Verifies that an active daemon is eventually stale when all activity stops. */
     @Test
     public void activeRequestWithNoRecentOutputEventuallyTimesOut() {
         assertTrue(DaemonBridge.shouldTreatAsUnresponsive(OVER_ACTIVE_REQUEST_THRESHOLD, OVER_ACTIVE_REQUEST_THRESHOLD, 1));
@@ -43,11 +67,726 @@ public class DaemonBridgeTest {
      * Documents the exact restart-storm scenario from issue #1512: a stale
      * heartbeat age (left over from the previous dead process) combined with
      * a fresh activity age and no active requests IS treated as unresponsive.
-     * The fix prevents this stale value from ever reaching the check by
-     * resetting lastHeartbeatResponse when a new process is spawned.
+     * A generation context prevents this stale combination from crossing a
+     * restart by owning and initializing both heartbeat clocks independently.
      */
     @Test
     public void staleHeartbeatWithFreshActivityIsUnresponsive() {
         assertTrue(DaemonBridge.shouldTreatAsUnresponsive(297_132, 149, 0));
+    }
+
+    /**
+     * Verifies a stderr reader records only for the current active generation,
+     * rejecting both a replaced generation and a generation that has stopped.
+     */
+    @Test
+    public void stderrReaderRejectsStoppedAndReplacedGenerations() {
+        DaemonBridge.DaemonGenerationContext sourceContext = newContext(1);
+        DaemonBridge.DaemonGenerationContext replacementContext = newContext(2);
+
+        assertTrue(DaemonBridge.shouldRecordStderrLine(sourceContext, sourceContext));
+        assertFalse(DaemonBridge.shouldRecordStderrLine(replacementContext, sourceContext));
+
+        sourceContext.stop();
+        assertFalse(DaemonBridge.shouldRecordStderrLine(sourceContext, sourceContext));
+    }
+
+    /** Verifies that the first stale observation sends a probe instead of killing the daemon. */
+    @Test
+    public void firstStaleObservationRequestsHeartbeatProbe() {
+        MutableTimeSource timeSource = new MutableTimeSource(46_000, nanos(46_000));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(30_000);
+
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies idle wake probes immediately when nanoTime pauses during suspend. */
+    @Test
+    public void idleWakeWithPausedMonotonicClockStillSendsProbe() {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(0);
+
+        timeSource.set(300_000, nanos(15_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+
+        timeSource.set(305_000, nanos(20_000));
+        timestamps.markHeartbeat(timeSource);
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.HEALTHY,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies idle wake has the same probe policy when nanoTime includes suspend. */
+    @Test
+    public void idleWakeWithAdvancingMonotonicClockAlsoSendsProbe() {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(0);
+
+        timeSource.set(300_000, nanos(300_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies a wake probe cannot succeed without a response when nanoTime paused. */
+    @Test
+    public void pausedMonotonicWakeWithoutResponseExpiresProbe() {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(0);
+
+        timeSource.set(300_000, nanos(15_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+        timeSource.set(315_000, nanos(30_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.WAIT_FOR_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+        timeSource.set(330_000, nanos(45_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.DECLARE_DEAD,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies a wake probe also expires without a response when nanoTime advanced. */
+    @Test
+    public void advancingMonotonicWakeWithoutResponseExpiresProbe() {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(0);
+
+        timeSource.set(300_000, nanos(300_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+        timeSource.set(315_000, nanos(315_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.WAIT_FOR_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+        timeSource.set(330_000, nanos(330_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.DECLARE_DEAD,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies active requests use wall age consistently when nanoTime pauses in sleep. */
+    @Test
+    public void activeRequestAfterSystemSleepKeepsExistingTimeoutSemantics() {
+        MutableTimeSource timeSource = new MutableTimeSource(300_000, nanos(15_000));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(0);
+
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.DECLARE_DEAD,
+                evaluate(state, timeSource, timestamps, 1));
+
+        timeSource.set(305_000, nanos(20_000));
+        timestamps.markHeartbeat(timeSource);
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.HEALTHY,
+                evaluate(state, timeSource, timestamps, 1));
+    }
+
+    /** Verifies active suspend timeout is identical when nanoTime includes the sleep. */
+    @Test
+    public void activeRequestWithAdvancingMonotonicClockUsesSameWallTimeout() {
+        MutableTimeSource timeSource = new MutableTimeSource(300_000, nanos(300_000));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(0);
+
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.DECLARE_DEAD,
+                evaluate(state, timeSource, timestamps, 1));
+    }
+
+    /** Verifies that a stale daemon is declared dead only after the bounded probe expires. */
+    @Test
+    public void unansweredProbeEventuallyDeclaresDaemonDead() {
+        MutableTimeSource timeSource = new MutableTimeSource(46_000, nanos(46_000));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(30_000);
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+
+        timeSource.set(61_000, nanos(61_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.WAIT_FOR_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+        timeSource.set(76_000, nanos(76_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.DECLARE_DEAD,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies that a heartbeat response clears the outstanding probe state. */
+    @Test
+    public void heartbeatResponseClearsOutstandingProbe() {
+        MutableTimeSource timeSource = new MutableTimeSource(46_000, nanos(46_000));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(30_000);
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+
+        timeSource.set(51_000, nanos(51_000));
+        timestamps.markHeartbeat(timeSource);
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.HEALTHY,
+                evaluate(state, timeSource, timestamps, 0));
+        timeSource.set(97_000, nanos(97_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /**
+     * Verifies that a sleep-sized scheduler gap replaces an old probe instead
+     * of treating its elapsed wall-clock time as a failed liveness check.
+     */
+    @Test
+    public void schedulerGapRearmsProbeWithoutKillingHealthyDaemon() {
+        MutableTimeSource timeSource = new MutableTimeSource(46_000, nanos(46_000));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(30_000);
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+
+        timeSource.set(346_000, nanos(51_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+        timeSource.set(351_000, nanos(56_000));
+        timestamps.markHeartbeat(timeSource);
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.HEALTHY,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies a wall-clock rollback rearms the idle probe without expiring it. */
+    @Test
+    public void wallClockRollbackRearmsProbeUsingMonotonicDeadline() {
+        MutableTimeSource timeSource = new MutableTimeSource(25_000, nanos(46_000));
+        DaemonBridge.HeartbeatTimestamps timestamps = timestampsAtZero();
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(10_000);
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+
+        timeSource.set(5_000, nanos(61_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies a negative nanoTime value can still own an active probe deadline. */
+    @Test
+    public void negativeMonotonicValueDoesNotCollideWithProbeState() {
+        MutableTimeSource timeSource = new MutableTimeSource(46_000, -nanos(1_000));
+        DaemonBridge.HeartbeatTimestamps timestamps =
+                new DaemonBridge.HeartbeatTimestamps(0, -nanos(50_000));
+        DaemonBridge.IdleHeartbeatProbeState state = new DaemonBridge.IdleHeartbeatProbeState();
+        state.reset(30_000);
+
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.SEND_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+        timeSource.set(61_000, nanos(14_000));
+        assertEquals(
+                DaemonBridge.HeartbeatDecision.WAIT_FOR_PROBE,
+                evaluate(state, timeSource, timestamps, 0));
+    }
+
+    /** Verifies a death claim revokes all subsequent output eligibility for its generation. */
+    @Test
+    public void claimedGenerationCannotBecomeActiveAgain() {
+        DaemonBridge.DaemonGenerationContext context = newContext(1);
+
+        assertTrue(context.isActive());
+        context.claimDeath();
+        assertFalse(context.isActive());
+    }
+
+    /** Verifies a late ready event cannot release or mutate the replacement generation. */
+    @Test
+    public void claimedGenerationRejectsLateReadyForReplacement() {
+        DaemonBridge.DaemonGenerationContext claimed = newContext(1);
+        DaemonBridge.DaemonGenerationContext replacement = newContext(2);
+        claimed.claimDeath();
+
+        assertFalse(claimed.signalReady(true));
+        assertEquals(1, claimed.readySignalsRemaining());
+        assertEquals(1, replacement.readySignalsRemaining());
+        assertFalse(replacement.isSdkPreloaded());
+    }
+
+    /** Verifies cleanup of one generation cannot remove a replacement request. */
+    @Test
+    public void generationScopedRequestCleanupCannotClearReplacementRequests() {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        DaemonBridge.DaemonGenerationContext claimed = newContext(1);
+        DaemonBridge.DaemonGenerationContext replacement = newContext(2);
+        DaemonBridge.RequestHandler oldHandler = newRequestHandler();
+        DaemonBridge.RequestHandler newHandler = newRequestHandler();
+
+        assertTrue(claimed.registerRequest("old", oldHandler, true, timeSource));
+        claimed.claimDeath();
+        assertEquals(1, claimed.drainRequests().size());
+        assertFalse(claimed.registerRequest("late", oldHandler, true, timeSource));
+
+        assertTrue(replacement.registerRequest("new", newHandler, true, timeSource));
+        assertTrue(claimed.drainRequests().isEmpty());
+        assertSame(newHandler, replacement.getRequestHandler("new"));
+    }
+
+    /** Verifies a heartbeat arriving after timeout observation cancels the death claim. */
+    @Test
+    public void heartbeatProgressInvalidatesPendingTimeoutObservation() {
+        MutableTimeSource timeSource = new MutableTimeSource(300_000, nanos(300_000));
+        DaemonBridge.DaemonGenerationContext context = newContext(1);
+        DaemonBridge.HeartbeatObservation observation =
+                context.captureHeartbeatObservation(timeSource);
+
+        assertTrue(context.matchesTimeoutObservation(observation));
+        timeSource.set(301_000, nanos(301_000));
+        context.markHeartbeat(timeSource);
+        assertFalse(context.matchesTimeoutObservation(observation));
+        assertTrue(context.isActive());
+    }
+
+    /** Verifies a cancelled timeout keeps the heartbeat watchdog loop running. */
+    @Test
+    public void cancelledTimeoutContinuesHeartbeatMonitoring() {
+        assertTrue(DaemonBridge.shouldContinueHeartbeatAfterDeath(
+                DaemonBridge.DeathHandlingResult.CANCELLED));
+        assertFalse(DaemonBridge.shouldContinueHeartbeatAfterDeath(
+                DaemonBridge.DeathHandlingResult.CLAIMED));
+        assertFalse(DaemonBridge.shouldContinueHeartbeatAfterDeath(
+                DaemonBridge.DeathHandlingResult.STALE_GENERATION));
+    }
+
+    /** Verifies a later explicit stop epoch vetoes an already prepared auto-restart. */
+    @Test
+    public void explicitStopEpochCancelsPreparedAutomaticRestart() {
+        DaemonBridge.DaemonGenerationContext claimed = newContext(1);
+        claimed.claimDeath();
+
+        assertTrue(DaemonBridge.shouldAutoRestart(
+                true, 4, 4, claimed, claimed, 1));
+        assertFalse(DaemonBridge.shouldAutoRestart(
+                false, 5, 4, claimed, claimed, 1));
+        assertFalse(DaemonBridge.shouldAutoRestart(
+                true, 5, 4, claimed, claimed, 1));
+    }
+
+    /** Verifies a concurrent explicit stop prevents the claimed daemon from launching B. */
+    @Test
+    public void stopDuringDeathCleanupPreventsAutomaticReplacementProcess() throws Exception {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        ControlledProcess firstProcess = new ControlledProcess(101);
+        ControlledProcess replacementProcess = new ControlledProcess(102);
+        firstProcess.emitReady();
+        replacementProcess.emitReady();
+        AtomicInteger launchCount = new AtomicInteger();
+        CountDownLatch beforeRestartCheck = new CountDownLatch(1);
+        CountDownLatch allowRestartCheck = new CountDownLatch(1);
+        CountDownLatch restartCheckFinished = new CountDownLatch(1);
+        DaemonBridge.DaemonLifecycleHooks hooks = new DaemonBridge.DaemonLifecycleHooks() {
+            @Override
+            public void beforeAutoRestartCheck(long generation) {
+                beforeRestartCheck.countDown();
+                await(allowRestartCheck);
+            }
+
+            @Override
+            public void afterAutoRestartCheck(long generation) {
+                restartCheckFinished.countDown();
+            }
+        };
+        DaemonBridge bridge = new DaemonBridge(
+                null,
+                null,
+                null,
+                timeSource,
+                () -> launchCount.getAndIncrement() == 0 ? firstProcess : replacementProcess,
+                hooks);
+
+        assertTrue(bridge.start());
+        firstProcess.exit();
+        assertTrue(beforeRestartCheck.await(2, TimeUnit.SECONDS));
+
+        Thread stopThread = new Thread(bridge::stop, "DaemonBridgeTest-Stop");
+        stopThread.start();
+        assertTrue(firstProcess.stdinFlushed.await(2, TimeUnit.SECONDS));
+        allowRestartCheck.countDown();
+        stopThread.join(2_000);
+
+        assertTrue(restartCheckFinished.await(2, TimeUnit.SECONDS));
+        assertEquals(1, launchCount.get());
+        assertFalse(replacementProcess.wasDestroyed());
+        assertFalse(bridge.isAlive());
+    }
+
+    /**
+     * Verifies a published dead generation retains the lifecycle slot and the
+     * watchdog claims it even while the stdout reader remains blocked.
+     */
+    @Test
+    public void deadPublishedGenerationIsNotOverwrittenBeforeReaderCleanup() throws Exception {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        ControlledProcess firstProcess = new ControlledProcess(151);
+        ControlledProcess replacementProcess = new ControlledProcess(152);
+        firstProcess.emitReady();
+        replacementProcess.emitReady();
+        AtomicInteger launchCount = new AtomicInteger();
+        CountDownLatch replacementLaunch = new CountDownLatch(1);
+        CountDownLatch heartbeatCheckReached = new CountDownLatch(1);
+        CountDownLatch allowHeartbeatCheck = new CountDownLatch(1);
+        DaemonBridge.DaemonLifecycleHooks hooks = new DaemonBridge.DaemonLifecycleHooks() {
+            @Override
+            public void beforeHeartbeatCheck(long generation) {
+                if (generation == 1) {
+                    heartbeatCheckReached.countDown();
+                    await(allowHeartbeatCheck);
+                }
+            }
+        };
+        DaemonBridge bridge = new DaemonBridge(
+                null,
+                null,
+                null,
+                timeSource,
+                () -> {
+                    if (launchCount.getAndIncrement() == 0) {
+                        return firstProcess;
+                    }
+                    replacementLaunch.countDown();
+                    return replacementProcess;
+                },
+                hooks,
+                5);
+
+        assertTrue(bridge.start());
+        assertTrue(heartbeatCheckReached.await(2, TimeUnit.SECONDS));
+        CompletableFuture<Boolean> oldFuture = bridge.sendCommand(
+                "claude.send", new JsonObject(), new NoOpDaemonOutputCallback());
+        firstProcess.markDeadWithoutClosingOutput();
+
+        assertFalse(bridge.start());
+        assertEquals(1, launchCount.get());
+        assertFalse(oldFuture.isDone());
+
+        allowHeartbeatCheck.countDown();
+        assertTrue(replacementLaunch.await(2, TimeUnit.SECONDS));
+        assertTrue(oldFuture.handle((value, error) -> error != null)
+                .get(2, TimeUnit.SECONDS));
+        assertTrue(bridge.start());
+        assertEquals(2, launchCount.get());
+        assertTrue(bridge.isAlive());
+        firstProcess.closeOutput();
+        bridge.stop();
+    }
+
+    /**
+     * Verifies a daemon that exits before its initial ready signal cannot start
+     * an ownerless replacement after {@link DaemonBridge#start()} returns false.
+     */
+    @Test
+    public void readyFailureDoesNotLaunchBackgroundReplacement() throws Exception {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        ControlledProcess failedProcess = new ControlledProcess(201);
+        ControlledProcess replacementProcess = new ControlledProcess(202);
+        failedProcess.exit();
+        replacementProcess.emitReady();
+        AtomicInteger launchCount = new AtomicInteger();
+        CountDownLatch replacementLaunch = new CountDownLatch(1);
+        DaemonBridge bridge = new DaemonBridge(
+                null,
+                null,
+                null,
+                timeSource,
+                () -> {
+                    if (launchCount.getAndIncrement() == 0) {
+                        return failedProcess;
+                    }
+                    replacementLaunch.countDown();
+                    return replacementProcess;
+                },
+                null);
+
+        assertFalse(bridge.start());
+        assertFalse(replacementLaunch.await(500, TimeUnit.MILLISECONDS));
+        assertEquals(1, launchCount.get());
+        assertFalse(bridge.isAlive());
+        assertFalse(replacementProcess.wasDestroyed());
+    }
+
+    /**
+     * Verifies stop can cancel a daemon waiting for ready without waiting for
+     * the full daemon startup timeout or leaving the launched process alive.
+     */
+    @Test
+    public void stopCancelsStartingDaemonWithoutWaitingForReadyTimeout() throws Exception {
+        MutableTimeSource timeSource = new MutableTimeSource(0, nanos(0));
+        ControlledProcess startingProcess = new ControlledProcess(301);
+        CountDownLatch processLaunchEntered = new CountDownLatch(1);
+        AtomicBoolean startResult = new AtomicBoolean(true);
+        DaemonBridge bridge = new DaemonBridge(
+                null,
+                null,
+                null,
+                timeSource,
+                () -> {
+                    processLaunchEntered.countDown();
+                    return startingProcess;
+                },
+                null);
+        Thread startThread = new Thread(
+                () -> startResult.set(bridge.start()), "DaemonBridgeTest-Start");
+        startThread.start();
+        assertTrue(processLaunchEntered.await(2, TimeUnit.SECONDS));
+
+        Thread stopThread = new Thread(bridge::stop, "DaemonBridgeTest-StopStarting");
+        stopThread.start();
+        stopThread.join(2_000);
+        startThread.join(2_000);
+
+        assertFalse("stop() must not wait for the 30-second ready timeout", stopThread.isAlive());
+        assertFalse("start() must observe the cancelled attempt", startThread.isAlive());
+        assertFalse(startResult.get());
+        assertTrue(startingProcess.wasDestroyed());
+        assertFalse(bridge.isAlive());
+    }
+
+    private static DaemonBridge.HeartbeatTimestamps timestampsAtZero() {
+        return new DaemonBridge.HeartbeatTimestamps(0, nanos(0));
+    }
+
+    private static DaemonBridge.HeartbeatDecision evaluate(
+            DaemonBridge.IdleHeartbeatProbeState state,
+            DaemonBridge.TimeSource timeSource,
+            DaemonBridge.HeartbeatTimestamps timestamps,
+            int activeRequestCount
+    ) {
+        return state.evaluate(timestamps.snapshot(timeSource, activeRequestCount));
+    }
+
+    private static DaemonBridge.DaemonGenerationContext newContext(long generation) {
+        StubProcess process = new StubProcess();
+        return new DaemonBridge.DaemonGenerationContext(
+                process,
+                new java.io.BufferedWriter(new java.io.OutputStreamWriter(process.getOutputStream())),
+                generation,
+                0,
+                nanos(0));
+    }
+
+    private static DaemonBridge.RequestHandler newRequestHandler() {
+        return new DaemonBridge.RequestHandler(
+                new NoOpDaemonOutputCallback(), new CompletableFuture<>());
+    }
+
+    private static long nanos(long millis) {
+        return TimeUnit.MILLISECONDS.toNanos(millis);
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await(2, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /** Mutable dual clock used to reproduce platform-specific suspend behavior. */
+    private static final class MutableTimeSource implements DaemonBridge.TimeSource {
+        private long wallTimeMs;
+        private long nanoTime;
+
+        private MutableTimeSource(long wallTimeMs, long nanoTime) {
+            set(wallTimeMs, nanoTime);
+        }
+
+        private void set(long wallTimeMs, long nanoTime) {
+            this.wallTimeMs = wallTimeMs;
+            this.nanoTime = nanoTime;
+        }
+
+        @Override
+        public long currentTimeMillis() {
+            return wallTimeMs;
+        }
+
+        @Override
+        public long nanoTime() {
+            return nanoTime;
+        }
+    }
+
+    /** No-op callback used to test request ownership without invoking provider logic. */
+    private static final class NoOpDaemonOutputCallback implements DaemonBridge.DaemonOutputCallback {
+        @Override
+        public void onLine(String line) {
+            // No-op.
+        }
+
+        @Override
+        public void onStderr(String text) {
+            // No-op.
+        }
+
+        @Override
+        public void onError(String error) {
+            // No-op.
+        }
+
+        @Override
+        public void onComplete(boolean success) {
+            // No-op.
+        }
+    }
+
+    /** Minimal process identity used to test generation ownership without starting an OS process. */
+    private static final class StubProcess extends Process {
+        @Override
+        public OutputStream getOutputStream() {
+            return new ByteArrayOutputStream();
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+
+        @Override
+        public int waitFor() {
+            return 0;
+        }
+
+        @Override
+        public int exitValue() {
+            return 0;
+        }
+
+        @Override
+        public void destroy() {
+            // No-op test process.
+        }
+    }
+
+    /** Controllable process used to drive the real reader/death/stop lifecycle deterministically. */
+    private static final class ControlledProcess extends Process {
+        private final long processId;
+        private final PipedInputStream stdout = new PipedInputStream();
+        private final PipedOutputStream stdoutWriter;
+        private final AtomicBoolean alive = new AtomicBoolean(true);
+        private final AtomicBoolean destroyed = new AtomicBoolean(false);
+        private final CountDownLatch stdinFlushed = new CountDownLatch(1);
+        private final OutputStream stdin = new ByteArrayOutputStream() {
+            @Override
+            public void flush() {
+                stdinFlushed.countDown();
+            }
+        };
+
+        private ControlledProcess(long processId) throws java.io.IOException {
+            this.processId = processId;
+            this.stdoutWriter = new PipedOutputStream(stdout);
+        }
+
+        private void emitReady() throws java.io.IOException {
+            stdoutWriter.write(("{\"type\":\"daemon\",\"event\":\"ready\","
+                    + "\"sdkPreloaded\":true}\n").getBytes(StandardCharsets.UTF_8));
+            stdoutWriter.flush();
+        }
+
+        private void exit() throws java.io.IOException {
+            markDeadWithoutClosingOutput();
+            closeOutput();
+        }
+
+        private void markDeadWithoutClosingOutput() {
+            alive.set(false);
+        }
+
+        private void closeOutput() throws java.io.IOException {
+            stdoutWriter.close();
+        }
+
+        private boolean wasDestroyed() {
+            return destroyed.get();
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return stdin;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return stdout;
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+
+        @Override
+        public int waitFor() {
+            return 0;
+        }
+
+        @Override
+        public int exitValue() {
+            return 0;
+        }
+
+        @Override
+        public void destroy() {
+            destroyed.set(true);
+            alive.set(false);
+        }
+
+        @Override
+        public Process destroyForcibly() {
+            destroy();
+            return this;
+        }
+
+        @Override
+        public boolean isAlive() {
+            return alive.get();
+        }
+
+        @Override
+        public long pid() {
+            return processId;
+        }
     }
 }

--- a/src/test/java/com/github/claudecodegui/provider/gemini/GeminiHistoryReaderTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/gemini/GeminiHistoryReaderTest.java
@@ -1,0 +1,110 @@
+package com.github.claudecodegui.provider.gemini;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class GeminiHistoryReaderTest {
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    @Test
+    public void testListSessionsAndParseSummary() throws Exception {
+        File brainDir = tempDir.newFolder("brain");
+        File historyFile = tempDir.newFile("history.jsonl");
+
+        String sessionId = "12345678-abcd-ef01-2345-6789abcdef01";
+        File sessionDir = new File(brainDir, sessionId);
+        File logsDir = new File(sessionDir, ".system_generated/logs");
+        assertTrue(logsDir.mkdirs());
+
+        File transcriptFile = new File(logsDir, "transcript.jsonl");
+        String transcriptContent =
+                "{\"step_index\":0,\"source\":\"USER_EXPLICIT\",\"type\":\"USER_INPUT\",\"created_at\":\"2026-08-07T10:00:00Z\",\"content\":\"<USER_REQUEST>Test Gemini Request</USER_REQUEST>\"}\n" +
+                "{\"step_index\":1,\"source\":\"MODEL\",\"type\":\"PLANNER_RESPONSE\",\"created_at\":\"2026-08-07T10:00:05Z\",\"content\":\"Here is the response\"}\n";
+        Files.writeString(transcriptFile.toPath(), transcriptContent, StandardCharsets.UTF_8);
+
+        String historyContent = "{\"conversationId\":\"" + sessionId + "\",\"workspace\":\"/test/project/path\"}\n";
+        Files.writeString(historyFile.toPath(), historyContent, StandardCharsets.UTF_8);
+
+        GeminiHistoryReader reader = new GeminiHistoryReader(brainDir.toPath(), historyFile.toPath(), new Gson());
+        List<GeminiHistoryReader.SessionInfo> sessions = reader.listAllSessions();
+
+        assertEquals(1, sessions.size());
+        GeminiHistoryReader.SessionInfo info = sessions.get(0);
+        assertEquals(sessionId, info.sessionId);
+        assertEquals("Test Gemini Request", info.title);
+        assertEquals(2, info.messageCount);
+        assertEquals("/test/project/path", info.cwd);
+        assertEquals("gemini", info.provider);
+
+        String jsonResult = reader.getSessionsForProjectAsJson("/test/project/path");
+        JsonObject json = JsonParser.parseString(jsonResult).getAsJsonObject();
+        assertTrue(json.get("success").getAsBoolean());
+        assertEquals(1, json.get("sessionCount").getAsInt());
+    }
+
+    @Test
+    public void testDeleteSession() throws Exception {
+        File brainDir = tempDir.newFolder("brain");
+        File historyFile = tempDir.newFile("history.jsonl");
+
+        String sessionId = "session-to-delete";
+        File sessionDir = new File(brainDir, sessionId);
+        assertTrue(sessionDir.mkdirs());
+        File dummyFile = new File(sessionDir, "data.txt");
+        assertTrue(dummyFile.createNewFile());
+
+        GeminiHistoryReader reader = new GeminiHistoryReader(brainDir.toPath(), historyFile.toPath(), new Gson());
+        assertTrue(reader.deleteSession(sessionId));
+        assertFalse(sessionDir.exists());
+    }
+
+    @Test
+    public void testGetSessionMessages() throws Exception {
+        File brainDir = tempDir.newFolder("brain");
+        File historyFile = tempDir.newFile("history.jsonl");
+
+        String sessionId = "session-messages-test";
+        File sessionDir = new File(brainDir, sessionId);
+        File logsDir = new File(sessionDir, ".system_generated/logs");
+        assertTrue(logsDir.mkdirs());
+
+        File transcriptFile = new File(logsDir, "transcript.jsonl");
+        String transcriptContent =
+                "{\"step_index\":0,\"source\":\"USER_EXPLICIT\",\"type\":\"USER_INPUT\",\"created_at\":\"2026-08-07T10:00:00Z\",\"content\":\"<USER_REQUEST>Hello AI</USER_REQUEST>\"}\n" +
+                "{\"step_index\":1,\"source\":\"MODEL\",\"type\":\"PLANNER_RESPONSE\",\"created_at\":\"2026-08-07T10:00:05Z\",\"content\":\"Hello Human!\",\"tool_calls\":[{\"name\":\"view_file\",\"args\":{\"AbsolutePath\":\"/tmp/test\"}}]}\n" +
+                "{\"step_index\":2,\"source\":\"MODEL\",\"type\":\"VIEW_FILE\",\"created_at\":\"2026-08-07T10:00:06Z\",\"content\":\"File content here\"}\n";
+        Files.writeString(transcriptFile.toPath(), transcriptContent, StandardCharsets.UTF_8);
+
+        GeminiHistoryReader reader = new GeminiHistoryReader(brainDir.toPath(), historyFile.toPath(), new Gson());
+        List<JsonObject> messages = reader.getSessionMessages(sessionId, null);
+
+        assertNotNull(messages);
+        assertFalse(messages.isEmpty());
+
+        // Should have user text message, assistant text + tool_use, and tool_result
+        assertTrue(messages.size() >= 3);
+        assertEquals("user", messages.get(0).get("type").getAsString());
+        assertEquals("assistant", messages.get(1).get("type").getAsString());
+
+        String jsonMessages = reader.getSessionMessagesAsJson(sessionId);
+        assertNotNull(jsonMessages);
+        assertTrue(jsonMessages.contains("Hello Human!"));
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/gemini/GeminiPlanUsageServiceTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/gemini/GeminiPlanUsageServiceTest.java
@@ -1,0 +1,91 @@
+package com.github.claudecodegui.provider.gemini;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GeminiPlanUsageServiceTest {
+
+    @Test
+    public void normalizeQuotaMap_splitsGeminiAndThirdPartyFamilies() {
+        JsonObject quota = JsonParser.parseString("""
+                {
+                  "gemini-weekly": {
+                    "remaining_fraction": 0.90,
+                    "reset_time": "2026-08-11T23:37:11Z"
+                  },
+                  "gemini-5h": {
+                    "remaining_fraction": 0.75,
+                    "reset_time": "2026-08-05T18:15:50Z"
+                  },
+                  "3p-weekly": {
+                    "remaining_fraction": 0.50,
+                    "reset_time": "2026-08-06T02:22:27Z"
+                  },
+                  "3p-5h": {
+                    "remaining_fraction": 0.25,
+                    "reset_time": "2026-08-05T18:55:52Z"
+                  }
+                }
+                """).getAsJsonObject();
+
+        JsonObject out = GeminiPlanUsageService.normalizeQuotaMap(quota, "user@example.com");
+        assertTrue(out.get("present").getAsBoolean());
+        assertEquals("gemini", out.get("provider").getAsString());
+        assertEquals("agy-statusline", out.get("source").getAsString());
+        assertEquals("gemini", out.get("default_family").getAsString());
+        // top-level mirrors default (gemini) family — 5h primary
+        assertEquals(25.0, out.get("capacity_pct").getAsDouble(), 0.01);
+        assertEquals("5h", out.get("period_type").getAsString());
+        assertEquals("user@example.com", out.get("worker_id").getAsString());
+
+        JsonObject families = out.getAsJsonObject("families");
+        assertTrue(families.has("gemini"));
+        assertTrue(families.has("third_party"));
+
+        JsonObject gem = families.getAsJsonObject("gemini");
+        assertEquals(25.0, gem.get("capacity_pct").getAsDouble(), 0.01);
+        JsonArray gemWindows = gem.getAsJsonArray("windows");
+        assertEquals(2, gemWindows.size());
+        assertEquals("5h", gemWindows.get(0).getAsJsonObject().get("id").getAsString());
+        assertEquals(25.0, gemWindows.get(0).getAsJsonObject().get("used_pct").getAsDouble(), 0.01);
+        assertEquals("7d", gemWindows.get(1).getAsJsonObject().get("id").getAsString());
+        assertEquals(10.0, gemWindows.get(1).getAsJsonObject().get("used_pct").getAsDouble(), 0.01);
+
+        JsonObject tp = families.getAsJsonObject("third_party");
+        assertEquals(75.0, tp.get("capacity_pct").getAsDouble(), 0.01);
+        JsonArray tpWindows = tp.getAsJsonArray("windows");
+        assertEquals(2, tpWindows.size());
+        assertEquals("5h", tpWindows.get(0).getAsJsonObject().get("id").getAsString());
+        assertEquals(75.0, tpWindows.get(0).getAsJsonObject().get("used_pct").getAsDouble(), 0.01);
+        assertEquals("7d", tpWindows.get(1).getAsJsonObject().get("id").getAsString());
+        assertEquals(50.0, tpWindows.get(1).getAsJsonObject().get("used_pct").getAsDouble(), 0.01);
+
+        // top-level windows also only 5h/7d (gemini family)
+        JsonArray topWindows = out.getAsJsonArray("windows");
+        assertEquals(2, topWindows.size());
+        assertEquals("5h", topWindows.get(0).getAsJsonObject().get("id").getAsString());
+        assertEquals("7d", topWindows.get(1).getAsJsonObject().get("id").getAsString());
+    }
+
+    @Test
+    public void familyFromBucketId_classifiesGeminiVsThirdParty() {
+        assertEquals("gemini", GeminiPlanUsageService.familyFromBucketId("gemini-5h"));
+        assertEquals("gemini", GeminiPlanUsageService.familyFromBucketId("gemini-weekly"));
+        assertEquals("third_party", GeminiPlanUsageService.familyFromBucketId("3p-5h"));
+        assertEquals("third_party", GeminiPlanUsageService.familyFromBucketId("3p-weekly"));
+        assertEquals("third_party", GeminiPlanUsageService.familyFromBucketId("claude-bucket"));
+    }
+
+    @Test
+    public void normalizeQuotaMap_emptyIsUnavailable() {
+        JsonObject out = GeminiPlanUsageService.normalizeQuotaMap(new JsonObject(), null);
+        assertFalse(out.get("present").getAsBoolean());
+        assertTrue(out.get("message").getAsString().length() > 0);
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/gemini/GeminiSDKBridgeTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/gemini/GeminiSDKBridgeTest.java
@@ -1,0 +1,182 @@
+package com.github.claudecodegui.provider.gemini;
+
+import com.github.claudecodegui.provider.common.MessageCallback;
+import com.github.claudecodegui.provider.common.SDKResult;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GeminiSDKBridgeTest {
+
+    private static final class RecordingCallback implements MessageCallback {
+        final List<String> types = new ArrayList<>();
+        final List<String> contents = new ArrayList<>();
+        String lastError = null;
+
+        @Override
+        public void onMessage(String type, String content) {
+            types.add(type);
+            contents.add(content == null ? "" : content);
+        }
+
+        @Override
+        public void onError(String error) {
+            lastError = error;
+        }
+
+        @Override
+        public void onComplete(SDKResult result) {
+        }
+    }
+
+    private static void feed(GeminiSDKBridge bridge, String line, MessageCallback cb, SDKResult result,
+                             StringBuilder assistant, AtomicBoolean hadErr, AtomicReference<String> nodeErr)
+            throws Exception {
+        Method m = GeminiSDKBridge.class.getDeclaredMethod(
+                "processOutputLine",
+                String.class,
+                MessageCallback.class,
+                SDKResult.class,
+                StringBuilder.class,
+                AtomicBoolean.class,
+                AtomicReference.class
+        );
+        m.setAccessible(true);
+        m.invoke(bridge, line, cb, result, assistant, hadErr, nodeErr);
+    }
+
+    @Test
+    public void processOutputLineMapsProtocolTags() throws Exception {
+        GeminiSDKBridge bridge = new GeminiSDKBridge();
+        RecordingCallback cb = new RecordingCallback();
+        SDKResult result = new SDKResult();
+        StringBuilder assistant = new StringBuilder();
+        AtomicBoolean hadErr = new AtomicBoolean(false);
+        AtomicReference<String> nodeErr = new AtomicReference<>();
+
+        feed(bridge, "[MESSAGE_START]", cb, result, assistant, hadErr, nodeErr);
+        feed(bridge, "[STREAM_START]", cb, result, assistant, hadErr, nodeErr);
+        feed(bridge, "[SESSION_ID] conv-99", cb, result, assistant, hadErr, nodeErr);
+        feed(bridge, "[CONTENT_DELTA] \"Hello\"", cb, result, assistant, hadErr, nodeErr);
+        feed(bridge, "[THINKING_DELTA] \"think\"", cb, result, assistant, hadErr, nodeErr);
+        feed(bridge, "[TOOL_RESULT] {\"type\":\"tool_result\"}", cb, result, assistant, hadErr, nodeErr);
+        feed(bridge, "[USAGE] {\"total_tokens\":42,\"input_tokens\":10,\"output_tokens\":32}", cb, result, assistant, hadErr, nodeErr);
+        feed(bridge, "[MESSAGE] {\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"Hello\"}]}}",
+                cb, result, assistant, hadErr, nodeErr);
+        feed(bridge, "[STREAM_END]", cb, result, assistant, hadErr, nodeErr);
+        feed(bridge, "[MESSAGE_END]", cb, result, assistant, hadErr, nodeErr);
+
+        assertTrue(cb.types.contains("message_start"));
+        assertTrue(cb.types.contains("stream_start"));
+        assertTrue(cb.types.contains("session_id"));
+        assertEquals("conv-99", cb.contents.get(cb.types.indexOf("session_id")));
+        assertTrue(cb.types.contains("content_delta"));
+        assertEquals("Hello", cb.contents.get(cb.types.indexOf("content_delta")));
+        assertTrue(cb.types.contains("thinking_delta"));
+        assertTrue(cb.types.contains("tool_result"));
+        assertTrue(cb.types.contains("usage"));
+        assertTrue(cb.types.contains("assistant"));
+        assertTrue(cb.types.contains("stream_end"));
+        assertTrue(cb.types.contains("message_end"));
+        assertEquals("Hello", assistant.toString());
+        assertFalse(hadErr.get());
+    }
+
+    @Test
+    public void processOutputLineSendErrorSetsFailure() throws Exception {
+        GeminiSDKBridge bridge = new GeminiSDKBridge();
+        RecordingCallback cb = new RecordingCallback();
+        SDKResult result = new SDKResult();
+        result.success = true;
+        StringBuilder assistant = new StringBuilder();
+        AtomicBoolean hadErr = new AtomicBoolean(false);
+        AtomicReference<String> nodeErr = new AtomicReference<>();
+
+        feed(bridge, "[SEND_ERROR] {\"error\":\"authentication required\"}", cb, result, assistant, hadErr, nodeErr);
+
+        assertTrue(hadErr.get());
+        assertFalse(result.success);
+        assertEquals("authentication required", result.error);
+        assertEquals("authentication required", cb.lastError);
+    }
+
+    @Test
+    public void processOutputLineIgnoresDebugLines() throws Exception {
+        GeminiSDKBridge bridge = new GeminiSDKBridge();
+        RecordingCallback cb = new RecordingCallback();
+        SDKResult result = new SDKResult();
+        StringBuilder assistant = new StringBuilder();
+        AtomicBoolean hadErr = new AtomicBoolean(false);
+        AtomicReference<String> nodeErr = new AtomicReference<>();
+
+        feed(bridge, "[DEBUG] noise", cb, result, assistant, hadErr, nodeErr);
+        feed(bridge, "[AGY] spawn ...", cb, result, assistant, hadErr, nodeErr);
+        feed(bridge, "[DIAG-EXEC] start", cb, result, assistant, hadErr, nodeErr);
+
+        assertTrue(cb.types.isEmpty());
+    }
+
+    @Test
+    public void getContextUsageReturnsLocalSynthesis() throws Exception {
+        GeminiSDKBridge bridge = new GeminiSDKBridge();
+        RecordingCallback cb = new RecordingCallback();
+        SDKResult result = new SDKResult();
+        StringBuilder assistant = new StringBuilder();
+        AtomicBoolean hadErr = new AtomicBoolean(false);
+        AtomicReference<String> nodeErr = new AtomicReference<>();
+
+        feed(bridge, "[USAGE] {\"total_tokens\":1234,\"input_tokens\":1000,\"output_tokens\":234}",
+                cb, result, assistant, hadErr, nodeErr);
+
+        JsonObject usage = bridge.getContextUsage("sid", "/cwd", "gemini-3.5-flash-medium").get();
+        assertTrue(usage.get("success").getAsBoolean());
+        JsonObject data = usage.getAsJsonObject("data");
+        // Context occupancy is input (+ cache), not total_tokens
+        assertEquals(1000, data.get("usedTokens").getAsInt());
+        assertEquals(1_000_000, data.get("maxTokens").getAsInt());
+        assertEquals("gemini-3.5-flash-medium", data.get("model").getAsString());
+        assertEquals("gemini-bridge", data.get("source").getAsString());
+    }
+
+    @Test
+    public void usagePeakIgnoresSmallerCheckpointRows() throws Exception {
+        GeminiSDKBridge bridge = new GeminiSDKBridge();
+        RecordingCallback cb = new RecordingCallback();
+        SDKResult result = new SDKResult();
+        StringBuilder assistant = new StringBuilder();
+        AtomicBoolean hadErr = new AtomicBoolean(false);
+        AtomicReference<String> nodeErr = new AtomicReference<>();
+
+        feed(bridge, "[USAGE] {\"input_tokens\":27000,\"output_tokens\":10,\"total_tokens\":27010}",
+                cb, result, assistant, hadErr, nodeErr);
+        feed(bridge, "[USAGE] {\"input_tokens\":96,\"output_tokens\":3,\"total_tokens\":99}",
+                cb, result, assistant, hadErr, nodeErr);
+
+        JsonObject usage = bridge.getContextUsage("sid", "/cwd", "claude-sonnet-4-6").get();
+        JsonObject data = usage.getAsJsonObject("data");
+        assertEquals(27000, data.get("usedTokens").getAsInt());
+        assertEquals(200_000, data.get("maxTokens").getAsInt());
+    }
+
+    @Test
+    public void getSessionMessagesReturnsEmptyList() {
+        GeminiSDKBridge bridge = new GeminiSDKBridge();
+        assertTrue(bridge.getSessionMessages("any", "/tmp").isEmpty());
+    }
+
+    @Test
+    public void providerNameIsGemini() throws Exception {
+        Method m = GeminiSDKBridge.class.getDeclaredMethod("getProviderName");
+        m.setAccessible(true);
+        assertEquals("gemini", m.invoke(new GeminiSDKBridge()));
+    }
+}

--- a/src/test/java/com/github/claudecodegui/session/GeminiMessageHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/session/GeminiMessageHandlerTest.java
@@ -1,0 +1,262 @@
+package com.github.claudecodegui.session;
+
+import com.github.claudecodegui.permission.PermissionRequest;
+import com.github.claudecodegui.provider.common.SDKResult;
+import com.github.claudecodegui.session.ClaudeSession.Message;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class GeminiMessageHandlerTest {
+
+    private static final class RecordingCallback implements ClaudeSession.SessionCallback {
+        int streamStartCount = 0;
+        int streamEndCount = 0;
+        int stateChangeCount = 0;
+        int messageUpdateCount = 0;
+        String lastSessionId = null;
+        String lastError = null;
+        boolean lastLoading = false;
+        boolean lastBusy = false;
+        final List<String> contentDeltas = new ArrayList<>();
+        final List<String> thinkingDeltas = new ArrayList<>();
+        final List<Message> lastMessages = new ArrayList<>();
+        final List<String> callOrder = new ArrayList<>();
+        final AtomicInteger lastUsedTokens = new AtomicInteger(-1);
+        final AtomicInteger lastMaxTokens = new AtomicInteger(-1);
+        final List<Integer> usageUpdates = new ArrayList<>();
+
+        @Override
+        public void onMessageUpdate(List<Message> messages) {
+            messageUpdateCount++;
+            callOrder.add("messageUpdate");
+            lastMessages.clear();
+            lastMessages.addAll(messages);
+        }
+
+        @Override
+        public void onUsageUpdate(int usedTokens, int maxTokens) {
+            lastUsedTokens.set(usedTokens);
+            lastMaxTokens.set(maxTokens);
+            usageUpdates.add(usedTokens);
+        }
+
+        @Override
+        public void onStateChange(boolean busy, boolean loading, String error) {
+            stateChangeCount++;
+            lastBusy = busy;
+            lastLoading = loading;
+            lastError = error;
+        }
+
+        @Override
+        public void onSessionIdReceived(String sessionId) {
+            lastSessionId = sessionId;
+        }
+
+        @Override
+        public void onPermissionRequested(PermissionRequest request) {
+        }
+
+        @Override
+        public void onThinkingStatusChanged(boolean isThinking) {
+        }
+
+        @Override
+        public void onSlashCommandsReceived(List<String> slashCommands) {
+        }
+
+        @Override
+        public void onNodeLog(String log) {
+        }
+
+        @Override
+        public void onSummaryReceived(String summary) {
+        }
+
+        @Override
+        public void onStreamStart() {
+            streamStartCount++;
+            callOrder.add("streamStart");
+        }
+
+        @Override
+        public void onStreamEnd() {
+            streamEndCount++;
+            callOrder.add("streamEnd");
+        }
+
+        @Override
+        public void onContentDelta(String delta) {
+            contentDeltas.add(delta);
+        }
+
+        @Override
+        public void onThinkingDelta(String delta) {
+            thinkingDeltas.add(delta);
+        }
+    }
+
+    private static GeminiMessageHandler newHandler(SessionState state, RecordingCallback callback) {
+        CallbackHandler callbackHandler = new CallbackHandler();
+        callbackHandler.setCallback(callback);
+        return new GeminiMessageHandler(state, callbackHandler);
+    }
+
+    @Test
+    public void streamMarkersDriveStandardStreamingLifecycle() {
+        SessionState state = new SessionState();
+        state.setBusy(true);
+        state.setLoading(true);
+
+        RecordingCallback callback = new RecordingCallback();
+        GeminiMessageHandler handler = newHandler(state, callback);
+
+        handler.onMessage("stream_start", "");
+        handler.onMessage("content_delta", "done");
+        handler.onMessage("stream_end", "");
+
+        assertEquals(1, callback.streamStartCount);
+        assertEquals(1, callback.streamEndCount);
+        assertFalse(state.isBusy());
+        assertFalse(state.isLoading());
+        assertTrue(callback.messageUpdateCount >= 1);
+        assertFalse(callback.lastMessages.isEmpty());
+        assertEquals("done", callback.lastMessages.get(callback.lastMessages.size() - 1).content);
+        assertEquals(List.of("done"), callback.contentDeltas);
+    }
+
+    @Test
+    public void sessionIdIsCapturedAndNotified() {
+        SessionState state = new SessionState();
+        RecordingCallback callback = new RecordingCallback();
+        GeminiMessageHandler handler = newHandler(state, callback);
+
+        handler.onMessage("session_id", "conv-xyz");
+
+        assertEquals("conv-xyz", state.getSessionId());
+        assertEquals("conv-xyz", callback.lastSessionId);
+    }
+
+    @Test
+    public void assistantMessageJsonUpdatesBubble() {
+        SessionState state = new SessionState();
+        RecordingCallback callback = new RecordingCallback();
+        GeminiMessageHandler handler = newHandler(state, callback);
+
+        handler.onMessage("stream_start", "");
+        handler.onMessage("assistant",
+                "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Hello gemini\"}]}}");
+        handler.onMessage("stream_end", "");
+
+        assertFalse(callback.lastMessages.isEmpty());
+        Message last = callback.lastMessages.get(callback.lastMessages.size() - 1);
+        assertEquals(Message.Type.ASSISTANT, last.type);
+        assertEquals("Hello gemini", last.content);
+    }
+
+    @Test
+    public void thinkingDeltaIsForwarded() {
+        SessionState state = new SessionState();
+        RecordingCallback callback = new RecordingCallback();
+        GeminiMessageHandler handler = newHandler(state, callback);
+
+        handler.onMessage("stream_start", "");
+        handler.onMessage("thinking_delta", "reason");
+        assertEquals(List.of("reason"), callback.thinkingDeltas);
+    }
+
+    @Test
+    public void onErrorClearsBusyAndAddsErrorMessage() {
+        SessionState state = new SessionState();
+        state.setBusy(true);
+        state.setLoading(true);
+        RecordingCallback callback = new RecordingCallback();
+        GeminiMessageHandler handler = newHandler(state, callback);
+
+        handler.onMessage("stream_start", "");
+        handler.onError("agy failed");
+
+        assertFalse(state.isBusy());
+        assertFalse(state.isLoading());
+        assertEquals("agy failed", state.getError());
+        assertEquals(1, callback.streamEndCount);
+        assertTrue(callback.lastMessages.stream().anyMatch(m -> m.type == Message.Type.ERROR));
+    }
+
+    @Test
+    public void onCompleteWithoutStreamEndForcesCleanup() {
+        SessionState state = new SessionState();
+        state.setBusy(true);
+        state.setLoading(true);
+        RecordingCallback callback = new RecordingCallback();
+        GeminiMessageHandler handler = newHandler(state, callback);
+
+        handler.onMessage("stream_start", "");
+        handler.onMessage("content_delta", "partial");
+        handler.onComplete(new SDKResult());
+
+        assertFalse(state.isBusy());
+        assertFalse(state.isLoading());
+        assertEquals(1, callback.streamEndCount);
+    }
+
+    @Test
+    public void blankSessionIdIsIgnored() {
+        SessionState state = new SessionState();
+        RecordingCallback callback = new RecordingCallback();
+        GeminiMessageHandler handler = newHandler(state, callback);
+
+        handler.onMessage("session_id", "   ");
+        assertNull(state.getSessionId());
+        assertNull(callback.lastSessionId);
+    }
+
+    @Test
+    public void usageUsesInputNotTotalAndIgnoresCheckpointRegression() {
+        SessionState state = new SessionState();
+        state.setProvider("gemini");
+        state.setModel("claude-sonnet-4-6");
+        RecordingCallback callback = new RecordingCallback();
+        GeminiMessageHandler handler = newHandler(state, callback);
+
+        handler.onMessage("stream_start", "");
+        handler.onMessage("usage",
+                "{\"input_tokens\":27793,\"output_tokens\":18,\"thinking_tokens\":0,\"cache_read_tokens\":0,\"total_tokens\":27811}");
+        handler.onMessage("usage",
+                "{\"input_tokens\":96,\"output_tokens\":3,\"thinking_tokens\":0,\"cache_read_tokens\":0,\"total_tokens\":99}");
+
+        assertEquals(27793, callback.lastUsedTokens.get());
+        assertEquals(1, callback.usageUpdates.size());
+        assertEquals(200_000, callback.lastMaxTokens.get());
+    }
+
+    @Test
+    public void resultUsageIsAuthoritativeAndStampsTurnUsage() {
+        SessionState state = new SessionState();
+        state.setProvider("gemini");
+        state.setModel("gemini-3.5-flash-medium");
+        RecordingCallback callback = new RecordingCallback();
+        GeminiMessageHandler handler = newHandler(state, callback);
+
+        handler.onMessage("stream_start", "");
+        handler.onMessage("content_delta", "2");
+        handler.onMessage("usage",
+                "{\"input_tokens\":100,\"output_tokens\":1,\"total_tokens\":101}");
+        handler.onMessage("result",
+                "{\"usage\":{\"input_tokens\":500,\"output_tokens\":20,\"total_tokens\":520}}");
+
+        assertEquals(500, callback.lastUsedTokens.get());
+        assertEquals(1_000_000, callback.lastMaxTokens.get());
+        Message last = callback.lastMessages.get(callback.lastMessages.size() - 1);
+        assertTrue(last.raw.has("turnUsage"));
+        assertEquals(500, last.raw.getAsJsonObject("turnUsage").get("input_tokens").getAsInt());
+    }
+}

--- a/src/test/java/com/github/claudecodegui/session/SessionProviderRouterGeminiTest.java
+++ b/src/test/java/com/github/claudecodegui/session/SessionProviderRouterGeminiTest.java
@@ -1,0 +1,141 @@
+package com.github.claudecodegui.session;
+
+import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
+import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.provider.gemini.GeminiSDKBridge;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SessionProviderRouterGeminiTest {
+
+    private static final class StubClaude extends ClaudeSDKBridge {
+        final AtomicBoolean interruptCalled = new AtomicBoolean(false);
+        final AtomicReference<String> lastLaunchChannel = new AtomicReference<>();
+
+        @Override
+        public JsonObject launchChannel(String channelId, String sessionId, String cwd) {
+            lastLaunchChannel.set("claude:" + channelId);
+            JsonObject r = new JsonObject();
+            r.addProperty("success", true);
+            r.addProperty("provider", "claude");
+            return r;
+        }
+
+        @Override
+        public void interruptChannel(String channelId) {
+            interruptCalled.set(true);
+        }
+
+        @Override
+        public List<JsonObject> getSessionMessages(String sessionId, String cwd) {
+            return Collections.emptyList();
+        }
+    }
+
+    private static final class StubCodex extends CodexSDKBridge {
+        final AtomicBoolean interruptCalled = new AtomicBoolean(false);
+
+        @Override
+        public JsonObject launchChannel(String channelId, String sessionId, String cwd) {
+            JsonObject r = new JsonObject();
+            r.addProperty("success", true);
+            r.addProperty("provider", "codex");
+            return r;
+        }
+
+        @Override
+        public void interruptChannel(String channelId) {
+            interruptCalled.set(true);
+        }
+
+        @Override
+        public List<JsonObject> getSessionMessages(String sessionId, String cwd) {
+            return Collections.emptyList();
+        }
+    }
+
+    private static final class StubGemini extends GeminiSDKBridge {
+        final AtomicBoolean interruptCalled = new AtomicBoolean(false);
+        final AtomicReference<String> lastLaunch = new AtomicReference<>();
+
+        @Override
+        public JsonObject launchChannel(String channelId, String sessionId, String cwd) {
+            lastLaunch.set(channelId + "|" + sessionId + "|" + cwd);
+            JsonObject r = new JsonObject();
+            r.addProperty("success", true);
+            r.addProperty("provider", "gemini");
+            r.addProperty("channelId", channelId);
+            return r;
+        }
+
+        @Override
+        public void interruptChannel(String channelId) {
+            interruptCalled.set(true);
+        }
+
+        @Override
+        public List<JsonObject> getSessionMessages(String sessionId, String cwd) {
+            JsonObject m = new JsonObject();
+            m.addProperty("type", "assistant");
+            m.addProperty("sessionId", sessionId);
+            return List.of(m);
+        }
+    }
+
+    @Test
+    public void launchChannelRoutesGemini() {
+        StubClaude claude = new StubClaude();
+        StubCodex codex = new StubCodex();
+        StubGemini gemini = new StubGemini();
+        SessionProviderRouter router = new SessionProviderRouter(claude, codex, null, gemini);
+
+        JsonObject result = router.launchChannel("gemini", "ch-1", "sid-1", "/tmp/p");
+        assertTrue(result.get("success").getAsBoolean());
+        assertEquals("gemini", result.get("provider").getAsString());
+        assertEquals("ch-1|sid-1|/tmp/p", gemini.lastLaunch.get());
+    }
+
+    @Test
+    public void interruptChannelRoutesGemini() {
+        StubClaude claude = new StubClaude();
+        StubCodex codex = new StubCodex();
+        StubGemini gemini = new StubGemini();
+        SessionProviderRouter router = new SessionProviderRouter(claude, codex, null, gemini);
+
+        router.interruptChannel("gemini", "ch-9");
+        assertTrue(gemini.interruptCalled.get());
+        assertTrue(!claude.interruptCalled.get());
+        assertTrue(!codex.interruptCalled.get());
+    }
+
+    @Test
+    public void getSessionMessagesRoutesGemini() {
+        StubClaude claude = new StubClaude();
+        StubCodex codex = new StubCodex();
+        StubGemini gemini = new StubGemini();
+        SessionProviderRouter router = new SessionProviderRouter(claude, codex, null, gemini);
+
+        List<JsonObject> msgs = router.getSessionMessages("gemini", "sid-g", "/cwd");
+        assertEquals(1, msgs.size());
+        assertEquals("sid-g", msgs.get(0).get("sessionId").getAsString());
+    }
+
+    @Test
+    public void nullGeminiBridgeFallsBackToClaude() {
+        StubClaude claude = new StubClaude();
+        StubCodex codex = new StubCodex();
+        SessionProviderRouter router = new SessionProviderRouter(claude, codex, null, null);
+
+        JsonObject result = router.launchChannel("gemini", "ch", "s", "/c");
+        assertEquals("claude", result.get("provider").getAsString());
+        assertEquals("claude:ch", claude.lastLaunchChannel.get());
+    }
+}

--- a/src/test/java/com/github/claudecodegui/session/SessionSendServiceTest.java
+++ b/src/test/java/com/github/claudecodegui/session/SessionSendServiceTest.java
@@ -55,7 +55,8 @@ public class SessionSendServiceTest {
         assertNull(SessionSendService.normalizeCliModelForProvider("kimi", "auto"));
         assertNull(SessionSendService.normalizeCliModelForProvider("opencode", "opencode-default"));
         assertEquals("kimi-k2.5", SessionSendService.normalizeCliModelForProvider("kimi", "kimi-k2.5"));
-        assertEquals("grok", SessionSendService.normalizeCliModelForProvider("grok", "grok-4.5"));
+        assertEquals("grok-4.5", SessionSendService.normalizeCliModelForProvider("grok", "grok-4.5"));
+        assertEquals("grok-4.5", SessionSendService.normalizeCliModelForProvider("grok", "grok"));
         assertNull(SessionSendService.normalizeCliModelForProvider("grok", "claude-sonnet-5"));
     }
 

--- a/src/test/java/com/github/claudecodegui/util/PathUtilsUnsafeCwdTest.java
+++ b/src/test/java/com/github/claudecodegui/util/PathUtilsUnsafeCwdTest.java
@@ -1,0 +1,82 @@
+package com.github.claudecodegui.util;
+
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class PathUtilsUnsafeCwdTest {
+
+    @Test
+    public void rejectsJetBrainsPluginTree() {
+        assertTrue(PathUtils.isUnsafeWorkingDirectory(
+                "/Users/x/Library/Application Support/JetBrains/IntelliJIdea2026.2/plugins/idea-claude-code-gui/ai-bridge"));
+    }
+
+    @Test
+    public void rejectsGeminiHome() {
+        assertTrue(PathUtils.isUnsafeWorkingDirectory("/Users/x/.gemini"));
+        assertTrue(PathUtils.isUnsafeWorkingDirectory("/Users/x/.gemini/antigravity-cli"));
+    }
+
+    @Test
+    public void rejectsAiBridgePath() {
+        assertTrue(PathUtils.isUnsafeWorkingDirectory("/path/to/plugin/ai-bridge"));
+    }
+
+    @Test
+    public void acceptsNormalProject() {
+        assertFalse(PathUtils.isUnsafeWorkingDirectory("/path/to/normal/project"));
+        assertFalse(PathUtils.isUnsafeWorkingDirectory("/Users/x/projects/my-app"));
+    }
+
+    @Test
+    public void guardFallsBackToProjectBase() throws Exception {
+        Path project = Files.createTempDirectory("ccg-cwd-project-");
+        try {
+            String unsafe = project.resolve("ai-bridge").toString();
+            Files.createDirectories(Path.of(unsafe));
+            String guarded = PathUtils.guardWorkingDirectory(unsafe, project.toString());
+            assertEquals(project.toRealPath().toString(), Path.of(guarded).toRealPath().toString());
+        } finally {
+            deleteRecursively(project);
+        }
+    }
+
+    @Test
+    public void guardKeepsSafeRequested() throws Exception {
+        Path project = Files.createTempDirectory("ccg-cwd-ok-");
+        try {
+            String guarded = PathUtils.guardWorkingDirectory(project.toString(), project.toString());
+            assertEquals(project.toRealPath().toString(), Path.of(guarded).toRealPath().toString());
+        } finally {
+            deleteRecursively(project);
+        }
+    }
+
+    @Test
+    public void guardReturnsNullWhenNothingSafe() {
+        assertNull(PathUtils.guardWorkingDirectory(
+                "/Users/x/.gemini",
+                "/Users/x/Library/Application Support/JetBrains/IntelliJIdea2026.2/plugins/idea-claude-code-gui"));
+    }
+
+    private static void deleteRecursively(Path root) throws Exception {
+        if (root == null || !Files.exists(root)) {
+            return;
+        }
+        try (var walk = Files.walk(root)) {
+            walk.sorted((a, b) -> b.compareTo(a)).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (Exception ignored) {
+                }
+            });
+        }
+    }
+}

--- a/src/test/java/com/github/claudecodegui/util/TokenUsageUtilsTest.java
+++ b/src/test/java/com/github/claudecodegui/util/TokenUsageUtilsTest.java
@@ -33,6 +33,32 @@ public class TokenUsageUtilsTest {
      * Verifies Codex context usage uses the provider's cache-inclusive input count only.
      */
     @Test
+    public void geminiContextTokensPreferInputAndAgyCacheFieldsNotTotal() {
+        JsonObject usage = new JsonObject();
+        usage.addProperty("input_tokens", 27793);
+        usage.addProperty("output_tokens", 18);
+        usage.addProperty("thinking_tokens", 0);
+        usage.addProperty("cache_read_tokens", 100);
+        usage.addProperty("total_tokens", 27911);
+
+        // Must NOT use total_tokens; must NOT sum input+cache (double-count)
+        assertEquals(27793, TokenUsageUtils.extractContextTokens(usage, "gemini"));
+    }
+
+    @Test
+    public void geminiDoesNotInflateWhenCacheEqualsInput() {
+        JsonObject usage = new JsonObject();
+        usage.addProperty("input_tokens", 900000);
+        usage.addProperty("cache_read_tokens", 900000);
+        usage.addProperty("cache_creation_input_tokens", 150000);
+        usage.addProperty("output_tokens", 10);
+        usage.addProperty("total_tokens", 1950010);
+
+        // Would be ~1.95M if we summed input+cache+creation; occupancy is input.
+        assertEquals(900000, TokenUsageUtils.extractContextTokens(usage, "gemini"));
+    }
+
+    @Test
     public void codexContextTokensUseInputOnly() {
         JsonObject usage = new JsonObject();
         usage.addProperty("input_tokens", 180000);

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -157,6 +157,8 @@ const App = () => {
     setPermissionMode, setCurrentProvider,
     setClaudePermissionMode, setCodexPermissionMode,
     setSelectedClaudeModel, setSelectedCodexModel,
+    setSelectedGrokModel, setSelectedKimiModel,
+    setSelectedOpenCodeModel, setSelectedPiModel,
     setLongContextEnabled, setReasoningEffort, setCodexFastMode,
     setProviderConfigVersion, setActiveProviderConfig,
     setClaudeSettingsAlwaysThinkingEnabled, setStreamingEnabledSetting,
@@ -272,6 +274,37 @@ const App = () => {
     setTaskEvents,
     setSubagentHistories,
     clearToasts, addToast, t,
+    applyHistoryModel: (provider, model, agent) => {
+      // Switch provider first when history row differs, then apply model.
+      if (provider && provider !== currentProvider) {
+        handleProviderSelect(provider);
+      }
+      if (model) {
+        // handleModelSelect reads currentProvider; after provider switch state
+        // may not have flushed yet — send bridge + setter for the target provider.
+        if (provider === 'codex') {
+          setSelectedCodexModel(model);
+          sendBridgeEvent('set_model', model);
+        } else if (provider === 'grok') {
+          setSelectedGrokModel(model);
+          sendBridgeEvent('set_model', model);
+        } else if (provider === 'kimi') {
+          setSelectedKimiModel(model);
+          sendBridgeEvent('set_model', model);
+        } else if (provider === 'opencode') {
+          setSelectedOpenCodeModel(model);
+          sendBridgeEvent('set_model', model);
+        } else if (provider === 'pi') {
+          setSelectedPiModel(model);
+          sendBridgeEvent('set_model', model);
+        } else {
+          handleModelSelect(model);
+        }
+      }
+      if (agent && provider === 'claude') {
+        handleAgentSelect({ id: agent, name: agent, prompt: '' });
+      }
+    },
   });
 
   useHistoryLoader({ currentView, currentProvider });
@@ -500,84 +533,95 @@ const App = () => {
           permissionDialogTimeoutSeconds={permissionDialogTimeoutSeconds}
           onPermissionDialogTimeoutChange={setPermissionDialogTimeoutSeconds}
         />
-      ) : currentView === 'chat' ? (
-        <ChatScreen
-          mergedMessages={mergedMessages}
-          sessionTitle={sessionTitle}
-          getMessageText={getMessageText}
-          getContentBlocks={getContentBlocks}
-          findToolResult={findToolResult}
-          getToolResultRaw={getToolResultRaw}
-          subagents={subagents}
-          globalTodos={globalTodos}
-          filteredFileChanges={filteredFileChanges}
-          subagentHistoryCtxValue={subagentHistoryCtxValue}
-          sessionIdCtxValue={sessionIdCtxValue}
-          chatInputRef={chatInputRef}
-          messagesContainerRef={messagesContainerRef}
-          messagesEndRef={messagesEndRef}
-          inputAreaRef={inputAreaRef}
-          messageNodeMapRef={messageNodeMapRef}
-          userCollapsedRef={userCollapsedRef}
-          messageListRef={messageListRef}
-          isAutoScrollingRef={isAutoScrollingRef}
-          anchorCollapsedCount={anchorCollapsedCount}
-          setAnchorCollapsedCount={setAnchorCollapsedCount}
-          onMessageNodeRef={handleMessageNodeRef}
-          statusPanelExpanded={statusPanelExpanded}
-          forceStatusUpdate={forceStatusUpdate}
-          onUndoFile={handleUndoFile}
-          onDiscardAll={onDiscardAll}
-          onKeepAll={handleKeepAll}
-          onSubmit={handleSubmit}
-          onInterrupt={interruptSession}
-          onRewind={handleOpenRewindSelectDialog}
-          onNavigateToProviderSettings={handleNavigateToProviderSettings}
-          onProviderSelect={wrappedHandleProviderSelect}
-          currentProvider={currentProvider}
-          selectedModel={selectedModel}
-          permissionMode={permissionMode}
-          selectedAgent={selectedAgent}
-          sdkStatusLoading={sdkStatusLoading}
-          sdkStatusError={sdkStatusError}
-          onRetrySdkStatus={retrySdkStatus}
-          currentSdkInstalled={currentSdkInstalled}
-          activeProviderConfig={activeProviderConfig}
-          claudeSettingsAlwaysThinkingEnabled={claudeSettingsAlwaysThinkingEnabled}
-          reasoningEffort={reasoningEffort}
-          codexFastMode={codexFastMode}
-          streamingEnabledSetting={streamingEnabledSetting}
-          sendShortcut={sendShortcut}
-          autoOpenFileEnabled={autoOpenFileEnabled}
-          longContextEnabled={longContextEnabled}
-          usagePercentage={usagePercentage}
-          usageUsedTokens={usageUsedTokens}
-          usageMaxTokens={usageMaxTokens}
-          onModeSelect={handleModeSelect}
-          onModelSelect={handleModelSelect}
-          onAgentSelect={handleAgentSelect}
-          onReasoningChange={handleReasoningChange}
-          onCodexFastModeChange={handleCodexFastModeChange}
-          onToggleThinking={handleToggleThinking}
-          onStreamingEnabledChange={handleStreamingEnabledChange}
-          onAutoOpenFileEnabledChange={handleAutoOpenFileEnabledChange}
-          onLongContextChange={handleLongContextChange}
-          messageQueue={messageQueue}
-          onRemoveFromQueue={dequeueMessage}
-        />
       ) : (
-        <HistoryView
-          historyData={historyData}
-          currentProvider={currentProvider}
-          currentSessionId={currentSessionId}
-          onLoadSession={loadHistorySession}
-          onDeleteSession={deleteHistorySession}
-          onDeleteSessions={deleteHistorySessions}
-          onExportSession={exportHistorySession}
-          onToggleFavorite={toggleFavoriteSession}
-          onUpdateTitle={updateHistoryTitle}
-          onConvertToCliSession={convertToCliSession}
-        />
+        <>
+          {/* Keep ChatScreen mounted while browsing history so model catalog,
+              scroll position, and draft attachments survive history ↔ chat. */}
+          <div
+            style={currentView === 'chat'
+              ? { display: 'flex', flex: 1, minHeight: 0, flexDirection: 'column', overflow: 'hidden' }
+              : { display: 'none' }}
+          >
+            <ChatScreen
+              mergedMessages={mergedMessages}
+              sessionTitle={sessionTitle}
+              getMessageText={getMessageText}
+              getContentBlocks={getContentBlocks}
+              findToolResult={findToolResult}
+              getToolResultRaw={getToolResultRaw}
+              subagents={subagents}
+              globalTodos={globalTodos}
+              filteredFileChanges={filteredFileChanges}
+              subagentHistoryCtxValue={subagentHistoryCtxValue}
+              sessionIdCtxValue={sessionIdCtxValue}
+              chatInputRef={chatInputRef}
+              messagesContainerRef={messagesContainerRef}
+              messagesEndRef={messagesEndRef}
+              inputAreaRef={inputAreaRef}
+              messageNodeMapRef={messageNodeMapRef}
+              userCollapsedRef={userCollapsedRef}
+              messageListRef={messageListRef}
+              isAutoScrollingRef={isAutoScrollingRef}
+              anchorCollapsedCount={anchorCollapsedCount}
+              setAnchorCollapsedCount={setAnchorCollapsedCount}
+              onMessageNodeRef={handleMessageNodeRef}
+              statusPanelExpanded={statusPanelExpanded}
+              forceStatusUpdate={forceStatusUpdate}
+              onUndoFile={handleUndoFile}
+              onDiscardAll={onDiscardAll}
+              onKeepAll={handleKeepAll}
+              onSubmit={handleSubmit}
+              onInterrupt={interruptSession}
+              onRewind={handleOpenRewindSelectDialog}
+              onNavigateToProviderSettings={handleNavigateToProviderSettings}
+              onProviderSelect={wrappedHandleProviderSelect}
+              currentProvider={currentProvider}
+              selectedModel={selectedModel}
+              permissionMode={permissionMode}
+              selectedAgent={selectedAgent}
+              sdkStatusLoading={sdkStatusLoading}
+              sdkStatusError={sdkStatusError}
+              onRetrySdkStatus={retrySdkStatus}
+              currentSdkInstalled={currentSdkInstalled}
+              activeProviderConfig={activeProviderConfig}
+              claudeSettingsAlwaysThinkingEnabled={claudeSettingsAlwaysThinkingEnabled}
+              reasoningEffort={reasoningEffort}
+              codexFastMode={codexFastMode}
+              streamingEnabledSetting={streamingEnabledSetting}
+              sendShortcut={sendShortcut}
+              autoOpenFileEnabled={autoOpenFileEnabled}
+              longContextEnabled={longContextEnabled}
+              usagePercentage={usagePercentage}
+              usageUsedTokens={usageUsedTokens}
+              usageMaxTokens={usageMaxTokens}
+              onModeSelect={handleModeSelect}
+              onModelSelect={handleModelSelect}
+              onAgentSelect={handleAgentSelect}
+              onReasoningChange={handleReasoningChange}
+              onCodexFastModeChange={handleCodexFastModeChange}
+              onToggleThinking={handleToggleThinking}
+              onStreamingEnabledChange={handleStreamingEnabledChange}
+              onAutoOpenFileEnabledChange={handleAutoOpenFileEnabledChange}
+              onLongContextChange={handleLongContextChange}
+              messageQueue={messageQueue}
+              onRemoveFromQueue={dequeueMessage}
+            />
+          </div>
+          {currentView === 'history' && (
+            <HistoryView
+              historyData={historyData}
+              currentProvider={currentProvider}
+              currentSessionId={currentSessionId}
+              onLoadSession={loadHistorySession}
+              onDeleteSession={deleteHistorySession}
+              onDeleteSessions={deleteHistorySessions}
+              onExportSession={exportHistorySession}
+              onToggleFavorite={toggleFavoriteSession}
+              onUpdateTitle={updateHistoryTitle}
+              onConvertToCliSession={convertToCliSession}
+            />
+          )}
+        </>
       )}
 
       <div id="image-preview-root" />

--- a/webview/src/components/ChangelogDialog.tsx
+++ b/webview/src/components/ChangelogDialog.tsx
@@ -21,9 +21,27 @@ function resolveContent(entry: ChangelogEntry): string[] {
   return parts;
 }
 
+const INLINE_CODE_RE = /`([^`]+)`/g;
+const BOLD_ITALIC_RE = /\*\*\*([^*]+)\*\*\*/g;
+const BOLD_RE = /\*\*([^*]+)\*\*/g;
+const ITALIC_RE = /\*([^*]+)\*/g;
+
+/**
+ * Apply inline markdown formatting: inline code, bold, italic, and bold-italic.
+ * Must run after HTML escaping, which preserves `*` and backticks. The emphasis
+ * patterns are matched longest-first so `***x***` is not swallowed by `**`/`*`.
+ */
+function renderInline(text: string): string {
+  return escapeHtml(text)
+    .replace(INLINE_CODE_RE, '<code>$1</code>')
+    .replace(BOLD_ITALIC_RE, '<strong><em>$1</em></strong>')
+    .replace(BOLD_RE, '<strong>$1</strong>')
+    .replace(ITALIC_RE, '<em>$1</em>');
+}
+
 /**
  * Simple markdown-to-HTML renderer for changelog content.
- * Handles: headings, bullet lists, bold, inline code, and emoji.
+ * Handles: headings, bullet lists, bold, italic, inline code, and emoji.
  */
 function renderChangelogMarkdown(text: string): string {
   if (!text) return '';
@@ -49,11 +67,7 @@ function renderChangelogMarkdown(text: string): string {
         htmlParts.push('<ul>');
         inList = true;
       }
-      const itemText = escapeHtml(trimmed.substring(2)).replace(
-        /`([^`]+)`/g,
-        '<code>$1</code>'
-      );
-      htmlParts.push(`<li>${itemText}</li>`);
+      htmlParts.push(`<li>${renderInline(trimmed.substring(2))}</li>`);
       continue;
     }
 
@@ -80,7 +94,7 @@ function renderChangelogMarkdown(text: string): string {
     }
 
     // Plain text
-    htmlParts.push(`<p>${escapeHtml(trimmed)}</p>`);
+    htmlParts.push(`<p>${renderInline(trimmed)}</p>`);
   }
 
   if (inList) {

--- a/webview/src/components/ChatInputBox/ButtonArea.tsx
+++ b/webview/src/components/ChatInputBox/ButtonArea.tsx
@@ -1,13 +1,14 @@
-import { useCallback, useMemo, useState, useEffect } from 'react';
+import { useCallback, useMemo, useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ButtonAreaProps, CodexFastMode, ModelInfo, PermissionMode, ReasoningEffort } from './types';
 import { CodexFastModeSelect, ConfigSelect, ModelSelect, ModeSelect, ProviderSelect, ReasoningSelect } from './selectors';
-import { CLAUDE_MODELS, CODEX_MODELS, GROK_MODELS } from './types';
-import { buildCodexModelList } from './codexModelList';
+import { CLAUDE_MODELS, CODEX_MODELS, GEMINI_MODELS, GROK_MODELS } from './types';
 import { STORAGE_KEYS, validateCodexCustomModels } from '../../types/provider';
 import type { CodexCustomModel } from '../../types/provider';
 import { readClaudeModelMapping } from '../../utils/claudeModelMapping';
 import { useCliModels } from '../../hooks/providers/useCliModels';
+import { buildCodexModelList } from './codexModelList';
+import { useToolbarSelectorCompact } from './hooks/useToolbarSelectorCompact';
 
 /**
  * Get custom Codex model list from localStorage
@@ -69,6 +70,8 @@ function getCustomClaudeModels(): ModelInfo[] {
  * Contains mode selector, model selector, attachment button, prompt enhancer button, send/stop button
  */
 export const ButtonArea = ({
+  geminiFamilies,
+  geminiModels,
   disabled = false,
   hasInputContent = false,
   isLoading = false,
@@ -99,7 +102,7 @@ export const ButtonArea = ({
 }: ButtonAreaProps) => {
   const { t } = useTranslation();
   // const fileInputRef = useRef<HTMLInputElement>(null);
-  const { cliModels, cliModelsLoading, cliModelsError, cliDefaultModel, cliCatalogHasEntries, refreshCliModels } = useCliModels(currentProvider);
+  const { cliModels, cliModelsLoading, cliModelsError, refreshCliModels, modelsByProvider, cliDefaultModel, cliCatalogHasEntries } = useCliModels(currentProvider);
 
   // Track changes to custom models in localStorage
   // When localStorage changes, updating this version number triggers useMemo recalculation
@@ -160,27 +163,27 @@ export const ButtonArea = ({
   // customModelsVersion triggers recalculation when localStorage changes
   const availableModels = useMemo(() => {
     if (currentProvider === 'codex') {
+      // Merge built-in models and custom models
       const customModels = getCustomCodexModels();
-      if (cliCatalogHasEntries) {
-        // Dynamic catalog arrived (config.toml model + model_catalog_json):
-        // show what the codex CLI picker would show, customs appended.
-        return buildCodexModelList(cliModels, customModels);
+      // Real catalog entries only (config default / model_catalog_json). When
+      // empty, cliModels is the static CODEX_MODELS fallback from useCliModels —
+      // pass [] so built-ins are applied once via the third argument, not twice.
+      const catalogModels = modelsByProvider['codex'] || [];
+      // customs → catalog → built-ins (deduped). Keeps plugin customs and the
+      // full built-in lineup even when a custom provider only returns its default.
+      return buildCodexModelList(catalogModels, customModels, CODEX_MODELS);
+    }
+    if (currentProvider === 'gemini') {
+      // Prefer live catalog rows when parent passes geminiModels; else static fallback.
+      if (geminiModels && geminiModels.length > 0) {
+        return geminiModels;
       }
-      // No catalog yet (still loading, fetch failed, or official provider):
-      // legacy merge of built-in models and custom models.
-      if (customModels.length === 0) {
-        return CODEX_MODELS;
-      }
-      // Custom models first, built-in models after
-      // Filter out built-in models that duplicate custom models
-      const customIds = new Set(customModels.map(m => m.id));
-      const filteredBuiltIn = CODEX_MODELS.filter(m => !customIds.has(m.id));
-      return [...customModels, ...filteredBuiltIn];
+      return GEMINI_MODELS;
     }
     if (currentProvider === 'grok') {
       return GROK_MODELS;
     }
-    if (currentProvider === 'kimi' || currentProvider === 'opencode' || currentProvider === 'pi') {
+    if (currentProvider === 'gemini' || currentProvider === 'kimi' || currentProvider === 'opencode' || currentProvider === 'pi') {
       return cliModels;
     }
     if (typeof window === 'undefined' || !window.localStorage) {
@@ -207,23 +210,34 @@ export const ButtonArea = ({
     const customIds = new Set(customModels.map(m => m.id));
     const filteredBuiltIn = builtInModels.filter(m => !customIds.has(m.id));
     return [...customModels, ...filteredBuiltIn];
-  }, [currentProvider, applyModelMapping, customModelsVersion, cliModels, cliCatalogHasEntries]);
+  }, [currentProvider, applyModelMapping, customModelsVersion, cliModels, geminiModels, modelsByProvider]);
 
-  // When a dynamic model catalog arrives, ensure selection is a real entry.
+  // When CLI model catalog arrives, ensure selection is a real entry.
   useEffect(() => {
-    const isDynamicProvider = currentProvider === 'kimi' || currentProvider === 'opencode'
-      || currentProvider === 'pi' || currentProvider === 'codex';
+    const isDynamicProvider = currentProvider === 'gemini' || currentProvider === 'kimi' || currentProvider === 'opencode'
+      || currentProvider === 'pi' || currentProvider === 'grok';
     if (!isDynamicProvider) return;
-    // Codex: only correct the selection once a real catalog arrived. With the
-    // official-provider fallback list (built-in GPT models) the user's explicit
-    // choice must be kept as-is.
-    if (currentProvider === 'codex' && !cliCatalogHasEntries) return;
+    // Only correct once a *real* catalog arrived. Static fallback lists
+    // (OPENCODE_MODELS = just "opencode-default", CODEX built-ins, …) must not
+    // clobber the user's choice — especially when ChatScreen remounts after
+    // leaving history and briefly shows the fallback before the cache/fetch
+    // lands.
+    if (!cliCatalogHasEntries) return;
+    if (cliModelsLoading) return;
     if (!availableModels.length || !onModelSelect) return;
-    const exists = availableModels.some((model) => model.id === selectedModel);
+    const exists = availableModels.some((model: ModelInfo) => model.id === selectedModel);
     if (!exists) {
-      onModelSelect(cliDefaultModel ?? availableModels[0].id);
+      onModelSelect(availableModels[0].id);
     }
-  }, [availableModels, currentProvider, onModelSelect, selectedModel, cliDefaultModel, cliCatalogHasEntries]);
+  }, [
+    availableModels,
+    currentProvider,
+    onModelSelect,
+    selectedModel,
+    cliDefaultModel,
+    cliCatalogHasEntries,
+    cliModelsLoading,
+  ]);
 
   /**
    * Handle submit button click
@@ -284,10 +298,34 @@ export const ButtonArea = ({
     onEnhancePrompt?.();
   }, [onEnhancePrompt]);
 
+  // Collapse selector labels for every CLI when left cluster is about to hit the send cluster (20px).
+  const buttonAreaRef = useRef<HTMLDivElement>(null);
+  const buttonAreaLeftRef = useRef<HTMLDivElement>(null);
+  const buttonAreaRightRef = useRef<HTMLDivElement>(null);
+  const selectorContentKey = [
+    currentProvider,
+    selectedModel,
+    permissionMode,
+    reasoningEffort,
+    codexFastMode,
+    selectedAgent?.id ?? '',
+    cliModelsLoading ? 'loading' : 'ready',
+  ].join('|');
+  const selectorsCompact = useToolbarSelectorCompact(
+    buttonAreaRef,
+    buttonAreaLeftRef,
+    buttonAreaRightRef,
+    selectorContentKey,
+  );
+
   return (
-    <div className="button-area" data-provider={currentProvider}>
+    <div
+      ref={buttonAreaRef}
+      className={`button-area${selectorsCompact ? ' button-area--compact' : ''}`}
+      data-provider={currentProvider}
+    >
       {/* Left side: selectors */}
-      <div className="button-area-left">
+      <div ref={buttonAreaLeftRef} className="button-area-left">
         <ConfigSelect
           alwaysThinkingEnabled={alwaysThinkingEnabled}
           onToggleThinking={onToggleThinking}
@@ -316,14 +354,20 @@ export const ButtonArea = ({
           longContextEnabled={longContextEnabled}
           onLongContextChange={onLongContextChange}
         />
-        <ReasoningSelect value={reasoningEffort} onChange={handleReasoningChange} selectedModel={selectedModel} currentProvider={currentProvider} />
+        <ReasoningSelect
+          value={reasoningEffort}
+          onChange={handleReasoningChange}
+          selectedModel={selectedModel}
+          currentProvider={currentProvider}
+          geminiFamilies={geminiFamilies}
+        />
         {currentProvider === 'codex' && (
           <CodexFastModeSelect value={codexFastMode} onChange={handleCodexFastModeChange} />
         )}
       </div>
 
       {/* Right side: tool buttons */}
-      <div className="button-area-right">
+      <div ref={buttonAreaRightRef} className="button-area-right">
         <div className="button-divider" />
 
         {/* Enhance prompt button */}

--- a/webview/src/components/ChatInputBox/ChatInputBoxHeader.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBoxHeader.tsx
@@ -123,7 +123,7 @@ export function ChatInputBoxHeader({
               : sdkStatusError
                 ? t('chat.sdkStatusUnavailable')
               : t('chat.sdkNotInstalled', {
-                  provider: currentProvider === 'codex' ? 'Codex' : 'Claude Code',
+                  provider: currentProvider === 'codex' ? 'Codex' : currentProvider === 'gemini' ? 'Gemini' : currentProvider === 'grok' ? 'Grok' : 'Claude Code',
                 })}
           </span>
           {sdkStatusError ? (

--- a/webview/src/components/ChatInputBox/ContextBar.tsx
+++ b/webview/src/components/ChatInputBox/ContextBar.tsx
@@ -1,6 +1,9 @@
-import React, { useRef, useState, useEffect, useCallback, memo } from 'react';
+import React, { useRef, useState, useEffect, useCallback, useMemo, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getFileIcon } from '../../utils/fileIcons';
+import { useGeminiPlanUsage } from '../../hooks/useGeminiPlanUsage';
+import { selectGeminiPlanFamily } from '../../utils/geminiBillingPace';
+import { GeminiPlanUsageIndicator } from './GeminiPlanUsageIndicator';
 import { TokenIndicator } from './TokenIndicator';
 import type { SelectedAgent } from './types';
 
@@ -28,6 +31,8 @@ interface ContextBarProps {
   onClearAgent?: () => void;
   /** Current provider (for conditional rendering) */
   currentProvider?: string;
+  /** Selected model id (Gemini: picks Gemini vs Claude/GPT quota family) */
+  selectedModel?: string;
   /** Whether there are messages (for rewind button visibility) */
   hasMessages?: boolean;
   /** Rewind callback */
@@ -54,6 +59,7 @@ export const ContextBar: React.FC<ContextBarProps> = memo(({
   selectedAgent,
   onClearAgent,
   currentProvider = 'claude',
+  selectedModel,
   hasMessages = false,
   onRewind,
   statusPanelExpanded = true,
@@ -63,6 +69,13 @@ export const ContextBar: React.FC<ContextBarProps> = memo(({
 }) => {
   const { t } = useTranslation();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const isGemini = currentProvider === 'gemini';
+  const geminiPlanUsage = useGeminiPlanUsage(currentProvider);
+  // Family (Gemini Models vs Claude/GPT) follows selected model; bar only switches 5h/7d
+  const geminiSnapshotForModel = useMemo(
+    () => selectGeminiPlanFamily(geminiPlanUsage.snapshot, selectedModel),
+    [geminiPlanUsage.snapshot, selectedModel],
+  );
   const popoverRef = useRef<HTMLDivElement>(null);
   const [showEnablePopover, setShowEnablePopover] = useState(false);
 
@@ -263,8 +276,15 @@ export const ContextBar: React.FC<ContextBarProps> = memo(({
         </div>
       )}
 
-      {/* Right side tools - StatusPanel toggle and Rewind button */}
+      {/* Right side tools - plan usage, StatusPanel toggle, Rewind */}
       <div className="context-tools-right">
+        {isGemini && (
+          <GeminiPlanUsageIndicator
+            snapshot={geminiSnapshotForModel}
+            status={geminiPlanUsage.status}
+          />
+        )}
+
         {/* StatusPanel expand/collapse toggle - always visible */}
         {onToggleStatusPanel && (
           <button

--- a/webview/src/components/ChatInputBox/GeminiPlanUsageIndicator.test.tsx
+++ b/webview/src/components/ChatInputBox/GeminiPlanUsageIndicator.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { GeminiPlanUsageIndicator } from './GeminiPlanUsageIndicator';
+
+describe('GeminiPlanUsageIndicator', () => {
+  it('shows Usage — when unavailable', () => {
+    render(
+      <GeminiPlanUsageIndicator
+        status="unavailable"
+        snapshot={{ present: false, message: 'down' }}
+      />,
+    );
+    expect(screen.getByText(/Usage/)).toBeTruthy();
+  });
+
+  it('renders bar percent and short reset on happy path', () => {
+    const { container } = render(
+      <GeminiPlanUsageIndicator
+        status="ready"
+        snapshot={{
+          present: true,
+          capacityPct: 47,
+          resetAt: '2026-07-28T00:00:00Z',
+          periodType: 'WEEKLY',
+        }}
+      />,
+    );
+    expect(screen.getByText('47%')).toBeTruthy();
+    expect(container.querySelector('.gemini-plan-usage-bar')).toBeTruthy();
+    expect(container.querySelector('.gemini-plan-usage-fill')).toBeTruthy();
+  });
+
+  it('applies pace color class from TP vs TT', () => {
+    // end far future, start far past → TT high → TP low → green
+    const far = new Date();
+    far.setDate(far.getDate() + 3);
+    const start = new Date();
+    start.setDate(start.getDate() - 4);
+    const { container } = render(
+      <GeminiPlanUsageIndicator
+        status="ready"
+        snapshot={{
+          present: true,
+          capacityPct: 10,
+          resetAt: far.toISOString(),
+          periodStart: start.toISOString(),
+        }}
+      />,
+    );
+    expect(container.querySelector('.pace-green')).toBeTruthy();
+  });
+
+  it('returns null when idle', () => {
+    const { container } = render(
+      <GeminiPlanUsageIndicator status="idle" snapshot={null} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/webview/src/components/ChatInputBox/GeminiPlanUsageIndicator.tsx
+++ b/webview/src/components/ChatInputBox/GeminiPlanUsageIndicator.tsx
@@ -1,0 +1,198 @@
+import React, { memo, useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  clampPercent,
+  formatFullReset,
+  formatShortReset,
+  nextWindowId,
+  paceColor,
+  readStoredWindowId,
+  resolveDisplayWindow,
+  resolveTimeBudget,
+  windowShortLabel,
+  worstPaceColor,
+  writeStoredWindowId,
+  type GeminiPlanUsageSnapshot,
+} from '../../utils/geminiBillingPace';
+
+export interface GeminiPlanUsageIndicatorProps {
+  snapshot: GeminiPlanUsageSnapshot | null;
+  status: 'idle' | 'loading' | 'ready' | 'unavailable';
+}
+
+/**
+ * Layout D: mini progress bar + % + window switcher + short reset.
+ * Click the window chip (7d / mo) to cycle weekly ↔ monthly (or 5h ↔ 7d).
+ */
+export const GeminiPlanUsageIndicator: React.FC<GeminiPlanUsageIndicatorProps> = memo(({
+  snapshot,
+  status,
+}) => {
+  const { t, i18n } = useTranslation();
+  const [windowId, setWindowId] = useState<string | null>(() => readStoredWindowId());
+
+  const display = useMemo(() => {
+    if (!snapshot?.present) return null;
+    return resolveDisplayWindow(snapshot, windowId);
+  }, [snapshot, windowId]);
+
+  const windows = snapshot?.windows ?? [];
+  const canSwitch = windows.length > 1;
+
+  const onCycleWindow = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!canSwitch) return;
+    const next = nextWindowId(windows, display?.windowId ?? windowId);
+    if (!next) return;
+    setWindowId(next);
+    writeStoredWindowId(next);
+  }, [canSwitch, windows, display?.windowId, windowId]);
+
+  const present = !!display && typeof display.capacityPct === 'number' && !!snapshot?.present;
+  const tp = present ? clampPercent(display!.capacityPct) : 0;
+  const tt = present
+    ? resolveTimeBudget({
+      resetAt: display!.resetAt,
+      periodStart: snapshot?.periodStart,
+      periodType: display!.periodType,
+    })
+    : null;
+  // Bar/% = selected window; leading dot = worst across all windows.
+  const color = present ? paceColor(tp, tt) : 'neutral';
+  const worstColor = present && snapshot ? worstPaceColor(snapshot) : 'neutral';
+  const shortReset = present ? formatShortReset(display!.resetAt, i18n.language) : '';
+  const fullReset = present ? formatFullReset(display!.resetAt, i18n.language) : '';
+  const winLabel = windowShortLabel(display?.windowId || display?.periodType);
+
+  const tooltip = useMemo(() => {
+    if (!present) {
+      return snapshot?.message
+        || t('chat.geminiPlanUsage.unavailable', { defaultValue: 'Usage unavailable' });
+    }
+    const pct = Math.round(tp);
+    const period = display?.periodType || display?.windowId || 'limit';
+    const lines: string[] = [];
+    if (fullReset) {
+      lines.push(
+        t('chat.geminiPlanUsage.tooltipWindowWithReset', {
+          period,
+          percent: pct,
+          value: fullReset,
+          defaultValue: '{{period}} {{percent}}% · Resets {{value}}',
+        }),
+      );
+    } else {
+      lines.push(
+        t('chat.geminiPlanUsage.tooltipWindow', {
+          period,
+          percent: pct,
+          defaultValue: '{{period}} {{percent}}%',
+        }),
+      );
+    }
+    if (windows.length > 1) {
+      const others = windows
+        .map((w) => `${w.id} ${Math.round(w.usedPct)}%`)
+        .join(' · ');
+      lines.push(others);
+      if (worstColor !== color && worstColor !== 'neutral' && worstColor !== 'green') {
+        lines.push(
+          t('chat.geminiPlanUsage.worstHint', {
+            color: worstColor,
+            defaultValue: 'Dot shows worst window ({{color}})',
+          }),
+        );
+      }
+      lines.push(
+        t('chat.geminiPlanUsage.clickToSwitch', {
+          defaultValue: 'Click period label to switch window',
+        }),
+      );
+    }
+    if (snapshot?.workerId) {
+      lines.push(snapshot.workerId);
+    }
+    return lines.join('\n');
+  }, [present, snapshot?.message, snapshot?.workerId, tp, fullReset, display, windows, worstColor, color, t]);
+
+  if (status === 'idle') return null;
+
+  if (!present && status === 'loading') {
+    return (
+      <div
+        className="gemini-plan-usage loading has-tooltip"
+        data-tooltip={t('chat.geminiPlanUsage.loading', { defaultValue: 'Loading usage…' })}
+        aria-label={t('chat.geminiPlanUsage.loading', { defaultValue: 'Loading usage…' })}
+      >
+        <span className="gemini-plan-usage-label">…</span>
+      </div>
+    );
+  }
+
+  if (!present) {
+    return (
+      <div
+        className="gemini-plan-usage unavailable has-tooltip"
+        data-tooltip={tooltip}
+        aria-label={tooltip}
+      >
+        <span className="gemini-plan-usage-label">
+          {t('chat.geminiPlanUsage.dash', { defaultValue: 'Usage —' })}
+        </span>
+      </div>
+    );
+  }
+
+  const fillWidth = `${tp}%`;
+  const rounded = Math.round(tp);
+  const labelPct = tp > 0 && rounded === 0 ? '<1%' : `${rounded}%`;
+
+  return (
+    <div
+      className={`gemini-plan-usage pace-${color} has-tooltip`}
+      data-tooltip={tooltip}
+      aria-label={tooltip}
+    >
+      <div className="gemini-plan-usage-bar" aria-hidden>
+        <div className="gemini-plan-usage-fill" style={{ width: fillWidth }} />
+      </div>
+      <span className="gemini-plan-usage-pct">{labelPct}</span>
+      {canSwitch || winLabel !== '·' ? (
+        <button
+          type="button"
+          className={`gemini-plan-usage-window${canSwitch ? ' switchable' : ''}`}
+          onClick={onCycleWindow}
+          disabled={!canSwitch}
+          title={
+            canSwitch
+              ? t('chat.geminiPlanUsage.clickToSwitch', {
+                defaultValue: 'Click to switch weekly / monthly',
+              })
+              : undefined
+          }
+        >
+          {winLabel}
+        </button>
+      ) : null}
+      {shortReset ? (
+        <span className="gemini-plan-usage-reset">{shortReset}</span>
+      ) : null}
+      {/* Worst pace across all windows — after reset date */}
+      <span
+        className={`gemini-plan-usage-worst-dot pace-${worstColor}`}
+        aria-hidden
+        title={
+          worstColor !== 'neutral'
+            ? t('chat.geminiPlanUsage.worstDot', {
+              color: worstColor,
+              defaultValue: 'Worst window: {{color}}',
+            })
+            : undefined
+        }
+      />
+    </div>
+  );
+});
+
+GeminiPlanUsageIndicator.displayName = 'GeminiPlanUsageIndicator';

--- a/webview/src/components/ChatInputBox/codexModelList.test.ts
+++ b/webview/src/components/ChatInputBox/codexModelList.test.ts
@@ -8,16 +8,30 @@ const catalog: ModelInfo[] = [
 ];
 
 describe('buildCodexModelList', () => {
-  it('puts catalog entries first and appends custom models', () => {
+  it('orders custom models first, then catalog, then built-ins', () => {
     const customs: ModelInfo[] = [{ id: 'my-model', label: 'My Model' }];
-    expect(buildCodexModelList(catalog, customs).map((m) => m.id)).toEqual(['kimi-k3', 'my-model']);
+    expect(
+      buildCodexModelList(catalog, customs, CODEX_MODELS).map((m) => m.id),
+    ).toEqual(['my-model', 'kimi-k3', ...CODEX_MODELS.map((m) => m.id)]);
   });
 
-  it('dedupes custom models that collide with catalog entries', () => {
+  it('dedupes catalog entries that collide with customs (custom wins)', () => {
     const customs: ModelInfo[] = [{ id: 'kimi-k3', label: 'Custom Label' }];
-    const merged = buildCodexModelList(catalog, customs);
+    const merged = buildCodexModelList(catalog, customs, []);
     expect(merged).toHaveLength(1);
-    expect(merged[0].label).toBe('kimi-k3');
+    expect(merged[0].label).toBe('Custom Label');
+  });
+
+  it('dedupes built-ins that collide with catalog (catalog wins)', () => {
+    const catalogWithBuiltin: ModelInfo[] = [
+      { id: 'gpt-5.5', label: 'gpt-5.5 (from config)' },
+    ];
+    const merged = buildCodexModelList(catalogWithBuiltin, [], CODEX_MODELS);
+    expect(merged.map((m) => m.id)).toEqual([
+      'gpt-5.5',
+      ...CODEX_MODELS.map((m) => m.id).filter((id) => id !== 'gpt-5.5'),
+    ]);
+    expect(merged[0].label).toBe('gpt-5.5 (from config)');
   });
 
   it('keeps the catalog order (config default pinned first by the backend)', () => {
@@ -25,17 +39,35 @@ describe('buildCodexModelList', () => {
       { id: 'kimi-k3', label: 'kimi-k3' },
       { id: 'other-model', label: 'Other' },
     ];
-    expect(buildCodexModelList(multi, []).map((m) => m.id)).toEqual(['kimi-k3', 'other-model']);
+    expect(buildCodexModelList(multi, [], []).map((m) => m.id)).toEqual([
+      'kimi-k3',
+      'other-model',
+    ]);
   });
 
-  it('returns customs when the catalog is empty', () => {
+  it('returns customs + built-ins when the catalog is empty', () => {
     const customs: ModelInfo[] = [{ id: 'my-model', label: 'My Model' }];
-    expect(buildCodexModelList([], customs).map((m) => m.id)).toEqual(['my-model']);
+    expect(buildCodexModelList([], customs, CODEX_MODELS).map((m) => m.id)).toEqual([
+      'my-model',
+      ...CODEX_MODELS.map((m) => m.id),
+    ]);
   });
 
-  it('falls back to the static built-in list shape when given CODEX_MODELS', () => {
-    // Official-provider path: hook substitutes CODEX_MODELS as the catalog.
-    const merged = buildCodexModelList(CODEX_MODELS, []);
+  it('falls back to the static built-in list when catalog and customs are empty', () => {
+    const merged = buildCodexModelList([], [], CODEX_MODELS);
     expect(merged.map((m) => m.id)).toEqual(CODEX_MODELS.map((m) => m.id));
+  });
+
+  it('custom-provider single default still surfaces full built-in lineup', () => {
+    // Backend rule: custom provider without catalog → only config default.
+    const singleDefault: ModelInfo[] = [{ id: 'gpt-5.5', label: 'gpt-5.5' }];
+    const customs: ModelInfo[] = [{ id: 'relay-model', label: 'Relay' }];
+    expect(
+      buildCodexModelList(singleDefault, customs, CODEX_MODELS).map((m) => m.id),
+    ).toEqual([
+      'relay-model',
+      'gpt-5.5',
+      ...CODEX_MODELS.map((m) => m.id).filter((id) => id !== 'gpt-5.5'),
+    ]);
   });
 });

--- a/webview/src/components/ChatInputBox/codexModelList.ts
+++ b/webview/src/components/ChatInputBox/codexModelList.ts
@@ -1,15 +1,26 @@
 import type { ModelInfo } from './types';
 
 /**
- * Merge the dynamic codex catalog (from ~/.codex/config.toml `model` +
- * `model_catalog_json`, fetched via get_cli_models) with user-added custom
- * models. Catalog entries come first — the backend already pins the config
- * default model at the top — customs follow, deduped by id.
+ * Build the Codex model picker list by merging three layers (deduped by id,
+ * first occurrence wins):
+ *
+ *  1. Plugin custom models (settings / localStorage)
+ *  2. Dynamic catalog from `get_cli_models` (config.toml `model` +
+ *     `model_catalog_json`; backend pins the config default first)
+ *  3. Built-in `CODEX_MODELS` fallback (Sol / Terra / Luna / 5.5 / 5.4)
+ *
+ * Always keep built-ins so custom providers that only surface a single default
+ * (e.g. `model = "gpt-5.5"`) still expose the full static lineup, while catalog
+ * / custom ids (e.g. kimi-k3) remain selectable.
  */
-export function buildCodexModelList(catalogModels: ModelInfo[], customModels: ModelInfo[]): ModelInfo[] {
+export function buildCodexModelList(
+  catalogModels: ModelInfo[],
+  customModels: ModelInfo[],
+  builtInModels: ModelInfo[] = [],
+): ModelInfo[] {
   const seen = new Set<string>();
   const out: ModelInfo[] = [];
-  for (const model of [...catalogModels, ...customModels]) {
+  for (const model of [...customModels, ...catalogModels, ...builtInModels]) {
     if (seen.has(model.id)) continue;
     seen.add(model.id);
     out.push(model);

--- a/webview/src/components/ChatInputBox/geminiModels.test.ts
+++ b/webview/src/components/ChatInputBox/geminiModels.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AVAILABLE_PROVIDERS,
+  DEFAULT_GEMINI_MODEL_ID,
+  GEMINI_MODELS,
+  composeGeminiAgyModelId,
+  splitGeminiAgyModelId,
+  toGeminiFamilyId,
+} from './types';
+
+describe('Gemini provider catalog', () => {
+  it('enables gemini in AVAILABLE_PROVIDERS', () => {
+    const gemini = AVAILABLE_PROVIDERS.find((p) => p.id === 'gemini');
+    expect(gemini).toBeDefined();
+    expect(gemini?.enabled).toBe(true);
+    expect(gemini?.beta).toBe(true);
+  });
+
+  it('lists family base ids including Claude/GPT via Antigravity', () => {
+    expect(DEFAULT_GEMINI_MODEL_ID).toBe('gemini-3.5-flash');
+    const ids = GEMINI_MODELS.map((m) => m.id);
+    expect(ids).toContain(DEFAULT_GEMINI_MODEL_ID);
+    expect(ids).toContain('gemini-3.6-flash');
+    expect(ids).toContain('gemini-3.1-pro');
+    expect(ids).toContain('claude-sonnet-4-6');
+    expect(ids).toContain('claude-opus-4-6');
+    expect(ids).toContain('gpt-oss-120b');
+    expect(GEMINI_MODELS.every((m) => m.label && m.id)).toBe(true);
+  });
+
+  it('splits and composes agy effort suffixes', () => {
+    expect(splitGeminiAgyModelId('gemini-3.5-flash-medium')).toEqual({
+      baseId: 'gemini-3.5-flash',
+      effort: 'medium',
+    });
+    expect(splitGeminiAgyModelId('claude-opus-4-6-thinking')).toEqual({
+      baseId: 'claude-opus-4-6',
+      effort: 'thinking',
+    });
+    expect(splitGeminiAgyModelId('claude-sonnet-4-6')).toEqual({
+      baseId: 'claude-sonnet-4-6',
+      effort: '',
+    });
+    expect(composeGeminiAgyModelId('gemini-3.5-flash', 'high')).toBe('gemini-3.5-flash-high');
+    expect(composeGeminiAgyModelId('gemini-3.5-flash-medium', 'low')).toBe('gemini-3.5-flash-low');
+    expect(toGeminiFamilyId('gpt-oss-120b-medium')).toBe('gpt-oss-120b');
+  });
+});

--- a/webview/src/components/ChatInputBox/hooks/index.ts
+++ b/webview/src/components/ChatInputBox/hooks/index.ts
@@ -40,3 +40,8 @@ export { useResetAttachmentsOnSessionChange } from './useResetAttachmentsOnSessi
 export { useSpaceKeyListener } from './useSpaceKeyListener.js';
 export { useResizableChatInputBox, computeResize } from './useResizableChatInputBox.js';
 export { useInlineHistoryCompletion } from './useInlineHistoryCompletion.js';
+export {
+  useToolbarSelectorCompact,
+  shouldCollapseToolbarSelectors,
+  TOOLBAR_SELECTOR_MIN_GAP_PX,
+} from './useToolbarSelectorCompact.js';

--- a/webview/src/components/ChatInputBox/hooks/useSubmitHandler.ts
+++ b/webview/src/components/ChatInputBox/hooks/useSubmitHandler.ts
@@ -80,7 +80,7 @@ export function useSubmitHandler({
     if (!sdkInstalled) {
       addToast?.(
         t('chat.sdkNotInstalled', {
-          provider: currentProvider === 'codex' ? 'Codex' : 'Claude Code',
+          provider: currentProvider === 'codex' ? 'Codex' : currentProvider === 'gemini' ? 'Gemini' : currentProvider === 'grok' ? 'Grok' : 'Claude Code',
         }) +
           ' ' +
           t('chat.goInstallSdk'),

--- a/webview/src/components/ChatInputBox/hooks/useToolbarSelectorCompact.test.ts
+++ b/webview/src/components/ChatInputBox/hooks/useToolbarSelectorCompact.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import {
+  TOOLBAR_SELECTOR_MIN_GAP_PX,
+  measureLeftContentWidth,
+  shouldCollapseToolbarSelectors,
+} from './useToolbarSelectorCompact';
+
+describe('shouldCollapseToolbarSelectors', () => {
+  it('does not collapse when left + right leave at least 20px gap', () => {
+    // root 400, left 200, right 80 → used 280, free 120 ≥ 20
+    expect(shouldCollapseToolbarSelectors(400, 200, 80)).toBe(false);
+  });
+
+  it('collapses when gap would be under 20px', () => {
+    // root 300, left 200, right 90 → 200+90+20=310 > 300
+    expect(shouldCollapseToolbarSelectors(300, 200, 90)).toBe(true);
+  });
+
+  it('collapses exactly at the 20px boundary (equal means would not fit with gap)', () => {
+    // left + right + 20 === root → still need compact to preserve the gap
+    expect(shouldCollapseToolbarSelectors(300, 200, 80, 20)).toBe(true);
+  });
+
+  it('does not collapse when free space equals min gap after content', () => {
+    // left 200 + right 80 + 20 = 300, root 301 → ok
+    expect(shouldCollapseToolbarSelectors(301, 200, 80, 20)).toBe(false);
+  });
+
+  it('uses TOOLBAR_SELECTOR_MIN_GAP_PX default of 20', () => {
+    expect(TOOLBAR_SELECTOR_MIN_GAP_PX).toBe(20);
+    expect(shouldCollapseToolbarSelectors(100, 50, 30)).toBe(true); // 50+30+20=100 → collapse at equality
+    expect(shouldCollapseToolbarSelectors(101, 50, 30)).toBe(false);
+  });
+
+  it('does not collapse for invalid / empty measurements', () => {
+    expect(shouldCollapseToolbarSelectors(0, 100, 50)).toBe(false);
+    expect(shouldCollapseToolbarSelectors(200, 0, 50)).toBe(false);
+  });
+
+  it('works for long OpenCode-style model labels (all CLIs same rule)', () => {
+    const longModel = 220; // e.g. "opencode/Deepseek-V4-Flash-Free" + icons + mode + reasoning
+    const right = 72; // enhance + send
+    const wide = 400;
+    const narrow = 280;
+    expect(shouldCollapseToolbarSelectors(wide, longModel, right)).toBe(false); // 220+72+20=312 < 400
+    expect(shouldCollapseToolbarSelectors(narrow, longModel, right)).toBe(true); // 312 > 280
+  });
+});
+
+describe('measureLeftContentWidth', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sums children widths and flex gap (not the stretched flex:1 box)', () => {
+    const childA = { offsetWidth: 40 } as HTMLElement;
+    const childB = { offsetWidth: 120 } as HTMLElement;
+    const childC = { offsetWidth: 60 } as HTMLElement;
+    const left = {
+      children: {
+        length: 3,
+        0: childA,
+        1: childB,
+        2: childC,
+      },
+    } as unknown as HTMLElement;
+
+    vi.stubGlobal('getComputedStyle', () => ({ columnGap: '4px', gap: '4px' }));
+
+    // 40 + 4 + 120 + 4 + 60 = 228
+    expect(measureLeftContentWidth(left)).toBe(228);
+  });
+
+  it('returns 0 for empty left cluster', () => {
+    const left = { children: { length: 0 } } as unknown as HTMLElement;
+    expect(measureLeftContentWidth(left)).toBe(0);
+  });
+});

--- a/webview/src/components/ChatInputBox/hooks/useToolbarSelectorCompact.ts
+++ b/webview/src/components/ChatInputBox/hooks/useToolbarSelectorCompact.ts
@@ -1,0 +1,123 @@
+import { useLayoutEffect, useRef, useState, type RefObject } from 'react';
+
+/** Collapse labels when left selectors would come within this many px of the send cluster. */
+export const TOOLBAR_SELECTOR_MIN_GAP_PX = 20;
+
+/**
+ * Whether toolbar selector labels should collapse to icon-only mode.
+ * Collapses when left content + right cluster + min gap would exceed the toolbar width.
+ */
+export function shouldCollapseToolbarSelectors(
+  rootWidth: number,
+  leftContentWidth: number,
+  rightWidth: number,
+  minGapPx: number = TOOLBAR_SELECTOR_MIN_GAP_PX,
+): boolean {
+  if (rootWidth <= 0 || leftContentWidth <= 0) return false;
+  // Collapse when free space between left content and right cluster is ≤ minGap.
+  // free = root - left - right; collapse when free <= minGap.
+  return leftContentWidth + rightWidth + minGapPx >= rootWidth;
+}
+
+/**
+ * Intrinsic width of the left selector cluster (sum of children + flex gap).
+ * Do not use left.scrollWidth: left is flex:1 so scrollWidth tracks the stretched box.
+ */
+export function measureLeftContentWidth(left: HTMLElement): number {
+  const children = left.children;
+  if (children.length === 0) return 0;
+
+  const styles = getComputedStyle(left);
+  const gapRaw = styles.columnGap || styles.gap || '0';
+  const gap = Number.parseFloat(gapRaw) || 0;
+
+  let total = 0;
+  for (let i = 0; i < children.length; i++) {
+    total += (children[i] as HTMLElement).offsetWidth;
+    if (i > 0) total += gap;
+  }
+  return total;
+}
+
+/** Content-box width of the toolbar (clientWidth minus horizontal padding). */
+export function measureRootContentWidth(root: HTMLElement): number {
+  const styles = getComputedStyle(root);
+  const padL = Number.parseFloat(styles.paddingLeft) || 0;
+  const padR = Number.parseFloat(styles.paddingRight) || 0;
+  return Math.max(0, root.clientWidth - padL - padR);
+}
+
+/**
+ * Measures expanded left content width. Temporarily sets `data-measuring` so CSS
+ * can expand labels even while compact is active (avoids chicken-and-egg flicker).
+ */
+export function measureExpandedLeftWidth(root: HTMLElement, left: HTMLElement): number {
+  root.setAttribute('data-measuring', '');
+  // Force layout with expanded styles applied.
+  const width = measureLeftContentWidth(left);
+  root.removeAttribute('data-measuring');
+  return width;
+}
+
+/**
+ * Proximity-based toolbar compact mode for all CLI providers.
+ * Hides selector labels when the left cluster would get within 20px of the send button.
+ */
+export function useToolbarSelectorCompact(
+  rootRef: RefObject<HTMLElement | null>,
+  leftRef: RefObject<HTMLElement | null>,
+  rightRef: RefObject<HTMLElement | null>,
+  /** Re-run when selector content may change (provider, model label, mode, etc.). */
+  contentKey: string | number,
+): boolean {
+  const [compact, setCompact] = useState(false);
+  const compactRef = useRef(compact);
+  compactRef.current = compact;
+
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    const left = leftRef.current;
+    const right = rightRef.current;
+    if (!root || !left || !right) return;
+
+    let disposed = false;
+
+    const recompute = () => {
+      if (disposed) return;
+      const rootEl = rootRef.current;
+      const leftEl = leftRef.current;
+      const rightEl = rightRef.current;
+      if (!rootEl || !leftEl || !rightEl) return;
+
+      // Always measure against expanded labels so compact/expand does not thrash.
+      const leftWidth = measureExpandedLeftWidth(rootEl, leftEl);
+      const needsCompact = shouldCollapseToolbarSelectors(
+        measureRootContentWidth(rootEl),
+        leftWidth,
+        rightEl.offsetWidth,
+      );
+
+      if (needsCompact !== compactRef.current) {
+        compactRef.current = needsCompact;
+        setCompact(needsCompact);
+      }
+    };
+
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(recompute) : null;
+    ro?.observe(root);
+    ro?.observe(left);
+    ro?.observe(right);
+
+    window.addEventListener('resize', recompute);
+    recompute();
+
+    return () => {
+      disposed = true;
+      ro?.disconnect();
+      window.removeEventListener('resize', recompute);
+      root.removeAttribute('data-measuring');
+    };
+  }, [rootRef, leftRef, rightRef, contentKey]);
+
+  return compact;
+}

--- a/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ModelSelect.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useDeferredValue, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AVAILABLE_MODELS, normalizeClaudeModelId, modelSupports1MContext, strip1MContextSuffix } from '../types';
+import {
+  AVAILABLE_MODELS,
+  normalizeClaudeModelId,
+  modelSupports1MContext,
+  strip1MContextSuffix,
+  toGeminiFamilyId,
+} from '../types';
 import type { ModelInfo } from '../types';
 import { readClaudeModelMapping } from '../../../utils/claudeModelMapping';
 import { ProviderModelIcon } from '../../shared/ProviderModelIcon';
@@ -163,13 +169,29 @@ export const ModelSelect = ({ value, onChange, models = AVAILABLE_MODELS, curren
     preferredAlignment: 'right',
   });
 
-  // Strip [1m] suffix for finding the model in the list
+  // Strip [1m] suffix for finding the model in the list.
+  // Gemini: backend may echo full agy slugs (...-high); UI list is family base ids.
   const strippedValue = strip1MContextSuffix(value);
-  const normalizedValue = currentProvider === 'claude' ? normalizeClaudeModelId(strippedValue) : strippedValue;
-  const currentModel = models.find(m => m.id === normalizedValue) || models.find(m => m.id === strippedValue) || models[0];
+  const normalizedValue = currentProvider === 'claude'
+    ? normalizeClaudeModelId(strippedValue)
+    : currentProvider === 'gemini'
+      ? toGeminiFamilyId(strippedValue) || strippedValue
+      : strippedValue;
+  // Prefer the user's selection even when the catalog is still loading / only a
+  // static fallback is available. Falling back to models[0] made OpenCode (and
+  // other dynamic providers) visually snap back to the first entry after leaving
+  // history and remounting ChatScreen.
+  const currentModel = models.find(m => m.id === normalizedValue)
+    || models.find(m => m.id === strippedValue)
+    || (strippedValue
+      ? { id: strippedValue, label: strippedValue } as ModelInfo
+      : models[0]);
   const modelMapping = readClaudeModelMapping();
 
   const isSelectedModel = (modelId: string): boolean => {
+    if (currentProvider === 'gemini') {
+      return modelId === normalizedValue || modelId === strippedValue;
+    }
     if (currentProvider !== 'claude') {
       return modelId === strippedValue;
     }

--- a/webview/src/components/ChatInputBox/selectors/ProviderSelect.beta.test.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ProviderSelect.beta.test.tsx
@@ -41,14 +41,14 @@ describe('ProviderSelect Beta badge and first-click notice', () => {
     window.updateCodexSubscriptionQuota = undefined;
   });
 
-  it('renders Beta badges on Grok, Kimi, OpenCode and PI', () => {
+  it('renders Beta badges on Gemini, Grok, Kimi, OpenCode and PI', () => {
     render(<ProviderSelect value="claude" />);
     fireEvent.click(screen.getByRole('button'));
 
     const badges = screen.getAllByText('Beta');
-    expect(badges).toHaveLength(4);
+    expect(badges).toHaveLength(5);
 
-    for (const id of ['grok', 'kimi', 'opencode', 'pi']) {
+    for (const id of ['gemini', 'grok', 'kimi', 'opencode', 'pi']) {
       const row = document.querySelector(`[data-provider-id="${id}"]`);
       expect(row?.querySelector('.provider-beta-badge')).toBeTruthy();
     }

--- a/webview/src/components/ChatInputBox/selectors/ReasoningSelect.test.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ReasoningSelect.test.tsx
@@ -161,4 +161,57 @@ describe('ReasoningSelect', () => {
 
     expect(screen.queryByRole('button')).toBeNull();
   });
+
+  it('hides reasoning dropdown for Gemini models with no efforts', () => {
+    const { container } = render(
+      <ReasoningSelect
+        value={'' as any}
+        onChange={vi.fn()}
+        currentProvider={'gemini'}
+        selectedModel={'claude-sonnet-4-6'}
+        geminiFamilies={[
+          {
+            id: 'claude-sonnet-4-6',
+            label: 'Claude Sonnet 4.6',
+            description: 'Default',
+            defaultEffort: '',
+            defaultModelId: 'claude-sonnet-4-6',
+            efforts: [
+              { id: '', label: 'Default', modelId: 'claude-sonnet-4-6' }
+            ]
+          }
+        ]}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows reasoning dropdown correctly and strips :current from selectedModel', () => {
+    const { getByRole, getAllByText } = render(
+      <ReasoningSelect
+        value={'medium'}
+        onChange={vi.fn()}
+        currentProvider={'gemini'}
+        selectedModel={'gpt-oss-120b-medium:current'}
+        geminiFamilies={[
+          {
+            id: 'gpt-oss-120b',
+            label: 'GPT-OSS 120B',
+            description: 'Medium',
+            defaultEffort: 'medium',
+            defaultModelId: 'gpt-oss-120b-medium',
+            efforts: [
+              { id: 'medium', label: 'Medium', modelId: 'gpt-oss-120b-medium' }
+            ]
+          }
+        ]}
+      />,
+    );
+    
+    const button = getByRole('button');
+    expect(button).toBeDefined();
+    
+    fireEvent.click(button);
+    expect(getAllByText('Medium').length).toBeGreaterThan(0);
+  });
 });

--- a/webview/src/components/ChatInputBox/selectors/ReasoningSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ReasoningSelect.tsx
@@ -6,7 +6,10 @@ import {
   MAX_EFFORT_CLAUDE_MODELS,
   XHIGH_EFFORT_CLAUDE_MODELS,
   codexModelSupportsMaxEffort,
+  toGeminiFamilyId,
+  type GeminiModelFamily,
   type ReasoningEffort,
+  type ReasoningInfo,
 } from '../types';
 import { useDropdownPosition } from '../../../hooks/useDropdownPosition';
 
@@ -22,12 +25,23 @@ const DROPDOWN_STYLE: React.CSSProperties = {
 };
 const LEVEL_INFO_STYLE: React.CSSProperties = { display: 'flex', flexDirection: 'column', flex: 1 };
 
+const GEMINI_EFFORT_ICONS: Record<string, string> = {
+  low: 'codicon-circle-small',
+  medium: 'codicon-circle-filled',
+  high: 'codicon-circle-large-filled',
+  xhigh: 'codicon-flame',
+  thinking: 'codicon-lightbulb',
+  '': 'codicon-circle-outline',
+};
+
 interface ReasoningSelectProps {
   value: ReasoningEffort;
   onChange: (effort: ReasoningEffort) => void;
   disabled?: boolean;
   selectedModel?: string;
   currentProvider?: string;
+  /** Live Gemini/agy families — drives subordinate effort list for gemini provider. */
+  geminiFamilies?: GeminiModelFamily[];
 }
 
 /**
@@ -39,7 +53,14 @@ interface ReasoningSelectProps {
  * - Claude Sonnet 5, Sonnet 4.7, Opus 4.6, and Sonnet 4.6: low/medium/high/max
  * - Claude Haiku 4.5 and legacy models: hidden (no adaptive thinking support)
  */
-export const ReasoningSelect = ({ value, onChange, disabled, selectedModel, currentProvider }: ReasoningSelectProps) => {
+export const ReasoningSelect = ({
+  value,
+  onChange,
+  disabled,
+  selectedModel,
+  currentProvider,
+  geminiFamilies,
+}: ReasoningSelectProps) => {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -50,32 +71,60 @@ export const ReasoningSelect = ({ value, onChange, disabled, selectedModel, curr
     preferredAlignment: 'right',
   });
 
-  // Determine visibility: for Claude, hide if model doesn't support adaptive thinking
-  const isVisible = currentProvider !== 'claude' || !selectedModel || EFFORT_SUPPORTED_CLAUDE_MODELS.has(selectedModel);
+  const strippedSelectedModel = selectedModel?.replace(/:current$/, '');
+  const geminiFamily = currentProvider === 'gemini' && strippedSelectedModel && geminiFamilies?.length
+    ? geminiFamilies.find((f) => f.id === strippedSelectedModel || f.id === toGeminiFamilyId(strippedSelectedModel))
+    : undefined;
 
-  // Build the list of available levels for the current model
-  const availableLevels = REASONING_LEVELS.filter(level => {
-    // Grok CLI only accepts low|medium|high.
-    if (currentProvider === 'grok') {
-      return level.id === 'low' || level.id === 'medium' || level.id === 'high';
-    }
-    if (currentProvider === 'codex') {
-      return level.id !== 'max' || (selectedModel !== undefined && codexModelSupportsMaxEffort(selectedModel));
-    }
-    if (currentProvider !== 'claude') {
-      return level.id !== 'max';
-    }
-    if (!selectedModel) {
+  const geminiLevels: ReasoningInfo[] | null = geminiFamily
+    ? geminiFamily.efforts
+        .filter((e) => e.id) // hide empty "Default" row when only bare slug exists without efforts
+        .map((e) => ({
+          id: e.id as ReasoningEffort,
+          label: e.label,
+          icon: GEMINI_EFFORT_ICONS[e.id] || 'codicon-circle-outline',
+          description: e.modelId,
+        }))
+    : currentProvider === 'gemini'
+      // Fallback static efforts before catalog loads
+      ? REASONING_LEVELS.filter((l) => l.id === 'low' || l.id === 'medium' || l.id === 'high')
+      : null;
+
+  // Hide when: Claude model without adaptive thinking; Gemini family with no effort variants
+  const isVisible = (() => {
+    if (currentProvider === 'gemini') {
+      if (geminiFamily) {
+        return geminiFamily.efforts.some((e) => e.id);
+      }
       return true;
     }
-    if (level.id === 'xhigh') {
-      return XHIGH_EFFORT_CLAUDE_MODELS.has(selectedModel);
-    }
-    if (level.id === 'max') {
-      return MAX_EFFORT_CLAUDE_MODELS.has(selectedModel);
-    }
-    return true;
-  });
+    return currentProvider !== 'claude' || !strippedSelectedModel || EFFORT_SUPPORTED_CLAUDE_MODELS.has(strippedSelectedModel);
+  })();
+
+  // Build the list of available levels for the current model
+  const availableLevels: ReasoningInfo[] = geminiLevels
+    ?? REASONING_LEVELS.filter(level => {
+      // Grok CLI only accepts low|medium|high.
+      if (currentProvider === 'grok') {
+        return level.id === 'low' || level.id === 'medium' || level.id === 'high';
+      }
+      if (currentProvider === 'codex') {
+        return level.id !== 'max' || (strippedSelectedModel !== undefined && codexModelSupportsMaxEffort(strippedSelectedModel));
+      }
+      if (currentProvider !== 'claude') {
+        return level.id !== 'max';
+      }
+      if (!strippedSelectedModel) {
+        return true;
+      }
+      if (level.id === 'xhigh') {
+        return XHIGH_EFFORT_CLAUDE_MODELS.has(strippedSelectedModel);
+      }
+      if (level.id === 'max') {
+        return MAX_EFFORT_CLAUDE_MODELS.has(strippedSelectedModel);
+      }
+      return true;
+    });
 
   const currentLevel = availableLevels.find(l => l.id === value) || availableLevels[availableLevels.length - 2] || availableLevels[0];
 
@@ -91,9 +140,10 @@ export const ReasoningSelect = ({ value, onChange, disabled, selectedModel, curr
   /**
    * Get translated text for reasoning level
    */
-  const getReasoningText = (levelId: ReasoningEffort, field: 'label' | 'description') => {
+  const getReasoningText = (levelId: ReasoningEffort | string, field: 'label' | 'description') => {
     const key = `reasoning.${levelId}.${field}`;
-    const fallback = REASONING_LEVELS.find(l => l.id === levelId)?.[field] || levelId;
+    const fromGemini = availableLevels.find(l => l.id === levelId)?.[field];
+    const fallback = fromGemini || REASONING_LEVELS.find(l => l.id === levelId)?.[field] || levelId;
     return t(key, { defaultValue: fallback });
   };
 

--- a/webview/src/components/ChatInputBox/styles/context-bar.css
+++ b/webview/src/components/ChatInputBox/styles/context-bar.css
@@ -365,3 +365,131 @@ button.context-file-placeholder:focus-visible {
   }
 }
 
+/* Grok plan usage (layout D: mini-bar + % + window + short reset) */
+.gemini-plan-usage {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  max-width: 200px;
+  min-width: 0;
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1;
+  flex-shrink: 1;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+/* Leading dot = worst pace across all windows (not just selected). */
+.gemini-plan-usage-worst-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--text-secondary);
+  opacity: 0.85;
+}
+.gemini-plan-usage-worst-dot.pace-green {
+  background: #3ba55d;
+  opacity: 1;
+}
+.gemini-plan-usage-worst-dot.pace-yellow {
+  background: #d4a017;
+  opacity: 1;
+}
+.gemini-plan-usage-worst-dot.pace-red {
+  background: #e34850;
+  opacity: 1;
+}
+.gemini-plan-usage-worst-dot.pace-neutral {
+  background: var(--text-secondary);
+  opacity: 0.5;
+}
+
+.gemini-plan-usage-bar {
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--input-border);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.gemini-plan-usage-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--text-secondary);
+  transition: width 0.25s ease, background 0.2s ease;
+}
+
+.gemini-plan-usage-pct {
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+.gemini-plan-usage-reset {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-secondary);
+  opacity: 0.9;
+}
+
+/* weekly/monthly (or 5h/7d) switcher */
+.gemini-plan-usage-window {
+  flex-shrink: 0;
+  margin: 0;
+  padding: 1px 4px;
+  border: 1px solid var(--input-border);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+  cursor: default;
+}
+.gemini-plan-usage-window.switchable {
+  cursor: pointer;
+}
+.gemini-plan-usage-window.switchable:hover {
+  background: var(--button-hover);
+  color: var(--text-primary);
+}
+.gemini-plan-usage-window:disabled {
+  opacity: 0.85;
+}
+
+.gemini-plan-usage.pace-green .gemini-plan-usage-fill {
+  background: #3ba55d;
+}
+.gemini-plan-usage.pace-green .gemini-plan-usage-pct {
+  color: #3ba55d;
+}
+
+.gemini-plan-usage.pace-yellow .gemini-plan-usage-fill {
+  background: #d4a017;
+}
+.gemini-plan-usage.pace-yellow .gemini-plan-usage-pct {
+  color: #d4a017;
+}
+
+.gemini-plan-usage.pace-red .gemini-plan-usage-fill {
+  background: #e34850;
+}
+.gemini-plan-usage.pace-red .gemini-plan-usage-pct {
+  color: #e34850;
+}
+
+.gemini-plan-usage.unavailable {
+  opacity: 0.75;
+}
+
+.gemini-plan-usage-label {
+  font-size: 11px;
+  color: var(--text-secondary);
+}

--- a/webview/src/components/ChatInputBox/styles/selectors.css
+++ b/webview/src/components/ChatInputBox/styles/selectors.css
@@ -71,111 +71,28 @@
   transition: max-width 0.2s ease, opacity 0.2s ease, margin 0.2s ease;
 }
 
-/* Container query for Claude: hide text when narrow (< 400px) */
-@container button-area (max-width: 400px) {
-  .button-area[data-provider="claude"] .selector-button-text {
-    max-width: 0;
-    opacity: 0;
-    overflow: hidden;
-    margin: 0;
-  }
-
-  .button-area[data-provider="claude"] .selector-button {
-    gap: 2px;
-    padding: 4px 6px;
-    min-width: 28px;
-  }
-
-  .button-area[data-provider="claude"] .selector-button > .codicon-chevron-up,
-  .button-area[data-provider="claude"] .selector-button > .codicon-chevron-down {
-    display: none;
-  }
+/*
+ * Proximity compact mode (all CLI providers).
+ * Applied by useToolbarSelectorCompact when left selectors would get within 20px
+ * of the send cluster. `data-measuring` forces expanded layout during measure so
+ * we can compare full label widths without a collapse/expand loop.
+ */
+.button-area--compact:not([data-measuring]) .selector-button-text {
+  max-width: 0;
+  opacity: 0;
+  overflow: hidden;
+  margin: 0;
 }
 
-@media (max-width: 450px) {
-  .button-area[data-provider="claude"] .selector-button-text {
-    max-width: 0;
-    opacity: 0;
-    overflow: hidden;
-    margin: 0;
-  }
-
-  .button-area[data-provider="claude"] .selector-button {
-    gap: 2px;
-    padding: 4px 6px;
-    min-width: 28px;
-  }
-
-  .button-area[data-provider="claude"] .selector-button > .codicon-chevron-up,
-  .button-area[data-provider="claude"] .selector-button > .codicon-chevron-down {
-    display: none;
-  }
+.button-area--compact:not([data-measuring]) .selector-button {
+  gap: 2px;
+  padding: 4px 6px;
+  min-width: 28px;
 }
 
-/* Container query for Codex: hide text when narrow (< 350px) */
-@container button-area (max-width: 380px) {
-  .button-area[data-provider="codex"] .selector-button-text {
-    max-width: 0;
-    opacity: 0;
-    overflow: hidden;
-    margin: 0;
-  }
-
-  .button-area[data-provider="codex"] .selector-button {
-    gap: 2px;
-    padding: 4px 6px;
-    min-width: 28px;
-  }
-
-  .button-area[data-provider="codex"] .selector-button > .codicon-chevron-up,
-  .button-area[data-provider="codex"] .selector-button > .codicon-chevron-down {
-    display: none;
-  }
-}
-
-/* Fallback for browsers without container query support */
-@supports not (container-type: inline-size) {
-  /* Claude fallback: 550px */
-  @media (max-width: 500px) {
-    .button-area[data-provider="claude"] .selector-button-text {
-      max-width: 0;
-      opacity: 0;
-      overflow: hidden;
-      margin: 0;
-    }
-
-    .button-area[data-provider="claude"] .selector-button {
-      gap: 2px;
-      padding: 4px 6px;
-      min-width: 28px;
-    }
-
-    .button-area[data-provider="claude"] .selector-button > .codicon-chevron-up,
-    .button-area[data-provider="claude"] .selector-button > .codicon-chevron-down {
-      display: none;
-    }
-  }
-
-  /* Codex fallback: 500px */
-  @media (max-width: 550px) {
-    .button-area[data-provider="codex"] .selector-button-text {
-      max-width: 0;
-      opacity: 0;
-      overflow: hidden;
-      margin: 0;
-    }
-
-    .button-area[data-provider="codex"] .selector-button {
-      gap: 2px;
-      padding: 4px 6px;
-      min-width: 28px;
-    }
-
-    .button-area[data-provider="codex"] .selector-button > .codicon-chevron-up,
-    .button-area[data-provider="codex"] .selector-button > .codicon-chevron-down {
-      display: none;
-    }
-  }
+.button-area--compact:not([data-measuring]) .selector-button > .codicon-chevron-up,
+.button-area--compact:not([data-measuring]) .selector-button > .codicon-chevron-down {
+  display: none;
 }
 
 .selector-dropdown {

--- a/webview/src/components/ChatInputBox/types.ts
+++ b/webview/src/components/ChatInputBox/types.ts
@@ -405,17 +405,32 @@ export const CODEX_MODELS: ModelInfo[] = [
  *
  * Passing `-m grok-4.5` hits official cli-chat-proxy and ignores custom base_url/api_key.
  */
-export const GROK_DEFAULT_MODEL_ID = 'grok';
+export const GROK_DEFAULT_MODEL_ID = 'grok-4.5';
 
 /**
  * Grok CLI model picker entries.
- * id = profile name for CLI `-m`; label can show the human-facing model name.
+ * id = model ID passed via ACP session/set_model or _meta.modelId.
  */
 export const GROK_MODELS: ModelInfo[] = [
   {
     id: GROK_DEFAULT_MODEL_ID,
     label: 'Grok 4.5',
     description: 'xAI Grok 4.5',
+  },
+  {
+    id: 'grok-3',
+    label: 'Grok 3',
+    description: 'xAI Grok 3',
+  },
+  {
+    id: 'grok-2',
+    label: 'Grok 2',
+    description: 'xAI Grok 2',
+  },
+  {
+    id: 'grok-beta',
+    label: 'Grok Beta',
+    description: 'xAI Grok Beta',
   },
 ];
 
@@ -465,6 +480,100 @@ export const PI_MODELS: ModelInfo[] = [
 /**
  * Available models (backward compatibility)
  */
+/**
+ * Gemini / Antigravity CLI model families (base ids).
+ * Live catalog is loaded via `agy models` → get_gemini_models.
+ * Effort (high/medium/low/thinking) is a subordinate ReasoningSelect list;
+ * full agy slugs are composed at send time (e.g. gemini-3.5-flash-medium).
+ */
+export const DEFAULT_GEMINI_MODEL_ID = 'gemini-3.5-flash';
+
+/** Fallback when agy is offline / listModels has not returned yet. */
+export const GEMINI_MODELS: ModelInfo[] = [
+  {
+    id: 'gemini-3.6-flash',
+    label: 'Gemini 3.6 Flash',
+    description: 'Newest Flash',
+  },
+  {
+    id: 'gemini-3.5-flash',
+    label: 'Gemini 3.5 Flash',
+    description: 'Flash 3.5 · default',
+  },
+  {
+    id: 'gemini-3.1-pro',
+    label: 'Gemini 3.1 Pro',
+    description: 'Pro 3.1',
+  },
+  {
+    id: 'claude-sonnet-4-6',
+    label: 'Claude Sonnet 4.6',
+    description: 'Sonnet via Antigravity',
+  },
+  {
+    id: 'claude-opus-4-6',
+    label: 'Claude Opus 4.6',
+    description: 'Opus via Antigravity',
+  },
+  {
+    id: 'gpt-oss-120b',
+    label: 'GPT-OSS 120B',
+    description: 'Open-weight GPT via Antigravity',
+  },
+];
+
+/** Effort option under a Gemini/agy model family. */
+export interface GeminiEffortOption {
+  id: string;
+  label: string;
+  /** Full agy model slug to send as --model */
+  modelId: string;
+}
+
+/** Family row from live `agy models` grouping. */
+export interface GeminiModelFamily {
+  id: string;
+  label: string;
+  description?: string;
+  efforts: GeminiEffortOption[];
+  defaultEffort: string;
+  defaultModelId: string;
+}
+
+export type GeminiAgyEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'thinking' | '';
+
+const AGY_EFFORT_SUFFIXES = ['thinking', 'max', 'xhigh', 'medium', 'high', 'low'] as const;
+
+/** Split full agy slug into family base + effort suffix. */
+export function splitGeminiAgyModelId(modelId: string): { baseId: string; effort: string } {
+  const id = (modelId || '').trim();
+  if (!id) return { baseId: '', effort: '' };
+  for (const effort of AGY_EFFORT_SUFFIXES) {
+    const suffix = `-${effort}`;
+    if (id.endsWith(suffix) && id.length > suffix.length) {
+      return { baseId: id.slice(0, -suffix.length), effort };
+    }
+  }
+  return { baseId: id, effort: '' };
+}
+
+/** Compose full agy slug from family + effort (effort may be empty). */
+export function composeGeminiAgyModelId(baseId: string, effort: string): string {
+  const base = (baseId || '').trim();
+  if (!base) return '';
+  const { baseId: stripped } = splitGeminiAgyModelId(base);
+  const family = stripped || base;
+  const e = (effort || '').trim().toLowerCase();
+  if (!e) return family;
+  return `${family}-${e}`;
+}
+
+/** Normalize a stored/full slug or family id to the family base used in ModelSelect. */
+export function toGeminiFamilyId(modelId: string): string {
+  const { baseId } = splitGeminiAgyModelId(modelId);
+  return baseId || modelId;
+}
+
 export const AVAILABLE_MODELS = CLAUDE_MODELS;
 
 /**
@@ -485,6 +594,7 @@ export interface ProviderInfo {
 export const AVAILABLE_PROVIDERS: ProviderInfo[] = [
   { id: 'claude', label: 'Claude Code', icon: 'codicon-terminal', enabled: true },
   { id: 'codex', label: 'Codex', icon: 'codicon-terminal', enabled: true },
+  { id: 'gemini', label: 'Gemini Cli', icon: 'codicon-terminal', enabled: true, beta: true },
   { id: 'grok', label: 'Grok CLI', icon: 'codicon-terminal', enabled: true, beta: true },
   { id: 'kimi', label: 'Kimi CLI', icon: 'codicon-terminal', enabled: true, beta: true },
   { id: 'opencode', label: 'OpenCode', icon: 'codicon-terminal', enabled: true, beta: true },
@@ -761,6 +871,11 @@ export interface ChatInputBoxProps {
   longContextEnabled?: boolean;
   /** Toggle long context callback */
   onLongContextChange?: (enabled: boolean) => void;
+  /** Live Gemini/agy families for subordinate effort list. */
+  geminiFamilies?: GeminiModelFamily[];
+  /** Live Gemini family rows for ModelSelect. */
+  geminiModels?: ModelInfo[];
+
 }
 
 /**
@@ -820,6 +935,11 @@ export interface ButtonAreaProps {
   longContextEnabled?: boolean;
   /** Toggle long context callback */
   onLongContextChange?: (enabled: boolean) => void;
+  /** Live Gemini/agy model families (effort subordinates). */
+  geminiFamilies?: GeminiModelFamily[];
+  /** Live Gemini family list for ModelSelect (fallback: GEMINI_MODELS). */
+  geminiModels?: ModelInfo[];
+
 }
 
 /**

--- a/webview/src/components/MessageItem/MessageItem.tsx
+++ b/webview/src/components/MessageItem/MessageItem.tsx
@@ -45,6 +45,9 @@ export interface MessageItemProps {
 /** Map provider id to a human-readable label used in UI text. */
 function getProviderDisplayName(providerId?: string): string {
   if (providerId === 'codex') return 'Codex';
+  if (providerId === 'grok') return 'Grok';
+  if (providerId === 'gemini') return 'Gemini';
+  if (providerId) return providerId.charAt(0).toUpperCase() + providerId.slice(1);
   return 'Claude';
 }
 

--- a/webview/src/components/history/HistoryView.tsx
+++ b/webview/src/components/history/HistoryView.tsx
@@ -62,7 +62,7 @@ interface HistoryViewProps {
   historyData: HistoryData | null;
   currentProvider?: string; // Current provider (claude or codex)
   currentSessionId?: string | null; // Active session ID; its row must not offer conversion
-  onLoadSession: (sessionId: string, provider?: string) => void;
+  onLoadSession: (sessionId: string, provider?: string, model?: string, agent?: string) => void;
   onDeleteSession: (sessionId: string) => void; // Delete session callback
   onDeleteSessions: (sessionIds: string[]) => void; // Batch delete sessions callback
   onExportSession: (sessionId: string, title: string) => void; // Export session callback
@@ -105,6 +105,8 @@ const deduplicateHistorySessions = (sessions: HistorySessionSummary[]) => {
       isFavorited: preferred.isFavorited || fallback.isFavorited,
       favoritedAt: Math.max(preferred.favoritedAt || 0, fallback.favoritedAt || 0) || undefined,
       provider: preferred.provider || fallback.provider,
+      model: preferred.model || fallback.model,
+      agent: preferred.agent || fallback.agent,
       entrypoint: preferred.entrypoint || fallback.entrypoint,
     });
   }
@@ -333,7 +335,7 @@ const HistoryView = ({ historyData, currentProvider, currentSessionId, onLoadSes
       return;
     }
     if (!isEditing) {
-      onLoadSession(session.sessionId, session.provider);
+      onLoadSession(session.sessionId, session.provider, session.model, session.agent);
     }
   }, [isSelectionMode, toggleSessionSelection, onLoadSession]);
 

--- a/webview/src/components/settings/CliSection/index.test.tsx
+++ b/webview/src/components/settings/CliSection/index.test.tsx
@@ -19,6 +19,8 @@ const translations: Record<string, string> = {
   'settings.cli.copyPath': 'Copy path',
   'settings.cli.copied': 'Copied',
   'settings.cli.copyFailed': 'Copy failed',
+  'settings.cli.tools.agy.name': 'Antigravity CLI',
+  'settings.cli.tools.agy.description': 'AGY desc',
   'settings.cli.tools.grok.name': 'Grok CLI',
   'settings.cli.tools.grok.description': 'Grok desc',
   'settings.cli.tools.kimi.name': 'Kimi CLI',
@@ -127,6 +129,7 @@ describe('CliSection', () => {
 
     await act(async () => {
       window.updateCliStatus?.(JSON.stringify({
+        agy: { id: 'agy', name: 'Antigravity CLI', binaryName: 'agy', installed: false },
         grok: { id: 'grok', name: 'Grok CLI', binaryName: 'grok', installed: false },
         kimi: { id: 'kimi', name: 'Kimi CLI', binaryName: 'kimi', installed: false },
         opencode: { id: 'opencode', name: 'OpenCode', binaryName: 'opencode', installed: false },
@@ -138,7 +141,7 @@ describe('CliSection', () => {
     fireEvent.click(guideButtons[0]);
 
     expect(await screen.findByRole('dialog')).toBeTruthy();
-    expect(screen.getByText(/curl -fsSL https:\/\/x\.ai\/cli\/install\.sh \| bash/)).toBeTruthy();
+    expect(screen.getByText(/curl -fsSL https:\/\/antigravity\.google\/docs\/cli\/install \| bash/)).toBeTruthy();
     // Never triggers install via Java bridge
     const calls = (window.sendToJava as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
     expect(calls.every((c) => !c.includes('install'))).toBe(true);

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -315,6 +315,17 @@ interface Window {
   updateMcpServers?: (json: string) => void;
 
   /**
+   * Update CLI tool detection status
+   */
+  updateCliStatus?: (json: string) => void;
+
+  /**
+   * Live Gemini/agy model catalog from `agy models` (get_gemini_models).
+   * JSON: { success, models:[{id,label}], families:[...], binary?, error? }
+   */
+  updateGeminiModels?: (json: string) => void;
+
+  /**
    * Update MCP server connection status
    */
   updateMcpServerStatus?: (json: string) => void;

--- a/webview/src/hooks/providers/useCliModels.test.ts
+++ b/webview/src/hooks/providers/useCliModels.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useCliModels } from './useCliModels';
-import { CODEX_MODELS, KIMI_MODELS } from '../../components/ChatInputBox/types';
+import { __resetCliModelsCacheForTests, useCliModels } from './useCliModels';
+import { KIMI_MODELS } from '../../components/ChatInputBox/types';
 import { installRuntimeProviderDispatchers } from '../../utils/runtimeProviderCapabilities';
 
 const sendBridgeEventMock = vi.hoisted(() => vi.fn());
@@ -19,17 +19,19 @@ function emitCliModels(payload: unknown) {
 describe('useCliModels', () => {
   beforeEach(() => {
     sendBridgeEventMock.mockClear();
+    __resetCliModelsCacheForTests();
     installRuntimeProviderDispatchers();
   });
 
   afterEach(() => {
     delete window.setCliModels;
+    __resetCliModelsCacheForTests();
     vi.useRealTimers();
   });
 
-  it('fetches the codex catalog when the codex provider is active', () => {
-    renderHook(() => useCliModels('codex'));
-    expect(sendBridgeEventMock).toHaveBeenCalledWith('get_cli_models', 'codex');
+  it('fetches the kimi catalog when the kimi provider is active', () => {
+    renderHook(() => useCliModels('kimi'));
+    expect(sendBridgeEventMock).toHaveBeenCalledWith('get_cli_models', 'kimi');
   });
 
   it('fetches the grok catalog when the grok provider is active', () => {
@@ -42,108 +44,88 @@ describe('useCliModels', () => {
     expect(sendBridgeEventMock).not.toHaveBeenCalled();
   });
 
-  it('falls back to the static CODEX_MODELS list before the catalog arrives', () => {
-    const { result } = renderHook(() => useCliModels('codex'));
-    expect(result.current.cliModels).toEqual(CODEX_MODELS);
+  it('falls back to the static KIMI_MODELS list before the catalog arrives', () => {
+    const { result } = renderHook(() => useCliModels('kimi'));
+    expect(result.current.cliModels).toEqual(KIMI_MODELS);
     expect(result.current.cliModelsLoading).toBe(true);
   });
 
-  it('stores the codex catalog and defaultModel from the backend payload', () => {
-    const { result } = renderHook(() => useCliModels('codex'));
+  it('stores the kimi catalog and defaultModel from the backend payload', () => {
+    const { result } = renderHook(() => useCliModels('kimi'));
     emitCliModels({
       success: true,
-      provider: 'codex',
+      provider: 'kimi',
       defaultModel: 'kimi-k3',
       models: [{ id: 'kimi-k3', label: 'kimi-k3', description: 'kimi-k3' }],
     });
     expect(result.current.cliModels).toEqual([
       { id: 'kimi-k3', label: 'kimi-k3', description: 'kimi-k3' },
     ]);
-    expect(result.current.cliDefaultModel).toBe('kimi-k3');
     expect(result.current.cliModelsLoading).toBe(false);
     expect(result.current.cliModelsError).toBeNull();
   });
 
-  it('falls back to CODEX_MODELS when the codex payload has no models (official provider)', () => {
-    const { result } = renderHook(() => useCliModels('codex'));
+  it('falls back to KIMI_MODELS when the kimi payload has no models', () => {
+    const { result } = renderHook(() => useCliModels('kimi'));
     emitCliModels({
       success: true,
-      provider: 'codex',
-      defaultModel: 'gpt-5.6-sol',
+      provider: 'kimi',
       models: [],
     });
-    expect(result.current.cliModels).toEqual(CODEX_MODELS);
-    expect(result.current.cliDefaultModel).toBe('gpt-5.6-sol');
-  });
-
-  it('keeps kimi fallback behavior intact', () => {
-    const { result } = renderHook(() => useCliModels('kimi'));
-    expect(sendBridgeEventMock).toHaveBeenCalledWith('get_cli_models', 'kimi');
     expect(result.current.cliModels).toEqual(KIMI_MODELS);
   });
 
-  it('records backend errors and supports manual retry for codex', () => {
-    const { result } = renderHook(() => useCliModels('codex'));
-    emitCliModels({ success: false, provider: 'codex', error: 'node missing', models: [] });
+  it('records backend errors and supports manual retry for kimi', () => {
+    const { result } = renderHook(() => useCliModels('kimi'));
+    emitCliModels({ success: false, provider: 'kimi', error: 'node missing', models: [] });
     expect(result.current.cliModelsError).toBe('node missing');
-    expect(result.current.cliModels).toEqual(CODEX_MODELS);
+    expect(result.current.cliModels).toEqual(KIMI_MODELS);
 
     sendBridgeEventMock.mockClear();
     act(() => {
-      result.current.refreshCliModels('codex');
+      result.current.refreshCliModels('kimi');
     });
-    expect(sendBridgeEventMock).toHaveBeenCalledWith('get_cli_models', 'codex');
-  });
-
-  it('refetches the codex catalog when the active codex provider changes', () => {
-    const { result, rerender } = renderHook(
-      ({ provider }) => useCliModels(provider),
-      { initialProps: { provider: 'codex' } },
-    );
-    emitCliModels({
-      success: true,
-      provider: 'codex',
-      defaultModel: 'kimi-k3',
-      models: [{ id: 'kimi-k3', label: 'kimi-k3' }],
-    });
-    expect(result.current.modelsByProvider.codex?.length).toBe(1);
-
-    sendBridgeEventMock.mockClear();
-    act(() => {
-      window.updateActiveCodexProvider?.(JSON.stringify({ id: 'other-provider' }));
-    });
-    // Cache cleared; effect refetches because the current provider is codex.
-    expect(sendBridgeEventMock).toHaveBeenCalledWith('get_cli_models', 'codex');
-    rerender({ provider: 'codex' });
-    expect(result.current.modelsByProvider.codex).toBeUndefined();
-  });
-
-  it('clears the codex cache without refetching when another provider is active', () => {
-    const { result } = renderHook(() => useCliModels('claude'));
-    emitCliModels({
-      success: true,
-      provider: 'codex',
-      defaultModel: 'kimi-k3',
-      models: [{ id: 'kimi-k3', label: 'kimi-k3' }],
-    });
-    expect(result.current.modelsByProvider.codex?.length).toBe(1);
-
-    sendBridgeEventMock.mockClear();
-    act(() => {
-      window.updateActiveCodexProvider?.(JSON.stringify({ id: 'other-provider' }));
-    });
-    expect(sendBridgeEventMock).not.toHaveBeenCalled();
-    expect(result.current.modelsByProvider.codex).toBeUndefined();
+    expect(sendBridgeEventMock).toHaveBeenCalledWith('get_cli_models', 'kimi');
   });
 
   it('times out into an error state and falls back to static models', () => {
     vi.useFakeTimers();
-    const { result } = renderHook(() => useCliModels('codex'));
+    const { result } = renderHook(() => useCliModels('kimi'));
     act(() => {
       vi.advanceTimersByTime(16_000);
     });
     expect(result.current.cliModelsLoading).toBe(false);
     expect(result.current.cliModelsError).toBe('timeout');
-    expect(result.current.cliModels).toEqual(CODEX_MODELS);
+    expect(result.current.cliModels).toEqual(KIMI_MODELS);
+  });
+
+  it('reuses the module cache on remount so history→chat does not re-fetch', () => {
+    const first = renderHook(() => useCliModels('opencode'));
+    emitCliModels({
+      success: true,
+      provider: 'opencode',
+      defaultModel: 'openai/gpt-5',
+      models: [
+        { id: 'opencode-default', label: 'OpenCode Default' },
+        { id: 'openai/gpt-5', label: 'gpt-5' },
+      ],
+    });
+    expect(first.result.current.cliModels.map((m) => m.id)).toEqual([
+      'opencode-default',
+      'openai/gpt-5',
+    ]);
+    first.unmount();
+
+    sendBridgeEventMock.mockClear();
+    const second = renderHook(() => useCliModels('opencode'));
+    // Cache already has entries — no bridge round-trip on remount.
+    expect(sendBridgeEventMock).not.toHaveBeenCalled();
+    expect(second.result.current.cliModels.map((m) => m.id)).toEqual([
+      'opencode-default',
+      'openai/gpt-5',
+    ]);
+    expect(second.result.current.cliCatalogHasEntries).toBe(true);
+    expect(second.result.current.cliDefaultModel).toBe('openai/gpt-5');
+    expect(second.result.current.cliModelsLoading).toBe(false);
   });
 });

--- a/webview/src/hooks/providers/useCliModels.ts
+++ b/webview/src/hooks/providers/useCliModels.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { sendBridgeEvent } from '../../utils/bridge';
 import type { ModelInfo } from '../../components/ChatInputBox/types';
-import { CODEX_MODELS, GROK_MODELS, KIMI_MODELS, OPENCODE_MODELS, PI_MODELS } from '../../components/ChatInputBox/types';
+import { GROK_MODELS, KIMI_MODELS, OPENCODE_MODELS, PI_MODELS } from '../../components/ChatInputBox/types';
 import { isCliOnlyProvider } from './cliProviders';
 import { subscribeActiveCodexProvider } from '../../utils/runtimeProviderCapabilities';
 
@@ -10,25 +10,38 @@ type CliModelsByProvider = Record<string, ModelInfo[]>;
 /** Java may never answer get_cli_models — don't leave the spinner on forever. */
 const CLI_MODELS_TIMEOUT_MS = 15_000;
 
+/**
+ * Module-level caches so switching away from chat (history/settings) and back
+ * does not drop the catalog and re-trigger a spinner + auto-select reset.
+ * ChatScreen unmounts on view change; these survive that remount.
+ */
+const modelsCache: CliModelsByProvider = {};
+const defaultModelCache: Record<string, string> = {};
+const catalogHasEntriesCache: Record<string, boolean> = {};
+
+/** Test-only: clear module caches between cases. */
+export function __resetCliModelsCacheForTests() {
+  for (const key of Object.keys(modelsCache)) delete modelsCache[key];
+  for (const key of Object.keys(defaultModelCache)) delete defaultModelCache[key];
+  for (const key of Object.keys(catalogHasEntriesCache)) delete catalogHasEntriesCache[key];
+}
+
 function fallbackModels(providerId: string): ModelInfo[] {
   if (providerId === 'grok') return GROK_MODELS;
   if (providerId === 'kimi') return KIMI_MODELS;
   if (providerId === 'opencode') return OPENCODE_MODELS;
   if (providerId === 'pi') return PI_MODELS;
-  if (providerId === 'codex') return CODEX_MODELS;
   return [];
 }
 
 /**
  * Providers whose model list is discovered dynamically via `get_cli_models`.
- * Codex is included even though it is not a CLI-only provider: its list comes
- * from ~/.codex/config.toml + model_catalog_json, same as the codex CLI picker.
+ * Codex and Gemini are included: their list comes dynamically from CLI/config.
  */
 function supportsDynamicModels(providerId: string): boolean {
-  if (providerId === 'codex') return true;
+  if (providerId === 'codex' || providerId === 'gemini') return true;
   return isCliOnlyProvider(providerId);
 }
-
 function normalizeModels(raw: unknown): ModelInfo[] {
   if (!Array.isArray(raw)) return [];
   const out: ModelInfo[] = [];
@@ -49,14 +62,19 @@ function normalizeModels(raw: unknown): ModelInfo[] {
 }
 
 /**
- * Loads model catalogs for headless CLI providers (Kimi / OpenCode) and Codex
- * via channel-manager `listModels`. Falls back to static defaults until loaded.
+ * Loads model catalogs for headless CLI providers (Kimi / OpenCode) via
+ * channel-manager `listModels`. Falls back to static defaults until loaded.
  */
 export function useCliModels(currentProvider: string) {
-  const [modelsByProvider, setModelsByProvider] = useState<CliModelsByProvider>({});
-  const [defaultModelByProvider, setDefaultModelByProvider] = useState<Record<string, string>>({});
+  // Seed from module cache so history→chat remounts keep the last catalog.
+  const [modelsByProvider, setModelsByProvider] = useState<CliModelsByProvider>(() => ({ ...modelsCache }));
+  const [defaultModelByProvider, setDefaultModelByProvider] = useState<Record<string, string>>(
+    () => ({ ...defaultModelCache }),
+  );
   /** Whether the last payload for a provider carried real catalog entries (vs empty → fallback). */
-  const [catalogHasEntriesByProvider, setCatalogHasEntriesByProvider] = useState<Record<string, boolean>>({});
+  const [catalogHasEntriesByProvider, setCatalogHasEntriesByProvider] = useState<Record<string, boolean>>(
+    () => ({ ...catalogHasEntriesCache }),
+  );
   const [loadingProvider, setLoadingProvider] = useState<string | null>(null);
   const [errorByProvider, setErrorByProvider] = useState<Record<string, string>>({});
   const pendingLoadRef = useRef<{ provider: string; timer: ReturnType<typeof setTimeout> } | null>(null);
@@ -91,8 +109,8 @@ export function useCliModels(currentProvider: string) {
   }, [clearPendingLoad]);
 
   useEffect(() => {
-    const handler = (dataOrStr: string | { provider?: string; models?: unknown; success?: boolean; error?: string; defaultModel?: unknown }) => {
-      let payload: { provider?: string; models?: unknown; success?: boolean; error?: string; defaultModel?: unknown } | null = null;
+    const handler = (dataOrStr: string | { provider?: string; models?: unknown; success?: boolean; error?: string }) => {
+      let payload: { provider?: string; models?: unknown; success?: boolean; error?: string; defaultModel?: string } | null = null;
       if (typeof dataOrStr === 'string') {
         try {
           payload = JSON.parse(dataOrStr);
@@ -105,14 +123,22 @@ export function useCliModels(currentProvider: string) {
       if (!payload?.provider) return;
       const provider = payload.provider;
       const models = normalizeModels(payload.models);
+      const resolvedModels = models.length > 0 ? models : fallbackModels(provider);
+      modelsCache[provider] = resolvedModels;
+      catalogHasEntriesCache[provider] = models.length > 0;
       setModelsByProvider((prev) => ({
         ...prev,
-        [provider]: models.length > 0 ? models : fallbackModels(provider),
+        [provider]: resolvedModels,
       }));
       setCatalogHasEntriesByProvider((prev) => ({ ...prev, [provider]: models.length > 0 }));
       const defaultModel = typeof payload.defaultModel === 'string' && payload.defaultModel.trim()
         ? payload.defaultModel.trim()
         : null;
+      if (defaultModel) {
+        defaultModelCache[provider] = defaultModel;
+      } else {
+        delete defaultModelCache[provider];
+      }
       setDefaultModelByProvider((prev) => {
         const next = { ...prev };
         if (defaultModel) {
@@ -164,6 +190,9 @@ export function useCliModels(currentProvider: string) {
   // and refetch when the chat is currently on codex.
   useEffect(() => {
     return subscribeActiveCodexProvider(() => {
+      delete modelsCache.codex;
+      delete defaultModelCache.codex;
+      delete catalogHasEntriesCache.codex;
       setModelsByProvider((prev) => {
         if (!('codex' in prev)) return prev;
         const next = { ...prev };
@@ -187,7 +216,6 @@ export function useCliModels(currentProvider: string) {
       }
     });
   }, [currentProvider, beginLoad]);
-
   const refreshCliModels = useCallback((providerId: string) => {
     if (!supportsDynamicModels(providerId)) return;
     beginLoad(providerId);
@@ -201,10 +229,10 @@ export function useCliModels(currentProvider: string) {
     cliModels,
     cliModelsLoading: loadingProvider === currentProvider,
     cliModelsError: errorByProvider[currentProvider] ?? null,
-    cliDefaultModel: defaultModelByProvider[currentProvider] ?? null,
-    cliCatalogHasEntries: catalogHasEntriesByProvider[currentProvider] ?? false,
     refreshCliModels,
     modelsByProvider,
+    cliDefaultModel: defaultModelByProvider[currentProvider] ?? null,
+    cliCatalogHasEntries: catalogHasEntriesByProvider[currentProvider] ?? false,
   };
 }
 

--- a/webview/src/hooks/providers/useGeminiProvider.ts
+++ b/webview/src/hooks/providers/useGeminiProvider.ts
@@ -1,0 +1,290 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  DEFAULT_GEMINI_MODEL_ID,
+  GEMINI_MODELS,
+  composeGeminiAgyModelId,
+  splitGeminiAgyModelId,
+  toGeminiFamilyId,
+  type GeminiEffortOption,
+  type GeminiModelFamily,
+  type ModelInfo,
+  type PermissionMode,
+  type ReasoningEffort,
+} from '../../components/ChatInputBox/types';
+import { sendBridgeEvent } from '../../utils/bridge';
+
+const AGY_EFFORT_ORDER = ['low', 'medium', 'high', 'xhigh', 'thinking', ''] as const;
+
+function effortLabel(effort: string): string {
+  const e = (effort || '').toLowerCase();
+  if (e === 'low') return 'Low';
+  if (e === 'medium') return 'Medium';
+  if (e === 'high') return 'High';
+  if (e === 'xhigh') return 'XHigh';
+  if (e === 'thinking') return 'Thinking';
+  if (!e) return 'Default';
+  return e.charAt(0).toUpperCase() + e.slice(1);
+}
+
+function stripParenEffort(label: string): string {
+  return (label || '')
+    .replace(/\s*\((?:Very\s+)?(?:High|Medium|Low|XHigh|Max|Thinking)\)\s*$/i, '')
+    .trim() || label;
+}
+
+/** Humanize a bare slug for display when agy only printed the id. */
+function humanizeFamilyLabel(baseId: string, rawLabel: string): string {
+  const stripped = stripParenEffort(rawLabel);
+  // If label is just the full slug / base id, prettify
+  if (!stripped || stripped === baseId || stripped.startsWith(baseId + '-')) {
+    return baseId
+      .split('-')
+      .map((p) => {
+        if (/^\d+(\.\d+)*$/.test(p)) return p;
+        if (p.toLowerCase() === 'gpt') return 'GPT';
+        if (p.toLowerCase() === 'oss') return 'OSS';
+        return p.charAt(0).toUpperCase() + p.slice(1);
+      })
+      .join(' ');
+  }
+  return stripped;
+}
+
+function normalizeFlatEntries(
+  models: unknown,
+): Array<{ id: string; label: string }> {
+  if (!Array.isArray(models)) return [];
+  const out: Array<{ id: string; label: string }> = [];
+  for (const m of models) {
+    if (typeof m === 'string' && m.trim()) {
+      out.push({ id: m.trim(), label: m.trim() });
+      continue;
+    }
+    if (m && typeof m === 'object' && typeof (m as { id?: string }).id === 'string') {
+      const id = (m as { id: string }).id.trim();
+      if (!id) continue;
+      const label = String((m as { label?: string }).label || id).trim() || id;
+      out.push({ id, label });
+    }
+  }
+  return out;
+}
+
+/** Group flat agy catalog into UI families (client-side fallback). */
+export function groupGeminiFamiliesFromFlat(
+  entries: Array<{ id: string; label: string }>,
+): GeminiModelFamily[] {
+  const families = new Map<string, {
+    id: string;
+    label: string;
+    efforts: GeminiEffortOption[];
+    order: number;
+  }>();
+  let order = 0;
+
+  for (const entry of entries) {
+    if (!entry?.id) continue;
+    const { baseId, effort } = splitGeminiAgyModelId(entry.id);
+    const familyId = baseId || entry.id;
+    let fam = families.get(familyId);
+    if (!fam) {
+      fam = {
+        id: familyId,
+        label: humanizeFamilyLabel(familyId, entry.label),
+        efforts: [],
+        order: order++,
+      };
+      families.set(familyId, fam);
+    } else {
+      const candidate = humanizeFamilyLabel(familyId, entry.label);
+      // Prefer human labels over slug-looking ones
+      if (candidate && !candidate.includes('-') && fam.label.includes('-')) {
+        fam.label = candidate;
+      }
+    }
+
+    if (effort) {
+      if (!fam.efforts.some((e) => e.id === effort)) {
+        fam.efforts.push({ id: effort, label: effortLabel(effort), modelId: entry.id });
+      }
+    } else if (!fam.efforts.some((e) => e.modelId === entry.id)) {
+      fam.efforts.push({ id: '', label: 'Default', modelId: entry.id });
+    }
+  }
+
+  const rank = (id: string) => {
+    const i = (AGY_EFFORT_ORDER as readonly string[]).indexOf(id);
+    return i >= 0 ? i : 50;
+  };
+
+  return [...families.values()]
+    .sort((a, b) => a.order - b.order)
+    .map((fam) => {
+      const efforts = [...fam.efforts].sort((a, b) => rank(a.id) - rank(b.id));
+      const defaultEffort =
+        efforts.find((e) => e.id === 'medium')?.id
+        ?? efforts.find((e) => e.id === 'high')?.id
+        ?? efforts.find((e) => e.id === 'thinking')?.id
+        ?? efforts[0]?.id
+        ?? '';
+      const defaultModelId =
+        efforts.find((e) => e.id === defaultEffort)?.modelId
+        ?? efforts[0]?.modelId
+        ?? fam.id;
+      return {
+        id: fam.id,
+        label: fam.label,
+        description: efforts.filter((e) => e.id).length > 1
+          ? `${efforts.filter((e) => e.id).length} effort levels`
+          : (efforts[0]?.label || ''),
+        efforts,
+        defaultEffort,
+        defaultModelId,
+      };
+    });
+}
+
+/**
+ * Gemini / Antigravity CLI selectable state + live model catalog from `agy models`.
+ */
+export function useGeminiProvider() {
+  const [selectedGeminiModel, setSelectedGeminiModel] = useState(DEFAULT_GEMINI_MODEL_ID);
+  const [geminiPermissionMode, setGeminiPermissionMode] = useState<PermissionMode>('default');
+  const [geminiFamilies, setGeminiFamilies] = useState<GeminiModelFamily[]>([]);
+  const [geminiModels, setGeminiModels] = useState<ModelInfo[]>(GEMINI_MODELS);
+  const [geminiCatalogLoaded, setGeminiCatalogLoaded] = useState(false);
+
+  const applyGeminiCatalog = useCallback((payload: {
+    success?: boolean;
+    families?: GeminiModelFamily[];
+    models?: unknown;
+  }) => {
+    if (!payload || payload.success === false) {
+      return;
+    }
+
+    let families = Array.isArray(payload.families) ? payload.families.filter(Boolean) : [];
+    // Prefer server families only if they have real effort nesting; else rebuild.
+    const familiesLookUsable = families.length > 0 && families.some(
+      (f) => Array.isArray(f.efforts) && f.efforts.length > 0 && f.id && f.label,
+    );
+
+    if (!familiesLookUsable) {
+      const flat = normalizeFlatEntries(payload.models);
+      if (flat.length > 0) {
+        families = groupGeminiFamiliesFromFlat(flat);
+      }
+    }
+
+    // Normalize server families: ensure labels are human when missing/slug-like
+    if (familiesLookUsable) {
+      families = families.map((f) => ({
+        ...f,
+        label: humanizeFamilyLabel(f.id, f.label || f.id),
+        efforts: Array.isArray(f.efforts) ? f.efforts : [],
+        defaultEffort: f.defaultEffort ?? '',
+        defaultModelId: f.defaultModelId || f.id,
+      }));
+    }
+
+    if (families.length === 0) {
+      return;
+    }
+
+    setGeminiFamilies(families);
+    setGeminiModels(
+      families.map((f) => ({
+        id: f.id,
+        label: f.label,
+        description: f.description || '',
+      })),
+    );
+    setGeminiCatalogLoaded(true);
+
+    // Keep selection on a known family; migrate full slugs -> family id.
+    // Never silently jump to catalog[0] when prev is a valid family we just lost
+    // only due to transient empty payload (already guarded above).
+    setSelectedGeminiModel((prev) => {
+      const familyId = toGeminiFamilyId(prev) || prev;
+      if (families.some((f) => f.id === familyId)) {
+        return familyId;
+      }
+      if (families.some((f) => f.id === prev)) {
+        return prev;
+      }
+      const preferred =
+        families.find((f) => f.id === DEFAULT_GEMINI_MODEL_ID)
+        || families[0];
+      return preferred?.id || prev;
+    });
+  }, []);
+
+  const fetchGeminiModels = useCallback(() => {
+    sendBridgeEvent('get_gemini_models', '');
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const prev = window.updateGeminiModels;
+    window.updateGeminiModels = (json: string) => {
+      try {
+        const payload = typeof json === 'string' ? JSON.parse(json) : json;
+        applyGeminiCatalog(payload || {});
+      } catch (e) {
+        console.warn('[useGeminiProvider] Failed to parse gemini models', e);
+      }
+      // Do not chain prev no-op placeholders that clear state.
+    };
+    return () => {
+      // Restore previous handler if it was a real one; keep our handler if prev was placeholder.
+      if (typeof prev === 'function' && prev !== window.updateGeminiModels) {
+        window.updateGeminiModels = prev;
+      }
+    };
+  }, [applyGeminiCatalog]);
+
+  const resolveGeminiAgyModelId = useCallback(
+    (familyId: string, effort: string): string => {
+      const fam = geminiFamilies.find((f) => f.id === familyId);
+      if (fam) {
+        const match = fam.efforts.find((e) => e.id === (effort || ''))
+          || fam.efforts.find((e) => e.id === fam.defaultEffort)
+          || fam.efforts[0];
+        if (match?.modelId) return match.modelId;
+        return fam.defaultModelId || composeGeminiAgyModelId(familyId, effort);
+      }
+      return composeGeminiAgyModelId(familyId, effort);
+    },
+    [geminiFamilies],
+  );
+
+  const resolveDefaultEffortForFamily = useCallback(
+    (familyId: string): ReasoningEffort => {
+      const fam = geminiFamilies.find((f) => f.id === familyId);
+      if (fam?.defaultEffort) {
+        return fam.defaultEffort as ReasoningEffort;
+      }
+      // Bare single-slug families (e.g. claude-sonnet-4-6) have empty effort
+      const only = fam?.efforts?.length === 1 ? fam.efforts[0].id : '';
+      if (only) return only as ReasoningEffort;
+      return 'medium';
+    },
+    [geminiFamilies],
+  );
+
+  return {
+    selectedGeminiModel,
+    setSelectedGeminiModel,
+    geminiPermissionMode,
+    setGeminiPermissionMode,
+    geminiFamilies,
+    geminiModels,
+    geminiCatalogLoaded,
+    fetchGeminiModels,
+    resolveGeminiAgyModelId,
+    resolveDefaultEffortForFamily,
+    applyGeminiCatalog,
+  };
+}
+
+export type UseGeminiProviderReturn = ReturnType<typeof useGeminiProvider>;

--- a/webview/src/hooks/providers/useModelStatePersistence.test.ts
+++ b/webview/src/hooks/providers/useModelStatePersistence.test.ts
@@ -15,8 +15,10 @@ function makeOptions(overrides: Partial<UseModelStatePersistenceOptions> = {}): 
     setCurrentProvider: vi.fn(),
     setSelectedClaudeModel: vi.fn(),
     setSelectedCodexModel: vi.fn(),
+    setSelectedGeminiModel: vi.fn(),
     setClaudePermissionMode: vi.fn(),
     setCodexPermissionMode: vi.fn(),
+    setGeminiPermissionMode: vi.fn(),
     setSelectedGrokModel: vi.fn(),
     setSelectedKimiModel: vi.fn(),
     setSelectedOpenCodeModel: vi.fn(),
@@ -32,9 +34,11 @@ function makeOptions(overrides: Partial<UseModelStatePersistenceOptions> = {}): 
     currentProvider: 'claude',
     selectedClaudeModel: 'claude-sonnet-4-5',
     selectedCodexModel: 'gpt-5-codex',
+    selectedGeminiModel: 'gemini-3.5-flash',
     claudePermissionMode: 'default' as PermissionMode,
     codexPermissionMode: 'default' as PermissionMode,
-    selectedGrokModel: 'grok',
+    geminiPermissionMode: 'default' as PermissionMode,
+    selectedGrokModel: 'grok-4.5',
     selectedKimiModel: 'auto',
     selectedOpenCodeModel: 'opencode-default',
     selectedPiModel: 'auto',
@@ -287,14 +291,14 @@ describe('useModelStatePersistence — CLI provider persistence', () => {
   it('honors a backend-supplied CLI provider via __INITIAL_TAB_PROVIDER__', () => {
     const setCurrentProvider = vi.fn();
     (window as unknown as { __INITIAL_TAB_PROVIDER__?: unknown }).__INITIAL_TAB_PROVIDER__ = 'grok';
-    (window as unknown as { __INITIAL_TAB_MODEL__?: unknown }).__INITIAL_TAB_MODEL__ = 'grok';
+    (window as unknown as { __INITIAL_TAB_MODEL__?: unknown }).__INITIAL_TAB_MODEL__ = 'grok-4.5';
 
     renderHook(() => useModelStatePersistence(makeOptions({ setCurrentProvider })));
     vi.advanceTimersByTime(200);
 
     expect(setCurrentProvider).toHaveBeenCalledWith('grok');
     expect(bridgeEventsFor('set_provider')).toEqual([['set_provider', 'grok']]);
-    expect(bridgeEventsFor('set_model')).toEqual([['set_model', 'grok']]);
+    expect(bridgeEventsFor('set_model')).toEqual([['set_model', 'grok-4.5']]);
   });
 
   it('persists CLI model and permission selections in the snapshot', () => {
@@ -308,71 +312,5 @@ describe('useModelStatePersistence — CLI provider persistence', () => {
     expect(saved.provider).toBe('opencode');
     expect(saved.openCodeModel).toBe('openai/gpt-5');
     expect(saved.openCodePermissionMode).toBe('acceptEdits');
-  });
-});
-
-describe('useModelStatePersistence — codex dynamic catalog models', () => {
-  beforeEach(() => {
-    localStorage.clear();
-    sendBridgeEventMock.mockClear();
-    (window as unknown as { sendToJava?: unknown }).sendToJava = () => {};
-    window.__CCGUI_PAGE_CONTEXT_READY__ = true;
-    window.__CCGUI_PAGE_LOAD_KIND__ = 'initial_load';
-    window.__CCGUI_RECOVERY_RELOAD__ = false;
-    vi.useFakeTimers();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-    delete (window as unknown as { sendToJava?: unknown }).sendToJava;
-    delete window.__CCGUI_PAGE_CONTEXT_READY__;
-    delete window.__CCGUI_PAGE_LOAD_KIND__;
-    delete window.__CCGUI_RECOVERY_RELOAD__;
-    delete window.__CCGUI_RECOVERY_STATE_APPLIED__;
-    delete (window as unknown as { __INITIAL_TAB_PROVIDER__?: unknown }).__INITIAL_TAB_PROVIDER__;
-    delete (window as unknown as { __INITIAL_TAB_MODEL__?: unknown }).__INITIAL_TAB_MODEL__;
-  });
-
-  it('restores a saved codex model that only exists in the dynamic catalog', () => {
-    // The codex model list is dynamic (config.toml `model` + model_catalog_json),
-    // so a catalog-only id like kimi-k3 must survive restart instead of being
-    // reset to CODEX_MODELS[0] before the catalog fetch lands.
-    const setSelectedCodexModel = vi.fn();
-    localStorage.setItem('model-selection-state', JSON.stringify({
-      provider: 'codex',
-      codexModel: 'kimi-k3',
-    }));
-
-    renderHook(() => useModelStatePersistence(makeOptions({ setSelectedCodexModel })));
-    vi.advanceTimersByTime(200);
-
-    expect(setSelectedCodexModel).toHaveBeenCalledWith('kimi-k3');
-    expect(bridgeEventsFor('set_model')).toEqual([['set_model', 'kimi-k3']]);
-  });
-
-  it('honors a backend-supplied dynamic codex model via __INITIAL_TAB_MODEL__', () => {
-    const setSelectedCodexModel = vi.fn();
-    (window as unknown as { __INITIAL_TAB_PROVIDER__?: unknown }).__INITIAL_TAB_PROVIDER__ = 'codex';
-    (window as unknown as { __INITIAL_TAB_MODEL__?: unknown }).__INITIAL_TAB_MODEL__ = 'kimi-k3';
-
-    renderHook(() => useModelStatePersistence(makeOptions({ setSelectedCodexModel })));
-    vi.advanceTimersByTime(200);
-
-    expect(setSelectedCodexModel).toHaveBeenCalledWith('kimi-k3');
-    expect(bridgeEventsFor('set_model')).toEqual([['set_model', 'kimi-k3']]);
-  });
-
-  it('ignores an empty saved codex model and keeps the default', () => {
-    const setSelectedCodexModel = vi.fn();
-    localStorage.setItem('model-selection-state', JSON.stringify({
-      provider: 'codex',
-      codexModel: '   ',
-    }));
-
-    renderHook(() => useModelStatePersistence(makeOptions({ setSelectedCodexModel })));
-    vi.advanceTimersByTime(200);
-
-    expect(setSelectedCodexModel).not.toHaveBeenCalled();
-    expect(bridgeEventsFor('set_model')).toHaveLength(1);
   });
 });

--- a/webview/src/hooks/providers/useModelStatePersistence.ts
+++ b/webview/src/hooks/providers/useModelStatePersistence.ts
@@ -4,6 +4,7 @@ import {
   CLAUDE_MODELS,
   CODEX_MODELS,
   DEFAULT_CLAUDE_MODEL_ID,
+  DEFAULT_GEMINI_MODEL_ID,
   GROK_DEFAULT_MODEL_ID,
   KIMI_DEFAULT_MODEL_ID,
   OPENCODE_DEFAULT_MODEL_ID,
@@ -12,12 +13,14 @@ import {
   normalizeClaudeModelId,
   apply1MContextSuffix,
   strip1MContextSuffix,
+  splitGeminiAgyModelId,
+  toGeminiFamilyId,
 } from '../../components/ChatInputBox/types';
 import type { CodexFastMode, PermissionMode, ReasoningEffort } from '../../components/ChatInputBox/types';
 import { isCliOnlyProvider, normalizeCliPermissionMode } from './cliProviders';
 
 const STORAGE_KEY = 'model-selection-state';
-const REASONING_VALUES = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+const REASONING_VALUES = ['low', 'medium', 'high', 'xhigh', 'max', 'thinking'] as const;
 const CODEX_FAST_MODE_VALUES = ['normal', 'fast'] as const;
 
 const getCustomModels = (key: string): { id: string }[] => {
@@ -40,8 +43,10 @@ export interface UseModelStatePersistenceOptions {
   setCurrentProvider: (value: string) => void;
   setSelectedClaudeModel: (value: string) => void;
   setSelectedCodexModel: (value: string) => void;
+  setSelectedGeminiModel: (value: string) => void;
   setClaudePermissionMode: (value: PermissionMode) => void;
   setCodexPermissionMode: (value: PermissionMode) => void;
+  setGeminiPermissionMode: (value: PermissionMode) => void;
   setSelectedGrokModel: (value: string) => void;
   setSelectedKimiModel: (value: string) => void;
   setSelectedOpenCodeModel: (value: string) => void;
@@ -58,8 +63,10 @@ export interface UseModelStatePersistenceOptions {
   currentProvider: string;
   selectedClaudeModel: string;
   selectedCodexModel: string;
+  selectedGeminiModel: string;
   claudePermissionMode: PermissionMode;
   codexPermissionMode: PermissionMode;
+  geminiPermissionMode: PermissionMode;
   selectedGrokModel: string;
   selectedKimiModel: string;
   selectedOpenCodeModel: string;
@@ -88,8 +95,10 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
     setCurrentProvider,
     setSelectedClaudeModel,
     setSelectedCodexModel,
+    setSelectedGeminiModel,
     setClaudePermissionMode,
     setCodexPermissionMode,
+    setGeminiPermissionMode,
     setSelectedGrokModel,
     setSelectedKimiModel,
     setSelectedOpenCodeModel,
@@ -105,8 +114,10 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
     currentProvider,
     selectedClaudeModel,
     selectedCodexModel,
+    selectedGeminiModel,
     claudePermissionMode,
     codexPermissionMode,
+    geminiPermissionMode,
     selectedGrokModel,
     selectedKimiModel,
     selectedOpenCodeModel,
@@ -140,14 +151,17 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
         : '';
       const hasBackendProvider = initialTabProvider === 'claude'
         || initialTabProvider === 'codex'
+        || initialTabProvider === 'gemini'
         || isCliOnlyProvider(initialTabProvider);
       const hasBackendModel = initialTabModel.length > 0;
 
       let restoredProvider = 'claude';
       let restoredClaudeModel = DEFAULT_CLAUDE_MODEL_ID;
       let restoredCodexModel = CODEX_MODELS[0].id;
+      let restoredGeminiModel = DEFAULT_GEMINI_MODEL_ID;
       let restoredClaudePermissionMode: PermissionMode = 'default';
       let restoredCodexPermissionMode: PermissionMode = 'default';
+      let restoredGeminiPermissionMode: PermissionMode = 'default';
       let restoredGrokModel = GROK_DEFAULT_MODEL_ID;
       let restoredKimiModel = KIMI_DEFAULT_MODEL_ID;
       let restoredOpenCodeModel = OPENCODE_DEFAULT_MODEL_ID;
@@ -171,12 +185,23 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
         }
       };
       const applyCodexModel = (modelId: string) => {
-        // Codex catalogs are dynamic (config.toml `model` + model_catalog_json),
-        // so any non-empty saved id is accepted — same policy as CLI providers.
-        // A stale id is corrected by the catalog auto-select once the fetch lands.
-        if (typeof modelId === 'string' && modelId.trim().length > 0) {
+        const customs = getCustomModels('codex-custom-models');
+        if (CODEX_MODELS.find(m => m.id === modelId) || customs.find(m => m.id === modelId)) {
           restoredCodexModel = modelId;
           setSelectedCodexModel(modelId);
+        }
+      };
+      const applyGeminiModel = (modelId: string) => {
+        if (typeof modelId !== 'string' || !modelId.trim()) return;
+        const split = splitGeminiAgyModelId(modelId);
+        const baseId = toGeminiFamilyId(modelId) || split.baseId || modelId;
+        const effort = split.effort;
+        if (baseId) {
+          restoredGeminiModel = baseId;
+          setSelectedGeminiModel(baseId);
+          if (effort && isReasoningEffort(effort)) {
+            setReasoningEffort(effort);
+          }
         }
       };
       // CLI catalogs are dynamic (user-defined Grok profiles, backend-reported
@@ -187,8 +212,9 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
         }
       };
       const applyGrokModel = makeCliModelApplier((id) => {
-        restoredGrokModel = id;
-        setSelectedGrokModel(id);
+        const normalized = id === 'grok' ? GROK_DEFAULT_MODEL_ID : id;
+        restoredGrokModel = normalized;
+        setSelectedGrokModel(normalized);
       });
       const applyKimiModel = makeCliModelApplier((id) => {
         restoredKimiModel = id;
@@ -210,7 +236,7 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
         // hydration so non-provider preferences (permission mode, reasoning
         // effort, codex fast mode, …) are restored from localStorage.
         const providerCandidate = hasBackendProvider ? initialTabProvider : state.provider;
-        if (['claude', 'codex'].includes(providerCandidate) || isCliOnlyProvider(providerCandidate)) {
+        if (['claude', 'codex', 'gemini'].includes(providerCandidate) || isCliOnlyProvider(providerCandidate)) {
           restoredProvider = providerCandidate;
           setCurrentProvider(providerCandidate);
         }
@@ -222,6 +248,9 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
           restoredCodexPermissionMode = state.codexPermissionMode === 'plan'
             ? 'default'
             : state.codexPermissionMode;
+        }
+        if (isValidPermissionMode(state.geminiPermissionMode)) {
+          restoredGeminiPermissionMode = state.geminiPermissionMode;
         }
         if (isValidPermissionMode(state.grokPermissionMode)) {
           restoredGrokPermissionMode = normalizeCliPermissionMode(state.grokPermissionMode);
@@ -259,6 +288,11 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
           : state.codexModel;
         applyCodexModel(codexModelCandidate);
 
+        const geminiModelCandidate = hasBackendModel && restoredProvider === 'gemini'
+          ? initialTabModel
+          : state.geminiModel;
+        applyGeminiModel(geminiModelCandidate);
+
         const grokModelCandidate = hasBackendModel && restoredProvider === 'grok'
           ? initialTabModel
           : state.grokModel;
@@ -286,6 +320,7 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
         if (hasBackendModel) {
           if (initialTabProvider === 'claude') applyClaudeModel(initialTabModel);
           else if (initialTabProvider === 'codex') applyCodexModel(initialTabModel);
+          else if (initialTabProvider === 'gemini') applyGeminiModel(initialTabModel);
           else if (initialTabProvider === 'grok') applyGrokModel(initialTabModel);
           else if (initialTabProvider === 'kimi') applyKimiModel(initialTabModel);
           else if (initialTabProvider === 'opencode') applyOpenCodeModel(initialTabModel);
@@ -295,17 +330,20 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
 
       const initialPermissionMode: PermissionMode = restoredProvider === 'codex'
         ? restoredCodexPermissionMode
-        : restoredProvider === 'grok'
-          ? restoredGrokPermissionMode
-          : restoredProvider === 'kimi'
-            ? restoredKimiPermissionMode
-            : restoredProvider === 'opencode'
-              ? restoredOpenCodePermissionMode
-              : restoredProvider === 'pi'
-                ? restoredPiPermissionMode
-                : restoredClaudePermissionMode;
+        : restoredProvider === 'gemini'
+          ? restoredGeminiPermissionMode
+          : restoredProvider === 'grok'
+            ? restoredGrokPermissionMode
+            : restoredProvider === 'kimi'
+              ? restoredKimiPermissionMode
+              : restoredProvider === 'opencode'
+                ? restoredOpenCodePermissionMode
+                : restoredProvider === 'pi'
+                  ? restoredPiPermissionMode
+                  : restoredClaudePermissionMode;
       setClaudePermissionMode(restoredClaudePermissionMode);
       setCodexPermissionMode(restoredCodexPermissionMode);
+      setGeminiPermissionMode(restoredGeminiPermissionMode);
       setGrokPermissionMode(restoredGrokPermissionMode);
       setKimiPermissionMode(restoredKimiPermissionMode);
       setOpenCodePermissionMode(restoredOpenCodePermissionMode);
@@ -326,15 +364,17 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
           sendBridgeEvent('set_provider', restoredProvider);
           const modelToSync = restoredProvider === 'codex'
             ? restoredCodexModel
-            : restoredProvider === 'grok'
-              ? restoredGrokModel
-              : restoredProvider === 'kimi'
-                ? restoredKimiModel
-                : restoredProvider === 'opencode'
-                  ? restoredOpenCodeModel
-                  : restoredProvider === 'pi'
-                    ? restoredPiModel
-                    : apply1MContextSuffix(restoredClaudeModel, restoredLongContextEnabled);
+            : restoredProvider === 'gemini'
+              ? restoredGeminiModel
+              : restoredProvider === 'grok'
+                ? restoredGrokModel
+                : restoredProvider === 'kimi'
+                  ? restoredKimiModel
+                  : restoredProvider === 'opencode'
+                    ? restoredOpenCodeModel
+                    : restoredProvider === 'pi'
+                      ? restoredPiModel
+                      : apply1MContextSuffix(restoredClaudeModel, restoredLongContextEnabled);
           sendBridgeEvent('set_model', modelToSync);
           // Do NOT push the permission mode to Java on boot. Java is the source
           // of truth for the mode (persisted app-level in PropertiesComponent,
@@ -387,8 +427,10 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
           provider: currentProvider,
           claudeModel: selectedClaudeModel,
           codexModel: selectedCodexModel,
+          geminiModel: selectedGeminiModel,
           claudePermissionMode,
           codexPermissionMode,
+          geminiPermissionMode,
           grokModel: selectedGrokModel,
           kimiModel: selectedKimiModel,
           openCodeModel: selectedOpenCodeModel,
@@ -416,8 +458,10 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
     currentProvider,
     selectedClaudeModel,
     selectedCodexModel,
+    selectedGeminiModel,
     claudePermissionMode,
     codexPermissionMode,
+    geminiPermissionMode,
     selectedGrokModel,
     selectedKimiModel,
     selectedOpenCodeModel,

--- a/webview/src/hooks/providers/useModelStatePersistence.ts.orig
+++ b/webview/src/hooks/providers/useModelStatePersistence.ts.orig
@@ -1,0 +1,476 @@
+import { useEffect } from 'react';
+import { sendBridgeEvent } from '../../utils/bridge';
+import {
+  CLAUDE_MODELS,
+  CODEX_MODELS,
+  DEFAULT_CLAUDE_MODEL_ID,
+  DEFAULT_GEMINI_MODEL_ID,
+  GROK_DEFAULT_MODEL_ID,
+  KIMI_DEFAULT_MODEL_ID,
+  OPENCODE_DEFAULT_MODEL_ID,
+  PI_DEFAULT_MODEL_ID,
+  isValidPermissionMode,
+  normalizeClaudeModelId,
+  apply1MContextSuffix,
+  strip1MContextSuffix,
+  splitGeminiAgyModelId,
+  toGeminiFamilyId,
+} from '../../components/ChatInputBox/types';
+import type { CodexFastMode, PermissionMode, ReasoningEffort } from '../../components/ChatInputBox/types';
+import { isCliOnlyProvider, normalizeCliPermissionMode } from './cliProviders';
+
+const STORAGE_KEY = 'model-selection-state';
+const REASONING_VALUES = ['low', 'medium', 'high', 'xhigh', 'max', 'thinking'] as const;
+const CODEX_FAST_MODE_VALUES = ['normal', 'fast'] as const;
+
+const getCustomModels = (key: string): { id: string }[] => {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+};
+
+const isReasoningEffort = (value: unknown): value is ReasoningEffort =>
+  typeof value === 'string' && (REASONING_VALUES as readonly string[]).includes(value);
+
+const isCodexFastMode = (value: unknown): value is CodexFastMode =>
+  typeof value === 'string' && (CODEX_FAST_MODE_VALUES as readonly string[]).includes(value);
+
+export interface UseModelStatePersistenceOptions {
+  // Cross-slice load setters (run once on mount)
+  setCurrentProvider: (value: string) => void;
+  setSelectedClaudeModel: (value: string) => void;
+  setSelectedCodexModel: (value: string) => void;
+  setSelectedGeminiModel: (value: string) => void;
+  setClaudePermissionMode: (value: PermissionMode) => void;
+  setCodexPermissionMode: (value: PermissionMode) => void;
+  setGeminiPermissionMode: (value: PermissionMode) => void;
+  setSelectedGrokModel: (value: string) => void;
+  setSelectedKimiModel: (value: string) => void;
+  setSelectedOpenCodeModel: (value: string) => void;
+  setSelectedPiModel: (value: string) => void;
+  setGrokPermissionMode: (value: PermissionMode) => void;
+  setKimiPermissionMode: (value: PermissionMode) => void;
+  setOpenCodePermissionMode: (value: PermissionMode) => void;
+  setPiPermissionMode: (value: PermissionMode) => void;
+  setPermissionMode: (value: PermissionMode) => void;
+  setLongContextEnabled: (value: boolean) => void;
+  setReasoningEffort: (value: ReasoningEffort) => void;
+  setCodexFastMode: (value: CodexFastMode) => void;
+  // Cross-slice save deps (re-saves on any change)
+  currentProvider: string;
+  selectedClaudeModel: string;
+  selectedCodexModel: string;
+  selectedGeminiModel: string;
+  claudePermissionMode: PermissionMode;
+  codexPermissionMode: PermissionMode;
+  geminiPermissionMode: PermissionMode;
+  selectedGrokModel: string;
+  selectedKimiModel: string;
+  selectedOpenCodeModel: string;
+  selectedPiModel: string;
+  grokPermissionMode: PermissionMode;
+  kimiPermissionMode: PermissionMode;
+  openCodePermissionMode: PermissionMode;
+  piPermissionMode: PermissionMode;
+  longContextEnabled: boolean;
+  reasoningEffort: ReasoningEffort;
+  codexFastMode: CodexFastMode;
+}
+
+/**
+ * Two effects for persisting cross-slice provider/model state to localStorage:
+ *  1. On mount: hydrate state from localStorage and sync the restored values
+ *     to the backend (retrying until the JCEF bridge is ready).
+ *  2. On change: re-save the snapshot to localStorage.
+ *
+ * Save uses `JSON.stringify` of the persisted keys; load applies
+ * defensive validation (custom models lookup, permission mode allowlist,
+ * reasoning effort allowlist) before invoking the slice setters.
+ */
+export function useModelStatePersistence(options: UseModelStatePersistenceOptions) {
+  const {
+    setCurrentProvider,
+    setSelectedClaudeModel,
+    setSelectedCodexModel,
+    setSelectedGeminiModel,
+    setClaudePermissionMode,
+    setCodexPermissionMode,
+    setGeminiPermissionMode,
+    setSelectedGrokModel,
+    setSelectedKimiModel,
+    setSelectedOpenCodeModel,
+    setSelectedPiModel,
+    setGrokPermissionMode,
+    setKimiPermissionMode,
+    setOpenCodePermissionMode,
+    setPiPermissionMode,
+    setPermissionMode,
+    setLongContextEnabled,
+    setReasoningEffort,
+    setCodexFastMode,
+    currentProvider,
+    selectedClaudeModel,
+    selectedCodexModel,
+    selectedGeminiModel,
+    claudePermissionMode,
+    codexPermissionMode,
+    geminiPermissionMode,
+    selectedGrokModel,
+    selectedKimiModel,
+    selectedOpenCodeModel,
+    selectedPiModel,
+    grokPermissionMode,
+    kimiPermissionMode,
+    openCodePermissionMode,
+    piPermissionMode,
+    longContextEnabled,
+    reasoningEffort,
+    codexFastMode,
+  } = options;
+
+  // Hydrate from localStorage and sync to backend (mount only).
+  // Setters are stable; deps left empty to ensure single execution.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      // Per-tab restore (issue #1353): when the Java backend has loaded a saved
+      // session for this specific tab, it injects __INITIAL_TAB_PROVIDER__ /
+      // __INITIAL_TAB_MODEL__ into the HTML before React boots. Those values
+      // win over the global localStorage snapshot, which is shared across every
+      // tab in the JCEF process and would otherwise cause every CC tab on
+      // restart to be set to whichever provider was last saved by ANY tab.
+      const initialTabProvider = typeof window.__INITIAL_TAB_PROVIDER__ === 'string'
+        ? window.__INITIAL_TAB_PROVIDER__.trim()
+        : '';
+      const initialTabModel = typeof window.__INITIAL_TAB_MODEL__ === 'string'
+        ? window.__INITIAL_TAB_MODEL__.trim()
+        : '';
+      const hasBackendProvider = initialTabProvider === 'claude'
+        || initialTabProvider === 'codex'
+        || initialTabProvider === 'gemini'
+        || isCliOnlyProvider(initialTabProvider);
+      const hasBackendModel = initialTabModel.length > 0;
+
+      let restoredProvider = 'claude';
+      let restoredClaudeModel = DEFAULT_CLAUDE_MODEL_ID;
+      let restoredCodexModel = CODEX_MODELS[0].id;
+      let restoredGeminiModel = DEFAULT_GEMINI_MODEL_ID;
+      let restoredClaudePermissionMode: PermissionMode = 'default';
+      let restoredCodexPermissionMode: PermissionMode = 'default';
+      let restoredGeminiPermissionMode: PermissionMode = 'default';
+      let restoredGrokModel = GROK_DEFAULT_MODEL_ID;
+      let restoredKimiModel = KIMI_DEFAULT_MODEL_ID;
+      let restoredOpenCodeModel = OPENCODE_DEFAULT_MODEL_ID;
+      let restoredPiModel = PI_DEFAULT_MODEL_ID;
+      let restoredGrokPermissionMode: PermissionMode = 'default';
+      let restoredKimiPermissionMode: PermissionMode = 'default';
+      let restoredOpenCodePermissionMode: PermissionMode = 'default';
+      let restoredPiPermissionMode: PermissionMode = 'default';
+      let restoredLongContextEnabled = true;
+      let restoredCodexFastMode: CodexFastMode = 'normal';
+
+      // Model validation helpers — close over the restored* lets so both
+      // branches (saved localStorage / fresh backend-only) share the same logic
+      // and each getCustomModels localStorage read happens at most once.
+      const applyClaudeModel = (modelId: string) => {
+        const normalized = normalizeClaudeModelId(strip1MContextSuffix(modelId));
+        const customs = getCustomModels('claude-custom-models');
+        if (CLAUDE_MODELS.find(m => m.id === normalized) || customs.find(m => m.id === normalized)) {
+          restoredClaudeModel = normalized;
+          setSelectedClaudeModel(normalized);
+        }
+      };
+      const applyCodexModel = (modelId: string) => {
+        const customs = getCustomModels('codex-custom-models');
+        if (CODEX_MODELS.find(m => m.id === modelId) || customs.find(m => m.id === modelId)) {
+          restoredCodexModel = modelId;
+          setSelectedCodexModel(modelId);
+        }
+      };
+      const applyGeminiModel = (modelId: string) => {
+        if (typeof modelId !== 'string' || !modelId.trim()) return;
+        const split = splitGeminiAgyModelId(modelId);
+        const baseId = toGeminiFamilyId(modelId) || split.baseId || modelId;
+        const effort = split.effort;
+        if (baseId) {
+          restoredGeminiModel = baseId;
+          setSelectedGeminiModel(baseId);
+          if (effort && isReasoningEffort(effort)) {
+            setReasoningEffort(effort);
+          }
+        }
+      };
+      // CLI catalogs are dynamic (user-defined Grok profiles, backend-reported
+      // Kimi/OpenCode models), so any non-empty saved id is accepted.
+      const makeCliModelApplier = (apply: (id: string) => void) => (modelId: unknown) => {
+        if (typeof modelId === 'string' && modelId.trim().length > 0) {
+          apply(modelId);
+        }
+      };
+      const applyGrokModel = makeCliModelApplier((id) => {
+        restoredGrokModel = id;
+        setSelectedGrokModel(id);
+      });
+      const applyKimiModel = makeCliModelApplier((id) => {
+        restoredKimiModel = id;
+        setSelectedKimiModel(id);
+      });
+      const applyOpenCodeModel = makeCliModelApplier((id) => {
+        restoredOpenCodeModel = id;
+        setSelectedOpenCodeModel(id);
+      });
+      const applyPiModel = makeCliModelApplier((id) => {
+        restoredPiModel = id;
+        setSelectedPiModel(id);
+      });
+
+      if (saved) {
+        const state = JSON.parse(saved);
+
+        // Backend-supplied provider wins. We still fall through the rest of the
+        // hydration so non-provider preferences (permission mode, reasoning
+        // effort, codex fast mode, …) are restored from localStorage.
+        const providerCandidate = hasBackendProvider ? initialTabProvider : state.provider;
+        if (['claude', 'codex', 'gemini'].includes(providerCandidate) || isCliOnlyProvider(providerCandidate)) {
+          restoredProvider = providerCandidate;
+          setCurrentProvider(providerCandidate);
+        }
+
+        if (isValidPermissionMode(state.claudePermissionMode)) {
+          restoredClaudePermissionMode = state.claudePermissionMode;
+        }
+        if (isValidPermissionMode(state.codexPermissionMode)) {
+          restoredCodexPermissionMode = state.codexPermissionMode === 'plan'
+            ? 'default'
+            : state.codexPermissionMode;
+        }
+        if (isValidPermissionMode(state.geminiPermissionMode)) {
+          restoredGeminiPermissionMode = state.geminiPermissionMode;
+        }
+        if (isValidPermissionMode(state.grokPermissionMode)) {
+          restoredGrokPermissionMode = normalizeCliPermissionMode(state.grokPermissionMode);
+        }
+        if (isValidPermissionMode(state.kimiPermissionMode)) {
+          restoredKimiPermissionMode = normalizeCliPermissionMode(state.kimiPermissionMode);
+        }
+        if (isValidPermissionMode(state.openCodePermissionMode)) {
+          restoredOpenCodePermissionMode = normalizeCliPermissionMode(state.openCodePermissionMode);
+        }
+        if (isValidPermissionMode(state.piPermissionMode)) {
+          restoredPiPermissionMode = normalizeCliPermissionMode(state.piPermissionMode);
+        }
+
+        if (typeof state.longContextEnabled === 'boolean') {
+          restoredLongContextEnabled = state.longContextEnabled;
+          setLongContextEnabled(state.longContextEnabled);
+        }
+
+        if (isReasoningEffort(state.reasoningEffort)) {
+          setReasoningEffort(state.reasoningEffort);
+        }
+        if (isCodexFastMode(state.codexFastMode)) {
+          restoredCodexFastMode = state.codexFastMode;
+          setCodexFastMode(restoredCodexFastMode);
+        }
+
+        const claudeModelCandidate = hasBackendModel && restoredProvider === 'claude'
+          ? initialTabModel
+          : state.claudeModel;
+        applyClaudeModel(claudeModelCandidate);
+
+        const codexModelCandidate = hasBackendModel && restoredProvider === 'codex'
+          ? initialTabModel
+          : state.codexModel;
+        applyCodexModel(codexModelCandidate);
+
+        const geminiModelCandidate = hasBackendModel && restoredProvider === 'gemini'
+          ? initialTabModel
+          : state.geminiModel;
+        applyGeminiModel(geminiModelCandidate);
+
+        const grokModelCandidate = hasBackendModel && restoredProvider === 'grok'
+          ? initialTabModel
+          : state.grokModel;
+        applyGrokModel(grokModelCandidate);
+
+        const kimiModelCandidate = hasBackendModel && restoredProvider === 'kimi'
+          ? initialTabModel
+          : state.kimiModel;
+        applyKimiModel(kimiModelCandidate);
+
+        const openCodeModelCandidate = hasBackendModel && restoredProvider === 'opencode'
+          ? initialTabModel
+          : state.openCodeModel;
+        applyOpenCodeModel(openCodeModelCandidate);
+
+        const piModelCandidate = hasBackendModel && restoredProvider === 'pi'
+          ? initialTabModel
+          : state.piModel;
+        applyPiModel(piModelCandidate);
+      } else if (hasBackendProvider) {
+        // No localStorage yet (fresh user) but backend supplied a provider:
+        // honor it so the tab starts with the right provider.
+        restoredProvider = initialTabProvider;
+        setCurrentProvider(initialTabProvider);
+        if (hasBackendModel) {
+          if (initialTabProvider === 'claude') applyClaudeModel(initialTabModel);
+          else if (initialTabProvider === 'codex') applyCodexModel(initialTabModel);
+          else if (initialTabProvider === 'gemini') applyGeminiModel(initialTabModel);
+          else if (initialTabProvider === 'grok') applyGrokModel(initialTabModel);
+          else if (initialTabProvider === 'kimi') applyKimiModel(initialTabModel);
+          else if (initialTabProvider === 'opencode') applyOpenCodeModel(initialTabModel);
+          else if (initialTabProvider === 'pi') applyPiModel(initialTabModel);
+        }
+      }
+
+      const initialPermissionMode: PermissionMode = restoredProvider === 'codex'
+        ? restoredCodexPermissionMode
+        : restoredProvider === 'gemini'
+          ? restoredGeminiPermissionMode
+          : restoredProvider === 'grok'
+            ? restoredGrokPermissionMode
+            : restoredProvider === 'kimi'
+              ? restoredKimiPermissionMode
+              : restoredProvider === 'opencode'
+                ? restoredOpenCodePermissionMode
+                : restoredProvider === 'pi'
+                  ? restoredPiPermissionMode
+                  : restoredClaudePermissionMode;
+      setClaudePermissionMode(restoredClaudePermissionMode);
+      setCodexPermissionMode(restoredCodexPermissionMode);
+      setGeminiPermissionMode(restoredGeminiPermissionMode);
+      setGrokPermissionMode(restoredGrokPermissionMode);
+      setKimiPermissionMode(restoredKimiPermissionMode);
+      setOpenCodePermissionMode(restoredOpenCodePermissionMode);
+      setPiPermissionMode(restoredPiPermissionMode);
+      setPermissionMode(initialPermissionMode);
+
+      let syncRetryCount = 0;
+      const MAX_SYNC_RETRIES = 30;
+
+      const syncToBackend = () => {
+        if (window.sendToJava) {
+          // Native watchdog reload reuses the original HTML snapshot. Java
+          // pushes the current Session state after frontend_ready; echoing the
+          // stale boot snapshot would route the existing transcript incorrectly.
+          if (window.__CCGUI_RECOVERY_RELOAD__ === true) {
+            return;
+          }
+          sendBridgeEvent('set_provider', restoredProvider);
+          const modelToSync = restoredProvider === 'codex'
+            ? restoredCodexModel
+            : restoredProvider === 'gemini'
+              ? restoredGeminiModel
+              : restoredProvider === 'grok'
+                ? restoredGrokModel
+                : restoredProvider === 'kimi'
+                  ? restoredKimiModel
+                  : restoredProvider === 'opencode'
+                    ? restoredOpenCodeModel
+                    : restoredProvider === 'pi'
+                      ? restoredPiModel
+                      : apply1MContextSuffix(restoredClaudeModel, restoredLongContextEnabled);
+          sendBridgeEvent('set_model', modelToSync);
+          // Do NOT push the permission mode to Java on boot. Java is the source
+          // of truth for the mode (persisted app-level in PropertiesComponent,
+          // which survives a plugin reinstall) and the webview seeds its own mode
+          // FROM Java via get_mode → onModeReceived. Our localStorage copy is
+          // wiped on reinstall, so pushing it here would clobber the surviving
+          // Java value with 'default' — the reported "reinstall forgets Auto" bug.
+          // The mode is only sent to Java on an explicit user switch
+          // (handleModeSelect → set_mode).
+          sendBridgeEvent('set_codex_fast_mode', restoredCodexFastMode);
+        } else {
+          syncRetryCount++;
+          if (syncRetryCount < MAX_SYNC_RETRIES) {
+            setTimeout(syncToBackend, 100);
+          }
+        }
+      };
+      setTimeout(syncToBackend, 200);
+    } catch {
+      // Failed to load model selection state — fall back to defaults already
+      // set by individual slice hooks.
+    }
+  }, []);
+
+  // Persist snapshot whenever any of the persisted keys change.
+  useEffect(() => {
+    let retryTimer: number | undefined;
+    let retryCount = 0;
+
+    const persistWhenPageContextIsReady = () => {
+      const pageContextPending = window.__CCGUI_PAGE_CONTEXT_READY__ !== true;
+      const recoveryStatePending = window.__CCGUI_RECOVERY_RELOAD__ === true
+        && window.__CCGUI_RECOVERY_STATE_APPLIED__ !== true;
+
+      // React may mount before onLoadEnd/fallback establishes the runtime page
+      // context. Never publish provisional HTML/default state to the localStorage
+      // snapshot shared by every tab. Keep the same fast-then-slow retry policy as
+      // bridge startup so delayed remote JCEF initialization can still settle.
+      if (pageContextPending || recoveryStatePending) {
+        retryCount += 1;
+        retryTimer = window.setTimeout(
+          persistWhenPageContextIsReady,
+          retryCount < 50 ? 100 : 1000,
+        );
+        return;
+      }
+
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({
+          provider: currentProvider,
+          claudeModel: selectedClaudeModel,
+          codexModel: selectedCodexModel,
+          geminiModel: selectedGeminiModel,
+          claudePermissionMode,
+          codexPermissionMode,
+          geminiPermissionMode,
+          grokModel: selectedGrokModel,
+          kimiModel: selectedKimiModel,
+          openCodeModel: selectedOpenCodeModel,
+          piModel: selectedPiModel,
+          grokPermissionMode,
+          kimiPermissionMode,
+          openCodePermissionMode,
+          piPermissionMode,
+          longContextEnabled,
+          reasoningEffort,
+          codexFastMode,
+        }));
+      } catch {
+        // Failed to save model selection state — non-fatal.
+      }
+    };
+
+    persistWhenPageContextIsReady();
+    return () => {
+      if (retryTimer !== undefined) {
+        window.clearTimeout(retryTimer);
+      }
+    };
+  }, [
+    currentProvider,
+    selectedClaudeModel,
+    selectedCodexModel,
+    selectedGeminiModel,
+    claudePermissionMode,
+    codexPermissionMode,
+    geminiPermissionMode,
+    selectedGrokModel,
+    selectedKimiModel,
+    selectedOpenCodeModel,
+    selectedPiModel,
+    grokPermissionMode,
+    kimiPermissionMode,
+    openCodePermissionMode,
+    piPermissionMode,
+    longContextEnabled,
+    reasoningEffort,
+    codexFastMode,
+  ]);
+}

--- a/webview/src/hooks/providers/useUsageTracking.gemini.test.ts
+++ b/webview/src/hooks/providers/useUsageTracking.gemini.test.ts
@@ -1,0 +1,42 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useUsageTracking } from './useUsageTracking';
+
+describe('useUsageTracking gemini mapping', () => {
+  it('treats gemini as installed when gemini-cli status is installed', () => {
+    const { result } = renderHook(() => useUsageTracking());
+
+    act(() => {
+      result.current.setSdkStatus({
+        'gemini-cli': { status: 'installed', installed: true },
+        'claude-sdk': { status: 'not_installed', installed: false },
+      });
+      result.current.setSdkStatusLoaded(true);
+    });
+
+    expect(result.current.isSdkInstalled('gemini')).toBe(true);
+    expect(result.current.isSdkInstalled('claude')).toBe(false);
+  });
+
+  it('returns false for gemini when status is unknown and not loaded', () => {
+    const { result } = renderHook(() => useUsageTracking());
+    act(() => {
+      result.current.setSdkStatus({});
+      result.current.setSdkStatusLoaded(false);
+    });
+    expect(result.current.isSdkInstalled('gemini')).toBe(false);
+    expect(result.current.isSdkStatusKnown('gemini')).toBe(false);
+  });
+
+  it('maps gemini provider id to gemini-cli for isSdkStatusKnown', () => {
+    const { result } = renderHook(() => useUsageTracking());
+    act(() => {
+      result.current.setSdkStatus({
+        'gemini-cli': { status: 'not_installed', installed: false },
+      });
+      result.current.setSdkStatusLoaded(true);
+    });
+    expect(result.current.isSdkStatusKnown('gemini')).toBe(true);
+    expect(result.current.isSdkInstalled('gemini')).toBe(false);
+  });
+});

--- a/webview/src/hooks/providers/useUsageTracking.ts
+++ b/webview/src/hooks/providers/useUsageTracking.ts
@@ -12,6 +12,7 @@ const PROVIDER_TO_SDK: Record<string, string> = {
   bedrock: 'claude-sdk',
   codex: 'codex-sdk',
   openai: 'codex-sdk',
+  gemini: 'gemini-cli',
   // CLI providers have no npm SDK — markers are only for lookups.
   grok: 'grok-cli',
   kimi: 'kimi-cli',

--- a/webview/src/hooks/useGeminiPlanUsage.ts
+++ b/webview/src/hooks/useGeminiPlanUsage.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  parseCapacityPayload,
+  type GeminiPlanUsageSnapshot,
+} from '../utils/geminiBillingPace';
+
+export type GeminiPlanUsageState = {
+  status: 'idle' | 'loading' | 'ready' | 'unavailable';
+  snapshot: GeminiPlanUsageSnapshot | null;
+};
+
+const EMPTY: GeminiPlanUsageState = { status: 'idle', snapshot: null };
+
+/**
+ * Gemini / Antigravity plan usage for ContextBar via Java bridge
+ * ({@code get_gemini_plan_usage} → temporary agy statusline hook, no token parsing).
+ * Same snapshot shape as Gemini/Claude so GeminiPlanUsageIndicator can render it.
+ */
+export function useGeminiPlanUsage(currentProvider: string) {
+  const [state, setState] = useState<GeminiPlanUsageState>(EMPTY);
+  const genRef = useRef(0);
+  const handlerRef = useRef<((json: string) => void) | null>(null);
+
+  const refresh = useCallback(() => {
+    if (currentProvider !== 'gemini') {
+      setState(EMPTY);
+      return;
+    }
+    const gen = ++genRef.current;
+    setState((prev) => ({
+      status: prev.snapshot?.present ? 'ready' : 'loading',
+      snapshot: prev.snapshot,
+    }));
+
+    const w = window as unknown as {
+      updateGeminiPlanUsage?: (json: string) => void;
+      sendToJava?: (cmd: string) => void;
+    };
+
+    const handler = (jsonStr: string) => {
+      if (gen !== genRef.current) return;
+      try {
+        const data = typeof jsonStr === 'string' ? JSON.parse(jsonStr) : jsonStr;
+        const snap = parseCapacityPayload(data);
+        if (snap.present) {
+          setState({ status: 'ready', snapshot: snap });
+        } else {
+          setState({ status: 'unavailable', snapshot: snap });
+        }
+      } catch {
+        setState({
+          status: 'unavailable',
+          snapshot: { present: false, message: 'Usage unavailable' },
+        });
+      }
+    };
+
+    handlerRef.current = handler;
+    w.updateGeminiPlanUsage = (json: string) => {
+      if (handlerRef.current) {
+        handlerRef.current(json);
+      }
+    };
+
+    try {
+      w.sendToJava?.('get_gemini_plan_usage:');
+    } catch {
+      if (gen === genRef.current) {
+        setState({
+          status: 'unavailable',
+          snapshot: { present: false, message: 'Usage unavailable' },
+        });
+      }
+    }
+  }, [currentProvider]);
+
+  useEffect(() => {
+    void refresh();
+    if (currentProvider !== 'gemini') {
+      return () => {
+        genRef.current += 1;
+      };
+    }
+    // agy statusline spawn is heavier than HTTP capacity — poll less often
+    const id = window.setInterval(() => {
+      void refresh();
+    }, 120_000);
+    return () => {
+      window.clearInterval(id);
+      genRef.current += 1;
+    };
+  }, [currentProvider, refresh]);
+
+  return { ...state, refresh };
+}
+
+export type UseGeminiPlanUsageReturn = ReturnType<typeof useGeminiPlanUsage>;

--- a/webview/src/hooks/useMessageSender.ts
+++ b/webview/src/hooks/useMessageSender.ts
@@ -324,7 +324,7 @@ export function useMessageSender({
     }
     if (!currentSdkInstalled) {
       addToast(
-        t('chat.sdkNotInstalled', { provider: currentProvider === 'codex' ? 'Codex' : 'Claude Code' }) + ' ' + t('chat.goInstallSdk'),
+        t('chat.sdkNotInstalled', { provider: currentProvider === 'codex' ? 'Codex' : currentProvider === 'gemini' ? 'Gemini' : currentProvider === 'grok' ? 'Grok' : 'Claude Code' }) + ' ' + t('chat.goInstallSdk'),
         'warning'
       );
       setSettingsInitialTab('dependencies');

--- a/webview/src/hooks/useModelProviderState.ts
+++ b/webview/src/hooks/useModelProviderState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { TFunction } from 'i18next';
 import { sendBridgeEvent } from '../utils/bridge';
 import {
@@ -6,10 +6,11 @@ import {
   normalizeClaudeModelId,
   strip1MContextSuffix,
 } from '../components/ChatInputBox/types';
-import type { PermissionMode } from '../components/ChatInputBox/types';
+import type { PermissionMode, ReasoningEffort } from '../components/ChatInputBox/types';
 import { isSpecialProviderId } from '../types/provider';
 import { useClaudeProvider } from './providers/useClaudeProvider';
 import { useCodexProvider } from './providers/useCodexProvider';
+import { useGeminiProvider } from './providers/useGeminiProvider';
 import { useGrokProvider } from './providers/useGrokProvider';
 import { useKimiProvider } from './providers/useKimiProvider';
 import { useOpenCodeProvider } from './providers/useOpenCodeProvider';
@@ -55,6 +56,7 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
   const claude = useClaudeProvider();
   const codex = useCodexProvider();
   const grok = useGrokProvider();
+  const gemini = useGeminiProvider();
   const kimi = useKimiProvider();
   const openCode = useOpenCodeProvider();
   const pi = usePiProvider();
@@ -72,11 +74,23 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
     codexPermissionMode, setCodexPermissionMode,
     reasoningEffort, setReasoningEffort,
     codexFastMode, setCodexFastMode,
+    handleReasoningChange: codexHandleReasoningChange,
+    handleCodexFastModeChange,
   } = codex;
   const {
     selectedGrokModel, setSelectedGrokModel,
     grokPermissionMode, setGrokPermissionMode,
   } = grok;
+  const {
+    selectedGeminiModel, setSelectedGeminiModel,
+    geminiPermissionMode, setGeminiPermissionMode,
+    geminiFamilies,
+    geminiModels,
+    geminiCatalogLoaded,
+    fetchGeminiModels,
+    resolveGeminiAgyModelId,
+    resolveDefaultEffortForFamily,
+  } = gemini;
   const {
     selectedKimiModel, setSelectedKimiModel,
     kimiPermissionMode, setKimiPermissionMode,
@@ -90,13 +104,60 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
     piPermissionMode, setPiPermissionMode,
   } = pi;
 
+  // Pull live agy catalog when Gemini is active (new tab / provider switch).
+  useEffect(() => {
+    if (currentProvider === 'gemini') {
+      fetchGeminiModels();
+    }
+  }, [currentProvider, fetchGeminiModels]);
+
+  // After catalog arrives, re-push full agy slug so session state is never left
+  // on a bare family id that agy rejects without --effort.
+  useEffect(() => {
+    if (currentProvider !== 'gemini' || !geminiCatalogLoaded) {
+      return;
+    }
+    const fullSlug = resolveGeminiAgyModelId(selectedGeminiModel, reasoningEffort);
+    if (fullSlug) {
+      sendBridgeEvent('set_model', fullSlug);
+    }
+  }, [
+    currentProvider,
+    geminiCatalogLoaded,
+    reasoningEffort,
+    resolveGeminiAgyModelId,
+    selectedGeminiModel,
+  ]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const prev = window.onTabActivated;
+    window.onTabActivated = () => {
+      if (currentProviderRef.current === 'gemini') {
+        fetchGeminiModels();
+      }
+      if (typeof prev === 'function') {
+        try {
+          prev();
+        } catch {
+          // ignore
+        }
+      }
+    };
+    return () => {
+      window.onTabActivated = prev;
+    };
+  }, [fetchGeminiModels]);
+
   // ── Persistence: load on mount + save on change ──
   useModelStatePersistence({
     setCurrentProvider,
     setSelectedClaudeModel,
     setSelectedCodexModel,
+    setSelectedGeminiModel,
     setClaudePermissionMode,
     setCodexPermissionMode,
+    setGeminiPermissionMode,
     setSelectedGrokModel,
     setSelectedKimiModel,
     setSelectedOpenCodeModel,
@@ -112,8 +173,10 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
     currentProvider,
     selectedClaudeModel,
     selectedCodexModel,
+    selectedGeminiModel,
     claudePermissionMode,
     codexPermissionMode,
+    geminiPermissionMode,
     selectedGrokModel,
     selectedKimiModel,
     selectedOpenCodeModel,
@@ -130,15 +193,17 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
   // ── Computed values ──
   const selectedModel = currentProvider === 'codex'
     ? selectedCodexModel
-    : currentProvider === 'grok'
-      ? selectedGrokModel
-      : currentProvider === 'kimi'
-        ? selectedKimiModel
-        : currentProvider === 'opencode'
-          ? selectedOpenCodeModel
-          : currentProvider === 'pi'
-            ? selectedPiModel
-            : selectedClaudeModel;
+    : currentProvider === 'gemini'
+      ? selectedGeminiModel
+      : currentProvider === 'grok'
+        ? selectedGrokModel
+        : currentProvider === 'kimi'
+          ? selectedKimiModel
+          : currentProvider === 'opencode'
+            ? selectedOpenCodeModel
+            : currentProvider === 'pi'
+              ? selectedPiModel
+              : selectedClaudeModel;
   const currentSdkInstalled = useMemo(
     () => isSdkInstalled(currentProvider),
     [isSdkInstalled, currentProvider],
@@ -164,6 +229,12 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
       sendBridgeEvent('set_mode', codexMode);
       return;
     }
+    if (currentProvider === 'gemini') {
+      setPermissionMode(mode);
+      setGeminiPermissionMode(mode);
+      sendBridgeEvent('set_mode', mode);
+      return;
+    }
     if (isCliOnlyProvider(currentProvider)) {
       const cliMode = normalizeCliPermissionMode(mode);
       setPermissionMode(cliMode);
@@ -181,6 +252,7 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
     currentProvider,
     setCodexPermissionMode,
     setClaudePermissionMode,
+    setGeminiPermissionMode,
     setGrokPermissionMode,
     setKimiPermissionMode,
     setOpenCodePermissionMode,
@@ -196,6 +268,13 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
     } else if (currentProvider === 'codex') {
       setSelectedCodexModel(modelId);
       sendBridgeEvent('set_model', modelId);
+    } else if (currentProvider === 'gemini') {
+      setSelectedGeminiModel(modelId);
+      const effort = resolveDefaultEffortForFamily(modelId);
+      setReasoningEffort(effort);
+      sendBridgeEvent('set_reasoning_effort', effort);
+      const fullSlug = resolveGeminiAgyModelId(modelId, effort);
+      sendBridgeEvent('set_model', fullSlug);
     } else if (currentProvider === 'grok') {
       setSelectedGrokModel(modelId);
       sendBridgeEvent('set_model', modelId);
@@ -212,21 +291,45 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
   }, [
     currentProvider,
     longContextEnabled,
+    resolveDefaultEffortForFamily,
+    resolveGeminiAgyModelId,
+    setReasoningEffort,
     setSelectedClaudeModel,
     setSelectedCodexModel,
+    setSelectedGeminiModel,
     setSelectedGrokModel,
     setSelectedKimiModel,
     setSelectedOpenCodeModel,
     setSelectedPiModel,
   ]);
 
-  const handleProviderSelect = useCallback((providerId: string) => {
+  const handleReasoningChange = useCallback((effort: ReasoningEffort) => {
+    if (currentProvider === 'gemini') {
+      setReasoningEffort(effort);
+      sendBridgeEvent('set_reasoning_effort', effort);
+      const fullSlug = resolveGeminiAgyModelId(selectedGeminiModel, effort);
+      sendBridgeEvent('set_model', fullSlug);
+      return;
+    }
+    codexHandleReasoningChange(effort);
+  }, [
+    codexHandleReasoningChange,
+    currentProvider,
+    resolveGeminiAgyModelId,
+    selectedGeminiModel,
+    setReasoningEffort,
+  ]);
+
+    const handleProviderSelect = useCallback((providerId: string) => {
     setCurrentProvider(providerId);
     sendBridgeEvent('set_provider', providerId);
 
     let modeToSet: PermissionMode = claudePermissionMode;
     if (providerId === 'codex') {
       modeToSet = normalizeCliPermissionMode(codexPermissionMode);
+    } else if (providerId === 'gemini') {
+      modeToSet = geminiPermissionMode;
+      fetchGeminiModels();
     } else if (providerId === 'grok') {
       modeToSet = normalizeCliPermissionMode(grokPermissionMode);
     } else if (providerId === 'kimi') {
@@ -241,6 +344,7 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
 
     let newModel = apply1MContextSuffix(selectedClaudeModel, longContextEnabled);
     if (providerId === 'codex') newModel = selectedCodexModel;
+    else if (providerId === 'gemini') newModel = resolveGeminiAgyModelId(selectedGeminiModel, reasoningEffort);
     else if (providerId === 'grok') newModel = selectedGrokModel;
     else if (providerId === 'kimi') newModel = selectedKimiModel;
     else if (providerId === 'opencode') newModel = selectedOpenCodeModel;
@@ -249,17 +353,22 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
   }, [
     claudePermissionMode,
     codexPermissionMode,
+    fetchGeminiModels,
+    geminiPermissionMode,
     grokPermissionMode,
     kimiPermissionMode,
     openCodePermissionMode,
     piPermissionMode,
+    longContextEnabled,
+    reasoningEffort,
+    resolveGeminiAgyModelId,
     selectedCodexModel,
     selectedClaudeModel,
+    selectedGeminiModel,
     selectedGrokModel,
     selectedKimiModel,
     selectedOpenCodeModel,
     selectedPiModel,
-    longContextEnabled,
   ]);
 
   const handleLongContextChange = useCallback((enabled: boolean) => {
@@ -311,6 +420,7 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
   return {
     ...claude,
     ...codex,
+    ...gemini,
     ...grok,
     ...kimi,
     ...openCode,
@@ -322,13 +432,20 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
     currentProvider, setCurrentProvider,
     permissionMode, setPermissionMode,
     selectedModel,
+    geminiFamilies,
+    geminiModels,
+    geminiCatalogLoaded,
     currentSdkInstalled,
     claudeSdkMeetsMinimum,
     currentProviderRef,
     handleModeSelect,
     handleModelSelect,
     handleProviderSelect,
+    handleReasoningChange,
+    handleCodexFastModeChange,
     handleLongContextChange,
     handleToggleThinking,
+    fetchGeminiModels,
+    resolveGeminiAgyModelId,
   };
 }

--- a/webview/src/hooks/useSessionManagement.test.ts
+++ b/webview/src/hooks/useSessionManagement.test.ts
@@ -102,7 +102,7 @@ describe('useSessionManagement', () => {
     expect(window.sendToJava).toHaveBeenNthCalledWith(1, 'interrupt_session:');
     expect(window.sendToJava).toHaveBeenNthCalledWith(
       2,
-      'load_session:{"sessionId":"history-1","provider":"claude"}'
+      'load_session:{"sessionId":"history-1","provider":"claude","model":"claude-sonnet-4-6"}'
     );
     expect(window.__sessionTransitioning).toBe(true);
     expect(window.__sessionTransitionToken).toBeTruthy();
@@ -571,7 +571,9 @@ describe('useSessionManagement', () => {
     // Should NOT send interrupt when not loading
     const calls = (window.sendToJava as any).mock.calls.map((c: any) => c[0]);
     expect(calls).not.toContain('interrupt_session:');
-    expect(calls).toContain('load_session:{"sessionId":"hist-2","provider":"claude"}');
+    expect(calls).toContain(
+      'load_session:{"sessionId":"hist-2","provider":"claude","model":"claude-sonnet-4-6"}',
+    );
 
     // But should still set transition guard
     expect(window.__sessionTransitioning).toBe(true);
@@ -616,7 +618,7 @@ describe('useSessionManagement', () => {
     });
 
     expect(window.sendToJava).toHaveBeenCalledWith(
-      'load_session:{"sessionId":"hist-codex","provider":"codex"}'
+      'load_session:{"sessionId":"hist-codex","provider":"codex","model":"gpt-5.4"}'
     );
   });
 

--- a/webview/src/hooks/useSessionManagement.ts
+++ b/webview/src/hooks/useSessionManagement.ts
@@ -38,6 +38,11 @@ interface UseSessionManagementOptions {
   clearToasts: () => void;
   addToast: (message: string, type?: ToastType) => void;
   t: TFunction;
+  /**
+   * Apply model (and optional agent) from a history row so the input bar
+   * matches the session being opened.
+   */
+  applyHistoryModel?: (provider: string, model: string, agent?: string | null) => void;
 }
 
 interface UseSessionManagementReturn {
@@ -51,7 +56,7 @@ interface UseSessionManagementReturn {
   handleCancelNewSession: () => void;
   handleConfirmInterrupt: () => void;
   handleCancelInterrupt: () => void;
-  loadHistorySession: (sessionId: string, provider?: string) => void;
+  loadHistorySession: (sessionId: string, provider?: string, model?: string, agent?: string) => void;
   deleteHistorySession: (sessionId: string) => void;
   deleteHistorySessions: (sessionIds: string[]) => void;
   exportHistorySession: (sessionId: string, title: string) => void;
@@ -88,6 +93,7 @@ export function useSessionManagement({
   clearToasts,
   addToast,
   t,
+  applyHistoryModel,
 }: UseSessionManagementOptions): UseSessionManagementReturn {
   const [showNewSessionConfirm, setShowNewSessionConfirm] = useState(false);
   const [showInterruptConfirm, setShowInterruptConfirm] = useState(false);
@@ -247,9 +253,22 @@ export function useSessionManagement({
   }, []);
 
   // Load history session
-  const loadHistorySession = useCallback((sessionId: string, provider?: string) => {
+  const loadHistorySession = useCallback((
+    sessionId: string,
+    provider?: string,
+    model?: string,
+    agent?: string,
+  ) => {
     const session = historyDataRef.current?.sessions?.find(s => s.sessionId === sessionId);
     const effectiveProvider = provider || session?.provider || currentProvider || 'claude';
+    const effectiveModel = (model || session?.model || '').trim();
+    const effectiveAgent = (agent || session?.agent || '').trim();
+
+    // Restore the session's model/agent in the UI before (or with) the load so
+    // the next send continues with the same selection the history used.
+    if (effectiveModel && applyHistoryModel) {
+      applyHistoryModel(effectiveProvider, effectiveModel, effectiveAgent || null);
+    }
 
     // Re-opening the very session already active: don't interrupt the in-flight
     // turn or wipe the view - just ask the backend to soft-reload the transcript
@@ -263,6 +282,7 @@ export function useSessionManagement({
       sendBridgeEvent('load_session', JSON.stringify({
         sessionId,
         provider: effectiveProvider,
+        ...(effectiveModel ? { model: effectiveModel } : {}),
       }));
       setCurrentView('chat');
       return;
@@ -277,9 +297,10 @@ export function useSessionManagement({
     sendBridgeEvent('load_session', JSON.stringify({
       sessionId,
       provider: effectiveProvider,
+      ...(effectiveModel ? { model: effectiveModel } : {}),
     }));
     setCurrentView('chat');
-  }, [beginSessionTransition, currentProvider, loading, setCurrentView, currentSessionId]);
+  }, [applyHistoryModel, beginSessionTransition, currentProvider, loading, setCurrentView, currentSessionId]);
 
   // Delete history session
   const deleteHistorySession = useCallback((sessionId: string) => {
@@ -363,9 +384,14 @@ export function useSessionManagement({
 
   // Export history session
   const exportHistorySession = useCallback((sessionId: string, title: string) => {
-    const exportData = JSON.stringify({ sessionId, title });
+    const session = historyDataRef.current?.sessions?.find(s => s.sessionId === sessionId);
+    const exportData = JSON.stringify({
+      sessionId,
+      title,
+      provider: session?.provider || currentProvider || 'claude',
+    });
     sendBridgeEvent('export_session', exportData);
-  }, []);
+  }, [currentProvider]);
 
   // Toggle favorite status
   const toggleFavoriteSession = useCallback((sessionId: string) => {

--- a/webview/src/hooks/useWindowCallbacks.ts
+++ b/webview/src/hooks/useWindowCallbacks.ts
@@ -48,8 +48,10 @@ export interface UseWindowCallbacksOptions {
   setCurrentProvider: React.Dispatch<React.SetStateAction<string>>;
   setClaudePermissionMode: React.Dispatch<React.SetStateAction<PermissionMode>>;
   setCodexPermissionMode: React.Dispatch<React.SetStateAction<PermissionMode>>;
+  setGeminiPermissionMode?: React.Dispatch<React.SetStateAction<PermissionMode>>;
   setSelectedClaudeModel: React.Dispatch<React.SetStateAction<string>>;
   setSelectedCodexModel: React.Dispatch<React.SetStateAction<string>>;
+  setSelectedGeminiModel?: React.Dispatch<React.SetStateAction<string>>;
   setLongContextEnabled: React.Dispatch<React.SetStateAction<boolean>>;
   setReasoningEffort: React.Dispatch<React.SetStateAction<ReasoningEffort>>;
   setCodexFastMode: React.Dispatch<React.SetStateAction<CodexFastMode>>;

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/sessionCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/sessionCallbacks.ts
@@ -43,22 +43,24 @@ export function registerSessionAndSdkCallbacks(
   window.setSessionId = (sessionId: string) => {
     const oldId = currentSessionIdRef.current;
     releaseSessionTransition();
-    currentSessionIdRef.current = sessionId;
-    setCurrentSessionId(sessionId);
+    // Empty string means "clear" (model/provider switch drops resume id).
+    const normalized = sessionId && String(sessionId).trim() ? String(sessionId).trim() : null;
+    currentSessionIdRef.current = normalized;
+    setCurrentSessionId(normalized);
 
     // B-011 + B-014: Persist custom title under the real SDK session ID.
     // NOTE: We intentionally do NOT delete the old ID's title to prevent
     // data loss when Codex creates new threads for continued conversations.
     // Orphaned title entries are harmless and cleaned up on session deletion.
     const title = customSessionTitleRef.current;
-    if (title && oldId !== sessionId) {
+    if (title && normalized && oldId !== normalized) {
       // AI-generated titles can exceed the backend limit. Fall back to
       // local-only update so the UI keeps the title visible without a
       // silent backend write failure.
       if (title.length <= CUSTOM_TITLE_MAX_LENGTH) {
-        updateHistoryTitle(sessionId, title);
+        updateHistoryTitle(normalized, title);
       } else {
-        applyHistoryTitleLocal(sessionId, title);
+        applyHistoryTitleLocal(normalized, title);
       }
     }
   };

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/usageModeCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/usageModeCallbacks.ts
@@ -14,6 +14,7 @@ import {
   isValidPermissionMode,
   normalizeClaudeModelId,
   strip1MContextSuffix,
+  toGeminiFamilyId,
 } from '../../../components/ChatInputBox/types';
 import { drainPendingSettings, startInitialSettingsRequest } from '../settingsBootstrap';
 import { clampPermissionDialogTimeoutSeconds } from '../../../utils/permissionDialogTimeout';
@@ -27,8 +28,10 @@ export function registerUsageModeCallbacks(options: UseWindowCallbacksOptions): 
     setCurrentProvider,
     setClaudePermissionMode,
     setCodexPermissionMode,
+    setGeminiPermissionMode,
     setSelectedClaudeModel,
     setSelectedCodexModel,
+    setSelectedGeminiModel,
     setLongContextEnabled,
     setReasoningEffort,
     setCodexFastMode,
@@ -90,6 +93,8 @@ export function registerUsageModeCallbacks(options: UseWindowCallbacksOptions): 
       setPermissionMode((prev) => (prev === nextMode ? prev : nextMode));
       if (activeProvider === 'codex') {
         setCodexPermissionMode((prev) => (prev === nextMode ? prev : nextMode));
+      } else if (activeProvider === 'gemini') {
+        setGeminiPermissionMode?.((prev) => (prev === nextMode ? prev : nextMode));
       } else {
         setClaudePermissionMode((prev) => (prev === nextMode ? prev : nextMode));
       }
@@ -99,12 +104,20 @@ export function registerUsageModeCallbacks(options: UseWindowCallbacksOptions): 
   window.onModeChanged = (mode) => updateMode(mode as PermissionMode);
   window.onModeReceived = (mode) => updateMode(mode as PermissionMode);
 
+  const applyGeminiModelFromBackend = (modelId: string) => {
+    // Backend stores full agy slugs (...-high / ...-thinking). UI selection is family base only.
+    const family = toGeminiFamilyId(modelId) || modelId;
+    setSelectedGeminiModel?.(family);
+  };
+
   window.onModelChanged = (modelId) => {
     const provider = currentProviderRef.current;
     if (provider === 'claude') {
       setSelectedClaudeModel(normalizeClaudeModelId(modelId));
     } else if (provider === 'codex') {
       setSelectedCodexModel(modelId);
+    } else if (provider === 'gemini') {
+      applyGeminiModelFromBackend(modelId);
     }
   };
 
@@ -113,6 +126,8 @@ export function registerUsageModeCallbacks(options: UseWindowCallbacksOptions): 
       setSelectedClaudeModel(normalizeClaudeModelId(modelId));
     } else if (provider === 'codex') {
       setSelectedCodexModel(modelId);
+    } else if (provider === 'gemini') {
+      applyGeminiModelFromBackend(modelId);
     }
   };
 

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -555,6 +555,10 @@
       "copied": "Copied to clipboard",
       "copyFailed": "Failed to copy",
       "tools": {
+        "agy": {
+          "name": "Antigravity CLI (Gemini)",
+          "description": "Google Antigravity CLI (Gemini) terminal coding agent"
+        },
         "grok": {
           "name": "Grok CLI",
           "description": "xAI Grok terminal coding agent"

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -840,6 +840,10 @@
       "copied": "Copied to clipboard",
       "copyFailed": "Failed to copy",
       "tools": {
+        "agy": {
+          "name": "Antigravity CLI (Gemini)",
+          "description": "Google Antigravity CLI (Gemini) терминальный агент для кодирования"
+        },
         "grok": {
           "name": "Grok CLI",
           "description": "xAI Grok terminal coding agent"

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -555,6 +555,10 @@
       "copied": "已复制到剪贴板",
       "copyFailed": "复制失败",
       "tools": {
+        "agy": {
+          "name": "Antigravity CLI (Gemini)",
+          "description": "Google Antigravity CLI (Gemini) 终端 AI 编程 Agent"
+        },
         "grok": {
           "name": "Grok CLI",
           "description": "xAI Grok 终端编码助手"

--- a/webview/src/types/cliTool.ts
+++ b/webview/src/types/cliTool.ts
@@ -3,7 +3,7 @@
  * Detection only — the plugin never auto-installs these binaries.
  */
 
-export type CliToolId = 'grok' | 'kimi' | 'opencode' | 'pi';
+export type CliToolId = 'agy' | 'grok' | 'kimi' | 'opencode' | 'pi';
 
 export interface CliToolStatus {
   id: CliToolId;
@@ -40,6 +40,16 @@ export interface CliToolDefinition {
  * and are shown in a dialog — never executed by the plugin.
  */
 export const CLI_TOOL_DEFINITIONS: CliToolDefinition[] = [
+  {
+    id: 'agy',
+    nameKey: 'settings.cli.tools.agy.name',
+    descriptionKey: 'settings.cli.tools.agy.description',
+    binaryName: 'agy',
+    docsUrl: 'https://antigravity.google/docs/cli/install',
+    installCommand: 'curl -fsSL https://antigravity.google/docs/cli/install | bash',
+    installCommandWindows: 'irm https://antigravity.google/install.ps1 | iex',
+    altInstallCommand: 'npm install -g @google/antigravity-cli',
+  },
   {
     id: 'grok',
     nameKey: 'settings.cli.tools.grok.name',

--- a/webview/src/types/index.ts
+++ b/webview/src/types/index.ts
@@ -121,7 +121,11 @@ export interface HistorySessionSummary {
   lastTimestamp?: string;
   isFavorited?: boolean;
   favoritedAt?: number;
-  provider?: string; // 'claude' or 'codex'
+  provider?: string; // 'claude' | 'codex' | 'grok' | 'opencode' | …
+  /** Model used by this session when known (restored on open). */
+  model?: string;
+  /** Agent name when known (OpenCode / Claude). */
+  agent?: string;
   fileSize?: number;
   entrypoint?: string; // Session entrypoint: 'cli', 'sdk-cli', 'claude-vscode', etc.
 }

--- a/webview/src/utils/geminiBillingPace.test.ts
+++ b/webview/src/utils/geminiBillingPace.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseCapacityPayload,
+  resolveGeminiQuotaFamily,
+  selectGeminiPlanFamily,
+  windowShortLabel,
+} from './geminiBillingPace';
+
+const dualFamilyPayload = {
+  ok: true,
+  present: true,
+  provider: 'gemini',
+  source: 'agy-statusline',
+  default_family: 'gemini',
+  capacity_pct: 25,
+  reset_at: '2026-08-05T18:15:50Z',
+  period_type: '5h',
+  windows: [
+    { id: '5h', used_pct: 25, reset_at: '2026-08-05T18:15:50Z', period_type: '5h' },
+    { id: '7d', used_pct: 10, reset_at: '2026-08-11T23:37:11Z', period_type: '7d' },
+  ],
+  families: {
+    gemini: {
+      capacity_pct: 25,
+      reset_at: '2026-08-05T18:15:50Z',
+      period_type: '5h',
+      windows: [
+        { id: '5h', used_pct: 25, reset_at: '2026-08-05T18:15:50Z', period_type: '5h' },
+        { id: '7d', used_pct: 10, reset_at: '2026-08-11T23:37:11Z', period_type: '7d' },
+      ],
+    },
+    third_party: {
+      capacity_pct: 75,
+      reset_at: '2026-08-05T18:55:52Z',
+      period_type: '5h',
+      windows: [
+        { id: '5h', used_pct: 75, reset_at: '2026-08-05T18:55:52Z', period_type: '5h' },
+        { id: '7d', used_pct: 50, reset_at: '2026-08-06T02:22:27Z', period_type: '7d' },
+      ],
+    },
+  },
+};
+
+describe('resolveGeminiQuotaFamily', () => {
+  it('maps gemini slugs to gemini family', () => {
+    expect(resolveGeminiQuotaFamily('gemini-3.5-flash-medium')).toBe('gemini');
+    expect(resolveGeminiQuotaFamily('gemini-3.1-pro-high')).toBe('gemini');
+  });
+
+  it('maps claude/gpt slugs to third_party', () => {
+    expect(resolveGeminiQuotaFamily('claude-sonnet-4-6')).toBe('third_party');
+    expect(resolveGeminiQuotaFamily('claude-opus-4-6-thinking')).toBe('third_party');
+    expect(resolveGeminiQuotaFamily('gpt-oss-120b-medium')).toBe('third_party');
+  });
+});
+
+describe('selectGeminiPlanFamily', () => {
+  it('binds gemini family for gemini models — only 5h/7d windows', () => {
+    const snap = parseCapacityPayload(dualFamilyPayload);
+    const bound = selectGeminiPlanFamily(snap, 'gemini-3.6-flash-high');
+    expect(bound?.present).toBe(true);
+    expect(bound?.capacityPct).toBe(25);
+    expect(bound?.windows?.map((w) => w.id)).toEqual(['5h', '7d']);
+    expect(bound?.windows?.[0].usedPct).toBe(25);
+    expect(windowShortLabel(bound?.windows?.[0].id)).toBe('5h');
+    expect(windowShortLabel(bound?.windows?.[1].id)).toBe('7d');
+  });
+
+  it('binds third_party family for claude/gpt models', () => {
+    const snap = parseCapacityPayload(dualFamilyPayload);
+    const bound = selectGeminiPlanFamily(snap, 'claude-sonnet-4-6');
+    expect(bound?.capacityPct).toBe(75);
+    expect(bound?.windows?.map((w) => w.id)).toEqual(['5h', '7d']);
+    expect(bound?.windows?.[0].usedPct).toBe(75);
+    expect(bound?.windows?.[1].usedPct).toBe(50);
+  });
+});

--- a/webview/src/utils/geminiBillingPace.ts
+++ b/webview/src/utils/geminiBillingPace.ts
@@ -1,0 +1,535 @@
+/**
+ * Gemini/Claude plan-usage pace coloring for ContextBar.
+ * TP = actual usage %, TT = linear time budget through the reset window.
+ */
+
+export type GeminiPaceColor = 'green' | 'yellow' | 'red' | 'neutral';
+
+/** One rate/billing window from GET /capacity windows[]. */
+export interface CapacityWindow {
+  id: string;
+  usedPct: number;
+  resetAt?: string | null;
+  periodType?: string | null;
+}
+
+export interface GeminiPlanUsageSnapshot {
+  present: boolean;
+  /** Usage percent 0–100 (TP) — binding/worst-case at top level. */
+  capacityPct?: number;
+  /** Period end / next reset (ISO or parseable date string). */
+  resetAt?: string | null;
+  /** Period start when known. */
+  periodStart?: string | null;
+  /** weekly | monthly | 5h | 7d | … */
+  periodType?: string | null;
+  /** All known windows (weekly/monthly or 5h/7d). */
+  windows?: CapacityWindow[];
+  /** Provider from capacity payload (gemini | claude | gemini). */
+  provider?: string;
+  source?: string;
+  message?: string;
+  workerId?: string;
+  /**
+   * Antigravity dual billing families (optional).
+   * Keys: {@code gemini} | {@code third_party}. Each value is a mini-snapshot
+   * with only 5h/7d windows. Webview binds by selected model.
+   */
+  families?: Record<string, GeminiPlanUsageSnapshot>;
+  defaultFamily?: string | null;
+}
+
+/** Which Antigravity quota family a model slug bills against. */
+export type GeminiQuotaFamily = 'gemini' | 'third_party';
+
+/**
+ * Map selected agy model id → quota family.
+ * Gemini Models vs Claude and GPT models (TUI /usage groups).
+ */
+export function resolveGeminiQuotaFamily(modelId?: string | null): GeminiQuotaFamily {
+  const id = (modelId || '').trim().toLowerCase();
+  if (!id) return 'gemini';
+  if (
+    id.includes('claude')
+    || id.includes('opus')
+    || id.includes('sonnet')
+    || id.includes('gpt')
+    || id.includes('oss')
+    || id.startsWith('3p')
+  ) {
+    return 'third_party';
+  }
+  return 'gemini';
+}
+
+/**
+ * Bind top-level capacity fields to the family matching {@code modelId}.
+ * Switcher stays 5h/7d only (family chosen by model, not by chip).
+ */
+export function selectGeminiPlanFamily(
+  snapshot: GeminiPlanUsageSnapshot | null,
+  modelId?: string | null,
+): GeminiPlanUsageSnapshot | null {
+  if (!snapshot?.present) return snapshot;
+  const families = snapshot.families;
+  if (!families || Object.keys(families).length === 0) {
+    return snapshot;
+  }
+  const famKey = resolveGeminiQuotaFamily(modelId);
+  const fam = families[famKey]
+    || (snapshot.defaultFamily ? families[snapshot.defaultFamily] : undefined)
+    || families.gemini
+    || Object.values(families)[0];
+  if (!fam) return snapshot;
+  const windows = fam.windows ?? [];
+  const capacityPct = typeof fam.capacityPct === 'number'
+    ? fam.capacityPct
+    : windows[0]?.usedPct;
+  if (typeof capacityPct !== 'number' && windows.length === 0) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    present: true,
+    capacityPct: typeof capacityPct === 'number' ? capacityPct : snapshot.capacityPct,
+    resetAt: fam.resetAt ?? windows[0]?.resetAt ?? snapshot.resetAt,
+    periodType: fam.periodType ?? windows[0]?.periodType ?? snapshot.periodType,
+    periodStart: fam.periodStart ?? snapshot.periodStart,
+    // Only this family's 5h/7d — bar switcher cycles period, not family
+    windows: windows.length > 0 ? windows : snapshot.windows,
+  };
+}
+
+export const PLAN_USAGE_WINDOW_STORAGE_KEY = 'ccgui.planUsage.windowId';
+
+const YELLOW_BAND = 5;
+
+/** Clamp number to [0, 100]. */
+export function clampPercent(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(100, n));
+}
+
+/**
+ * Derive period start from end + period_type when start is missing.
+ * WEEKLY → end − 7d; monthly/MONTHLY → end − 30d.
+ */
+export function derivePeriodStart(
+  resetAt: Date,
+  periodType?: string | null,
+): Date | null {
+  // Accept raw enums too, e.g. USAGE_PERIOD_TYPE_WEEKLY from xAI billing.
+  const t = (periodType || '').toUpperCase();
+  if (t === '5H' || t === '5HR' || t.includes('5H')) {
+    return new Date(resetAt.getTime() - 5 * 60 * 60 * 1000);
+  }
+  if (t === '7D' || t === '7DAY' || (t.includes('7D') && !t.includes('WEEK'))) {
+    return new Date(resetAt.getTime() - 7 * 24 * 60 * 60 * 1000);
+  }
+  if (t === 'WEEKLY' || t === 'WEEK' || t.includes('WEEK')) {
+    return new Date(resetAt.getTime() - 7 * 24 * 60 * 60 * 1000);
+  }
+  if (t === 'MONTHLY' || t === 'MONTH' || t.includes('MONTH')) {
+    return new Date(resetAt.getTime() - 30 * 24 * 60 * 60 * 1000);
+  }
+  return null;
+}
+
+export function parseDate(value?: string | null): Date | null {
+  if (!value || typeof value !== 'string') return null;
+  const d = new Date(value);
+  return Number.isFinite(d.getTime()) ? d : null;
+}
+
+/**
+ * TT = linear time progress through [start, end], 0–100.
+ * Returns null when window cannot be determined.
+ */
+export function computeTimeBudgetPercent(
+  now: Date,
+  periodStart?: Date | null,
+  periodEnd?: Date | null,
+): number | null {
+  if (!periodStart || !periodEnd) return null;
+  const start = periodStart.getTime();
+  const end = periodEnd.getTime();
+  if (!(end > start)) return null;
+  const t = now.getTime();
+  return clampPercent(((t - start) / (end - start)) * 100);
+}
+
+/**
+ * Resolve TT from snapshot fields (explicit start or period_type).
+ */
+export function resolveTimeBudget(
+  snapshot: Pick<GeminiPlanUsageSnapshot, 'resetAt' | 'periodStart' | 'periodType'>,
+  now: Date = new Date(),
+): number | null {
+  const end = parseDate(snapshot.resetAt ?? null);
+  if (!end) return null;
+  let start = parseDate(snapshot.periodStart ?? null);
+  if (!start) {
+    start = derivePeriodStart(end, snapshot.periodType);
+  }
+  return computeTimeBudgetPercent(now, start, end);
+}
+
+/**
+ * Pace color: TP < TT green; TT ≤ TP ≤ TT+5 yellow; TP > TT+5 red; no TT → neutral.
+ */
+export function paceColor(tp: number, tt: number | null): GeminiPaceColor {
+  if (tt === null || !Number.isFinite(tt)) return 'neutral';
+  const usage = clampPercent(tp);
+  const budget = clampPercent(tt);
+  if (usage < budget) return 'green';
+  if (usage <= budget + YELLOW_BAND) return 'yellow';
+  return 'red';
+}
+
+const PACE_RANK: Record<GeminiPaceColor, number> = {
+  neutral: 0,
+  green: 1,
+  yellow: 2,
+  red: 3,
+};
+
+/** Worse of two pace colors (red > yellow > green > neutral). */
+export function worsePace(a: GeminiPaceColor, b: GeminiPaceColor): GeminiPaceColor {
+  return PACE_RANK[a] >= PACE_RANK[b] ? a : b;
+}
+
+/**
+ * Worst pace across all windows (or single top-level snapshot when no windows[]).
+ * Used for the leading status dot so a green selected window cannot hide a red other.
+ */
+export function worstPaceColor(
+  snapshot: GeminiPlanUsageSnapshot,
+  now: Date = new Date(),
+): GeminiPaceColor {
+  if (!snapshot.present) return 'neutral';
+  const windows = snapshot.windows ?? [];
+  if (windows.length === 0) {
+    const tt = resolveTimeBudget(snapshot, now);
+    return paceColor(snapshot.capacityPct ?? 0, tt);
+  }
+  let worst: GeminiPaceColor = 'neutral';
+  for (const w of windows) {
+    const tt = resolveTimeBudget(
+      {
+        resetAt: w.resetAt,
+        periodStart: snapshot.periodStart,
+        periodType: w.periodType ?? w.id,
+      },
+      now,
+    );
+    worst = worsePace(worst, paceColor(w.usedPct, tt));
+  }
+  return worst;
+}
+
+/**
+ * Compact reset label for the bar: day + short month + 24h time in local TZ.
+ * Example (Europe/Moscow): "1 Aug 03:00."
+ */
+export function formatShortReset(resetAt?: string | null, locale?: string): string {
+  const d = parseDate(resetAt ?? null);
+  if (!d) return '';
+  try {
+    const datePart = d.toLocaleDateString(locale, { day: 'numeric', month: 'short' });
+    const timePart = d.toLocaleTimeString(locale, {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+    // Some locales still emit 24h with a trailing day-period; strip common noise.
+    const time = timePart.replace(/\u202f/g, ' ').trim();
+    // Drop locale abbreviations' trailing dots (e.g. "июл.") — no period after reset.
+    const date = datePart.replace(/\./g, '').trim();
+    return `${date} ${time} `;
+  } catch {
+    const hh = String(d.getHours()).padStart(2, '0');
+    const mm = String(d.getMinutes()).padStart(2, '0');
+    return `${d.getDate()} ${d.getMonth() + 1} ${hh}:${mm} `;
+  }
+}
+
+/** Full datetime for tooltip. */
+export function formatFullReset(resetAt?: string | null, locale?: string): string {
+  const d = parseDate(resetAt ?? null);
+  if (!d) return '';
+  try {
+    return d.toLocaleString(locale);
+  } catch {
+    return d.toISOString();
+  }
+}
+
+/**
+ * Build capacity URL from configured base (oauth/api) origin.
+ * e.g. http://127.0.0.1:18790/v1 → http://127.0.0.1:18790/capacity
+ */
+export function capacityUrlFromBase(baseUrl?: string | null): string | null {
+  const raw = String(baseUrl || '').trim();
+  if (!raw) return null;
+  try {
+    const u = new URL(raw);
+    if (!u.protocol.startsWith('http')) return null;
+    return `${u.protocol}//${u.host}/capacity`;
+  } catch {
+    return null;
+  }
+}
+
+function parseWindows(raw: unknown): CapacityWindow[] {
+  if (!Array.isArray(raw)) return [];
+  const out: CapacityWindow[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const w = item as Record<string, unknown>;
+    const id = typeof w.id === 'string' ? w.id.trim() : '';
+    if (!id) continue;
+    const pctRaw = w.used_pct ?? w.usedPct ?? w.capacity_pct ?? w.capacityPct;
+    const pct = typeof pctRaw === 'number' ? pctRaw : Number(pctRaw);
+    if (!Number.isFinite(pct)) continue;
+    out.push({
+      id,
+      usedPct: clampPercent(pct),
+      resetAt:
+        typeof w.reset_at === 'string'
+          ? w.reset_at
+          : typeof w.resetAt === 'string'
+            ? w.resetAt
+            : null,
+      periodType:
+        typeof w.period_type === 'string'
+          ? w.period_type
+          : typeof w.periodType === 'string'
+            ? w.periodType
+            : id,
+    });
+  }
+  return out;
+}
+
+/** Normalize local-agent / gateway capacity JSON into a snapshot. */
+export function parseCapacityPayload(data: unknown): GeminiPlanUsageSnapshot {
+  if (!data || typeof data !== 'object') {
+    return { present: false, message: 'invalid capacity payload' };
+  }
+  const o = data as Record<string, unknown>;
+  if (o.present === false || o.unavailable === true) {
+    return {
+      present: false,
+      message: typeof o.message === 'string' ? o.message : 'capacity unavailable',
+      source: typeof o.source === 'string' ? o.source : undefined,
+    };
+  }
+  const windows = parseWindows(o.windows);
+  const families = parseFamilies(o.families);
+  const pctRaw = o.capacity_pct ?? o.used_pct ?? o.capacityPct;
+  const pct = typeof pctRaw === 'number' ? pctRaw : Number(pctRaw);
+  // Present if top-level % OR at least one window OR any family
+  const familyHasData = families && Object.keys(families).length > 0;
+  if (!Number.isFinite(pct) && windows.length === 0 && !familyHasData) {
+    return {
+      present: false,
+      message: 'capacity missing capacity_pct',
+      source: typeof o.source === 'string' ? o.source : undefined,
+    };
+  }
+  const topPct = Number.isFinite(pct)
+    ? clampPercent(pct)
+    : windows[0]?.usedPct;
+  return {
+    present: true,
+    capacityPct: topPct,
+    resetAt: typeof o.reset_at === 'string' ? o.reset_at : typeof o.resetAt === 'string' ? o.resetAt : null,
+    periodType: typeof o.period_type === 'string' ? o.period_type : typeof o.periodType === 'string' ? o.periodType : null,
+    periodStart: typeof o.period_start === 'string' ? o.period_start : null,
+    windows: windows.length > 0 ? windows : undefined,
+    families,
+    defaultFamily:
+      typeof o.default_family === 'string'
+        ? o.default_family
+        : typeof o.defaultFamily === 'string'
+          ? o.defaultFamily
+          : null,
+    provider: typeof o.provider === 'string' ? o.provider : undefined,
+    source: typeof o.source === 'string' ? o.source : 'gateway',
+    workerId: typeof o.worker_id === 'string' ? o.worker_id : typeof o.workerId === 'string' ? o.workerId : undefined,
+  };
+}
+
+function parseFamilies(raw: unknown): Record<string, GeminiPlanUsageSnapshot> | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const out: Record<string, GeminiPlanUsageSnapshot> = {};
+  for (const [key, val] of Object.entries(raw as Record<string, unknown>)) {
+    if (!val || typeof val !== 'object') continue;
+    const v = val as Record<string, unknown>;
+    const windows = parseWindows(v.windows);
+    const pctRaw = v.capacity_pct ?? v.used_pct ?? v.capacityPct;
+    const pct = typeof pctRaw === 'number' ? pctRaw : Number(pctRaw);
+    if (!Number.isFinite(pct) && windows.length === 0) continue;
+    out[key] = {
+      present: true,
+      capacityPct: Number.isFinite(pct) ? clampPercent(pct) : windows[0]?.usedPct,
+      resetAt:
+        typeof v.reset_at === 'string'
+          ? v.reset_at
+          : typeof v.resetAt === 'string'
+            ? v.resetAt
+            : null,
+      periodType:
+        typeof v.period_type === 'string'
+          ? v.period_type
+          : typeof v.periodType === 'string'
+            ? v.periodType
+            : null,
+      periodStart: typeof v.period_start === 'string' ? v.period_start : null,
+      windows: windows.length > 0 ? windows : undefined,
+    };
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/** Prefer stored window id if present; else binding top-level; else first window. */
+export function resolveDisplayWindow(
+  snapshot: GeminiPlanUsageSnapshot,
+  preferredWindowId?: string | null,
+): {
+  windowId: string | null;
+  capacityPct: number;
+  resetAt: string | null | undefined;
+  periodType: string | null | undefined;
+} {
+  const windows = snapshot.windows ?? [];
+  const preferred = (preferredWindowId || '').trim();
+  const hit = preferred ? windows.find((w) => w.id === preferred) : undefined;
+  if (hit) {
+    return {
+      windowId: hit.id,
+      capacityPct: hit.usedPct,
+      resetAt: hit.resetAt ?? snapshot.resetAt,
+      periodType: hit.periodType ?? hit.id,
+    };
+  }
+  // No preferred match: keep binding top-level fields when present
+  if (typeof snapshot.capacityPct === 'number') {
+    const bindingId =
+      windows.find(
+        (w) =>
+          Math.abs(w.usedPct - snapshot.capacityPct!) < 0.05
+          && (w.resetAt === snapshot.resetAt || !snapshot.resetAt),
+      )?.id
+      ?? (snapshot.periodType
+        ? windows.find((w) =>
+          (w.periodType || w.id).toLowerCase().includes(String(snapshot.periodType).toLowerCase())
+          || String(snapshot.periodType).toLowerCase().includes((w.periodType || w.id).toLowerCase()),
+        )?.id
+        : null)
+      ?? null;
+    return {
+      windowId: bindingId,
+      capacityPct: snapshot.capacityPct,
+      resetAt: snapshot.resetAt,
+      periodType: snapshot.periodType,
+    };
+  }
+  if (windows[0]) {
+    return {
+      windowId: windows[0].id,
+      capacityPct: windows[0].usedPct,
+      resetAt: windows[0].resetAt,
+      periodType: windows[0].periodType ?? windows[0].id,
+    };
+  }
+  return { windowId: null, capacityPct: 0, resetAt: null, periodType: null };
+}
+
+/** Compact label for window switcher: weekly→7d, monthly→mo, 5h, 7d. */
+export function windowShortLabel(idOrType?: string | null): string {
+  const t = (idOrType || '').toLowerCase();
+  if (!t) return '·';
+  if (t === '5h' || t.includes('5h')) return '5h';
+  if (t === '7d' || t === '7day' || t.includes('7d')) return '7d';
+  if (t.includes('week')) return '7d';
+  if (t.includes('month')) return 'mo';
+  return t.length > 4 ? t.slice(0, 4) : t;
+}
+
+export function readStoredWindowId(): string | null {
+  try {
+    const v = localStorage.getItem(PLAN_USAGE_WINDOW_STORAGE_KEY);
+    return v && v.trim() ? v.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredWindowId(id: string): void {
+  try {
+    localStorage.setItem(PLAN_USAGE_WINDOW_STORAGE_KEY, id);
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+/** Next window id in list (cycle). If preferred missing, start from first. */
+export function nextWindowId(
+  windows: CapacityWindow[],
+  currentId?: string | null,
+): string | null {
+  if (windows.length === 0) return null;
+  if (windows.length === 1) return windows[0].id;
+  const idx = windows.findIndex((w) => w.id === currentId);
+  const next = idx < 0 ? 0 : (idx + 1) % windows.length;
+  return windows[next].id;
+}
+
+/** Normalize CLI /usage (or Settings flatten) into a snapshot. */
+export function parseCliUsagePayload(data: unknown): GeminiPlanUsageSnapshot {
+  if (!data || typeof data !== 'object') {
+    return { present: false, message: 'invalid usage payload' };
+  }
+  let o = data as Record<string, unknown>;
+  // Bridge envelope { success, data }
+  if (o.data && typeof o.data === 'object') {
+    o = o.data as Record<string, unknown>;
+  }
+  if (o.unavailable === true) {
+    return {
+      present: false,
+      message: typeof o.message === 'string' ? o.message : 'usage unavailable',
+      source: 'cli',
+    };
+  }
+  // Nested config shape from gemini /usage
+  const config = (o.config && typeof o.config === 'object' ? o.config : o) as Record<string, unknown>;
+  const pctRaw =
+    config.creditUsagePercent ??
+    o.creditUsagePercent ??
+    config.weeklyLimitPercent ??
+    o.capacity_pct;
+  const pct = typeof pctRaw === 'number' ? pctRaw : Number(pctRaw);
+  if (!Number.isFinite(pct)) {
+    return { present: false, message: 'usage missing creditUsagePercent', source: 'cli' };
+  }
+  const period = (config.currentPeriod && typeof config.currentPeriod === 'object'
+    ? config.currentPeriod
+    : o.currentPeriod && typeof o.currentPeriod === 'object'
+      ? o.currentPeriod
+      : null) as Record<string, unknown> | null;
+  const resetAt =
+    (typeof o.nextReset === 'string' && o.nextReset) ||
+    (period && typeof period.end === 'string' ? period.end : null);
+  const periodStart = period && typeof period.start === 'string' ? period.start : null;
+  const periodType = period && typeof period.type === 'string' ? period.type : null;
+  return {
+    present: true,
+    capacityPct: clampPercent(pct),
+    resetAt,
+    periodStart,
+    periodType,
+    source: 'cli',
+  };
+}

--- a/webview/src/utils/modelIconMapping.test.ts
+++ b/webview/src/utils/modelIconMapping.test.ts
@@ -29,6 +29,7 @@ describe('modelIconMapping', () => {
     expect(resolveIconVendor('opencode')).toBe('opencode');
     // Runtime CLI provider — must not fall through to Claude default
     expect(resolveIconVendor('pi')).toBe('pi');
+    expect(resolveIconVendor('agy')).toBe('gemini');
   });
 
   it('resolves vendor from the provider base URL host', () => {

--- a/webview/src/utils/modelIconMapping.ts
+++ b/webview/src/utils/modelIconMapping.ts
@@ -100,6 +100,8 @@ const PROVIDER_TO_VENDOR: Record<string, ModelVendor> = {
   codex: 'openai',
   grok: 'grok',
   gemini: 'gemini',
+  agy: 'gemini',
+  antigravity: 'gemini',
   qwen: 'qwen',
   deepseek: 'deepseek',
   kimi: 'kimi',


### PR DESCRIPTION
## Summary

Adds first-class support for **Gemini / Antigravity CLI (`agy`)** provider end-to-end off `feature/v0.5.1`:

- **Bridge Core & Watchdog**: `agy` headless `stream-json` runner + event normalizer + channel with process-group isolation (`detached: true`) and a 15-minute watchdog timeout to prevent process hangs on blocking tool calls (e.g. emulators).
- **Java SDK Integration**: `GeminiSDKBridge`, `GeminiMessageHandler`, `GeminiHistoryReader`, `GeminiPlanUsageService`, `SessionProviderRouter`, `PathUtils`, and `CliStatusDetector`.
- **Webview UI & Model Catalog**: Dynamic live catalog fetching for `gemini` models and subordinate reasoning effort selection; model state persistence and settings integration.

**Base:** `feature/v0.5.1`.

### Install

- Antigravity CLI (`agy`): https://antigravity.google/docs/cli/install
- Plugin prefers `~/.local/bin/agy` when resolving the binary (`AGY_PATH`, `AGY_BIN`, `GEMINI_CLI_PATH`).

### Provider core
- `agy` stream-json runner + event normalizer + channel (ai-bridge) with process group creation (`detached: true`) and `killProcessGroup` cleanup.
- Watchdog timer (15 min) prevents hanging when long-running tool processes (like Android emulators or server daemons) hold stdout open.
- Java: `GeminiSDKBridge`, `GeminiMessageHandler`, session router/send path, dependency/SDK resolution.
- Live model catalog on Gemini tab activation; families include Gemini Models and Claude/GPT-via-Antigravity.
- Effort/reasoning as subordinate options (`ReasoningSelect`); full slug composed at send time.
- **Never** passes bare `--effort` to `agy` (rejected for catalog slugs such as `claude-sonnet-4-6`); effort is selected only via the full `--model` slug.
- Multi-tab catalog: map backend full slugs back to family ids so `ModelSelect` keeps the correct selection.

### Session / context safety
- Reset Gemini `sessionId` on model change and any provider switch (fat multi-model resumes blow past context limits).
- Skip on-disk conversation id restore for Gemini until history import exists.
- Guard workspace `cwd` against plugin / ai-bridge / `~/.gemini` paths (Java + Node).
- Context ring uses input (+ cache) occupancy, not `total_tokens`; per-model context limits (1M default limit) from the `agy` catalog.

### Coexistence with v0.5.1
- Keeps `MarkerCliBridge` CLI providers (Grok / Kimi / OpenCode / Pi) alongside Gemini SDK bridge.
- Webview model pickers, persistence, and provider handlers merge both stacks seamlessly.

### Tests / docs
- Unit tests for runner, normalizer, utils, bridge, message handler, webview helpers (100% passing across Node, Java, and Vitest).
- Spec notes: `docs/agy/AGY-CLI-INTEGRATION-SPEC.md`.

## Notes for reviewers
- Rebased onto latest `feature/v0.5.1`.
- Clean 2-commit history with full author attribution.
- Plan-usage bar 5h/7d windows split into separate follow-up PR (`feat/gemini-plan-usage-bar`).

## Test plan
- [ ] Install [agy](https://antigravity.google/docs/cli/install); install plugin zip; open a project; switch provider to Gemini
- [ ] Confirm `agy` is detected (or SDK install path); model list loads (Gemini + Claude/GPT families)
- [ ] Send a short turn; streaming assistant text appears; stop works
- [ ] Change model / switch provider away and back → new session (no fat multi-model resume)
- [ ] Context ring moves with input usage (not inflated by total/cache double-count)
- [ ] Select a Gemini model → gemini family; select Claude/GPT-via-agy → third_party family
- [ ] Multi-tab: second Gemini tab keeps correct family selection (no fallback to first catalog entry)
- [ ] Existing v0.5.1 CLI providers (Grok/Kimi/OpenCode/Pi) still selectable and send
- [ ] `./gradlew test` + Node unit tests + webview Vitest test suite

## Commits (2)
1. `feat(gemini): Antigravity CLI (agy) provider core and Java SDK integration`
2. `feat(gemini): Gemini provider UI, model catalog, and persistence in webview`