### PR TITLE
fix(sound): suppress completion sound on manual stop

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/SessionHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SessionHandler.java
@@ -205,8 +205,10 @@ public class SessionHandler extends BaseMessageHandler {
                 .thenRun(() -> {
                     // Claude now triggers success on actual stream_end callback.
                     // Codex has no stream_end event, keep success trigger at completion.
-                    if (project != null && "codex".equals(context.getSession().getProvider())) {
-                        var session = context.getSession();
+                    var session = context.getSession();
+                    if (project != null
+                            && "codex".equals(session.getProvider())
+                            && !session.isManuallyInterrupted()) {
                         ClaudeNotifier.showSuccess(
                             project,
                             ClaudeNotifier.buildTitleFromSession(session),
@@ -365,8 +367,10 @@ public class SessionHandler extends BaseMessageHandler {
                 .thenRun(() -> {
                     // Claude now triggers success on actual stream_end callback.
                     // Codex has no stream_end event, keep success trigger at completion.
-                    if (project != null && "codex".equals(context.getSession().getProvider())) {
-                        var session = context.getSession();
+                    var session = context.getSession();
+                    if (project != null
+                            && "codex".equals(session.getProvider())
+                            && !session.isManuallyInterrupted()) {
                         ClaudeNotifier.showSuccess(
                             project,
                             ClaudeNotifier.buildTitleFromSession(session),

--- a/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
@@ -35,6 +35,14 @@ public class ClaudeSession {
     /** Start time of the latest submitted turn, retained across Webview rebuilds. */
     private volatile long lastTurnStartedAtMillis;
 
+    /**
+     * Flag set when the user manually interrupts the current turn (clicks Stop).
+     * Checked by {@link com.github.claudecodegui.ui.toolwindow.ClaudeChatWindow#onStreamEnded()}
+     * to suppress the task-completion notification sound for manual stops.
+     * Reset to {@code false} at the start of each new {@link #send} call.
+     */
+    private volatile boolean manuallyInterrupted = false;
+
     // Session state manager
     private final com.github.claudecodegui.session.SessionState state;
 
@@ -232,6 +240,16 @@ public class ClaudeSession {
 
     public String getError() {
         return state.getError();
+    }
+
+    /**
+     * Returns whether the current (or most recent) turn was manually interrupted
+     * by the user clicking Stop. Used to suppress the task-completion sound.
+     *
+     * @return {@code true} if the user manually interrupted the current turn
+     */
+    public boolean isManuallyInterrupted() {
+        return manuallyInterrupted;
     }
 
     public List<Message> getMessages() {
@@ -482,6 +500,9 @@ public class ClaudeSession {
             String requestedCodexFastMode
     ) {
         lastTurnStartedAtMillis = System.currentTimeMillis();
+        // Reset the manual-interrupt flag at the start of a new turn so that
+        // a fresh send is not mistaken for a user-initiated stop.
+        manuallyInterrupted = false;
         String normalizedInput = (input != null) ? input.trim() : "";
         Message userMessage = contextService.buildUserMessage(normalizedInput, attachments);
         sendService.updateSessionStateForSend(userMessage, normalizedInput);
@@ -525,6 +546,10 @@ public class ClaudeSession {
      * Interrupt the current execution.
      */
     public CompletableFuture<Void> interrupt() {
+        // Mark this turn as manually interrupted so the stream-end handler
+        // suppresses the task-completion notification sound.
+        manuallyInterrupted = true;
+
         String provider = state.getProvider();
         String channelId = state.getChannelId();
         if (channelId == null) {

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -2564,6 +2564,12 @@ public class ClaudeChatWindow {
         if (session == null) {
             return;
         }
+        // Suppress the task-completion notification (sound + toast) when the user
+        // manually stopped the turn. Only natural completions should produce a sound.
+        if (session.isManuallyInterrupted()) {
+            LOG.debug("Stream ended after manual interrupt - suppressing completion sound");
+            return;
+        }
         if ("claude".equals(session.getProvider()) && session.getError() == null) {
             com.github.claudecodegui.notifications.ClaudeNotifier.showSuccess(
                 project,


### PR DESCRIPTION
## Summary

Fixes #1597 - When the user clicks Stop to interrupt the current turn, the task-completion sound still plays.

### Root Cause

When the user clicks Stop, `SessionHandler.handleInterruptSession()` calls `session.interrupt()`. Although `interrupt()` itself does not call `notifyStreamEnd()`, the Claude daemon process sends a `stream_end` event after being interrupted, which triggers `SessionCallbackAdapter.onStreamEnd()` -> `ClaudeChatWindow.onStreamEnded()`.

`onStreamEnded()` unconditionally calls `ClaudeNotifier.showSuccess()`, which plays the task-completion sound. The user hears the same sound whether the task completed naturally or was manually stopped, which is confusing.

### Fix

1. **`ClaudeSession`** - Add a `volatile boolean manuallyInterrupted` flag, set to `true` in `interrupt()` and reset to `false` at the start of each new `send()` call. Expose via `isManuallyInterrupted()`.

2. **`ClaudeChatWindow.onStreamEnded()`** - Check `session.isManuallyInterrupted()` before calling `ClaudeNotifier.showSuccess()`. If the user manually stopped, skip the sound and toast entirely. Natural completions are unaffected.

### Behavior

| Scenario | Before | After |
|---|---|---|
| Task completes naturally | Sound + toast | Sound + toast |
| User clicks Stop | Sound + toast (bug) | No sound, no toast |
| User clicks Stop, then sends new message | N/A | Sound plays normally on completion |

Closes #1597