### PR TITLE
fix(theme): repaint all open sessions on IDE theme change

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
@@ -28,6 +28,10 @@ public class SettingsHandler extends BaseMessageHandler {
     private final NodePathHandler nodePathHandler;
     private final ClaudeCliPathHandler claudeCliPathHandler;
     private final ProjectConfigHandler projectConfigHandler;
+    // Handle for the theme-change callback registered with ThemeConfigService.
+    // Kept so it can be cleanly unregistered when the owning window is disposed,
+    // preventing notifications to disposed webviews (issue #1586).
+    private ThemeConfigService.RegisteredCallback themeCallbackHandle;
     private final CodexSubscriptionQuotaHandler codexSubscriptionQuotaHandler;
     private final TokenTrackerHandler tokenTrackerHandler;
 
@@ -124,13 +128,27 @@ public class SettingsHandler extends BaseMessageHandler {
 
     /**
      * Register theme change listener.
+     * Uses the multi-callback API so that every open ClaudeChatWindow receives
+     * theme change notifications. The returned handle is stored for clean
+     * unregistration in {@link #dispose()}.
      */
     private void registerThemeChangeListener() {
-        ThemeConfigService.registerThemeChangeListener(themeConfig -> {
+        themeCallbackHandle = ThemeConfigService.registerThemeChangeListener(themeConfig -> {
             ApplicationManager.getApplication().invokeLater(() -> {
                 callJavaScript("window.onIdeThemeChanged", escapeJs(themeConfig.toString()));
             });
-        });
+        }, true);
+    }
+
+    /**
+     * Unregister the theme change callback to prevent notifications to a disposed webview.
+     * Should be called when the owning ClaudeChatWindow is disposed.
+     */
+    public void dispose() {
+        if (themeCallbackHandle != null) {
+            ThemeConfigService.unregisterThemeChangeListener(themeCallbackHandle);
+            themeCallbackHandle = null;
+        }
     }
 
     @Override

--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -130,6 +130,8 @@ public class ChatWindowDelegate {
     private ScheduledFuture<?> statusResetTask;
     private volatile String pendingQuickFixPrompt = null;
     private volatile MessageCallback pendingQuickFixCallback = null;
+    // Reference to the SettingsHandler for clean theme-callback unregistration on dispose.
+    private com.github.claudecodegui.handler.SettingsHandler settingsHandler;
 
     public ChatWindowDelegate(DelegateHost host) {
         this.host = host;
@@ -343,7 +345,8 @@ public class ChatWindowDelegate {
         messageDispatcher.registerHandler(new CodexPetHandler(handlerContext));
         messageDispatcher.registerHandler(new SkillHandler(handlerContext));
         messageDispatcher.registerHandler(new FileHandler(handlerContext));
-        messageDispatcher.registerHandler(new SettingsHandler(handlerContext));
+        this.settingsHandler = new SettingsHandler(handlerContext);
+        messageDispatcher.registerHandler(this.settingsHandler);
         messageDispatcher.registerHandler(new SessionHandler(handlerContext));
         messageDispatcher.registerHandler(new ContextHandler(handlerContext));
         messageDispatcher.registerHandler(new FileExportHandler(handlerContext));
@@ -751,6 +754,13 @@ public class ChatWindowDelegate {
             statusResetTask.cancel(false);
             statusResetTask = null;
             LOG.debug("[TabStatus] Cancelled pending status reset task");
+        }
+        // Unregister the theme-change callback to prevent notifications to the disposed webview.
+        // This fixes the "Cannot call JS function window.onIdeThemeChanged: disposed=true" warning
+        // and ensures stale sessions don't interfere with theme updates for remaining windows.
+        if (settingsHandler != null) {
+            settingsHandler.dispose();
+            settingsHandler = null;
         }
     }
 }

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -32,6 +32,7 @@ import com.github.claudecodegui.ui.detached.DetachedChatFrame;
 import com.github.claudecodegui.ui.detached.DetachedWindowManager;
 import com.github.claudecodegui.util.HtmlLoader;
 import com.github.claudecodegui.util.JsUtils;
+import com.github.claudecodegui.util.ThemeConfigService;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -151,6 +152,11 @@ public class ClaudeChatWindow {
     // Daemon event listener for AI title forwarding. Held so it can be removed on dispose.
     private DaemonBridge.DaemonEventListener titleEventListener;
     private volatile int fetchedSlashCommandsCount = 0;
+
+    // Theme-change callback handle for updating Swing component backgrounds (mainPanel, browser).
+    // Separate from the SettingsHandler's JS-notification callback: this one ensures the Java-side
+    // Swing containers repaint with the new theme color, not just the webview's CSS.
+    private ThemeConfigService.RegisteredCallback swingThemeCallbackHandle;
 
     // Coalesces session_updated reloads. SessionState's message list is not
     // thread-safe and loadFromServer() runs async, so concurrent background-task
@@ -390,6 +396,32 @@ public class ClaudeChatWindow {
             }
         });
         editorContextTracker.registerListeners();
+
+        // Register a Swing-level theme change callback to update the background color of
+        // mainPanel and the browser component when the IDE theme changes. This ensures
+        // Java-side containers repaint with the correct color, complementing the webview's
+        // CSS theme update (handled by SettingsHandler). Fixes issue #1586.
+        swingThemeCallbackHandle = ThemeConfigService.registerThemeChangeListener(themeConfig -> {
+            ApplicationManager.getApplication().invokeLater(() -> {
+                if (disposed) {
+                    return;
+                }
+                Color bgColor = ThemeConfigService.getBackgroundColor();
+                mainPanel.setBackground(bgColor);
+                JBCefBrowser currentBrowser = browser;
+                if (currentBrowser != null) {
+                    try {
+                        java.awt.Component browserComp = currentBrowser.getComponent();
+                        if (browserComp != null) {
+                            browserComp.setBackground(bgColor);
+                        }
+                    } catch (Exception | LinkageError e) {
+                        LOG.debug("Failed to update browser component background on theme change: " + e.getMessage());
+                    }
+                }
+                mainPanel.repaint();
+            });
+        }, true);
 
         this.webviewInitializer = new WebviewInitializer(createWebviewHost());
 
@@ -2717,6 +2749,12 @@ public class ClaudeChatWindow {
         chatWindowDelegate.dispose();
         editorContextTracker.dispose();
         streamCoalescer.dispose();
+        // Unregister the Swing-level theme change callback to prevent background updates
+        // on a disposed panel. The SettingsHandler's callback is cleaned up via chatWindowDelegate.dispose().
+        if (swingThemeCallbackHandle != null) {
+            ThemeConfigService.unregisterThemeChangeListener(swingThemeCallbackHandle);
+            swingThemeCallbackHandle = null;
+        }
         Disposer.dispose(surfaceRefreshAlarmDisposable);
         deferredReloadSafetyAlarm.cancelAllRequests();
         Disposer.dispose(safetyAlarmDisposable);

--- a/src/main/java/com/github/claudecodegui/util/ThemeConfigService.java
+++ b/src/main/java/com/github/claudecodegui/util/ThemeConfigService.java
@@ -9,6 +9,8 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 
 import java.awt.Color;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * IDE theme configuration service.
@@ -31,9 +33,32 @@ public class ThemeConfigService {
     public static final Color LIGHT_BG_COLOR = Color.WHITE;             // #ffffff
     public static final String DARK_BG_HEX = "#1e1e1e";
     public static final String LIGHT_BG_HEX = "#ffffff";
-    private static ThemeChangeCallback themeChangeCallback = null;
+    private static ThemeChangeCallback themeChangeCallback = null; // Deprecated: kept for backward compatibility
     private static Boolean lastKnownIsDark = null; // Cache the last known theme state for deduplication
     private static boolean listenerRegistered = false;
+
+    // Multi-callback support: each ClaudeChatWindow registers its own callback so that
+    // theme changes are delivered to every open session, not just the last one registered.
+    // CopyOnWriteArraySet ensures safe iteration on the LafManager thread without explicit locking.
+    private static final CopyOnWriteArraySet<RegisteredCallback> themeChangeCallbacks = new CopyOnWriteArraySet<>();
+    private static final AtomicLong callbackIdSeq = new AtomicLong(0);
+
+    /**
+     * Opaque handle returned by {@link #registerThemeChangeListener(ThemeChangeCallback, boolean)}
+     * for later unregistration via {@link #unregisterThemeChangeListener(RegisteredCallback)}.
+     */
+    public static final class RegisteredCallback {
+        private final long id;
+        private final ThemeChangeCallback callback;
+
+        RegisteredCallback(long id, ThemeChangeCallback callback) {
+            this.id = id;
+            this.callback = callback;
+        }
+
+        long getId() { return id; }
+        ThemeChangeCallback getCallback() { return callback; }
+    }
 
     /**
      * Callback interface for theme changes.
@@ -43,26 +68,83 @@ public class ThemeConfigService {
     }
 
     /**
-     * Register a theme change listener.
-     * Uses LafManagerListener to listen for all Look and Feel changes.
+     * Register a theme change listener (backward-compatible single-callback overload).
      *
-     * The listener fires in these situations:
-     * - User manually switches theme (View - Appearance - Theme)
-     * - IDE follows OS theme changes (Settings - Sync with OS enabled)
-     * - Toggling Sync with OS causes an actual theme change
-     * - Installing or switching to a custom theme
+     * <p>This overload replaces the legacy single-callback field. New callers should prefer
+     * {@link #registerThemeChangeListener(ThemeChangeCallback, boolean)} which returns a
+     * handle that can be used for clean unregistration on dispose.
      *
-     * Notes:
-     * - The listener is registered once (Application level) and remains active for the IDE's lifetime
-     * - Each call updates the callback, supporting project close/reopen scenarios
+     * @param callback the callback to invoke on theme change
      */
     public static void registerThemeChangeListener(ThemeChangeCallback callback) {
-        // Always update the callback to support project reopen scenarios
-        // Even if listenerRegistered is true, the callback needs updating after project reopen
+        registerThemeChangeListener(callback, false);
+    }
+
+    /**
+     * Register a theme change listener and return a handle for later unregistration.
+     *
+     * <p>Each {@link com.github.claudecodegui.ui.toolwindow.ClaudeChatWindow ClaudeChatWindow}
+     * registers its own callback so that theme changes are delivered to <em>every</em> open
+     * session, not just the last one registered. The returned handle should be passed to
+     * {@link #unregisterThemeChangeListener(RegisteredCallback)} when the window is disposed
+     * to prevent notifications to disposed webviews.
+     *
+     * <p>The listener is registered once at the Application level and remains active for the
+     * IDE's lifetime. Multiple callbacks can coexist and are all notified on each theme change.
+     *
+     * @param callback the callback to invoke on theme change
+     * @param returnHandle if {@code true}, returns a {@link RegisteredCallback} handle for
+     *                     later unregistration; if {@code false}, returns {@code null}
+     * @return a handle for unregistration, or {@code null} if {@code returnHandle} is false
+     */
+    public static RegisteredCallback registerThemeChangeListener(ThemeChangeCallback callback, boolean returnHandle) {
+        // Always update the legacy single-callback field for backward compatibility
+        // with any code path that still reads it directly.
         themeChangeCallback = callback;
         LOG.info("[ThemeConfig] Theme change callback updated");
 
         // Register the listener only once (Application level)
+        ensureListenerRegistered();
+
+        RegisteredCallback handle = null;
+        if (returnHandle && callback != null) {
+            handle = new RegisteredCallback(callbackIdSeq.incrementAndGet(), callback);
+            themeChangeCallbacks.add(handle);
+            LOG.info("[ThemeConfig] Multi-callback registered (id=" + handle.getId()
+                    + ", total=" + themeChangeCallbacks.size() + ")");
+        }
+
+        return handle;
+    }
+
+    /**
+     * Unregister a previously registered theme change callback.
+     *
+     * <p>Should be called when a {@link com.github.claudecodegui.ui.toolwindow.ClaudeChatWindow}
+     * is disposed, so that theme changes no longer attempt to call JavaScript on a disposed
+     * webview (which logs the warning "Cannot call JS function window.onIdeThemeChanged: disposed=true").
+     *
+     * @param handle the handle returned by {@link #registerThemeChangeListener(ThemeChangeCallback, boolean)}
+     */
+    public static void unregisterThemeChangeListener(RegisteredCallback handle) {
+        if (handle == null) {
+            return;
+        }
+        boolean removed = themeChangeCallbacks.remove(handle);
+        if (removed) {
+            LOG.info("[ThemeConfig] Multi-callback unregistered (id=" + handle.getId()
+                    + ", remaining=" + themeChangeCallbacks.size() + ")");
+        }
+        // Clear the legacy single-callback if it matches the one being removed
+        if (removed && themeChangeCallback == handle.getCallback()) {
+            themeChangeCallback = null;
+        }
+    }
+
+    /**
+     * Ensure the LafManagerListener is registered exactly once at the Application level.
+     */
+    private static void ensureListenerRegistered() {
         if (listenerRegistered) {
             LOG.debug("[ThemeConfig] Listener already registered, callback updated");
             return;
@@ -95,12 +177,14 @@ public class ThemeConfigService {
     }
 
     /**
-     * Notify the frontend of a theme change.
+     * Notify all registered callbacks of a theme change.
      * Only sends a notification when the theme actually changes, avoiding duplicate notifications and unnecessary UI updates.
      */
     private static void notifyThemeChange() {
-        if (themeChangeCallback == null) {
-            LOG.warn("[ThemeConfig] Theme callback is null, cannot notify");
+        // Collect all active callbacks (multi-callback set + legacy single callback)
+        boolean hasCallbacks = !themeChangeCallbacks.isEmpty() || themeChangeCallback != null;
+        if (!hasCallbacks) {
+            LOG.warn("[ThemeConfig] No theme callbacks registered, cannot notify");
             return;
         }
 
@@ -116,8 +200,36 @@ public class ThemeConfigService {
 
             // Update cache and notify
             lastKnownIsDark = currentIsDark;
-            LOG.info("[ThemeConfig] Theme changed to: " + (currentIsDark ? "DARK" : "LIGHT") + ", notifying webview");
-            themeChangeCallback.onThemeChanged(config);
+            LOG.info("[ThemeConfig] Theme changed to: " + (currentIsDark ? "DARK" : "LIGHT")
+                    + ", notifying " + themeChangeCallbacks.size() + " webview(s)");
+
+            // Notify all registered multi-callbacks (one per open ClaudeChatWindow)
+            for (RegisteredCallback rc : themeChangeCallbacks) {
+                try {
+                    rc.getCallback().onThemeChanged(config);
+                } catch (Exception e) {
+                    LOG.warn("[ThemeConfig] Failed to notify callback id=" + rc.getId() + ": " + e.getMessage(), e);
+                }
+            }
+
+            // Also notify the legacy single-callback if it is not already in the multi-callback set.
+            // This preserves backward compatibility for any code path that used the old API.
+            if (themeChangeCallback != null) {
+                boolean alreadyNotified = false;
+                for (RegisteredCallback rc : themeChangeCallbacks) {
+                    if (rc.getCallback() == themeChangeCallback) {
+                        alreadyNotified = true;
+                        break;
+                    }
+                }
+                if (!alreadyNotified) {
+                    try {
+                        themeChangeCallback.onThemeChanged(config);
+                    } catch (Exception e) {
+                        LOG.warn("[ThemeConfig] Failed to notify legacy callback: " + e.getMessage(), e);
+                    }
+                }
+            }
         } catch (Exception e) {
             LOG.error("[ThemeConfig] Failed to notify theme change: " + e.getMessage(), e);
         }


### PR DESCRIPTION
## Summary

Fixes #1586 - "Follow IDE" theme change does not repaint open sessions; only new sessions get the right colors.

### Root Cause

`ThemeConfigService` used a **single static callback field** (`themeChangeCallback`). Every new `ClaudeChatWindow` -> `SettingsHandler.registerThemeChangeListener()` call **overwrote** the previous callback. As a result:

- Only the **last-registered** window received `window.onIdeThemeChanged` JS calls.
- All other open sessions kept the old theme colors until manually reopened.
- Disposed windows still held the callback reference, producing the log warning: `Cannot call JS function window.onIdeThemeChanged: disposed=true`.

### Fix

1. **`ThemeConfigService`** - Replace the single-callback field with a `CopyOnWriteArraySet<RegisteredCallback>`. Every `ClaudeChatWindow` now registers its own callback and receives theme change notifications independently. A new `registerThemeChangeListener(callback, returnHandle)` API returns an opaque `RegisteredCallback` handle for clean unregistration.

2. **`SettingsHandler`** - Uses the new multi-callback API and stores the handle. A new `dispose()` method unregisters the callback when the owning window is disposed.

3. **`ChatWindowDelegate`** - Saves a reference to `SettingsHandler` and calls `settingsHandler.dispose()` in its own `dispose()`, ensuring theme callbacks are cleaned up on tab/window close.

4. **`ClaudeChatWindow`** - Registers an additional Swing-level theme callback to update `mainPanel` and `browser` component background colors on theme change. This complements the webview CSS update (handled by `SettingsHandler`) and ensures Java-side containers repaint with the correct color.

### Before / After

| | Before | After |
|---|---|---|
| Open sessions on theme switch | Stale colors, only last tab updates | All sessions repaint immediately |
| `disposed=true` warning | Logged on every theme switch | Eliminated - callbacks unregistered on dispose |
| Swing container background | Never updated (set once at init) | Updated alongside webview CSS |

### Backward Compatibility

The old single-arg `registerThemeChangeListener(callback)` overload is preserved for backward compatibility. It delegates to the new API with `returnHandle=false`.

Closes #1586