### PR TITLE
feat(slash): add /mcp to Claude builtin slash commands

### DIFF
--- a/src/main/java/com/github/claudecodegui/skill/SlashCommandRegistry.java
+++ b/src/main/java/com/github/claudecodegui/skill/SlashCommandRegistry.java
@@ -53,6 +53,7 @@ public final class SlashCommandRegistry {
             new SlashCommand("/context", "Visualize current context usage as a colored grid", "builtin"),
             new SlashCommand("/goal", "Keep working across turns until the goal condition is met", "builtin"),
             new SlashCommand("/init", "Initialize a new CLAUDE.md file with codebase documentation", "builtin"),
+            new SlashCommand("/mcp", "List configured MCP servers and their connection status", "builtin"),
             new SlashCommand("/plan", "Switch to plan mode", "builtin"),
             new SlashCommand("/resume", "Resume a previous conversation", "builtin"),
             new SlashCommand("/review", "Review a pull request", "builtin"),


### PR DESCRIPTION
## Summary

Fixes #1521 - the `/mcp` slash command is missing from the plugin entirely. It does not appear in the slash-command suggestion list, and typing it does nothing.

### Root Cause

`/mcp` was absent from `SlashCommandRegistry.CLAUDE_BUILTIN`. This static list drives the slash-command suggestion popup, so a command not in it never surfaces in the list and, when typed manually, appears to be swallowed.

`/mcp` is a built-in Claude CLI command that lists configured MCP servers with their connection status and tool count, and is the entry point for OAuth-authenticating remote servers. There is no in-conversation way to query which MCP servers the current session actually sees.

### Fix

Add `/mcp` to `CLAUDE_BUILTIN` alongside the other SDK-handled built-in commands:

```java
new SlashCommand("/mcp", "List configured MCP servers and their connection status", "builtin"),
```

Claude messages are forwarded verbatim to the SDK as the prompt (`ai-bridge/services/claude/message-sender.js` uses `queryFn({ prompt: message })`), so the SDK handles `/mcp` natively and returns the MCP server list. This follows the project's established pattern for adding built-in slash commands - the same way `/goal` was added (commit `b5359842`).

### Behavior

| Before | After |
|---|---|
| `/mcp` absent from suggestion list | `/mcp` appears alongside other built-in commands |
| Typing `/mcp` does nothing | SDK returns the MCP server list |

Closes #1521