### PR TITLE
fix(webview): add word-break to assistant markdown content for auto-wrapping

### DIFF
--- a/webview/src/styles/less/components/message.less
+++ b/webview/src/styles/less/components/message.less
@@ -596,6 +596,8 @@
 .text-block {
     white-space: pre-wrap;
     word-wrap: break-word;
+    word-break: break-word;
+    overflow-wrap: break-word;
 }
 
 /* Markdown Content */
@@ -604,6 +606,7 @@
     line-height: 1.6;
     color: var(--text-primary);
     word-wrap: break-word;
+    word-break: break-word;
     overflow-wrap: break-word;
     cursor: text;
 }
@@ -618,6 +621,7 @@
 .markdown-content p {
     margin-bottom: 10px;
     word-wrap: break-word;
+    word-break: break-word;
     overflow-wrap: break-word;
     max-width: 100%;
 }


### PR DESCRIPTION
## Summary

Fixes #1508 - AI output content can exceed the display area without wrapping, requiring horizontal scroll to read.

### Root Cause

The `.markdown-content` and `.text-block` CSS rules in `message.less` had `overflow-wrap: break-word` but were missing `word-break: break-word`. In the JCEF rendering engine, long unbroken strings (URLs, code identifiers, base64 blobs, long file paths) can overflow the message container horizontally when only `overflow-wrap` is set, because `overflow-wrap` only breaks at allowed break points.

Notably, `.message.user .markdown-content` (user messages) already had `word-break: break-word`, but the base `.markdown-content` (used for assistant messages) did not - creating an inconsistency where user input wrapped correctly but AI output could overflow.

### Fix

Add `word-break: break-word` to three selectors:
- `.text-block`
- `.markdown-content`
- `.markdown-content p`

This ensures all message content - both user and assistant - wraps within the container width, matching the behavior already applied to user messages.

Closes #1508