### PR TITLE
fix(ui): dynamic provider displayName in streaming connection status

### DIFF
--- a/webview/src/components/MessageItem/MessageItem.tsx
+++ b/webview/src/components/MessageItem/MessageItem.tsx
@@ -45,6 +45,12 @@ export interface MessageItemProps {
 /** Map provider id to a human-readable label used in UI text. */
 function getProviderDisplayName(providerId?: string): string {
   if (providerId === 'codex') return 'Codex';
+  if (providerId === 'grok') return 'Grok';
+  if (providerId === 'gemini') return 'Gemini';
+  if (providerId === 'opencode') return 'OpenCode';
+  if (providerId === 'kimi') return 'Kimi';
+  if (providerId === 'pi') return 'Pi';
+  if (providerId) return providerId.charAt(0).toUpperCase() + providerId.slice(1);
   return 'Claude';
 }
 


### PR DESCRIPTION
### Description
`getProviderDisplayName` in `MessageItem.tsx` previously only mapped `codex` and defaulted everything else to `Claude`. This caused the connection status indicator (`chat.streamingConnected`, e.g. "Connecting to...") to show "Claude" when streaming responses for non-Claude providers like `Grok`, `Gemini`, `OpenCode`, `Kimi`, `Pi`, etc.

### Changes
- Add explicit mappings for `grok`, `gemini`, `opencode`, `kimi`, `pi` in `getProviderDisplayName`.
- Add a capitalized fallback for any unknown provider ID (`providerId.charAt(0).toUpperCase() + providerId.slice(1)`).
- Default to `Claude` when `providerId` is undefined.

### Impact
The streaming connection banner now displays the correct human-readable provider name across all integrated CLI providers.