### PR TITLE
fix(claude): surface async subagent report and keep its card alive

### DIFF
--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -37,7 +37,9 @@ import {
   setCachedQueryFn,
   touchRuntime,
   createTurnSink,
+  emitTaskEvent,
 } from './runtime-lifecycle.js';
+import { parseTaskNotificationXml, buildTaskNotificationEvent, extractUserMessageTaskNotificationXml } from './task-notification-parser.js';
 import {
   SESSION_CLEANUP_INTERVAL_MS,
   clearActiveTurnRuntime,
@@ -308,6 +310,28 @@ _sessionCleanupTimer.unref();
       // session stream, otherwise the subagent's internals pollute the main chat.
       // task_notification (type:'system') has no parent_tool_use_id and is preserved.
       if (msg?.parent_tool_use_id) {
+        continue;
+      }
+
+      // In-turn task-notification: a background agent that finishes while the
+      // main turn is still live delivers its report as a <task-notification> XML
+      // in the content of a plain user message, not as an SDK event. Synthesize
+      // the task_notification the SDK no longer emits and continue, so the
+      // report reaches the frontend subagent card and the raw XML never leaks
+      // into the [MESSAGE] stream (which would only render as an opaque user
+      // message). The frontend also recovers these from history on its own.
+      const taskNotificationXml = extractUserMessageTaskNotificationXml(msg);
+      if (taskNotificationXml !== null) {
+        const parsed = parseTaskNotificationXml(taskNotificationXml);
+        const event = buildTaskNotificationEvent(parsed);
+        if (event && runtime.sessionId) {
+          console.log('[LIFECYCLE] In-turn task-notification user message for sessionId=' + runtime.sessionId + ', toolUseId=' + parsed.toolUseId + ', status=' + event.status);
+          emitTaskEvent(runtime.sessionId, event);
+        } else if (!event) {
+          console.log('[LIFECYCLE] In-turn task-notification user message could not be parsed (no tool_use_id or non-terminal status), consuming silently');
+        } else {
+          console.log('[LIFECYCLE] In-turn task-notification user message for anonymous runtime, consuming silently');
+        }
         continue;
       }
 

--- a/ai-bridge/services/claude/runtime-lifecycle.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.js
@@ -1,6 +1,7 @@
 import { AsyncStream } from '../../utils/async-stream.js';
 import { loadClaudeSdk } from '../../utils/sdk-loader.js';
 import { createPreToolUseHook, normalizePermissionMode } from './permission-mode.js';
+import { parseTaskNotificationXml, buildTaskNotificationEvent, extractUserMessageTaskNotificationXml } from './task-notification-parser.js';
 import {
   beginRuntimeTurn,
   cleanupStaleAnonymousRuntimes as cleanupAnonymousFromRegistry,
@@ -15,6 +16,52 @@ import {
 } from './runtime-registry.js';
 
 let cachedQueryFn = null;
+
+/**
+ * Emit a process-level daemon event that bypasses daemon.js's activeRequestId
+ * interception.
+ *
+ * _originalStdoutWrite is required because daemon.js intercepts process.stdout
+ * .write and wraps output with the active request's id; a plain console.log
+ * here would tag the event with whatever request is currently active (possibly
+ * a different session) and misdeliver it. Writing directly to the original
+ * stdout keeps the event process-level, which Java's DaemonBridge.handleDaemon
+ * Event then routes to registered listeners.
+ *
+ * Hoisted to module scope (out of the perpetual reader closure) so executeTurn
+ * can emit task events on the in-turn path too — see emitTaskEvent.
+ */
+function emitDaemonEvent(event, sessionId, payload = {}) {
+  try {
+    const originalWrite = process.stdout._originalStdoutWrite;
+    if (!originalWrite) {
+      console.error(`[PERPETUAL_READER] _originalStdoutWrite not available (daemon.js not initialized?), cannot emit ${event} event`);
+      return;
+    }
+    const eventPayload = { type: 'daemon', event, sessionId, ...payload };
+    originalWrite.call(process.stdout, JSON.stringify(eventPayload) + '\n', 'utf8');
+  } catch (err) {
+    console.error(`[PERPETUAL_READER] Failed to emit ${event} event:`, err);
+  }
+}
+
+function emitInterTurnEvent(sessionId) {
+  emitDaemonEvent('session_updated', sessionId);
+}
+
+/**
+ * Forward a task lifecycle event to Java as a daemon event. The message is
+ * either a real SDK task_* system event (settled after the turn's result, so
+ * it arrives inter-turn) or a task_notification synthesized from a
+ * <task-notification> XML carried by a main-session user message (recent
+ * Claude Code delivers the background agent's terminal report that way
+ * instead of emitting an SDK event). Both the perpetual reader (inter-turn)
+ * and executeTurn (in-turn) call this so every delivery path converges on
+ * window.onTaskEvent, which dedups by tool_use_id + observable fields.
+ */
+export function emitTaskEvent(sessionId, taskMsg) {
+  emitDaemonEvent('task_event', sessionId, { taskEvent: taskMsg });
+}
 
 /**
  * TurnSink: A simple queue/channel for passing messages from the perpetual reader to executeTurn.
@@ -249,58 +296,9 @@ async function createRuntime(requestContext, callbacks) {
  * Exported for testing; returns the reader loop promise.
  */
 export function startPerpetualReader(runtime, callbacks) {
-  /**
-   * Emit an inter-turn daemon event using daemon.js's writeRawLine mechanism.
-   *
-   * IMPORTANT: Must bypass activeRequestId interception to avoid misrouting.
-   *
-   * Why writeRawLine is required:
-   * - daemon.js intercepts process.stdout.write and wraps output with activeRequestId
-   * - If we used console.log() here, the event would be tagged with whatever request
-   *   is currently active (possibly from a different session)
-   * - This would cause the event to be delivered to the wrong session
-   * - writeRawLine (_originalStdoutWrite) bypasses the interception layer and outputs
-   *   directly to stdout, ensuring the event is process-level and not request-scoped
-   *
-   * The event format {type: 'daemon', event, sessionId, ...payload} is recognized
-   * by Java's DaemonBridge.handleDaemonEvent() which routes it to registered listeners.
-   */
-  const emitDaemonEvent = (event, sessionId, payload = {}) => {
-    try {
-      // daemon.js stores the original stdout.write as _originalStdoutWrite.
-      // We must use _originalStdoutWrite to bypass activeRequestId wrapping.
-      const originalWrite = process.stdout._originalStdoutWrite;
-      if (!originalWrite) {
-        console.error(`[PERPETUAL_READER] _originalStdoutWrite not available (daemon.js not initialized?), cannot emit ${event} event`);
-        return;
-      }
-      const eventPayload = { type: 'daemon', event, sessionId, ...payload };
-      originalWrite.call(process.stdout, JSON.stringify(eventPayload) + '\n', 'utf8');
-    } catch (err) {
-      console.error(`[PERPETUAL_READER] Failed to emit ${event} event:`, err);
-    }
-  };
-
-  const emitInterTurnEvent = (sessionId) => emitDaemonEvent('session_updated', sessionId);
-
-  // Forward a task_* SDK system event (async subagent lifecycle) to Java as a
-  // daemon event. This is the inter-turn delivery path for a task_notification
-  // that settles AFTER the turn's result: executeTurn breaks on the result and
-  // clears turnSink (in its finally) before the perpetual reader's next
-  // query.next() resolves, so the late event arrives with turnSink already
-  // null and the in-turn [MESSAGE] stream cannot carry it. Without this
-  // forward, that late event is silently dropped and the frontend subagent
-  // list stays stuck on "running" until a manual reload.
-  //
-  // A task_notification that settles BEFORE the turn's result is still pushed
-  // to turnSink while it is live, so executeTurn processes it via the in-turn
-  // [MESSAGE] stream (ClaudeMessageHandler.handleSystemMessage ->
-  // notifyTaskEvent). Both paths converge on window.onTaskEvent, which dedups
-  // by tool_use_id + observable fields - see DaemonBridge.handleDaemonEvent
-  // for the defense-in-depth rationale. Do NOT delete either path without
-  // confirming at runtime which one a given task_notification takes.
-  const emitTaskEvent = (sessionId, taskMsg) =>
-    emitDaemonEvent('task_event', sessionId, { taskEvent: taskMsg });
+  // emitDaemonEvent / emitInterTurnEvent / emitTaskEvent are defined at module
+  // scope above so executeTurn can share the in-turn task-event emission path.
+  // See those definitions for the bypass-activeRequestId rationale.
 
   // Start the perpetual reader loop; return the promise so callers (and tests)
   // can await its completion.
@@ -381,6 +379,31 @@ export function startPerpetualReader(runtime, callbacks) {
               emitTaskEvent(runtime.sessionId, msg);
             } else {
               console.log('[PERPETUAL_READER] Inter-turn task_* event for anonymous runtime, consuming silently (subtype=' + msg.subtype + ')');
+            }
+          }
+          // Recent Claude Code terminates a background Agent by injecting a
+          // <task-notification> XML as the CONTENT of a plain user message in
+          // the main session, not as a queued_command attachment and not as an
+          // SDK task_notification event. The user message carries the agent's
+          // full <result> report; inter-turn it is otherwise silently consumed
+          // (the frontend only sees it after a reload). Parse the XML and
+          // synthesize the task_notification event the SDK no longer emits, so
+          // window.onTaskEvent can surface the report without waiting for a
+          // reload. (The frontend also recovers these from history on its own —
+          // see collectTaskEventsFromMessages — so this is the live fast-path.)
+          const taskNotificationXml = extractUserMessageTaskNotificationXml(msg);
+          if (taskNotificationXml !== null) {
+            if (runtime.sessionId) {
+              const parsed = parseTaskNotificationXml(taskNotificationXml);
+              const event = buildTaskNotificationEvent(parsed);
+              if (event) {
+                console.log('[PERPETUAL_READER] Inter-turn task-notification user message for sessionId=' + runtime.sessionId + ', toolUseId=' + parsed.toolUseId + ', status=' + event.status);
+                emitTaskEvent(runtime.sessionId, event);
+              } else {
+                console.log('[PERPETUAL_READER] Inter-turn task-notification user message could not be parsed (no tool_use_id or non-terminal status), consuming silently');
+              }
+            } else {
+              console.log('[PERPETUAL_READER] Inter-turn task-notification user message for anonymous runtime, consuming silently');
             }
           }
           // For other message types during inter-turn, we silently consume

--- a/ai-bridge/services/claude/task-notification-parser.js
+++ b/ai-bridge/services/claude/task-notification-parser.js
@@ -1,0 +1,107 @@
+/**
+ * Parse a Claude Code task-notification XML string.
+ *
+ * Recent Claude Code terminates a background (run_in_background) Agent by
+ * injecting a <task-notification> XML as the content of a plain user message
+ * in the main session, NOT by emitting a task_notification SDK event. The
+ * <result> tag carries the agent's finalMessage (its full report); the
+ * <summary> tag is only a one-liner like `Agent "desc" finished`. Without
+ * parsing this XML the frontend subagent card never sees the report and stays
+ * stuck on the launch ack text ("Async agent launched successfully.").
+ *
+ * The XML body is escaped with a minimal escaper (only & < >), so a
+ * non-greedy indexOf scan for the closing tag is safe — the escaped report
+ * text cannot contain a real `</result>`.
+ */
+
+export function parseTaskNotificationXml(xml) {
+  if (typeof xml !== 'string') return null;
+  // Reject non-task-notification payloads early so a stray queued_command
+  // (e.g. a user prompt enqueued as an attachment) never yields a bogus event.
+  if (!xml.includes('<task-notification')) return null;
+
+  const toolUseId = extractTag(xml, 'tool-use-id');
+  // tool_use_id is the only field the downstream dedup/routing depends on;
+  // without it the event cannot be matched to a subagent card, so drop it.
+  if (!toolUseId) return null;
+
+  return {
+    taskId: extractTag(xml, 'task-id'),
+    toolUseId,
+    taskType: extractTag(xml, 'task-type'),
+    outputFile: extractTag(xml, 'output-file'),
+    status: extractTag(xml, 'status'),
+    summary: extractTag(xml, 'summary'),
+    result: extractTag(xml, 'result'),
+  };
+}
+
+/**
+ * If `msg` is a main-session user message whose content carries a
+ * <task-notification> XML, return that XML string; otherwise return null. The
+ * content may be a plain string or an array of text blocks (Claude Code uses
+ * the string form, but both are accepted). Returning null for "not a carrier"
+ * lets the caller keep processing a normal user message (in-turn) or silently
+ * consume it (inter-turn) without conflating it with an unparseable payload.
+ */
+export function extractUserMessageTaskNotificationXml(msg) {
+  if (!msg || msg.type !== 'user') return null;
+  const rawContent = msg.message?.content ?? msg.content;
+  const xml = typeof rawContent === 'string' ? rawContent
+    : (Array.isArray(rawContent)
+      ? rawContent.map((b) => (b && typeof b.text === 'string' ? b.text : '')).join('')
+      : '');
+  return xml.includes('<task-notification') ? xml : null;
+}
+
+function extractTag(xml, tag) {
+  const open = `<${tag}>`;
+  const start = xml.indexOf(open);
+  if (start < 0) return undefined;
+  const contentStart = start + open.length;
+  const end = xml.indexOf(`</${tag}>`, contentStart);
+  if (end < 0) return undefined;
+  return unescapeXml(xml.slice(contentStart, end));
+}
+
+function unescapeXml(s) {
+  // Na() only escapes & < >, but Claude Code uses &quot;/&apos; elsewhere in
+  // the envelope. Unescape every named entity that is actually present;
+  // &amp; must go last so it does not half-decode the others mid-flight.
+  return s
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&amp;', '&');
+}
+
+const STATUS_ALIASES = { killed: 'stopped' };
+const VALID_TERMINAL_STATUSES = new Set(['completed', 'failed', 'stopped']);
+
+/**
+ * Build a synthetic task_notification system message from a parsed XML payload,
+ * shaped to match what Claude Code's emitTaskTerminatedSdk emits so the
+ * existing DaemonBridge -> ClaudeChatWindow -> window.onTaskEvent path needs no
+ * changes. The full <result> report is preferred over the one-line <summary>
+ * as the event's summary so the frontend resultText shows the actual report.
+ *
+ * Returns null when the parsed status is not a terminal value the frontend
+ * accepts, so a non-terminal or malformed envelope is ignored rather than
+ * producing an event that parseTaskNotification would reject downstream.
+ */
+export function buildTaskNotificationEvent(parsed) {
+  if (!parsed) return null;
+  const status = STATUS_ALIASES[parsed.status] || parsed.status;
+  if (!VALID_TERMINAL_STATUSES.has(status)) return null;
+  const report = parsed.result || parsed.summary;
+  return {
+    type: 'system',
+    subtype: 'task_notification',
+    ...(parsed.taskId && { task_id: parsed.taskId }),
+    tool_use_id: parsed.toolUseId,
+    status,
+    output_file: parsed.outputFile ?? '',
+    ...(report !== undefined && { summary: report }),
+  };
+}

--- a/ai-bridge/services/claude/task-notification-parser.test.js
+++ b/ai-bridge/services/claude/task-notification-parser.test.js
@@ -1,0 +1,133 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseTaskNotificationXml, buildTaskNotificationEvent } from './task-notification-parser.js';
+
+// Mirrors the user-message content Claude Code injects when a background Agent
+// terminates (built by enqueueAgentNotification). The <result> body is escaped
+// with a minimal escaper (only & < >), so &amp;/&lt; appear inline.
+const FULL_XML = `<task-notification>
+<task-id>w-abc123</task-id>
+<tool-use-id>toolu_01XYZ</tool-use-id>
+<output-file>/home/user/.codemoss/agents/abc.jsonl</output-file>
+<status>completed</status>
+<summary>Agent "research" finished</summary>
+<note>A task-notification fires each time this agent stops with no live background children of its own.</note>
+<result>Found 3 issues &amp; fixed them. See &lt;report&gt; for details.</result>
+</task-notification>`;
+
+test('parseTaskNotificationXml extracts every field and unescapes the result body', () => {
+  const parsed = parseTaskNotificationXml(FULL_XML);
+  assert.deepEqual(parsed, {
+    taskId: 'w-abc123',
+    toolUseId: 'toolu_01XYZ',
+    taskType: undefined,
+    outputFile: '/home/user/.codemoss/agents/abc.jsonl',
+    status: 'completed',
+    summary: 'Agent "research" finished',
+    result: 'Found 3 issues & fixed them. See <report> for details.',
+  });
+});
+
+test('parseTaskNotificationXml leaves result undefined when the tag is absent', () => {
+  // A task that produced no finalMessage omits <result> entirely (enqueueAgent
+  // Notification builds the tag conditionally). The parser must surface that as
+  // undefined, not an empty string, so buildTaskNotificationEvent can fall back
+  // to the one-line summary.
+  const xml = `<task-notification>
+<tool-use-id>toolu_02</tool-use-id>
+<status>completed</status>
+<summary>Agent "x" finished</summary>
+</task-notification>`;
+  const parsed = parseTaskNotificationXml(xml);
+  assert.strictEqual(parsed.result, undefined);
+  assert.strictEqual(parsed.summary, 'Agent "x" finished');
+});
+
+test('parseTaskNotificationXml returns null without a tool-use-id', () => {
+  // tool_use_id routes the event to a subagent card; without it the event is
+  // unrouteable, so drop the payload rather than emit a dangling event.
+  const xml = `<task-notification>
+<task-id>w-1</task-id>
+<status>completed</status>
+</task-notification>`;
+  assert.strictEqual(parseTaskNotificationXml(xml), null);
+});
+
+test('parseTaskNotificationXml returns null for non-task-notification payloads', () => {
+  // A stray queued_command (e.g. a user prompt) must never yield a bogus event.
+  assert.strictEqual(parseTaskNotificationXml('just a user message'), null);
+  assert.strictEqual(parseTaskNotificationXml('<command-message>run</command-message>'), null);
+});
+
+test('parseTaskNotificationXml returns null for non-string input', () => {
+  assert.strictEqual(parseTaskNotificationXml(null), null);
+  assert.strictEqual(parseTaskNotificationXml(undefined), null);
+  assert.strictEqual(parseTaskNotificationXml(42), null);
+  assert.strictEqual(parseTaskNotificationXml({ prompt: 'x' }), null);
+});
+
+test('parseTaskNotificationXml accepts an array prompt by rejecting it', () => {
+  // queued_command.prompt is usually a string but may be a content-block array;
+  // the parser must not crash, just decline to parse.
+  assert.strictEqual(parseTaskNotificationXml([{ type: 'text', text: 'x' }]), null);
+});
+
+test('buildTaskNotificationEvent prefers the full result over the one-line summary', () => {
+  const event = buildTaskNotificationEvent(parseTaskNotificationXml(FULL_XML));
+  // The frontend reads `summary` as resultText, so putting the full report here
+  // is what surfaces it in the subagent card instead of "Agent ... finished".
+  assert.strictEqual(event.summary, 'Found 3 issues & fixed them. See <report> for details.');
+  assert.strictEqual(event.type, 'system');
+  assert.strictEqual(event.subtype, 'task_notification');
+  assert.strictEqual(event.tool_use_id, 'toolu_01XYZ');
+  assert.strictEqual(event.status, 'completed');
+  assert.strictEqual(event.task_id, 'w-abc123');
+  assert.strictEqual(event.output_file, '/home/user/.codemoss/agents/abc.jsonl');
+});
+
+test('buildTaskNotificationEvent falls back to summary when result is absent', () => {
+  const xml = `<task-notification>
+<tool-use-id>toolu_03</tool-use-id>
+<status>failed</status>
+<summary>Agent "y" failed: boom</summary>
+</task-notification>`;
+  const event = buildTaskNotificationEvent(parseTaskNotificationXml(xml));
+  assert.strictEqual(event.summary, 'Agent "y" failed: boom');
+  assert.strictEqual(event.status, 'failed');
+});
+
+test('buildTaskNotificationEvent maps killed status to stopped', () => {
+  // print.ts maps XML 'killed' -> 'stopped'; mirror that so the frontend's
+  // terminal-status enum (completed/failed/stopped) accepts the event.
+  const xml = `<task-notification>
+<tool-use-id>toolu_04</tool-use-id>
+<status>killed</status>
+</task-notification>`;
+  const event = buildTaskNotificationEvent(parseTaskNotificationXml(xml));
+  assert.strictEqual(event.status, 'stopped');
+});
+
+test('buildTaskNotificationEvent rejects non-terminal statuses', () => {
+  // A non-terminal or malformed status must not produce an event that
+  // parseTaskNotification (frontend) would reject downstream anyway.
+  const xml = `<task-notification>
+<tool-use-id>toolu_05</tool-use-id>
+<status>running</status>
+</task-notification>`;
+  assert.strictEqual(buildTaskNotificationEvent(parseTaskNotificationXml(xml)), null);
+});
+
+test('buildTaskNotificationEvent returns null for a null parsed payload', () => {
+  assert.strictEqual(buildTaskNotificationEvent(null), null);
+});
+
+test('buildTaskNotificationEvent omits summary when both result and summary are absent', () => {
+  const xml = `<task-notification>
+<tool-use-id>toolu_06</tool-use-id>
+<status>completed</status>
+</task-notification>`;
+  const event = buildTaskNotificationEvent(parseTaskNotificationXml(xml));
+  // No summary key at all, so the frontend falls all the way back to the
+  // launch ack text rather than rendering an empty report.
+  assert.strictEqual('summary' in event, false);
+});

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -26,6 +26,7 @@ import {
   CONTEXT_COMMANDS,
 } from './hooks/useMessageSender';
 import { applyDiffTheme, getStoredDiffTheme } from './utils/diffTheme';
+import { collectTaskEventsFromMessages } from './utils/taskNotificationMessage';
 import type { Attachment, ChatInputBoxHandle } from './components/ChatInputBox/types';
 import { ToastContainer } from './components/Toast';
 import { ChatHeader } from './components/ChatHeader';
@@ -255,6 +256,27 @@ const App = () => {
     if (isFirstMountRef.current) { isFirstMountRef.current = false; return; }
     if (currentView === 'chat') { forceRefreshPrompts(); }
   }, [currentView]);
+
+  // Recover task events from task-notification user messages. Recent Claude Code
+  // delivers a background agent's terminal report as a plain user message (XML
+  // in content) instead of an SDK task_notification event, so history replay —
+  // and any live session that never fired the SDK path — would otherwise leave
+  // the subagent card stuck on the launch ack text. Derived entries only fill
+  // gaps: a real SDK event already in the map is kept as-is.
+  useEffect(() => {
+    const derived = collectTaskEventsFromMessages(messages);
+    if (Object.keys(derived).length === 0) return;
+    setTaskEvents((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      for (const [id, event] of Object.entries(derived)) {
+        if (next[id]) continue;
+        next[id] = event;
+        changed = true;
+      }
+      return changed ? next : prev;
+    });
+  }, [messages, setTaskEvents]);
 
   // ── Session management ──
   const {

--- a/webview/src/components/settings/hooks/useSettingsWindowCallbacks.test.ts
+++ b/webview/src/components/settings/hooks/useSettingsWindowCallbacks.test.ts
@@ -65,9 +65,11 @@ describe('useSettingsWindowCallbacks', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
-    // Force setTimeout path so fake timers control deferred batches.
-    delete (window as Window & { requestIdleCallback?: unknown }).requestIdleCallback;
-    delete (window as Window & { cancelIdleCallback?: unknown }).cancelIdleCallback;
+    // Force setTimeout path so fake timers control deferred batches. Asserting
+    // to a plain optional-field type keeps delete legal: intersecting with
+    // Window re-introduces lib.dom's required requestIdleCallback signature.
+    delete (window as { requestIdleCallback?: unknown }).requestIdleCallback;
+    delete (window as { cancelIdleCallback?: unknown }).cancelIdleCallback;
     window.sendToJava = vi.fn();
     window.applyUiFontConfig = vi.fn();
     window.applyCodeFontConfig = vi.fn();

--- a/webview/src/components/toolBlocks/AgentGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/AgentGroupBlock.tsx
@@ -9,6 +9,7 @@ import {
   isAsyncAgentInput,
   parseAgentToolMeta,
   parseSpawnAgentMeta,
+  readToolUseStatus,
 } from '../../utils/subagentResult';
 import {
   useSubagentHistories,
@@ -85,8 +86,10 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
   // tool_result; its real terminal status arrives later via task_notification,
   // so stay "running" until that event lands. Sync agents complete inline.
   // isAsyncAgentInput centralizes the strict === true check (and the snake/camel
-  // guard) shared with useSubagents and TaskExecutionBlock.
-  const isAsync = isAsyncAgentInput(input, toolName);
+  // guard) shared with useSubagents and TaskExecutionBlock. The launch ack text
+  // and tool-use status are passed as fallbacks so an agent spawned without
+  // run_in_background is still recognized as async.
+  const isAsync = isAsyncAgentInput(input, toolName, result, readToolUseStatus(toolId ? getToolResultRaw(toolId) : null));
   const taskEvent = useTaskEvent(toolId);
   const taskFailed = taskEvent?.status === 'failed' || taskEvent?.status === 'stopped';
 

--- a/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
+++ b/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
@@ -8,6 +8,7 @@ import {
   isAsyncAgentInput,
   parseAgentToolMeta,
   parseSpawnAgentMeta,
+  readToolUseStatus,
 } from '../../utils/subagentResult';
 import {
   useSubagentHistories,
@@ -84,8 +85,12 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
   // was registered) returns an is_error tool_result and never emits a
   // task_notification, so treat that as an error instead of staying stuck.
   // isAsyncAgentInput centralizes the strict === true check shared with
-  // useSubagents and AgentGroupBlock.
-  const isAsync = input ? isAsyncAgentInput(input, normalizedName) : false;
+  // useSubagents and AgentGroupBlock. The launch ack text and tool-use status
+  // are passed as fallbacks so an agent spawned without run_in_background is
+  // still recognized as async.
+  const isAsync = input
+    ? isAsyncAgentInput(input, normalizedName, result, readToolUseStatus(toolId ? getToolResultRaw(toolId) : null))
+    : false;
   const hasTerminalResult = result !== undefined && result !== null;
   const taskFailed = taskEvent?.status === 'failed' || taskEvent?.status === 'stopped';
   // Async completion has two authoritative sources: the live task_notification,

--- a/webview/src/hooks/useChatComputations.ts
+++ b/webview/src/hooks/useChatComputations.ts
@@ -18,12 +18,13 @@ import {
 } from '../utils/messageUtils';
 import { extractTodosFromToolUse, extractAccumulatedTasks } from '../utils/todoToolNormalization';
 import {
+  computeStatusScopeMessages,
   finalizeSubagentsForSettledTurn,
   finalizeTodosForSettledTurn,
   sliceLatestConversationTurn,
 } from '../utils/turnScope';
 import { FILE_MODIFY_TOOL_NAMES, isToolName } from '../utils/toolConstants';
-import { useSubagents } from './useSubagents';
+import { extractSubagentsFromMessages, useSubagents } from './useSubagents';
 import { useFileChanges } from './useFileChanges';
 import { useFileChangesManagement } from './useFileChangesManagement';
 import type { useMessageProcessing } from './useMessageProcessing';
@@ -170,6 +171,22 @@ export function useChatComputations({
 
   const latestTurnMessages = useMemo(() => sliceLatestConversationTurn(messages), [messages]);
 
+  // A run_in_background agent outlives the turn that launched it: the main turn
+  // settles while the sidechain keeps running, and its terminal report arrives
+  // as a later turn's task-notification user message. The turn-scoped narrowing
+  // below exists to focus sync tool progress on the current turn; if the
+  // session contains any async agent, narrowing would drop the agent's card
+  // from StatusPanel while the user waits for it to return — the reported
+  // "subagent list disappears after the session ends" symptom. Keep the full
+  // conversation in scope in that case. The check reuses the same extraction
+  // as the list itself (isAsyncAgentInput on the raw tool input) so the two
+  // can never disagree.
+  const asyncAgentPresence = useMemo(
+    () => extractSubagentsFromMessages(messages, getContentBlocks, findToolResult, getToolResultRaw, {})
+      .some((subagent) => subagent.isAsync === true),
+    [messages, getContentBlocks, findToolResult, getToolResultRaw],
+  );
+
   // While streaming, focus on the current turn's task progress; once settled
   // (history replay or idle), widen the scope to the whole conversation -
   // otherwise a multi-turn history session whose last turn has no task tool
@@ -182,12 +199,11 @@ export function useChatComputations({
   // reload's message refresh lands at the frontend a moment before the
   // stream-end signal flips streamingActive back to false. Widening only adds
   // content (earlier turns' settled items) - it never drops the current turn's.
+  // A session with any async agent likewise never narrows (see asyncAgentPresence).
   const statusScopeMessages = useMemo(() => {
-    if (!streamingActive) return messages;
-    return latestTurnMessages.length > 0 && sliceHasToolUse(latestTurnMessages, getContentBlocks)
-      ? latestTurnMessages
-      : messages;
-  }, [streamingActive, latestTurnMessages, messages, getContentBlocks]);
+    const latestTurnHasToolUse = latestTurnMessages.length > 0 && sliceHasToolUse(latestTurnMessages, getContentBlocks);
+    return computeStatusScopeMessages(streamingActive, asyncAgentPresence, latestTurnMessages, messages, latestTurnHasToolUse);
+  }, [streamingActive, asyncAgentPresence, latestTurnMessages, messages, getContentBlocks]);
 
   const latestTurnSubagents = useSubagents({
     messages: statusScopeMessages,

--- a/webview/src/hooks/useSubagents.ts
+++ b/webview/src/hooks/useSubagents.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import type { ClaudeMessage, ClaudeRawMessage, ClaudeContentBlock, ToolResultBlock, SubagentHistoryResponse, SubagentInfo, SubagentStatus, TaskEvent, TaskEventMap } from '../types';
 import { normalizeToolInput } from '../utils/toolInputNormalization';
 import { normalizeToolName } from '../utils/toolConstants';
-import { extractResultText, isAsyncAgentInput, parseSpawnAgentMeta } from '../utils/subagentResult';
+import { extractResultText, isAsyncAgentInput, parseSpawnAgentMeta, readToolUseStatus } from '../utils/subagentResult';
 import { useTaskEvents } from '../contexts/SubagentContext';
 
 type GetToolResultRawFn = (toolUseId: string) => ClaudeRawMessage | null;
@@ -123,8 +123,13 @@ export function extractSubagentsFromMessages(
       const result = findToolResult(toolUseId, messageIndex);
       const taskEvent = taskEvents[toolUseId];
       // isAsync is read via the shared isAsyncAgentInput helper so the
-      // StatusPanel list and the inline Agent cards stay in lockstep.
-      const isAsync = isAsyncAgentInput(input, toolName);
+      // StatusPanel list and the inline Agent cards stay in lockstep. The
+      // launch ack text and tool-use status are passed as fallbacks so a
+      // background agent whose input lacks run_in_background is still kept
+      // "running" until its terminal event lands, instead of being marked
+      // completed the instant the ack arrives.
+      const toolUseStatus = readToolUseStatus(getToolResultRaw(toolUseId));
+      const isAsync = isAsyncAgentInput(input, toolName, result, toolUseStatus);
       const status = determineStatus(result, isAsync, taskEvent);
       const resultMetadata = extractResultMetadata(result, getToolResultRaw, toolUseId, taskEvent);
       const spawnMeta = toolName === 'spawn_agent' ? parseSpawnAgentMeta(input, result) : {};

--- a/webview/src/types/aiFeatureConfig.test.ts
+++ b/webview/src/types/aiFeatureConfig.test.ts
@@ -26,6 +26,8 @@ describe('normalizeAiFeatureConfig', () => {
       provider: 'grok',
       effectiveProvider: 'grok',
       resolutionSource: 'manual',
+      // Partial payload from the backend: only three providers configured,
+      // the rest must be filled from defaults by normalize.
       models: { claude: 'claude-opus-4-8', codex: 'gpt-5.4', grok: 'grok' },
       availability: { claude: true, codex: false, grok: true },
     });

--- a/webview/src/types/aiFeatureConfig.ts
+++ b/webview/src/types/aiFeatureConfig.ts
@@ -39,6 +39,20 @@ export type CommitAiProvider = AiFeatureProvider;
 export type CommitAiResolutionSource = AiFeatureResolutionSource;
 export type CommitAiConfig = AiFeatureConfig;
 
+/**
+ * Backend/partial payload shape accepted by normalizeAiFeatureConfig: models
+ * and availability may carry only a subset of providers — the normalize step
+ * fills the rest from defaults. The full AiFeatureConfig shape (all six
+ * providers required) is what consumers receive after normalization.
+ */
+export interface AiFeatureConfigInput {
+  provider?: AiFeatureProvider | null;
+  effectiveProvider?: AiFeatureProvider | null;
+  resolutionSource?: AiFeatureResolutionSource;
+  models?: Partial<AiFeatureModels> | null;
+  availability?: Partial<AiFeatureAvailability> | null;
+}
+
 function emptyAvailability(value = false): AiFeatureAvailability {
   return {
     claude: value,
@@ -105,7 +119,7 @@ function normalizeAvailability(
  * complete controlled-component state (never missing availability/models).
  */
 export function normalizeAiFeatureConfig(
-  raw: Partial<AiFeatureConfig> | null | undefined,
+  raw: AiFeatureConfigInput | null | undefined,
   defaults: AiFeatureConfig = DEFAULT_COMMIT_AI_CONFIG,
 ): AiFeatureConfig {
   if (raw == null) {

--- a/webview/src/utils/subagentResult.test.ts
+++ b/webview/src/utils/subagentResult.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
+import type { ToolResultBlock } from '../types';
 import {
   isAsyncAgentInput,
   extractResultText,
   parseAgentToolMeta,
   parseSpawnAgentMeta,
+  readToolUseStatus,
 } from './subagentResult';
 
 describe('isAsyncAgentInput', () => {
@@ -41,6 +43,50 @@ describe('isAsyncAgentInput', () => {
   it('treats Codex spawn_agent as asynchronous without a background flag', () => {
     expect(isAsyncAgentInput({ task_name: 'audit_ui' }, 'spawn_agent')).toBe(true);
     expect(isAsyncAgentInput({ task_name: 'audit_ui' }, 'functions.spawn_agent')).toBe(true);
+  });
+
+  it('returns true when the launch ack text indicates async', () => {
+    // Claude stamps the async launch ack with a fixed "Async agent launched"
+    // text; matching it keeps a background agent (whose input may lack
+    // run_in_background) from being marked completed the instant the ack lands.
+    const result: ToolResultBlock = { type: 'tool_result', content: 'Async agent launched successfully. (internal metadata)' };
+    expect(isAsyncAgentInput({ prompt: 'do stuff' }, 'agent', result)).toBe(true);
+  });
+
+  it('returns true for launch ack text supplied as content blocks', () => {
+    const result: ToolResultBlock = { type: 'tool_result', content: [{ type: 'text', text: 'Async agent launched successfully.' }] };
+    expect(isAsyncAgentInput({ description: 'x' }, 'agent', result)).toBe(true);
+  });
+
+  it('does not false-positive on a sync result that merely mentions async', () => {
+    const result: ToolResultBlock = { type: 'tool_result', content: 'Refactored the async handler and landed the fix.' };
+    expect(isAsyncAgentInput({ prompt: 'x' }, 'agent', result)).toBe(false);
+  });
+
+  it('returns true for an async tool-use status even without run_in_background', () => {
+    expect(isAsyncAgentInput({ prompt: 'x' }, 'agent', null, 'async_launched')).toBe(true);
+    expect(isAsyncAgentInput({ prompt: 'x' }, 'agent', null, 'remote_launched')).toBe(true);
+    expect(isAsyncAgentInput({ prompt: 'x' }, 'agent', null, 'teammate_spawned')).toBe(true);
+  });
+
+  it('returns false for a completed tool-use status (sync agent)', () => {
+    expect(isAsyncAgentInput({ prompt: 'x' }, 'agent', null, 'completed')).toBe(false);
+    expect(isAsyncAgentInput({ prompt: 'x' }, 'agent', null, 'running')).toBe(false);
+  });
+});
+
+describe('readToolUseStatus', () => {
+  it('reads status from toolUseResult metadata', () => {
+    expect(readToolUseStatus({ toolUseResult: { status: 'async_launched', agentId: 'x' } })).toBe('async_launched');
+  });
+
+  it('returns undefined when toolUseResult is missing or non-object', () => {
+    expect(readToolUseStatus({ content: 'x' })).toBeUndefined();
+    expect(readToolUseStatus(null)).toBeUndefined();
+    expect(readToolUseStatus(undefined)).toBeUndefined();
+    expect(readToolUseStatus({ toolUseResult: 'error string' })).toBeUndefined();
+    expect(readToolUseStatus({ toolUseResult: null })).toBeUndefined();
+    expect(readToolUseStatus({ toolUseResult: [] })).toBeUndefined();
   });
 });
 

--- a/webview/src/utils/subagentResult.ts
+++ b/webview/src/utils/subagentResult.ts
@@ -21,6 +21,14 @@ export function extractResultText(result?: ToolResultBlock | null): string | und
   return undefined;
 }
 
+// Claude Code's async-launch ack is a fixed, hard-coded tool_result text. It is
+// the only signal we can rely on across versions, because recent versions no longer
+// guarantees a task_notification SDK event for background agents — the agent's
+// terminal report is delivered solely as a main-session XML (see the ai-bridge
+// interception in runtime-lifecycle.js). Matching this text is what keeps the
+// card from flipping to "completed" the instant the ack lands.
+const ASYNC_LAUNCH_TEXT = /Async agent launched/i;
+
 /**
  * Whether an Agent/Task tool input launches a background (async) subagent.
  *
@@ -33,12 +41,56 @@ export function extractResultText(result?: ToolResultBlock | null): string | und
  * Strict === true avoids truthy strings (e.g. "false") flipping the flag. The
  * camelCase `runInBackground` form is also checked as a guard against future
  * normalization changes. Shared by all three call sites so they cannot drift.
+ *
+ * Beyond the input flag, recent Claude Code also returns an `async_launched`
+ * / `remote_launched` / `teammate_spawned` tool-use status and stamps the
+ * launch ack with a fixed "Async agent launched" text. Both are accepted as
+ * fallbacks so an agent whose input lacks `run_in_background` (e.g. spawned
+ * via a different async path) is still recognized and does not get marked
+ * completed on the launch ack alone.
  */
-export function isAsyncAgentInput(input: unknown, normalizedToolName?: string): boolean {
+export function isAsyncAgentInput(
+  input: unknown,
+  normalizedToolName?: string,
+  result?: ToolResultBlock | null,
+  toolUseStatus?: unknown,
+): boolean {
   if (normalizedToolName?.split('.').at(-1) === 'spawn_agent') return true;
-  if (!input || typeof input !== 'object') return false;
+  if (!input || typeof input !== 'object') {
+    // Even a stripped input still betrays an async launch via its ack text or
+    // tool-use status, so do not fall through to "sync" just because input is
+    // missing.
+    return isAsyncLaunchStatus(toolUseStatus) || isAsyncLaunchText(result);
+  }
   const record = input as Record<string, unknown>;
-  return record.run_in_background === true || record.runInBackground === true;
+  if (record.run_in_background === true || record.runInBackground === true) return true;
+  return isAsyncLaunchStatus(toolUseStatus) || isAsyncLaunchText(result);
+}
+
+function isAsyncLaunchText(result?: ToolResultBlock | null): boolean {
+  const text = extractResultText(result);
+  return !!text && ASYNC_LAUNCH_TEXT.test(text);
+}
+
+const ASYNC_LAUNCH_STATUSES = new Set(['async_launched', 'remote_launched', 'teammate_spawned']);
+
+function isAsyncLaunchStatus(status: unknown): boolean {
+  return typeof status === 'string' && ASYNC_LAUNCH_STATUSES.has(status);
+}
+
+/**
+ * Read the `status` field of a tool_result's toolUseResult metadata, returning
+ * undefined for any shape that does not carry one. Centralized so the three
+ * isAsyncAgentInput call sites extract the same field without drifting.
+ */
+export function readToolUseStatus(raw: unknown): unknown {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const record = raw as Record<string, unknown>;
+  const toolUseResult = record.toolUseResult;
+  if (!toolUseResult || typeof toolUseResult !== 'object' || Array.isArray(toolUseResult)) {
+    return undefined;
+  }
+  return (toolUseResult as Record<string, unknown>).status;
 }
 
 export interface SpawnAgentMeta {

--- a/webview/src/utils/taskNotificationMessage.test.ts
+++ b/webview/src/utils/taskNotificationMessage.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import type { ClaudeMessage } from '../types';
+import { parseTaskNotificationXml, collectTaskEventsFromMessages } from './taskNotificationMessage';
+
+// Mirrors the user-message content Claude Code injects when a background Agent
+// terminates. The <result> body is escaped with Na() (only & < >).
+const FULL_XML = `<task-notification>
+<task-id>w-abc123</task-id>
+<tool-use-id>toolu_01XYZ</tool-use-id>
+<output-file>/home/user/.codemoss/agents/abc.jsonl</output-file>
+<status>completed</status>
+<summary>Agent "research" finished</summary>
+<result>Found 3 issues &amp; fixed them. See &lt;report&gt; for details.</result>
+</task-notification>`;
+
+describe('parseTaskNotificationXml', () => {
+  it('extracts fields, unescapes the result body, and prefers result over summary', () => {
+    const event = parseTaskNotificationXml(FULL_XML);
+    expect(event).toEqual({
+      toolUseId: 'toolu_01XYZ',
+      status: 'completed',
+      agentId: 'w-abc123',
+      summary: 'Found 3 issues & fixed them. See <report> for details.',
+      outputFilePath: '/home/user/.codemoss/agents/abc.jsonl',
+    });
+  });
+
+  it('falls back to the one-line summary when result is absent', () => {
+    const xml = `<task-notification>
+<tool-use-id>toolu_02</tool-use-id>
+<status>failed</status>
+<summary>Agent "y" failed: boom</summary>
+</task-notification>`;
+    expect(parseTaskNotificationXml(xml)).toEqual({
+      toolUseId: 'toolu_02',
+      status: 'failed',
+      summary: 'Agent "y" failed: boom',
+    });
+  });
+
+  it('maps killed status to stopped', () => {
+    const xml = `<task-notification>\n<tool-use-id>t</tool-use-id>\n<status>killed</status>\n</task-notification>`;
+    expect(parseTaskNotificationXml(xml)?.status).toBe('stopped');
+  });
+
+  it('returns null without a tool-use-id (unrouteable)', () => {
+    const xml = `<task-notification>\n<task-id>w-1</task-id>\n<status>completed</status>\n</task-notification>`;
+    expect(parseTaskNotificationXml(xml)).toBeNull();
+  });
+
+  it('returns null for a non-terminal status', () => {
+    const xml = `<task-notification>\n<tool-use-id>t</tool-use-id>\n<status>running</status>\n</task-notification>`;
+    expect(parseTaskNotificationXml(xml)).toBeNull();
+  });
+
+  it('returns null for a non-task-notification payload', () => {
+    expect(parseTaskNotificationXml('just a user message')).toBeNull();
+    expect(parseTaskNotificationXml('<command-message>run</command-message>')).toBeNull();
+  });
+
+  it('omits optional fields when the tags are absent', () => {
+    const xml = `<task-notification>\n<tool-use-id>t</tool-use-id>\n<status>completed</status>\n</task-notification>`;
+    const event = parseTaskNotificationXml(xml);
+    expect(event).toEqual({ toolUseId: 't', status: 'completed' });
+    expect(event && 'summary' in event).toBe(false);
+  });
+});
+
+describe('collectTaskEventsFromMessages', () => {
+  function user(content: string): ClaudeMessage {
+    return { type: 'user', content };
+  }
+
+  it('collects a task event from a task-notification user message', () => {
+    const derived = collectTaskEventsFromMessages([user(FULL_XML)]);
+    expect(derived.toolu_01XYZ).toEqual({
+      toolUseId: 'toolu_01XYZ',
+      status: 'completed',
+      agentId: 'w-abc123',
+      summary: 'Found 3 issues & fixed them. See <report> for details.',
+      outputFilePath: '/home/user/.codemoss/agents/abc.jsonl',
+    });
+  });
+
+  it('skips non-user messages and ordinary user messages', () => {
+    const messages: ClaudeMessage[] = [
+      { type: 'assistant', content: 'thinking...' },
+      user('please review the JSON files'),
+      { type: 'task_notification', icon: '✓', summary: 'done', status: 'completed' },
+    ];
+    expect(collectTaskEventsFromMessages(messages)).toEqual({});
+  });
+
+  it('keys multiple task-notifications by their tool-use-id', () => {
+    const messages: ClaudeMessage[] = [
+      user(FULL_XML),
+      user(`<task-notification>\n<tool-use-id>toolu_99</tool-use-id>\n<status>stopped</status>\n</task-notification>`),
+    ];
+    const derived = collectTaskEventsFromMessages(messages);
+    expect(Object.keys(derived).sort()).toEqual(['toolu_01XYZ', 'toolu_99']);
+  });
+});

--- a/webview/src/utils/taskNotificationMessage.ts
+++ b/webview/src/utils/taskNotificationMessage.ts
@@ -1,0 +1,80 @@
+import type { ClaudeMessage, TaskEvent, TaskEventMap, TaskEventStatus } from '../types';
+
+// Recent Claude Code terminates a background Agent by injecting a
+// <task-notification> XML as the content of a plain user message in the main
+// session — NOT as a queued_command attachment and NOT as a task_notification
+// SDK system event. The XML's <result> tag is the only place the agent's full
+// report lives, so without parsing it the subagent card stays stuck on the
+// launch ack text. This marker is the cheapest possible reject for non-carriers.
+const TASK_NOTIFICATION_MARKER = '<task-notification>';
+
+const STATUS_ALIASES: Record<string, TaskEventStatus> = { killed: 'stopped' };
+const VALID_TERMINAL_STATUSES = new Set<TaskEventStatus>(['completed', 'failed', 'stopped']);
+
+function extractTag(xml: string, tag: string): string | undefined {
+  const open = `<${tag}>`;
+  const start = xml.indexOf(open);
+  if (start < 0) return undefined;
+  const contentStart = start + open.length;
+  const end = xml.indexOf(`</${tag}>`, contentStart);
+  if (end < 0) return undefined;
+  return unescapeXml(xml.slice(contentStart, end));
+}
+
+// Claude Code's Na() escapes only & < >, but the envelope may carry &quot;/
+// &apos;. &amp; is decoded last so it cannot half-decode the others mid-flight.
+function unescapeXml(s: string): string {
+  return s
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&amp;', '&');
+}
+
+/**
+ * Parse a task-notification XML string into a {@link TaskEvent}, mirroring the
+ * SDK's emitTaskTerminatedSdk shape so the existing taskEvents consumers
+ * (useSubagents, AgentGroupBlock, TaskExecutionBlock) need no changes. The full
+ * <result> report is preferred over the one-line <summary>. Returns null when
+ * the payload lacks a tool_use_id or carries a non-terminal status, so a
+ * non-terminal or malformed envelope is ignored rather than producing an event
+ * the downstream dedup would reject anyway.
+ */
+export function parseTaskNotificationXml(xml: string): TaskEvent | null {
+  const toolUseId = extractTag(xml, 'tool-use-id');
+  if (!toolUseId) return null;
+  const rawStatus = extractTag(xml, 'status');
+  if (!rawStatus) return null;
+  const status = STATUS_ALIASES[rawStatus] ?? rawStatus;
+  if (!VALID_TERMINAL_STATUSES.has(status)) return null;
+  const agentId = extractTag(xml, 'task-id');
+  const report = extractTag(xml, 'result') || extractTag(xml, 'summary');
+  const outputFile = extractTag(xml, 'output-file');
+  const event: TaskEvent = { toolUseId, status };
+  if (agentId) event.agentId = agentId;
+  if (report) event.summary = report;
+  if (outputFile) event.outputFilePath = outputFile;
+  return event;
+}
+
+/**
+ * Scan the main-session message list and build a tool_use_id -> TaskEvent map
+ * from any task-notification user messages. This is the recovery path for the
+ * recent Claude Code behavior where a background agent's terminal report is
+ * delivered as a user message rather than an SDK event — it covers both history
+ * replay (no live SDK stream) and any live session where the SDK event path did
+ * not fire. Callers merge this into the live taskEvents map without overwriting
+ * entries already supplied by a real SDK event.
+ */
+export function collectTaskEventsFromMessages(messages: ClaudeMessage[]): TaskEventMap {
+  const derived: TaskEventMap = {};
+  for (const message of messages) {
+    if (message.type !== 'user') continue;
+    const content = typeof message.content === 'string' ? message.content : '';
+    if (!content.includes(TASK_NOTIFICATION_MARKER)) continue;
+    const event = parseTaskNotificationXml(content);
+    if (event) derived[event.toolUseId] = event;
+  }
+  return derived;
+}

--- a/webview/src/utils/turnScope.test.ts
+++ b/webview/src/utils/turnScope.test.ts
@@ -1,6 +1,43 @@
 import { describe, expect, it } from 'vitest';
-import { finalizeSubagentsForSettledTurn } from './turnScope';
-import type { SubagentInfo } from '../types';
+import { computeStatusScopeMessages, finalizeSubagentsForSettledTurn } from './turnScope';
+import type { ClaudeMessage, SubagentInfo } from '../types';
+
+const userMsg = (content: string): ClaudeMessage => ({ type: 'user', content });
+const assistantMsg = (): ClaudeMessage => ({ type: 'assistant', content: 'ok' });
+
+describe('computeStatusScopeMessages', () => {
+  it('uses the full conversation when not streaming', () => {
+    const messages = [userMsg('a'), assistantMsg()];
+    expect(computeStatusScopeMessages(false, false, [], messages, false)).toBe(messages);
+    expect(computeStatusScopeMessages(false, true, [], messages, true)).toBe(messages);
+  });
+
+  it('keeps the full conversation while streaming when async agents are present', () => {
+    // The reported symptom: a run_in_background agent started in an earlier turn
+    // keeps running after the main turn settles; a later turn (agent report /
+    // new user request) starts streaming and narrowing would drop its card.
+    const messages = [userMsg('a'), assistantMsg()];
+    const latest = [userMsg('b'), assistantMsg()];
+    expect(computeStatusScopeMessages(true, true, latest, messages, true)).toBe(messages);
+    expect(computeStatusScopeMessages(true, true, [], messages, false)).toBe(messages);
+  });
+
+  it('narrows to the latest turn while streaming, no async agents, with tool use', () => {
+    const latest = [userMsg('b'), assistantMsg()];
+    const messages = [userMsg('a'), assistantMsg(), ...latest];
+    expect(computeStatusScopeMessages(true, false, latest, messages, true)).toBe(latest);
+  });
+
+  it('widens to the full conversation when the latest turn carries no tool use', () => {
+    const messages = [userMsg('a'), assistantMsg()];
+    expect(computeStatusScopeMessages(true, false, [assistantMsg()], messages, false)).toBe(messages);
+  });
+
+  it('widens when the latest-turn slice is empty', () => {
+    const messages = [userMsg('a'), assistantMsg()];
+    expect(computeStatusScopeMessages(true, false, [], messages, false)).toBe(messages);
+  });
+});
 
 const subagent = (overrides: Partial<SubagentInfo>): SubagentInfo => ({
   id: 'tu_1',

--- a/webview/src/utils/turnScope.ts
+++ b/webview/src/utils/turnScope.ts
@@ -30,6 +30,28 @@ export function sliceLatestConversationTurn(messages: ClaudeMessage[]): ClaudeMe
   return start >= 0 ? messages.slice(start) : [];
 }
 
+/**
+ * Decide which message slice feeds the StatusPanel-derived lists (subagents,
+ * todos). While a turn is streaming, the scope narrows to the latest turn so
+ * settled sync tool progress from older turns does not clutter the panel; once
+ * settled, the full conversation is shown. A run_in_background agent is the
+ * exception: it starts in an older turn but keeps running after that turn
+ * settles, and its terminal report lands in a later turn. Narrowing would drop
+ * the agent's card while the user waits for it to return, so a session that
+ * contains any async agent keeps the full conversation in scope.
+ */
+export function computeStatusScopeMessages(
+  streamingActive: boolean,
+  hasAsyncAgents: boolean,
+  latestTurnMessages: ClaudeMessage[],
+  messages: ClaudeMessage[],
+  latestTurnHasToolUse: boolean,
+): ClaudeMessage[] {
+  if (!streamingActive) return messages;
+  if (hasAsyncAgents) return messages;
+  return latestTurnMessages.length > 0 && latestTurnHasToolUse ? latestTurnMessages : messages;
+}
+
 export function finalizeTodosForSettledTurn(todos: TodoItem[], isStreaming: boolean): TodoItem[] {
   if (isStreaming) return todos;
   return todos.map((todo) => (


### PR DESCRIPTION
Recent Claude Code delivers a background Agent's terminal report as a
<task-notification> XML in the content of a plain main-session user
message, instead of emitting a task_notification SDK event. The user
message was silently consumed inter-turn and carried no signal during
history replay, so the subagent card stayed stuck on the launch ack
text ("Async agent launched successfully.").

Recover the report on two paths. On the frontend, App.tsx derives
taskEvents from task-notification user messages via
collectTaskEventsFromMessages (filling gaps without overwriting a real
SDK event); the inline agent cards already read taskEvent.summary as
resultText. In the ai-bridge, the perpetual reader (inter-turn) and
executeTurn (in-turn) intercept task-notification user messages and
synthesize the event the SDK no longer emits, as the live fast-path.

isAsyncAgentInput now also falls back to the launch ack text and the
async_launched / remote_launched / teammate_spawned tool-use status, so
an agent spawned without run_in_background is kept running until its
terminal event lands instead of being marked completed on the ack alone.

The StatusPanel subagent list could also disappear while a background
agent was still running: the agent starts in an earlier turn but keeps
running after that turn settles, and a later turn (agent report / new
user request) starting to stream narrowed the StatusPanel scope to the
latest turn, dropping the agent's card. The scope decision is now a
pure function (computeStatusScopeMessages) that keeps the full
conversation in scope whenever the session contains any async agent,
so the list never vanishes while the user waits for the agent.