### PR TITLE
fix: teach the changelog dialog to embrace bold, italic, and bold-italic text

### DIFF
--- a/webview/src/components/ChangelogDialog.tsx
+++ b/webview/src/components/ChangelogDialog.tsx
@@ -21,9 +21,27 @@ function resolveContent(entry: ChangelogEntry): string[] {
   return parts;
 }
 
+const INLINE_CODE_RE = /`([^`]+)`/g;
+const BOLD_ITALIC_RE = /\*\*\*([^*]+)\*\*\*/g;
+const BOLD_RE = /\*\*([^*]+)\*\*/g;
+const ITALIC_RE = /\*([^*]+)\*/g;
+
+/**
+ * Apply inline markdown formatting: inline code, bold, italic, and bold-italic.
+ * Must run after HTML escaping, which preserves `*` and backticks. The emphasis
+ * patterns are matched longest-first so `***x***` is not swallowed by `**`/`*`.
+ */
+function renderInline(text: string): string {
+  return escapeHtml(text)
+    .replace(INLINE_CODE_RE, '<code>$1</code>')
+    .replace(BOLD_ITALIC_RE, '<strong><em>$1</em></strong>')
+    .replace(BOLD_RE, '<strong>$1</strong>')
+    .replace(ITALIC_RE, '<em>$1</em>');
+}
+
 /**
  * Simple markdown-to-HTML renderer for changelog content.
- * Handles: headings, bullet lists, bold, inline code, and emoji.
+ * Handles: headings, bullet lists, bold, italic, inline code, and emoji.
  */
 function renderChangelogMarkdown(text: string): string {
   if (!text) return '';
@@ -49,11 +67,7 @@ function renderChangelogMarkdown(text: string): string {
         htmlParts.push('<ul>');
         inList = true;
       }
-      const itemText = escapeHtml(trimmed.substring(2)).replace(
-        /`([^`]+)`/g,
-        '<code>$1</code>'
-      );
-      htmlParts.push(`<li>${itemText}</li>`);
+      htmlParts.push(`<li>${renderInline(trimmed.substring(2))}</li>`);
       continue;
     }
 
@@ -80,7 +94,7 @@ function renderChangelogMarkdown(text: string): string {
     }
 
     // Plain text
-    htmlParts.push(`<p>${escapeHtml(trimmed)}</p>`);
+    htmlParts.push(`<p>${renderInline(trimmed)}</p>`);
   }
 
   if (inList) {


### PR DESCRIPTION
The hand-rolled markdown renderer in ChangelogDialog only highlighted a subset of inline syntax, so **bold** appeared literally instead of being rendered. Extract inline formatting into a shared renderInline helper that handles inline code plus all three emphasis forms, matching longest-first so ***bold-italic*** is not swallowed by **/** patterns. Reuse it for both list items and plain paragraphs, which also closes a gap where paragraphs skipped inline code entirely. Hoist the emphasis regexes to module scope since they run once per line while rendering.