### PR TITLE
feat(grok): GrokSDKBridge runtime (env/proxy + session/UI wiring)

### DIFF
--- a/ai-bridge/services/grok/grok-acp-client.js
+++ b/ai-bridge/services/grok/grok-acp-client.js
@@ -351,7 +351,7 @@ export class GrokAcpClient {
     }
     this.pending.clear();
 
-    if (killProcess && this.proc && !this.proc.killed) {
+    if (killProcess && this.proc && this.proc.exitCode === null) {
       try {
         this.proc.kill('SIGTERM');
       } catch {
@@ -361,7 +361,7 @@ export class GrokAcpClient {
       const proc = this.proc;
       setTimeout(() => {
         try {
-          if (proc && !proc.killed) proc.kill('SIGKILL');
+          if (proc && proc.exitCode === null) proc.kill('SIGKILL');
         } catch {
           // ignore
         }
@@ -404,7 +404,7 @@ export class GrokAcpClient {
     } catch {
       // ignore
     }
-    if (this.proc && !this.proc.killed) {
+    if (this.proc && this.proc.exitCode === null) {
       try {
         this.proc.kill('SIGTERM');
       } catch {
@@ -412,7 +412,7 @@ export class GrokAcpClient {
       }
       // Force kill if still alive after a short grace period
       await new Promise((r) => setTimeout(r, 300));
-      if (this.proc && !this.proc.killed) {
+      if (this.proc && this.proc.exitCode === null) {
         try {
           this.proc.kill('SIGKILL');
         } catch {

--- a/ai-bridge/services/grok/grok-event-normalizer.js
+++ b/ai-bridge/services/grok/grok-event-normalizer.js
@@ -139,20 +139,42 @@ export class GrokEventNormalizer {
 
     switch (kind) {
       case 'agent_message_chunk': {
-        const text = extractText(update.content);
+        const text = extractText(update.content) || extractText(update.delta) || update.text || '';
         if (text) {
-          this.assistantText += text;
-          this.#emit(`[CONTENT_DELTA] ${JSON.stringify(text)}`);
+          let delta = '';
+          if (text.startsWith(this.assistantText)) {
+            delta = text.slice(this.assistantText.length);
+            this.assistantText = text;
+          } else if (this.assistantText.startsWith(text)) {
+            delta = '';
+          } else {
+            delta = text;
+            this.assistantText += text;
+          }
+          if (delta) {
+            this.#emit(`[CONTENT_DELTA] ${JSON.stringify(delta)}`);
+          }
         }
         break;
       }
       case 'agent_thought_chunk':
       case 'agent_thinking_chunk':
       case 'thought_chunk': {
-        const text = extractText(update.content) || update.text || '';
+        const text = extractText(update.content) || extractText(update.delta) || update.text || '';
         if (text) {
-          this.thinkingText += text;
-          this.#emit(`[THINKING_DELTA] ${JSON.stringify(text)}`);
+          let delta = '';
+          if (text.startsWith(this.thinkingText)) {
+            delta = text.slice(this.thinkingText.length);
+            this.thinkingText = text;
+          } else if (this.thinkingText.startsWith(text)) {
+            delta = '';
+          } else {
+            delta = text;
+            this.thinkingText += text;
+          }
+          if (delta) {
+            this.#emit(`[THINKING_DELTA] ${JSON.stringify(delta)}`);
+          }
         }
         break;
       }
@@ -175,10 +197,21 @@ export class GrokEventNormalizer {
         break;
       default: {
         // Try generic text fields
-        const text = extractText(update.content) || update.text;
+        const text = extractText(update.content) || extractText(update.delta) || update.text;
         if (text && kind.includes('message')) {
-          this.assistantText += text;
-          this.#emit(`[CONTENT_DELTA] ${JSON.stringify(text)}`);
+          let delta = '';
+          if (text.startsWith(this.assistantText)) {
+            delta = text.slice(this.assistantText.length);
+            this.assistantText = text;
+          } else if (this.assistantText.startsWith(text)) {
+            delta = '';
+          } else {
+            delta = text;
+            this.assistantText += text;
+          }
+          if (delta) {
+            this.#emit(`[CONTENT_DELTA] ${JSON.stringify(delta)}`);
+          }
         }
         break;
       }
@@ -299,9 +332,15 @@ export class GrokEventNormalizer {
 function extractText(content) {
   if (content == null) return '';
   if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content.map(extractText).join('');
+  }
   if (typeof content === 'object') {
     if (typeof content.text === 'string') return content.text;
-    if (typeof content.content === 'string') return content.content;
+    if (typeof content.content === 'string' || typeof content.content === 'object') {
+      return extractText(content.content);
+    }
+    if (typeof content.delta === 'string') return content.delta;
   }
   return '';
 }

--- a/build.gradle
+++ b/build.gradle
@@ -291,6 +291,10 @@ tasks.named('instrumentCode') {
     enabled = false
 }
 
+tasks.named('instrumentTestCode') {
+    enabled = false
+}
+
 tasks.named('jarSearchableOptions') {
     enabled = false
 }

--- a/src/main/java/com/github/claudecodegui/bridge/EnvironmentConfigurator.java
+++ b/src/main/java/com/github/claudecodegui/bridge/EnvironmentConfigurator.java
@@ -185,6 +185,7 @@ public class EnvironmentConfigurator {
 
         configurePermissionEnv(env, nodeExecutable);
         configureProxyEnv(env);
+        configureGrokEnv(env);
     }
 
     private void configureProxyEnv(Map<String, String> env) {
@@ -216,6 +217,15 @@ public class EnvironmentConfigurator {
                     env.put("http_proxy", proxyUrl);
                     env.put("https_proxy", proxyUrl);
                     env.put("all_proxy", proxyUrl);
+                    
+                    String noProxy = resolveEnvValue("NO_PROXY");
+                    if (noProxy == null || noProxy.isEmpty()) {
+                        noProxy = resolveEnvValue("no_proxy");
+                    }
+                    if (noProxy != null && !noProxy.isEmpty()) {
+                        env.put("NO_PROXY", noProxy);
+                        env.put("no_proxy", noProxy);
+                    }
                 }
             }
         } catch (Exception e) {
@@ -585,6 +595,36 @@ public class EnvironmentConfigurator {
             }
         } catch (Exception e) {
             LOG.warn("[Codex] Error configuring Codex env: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Configure Grok-specific environment variables.
+     * Loads custom base URLs and proxy configs from the shell environment.
+     */
+    public void configureGrokEnv(Map<String, String> env) {
+        if (env == null) {
+            return;
+        }
+        String[] grokEnvKeys = {
+            "GROK_MODELS_BASE_URL",
+            "GROK_XAI_API_BASE_URL",
+            "XAI_API_BASE_URL",
+            "GROK_CLI_CHAT_PROXY_BASE_URL",
+            "GROK_HOME",
+            "GROK_API_KEY",
+            "XAI_API_KEY",
+            "NO_PROXY",
+            "no_proxy"
+        };
+        for (String key : grokEnvKeys) {
+            if (env.containsKey(key) && env.get(key) != null && !env.get(key).isEmpty()) {
+                continue; // Already set
+            }
+            String value = resolveEnvValue(key);
+            if (value != null && !value.trim().isEmpty()) {
+                env.put(key, value.trim());
+            }
         }
     }
 

--- a/src/main/java/com/github/claudecodegui/bridge/EnvironmentConfigurator.java
+++ b/src/main/java/com/github/claudecodegui/bridge/EnvironmentConfigurator.java
@@ -27,6 +27,9 @@ import java.util.regex.Pattern;
  * Environment configurator.
  * Responsible for configuring process environment variables.
  */
+import com.intellij.util.EnvironmentUtil;
+import com.intellij.util.net.HttpConfigurable;
+
 public class EnvironmentConfigurator {
 
     private static final Logger LOG = Logger.getInstance(EnvironmentConfigurator.class);
@@ -59,6 +62,16 @@ public class EnvironmentConfigurator {
      */
     public void updateProcessEnvironment(ProcessBuilder pb, String nodeExecutable) {
         Map<String, String> env = pb.environment();
+        
+        // Merge login shell environment variables (e.g. proxy, API keys in ~/.zshrc)
+        try {
+            Map<String, String> shellEnv = EnvironmentUtil.getEnvironmentMap();
+            for (Map.Entry<String, String> entry : shellEnv.entrySet()) {
+                env.putIfAbsent(entry.getKey(), entry.getValue());
+            }
+        } catch (Exception e) {
+            LOG.warn("[EnvironmentConfigurator] Failed to load shell environment: " + e.getMessage());
+        }
 
         // Use PlatformUtils to get the PATH variable (case-insensitive)
         String path = PlatformUtils.isWindows() ?
@@ -171,6 +184,43 @@ public class EnvironmentConfigurator {
         }
 
         configurePermissionEnv(env, nodeExecutable);
+        configureProxyEnv(env);
+    }
+
+    private void configureProxyEnv(Map<String, String> env) {
+        try {
+            HttpConfigurable proxySettings = HttpConfigurable.getInstance();
+            if (proxySettings != null && proxySettings.USE_HTTP_PROXY) {
+                String host = proxySettings.PROXY_HOST;
+                int port = proxySettings.PROXY_PORT;
+                if (host != null && !host.isEmpty()) {
+                    String auth = "";
+                    if (proxySettings.PROXY_AUTHENTICATION) {
+                        String user = proxySettings.getProxyLogin();
+                        String pass = proxySettings.getPlainProxyPassword();
+                        if (user != null && !user.isEmpty()) {
+                            auth = user + (pass != null ? ":" + pass : "") + "@";
+                        }
+                    }
+                    boolean isSocks = false;
+                    try {
+                        java.lang.reflect.Field field = proxySettings.getClass().getField("PROXY_TYPE_IS_SOCKS");
+                        isSocks = field.getBoolean(proxySettings);
+                    } catch (Exception ignored) {}
+
+                    String scheme = isSocks ? "socks5://" : "http://";
+                    String proxyUrl = scheme + auth + host + ":" + port;
+                    env.put("HTTP_PROXY", proxyUrl);
+                    env.put("HTTPS_PROXY", proxyUrl);
+                    env.put("ALL_PROXY", proxyUrl);
+                    env.put("http_proxy", proxyUrl);
+                    env.put("https_proxy", proxyUrl);
+                    env.put("all_proxy", proxyUrl);
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("[EnvironmentConfigurator] Failed to configure proxy: " + e.getMessage());
+        }
     }
 
     static String resolveHomeForNodeEnvironment(String nodeExecutable, String currentHome) {

--- a/src/main/java/com/github/claudecodegui/handler/core/HandlerContext.java
+++ b/src/main/java/com/github/claudecodegui/handler/core/HandlerContext.java
@@ -3,6 +3,7 @@ package com.github.claudecodegui.handler.core;
 import com.github.claudecodegui.session.ClaudeSession;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.provider.grok.GrokSDKBridge;
 import com.github.claudecodegui.settings.CodemossSettingsService;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
@@ -23,6 +24,7 @@ public class HandlerContext {
     private final Project project;
     private final ClaudeSDKBridge claudeSDKBridge;
     private final CodexSDKBridge codexSDKBridge;
+    private final GrokSDKBridge grokSDKBridge;
     private final CodemossSettingsService settingsService;
     private final JsCallback jsCallback;
     private final BooleanSupplier activeContentSupplier;
@@ -51,7 +53,7 @@ public class HandlerContext {
             CodemossSettingsService settingsService,
             JsCallback jsCallback
     ) {
-        this(project, claudeSDKBridge, codexSDKBridge, settingsService, jsCallback, () -> true, () -> null);
+        this(project, claudeSDKBridge, codexSDKBridge, null, settingsService, jsCallback, () -> true, () -> null);
     }
 
     public HandlerContext(
@@ -63,9 +65,24 @@ public class HandlerContext {
             BooleanSupplier activeContentSupplier,
             Supplier<String> contentTitleSupplier
     ) {
+        this(project, claudeSDKBridge, codexSDKBridge, null, settingsService, jsCallback,
+                activeContentSupplier, contentTitleSupplier);
+    }
+
+    public HandlerContext(
+            Project project,
+            ClaudeSDKBridge claudeSDKBridge,
+            CodexSDKBridge codexSDKBridge,
+            GrokSDKBridge grokSDKBridge,
+            CodemossSettingsService settingsService,
+            JsCallback jsCallback,
+            BooleanSupplier activeContentSupplier,
+            Supplier<String> contentTitleSupplier
+    ) {
         this.project = project;
         this.claudeSDKBridge = claudeSDKBridge;
         this.codexSDKBridge = codexSDKBridge;
+        this.grokSDKBridge = grokSDKBridge;
         this.settingsService = settingsService;
         this.jsCallback = jsCallback;
         this.activeContentSupplier = activeContentSupplier == null ? () -> true : activeContentSupplier;
@@ -83,6 +100,10 @@ public class HandlerContext {
 
     public CodexSDKBridge getCodexSDKBridge() {
         return codexSDKBridge;
+    }
+
+    public GrokSDKBridge getGrokSDKBridge() {
+        return grokSDKBridge;
     }
 
     public CodemossSettingsService getSettingsService() {

--- a/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
@@ -21,6 +21,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 
 /**
  * Manages a long-running Node.js daemon process for AI SDK communication.
@@ -57,6 +58,7 @@ public class DaemonBridge {
     private final DaemonProcessLauncher processLauncher;
     private final DaemonLifecycleHooks lifecycleHooks;
     private final long heartbeatIntervalMs;
+    private final Consumer<Map<String, String>> customEnvConfigurator;
     // Daemon process state. Every asynchronous callback is scoped to one context.
     private volatile DaemonGenerationContext daemonContext;
     private final AtomicLong daemonGenerationCounter = new AtomicLong(0);
@@ -82,7 +84,16 @@ public class DaemonBridge {
             BridgeDirectoryResolver directoryResolver,
             EnvironmentConfigurator envConfigurator
     ) {
-        this(nodeDetector, directoryResolver, envConfigurator, TimeSource.system());
+        this(nodeDetector, directoryResolver, envConfigurator, (Consumer<Map<String, String>>) null);
+    }
+
+    public DaemonBridge(
+            NodeDetector nodeDetector,
+            BridgeDirectoryResolver directoryResolver,
+            EnvironmentConfigurator envConfigurator,
+            Consumer<Map<String, String>> customEnvConfigurator
+    ) {
+        this(nodeDetector, directoryResolver, envConfigurator, TimeSource.system(), null, null, HEARTBEAT_INTERVAL_MS, customEnvConfigurator);
     }
 
     DaemonBridge(
@@ -109,7 +120,8 @@ public class DaemonBridge {
                 timeSource,
                 processLauncher,
                 lifecycleHooks,
-                HEARTBEAT_INTERVAL_MS);
+                HEARTBEAT_INTERVAL_MS,
+                null);
     }
 
     DaemonBridge(
@@ -119,7 +131,8 @@ public class DaemonBridge {
             TimeSource timeSource,
             DaemonProcessLauncher processLauncher,
             DaemonLifecycleHooks lifecycleHooks,
-            long heartbeatIntervalMs
+            long heartbeatIntervalMs,
+            Consumer<Map<String, String>> customEnvConfigurator
     ) {
         this.nodeDetector = nodeDetector;
         this.directoryResolver = directoryResolver;
@@ -130,6 +143,7 @@ public class DaemonBridge {
         this.lifecycleHooks = lifecycleHooks != null
                 ? lifecycleHooks : DaemonLifecycleHooks.NO_OP;
         this.heartbeatIntervalMs = heartbeatIntervalMs;
+        this.customEnvConfigurator = customEnvConfigurator;
     }
 
     // =========================================================================
@@ -342,6 +356,9 @@ public class DaemonBridge {
         ProcessBuilder processBuilder = new ProcessBuilder(daemonCmd);
         processBuilder.directory(bridgeDir);
         envConfigurator.updateProcessEnvironment(processBuilder, nodePath);
+        if (customEnvConfigurator != null) {
+            customEnvConfigurator.accept(processBuilder.environment());
+        }
 
         Map<String, String> environment = processBuilder.environment();
         String claudeCliPath = PropertiesComponent.getInstance()

--- a/src/main/java/com/github/claudecodegui/provider/grok/GrokCliBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/grok/GrokCliBridge.java
@@ -1,6 +1,7 @@
 package com.github.claudecodegui.provider.grok;
 
 import com.github.claudecodegui.provider.common.MarkerCliBridge;
+import com.github.claudecodegui.settings.CodemossSettingsService;
 import com.google.gson.JsonObject;
 
 import java.util.Collections;
@@ -15,6 +16,8 @@ import java.util.Map;
  * streaming-json NDJSON onto the shared marker protocol.
  */
 public class GrokCliBridge extends MarkerCliBridge {
+
+    private final CodemossSettingsService settingsService = new CodemossSettingsService();
 
     public GrokCliBridge() {
         super(GrokCliBridge.class);
@@ -33,6 +36,67 @@ public class GrokCliBridge extends MarkerCliBridge {
     @Override
     protected void configureExtraEnv(Map<String, String> env) {
         env.put("GROK_DISABLE_AUTOUPDATER", "1");
+        env.put("GROK_NO_AUTO_UPDATE", "1");
+        env.put("CI", "1");
+
+        try {
+            JsonObject grokEnv = settingsService.getGrokEnv();
+            if (grokEnv != null && grokEnv.size() > 0) {
+                for (String key : grokEnv.keySet()) {
+                    if (grokEnv.get(key) != null && !grokEnv.get(key).isJsonNull()) {
+                        env.put(key, grokEnv.get(key).getAsString());
+                    }
+                }
+            }
+
+            String authMethod = settingsService.getGrokAuthMethod();
+            String apiKey = settingsService.getGrokApiKey();
+            String apiBaseUrl = settingsService.getGrokApiBaseUrl();
+
+            GrokLocalAuthResolver.ResolvedAuth resolved = GrokLocalAuthResolver.resolve(
+                    authMethod,
+                    apiKey,
+                    apiBaseUrl
+            );
+
+            env.put("GROK_AUTH_METHOD", resolved.authMethod);
+
+            if (CodemossSettingsService.GROK_AUTH_METHOD_OAUTH.equals(resolved.authMethod)) {
+                env.remove("XAI_API_KEY");
+                env.remove("GROK_API_KEY");
+            } else {
+                if (resolved.apiKey != null && !resolved.apiKey.isEmpty()) {
+                    env.put("XAI_API_KEY", resolved.apiKey);
+                    env.put("GROK_API_KEY", resolved.apiKey);
+                }
+            }
+
+            if (resolved.baseUrl != null && !resolved.baseUrl.isEmpty()) {
+                String effectiveBase = resolved.baseUrl;
+                String modelsList = effectiveBase.replaceAll("/+$", "") + "/models";
+                env.put("GROK_MODELS_BASE_URL", effectiveBase);
+                env.put("GROK_MODELS_LIST_URL", modelsList);
+                env.put("GROK_BASE_URL", effectiveBase);
+
+                if (CodemossSettingsService.GROK_AUTH_METHOD_API_KEY.equals(resolved.authMethod)) {
+                    env.put("XAI_API_BASE_URL", effectiveBase);
+                    env.put("GROK_CLI_CHAT_PROXY_BASE_URL", effectiveBase);
+                } else if (CodemossSettingsService.GROK_AUTH_METHOD_OAUTH.equals(resolved.authMethod)) {
+                    env.put("GROK_CLI_CHAT_PROXY_BASE_URL", effectiveBase);
+                    env.remove("XAI_API_BASE_URL");
+                } else {
+                    env.put("XAI_API_BASE_URL", effectiveBase);
+                    env.put("GROK_CLI_CHAT_PROXY_BASE_URL", effectiveBase);
+                }
+            }
+
+            LOG.info("[GrokCliBridge] Configured Grok environment: authMethod=" + resolved.authMethod
+                    + ", baseUrl=" + resolved.baseUrl
+                    + ", apiKeySet=" + (resolved.apiKey != null && !resolved.apiKey.isEmpty()));
+
+        } catch (Exception e) {
+            LOG.warn("[GrokCliBridge] Failed to configure Grok environment: " + e.getMessage());
+        }
     }
 
     @Override

--- a/src/main/java/com/github/claudecodegui/provider/grok/GrokDaemonCoordinator.java
+++ b/src/main/java/com/github/claudecodegui/provider/grok/GrokDaemonCoordinator.java
@@ -8,9 +8,11 @@ import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
@@ -25,6 +27,7 @@ class GrokDaemonCoordinator {
     private final NodeDetector nodeDetector;
     private final Supplier<BridgeDirectoryResolver> directoryResolverSupplier;
     private final EnvironmentConfigurator envConfigurator;
+    private final Consumer<Map<String, String>> customEnvConfigurator;
 
     private volatile DaemonBridge daemonBridge;
     private final Object daemonLock = new Object();
@@ -36,12 +39,14 @@ class GrokDaemonCoordinator {
             Logger log,
             NodeDetector nodeDetector,
             Supplier<BridgeDirectoryResolver> directoryResolverSupplier,
-            EnvironmentConfigurator envConfigurator
+            EnvironmentConfigurator envConfigurator,
+            Consumer<Map<String, String>> customEnvConfigurator
     ) {
         this.log = log;
         this.nodeDetector = nodeDetector;
         this.directoryResolverSupplier = directoryResolverSupplier;
         this.envConfigurator = envConfigurator;
+        this.customEnvConfigurator = customEnvConfigurator;
     }
 
     void addDaemonEventListener(DaemonBridge.DaemonEventListener listener) {
@@ -86,7 +91,8 @@ class GrokDaemonCoordinator {
                 DaemonBridge newBridge = new DaemonBridge(
                         nodeDetector,
                         directoryResolverSupplier.get(),
-                        envConfigurator
+                        envConfigurator,
+                        customEnvConfigurator
                 );
                 if (newBridge.start()) {
                     daemonBridge = newBridge;

--- a/src/main/java/com/github/claudecodegui/provider/grok/GrokHistoryReader.java
+++ b/src/main/java/com/github/claudecodegui/provider/grok/GrokHistoryReader.java
@@ -27,7 +27,8 @@ import java.util.Map;
 
 /**
  * Reads Grok CLI session history from
- * {@code ~/.grok/sessions/<url-encoded-cwd>/<sessionId>/{summary.json,chat_history.jsonl}}.
+ * {@code $GROK_HOME/sessions/<url-encoded-cwd>/<sessionId>/{summary.json,chat_history.jsonl}}
+ * (default home {@code ~/.grok}; often {@code ~/.antig-grok} when {@code GROK_HOME} is set).
  */
 public class GrokHistoryReader {
 
@@ -36,24 +37,38 @@ public class GrokHistoryReader {
     private static final int MAX_TOOL_RESULT_CHARS = 20_000;
 
     private final Gson gson;
-    private final Path sessionsRoot;
+    /** Ordered session roots (primary GROK_HOME first, then fallbacks). */
+    private final List<Path> sessionsRoots;
 
     public GrokHistoryReader() {
-        this(defaultSessionsRoot(), new Gson());
+        this(defaultSessionsRoots(), new Gson());
     }
 
     GrokHistoryReader(Path sessionsRoot, Gson gson) {
-        this.sessionsRoot = sessionsRoot;
+        this(sessionsRoot != null ? List.of(sessionsRoot) : List.of(), gson);
+    }
+
+    GrokHistoryReader(List<Path> sessionsRoots, Gson gson) {
+        this.sessionsRoots = sessionsRoots != null ? List.copyOf(sessionsRoots) : List.of();
         this.gson = gson;
     }
 
-    private static Path defaultSessionsRoot() {
-        String home = NodeDetector.resolveHomeForFileOps();
-        String grokHome = System.getenv("GROK_HOME");
-        if (grokHome != null && !grokHome.trim().isEmpty()) {
-            return Paths.get(grokHome.trim(), "sessions");
+    private static List<Path> defaultSessionsRoots() {
+        List<Path> roots = new ArrayList<>();
+        for (Path home : GrokLocalAuthResolver.resolveGrokHomeCandidates()) {
+            if (home != null) {
+                roots.add(home.resolve("sessions"));
+            }
         }
-        return Paths.get(home, ".grok", "sessions");
+        // Last-resort default if PlatformUtils home resolution failed above.
+        if (roots.isEmpty()) {
+            String home = NodeDetector.resolveHomeForFileOps();
+            if (home != null && !home.isEmpty()) {
+                roots.add(Paths.get(home, ".grok", "sessions"));
+            }
+        }
+        LOG.info("[GrokHistoryReader] Session roots: " + roots);
+        return roots;
     }
 
     public static class SessionInfo {
@@ -113,34 +128,44 @@ public class GrokHistoryReader {
 
     public List<SessionInfo> listAllSessions() throws IOException {
         List<SessionInfo> sessions = new ArrayList<>();
-        if (!Files.isDirectory(sessionsRoot)) {
-            LOG.info("[GrokHistoryReader] Sessions root missing: " + sessionsRoot);
-            return sessions;
-        }
-
-        try (DirectoryStream<Path> cwdDirs = Files.newDirectoryStream(sessionsRoot)) {
-            for (Path cwdDir : cwdDirs) {
-                if (!Files.isDirectory(cwdDir)) {
-                    continue;
-                }
-                String name = cwdDir.getFileName().toString();
-                if (name.startsWith(".") || name.endsWith(".sqlite") || name.endsWith(".db")) {
-                    continue;
-                }
-                String cwd = decodeCwdDirName(name);
-                try (DirectoryStream<Path> sessionDirs = Files.newDirectoryStream(cwdDir)) {
-                    for (Path sessionDir : sessionDirs) {
-                        if (!Files.isDirectory(sessionDir)) {
-                            continue;
-                        }
-                        SessionInfo info = readSessionSummary(sessionDir, cwd);
-                        if (info != null) {
-                            sessions.add(info);
+        // Prefer the first root that owns a given sessionId when the same id
+        // appears in multiple homes (should be rare).
+        Map<String, SessionInfo> byId = new HashMap<>();
+        boolean anyRoot = false;
+        for (Path sessionsRoot : sessionsRoots) {
+            if (!Files.isDirectory(sessionsRoot)) {
+                LOG.info("[GrokHistoryReader] Sessions root missing: " + sessionsRoot);
+                continue;
+            }
+            anyRoot = true;
+            try (DirectoryStream<Path> cwdDirs = Files.newDirectoryStream(sessionsRoot)) {
+                for (Path cwdDir : cwdDirs) {
+                    if (!Files.isDirectory(cwdDir)) {
+                        continue;
+                    }
+                    String name = cwdDir.getFileName().toString();
+                    if (name.startsWith(".") || name.endsWith(".sqlite") || name.endsWith(".db")) {
+                        continue;
+                    }
+                    String cwd = decodeCwdDirName(name);
+                    try (DirectoryStream<Path> sessionDirs = Files.newDirectoryStream(cwdDir)) {
+                        for (Path sessionDir : sessionDirs) {
+                            if (!Files.isDirectory(sessionDir)) {
+                                continue;
+                            }
+                            SessionInfo info = readSessionSummary(sessionDir, cwd);
+                            if (info != null && info.sessionId != null) {
+                                byId.putIfAbsent(info.sessionId, info);
+                            }
                         }
                     }
                 }
             }
         }
+        if (!anyRoot) {
+            LOG.info("[GrokHistoryReader] No sessions roots available: " + sessionsRoots);
+        }
+        sessions.addAll(byId.values());
         sessions.sort(Comparator.comparingLong((SessionInfo s) -> s.lastTimestamp).reversed());
         return sessions;
     }
@@ -295,35 +320,42 @@ public class GrokHistoryReader {
             return null;
         }
         if (cwd != null && !cwd.trim().isEmpty()) {
-            Path direct = sessionsRoot.resolve(encodeCwd(cwd)).resolve(id);
-            if (Files.isDirectory(direct)) {
-                return direct;
-            }
-            // macOS may canonicalize /var → /private/var etc.
-            Path canon = sessionsRoot.resolve(encodeCwd(canonicalizePath(cwd))).resolve(id);
-            if (Files.isDirectory(canon)) {
-                return canon;
+            String encoded = encodeCwd(cwd);
+            String encodedCanon = encodeCwd(canonicalizePath(cwd));
+            for (Path sessionsRoot : sessionsRoots) {
+                Path direct = sessionsRoot.resolve(encoded).resolve(id);
+                if (Files.isDirectory(direct)) {
+                    return direct;
+                }
+                // macOS may canonicalize /var → /private/var etc.
+                Path canon = sessionsRoot.resolve(encodedCanon).resolve(id);
+                if (Files.isDirectory(canon)) {
+                    return canon;
+                }
             }
         }
         return findSessionDirById(id);
     }
 
     private Path findSessionDirById(String sessionId) {
-        if (!Files.isDirectory(sessionsRoot)) {
-            return null;
-        }
-        try (DirectoryStream<Path> cwdDirs = Files.newDirectoryStream(sessionsRoot)) {
-            for (Path cwdDir : cwdDirs) {
-                if (!Files.isDirectory(cwdDir)) {
-                    continue;
-                }
-                Path candidate = cwdDir.resolve(sessionId);
-                if (Files.isDirectory(candidate)) {
-                    return candidate;
-                }
+        for (Path sessionsRoot : sessionsRoots) {
+            if (!Files.isDirectory(sessionsRoot)) {
+                continue;
             }
-        } catch (IOException e) {
-            LOG.warn("[GrokHistoryReader] Scan for session id failed: " + e.getMessage());
+            try (DirectoryStream<Path> cwdDirs = Files.newDirectoryStream(sessionsRoot)) {
+                for (Path cwdDir : cwdDirs) {
+                    if (!Files.isDirectory(cwdDir)) {
+                        continue;
+                    }
+                    Path candidate = cwdDir.resolve(sessionId);
+                    if (Files.isDirectory(candidate)) {
+                        return candidate;
+                    }
+                }
+            } catch (IOException e) {
+                LOG.warn("[GrokHistoryReader] Scan for session id failed under "
+                        + sessionsRoot + ": " + e.getMessage());
+            }
         }
         return null;
     }

--- a/src/main/java/com/github/claudecodegui/provider/grok/GrokLocalAuthResolver.java
+++ b/src/main/java/com/github/claudecodegui/provider/grok/GrokLocalAuthResolver.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.util.EnvironmentUtil;
 
 import com.github.claudecodegui.settings.CodemossSettingsService;
 import com.github.claudecodegui.util.PlatformUtils;
@@ -13,7 +14,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -77,12 +81,69 @@ public final class GrokLocalAuthResolver {
         }
     }
 
+    /**
+     * Resolve Grok CLI home directory.
+     *
+     * <p>Order:
+     * <ol>
+     *   <li>{@code System.getenv("GROK_HOME")} (process env — rare for GUI apps)</li>
+     *   <li>IDE login-shell map via {@link EnvironmentUtil#getEnvironmentMap()}
+     *       (picks up {@code export GROK_HOME=...} from {@code ~/.zshrc})</li>
+     *   <li>{@code ~/.grok} default</li>
+     * </ol>
+     *
+     * <p>Daemon / {@code grok agent} processes inherit shell env through
+     * {@link com.github.claudecodegui.bridge.EnvironmentConfigurator}, so they
+     * often write sessions under a custom {@code GROK_HOME} (e.g. {@code ~/.antig-grok}).
+     * History readers must use the same resolution or tab restore finds nothing.
+     */
     public static Path resolveGrokHome() {
-        String env = System.getenv("GROK_HOME");
-        if (env != null && !env.trim().isEmpty()) {
-            return Paths.get(env.trim());
+        String env = firstNonBlank(
+                System.getenv("GROK_HOME"),
+                environmentMapValue("GROK_HOME")
+        );
+        if (env != null) {
+            return Paths.get(env);
         }
         return Paths.get(PlatformUtils.getHomeDirectory(), ".grok");
+    }
+
+    /**
+     * Candidate Grok homes for on-disk history lookup. Primary home first, then
+     * the default {@code ~/.grok} when {@code GROK_HOME} points elsewhere so older
+     * sessions remain visible after a home migration.
+     */
+    public static List<Path> resolveGrokHomeCandidates() {
+        LinkedHashSet<Path> homes = new LinkedHashSet<>();
+        homes.add(resolveGrokHome());
+        Path defaultHome = Paths.get(PlatformUtils.getHomeDirectory(), ".grok");
+        homes.add(defaultHome);
+        return new ArrayList<>(homes);
+    }
+
+    private static String environmentMapValue(String key) {
+        try {
+            Map<String, String> map = EnvironmentUtil.getEnvironmentMap();
+            if (map == null) {
+                return null;
+            }
+            return map.get(key);
+        } catch (Exception e) {
+            LOG.debug("[Grok] EnvironmentUtil lookup failed for " + key + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    private static String firstNonBlank(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (value != null && !value.trim().isEmpty()) {
+                return value.trim();
+            }
+        }
+        return null;
     }
 
     public static boolean hasOAuthToken() {

--- a/src/main/java/com/github/claudecodegui/provider/grok/GrokSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/grok/GrokSDKBridge.java
@@ -52,7 +52,8 @@ public class GrokSDKBridge extends BaseSDKBridge {
                 LOG,
                 nodeDetector,
                 this::getDirectoryResolver,
-                envConfigurator
+                envConfigurator,
+                env -> configureProviderEnv(env, "{}")
         );
         this.daemonRequestExecutor = new GrokDaemonRequestExecutor(LOG, this);
     }
@@ -71,6 +72,19 @@ public class GrokSDKBridge extends BaseSDKBridge {
         env.put("GROK_USE_STDIN", "true");
         env.put("GROK_NO_AUTO_UPDATE", "1");
         env.put("CI", "1");
+
+        try {
+            JsonObject grokEnv = settingsService.getGrokEnv();
+            if (grokEnv != null && grokEnv.size() > 0) {
+                for (String key : grokEnv.keySet()) {
+                    if (grokEnv.get(key) != null && !grokEnv.get(key).isJsonNull()) {
+                        env.put(key, grokEnv.get(key).getAsString());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("[Grok] Failed to apply custom grok environment: " + e.getMessage());
+        }
 
         GrokLocalAuthResolver.ResolvedAuth resolved = resolveEffectiveAuth();
         String authMethod = resolved.authMethod;
@@ -1047,7 +1061,8 @@ public class GrokSDKBridge extends BaseSDKBridge {
     }
 
     /**
-     * Session messages from Grok CLI on-disk history ({@code ~/.grok/sessions}).
+     * Session messages from Grok CLI on-disk history
+     * ({@code $GROK_HOME/sessions}, default {@code ~/.grok/sessions}).
      */
     public List<JsonObject> getSessionMessages(String sessionId, String cwd) {
         try {

--- a/src/main/java/com/github/claudecodegui/service/NodeProcessRegistry.java
+++ b/src/main/java/com/github/claudecodegui/service/NodeProcessRegistry.java
@@ -3,6 +3,7 @@ package com.github.claudecodegui.service;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
 import com.github.claudecodegui.provider.common.DaemonBridge;
+import com.github.claudecodegui.provider.grok.GrokSDKBridge;
 import com.github.claudecodegui.ui.toolwindow.ClaudeChatWindow;
 import com.github.claudecodegui.ui.toolwindow.ClaudeSDKToolWindow;
 import com.github.claudecodegui.util.PlatformUtils;
@@ -29,8 +30,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * <p>Three data sources are unified:
  * <ol>
- *   <li><b>Claude daemon processes</b>: one per {@link ClaudeChatWindow}, accessed via
- *       {@link ClaudeSDKBridge#getCurrentDaemonBridgeForInspection()}.</li>
+ *   <li><b>Daemon processes</b>: Claude and Grok each own a long-lived {@code daemon.js}
+ *       via {@link ClaudeSDKBridge#getCurrentDaemonBridgeForInspection()} /
+ *       {@link GrokSDKBridge#getCurrentDaemonBridgeForInspection()}.</li>
  *   <li><b>Per-channel processes</b>: tracked in each bridge's {@code ProcessManager}.</li>
  *   <li><b>Orphan processes</b>: discovered by scanning {@link ProcessHandle#allProcesses()}
  *       for {@code daemon.js} / {@code channel-manager.js} command lines that don't match
@@ -102,97 +104,68 @@ public final class NodeProcessRegistry implements Disposable {
             // the user. The physical SDK type is preserved in the command tooltip.
             String tabProvider = safeGetCurrentProvider(window);
 
-            // -- DAEMON entries from ClaudeSDKBridge --
+            // -- DAEMON + CHANNEL entries from Claude / Grok / Codex bridges --
             ClaudeSDKBridge claudeBridge = safeClaudeBridge(window);
+            GrokSDKBridge grokBridge = safeGrokBridge(window);
             if (claudeBridge != null) {
-                DaemonBridge daemon = claudeBridge.getCurrentDaemonBridgeForInspection();
-                if (daemon != null && daemon.isAlive()) {
-                    Process daemonProcess = daemon.getDaemonProcessForInspection();
-                    if (daemonProcess != null && daemonProcess.isAlive()) {
-                        long pid = daemonProcess.pid();
-                        knownPids.add(pid);
-                        ProcessHandle.Info info = safeInfo(daemonProcess);
-                        long startedAt = info != null
-                                ? info.startInstant().map(Instant::toEpochMilli).orElse(-1L)
-                                : -1L;
-                        result.add(NodeProcessInfo.builder()
-                                .kind(NodeProcessInfo.Kind.DAEMON)
-                                .provider(tabProvider)
-                                .pid(pid)
-                                .alive(true)
-                                .startedAtMs(startedAt)
-                                .uptimeMs(startedAt > 0 ? Math.max(0, now - startedAt) : 0L)
-                                .command(extractCommand(info))
-                                .activeRequestCount(daemon.getActiveRequestCount())
-                                .sessionId(sessionId)
-                                .tabName(tabName)
-                                .build());
-
-                        // Also include daemon's child processes (e.g., spawned Claude CLI).
-                        // These are "owned" by us, so add to knownPids to keep them out of orphan list.
-                        try {
-                            daemonProcess.toHandle().descendants().forEach(child -> knownPids.add(child.pid()));
-                        } catch (Exception ignored) {
-                        }
-                    }
-                }
+                collectDaemonEntry(
+                        result,
+                        knownPids,
+                        claudeBridge.getCurrentDaemonBridgeForInspection(),
+                        tabProvider,
+                        sessionId,
+                        tabName,
+                        now
+                );
 
                 // -- CHANNEL entries from claudeBridge.processManager --
-                Map<String, Process> claudeChannels = claudeBridge.getProcessManager().getActiveChannelSnapshot();
-                for (Map.Entry<String, Process> entry : claudeChannels.entrySet()) {
-                    Process p = entry.getValue();
-                    if (p == null || !p.isAlive()) {
-                        continue;
-                    }
-                    long pid = p.pid();
-                    knownPids.add(pid);
-                    ProcessHandle.Info info = safeInfo(p);
-                    long startedAt = info != null
-                            ? info.startInstant().map(Instant::toEpochMilli).orElse(-1L)
-                            : -1L;
-                    result.add(NodeProcessInfo.builder()
-                            .kind(NodeProcessInfo.Kind.CHANNEL)
-                            .provider(tabProvider)
-                            .pid(pid)
-                            .alive(true)
-                            .startedAtMs(startedAt)
-                            .uptimeMs(startedAt > 0 ? Math.max(0, now - startedAt) : 0L)
-                            .command(extractCommand(info))
-                            .channelId(entry.getKey())
-                            .sessionId(sessionId)
-                            .tabName(tabName)
-                            .build());
-                }
+                collectChannelEntries(
+                        result,
+                        knownPids,
+                        claudeBridge.getProcessManager().getActiveChannelSnapshot(),
+                        tabProvider,
+                        sessionId,
+                        tabName,
+                        now
+                );
             }
 
-            // -- CHANNEL entries from codexBridge.processManager (per-message processes) --
+            // Grok persistent ACP daemon (grok agent stdio under daemon.js).
+            // Without this, the live Grok daemon is mislabeled ORPHAN and "Kill all
+            // orphans" / panel kill destroys multi-turn ACP state.
+            if (grokBridge != null) {
+                collectDaemonEntry(
+                        result,
+                        knownPids,
+                        grokBridge.getCurrentDaemonBridgeForInspection(),
+                        tabProvider,
+                        sessionId,
+                        tabName,
+                        now
+                );
+                collectChannelEntries(
+                        result,
+                        knownPids,
+                        grokBridge.getProcessManager().getActiveChannelSnapshot(),
+                        tabProvider,
+                        sessionId,
+                        tabName,
+                        now
+                );
+            }
+
+            // -- CHANNEL entries from codex (per-message processes) --
             CodexSDKBridge codexBridge = safeCodexBridge(window);
             if (codexBridge != null) {
-                Map<String, Process> codexChannels = codexBridge.getProcessManager().getActiveChannelSnapshot();
-                for (Map.Entry<String, Process> entry : codexChannels.entrySet()) {
-                    Process p = entry.getValue();
-                    if (p == null || !p.isAlive()) {
-                        continue;
-                    }
-                    long pid = p.pid();
-                    knownPids.add(pid);
-                    ProcessHandle.Info info = safeInfo(p);
-                    long startedAt = info != null
-                            ? info.startInstant().map(Instant::toEpochMilli).orElse(-1L)
-                            : -1L;
-                    result.add(NodeProcessInfo.builder()
-                            .kind(NodeProcessInfo.Kind.CHANNEL)
-                            .provider(tabProvider)
-                            .pid(pid)
-                            .alive(true)
-                            .startedAtMs(startedAt)
-                            .uptimeMs(startedAt > 0 ? Math.max(0, now - startedAt) : 0L)
-                            .command(extractCommand(info))
-                            .channelId(entry.getKey())
-                            .sessionId(sessionId)
-                            .tabName(tabName)
-                            .build());
-                }
+                collectChannelEntries(
+                        result,
+                        knownPids,
+                        codexBridge.getProcessManager().getActiveChannelSnapshot(),
+                        tabProvider,
+                        sessionId,
+                        tabName,
+                        now
+                );
             }
         }
 
@@ -349,25 +322,36 @@ public final class NodeProcessRegistry implements Disposable {
     public boolean restartDaemonByPid(long pid) {
         Set<ClaudeChatWindow> windows = ClaudeSDKToolWindow.getAllChatWindowsForProject(project);
         for (ClaudeChatWindow window : windows) {
-            ClaudeSDKBridge bridge = safeClaudeBridge(window);
-            if (bridge == null) {
-                continue;
+            ClaudeSDKBridge claudeBridge = safeClaudeBridge(window);
+            if (tryRestartDaemon(claudeBridge != null ? claudeBridge.getCurrentDaemonBridgeForInspection() : null,
+                    claudeBridge != null ? claudeBridge::shutdownDaemon : null, pid)) {
+                return true;
             }
-            DaemonBridge daemon = bridge.getCurrentDaemonBridgeForInspection();
-            if (daemon == null || !daemon.isAlive()) {
-                continue;
+            GrokSDKBridge grokBridge = safeGrokBridge(window);
+            if (tryRestartDaemon(grokBridge != null ? grokBridge.getCurrentDaemonBridgeForInspection() : null,
+                    grokBridge != null ? grokBridge::shutdownDaemon : null, pid)) {
+                return true;
             }
-            Process p = daemon.getDaemonProcessForInspection();
-            if (p == null || p.pid() != pid) {
-                continue;
-            }
-            LOG.info("[NodeProcessRegistry] Restarting daemon for window PID=" + pid);
-            // shutdownDaemon stops the current daemon; next message will lazily start a new one
-            bridge.shutdownDaemon();
-            return true;
         }
         // PID didn't match any tracked daemon — fall back to plain kill
         return killByPid(pid);
+    }
+
+    private boolean tryRestartDaemon(
+            @Nullable DaemonBridge daemon,
+            @Nullable Runnable shutdown,
+            long pid
+    ) {
+        if (daemon == null || !daemon.isAlive() || shutdown == null) {
+            return false;
+        }
+        Process p = daemon.getDaemonProcessForInspection();
+        if (p == null || p.pid() != pid) {
+            return false;
+        }
+        LOG.info("[NodeProcessRegistry] Restarting daemon for window PID=" + pid);
+        shutdown.run();
+        return true;
     }
 
     /**
@@ -410,16 +394,119 @@ public final class NodeProcessRegistry implements Disposable {
             return null;
         }
         String lower = cmd.toLowerCase();
+        // Shared daemon.js is used by Claude and Grok; channel-manager fingerprints are clearer.
+        if (lower.contains("channel-manager") && lower.contains("grok")) {
+            return "grok";
+        }
+        if (lower.contains("channel-manager") && lower.contains("gemini")) {
+            return "gemini";
+        }
+        if (lower.contains("channel-manager") && lower.contains("codex")) {
+            return "codex";
+        }
         if (lower.contains("daemon.js")) {
+            // Cannot distinguish Claude vs Grok daemon from cmd alone.
             return "claude";
         }
         if (lower.contains("codex")) {
             return "codex";
         }
+        if (lower.contains("grok")) {
+            return "grok";
+        }
+        if (lower.contains("gemini")) {
+            return "gemini";
+        }
         if (lower.contains("claude")) {
             return "claude";
         }
         return null;
+    }
+
+    private static void collectDaemonEntry(
+            List<NodeProcessInfo> result,
+            Set<Long> knownPids,
+            @Nullable DaemonBridge daemon,
+            String tabProvider,
+            @Nullable String sessionId,
+            @Nullable String tabName,
+            long now
+    ) {
+        if (daemon == null || !daemon.isAlive()) {
+            return;
+        }
+        Process daemonProcess = daemon.getDaemonProcessForInspection();
+        if (daemonProcess == null || !daemonProcess.isAlive()) {
+            return;
+        }
+        long pid = daemonProcess.pid();
+        knownPids.add(pid);
+        ProcessHandle.Info info = safeInfo(daemonProcess);
+        long startedAt = info != null
+                ? info.startInstant().map(Instant::toEpochMilli).orElse(-1L)
+                : -1L;
+        result.add(NodeProcessInfo.builder()
+                .kind(NodeProcessInfo.Kind.DAEMON)
+                .provider(tabProvider)
+                .pid(pid)
+                .alive(true)
+                .startedAtMs(startedAt)
+                .uptimeMs(startedAt > 0 ? Math.max(0, now - startedAt) : 0L)
+                .command(extractCommand(info))
+                .activeRequestCount(daemon.getActiveRequestCount())
+                .sessionId(sessionId)
+                .tabName(tabName)
+                .build());
+
+        // Include daemon children (Claude CLI / grok agent stdio) so they are not
+        // listed as orphans and "Kill all orphans" does not tear down live ACP turns.
+        try {
+            daemonProcess.toHandle().descendants().forEach(child -> knownPids.add(child.pid()));
+        } catch (Exception ignored) {
+        }
+    }
+
+    private static void collectChannelEntries(
+            List<NodeProcessInfo> result,
+            Set<Long> knownPids,
+            @Nullable Map<String, Process> channels,
+            String tabProvider,
+            @Nullable String sessionId,
+            @Nullable String tabName,
+            long now
+    ) {
+        if (channels == null || channels.isEmpty()) {
+            return;
+        }
+        for (Map.Entry<String, Process> entry : channels.entrySet()) {
+            Process p = entry.getValue();
+            if (p == null || !p.isAlive()) {
+                continue;
+            }
+            long pid = p.pid();
+            knownPids.add(pid);
+            // channel-manager children (e.g. grok agent stdio one-shot path)
+            try {
+                p.toHandle().descendants().forEach(child -> knownPids.add(child.pid()));
+            } catch (Exception ignored) {
+            }
+            ProcessHandle.Info info = safeInfo(p);
+            long startedAt = info != null
+                    ? info.startInstant().map(Instant::toEpochMilli).orElse(-1L)
+                    : -1L;
+            result.add(NodeProcessInfo.builder()
+                    .kind(NodeProcessInfo.Kind.CHANNEL)
+                    .provider(tabProvider)
+                    .pid(pid)
+                    .alive(true)
+                    .startedAtMs(startedAt)
+                    .uptimeMs(startedAt > 0 ? Math.max(0, now - startedAt) : 0L)
+                    .command(extractCommand(info))
+                    .channelId(entry.getKey())
+                    .sessionId(sessionId)
+                    .tabName(tabName)
+                    .build());
+        }
     }
 
     private static @Nullable ProcessHandle.Info safeInfo(Process p) {
@@ -445,6 +532,14 @@ public final class NodeProcessRegistry implements Disposable {
     private static @Nullable ClaudeSDKBridge safeClaudeBridge(ClaudeChatWindow window) {
         try {
             return window != null ? window.getClaudeSDKBridge() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static @Nullable GrokSDKBridge safeGrokBridge(ClaudeChatWindow window) {
+        try {
+            return window != null ? window.getGrokSDKBridge() : null;
         } catch (Exception e) {
             return null;
         }

--- a/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
@@ -4,6 +4,7 @@ import com.github.claudecodegui.permission.PermissionManager;
 import com.github.claudecodegui.permission.PermissionRequest;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.provider.grok.GrokSDKBridge;
 import com.github.claudecodegui.provider.common.MarkerCliBridge;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -53,6 +54,7 @@ public class ClaudeSession {
     // Context collector
     private final com.github.claudecodegui.session.EditorContextCollector contextCollector;
     private final SessionContextService contextService;
+    private final GrokSDKBridge grokSDKBridge;
     private final SessionProviderRouter providerRouter;
     private final SessionSendService sendService;
     private final SessionMessageOrchestrator messageOrchestrator;
@@ -165,6 +167,16 @@ public class ClaudeSession {
             CodexSDKBridge codexSDKBridge,
             Map<String, MarkerCliBridge> cliBridges
     ) {
+        this(project, claudeSDKBridge, codexSDKBridge, cliBridges, null);
+    }
+
+    public ClaudeSession(
+            Project project,
+            ClaudeSDKBridge claudeSDKBridge,
+            CodexSDKBridge codexSDKBridge,
+            Map<String, MarkerCliBridge> cliBridges,
+            GrokSDKBridge grokSDKBridge
+    ) {
         this.project = project;
         this.claudeSDKBridge = claudeSDKBridge;
         this.codexSDKBridge = codexSDKBridge;
@@ -176,7 +188,8 @@ public class ClaudeSession {
         this.contextCollector = new com.github.claudecodegui.session.EditorContextCollector(project);
         this.callbackFacade = new SessionCallbackFacade(project);
         this.contextService = new SessionContextService(project, MAX_FILE_SIZE_BYTES);
-        this.providerRouter = new SessionProviderRouter(claudeSDKBridge, codexSDKBridge, cliBridges);
+        this.grokSDKBridge = grokSDKBridge;
+        this.providerRouter = new SessionProviderRouter(claudeSDKBridge, codexSDKBridge, cliBridges, this.grokSDKBridge);
         this.sendService = new SessionSendService(
                 project,
                 state,
@@ -187,8 +200,8 @@ public class ClaudeSession {
                 claudeSDKBridge,
                 codexSDKBridge,
                 cliBridges,
-                contextService
-        );
+                contextService,
+                this.grokSDKBridge);
         this.messageOrchestrator = new SessionMessageOrchestrator(
                 project,
                 state,

--- a/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
@@ -41,6 +41,10 @@ public class SessionLifecycleManager {
 
         CodexSDKBridge getCodexSDKBridge();
 
+        default com.github.claudecodegui.provider.grok.GrokSDKBridge getGrokSDKBridge() {
+            return null;
+        }
+
         Map<String, MarkerCliBridge> getCliBridges();
 
         ClaudeSession getSession();
@@ -100,8 +104,12 @@ public class SessionLifecycleManager {
 
         interruptFuture.thenRun(() -> {
             if (oldSession != null) {
-                host.getClaudeSDKBridge().resetPersistentRuntime(oldSession.getRuntimeSessionEpoch());
-                LOG.info("[Lifecycle] Requested daemon runtime reset for old epoch=" + oldSession.getRuntimeSessionEpoch());
+                String oldEpoch = oldSession.getRuntimeSessionEpoch();
+                host.getClaudeSDKBridge().resetPersistentRuntime(oldEpoch);
+                if (host.getGrokSDKBridge() != null) {
+                    host.getGrokSDKBridge().resetPersistentRuntime(oldEpoch);
+                }
+                LOG.info("[Lifecycle] Requested daemon runtime reset for old epoch=" + oldEpoch);
             }
             LOG.info("Old session interrupted, creating new session");
 
@@ -148,8 +156,12 @@ public class SessionLifecycleManager {
 
         interruptFuture.thenRun(() -> {
             if (oldSession != null) {
-                host.getClaudeSDKBridge().resetPersistentRuntime(oldSession.getRuntimeSessionEpoch());
-                LOG.info("[Lifecycle] Requested daemon runtime reset for old epoch=" + oldSession.getRuntimeSessionEpoch());
+                String oldEpoch = oldSession.getRuntimeSessionEpoch();
+                host.getClaudeSDKBridge().resetPersistentRuntime(oldEpoch);
+                if (host.getGrokSDKBridge() != null) {
+                    host.getGrokSDKBridge().resetPersistentRuntime(oldEpoch);
+                }
+                LOG.info("[Lifecycle] Requested daemon runtime reset for old epoch=" + oldEpoch);
             }
             LOG.info("Old session interrupted, creating new session from template");
 
@@ -250,16 +262,16 @@ public class SessionLifecycleManager {
 
         interruptFuture.thenRun(() -> {
             if (oldSession != null) {
-                host.getClaudeSDKBridge().resetPersistentRuntime(oldSession.getRuntimeSessionEpoch());
+                String oldEpoch = oldSession.getRuntimeSessionEpoch();
+                host.getClaudeSDKBridge().resetPersistentRuntime(oldEpoch);
+                if (host.getGrokSDKBridge() != null) {
+                    host.getGrokSDKBridge().resetPersistentRuntime(oldEpoch);
+                }
                 LOG.info("[Lifecycle] Requested daemon runtime reset before history load for old epoch="
-                        + oldSession.getRuntimeSessionEpoch());
+                        + oldEpoch);
             }
 
-            ClaudeSession newSession = new ClaudeSession(
-                    host.getProject(),
-                    host.getClaudeSDKBridge(),
-                    host.getCodexSDKBridge(),
-                    host.getCliBridges());
+            ClaudeSession newSession = createDefaultSession();
             newSession.setPermissionMode(previousPermissionMode);
             newSession.setProvider(provider != null && !provider.trim().isEmpty() ? provider : previousProvider);
             newSession.setModel(modelToRestore);
@@ -275,7 +287,11 @@ public class SessionLifecycleManager {
             newSession.setSessionInfo(sessionId, workingDir);
 
             // Prewarm daemon runtime for the historical session so /context and first message are fast
-            host.getClaudeSDKBridge().prewarmDaemonAsync(workingDir, newSession.getRuntimeSessionEpoch(), sessionId);
+            if ("claude".equals(newSession.getProvider())) {
+                host.getClaudeSDKBridge().prewarmDaemonAsync(workingDir, newSession.getRuntimeSessionEpoch(), sessionId);
+            } else if ("grok".equals(newSession.getProvider()) && host.getGrokSDKBridge() != null) {
+                host.getGrokSDKBridge().prewarmDaemonAsync(workingDir, newSession.getRuntimeSessionEpoch(), sessionId);
+            }
 
             newSession.loadFromServer().thenRun(() -> ApplicationManager.getApplication().invokeLater(() -> {
                 host.callJavaScript("historyLoadComplete");
@@ -425,7 +441,8 @@ public class SessionLifecycleManager {
                 host.getProject(),
                 host.getClaudeSDKBridge(),
                 host.getCodexSDKBridge(),
-                host.getCliBridges());
+                host.getCliBridges(),
+                host.getGrokSDKBridge());
     }
 
     private void completeNewSessionBootstrap(ClaudeSession newSession, String workingDirectory, String successLogPrefix) {
@@ -437,7 +454,11 @@ public class SessionLifecycleManager {
 
         newSession.setSessionInfo(null, workingDirectory);
         LOG.info(successLogPrefix + workingDirectory + ", epoch=" + newSession.getRuntimeSessionEpoch());
-        host.getClaudeSDKBridge().prewarmDaemonAsync(workingDirectory, newSession.getRuntimeSessionEpoch());
+        if ("claude".equals(newSession.getProvider())) {
+            host.getClaudeSDKBridge().prewarmDaemonAsync(workingDirectory, newSession.getRuntimeSessionEpoch());
+        } else if ("grok".equals(newSession.getProvider()) && host.getGrokSDKBridge() != null) {
+            host.getGrokSDKBridge().prewarmDaemonAsync(workingDirectory, newSession.getRuntimeSessionEpoch());
+        }
         fetchSlashCommandsOnStartup();
 
         ApplicationManager.getApplication().invokeLater(() -> {

--- a/src/main/java/com/github/claudecodegui/session/SessionProviderRouter.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionProviderRouter.java
@@ -2,6 +2,7 @@ package com.github.claudecodegui.session;
 
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.provider.grok.GrokSDKBridge;
 import com.github.claudecodegui.provider.common.MarkerCliBridge;
 import com.google.gson.JsonObject;
 
@@ -21,7 +22,7 @@ public class SessionProviderRouter {
      * {@link MarkerCliBridge} — the keys of the map built by
      * {@link #registerCliBridges(MarkerCliBridge...)} for the bundled bridges.
      */
-    private static final Set<String> CLI_PROVIDER_IDS = Set.of("grok", "kimi", "opencode", "pi");
+    private static final Set<String> CLI_PROVIDER_IDS = Set.of("kimi", "opencode", "pi");
 
     /**
      * Whether {@code provider} is a headless CLI provider routed through the
@@ -33,6 +34,7 @@ public class SessionProviderRouter {
 
     private final ClaudeSDKBridge claudeSDKBridge;
     private final CodexSDKBridge codexSDKBridge;
+    private final GrokSDKBridge grokSDKBridge;
     private final Map<String, MarkerCliBridge> cliBridges;
 
     public SessionProviderRouter(
@@ -40,8 +42,18 @@ public class SessionProviderRouter {
             CodexSDKBridge codexSDKBridge,
             Map<String, MarkerCliBridge> cliBridges
     ) {
+        this(claudeSDKBridge, codexSDKBridge, cliBridges, null);
+    }
+
+    public SessionProviderRouter(
+            ClaudeSDKBridge claudeSDKBridge,
+            CodexSDKBridge codexSDKBridge,
+            Map<String, MarkerCliBridge> cliBridges,
+            GrokSDKBridge grokSDKBridge
+    ) {
         this.claudeSDKBridge = claudeSDKBridge;
         this.codexSDKBridge = codexSDKBridge;
+        this.grokSDKBridge = grokSDKBridge;
         this.cliBridges = cliBridges != null
                 ? Collections.unmodifiableMap(new LinkedHashMap<>(cliBridges))
                 : Collections.emptyMap();
@@ -68,6 +80,9 @@ public class SessionProviderRouter {
         if ("codex".equals(provider)) {
             return codexSDKBridge.launchChannel(channelId, sessionId, cwd);
         }
+        if ("grok".equals(provider) && grokSDKBridge != null) {
+            return grokSDKBridge.launchChannel(channelId, sessionId, cwd);
+        }
         MarkerCliBridge bridge = cli(provider);
         if (bridge != null) {
             return bridge.launchChannel(channelId, sessionId, cwd);
@@ -78,6 +93,10 @@ public class SessionProviderRouter {
     public void interruptChannel(String provider, String channelId) {
         if ("codex".equals(provider)) {
             codexSDKBridge.interruptChannel(channelId);
+            return;
+        }
+        if ("grok".equals(provider) && grokSDKBridge != null) {
+            grokSDKBridge.interruptChannel(channelId);
             return;
         }
         MarkerCliBridge bridge = cli(provider);
@@ -92,6 +111,9 @@ public class SessionProviderRouter {
         if ("codex".equals(provider)) {
             return codexSDKBridge.getSessionMessages(sessionId, cwd);
         }
+        if ("grok".equals(provider) && grokSDKBridge != null) {
+            return grokSDKBridge.getSessionMessages(sessionId, cwd);
+        }
         MarkerCliBridge bridge = cli(provider);
         if (bridge != null) {
             return bridge.getSessionMessages(sessionId, cwd);
@@ -101,5 +123,9 @@ public class SessionProviderRouter {
 
     public Map<String, MarkerCliBridge> getCliBridges() {
         return cliBridges;
+    }
+
+    public GrokSDKBridge getGrokSDKBridge() {
+        return grokSDKBridge;
     }
 }

--- a/src/main/java/com/github/claudecodegui/session/SessionSendService.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionSendService.java
@@ -6,6 +6,7 @@ import com.github.claudecodegui.settings.CodexSettingsManager;
 import com.github.claudecodegui.notifications.ClaudeNotifier;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.provider.grok.GrokSDKBridge;
 import com.github.claudecodegui.provider.common.MarkerCliBridge;
 import com.github.claudecodegui.provider.common.MessageCallback;
 import com.google.gson.Gson;
@@ -34,6 +35,7 @@ public class SessionSendService {
     private final Gson gson;
     private final ClaudeSDKBridge claudeSDKBridge;
     private final CodexSDKBridge codexSDKBridge;
+    private final GrokSDKBridge grokSDKBridge;
     private final Map<String, MarkerCliBridge> cliBridges;
     private final SessionContextService contextService;
 
@@ -49,6 +51,23 @@ public class SessionSendService {
             Map<String, MarkerCliBridge> cliBridges,
             SessionContextService contextService
     ) {
+        this(project, state, callbackFacade, messageParser, messageMerger, gson,
+                claudeSDKBridge, codexSDKBridge, cliBridges, contextService, null);
+    }
+
+    public SessionSendService(
+            Project project,
+            SessionState state,
+            SessionCallbackFacade callbackFacade,
+            MessageParser messageParser,
+            MessageMerger messageMerger,
+            Gson gson,
+            ClaudeSDKBridge claudeSDKBridge,
+            CodexSDKBridge codexSDKBridge,
+            Map<String, MarkerCliBridge> cliBridges,
+            SessionContextService contextService,
+            GrokSDKBridge grokSDKBridge
+    ) {
         this.project = project;
         this.state = state;
         this.callbackFacade = callbackFacade;
@@ -57,6 +76,7 @@ public class SessionSendService {
         this.gson = gson;
         this.claudeSDKBridge = claudeSDKBridge;
         this.codexSDKBridge = codexSDKBridge;
+        this.grokSDKBridge = grokSDKBridge;
         this.cliBridges = cliBridges != null ? cliBridges : Collections.emptyMap();
         this.contextService = contextService;
     }
@@ -142,7 +162,20 @@ public class SessionSendService {
             );
         }
 
-        if (cliBridges.containsKey(currentProvider)) {
+        if ("grok".equals(currentProvider) && grokSDKBridge != null) {
+            return sendToGrok(
+                    channelId,
+                    input,
+                    attachments,
+                    openedFilesJson,
+                    agentPrompt,
+                    fileTagPaths,
+                    effectivePermissionMode,
+                    normalizedRequestedEffort
+            );
+        }
+
+        if (cliBridges.containsKey(currentProvider) && !"grok".equals(currentProvider)) {
             return sendToCliProvider(
                     currentProvider,
                     channelId,
@@ -303,7 +336,59 @@ public class SessionSendService {
         ).thenApply(result -> null);
     }
 
-    private CompletableFuture<Void> sendToCliProvider(
+        private CompletableFuture<Void> sendToGrok(
+            String channelId,
+            String input,
+            List<ClaudeSession.Attachment> attachments,
+            JsonObject openedFilesJson,
+            String agentPrompt,
+            List<String> fileTagPaths,
+            String effectivePermissionMode,
+            String requestedReasoningEffort
+    ) {
+        if (grokSDKBridge == null) {
+            LOG.error("[Lifecycle] sendToGrok called but GrokSDKBridge is null");
+            callbackFacade.notifyStateChange(false, false, "Grok bridge not available");
+            return CompletableFuture.completedFuture(null);
+        }
+        GrokMessageHandler handler = new GrokMessageHandler(state, callbackFacade.getCallbackHandler());
+        Boolean streaming = readStreamingEnabled();
+        final String runtimeSessionEpoch = state.getRuntimeSessionEpoch();
+        final String currentModel = state.getModel();
+        String projectBase = project != null ? project.getBasePath() : null;
+        String guardedCwd = com.github.claudecodegui.util.PathUtils.guardWorkingDirectory(
+                state.getCwd(), projectBase);
+        if (guardedCwd == null) {
+            guardedCwd = state.getCwd();
+        } else if (state.getCwd() == null || !guardedCwd.equals(state.getCwd())) {
+            LOG.warn("[Lifecycle] sendToGrok cwd guard: " + state.getCwd() + " -> " + guardedCwd);
+            state.setCwd(guardedCwd);
+        }
+        LOG.info("[Lifecycle] sendToGrok sessionId=" + (state.getSessionId() != null ? state.getSessionId() : "(new)")
+                + ", epoch=" + runtimeSessionEpoch
+                + ", cwd=" + guardedCwd
+                + ", model=" + currentModel
+                + ", fileTags=" + (fileTagPaths != null ? fileTagPaths.size() : 0));
+
+        return grokSDKBridge.sendMessage(
+                channelId,
+                input,
+                state.getSessionId(),
+                runtimeSessionEpoch,
+                guardedCwd,
+                attachments,
+                effectivePermissionMode,
+                currentModel,
+                openedFilesJson,
+                agentPrompt,
+                streaming,
+                false,
+                requestedReasoningEffort != null ? requestedReasoningEffort : state.getReasoningEffort(),
+                handler
+        ).thenApply(result -> null);
+    }
+
+private CompletableFuture<Void> sendToCliProvider(
             String provider,
             String channelId,
             String input,

--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -82,6 +82,9 @@ public class ChatWindowDelegate {
         Project getProject();
         ClaudeSDKBridge getClaudeSDKBridge();
         CodexSDKBridge getCodexSDKBridge();
+        default com.github.claudecodegui.provider.grok.GrokSDKBridge getGrokSDKBridge() {
+            return null;
+        }
         Map<String, MarkerCliBridge> getCliBridges();
         ClaudeSession getSession();
         CodemossSettingsService getSettingsService();
@@ -318,6 +321,7 @@ public class ChatWindowDelegate {
                 project,
                 claudeSDKBridge,
                 codexSDKBridge,
+                host.getGrokSDKBridge(),
                 settingsService,
                 jsCallback,
                 host::isActiveContent,

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -10,6 +10,7 @@ import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
 import com.github.claudecodegui.provider.common.MarkerCliBridge;
 import com.github.claudecodegui.provider.grok.GrokCliBridge;
+import com.github.claudecodegui.provider.grok.GrokSDKBridge;
 import com.github.claudecodegui.provider.kimi.KimiCliBridge;
 import com.github.claudecodegui.provider.opencode.OpenCodeCliBridge;
 import com.github.claudecodegui.provider.pi.PiCliBridge;
@@ -72,6 +73,7 @@ public class ClaudeChatWindow {
     private final JPanel mainPanel;
     private final ClaudeSDKBridge claudeSDKBridge;
     private final CodexSDKBridge codexSDKBridge;
+    private final GrokSDKBridge grokSDKBridge;
     private final Map<String, MarkerCliBridge> cliBridges;
     private final GrokCliBridge grokCliBridge;
     private final KimiCliBridge kimiCliBridge;
@@ -216,12 +218,14 @@ public class ClaudeChatWindow {
         this.project = project;
         this.claudeSDKBridge = new ClaudeSDKBridge();
         this.codexSDKBridge = new CodexSDKBridge();
+        this.grokSDKBridge = new GrokSDKBridge();
         this.grokCliBridge = new GrokCliBridge();
         this.kimiCliBridge = new KimiCliBridge();
         this.openCodeCliBridge = new OpenCodeCliBridge();
         this.piCliBridge = new PiCliBridge();
+        // Grok uses GrokSDKBridge (persistent ACP / grok agent stdio), not MarkerCliBridge.
         this.cliBridges = SessionProviderRouter.registerCliBridges(
-                this.grokCliBridge, this.kimiCliBridge, this.openCodeCliBridge, this.piCliBridge);
+                this.kimiCliBridge, this.openCodeCliBridge, this.piCliBridge);
         this.settingsService = new CodemossSettingsService();
         this.htmlLoader = new HtmlLoader(getClass());
         this.mainPanel = new JPanel(new BorderLayout());
@@ -277,7 +281,7 @@ public class ClaudeChatWindow {
                 () -> frontendReady
         );
 
-        this.session = new ClaudeSession(project, claudeSDKBridge, codexSDKBridge, cliBridges);
+        this.session = new ClaudeSession(project, claudeSDKBridge, codexSDKBridge, cliBridges, grokSDKBridge);
 
         this.chatWindowDelegate = new ChatWindowDelegate(createDelegateHost());
         chatWindowDelegate.loadPermissionModeFromSettings();
@@ -301,6 +305,11 @@ public class ClaudeChatWindow {
             @Override
             public CodexSDKBridge getCodexSDKBridge() {
                 return codexSDKBridge;
+            }
+
+            @Override
+            public GrokSDKBridge getGrokSDKBridge() {
+                return grokSDKBridge;
             }
 
             @Override
@@ -1361,6 +1370,10 @@ public class ClaudeChatWindow {
 
     public ClaudeSDKBridge getClaudeSDKBridge() {
         return claudeSDKBridge;
+    }
+
+    public GrokSDKBridge getGrokSDKBridge() {
+        return grokSDKBridge;
     }
 
     public CodexSDKBridge getCodexSDKBridge() {
@@ -2829,6 +2842,18 @@ public class ClaudeChatWindow {
         }
 
         try {
+            if (grokSDKBridge != null) {
+                int activeCount = grokSDKBridge.getActiveProcessCount();
+                if (activeCount > 0) {
+                    LOG.info("Cleaning up " + activeCount + " active Grok process(es)...");
+                }
+                grokSDKBridge.cleanupAllProcesses();
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to clean up Grok processes: " + e.getMessage());
+        }
+
+        try {
             if (targetBrowser != null) {
                 targetBrowser.dispose();
             }
@@ -2992,6 +3017,11 @@ public class ClaudeChatWindow {
             @Override
             public CodexSDKBridge getCodexSDKBridge() {
                 return codexSDKBridge;
+            }
+
+            @Override
+            public GrokSDKBridge getGrokSDKBridge() {
+                return grokSDKBridge;
             }
 
             @Override

--- a/src/test/java/com/github/claudecodegui/provider/common/DaemonBridgeTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/common/DaemonBridgeTest.java
@@ -484,7 +484,8 @@ public class DaemonBridgeTest {
                     return replacementProcess;
                 },
                 hooks,
-                5);
+                5,
+                null);
 
         assertTrue(bridge.start());
         assertTrue(heartbeatCheckReached.await(2, TimeUnit.SECONDS));


### PR DESCRIPTION
## Summary
Ports the Grok **runtime** stack onto `feature/v0.5.2` (no Gemini):

1. **Fix Grok environment and proxy config** — `EnvironmentConfigurator` + grok ACP client env/proxy fixes so Grok processes get the right key/proxy surface.
2. **Wire persistent GrokSDKBridge** — route Grok via `GrokSDKBridge` (ACP daemon) instead of `MarkerCliBridge`; extend session/send/lifecycle/UI host; harden daemon process registry, history, and event normalization for multi-turn Grok.

`feature/v0.5.2` already has Grok provider pieces; this adds the persistent SDK wiring path end-to-end.

## Commits
- Fix Grok environment and proxy config
- feat(grok): wire persistent GrokSDKBridge through session and UI host

## Follow-up
Settings UI (auth method / API key / base URLs) is a stacked PR on top of this branch.

## Test plan
- [ ] Switch provider to Grok, multi-turn chat keeps ACP daemon (not orphaned Node)
- [ ] Interrupt / new session / load history with Grok selected
- [ ] Node process panel labels Grok daemon correctly; kill-all orphans does not kill live Grok ACP
- [ ] Proxy/env applied for Grok ACP client
- [ ] CI green on this base