### PR TITLE
feat(grok): persistent Grok ACP runtime + auth settings (supersedes #1643)

### DIFF
--- a/ai-bridge/services/grok/grok-acp-client.js
+++ b/ai-bridge/services/grok/grok-acp-client.js
@@ -351,7 +351,7 @@ export class GrokAcpClient {
     }
     this.pending.clear();
 
-    if (killProcess && this.proc && !this.proc.killed) {
+    if (killProcess && this.proc && this.proc.exitCode === null) {
       try {
         this.proc.kill('SIGTERM');
       } catch {
@@ -361,7 +361,7 @@ export class GrokAcpClient {
       const proc = this.proc;
       setTimeout(() => {
         try {
-          if (proc && !proc.killed) proc.kill('SIGKILL');
+          if (proc && proc.exitCode === null) proc.kill('SIGKILL');
         } catch {
           // ignore
         }
@@ -404,7 +404,7 @@ export class GrokAcpClient {
     } catch {
       // ignore
     }
-    if (this.proc && !this.proc.killed) {
+    if (this.proc && this.proc.exitCode === null) {
       try {
         this.proc.kill('SIGTERM');
       } catch {
@@ -412,7 +412,7 @@ export class GrokAcpClient {
       }
       // Force kill if still alive after a short grace period
       await new Promise((r) => setTimeout(r, 300));
-      if (this.proc && !this.proc.killed) {
+      if (this.proc && this.proc.exitCode === null) {
         try {
           this.proc.kill('SIGKILL');
         } catch {

--- a/ai-bridge/services/grok/grok-acp-timeout.test.js
+++ b/ai-bridge/services/grok/grok-acp-timeout.test.js
@@ -26,6 +26,13 @@ function mockClientForRequest() {
     get killed() {
       return killed;
     },
+    // Mirror Node's ChildProcess: exitCode is null while the process is still
+    // running and a number once it has exited. grok-acp-client gates kill() on
+    // `exitCode === null` (real liveness), not on `killed` (which only signals
+    // that kill() was *called*), so the mock must expose exitCode too.
+    get exitCode() {
+      return killed ? 0 : null;
+    },
     kill() {
       killed = true;
     },

--- a/ai-bridge/services/grok/grok-event-normalizer.js
+++ b/ai-bridge/services/grok/grok-event-normalizer.js
@@ -139,20 +139,42 @@ export class GrokEventNormalizer {
 
     switch (kind) {
       case 'agent_message_chunk': {
-        const text = extractText(update.content);
+        const text = extractText(update.content) || extractText(update.delta) || update.text || '';
         if (text) {
-          this.assistantText += text;
-          this.#emit(`[CONTENT_DELTA] ${JSON.stringify(text)}`);
+          let delta = '';
+          if (text.startsWith(this.assistantText)) {
+            delta = text.slice(this.assistantText.length);
+            this.assistantText = text;
+          } else if (this.assistantText.startsWith(text)) {
+            delta = '';
+          } else {
+            delta = text;
+            this.assistantText += text;
+          }
+          if (delta) {
+            this.#emit(`[CONTENT_DELTA] ${JSON.stringify(delta)}`);
+          }
         }
         break;
       }
       case 'agent_thought_chunk':
       case 'agent_thinking_chunk':
       case 'thought_chunk': {
-        const text = extractText(update.content) || update.text || '';
+        const text = extractText(update.content) || extractText(update.delta) || update.text || '';
         if (text) {
-          this.thinkingText += text;
-          this.#emit(`[THINKING_DELTA] ${JSON.stringify(text)}`);
+          let delta = '';
+          if (text.startsWith(this.thinkingText)) {
+            delta = text.slice(this.thinkingText.length);
+            this.thinkingText = text;
+          } else if (this.thinkingText.startsWith(text)) {
+            delta = '';
+          } else {
+            delta = text;
+            this.thinkingText += text;
+          }
+          if (delta) {
+            this.#emit(`[THINKING_DELTA] ${JSON.stringify(delta)}`);
+          }
         }
         break;
       }
@@ -175,10 +197,21 @@ export class GrokEventNormalizer {
         break;
       default: {
         // Try generic text fields
-        const text = extractText(update.content) || update.text;
+        const text = extractText(update.content) || extractText(update.delta) || update.text;
         if (text && kind.includes('message')) {
-          this.assistantText += text;
-          this.#emit(`[CONTENT_DELTA] ${JSON.stringify(text)}`);
+          let delta = '';
+          if (text.startsWith(this.assistantText)) {
+            delta = text.slice(this.assistantText.length);
+            this.assistantText = text;
+          } else if (this.assistantText.startsWith(text)) {
+            delta = '';
+          } else {
+            delta = text;
+            this.assistantText += text;
+          }
+          if (delta) {
+            this.#emit(`[CONTENT_DELTA] ${JSON.stringify(delta)}`);
+          }
         }
         break;
       }
@@ -299,9 +332,15 @@ export class GrokEventNormalizer {
 function extractText(content) {
   if (content == null) return '';
   if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content.map(extractText).join('');
+  }
   if (typeof content === 'object') {
     if (typeof content.text === 'string') return content.text;
-    if (typeof content.content === 'string') return content.content;
+    if (typeof content.content === 'string' || typeof content.content === 'object') {
+      return extractText(content.content);
+    }
+    if (typeof content.delta === 'string') return content.delta;
   }
   return '';
 }

--- a/build.gradle
+++ b/build.gradle
@@ -291,6 +291,10 @@ tasks.named('instrumentCode') {
     enabled = false
 }
 
+tasks.named('instrumentTestCode') {
+    enabled = false
+}
+
 tasks.named('jarSearchableOptions') {
     enabled = false
 }

--- a/src/main/java/com/github/claudecodegui/bridge/EnvironmentConfigurator.java
+++ b/src/main/java/com/github/claudecodegui/bridge/EnvironmentConfigurator.java
@@ -185,6 +185,7 @@ public class EnvironmentConfigurator {
 
         configurePermissionEnv(env, nodeExecutable);
         configureProxyEnv(env);
+        configureGrokEnv(env);
     }
 
     private void configureProxyEnv(Map<String, String> env) {
@@ -216,6 +217,15 @@ public class EnvironmentConfigurator {
                     env.put("http_proxy", proxyUrl);
                     env.put("https_proxy", proxyUrl);
                     env.put("all_proxy", proxyUrl);
+                    
+                    String noProxy = resolveEnvValue("NO_PROXY");
+                    if (noProxy == null || noProxy.isEmpty()) {
+                        noProxy = resolveEnvValue("no_proxy");
+                    }
+                    if (noProxy != null && !noProxy.isEmpty()) {
+                        env.put("NO_PROXY", noProxy);
+                        env.put("no_proxy", noProxy);
+                    }
                 }
             }
         } catch (Exception e) {
@@ -585,6 +595,36 @@ public class EnvironmentConfigurator {
             }
         } catch (Exception e) {
             LOG.warn("[Codex] Error configuring Codex env: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Configure Grok-specific environment variables.
+     * Loads custom base URLs and proxy configs from the shell environment.
+     */
+    public void configureGrokEnv(Map<String, String> env) {
+        if (env == null) {
+            return;
+        }
+        String[] grokEnvKeys = {
+            "GROK_MODELS_BASE_URL",
+            "GROK_XAI_API_BASE_URL",
+            "XAI_API_BASE_URL",
+            "GROK_CLI_CHAT_PROXY_BASE_URL",
+            "GROK_HOME",
+            "GROK_API_KEY",
+            "XAI_API_KEY",
+            "NO_PROXY",
+            "no_proxy"
+        };
+        for (String key : grokEnvKeys) {
+            if (env.containsKey(key) && env.get(key) != null && !env.get(key).isEmpty()) {
+                continue; // Already set
+            }
+            String value = resolveEnvValue(key);
+            if (value != null && !value.trim().isEmpty()) {
+                env.put(key, value.trim());
+            }
         }
     }
 

--- a/src/main/java/com/github/claudecodegui/bridge/EnvironmentConfigurator.java
+++ b/src/main/java/com/github/claudecodegui/bridge/EnvironmentConfigurator.java
@@ -27,6 +27,9 @@ import java.util.regex.Pattern;
  * Environment configurator.
  * Responsible for configuring process environment variables.
  */
+import com.intellij.util.EnvironmentUtil;
+import com.intellij.util.net.HttpConfigurable;
+
 public class EnvironmentConfigurator {
 
     private static final Logger LOG = Logger.getInstance(EnvironmentConfigurator.class);
@@ -59,6 +62,16 @@ public class EnvironmentConfigurator {
      */
     public void updateProcessEnvironment(ProcessBuilder pb, String nodeExecutable) {
         Map<String, String> env = pb.environment();
+        
+        // Merge login shell environment variables (e.g. proxy, API keys in ~/.zshrc)
+        try {
+            Map<String, String> shellEnv = EnvironmentUtil.getEnvironmentMap();
+            for (Map.Entry<String, String> entry : shellEnv.entrySet()) {
+                env.putIfAbsent(entry.getKey(), entry.getValue());
+            }
+        } catch (Exception e) {
+            LOG.warn("[EnvironmentConfigurator] Failed to load shell environment: " + e.getMessage());
+        }
 
         // Use PlatformUtils to get the PATH variable (case-insensitive)
         String path = PlatformUtils.isWindows() ?
@@ -171,6 +184,43 @@ public class EnvironmentConfigurator {
         }
 
         configurePermissionEnv(env, nodeExecutable);
+        configureProxyEnv(env);
+    }
+
+    private void configureProxyEnv(Map<String, String> env) {
+        try {
+            HttpConfigurable proxySettings = HttpConfigurable.getInstance();
+            if (proxySettings != null && proxySettings.USE_HTTP_PROXY) {
+                String host = proxySettings.PROXY_HOST;
+                int port = proxySettings.PROXY_PORT;
+                if (host != null && !host.isEmpty()) {
+                    String auth = "";
+                    if (proxySettings.PROXY_AUTHENTICATION) {
+                        String user = proxySettings.getProxyLogin();
+                        String pass = proxySettings.getPlainProxyPassword();
+                        if (user != null && !user.isEmpty()) {
+                            auth = user + (pass != null ? ":" + pass : "") + "@";
+                        }
+                    }
+                    boolean isSocks = false;
+                    try {
+                        java.lang.reflect.Field field = proxySettings.getClass().getField("PROXY_TYPE_IS_SOCKS");
+                        isSocks = field.getBoolean(proxySettings);
+                    } catch (Exception ignored) {}
+
+                    String scheme = isSocks ? "socks5://" : "http://";
+                    String proxyUrl = scheme + auth + host + ":" + port;
+                    env.put("HTTP_PROXY", proxyUrl);
+                    env.put("HTTPS_PROXY", proxyUrl);
+                    env.put("ALL_PROXY", proxyUrl);
+                    env.put("http_proxy", proxyUrl);
+                    env.put("https_proxy", proxyUrl);
+                    env.put("all_proxy", proxyUrl);
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("[EnvironmentConfigurator] Failed to configure proxy: " + e.getMessage());
+        }
     }
 
     static String resolveHomeForNodeEnvironment(String nodeExecutable, String currentHome) {

--- a/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
@@ -8,6 +8,7 @@ import com.github.claudecodegui.util.LanguageConfigService;
 import com.github.claudecodegui.util.ThemeConfigService;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 
@@ -106,6 +107,8 @@ public class SettingsHandler extends BaseMessageHandler {
         "browse_sound_file",
         // User language preference
         "set_user_language",
+        "get_grok_auth_config",
+        "set_grok_auth_config",
         "get_user_language",
         "clear_user_language"
     };
@@ -380,6 +383,12 @@ public class SettingsHandler extends BaseMessageHandler {
             case "clear_user_language":
                 handleClearUserLanguage();
                 return true;
+            case "get_grok_auth_config":
+                handleGetGrokAuthConfig();
+                return true;
+            case "set_grok_auth_config":
+                handleSetGrokAuthConfig(content);
+                return true;
             default:
                 return false;
         }
@@ -439,6 +448,51 @@ public class SettingsHandler extends BaseMessageHandler {
     private void pushLanguageConfig() {
         JsonObject languageConfig = LanguageConfigService.getLanguageConfig(context.getSettingsService());
         callJavaScript("window.applyIdeaLanguageConfig", escapeJs(languageConfig.toString()));
+    }
+
+    private void handleGetGrokAuthConfig() {
+        try {
+            JsonObject config = new JsonObject();
+            config.addProperty("authMethod", context.getSettingsService().getGrokAuthMethod());
+            config.addProperty("apiKey", context.getSettingsService().getGrokApiKey());
+            config.addProperty("apiBaseUrl", context.getSettingsService().getGrokApiBaseUrl());
+            config.addProperty("oauthBaseUrl", context.getSettingsService().getGrokOauthBaseUrl());
+            config.add("env", context.getSettingsService().getGrokEnv());
+            // hasApiKey logic is somewhat handled by JS but let's provide it if needed
+            config.addProperty("hasApiKey", !context.getSettingsService().getGrokApiKey().isEmpty());
+            callJavaScript("window.updateGrokAuthConfig", escapeJs(config.toString()));
+        } catch (Exception e) {
+            LOG.error("[SettingsHandler] Error getting Grok config", e);
+        }
+    }
+
+    private void handleSetGrokAuthConfig(String content) {
+        try {
+            JsonObject json = JsonParser.parseString(content).getAsJsonObject();
+            if (json.has("authMethod")) {
+                context.getSettingsService().setGrokAuthMethod(json.get("authMethod").getAsString());
+            }
+            if (json.has("apiKey")) {
+                context.getSettingsService().setGrokApiKey(json.get("apiKey").getAsString());
+            }
+            if (json.has("apiBaseUrl")) {
+                context.getSettingsService().setGrokApiBaseUrl(json.get("apiBaseUrl").getAsString());
+            }
+            if (json.has("oauthBaseUrl")) {
+                context.getSettingsService().setGrokOauthBaseUrl(json.get("oauthBaseUrl").getAsString());
+            }
+            if (json.has("env") && json.get("env").isJsonObject()) {
+                context.getSettingsService().setGrokEnv(json.getAsJsonObject("env"));
+            }
+            try {
+                new com.github.claudecodegui.provider.grok.GrokSDKBridge().shutdownDaemon();
+            } catch (Exception e) {
+                LOG.warn("[SettingsHandler] Failed to restart Grok daemon: " + e.getMessage());
+            }
+            LOG.info("[SettingsHandler] Saved Grok Auth Config");
+        } catch (Exception e) {
+            LOG.error("[SettingsHandler] Error setting Grok config", e);
+        }
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/handler/core/HandlerContext.java
+++ b/src/main/java/com/github/claudecodegui/handler/core/HandlerContext.java
@@ -3,6 +3,7 @@ package com.github.claudecodegui.handler.core;
 import com.github.claudecodegui.session.ClaudeSession;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.provider.grok.GrokSDKBridge;
 import com.github.claudecodegui.settings.CodemossSettingsService;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
@@ -23,6 +24,7 @@ public class HandlerContext {
     private final Project project;
     private final ClaudeSDKBridge claudeSDKBridge;
     private final CodexSDKBridge codexSDKBridge;
+    private final GrokSDKBridge grokSDKBridge;
     private final CodemossSettingsService settingsService;
     private final JsCallback jsCallback;
     private final BooleanSupplier activeContentSupplier;
@@ -51,7 +53,7 @@ public class HandlerContext {
             CodemossSettingsService settingsService,
             JsCallback jsCallback
     ) {
-        this(project, claudeSDKBridge, codexSDKBridge, settingsService, jsCallback, () -> true, () -> null);
+        this(project, claudeSDKBridge, codexSDKBridge, null, settingsService, jsCallback, () -> true, () -> null);
     }
 
     public HandlerContext(
@@ -63,9 +65,24 @@ public class HandlerContext {
             BooleanSupplier activeContentSupplier,
             Supplier<String> contentTitleSupplier
     ) {
+        this(project, claudeSDKBridge, codexSDKBridge, null, settingsService, jsCallback,
+                activeContentSupplier, contentTitleSupplier);
+    }
+
+    public HandlerContext(
+            Project project,
+            ClaudeSDKBridge claudeSDKBridge,
+            CodexSDKBridge codexSDKBridge,
+            GrokSDKBridge grokSDKBridge,
+            CodemossSettingsService settingsService,
+            JsCallback jsCallback,
+            BooleanSupplier activeContentSupplier,
+            Supplier<String> contentTitleSupplier
+    ) {
         this.project = project;
         this.claudeSDKBridge = claudeSDKBridge;
         this.codexSDKBridge = codexSDKBridge;
+        this.grokSDKBridge = grokSDKBridge;
         this.settingsService = settingsService;
         this.jsCallback = jsCallback;
         this.activeContentSupplier = activeContentSupplier == null ? () -> true : activeContentSupplier;
@@ -83,6 +100,10 @@ public class HandlerContext {
 
     public CodexSDKBridge getCodexSDKBridge() {
         return codexSDKBridge;
+    }
+
+    public GrokSDKBridge getGrokSDKBridge() {
+        return grokSDKBridge;
     }
 
     public CodemossSettingsService getSettingsService() {

--- a/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/DaemonBridge.java
@@ -21,6 +21,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 
 /**
  * Manages a long-running Node.js daemon process for AI SDK communication.
@@ -57,6 +58,7 @@ public class DaemonBridge {
     private final DaemonProcessLauncher processLauncher;
     private final DaemonLifecycleHooks lifecycleHooks;
     private final long heartbeatIntervalMs;
+    private final Consumer<Map<String, String>> customEnvConfigurator;
     // Daemon process state. Every asynchronous callback is scoped to one context.
     private volatile DaemonGenerationContext daemonContext;
     private final AtomicLong daemonGenerationCounter = new AtomicLong(0);
@@ -82,7 +84,16 @@ public class DaemonBridge {
             BridgeDirectoryResolver directoryResolver,
             EnvironmentConfigurator envConfigurator
     ) {
-        this(nodeDetector, directoryResolver, envConfigurator, TimeSource.system());
+        this(nodeDetector, directoryResolver, envConfigurator, (Consumer<Map<String, String>>) null);
+    }
+
+    public DaemonBridge(
+            NodeDetector nodeDetector,
+            BridgeDirectoryResolver directoryResolver,
+            EnvironmentConfigurator envConfigurator,
+            Consumer<Map<String, String>> customEnvConfigurator
+    ) {
+        this(nodeDetector, directoryResolver, envConfigurator, TimeSource.system(), null, null, HEARTBEAT_INTERVAL_MS, customEnvConfigurator);
     }
 
     DaemonBridge(
@@ -109,7 +120,8 @@ public class DaemonBridge {
                 timeSource,
                 processLauncher,
                 lifecycleHooks,
-                HEARTBEAT_INTERVAL_MS);
+                HEARTBEAT_INTERVAL_MS,
+                null);
     }
 
     DaemonBridge(
@@ -119,7 +131,8 @@ public class DaemonBridge {
             TimeSource timeSource,
             DaemonProcessLauncher processLauncher,
             DaemonLifecycleHooks lifecycleHooks,
-            long heartbeatIntervalMs
+            long heartbeatIntervalMs,
+            Consumer<Map<String, String>> customEnvConfigurator
     ) {
         this.nodeDetector = nodeDetector;
         this.directoryResolver = directoryResolver;
@@ -130,6 +143,7 @@ public class DaemonBridge {
         this.lifecycleHooks = lifecycleHooks != null
                 ? lifecycleHooks : DaemonLifecycleHooks.NO_OP;
         this.heartbeatIntervalMs = heartbeatIntervalMs;
+        this.customEnvConfigurator = customEnvConfigurator;
     }
 
     // =========================================================================
@@ -342,6 +356,9 @@ public class DaemonBridge {
         ProcessBuilder processBuilder = new ProcessBuilder(daemonCmd);
         processBuilder.directory(bridgeDir);
         envConfigurator.updateProcessEnvironment(processBuilder, nodePath);
+        if (customEnvConfigurator != null) {
+            customEnvConfigurator.accept(processBuilder.environment());
+        }
 
         Map<String, String> environment = processBuilder.environment();
         String claudeCliPath = PropertiesComponent.getInstance()

--- a/src/main/java/com/github/claudecodegui/provider/grok/GrokCliBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/grok/GrokCliBridge.java
@@ -1,6 +1,7 @@
 package com.github.claudecodegui.provider.grok;
 
 import com.github.claudecodegui.provider.common.MarkerCliBridge;
+import com.github.claudecodegui.settings.CodemossSettingsService;
 import com.google.gson.JsonObject;
 
 import java.util.Collections;
@@ -15,6 +16,8 @@ import java.util.Map;
  * streaming-json NDJSON onto the shared marker protocol.
  */
 public class GrokCliBridge extends MarkerCliBridge {
+
+    private final CodemossSettingsService settingsService = new CodemossSettingsService();
 
     public GrokCliBridge() {
         super(GrokCliBridge.class);
@@ -33,6 +36,67 @@ public class GrokCliBridge extends MarkerCliBridge {
     @Override
     protected void configureExtraEnv(Map<String, String> env) {
         env.put("GROK_DISABLE_AUTOUPDATER", "1");
+        env.put("GROK_NO_AUTO_UPDATE", "1");
+        env.put("CI", "1");
+
+        try {
+            JsonObject grokEnv = settingsService.getGrokEnv();
+            if (grokEnv != null && grokEnv.size() > 0) {
+                for (String key : grokEnv.keySet()) {
+                    if (grokEnv.get(key) != null && !grokEnv.get(key).isJsonNull()) {
+                        env.put(key, grokEnv.get(key).getAsString());
+                    }
+                }
+            }
+
+            String authMethod = settingsService.getGrokAuthMethod();
+            String apiKey = settingsService.getGrokApiKey();
+            String apiBaseUrl = settingsService.getGrokApiBaseUrl();
+
+            GrokLocalAuthResolver.ResolvedAuth resolved = GrokLocalAuthResolver.resolve(
+                    authMethod,
+                    apiKey,
+                    apiBaseUrl
+            );
+
+            env.put("GROK_AUTH_METHOD", resolved.authMethod);
+
+            if (CodemossSettingsService.GROK_AUTH_METHOD_OAUTH.equals(resolved.authMethod)) {
+                env.remove("XAI_API_KEY");
+                env.remove("GROK_API_KEY");
+            } else {
+                if (resolved.apiKey != null && !resolved.apiKey.isEmpty()) {
+                    env.put("XAI_API_KEY", resolved.apiKey);
+                    env.put("GROK_API_KEY", resolved.apiKey);
+                }
+            }
+
+            if (resolved.baseUrl != null && !resolved.baseUrl.isEmpty()) {
+                String effectiveBase = resolved.baseUrl;
+                String modelsList = effectiveBase.replaceAll("/+$", "") + "/models";
+                env.put("GROK_MODELS_BASE_URL", effectiveBase);
+                env.put("GROK_MODELS_LIST_URL", modelsList);
+                env.put("GROK_BASE_URL", effectiveBase);
+
+                if (CodemossSettingsService.GROK_AUTH_METHOD_API_KEY.equals(resolved.authMethod)) {
+                    env.put("XAI_API_BASE_URL", effectiveBase);
+                    env.put("GROK_CLI_CHAT_PROXY_BASE_URL", effectiveBase);
+                } else if (CodemossSettingsService.GROK_AUTH_METHOD_OAUTH.equals(resolved.authMethod)) {
+                    env.put("GROK_CLI_CHAT_PROXY_BASE_URL", effectiveBase);
+                    env.remove("XAI_API_BASE_URL");
+                } else {
+                    env.put("XAI_API_BASE_URL", effectiveBase);
+                    env.put("GROK_CLI_CHAT_PROXY_BASE_URL", effectiveBase);
+                }
+            }
+
+            LOG.info("[GrokCliBridge] Configured Grok environment: authMethod=" + resolved.authMethod
+                    + ", baseUrl=" + resolved.baseUrl
+                    + ", apiKeySet=" + (resolved.apiKey != null && !resolved.apiKey.isEmpty()));
+
+        } catch (Exception e) {
+            LOG.warn("[GrokCliBridge] Failed to configure Grok environment: " + e.getMessage());
+        }
     }
 
     @Override

--- a/src/main/java/com/github/claudecodegui/provider/grok/GrokDaemonCoordinator.java
+++ b/src/main/java/com/github/claudecodegui/provider/grok/GrokDaemonCoordinator.java
@@ -8,9 +8,11 @@ import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
@@ -25,6 +27,7 @@ class GrokDaemonCoordinator {
     private final NodeDetector nodeDetector;
     private final Supplier<BridgeDirectoryResolver> directoryResolverSupplier;
     private final EnvironmentConfigurator envConfigurator;
+    private final Consumer<Map<String, String>> customEnvConfigurator;
 
     private volatile DaemonBridge daemonBridge;
     private final Object daemonLock = new Object();
@@ -36,12 +39,14 @@ class GrokDaemonCoordinator {
             Logger log,
             NodeDetector nodeDetector,
             Supplier<BridgeDirectoryResolver> directoryResolverSupplier,
-            EnvironmentConfigurator envConfigurator
+            EnvironmentConfigurator envConfigurator,
+            Consumer<Map<String, String>> customEnvConfigurator
     ) {
         this.log = log;
         this.nodeDetector = nodeDetector;
         this.directoryResolverSupplier = directoryResolverSupplier;
         this.envConfigurator = envConfigurator;
+        this.customEnvConfigurator = customEnvConfigurator;
     }
 
     void addDaemonEventListener(DaemonBridge.DaemonEventListener listener) {
@@ -86,7 +91,8 @@ class GrokDaemonCoordinator {
                 DaemonBridge newBridge = new DaemonBridge(
                         nodeDetector,
                         directoryResolverSupplier.get(),
-                        envConfigurator
+                        envConfigurator,
+                        customEnvConfigurator
                 );
                 if (newBridge.start()) {
                     daemonBridge = newBridge;

--- a/src/main/java/com/github/claudecodegui/provider/grok/GrokHistoryReader.java
+++ b/src/main/java/com/github/claudecodegui/provider/grok/GrokHistoryReader.java
@@ -27,7 +27,8 @@ import java.util.Map;
 
 /**
  * Reads Grok CLI session history from
- * {@code ~/.grok/sessions/<url-encoded-cwd>/<sessionId>/{summary.json,chat_history.jsonl}}.
+ * {@code $GROK_HOME/sessions/<url-encoded-cwd>/<sessionId>/{summary.json,chat_history.jsonl}}
+ * (default home {@code ~/.grok}; often {@code ~/.antig-grok} when {@code GROK_HOME} is set).
  */
 public class GrokHistoryReader {
 
@@ -36,24 +37,38 @@ public class GrokHistoryReader {
     private static final int MAX_TOOL_RESULT_CHARS = 20_000;
 
     private final Gson gson;
-    private final Path sessionsRoot;
+    /** Ordered session roots (primary GROK_HOME first, then fallbacks). */
+    private final List<Path> sessionsRoots;
 
     public GrokHistoryReader() {
-        this(defaultSessionsRoot(), new Gson());
+        this(defaultSessionsRoots(), new Gson());
     }
 
     GrokHistoryReader(Path sessionsRoot, Gson gson) {
-        this.sessionsRoot = sessionsRoot;
+        this(sessionsRoot != null ? List.of(sessionsRoot) : List.of(), gson);
+    }
+
+    GrokHistoryReader(List<Path> sessionsRoots, Gson gson) {
+        this.sessionsRoots = sessionsRoots != null ? List.copyOf(sessionsRoots) : List.of();
         this.gson = gson;
     }
 
-    private static Path defaultSessionsRoot() {
-        String home = NodeDetector.resolveHomeForFileOps();
-        String grokHome = System.getenv("GROK_HOME");
-        if (grokHome != null && !grokHome.trim().isEmpty()) {
-            return Paths.get(grokHome.trim(), "sessions");
+    private static List<Path> defaultSessionsRoots() {
+        List<Path> roots = new ArrayList<>();
+        for (Path home : GrokLocalAuthResolver.resolveGrokHomeCandidates()) {
+            if (home != null) {
+                roots.add(home.resolve("sessions"));
+            }
         }
-        return Paths.get(home, ".grok", "sessions");
+        // Last-resort default if PlatformUtils home resolution failed above.
+        if (roots.isEmpty()) {
+            String home = NodeDetector.resolveHomeForFileOps();
+            if (home != null && !home.isEmpty()) {
+                roots.add(Paths.get(home, ".grok", "sessions"));
+            }
+        }
+        LOG.info("[GrokHistoryReader] Session roots: " + roots);
+        return roots;
     }
 
     public static class SessionInfo {
@@ -113,34 +128,44 @@ public class GrokHistoryReader {
 
     public List<SessionInfo> listAllSessions() throws IOException {
         List<SessionInfo> sessions = new ArrayList<>();
-        if (!Files.isDirectory(sessionsRoot)) {
-            LOG.info("[GrokHistoryReader] Sessions root missing: " + sessionsRoot);
-            return sessions;
-        }
-
-        try (DirectoryStream<Path> cwdDirs = Files.newDirectoryStream(sessionsRoot)) {
-            for (Path cwdDir : cwdDirs) {
-                if (!Files.isDirectory(cwdDir)) {
-                    continue;
-                }
-                String name = cwdDir.getFileName().toString();
-                if (name.startsWith(".") || name.endsWith(".sqlite") || name.endsWith(".db")) {
-                    continue;
-                }
-                String cwd = decodeCwdDirName(name);
-                try (DirectoryStream<Path> sessionDirs = Files.newDirectoryStream(cwdDir)) {
-                    for (Path sessionDir : sessionDirs) {
-                        if (!Files.isDirectory(sessionDir)) {
-                            continue;
-                        }
-                        SessionInfo info = readSessionSummary(sessionDir, cwd);
-                        if (info != null) {
-                            sessions.add(info);
+        // Prefer the first root that owns a given sessionId when the same id
+        // appears in multiple homes (should be rare).
+        Map<String, SessionInfo> byId = new HashMap<>();
+        boolean anyRoot = false;
+        for (Path sessionsRoot : sessionsRoots) {
+            if (!Files.isDirectory(sessionsRoot)) {
+                LOG.info("[GrokHistoryReader] Sessions root missing: " + sessionsRoot);
+                continue;
+            }
+            anyRoot = true;
+            try (DirectoryStream<Path> cwdDirs = Files.newDirectoryStream(sessionsRoot)) {
+                for (Path cwdDir : cwdDirs) {
+                    if (!Files.isDirectory(cwdDir)) {
+                        continue;
+                    }
+                    String name = cwdDir.getFileName().toString();
+                    if (name.startsWith(".") || name.endsWith(".sqlite") || name.endsWith(".db")) {
+                        continue;
+                    }
+                    String cwd = decodeCwdDirName(name);
+                    try (DirectoryStream<Path> sessionDirs = Files.newDirectoryStream(cwdDir)) {
+                        for (Path sessionDir : sessionDirs) {
+                            if (!Files.isDirectory(sessionDir)) {
+                                continue;
+                            }
+                            SessionInfo info = readSessionSummary(sessionDir, cwd);
+                            if (info != null && info.sessionId != null) {
+                                byId.putIfAbsent(info.sessionId, info);
+                            }
                         }
                     }
                 }
             }
         }
+        if (!anyRoot) {
+            LOG.info("[GrokHistoryReader] No sessions roots available: " + sessionsRoots);
+        }
+        sessions.addAll(byId.values());
         sessions.sort(Comparator.comparingLong((SessionInfo s) -> s.lastTimestamp).reversed());
         return sessions;
     }
@@ -295,35 +320,42 @@ public class GrokHistoryReader {
             return null;
         }
         if (cwd != null && !cwd.trim().isEmpty()) {
-            Path direct = sessionsRoot.resolve(encodeCwd(cwd)).resolve(id);
-            if (Files.isDirectory(direct)) {
-                return direct;
-            }
-            // macOS may canonicalize /var → /private/var etc.
-            Path canon = sessionsRoot.resolve(encodeCwd(canonicalizePath(cwd))).resolve(id);
-            if (Files.isDirectory(canon)) {
-                return canon;
+            String encoded = encodeCwd(cwd);
+            String encodedCanon = encodeCwd(canonicalizePath(cwd));
+            for (Path sessionsRoot : sessionsRoots) {
+                Path direct = sessionsRoot.resolve(encoded).resolve(id);
+                if (Files.isDirectory(direct)) {
+                    return direct;
+                }
+                // macOS may canonicalize /var → /private/var etc.
+                Path canon = sessionsRoot.resolve(encodedCanon).resolve(id);
+                if (Files.isDirectory(canon)) {
+                    return canon;
+                }
             }
         }
         return findSessionDirById(id);
     }
 
     private Path findSessionDirById(String sessionId) {
-        if (!Files.isDirectory(sessionsRoot)) {
-            return null;
-        }
-        try (DirectoryStream<Path> cwdDirs = Files.newDirectoryStream(sessionsRoot)) {
-            for (Path cwdDir : cwdDirs) {
-                if (!Files.isDirectory(cwdDir)) {
-                    continue;
-                }
-                Path candidate = cwdDir.resolve(sessionId);
-                if (Files.isDirectory(candidate)) {
-                    return candidate;
-                }
+        for (Path sessionsRoot : sessionsRoots) {
+            if (!Files.isDirectory(sessionsRoot)) {
+                continue;
             }
-        } catch (IOException e) {
-            LOG.warn("[GrokHistoryReader] Scan for session id failed: " + e.getMessage());
+            try (DirectoryStream<Path> cwdDirs = Files.newDirectoryStream(sessionsRoot)) {
+                for (Path cwdDir : cwdDirs) {
+                    if (!Files.isDirectory(cwdDir)) {
+                        continue;
+                    }
+                    Path candidate = cwdDir.resolve(sessionId);
+                    if (Files.isDirectory(candidate)) {
+                        return candidate;
+                    }
+                }
+            } catch (IOException e) {
+                LOG.warn("[GrokHistoryReader] Scan for session id failed under "
+                        + sessionsRoot + ": " + e.getMessage());
+            }
         }
         return null;
     }

--- a/src/main/java/com/github/claudecodegui/provider/grok/GrokLocalAuthResolver.java
+++ b/src/main/java/com/github/claudecodegui/provider/grok/GrokLocalAuthResolver.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.util.EnvironmentUtil;
 
 import com.github.claudecodegui.settings.CodemossSettingsService;
 import com.github.claudecodegui.util.PlatformUtils;
@@ -13,7 +14,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -77,12 +81,69 @@ public final class GrokLocalAuthResolver {
         }
     }
 
+    /**
+     * Resolve Grok CLI home directory.
+     *
+     * <p>Order:
+     * <ol>
+     *   <li>{@code System.getenv("GROK_HOME")} (process env — rare for GUI apps)</li>
+     *   <li>IDE login-shell map via {@link EnvironmentUtil#getEnvironmentMap()}
+     *       (picks up {@code export GROK_HOME=...} from {@code ~/.zshrc})</li>
+     *   <li>{@code ~/.grok} default</li>
+     * </ol>
+     *
+     * <p>Daemon / {@code grok agent} processes inherit shell env through
+     * {@link com.github.claudecodegui.bridge.EnvironmentConfigurator}, so they
+     * often write sessions under a custom {@code GROK_HOME} (e.g. {@code ~/.antig-grok}).
+     * History readers must use the same resolution or tab restore finds nothing.
+     */
     public static Path resolveGrokHome() {
-        String env = System.getenv("GROK_HOME");
-        if (env != null && !env.trim().isEmpty()) {
-            return Paths.get(env.trim());
+        String env = firstNonBlank(
+                System.getenv("GROK_HOME"),
+                environmentMapValue("GROK_HOME")
+        );
+        if (env != null) {
+            return Paths.get(env);
         }
         return Paths.get(PlatformUtils.getHomeDirectory(), ".grok");
+    }
+
+    /**
+     * Candidate Grok homes for on-disk history lookup. Primary home first, then
+     * the default {@code ~/.grok} when {@code GROK_HOME} points elsewhere so older
+     * sessions remain visible after a home migration.
+     */
+    public static List<Path> resolveGrokHomeCandidates() {
+        LinkedHashSet<Path> homes = new LinkedHashSet<>();
+        homes.add(resolveGrokHome());
+        Path defaultHome = Paths.get(PlatformUtils.getHomeDirectory(), ".grok");
+        homes.add(defaultHome);
+        return new ArrayList<>(homes);
+    }
+
+    private static String environmentMapValue(String key) {
+        try {
+            Map<String, String> map = EnvironmentUtil.getEnvironmentMap();
+            if (map == null) {
+                return null;
+            }
+            return map.get(key);
+        } catch (Exception e) {
+            LOG.debug("[Grok] EnvironmentUtil lookup failed for " + key + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    private static String firstNonBlank(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (value != null && !value.trim().isEmpty()) {
+                return value.trim();
+            }
+        }
+        return null;
     }
 
     public static boolean hasOAuthToken() {

--- a/src/main/java/com/github/claudecodegui/provider/grok/GrokSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/grok/GrokSDKBridge.java
@@ -52,7 +52,8 @@ public class GrokSDKBridge extends BaseSDKBridge {
                 LOG,
                 nodeDetector,
                 this::getDirectoryResolver,
-                envConfigurator
+                envConfigurator,
+                env -> configureProviderEnv(env, "{}")
         );
         this.daemonRequestExecutor = new GrokDaemonRequestExecutor(LOG, this);
     }
@@ -71,6 +72,19 @@ public class GrokSDKBridge extends BaseSDKBridge {
         env.put("GROK_USE_STDIN", "true");
         env.put("GROK_NO_AUTO_UPDATE", "1");
         env.put("CI", "1");
+
+        try {
+            JsonObject grokEnv = settingsService.getGrokEnv();
+            if (grokEnv != null && grokEnv.size() > 0) {
+                for (String key : grokEnv.keySet()) {
+                    if (grokEnv.get(key) != null && !grokEnv.get(key).isJsonNull()) {
+                        env.put(key, grokEnv.get(key).getAsString());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("[Grok] Failed to apply custom grok environment: " + e.getMessage());
+        }
 
         GrokLocalAuthResolver.ResolvedAuth resolved = resolveEffectiveAuth();
         String authMethod = resolved.authMethod;
@@ -1047,7 +1061,8 @@ public class GrokSDKBridge extends BaseSDKBridge {
     }
 
     /**
-     * Session messages from Grok CLI on-disk history ({@code ~/.grok/sessions}).
+     * Session messages from Grok CLI on-disk history
+     * ({@code $GROK_HOME/sessions}, default {@code ~/.grok/sessions}).
      */
     public List<JsonObject> getSessionMessages(String sessionId, String cwd) {
         try {

--- a/src/main/java/com/github/claudecodegui/service/NodeProcessRegistry.java
+++ b/src/main/java/com/github/claudecodegui/service/NodeProcessRegistry.java
@@ -3,6 +3,7 @@ package com.github.claudecodegui.service;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
 import com.github.claudecodegui.provider.common.DaemonBridge;
+import com.github.claudecodegui.provider.grok.GrokSDKBridge;
 import com.github.claudecodegui.ui.toolwindow.ClaudeChatWindow;
 import com.github.claudecodegui.ui.toolwindow.ClaudeSDKToolWindow;
 import com.github.claudecodegui.util.PlatformUtils;
@@ -29,8 +30,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * <p>Three data sources are unified:
  * <ol>
- *   <li><b>Claude daemon processes</b>: one per {@link ClaudeChatWindow}, accessed via
- *       {@link ClaudeSDKBridge#getCurrentDaemonBridgeForInspection()}.</li>
+ *   <li><b>Daemon processes</b>: Claude and Grok each own a long-lived {@code daemon.js}
+ *       via {@link ClaudeSDKBridge#getCurrentDaemonBridgeForInspection()} /
+ *       {@link GrokSDKBridge#getCurrentDaemonBridgeForInspection()}.</li>
  *   <li><b>Per-channel processes</b>: tracked in each bridge's {@code ProcessManager}.</li>
  *   <li><b>Orphan processes</b>: discovered by scanning {@link ProcessHandle#allProcesses()}
  *       for {@code daemon.js} / {@code channel-manager.js} command lines that don't match
@@ -102,97 +104,68 @@ public final class NodeProcessRegistry implements Disposable {
             // the user. The physical SDK type is preserved in the command tooltip.
             String tabProvider = safeGetCurrentProvider(window);
 
-            // -- DAEMON entries from ClaudeSDKBridge --
+            // -- DAEMON + CHANNEL entries from Claude / Grok / Codex bridges --
             ClaudeSDKBridge claudeBridge = safeClaudeBridge(window);
+            GrokSDKBridge grokBridge = safeGrokBridge(window);
             if (claudeBridge != null) {
-                DaemonBridge daemon = claudeBridge.getCurrentDaemonBridgeForInspection();
-                if (daemon != null && daemon.isAlive()) {
-                    Process daemonProcess = daemon.getDaemonProcessForInspection();
-                    if (daemonProcess != null && daemonProcess.isAlive()) {
-                        long pid = daemonProcess.pid();
-                        knownPids.add(pid);
-                        ProcessHandle.Info info = safeInfo(daemonProcess);
-                        long startedAt = info != null
-                                ? info.startInstant().map(Instant::toEpochMilli).orElse(-1L)
-                                : -1L;
-                        result.add(NodeProcessInfo.builder()
-                                .kind(NodeProcessInfo.Kind.DAEMON)
-                                .provider(tabProvider)
-                                .pid(pid)
-                                .alive(true)
-                                .startedAtMs(startedAt)
-                                .uptimeMs(startedAt > 0 ? Math.max(0, now - startedAt) : 0L)
-                                .command(extractCommand(info))
-                                .activeRequestCount(daemon.getActiveRequestCount())
-                                .sessionId(sessionId)
-                                .tabName(tabName)
-                                .build());
-
-                        // Also include daemon's child processes (e.g., spawned Claude CLI).
-                        // These are "owned" by us, so add to knownPids to keep them out of orphan list.
-                        try {
-                            daemonProcess.toHandle().descendants().forEach(child -> knownPids.add(child.pid()));
-                        } catch (Exception ignored) {
-                        }
-                    }
-                }
+                collectDaemonEntry(
+                        result,
+                        knownPids,
+                        claudeBridge.getCurrentDaemonBridgeForInspection(),
+                        tabProvider,
+                        sessionId,
+                        tabName,
+                        now
+                );
 
                 // -- CHANNEL entries from claudeBridge.processManager --
-                Map<String, Process> claudeChannels = claudeBridge.getProcessManager().getActiveChannelSnapshot();
-                for (Map.Entry<String, Process> entry : claudeChannels.entrySet()) {
-                    Process p = entry.getValue();
-                    if (p == null || !p.isAlive()) {
-                        continue;
-                    }
-                    long pid = p.pid();
-                    knownPids.add(pid);
-                    ProcessHandle.Info info = safeInfo(p);
-                    long startedAt = info != null
-                            ? info.startInstant().map(Instant::toEpochMilli).orElse(-1L)
-                            : -1L;
-                    result.add(NodeProcessInfo.builder()
-                            .kind(NodeProcessInfo.Kind.CHANNEL)
-                            .provider(tabProvider)
-                            .pid(pid)
-                            .alive(true)
-                            .startedAtMs(startedAt)
-                            .uptimeMs(startedAt > 0 ? Math.max(0, now - startedAt) : 0L)
-                            .command(extractCommand(info))
-                            .channelId(entry.getKey())
-                            .sessionId(sessionId)
-                            .tabName(tabName)
-                            .build());
-                }
+                collectChannelEntries(
+                        result,
+                        knownPids,
+                        claudeBridge.getProcessManager().getActiveChannelSnapshot(),
+                        tabProvider,
+                        sessionId,
+                        tabName,
+                        now
+                );
             }
 
-            // -- CHANNEL entries from codexBridge.processManager (per-message processes) --
+            // Grok persistent ACP daemon (grok agent stdio under daemon.js).
+            // Without this, the live Grok daemon is mislabeled ORPHAN and "Kill all
+            // orphans" / panel kill destroys multi-turn ACP state.
+            if (grokBridge != null) {
+                collectDaemonEntry(
+                        result,
+                        knownPids,
+                        grokBridge.getCurrentDaemonBridgeForInspection(),
+                        tabProvider,
+                        sessionId,
+                        tabName,
+                        now
+                );
+                collectChannelEntries(
+                        result,
+                        knownPids,
+                        grokBridge.getProcessManager().getActiveChannelSnapshot(),
+                        tabProvider,
+                        sessionId,
+                        tabName,
+                        now
+                );
+            }
+
+            // -- CHANNEL entries from codex (per-message processes) --
             CodexSDKBridge codexBridge = safeCodexBridge(window);
             if (codexBridge != null) {
-                Map<String, Process> codexChannels = codexBridge.getProcessManager().getActiveChannelSnapshot();
-                for (Map.Entry<String, Process> entry : codexChannels.entrySet()) {
-                    Process p = entry.getValue();
-                    if (p == null || !p.isAlive()) {
-                        continue;
-                    }
-                    long pid = p.pid();
-                    knownPids.add(pid);
-                    ProcessHandle.Info info = safeInfo(p);
-                    long startedAt = info != null
-                            ? info.startInstant().map(Instant::toEpochMilli).orElse(-1L)
-                            : -1L;
-                    result.add(NodeProcessInfo.builder()
-                            .kind(NodeProcessInfo.Kind.CHANNEL)
-                            .provider(tabProvider)
-                            .pid(pid)
-                            .alive(true)
-                            .startedAtMs(startedAt)
-                            .uptimeMs(startedAt > 0 ? Math.max(0, now - startedAt) : 0L)
-                            .command(extractCommand(info))
-                            .channelId(entry.getKey())
-                            .sessionId(sessionId)
-                            .tabName(tabName)
-                            .build());
-                }
+                collectChannelEntries(
+                        result,
+                        knownPids,
+                        codexBridge.getProcessManager().getActiveChannelSnapshot(),
+                        tabProvider,
+                        sessionId,
+                        tabName,
+                        now
+                );
             }
         }
 
@@ -349,25 +322,36 @@ public final class NodeProcessRegistry implements Disposable {
     public boolean restartDaemonByPid(long pid) {
         Set<ClaudeChatWindow> windows = ClaudeSDKToolWindow.getAllChatWindowsForProject(project);
         for (ClaudeChatWindow window : windows) {
-            ClaudeSDKBridge bridge = safeClaudeBridge(window);
-            if (bridge == null) {
-                continue;
+            ClaudeSDKBridge claudeBridge = safeClaudeBridge(window);
+            if (tryRestartDaemon(claudeBridge != null ? claudeBridge.getCurrentDaemonBridgeForInspection() : null,
+                    claudeBridge != null ? claudeBridge::shutdownDaemon : null, pid)) {
+                return true;
             }
-            DaemonBridge daemon = bridge.getCurrentDaemonBridgeForInspection();
-            if (daemon == null || !daemon.isAlive()) {
-                continue;
+            GrokSDKBridge grokBridge = safeGrokBridge(window);
+            if (tryRestartDaemon(grokBridge != null ? grokBridge.getCurrentDaemonBridgeForInspection() : null,
+                    grokBridge != null ? grokBridge::shutdownDaemon : null, pid)) {
+                return true;
             }
-            Process p = daemon.getDaemonProcessForInspection();
-            if (p == null || p.pid() != pid) {
-                continue;
-            }
-            LOG.info("[NodeProcessRegistry] Restarting daemon for window PID=" + pid);
-            // shutdownDaemon stops the current daemon; next message will lazily start a new one
-            bridge.shutdownDaemon();
-            return true;
         }
         // PID didn't match any tracked daemon — fall back to plain kill
         return killByPid(pid);
+    }
+
+    private boolean tryRestartDaemon(
+            @Nullable DaemonBridge daemon,
+            @Nullable Runnable shutdown,
+            long pid
+    ) {
+        if (daemon == null || !daemon.isAlive() || shutdown == null) {
+            return false;
+        }
+        Process p = daemon.getDaemonProcessForInspection();
+        if (p == null || p.pid() != pid) {
+            return false;
+        }
+        LOG.info("[NodeProcessRegistry] Restarting daemon for window PID=" + pid);
+        shutdown.run();
+        return true;
     }
 
     /**
@@ -410,16 +394,119 @@ public final class NodeProcessRegistry implements Disposable {
             return null;
         }
         String lower = cmd.toLowerCase();
+        // Shared daemon.js is used by Claude and Grok; channel-manager fingerprints are clearer.
+        if (lower.contains("channel-manager") && lower.contains("grok")) {
+            return "grok";
+        }
+        if (lower.contains("channel-manager") && lower.contains("gemini")) {
+            return "gemini";
+        }
+        if (lower.contains("channel-manager") && lower.contains("codex")) {
+            return "codex";
+        }
         if (lower.contains("daemon.js")) {
+            // Cannot distinguish Claude vs Grok daemon from cmd alone.
             return "claude";
         }
         if (lower.contains("codex")) {
             return "codex";
         }
+        if (lower.contains("grok")) {
+            return "grok";
+        }
+        if (lower.contains("gemini")) {
+            return "gemini";
+        }
         if (lower.contains("claude")) {
             return "claude";
         }
         return null;
+    }
+
+    private static void collectDaemonEntry(
+            List<NodeProcessInfo> result,
+            Set<Long> knownPids,
+            @Nullable DaemonBridge daemon,
+            String tabProvider,
+            @Nullable String sessionId,
+            @Nullable String tabName,
+            long now
+    ) {
+        if (daemon == null || !daemon.isAlive()) {
+            return;
+        }
+        Process daemonProcess = daemon.getDaemonProcessForInspection();
+        if (daemonProcess == null || !daemonProcess.isAlive()) {
+            return;
+        }
+        long pid = daemonProcess.pid();
+        knownPids.add(pid);
+        ProcessHandle.Info info = safeInfo(daemonProcess);
+        long startedAt = info != null
+                ? info.startInstant().map(Instant::toEpochMilli).orElse(-1L)
+                : -1L;
+        result.add(NodeProcessInfo.builder()
+                .kind(NodeProcessInfo.Kind.DAEMON)
+                .provider(tabProvider)
+                .pid(pid)
+                .alive(true)
+                .startedAtMs(startedAt)
+                .uptimeMs(startedAt > 0 ? Math.max(0, now - startedAt) : 0L)
+                .command(extractCommand(info))
+                .activeRequestCount(daemon.getActiveRequestCount())
+                .sessionId(sessionId)
+                .tabName(tabName)
+                .build());
+
+        // Include daemon children (Claude CLI / grok agent stdio) so they are not
+        // listed as orphans and "Kill all orphans" does not tear down live ACP turns.
+        try {
+            daemonProcess.toHandle().descendants().forEach(child -> knownPids.add(child.pid()));
+        } catch (Exception ignored) {
+        }
+    }
+
+    private static void collectChannelEntries(
+            List<NodeProcessInfo> result,
+            Set<Long> knownPids,
+            @Nullable Map<String, Process> channels,
+            String tabProvider,
+            @Nullable String sessionId,
+            @Nullable String tabName,
+            long now
+    ) {
+        if (channels == null || channels.isEmpty()) {
+            return;
+        }
+        for (Map.Entry<String, Process> entry : channels.entrySet()) {
+            Process p = entry.getValue();
+            if (p == null || !p.isAlive()) {
+                continue;
+            }
+            long pid = p.pid();
+            knownPids.add(pid);
+            // channel-manager children (e.g. grok agent stdio one-shot path)
+            try {
+                p.toHandle().descendants().forEach(child -> knownPids.add(child.pid()));
+            } catch (Exception ignored) {
+            }
+            ProcessHandle.Info info = safeInfo(p);
+            long startedAt = info != null
+                    ? info.startInstant().map(Instant::toEpochMilli).orElse(-1L)
+                    : -1L;
+            result.add(NodeProcessInfo.builder()
+                    .kind(NodeProcessInfo.Kind.CHANNEL)
+                    .provider(tabProvider)
+                    .pid(pid)
+                    .alive(true)
+                    .startedAtMs(startedAt)
+                    .uptimeMs(startedAt > 0 ? Math.max(0, now - startedAt) : 0L)
+                    .command(extractCommand(info))
+                    .channelId(entry.getKey())
+                    .sessionId(sessionId)
+                    .tabName(tabName)
+                    .build());
+        }
     }
 
     private static @Nullable ProcessHandle.Info safeInfo(Process p) {
@@ -445,6 +532,14 @@ public final class NodeProcessRegistry implements Disposable {
     private static @Nullable ClaudeSDKBridge safeClaudeBridge(ClaudeChatWindow window) {
         try {
             return window != null ? window.getClaudeSDKBridge() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static @Nullable GrokSDKBridge safeGrokBridge(ClaudeChatWindow window) {
+        try {
+            return window != null ? window.getGrokSDKBridge() : null;
         } catch (Exception e) {
             return null;
         }

--- a/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
@@ -4,6 +4,7 @@ import com.github.claudecodegui.permission.PermissionManager;
 import com.github.claudecodegui.permission.PermissionRequest;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.provider.grok.GrokSDKBridge;
 import com.github.claudecodegui.provider.common.MarkerCliBridge;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -53,6 +54,7 @@ public class ClaudeSession {
     // Context collector
     private final com.github.claudecodegui.session.EditorContextCollector contextCollector;
     private final SessionContextService contextService;
+    private final GrokSDKBridge grokSDKBridge;
     private final SessionProviderRouter providerRouter;
     private final SessionSendService sendService;
     private final SessionMessageOrchestrator messageOrchestrator;
@@ -176,6 +178,16 @@ public class ClaudeSession {
             CodexSDKBridge codexSDKBridge,
             Map<String, MarkerCliBridge> cliBridges
     ) {
+        this(project, claudeSDKBridge, codexSDKBridge, cliBridges, null);
+    }
+
+    public ClaudeSession(
+            Project project,
+            ClaudeSDKBridge claudeSDKBridge,
+            CodexSDKBridge codexSDKBridge,
+            Map<String, MarkerCliBridge> cliBridges,
+            GrokSDKBridge grokSDKBridge
+    ) {
         this.project = project;
         this.claudeSDKBridge = claudeSDKBridge;
         this.codexSDKBridge = codexSDKBridge;
@@ -187,7 +199,8 @@ public class ClaudeSession {
         this.contextCollector = new com.github.claudecodegui.session.EditorContextCollector(project);
         this.callbackFacade = new SessionCallbackFacade(project);
         this.contextService = new SessionContextService(project, MAX_FILE_SIZE_BYTES);
-        this.providerRouter = new SessionProviderRouter(claudeSDKBridge, codexSDKBridge, cliBridges);
+        this.grokSDKBridge = grokSDKBridge;
+        this.providerRouter = new SessionProviderRouter(claudeSDKBridge, codexSDKBridge, cliBridges, this.grokSDKBridge);
         this.sendService = new SessionSendService(
                 project,
                 state,
@@ -198,8 +211,8 @@ public class ClaudeSession {
                 claudeSDKBridge,
                 codexSDKBridge,
                 cliBridges,
-                contextService
-        );
+                contextService,
+                this.grokSDKBridge);
         this.messageOrchestrator = new SessionMessageOrchestrator(
                 project,
                 state,

--- a/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionLifecycleManager.java
@@ -41,6 +41,10 @@ public class SessionLifecycleManager {
 
         CodexSDKBridge getCodexSDKBridge();
 
+        default com.github.claudecodegui.provider.grok.GrokSDKBridge getGrokSDKBridge() {
+            return null;
+        }
+
         Map<String, MarkerCliBridge> getCliBridges();
 
         ClaudeSession getSession();
@@ -100,8 +104,12 @@ public class SessionLifecycleManager {
 
         interruptFuture.thenRun(() -> {
             if (oldSession != null) {
-                host.getClaudeSDKBridge().resetPersistentRuntime(oldSession.getRuntimeSessionEpoch());
-                LOG.info("[Lifecycle] Requested daemon runtime reset for old epoch=" + oldSession.getRuntimeSessionEpoch());
+                String oldEpoch = oldSession.getRuntimeSessionEpoch();
+                host.getClaudeSDKBridge().resetPersistentRuntime(oldEpoch);
+                if (host.getGrokSDKBridge() != null) {
+                    host.getGrokSDKBridge().resetPersistentRuntime(oldEpoch);
+                }
+                LOG.info("[Lifecycle] Requested daemon runtime reset for old epoch=" + oldEpoch);
             }
             LOG.info("Old session interrupted, creating new session");
 
@@ -148,8 +156,12 @@ public class SessionLifecycleManager {
 
         interruptFuture.thenRun(() -> {
             if (oldSession != null) {
-                host.getClaudeSDKBridge().resetPersistentRuntime(oldSession.getRuntimeSessionEpoch());
-                LOG.info("[Lifecycle] Requested daemon runtime reset for old epoch=" + oldSession.getRuntimeSessionEpoch());
+                String oldEpoch = oldSession.getRuntimeSessionEpoch();
+                host.getClaudeSDKBridge().resetPersistentRuntime(oldEpoch);
+                if (host.getGrokSDKBridge() != null) {
+                    host.getGrokSDKBridge().resetPersistentRuntime(oldEpoch);
+                }
+                LOG.info("[Lifecycle] Requested daemon runtime reset for old epoch=" + oldEpoch);
             }
             LOG.info("Old session interrupted, creating new session from template");
 
@@ -250,16 +262,16 @@ public class SessionLifecycleManager {
 
         interruptFuture.thenRun(() -> {
             if (oldSession != null) {
-                host.getClaudeSDKBridge().resetPersistentRuntime(oldSession.getRuntimeSessionEpoch());
+                String oldEpoch = oldSession.getRuntimeSessionEpoch();
+                host.getClaudeSDKBridge().resetPersistentRuntime(oldEpoch);
+                if (host.getGrokSDKBridge() != null) {
+                    host.getGrokSDKBridge().resetPersistentRuntime(oldEpoch);
+                }
                 LOG.info("[Lifecycle] Requested daemon runtime reset before history load for old epoch="
-                        + oldSession.getRuntimeSessionEpoch());
+                        + oldEpoch);
             }
 
-            ClaudeSession newSession = new ClaudeSession(
-                    host.getProject(),
-                    host.getClaudeSDKBridge(),
-                    host.getCodexSDKBridge(),
-                    host.getCliBridges());
+            ClaudeSession newSession = createDefaultSession();
             newSession.setPermissionMode(previousPermissionMode);
             newSession.setProvider(provider != null && !provider.trim().isEmpty() ? provider : previousProvider);
             newSession.setModel(modelToRestore);
@@ -275,7 +287,11 @@ public class SessionLifecycleManager {
             newSession.setSessionInfo(sessionId, workingDir);
 
             // Prewarm daemon runtime for the historical session so /context and first message are fast
-            host.getClaudeSDKBridge().prewarmDaemonAsync(workingDir, newSession.getRuntimeSessionEpoch(), sessionId);
+            if ("claude".equals(newSession.getProvider())) {
+                host.getClaudeSDKBridge().prewarmDaemonAsync(workingDir, newSession.getRuntimeSessionEpoch(), sessionId);
+            } else if ("grok".equals(newSession.getProvider()) && host.getGrokSDKBridge() != null) {
+                host.getGrokSDKBridge().prewarmDaemonAsync(workingDir, newSession.getRuntimeSessionEpoch(), sessionId);
+            }
 
             newSession.loadFromServer().thenRun(() -> ApplicationManager.getApplication().invokeLater(() -> {
                 host.callJavaScript("historyLoadComplete");
@@ -425,7 +441,8 @@ public class SessionLifecycleManager {
                 host.getProject(),
                 host.getClaudeSDKBridge(),
                 host.getCodexSDKBridge(),
-                host.getCliBridges());
+                host.getCliBridges(),
+                host.getGrokSDKBridge());
     }
 
     private void completeNewSessionBootstrap(ClaudeSession newSession, String workingDirectory, String successLogPrefix) {
@@ -437,7 +454,11 @@ public class SessionLifecycleManager {
 
         newSession.setSessionInfo(null, workingDirectory);
         LOG.info(successLogPrefix + workingDirectory + ", epoch=" + newSession.getRuntimeSessionEpoch());
-        host.getClaudeSDKBridge().prewarmDaemonAsync(workingDirectory, newSession.getRuntimeSessionEpoch());
+        if ("claude".equals(newSession.getProvider())) {
+            host.getClaudeSDKBridge().prewarmDaemonAsync(workingDirectory, newSession.getRuntimeSessionEpoch());
+        } else if ("grok".equals(newSession.getProvider()) && host.getGrokSDKBridge() != null) {
+            host.getGrokSDKBridge().prewarmDaemonAsync(workingDirectory, newSession.getRuntimeSessionEpoch());
+        }
         fetchSlashCommandsOnStartup();
 
         ApplicationManager.getApplication().invokeLater(() -> {

--- a/src/main/java/com/github/claudecodegui/session/SessionProviderRouter.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionProviderRouter.java
@@ -2,6 +2,7 @@ package com.github.claudecodegui.session;
 
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.provider.grok.GrokSDKBridge;
 import com.github.claudecodegui.provider.common.MarkerCliBridge;
 import com.google.gson.JsonObject;
 
@@ -21,7 +22,7 @@ public class SessionProviderRouter {
      * {@link MarkerCliBridge} — the keys of the map built by
      * {@link #registerCliBridges(MarkerCliBridge...)} for the bundled bridges.
      */
-    private static final Set<String> CLI_PROVIDER_IDS = Set.of("grok", "kimi", "opencode", "pi");
+    private static final Set<String> CLI_PROVIDER_IDS = Set.of("kimi", "opencode", "pi");
 
     /**
      * Whether {@code provider} is a headless CLI provider routed through the
@@ -33,6 +34,7 @@ public class SessionProviderRouter {
 
     private final ClaudeSDKBridge claudeSDKBridge;
     private final CodexSDKBridge codexSDKBridge;
+    private final GrokSDKBridge grokSDKBridge;
     private final Map<String, MarkerCliBridge> cliBridges;
 
     public SessionProviderRouter(
@@ -40,8 +42,18 @@ public class SessionProviderRouter {
             CodexSDKBridge codexSDKBridge,
             Map<String, MarkerCliBridge> cliBridges
     ) {
+        this(claudeSDKBridge, codexSDKBridge, cliBridges, null);
+    }
+
+    public SessionProviderRouter(
+            ClaudeSDKBridge claudeSDKBridge,
+            CodexSDKBridge codexSDKBridge,
+            Map<String, MarkerCliBridge> cliBridges,
+            GrokSDKBridge grokSDKBridge
+    ) {
         this.claudeSDKBridge = claudeSDKBridge;
         this.codexSDKBridge = codexSDKBridge;
+        this.grokSDKBridge = grokSDKBridge;
         this.cliBridges = cliBridges != null
                 ? Collections.unmodifiableMap(new LinkedHashMap<>(cliBridges))
                 : Collections.emptyMap();
@@ -68,6 +80,9 @@ public class SessionProviderRouter {
         if ("codex".equals(provider)) {
             return codexSDKBridge.launchChannel(channelId, sessionId, cwd);
         }
+        if ("grok".equals(provider) && grokSDKBridge != null) {
+            return grokSDKBridge.launchChannel(channelId, sessionId, cwd);
+        }
         MarkerCliBridge bridge = cli(provider);
         if (bridge != null) {
             return bridge.launchChannel(channelId, sessionId, cwd);
@@ -78,6 +93,10 @@ public class SessionProviderRouter {
     public void interruptChannel(String provider, String channelId) {
         if ("codex".equals(provider)) {
             codexSDKBridge.interruptChannel(channelId);
+            return;
+        }
+        if ("grok".equals(provider) && grokSDKBridge != null) {
+            grokSDKBridge.interruptChannel(channelId);
             return;
         }
         MarkerCliBridge bridge = cli(provider);
@@ -92,6 +111,9 @@ public class SessionProviderRouter {
         if ("codex".equals(provider)) {
             return codexSDKBridge.getSessionMessages(sessionId, cwd);
         }
+        if ("grok".equals(provider) && grokSDKBridge != null) {
+            return grokSDKBridge.getSessionMessages(sessionId, cwd);
+        }
         MarkerCliBridge bridge = cli(provider);
         if (bridge != null) {
             return bridge.getSessionMessages(sessionId, cwd);
@@ -101,5 +123,9 @@ public class SessionProviderRouter {
 
     public Map<String, MarkerCliBridge> getCliBridges() {
         return cliBridges;
+    }
+
+    public GrokSDKBridge getGrokSDKBridge() {
+        return grokSDKBridge;
     }
 }

--- a/src/main/java/com/github/claudecodegui/session/SessionSendService.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionSendService.java
@@ -232,8 +232,11 @@ public class SessionSendService {
             resolvedMode = "default";
         }
 
-        // Codex + headless CLI providers have no plan mode equivalent.
-        if (("codex".equals(provider) || SessionProviderRouter.isCliProvider(provider)) && "plan".equals(resolvedMode)) {
+        // Codex and Grok run as full SDK bridges (not MarkerCli providers, so they
+        // are absent from CLI_PROVIDER_IDS), but like the headless CLI providers
+        // they have no plan-mode equivalent — so plan still downgrades to default.
+        if (("codex".equals(provider) || "grok".equals(provider)
+                || SessionProviderRouter.isCliProvider(provider)) && "plan".equals(resolvedMode)) {
             return "default";
         }
         return resolvedMode;

--- a/src/main/java/com/github/claudecodegui/session/SessionSendService.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionSendService.java
@@ -6,6 +6,7 @@ import com.github.claudecodegui.settings.CodexSettingsManager;
 import com.github.claudecodegui.notifications.ClaudeNotifier;
 import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
+import com.github.claudecodegui.provider.grok.GrokSDKBridge;
 import com.github.claudecodegui.provider.common.MarkerCliBridge;
 import com.github.claudecodegui.provider.common.MessageCallback;
 import com.google.gson.Gson;
@@ -34,6 +35,7 @@ public class SessionSendService {
     private final Gson gson;
     private final ClaudeSDKBridge claudeSDKBridge;
     private final CodexSDKBridge codexSDKBridge;
+    private final GrokSDKBridge grokSDKBridge;
     private final Map<String, MarkerCliBridge> cliBridges;
     private final SessionContextService contextService;
 
@@ -49,6 +51,23 @@ public class SessionSendService {
             Map<String, MarkerCliBridge> cliBridges,
             SessionContextService contextService
     ) {
+        this(project, state, callbackFacade, messageParser, messageMerger, gson,
+                claudeSDKBridge, codexSDKBridge, cliBridges, contextService, null);
+    }
+
+    public SessionSendService(
+            Project project,
+            SessionState state,
+            SessionCallbackFacade callbackFacade,
+            MessageParser messageParser,
+            MessageMerger messageMerger,
+            Gson gson,
+            ClaudeSDKBridge claudeSDKBridge,
+            CodexSDKBridge codexSDKBridge,
+            Map<String, MarkerCliBridge> cliBridges,
+            SessionContextService contextService,
+            GrokSDKBridge grokSDKBridge
+    ) {
         this.project = project;
         this.state = state;
         this.callbackFacade = callbackFacade;
@@ -57,6 +76,7 @@ public class SessionSendService {
         this.gson = gson;
         this.claudeSDKBridge = claudeSDKBridge;
         this.codexSDKBridge = codexSDKBridge;
+        this.grokSDKBridge = grokSDKBridge;
         this.cliBridges = cliBridges != null ? cliBridges : Collections.emptyMap();
         this.contextService = contextService;
     }
@@ -142,7 +162,20 @@ public class SessionSendService {
             );
         }
 
-        if (cliBridges.containsKey(currentProvider)) {
+        if ("grok".equals(currentProvider) && grokSDKBridge != null) {
+            return sendToGrok(
+                    channelId,
+                    input,
+                    attachments,
+                    openedFilesJson,
+                    agentPrompt,
+                    fileTagPaths,
+                    effectivePermissionMode,
+                    normalizedRequestedEffort
+            );
+        }
+
+        if (cliBridges.containsKey(currentProvider) && !"grok".equals(currentProvider)) {
             return sendToCliProvider(
                     currentProvider,
                     channelId,
@@ -303,7 +336,59 @@ public class SessionSendService {
         ).thenApply(result -> null);
     }
 
-    private CompletableFuture<Void> sendToCliProvider(
+        private CompletableFuture<Void> sendToGrok(
+            String channelId,
+            String input,
+            List<ClaudeSession.Attachment> attachments,
+            JsonObject openedFilesJson,
+            String agentPrompt,
+            List<String> fileTagPaths,
+            String effectivePermissionMode,
+            String requestedReasoningEffort
+    ) {
+        if (grokSDKBridge == null) {
+            LOG.error("[Lifecycle] sendToGrok called but GrokSDKBridge is null");
+            callbackFacade.notifyStateChange(false, false, "Grok bridge not available");
+            return CompletableFuture.completedFuture(null);
+        }
+        GrokMessageHandler handler = new GrokMessageHandler(state, callbackFacade.getCallbackHandler());
+        Boolean streaming = readStreamingEnabled();
+        final String runtimeSessionEpoch = state.getRuntimeSessionEpoch();
+        final String currentModel = state.getModel();
+        String projectBase = project != null ? project.getBasePath() : null;
+        String guardedCwd = com.github.claudecodegui.util.PathUtils.guardWorkingDirectory(
+                state.getCwd(), projectBase);
+        if (guardedCwd == null) {
+            guardedCwd = state.getCwd();
+        } else if (state.getCwd() == null || !guardedCwd.equals(state.getCwd())) {
+            LOG.warn("[Lifecycle] sendToGrok cwd guard: " + state.getCwd() + " -> " + guardedCwd);
+            state.setCwd(guardedCwd);
+        }
+        LOG.info("[Lifecycle] sendToGrok sessionId=" + (state.getSessionId() != null ? state.getSessionId() : "(new)")
+                + ", epoch=" + runtimeSessionEpoch
+                + ", cwd=" + guardedCwd
+                + ", model=" + currentModel
+                + ", fileTags=" + (fileTagPaths != null ? fileTagPaths.size() : 0));
+
+        return grokSDKBridge.sendMessage(
+                channelId,
+                input,
+                state.getSessionId(),
+                runtimeSessionEpoch,
+                guardedCwd,
+                attachments,
+                effectivePermissionMode,
+                currentModel,
+                openedFilesJson,
+                agentPrompt,
+                streaming,
+                false,
+                requestedReasoningEffort != null ? requestedReasoningEffort : state.getReasoningEffort(),
+                handler
+        ).thenApply(result -> null);
+    }
+
+private CompletableFuture<Void> sendToCliProvider(
             String provider,
             String channelId,
             String input,

--- a/src/main/java/com/github/claudecodegui/settings/CodemossSettingsService.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodemossSettingsService.java
@@ -152,6 +152,32 @@ public class CodemossSettingsService {
         LOG.info("[CodemossSettingsService] Set grok.oauthBaseUrl=" + redactUrl(url));
     }
 
+    public JsonObject getGrokEnv() throws IOException {
+        JsonObject config = readConfig();
+        if (!config.has("grok") || config.get("grok").isJsonNull()) {
+            return new JsonObject();
+        }
+        JsonObject grok = config.getAsJsonObject("grok");
+        if (grok.has("env") && grok.get("env").isJsonObject()) {
+            return grok.getAsJsonObject("env");
+        }
+        return new JsonObject();
+    }
+
+    public void setGrokEnv(JsonObject env) throws IOException {
+        JsonObject config = readConfig();
+        JsonObject grok = config.has("grok") && !config.get("grok").isJsonNull()
+                ? config.getAsJsonObject("grok")
+                : new JsonObject();
+        if (env == null || env.size() == 0) {
+            grok.remove("env");
+        } else {
+            grok.add("env", env);
+        }
+        config.add("grok", grok);
+        writeConfig(config);
+    }
+
     public String getGrokGatewayOrigin() throws IOException {
         return getGrokStringSetting("gatewayOrigin");
     }

--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -82,6 +82,9 @@ public class ChatWindowDelegate {
         Project getProject();
         ClaudeSDKBridge getClaudeSDKBridge();
         CodexSDKBridge getCodexSDKBridge();
+        default com.github.claudecodegui.provider.grok.GrokSDKBridge getGrokSDKBridge() {
+            return null;
+        }
         Map<String, MarkerCliBridge> getCliBridges();
         ClaudeSession getSession();
         CodemossSettingsService getSettingsService();
@@ -318,6 +321,7 @@ public class ChatWindowDelegate {
                 project,
                 claudeSDKBridge,
                 codexSDKBridge,
+                host.getGrokSDKBridge(),
                 settingsService,
                 jsCallback,
                 host::isActiveContent,

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -10,6 +10,7 @@ import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
 import com.github.claudecodegui.provider.common.MarkerCliBridge;
 import com.github.claudecodegui.provider.grok.GrokCliBridge;
+import com.github.claudecodegui.provider.grok.GrokSDKBridge;
 import com.github.claudecodegui.provider.kimi.KimiCliBridge;
 import com.github.claudecodegui.provider.opencode.OpenCodeCliBridge;
 import com.github.claudecodegui.provider.pi.PiCliBridge;
@@ -72,6 +73,7 @@ public class ClaudeChatWindow {
     private final JPanel mainPanel;
     private final ClaudeSDKBridge claudeSDKBridge;
     private final CodexSDKBridge codexSDKBridge;
+    private final GrokSDKBridge grokSDKBridge;
     private final Map<String, MarkerCliBridge> cliBridges;
     private final GrokCliBridge grokCliBridge;
     private final KimiCliBridge kimiCliBridge;
@@ -216,12 +218,14 @@ public class ClaudeChatWindow {
         this.project = project;
         this.claudeSDKBridge = new ClaudeSDKBridge();
         this.codexSDKBridge = new CodexSDKBridge();
+        this.grokSDKBridge = new GrokSDKBridge();
         this.grokCliBridge = new GrokCliBridge();
         this.kimiCliBridge = new KimiCliBridge();
         this.openCodeCliBridge = new OpenCodeCliBridge();
         this.piCliBridge = new PiCliBridge();
+        // Grok uses GrokSDKBridge (persistent ACP / grok agent stdio), not MarkerCliBridge.
         this.cliBridges = SessionProviderRouter.registerCliBridges(
-                this.grokCliBridge, this.kimiCliBridge, this.openCodeCliBridge, this.piCliBridge);
+                this.kimiCliBridge, this.openCodeCliBridge, this.piCliBridge);
         this.settingsService = new CodemossSettingsService();
         this.htmlLoader = new HtmlLoader(getClass());
         this.mainPanel = new JPanel(new BorderLayout());
@@ -277,7 +281,7 @@ public class ClaudeChatWindow {
                 () -> frontendReady
         );
 
-        this.session = new ClaudeSession(project, claudeSDKBridge, codexSDKBridge, cliBridges);
+        this.session = new ClaudeSession(project, claudeSDKBridge, codexSDKBridge, cliBridges, grokSDKBridge);
 
         this.chatWindowDelegate = new ChatWindowDelegate(createDelegateHost());
         chatWindowDelegate.loadPermissionModeFromSettings();
@@ -301,6 +305,11 @@ public class ClaudeChatWindow {
             @Override
             public CodexSDKBridge getCodexSDKBridge() {
                 return codexSDKBridge;
+            }
+
+            @Override
+            public GrokSDKBridge getGrokSDKBridge() {
+                return grokSDKBridge;
             }
 
             @Override
@@ -1361,6 +1370,10 @@ public class ClaudeChatWindow {
 
     public ClaudeSDKBridge getClaudeSDKBridge() {
         return claudeSDKBridge;
+    }
+
+    public GrokSDKBridge getGrokSDKBridge() {
+        return grokSDKBridge;
     }
 
     public CodexSDKBridge getCodexSDKBridge() {
@@ -2829,6 +2842,18 @@ public class ClaudeChatWindow {
         }
 
         try {
+            if (grokSDKBridge != null) {
+                int activeCount = grokSDKBridge.getActiveProcessCount();
+                if (activeCount > 0) {
+                    LOG.info("Cleaning up " + activeCount + " active Grok process(es)...");
+                }
+                grokSDKBridge.cleanupAllProcesses();
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to clean up Grok processes: " + e.getMessage());
+        }
+
+        try {
             if (targetBrowser != null) {
                 targetBrowser.dispose();
             }
@@ -2992,6 +3017,11 @@ public class ClaudeChatWindow {
             @Override
             public CodexSDKBridge getCodexSDKBridge() {
                 return codexSDKBridge;
+            }
+
+            @Override
+            public GrokSDKBridge getGrokSDKBridge() {
+                return grokSDKBridge;
             }
 
             @Override

--- a/src/main/java/com/github/claudecodegui/util/PathUtils.java
+++ b/src/main/java/com/github/claudecodegui/util/PathUtils.java
@@ -71,6 +71,51 @@ public class PathUtils {
         }
     }
 
+    /**
+     * Guard a provider daemon's requested working directory against the project
+     * base so it cannot be pointed outside the project.
+     *
+     * <p>Returns {@code null} when there is no project base to guard against, in
+     * which case the caller should keep the original cwd. When the cwd is missing
+     * or resolves outside the project base, the project base is returned (clamping
+     * the daemon back inside the project). When the cwd already resolves inside
+     * (or equal to) the project base, the cwd is returned verbatim so legitimate
+     * sub-directory selections are preserved. Comparison is done on normalized
+     * absolute paths (so trailing-slash / relative differences don't bypass the
+     * guard), but the returned value keeps the original path form.
+     */
+    public static String guardWorkingDirectory(String cwd, String projectBase) {
+        if (projectBase == null || projectBase.isEmpty()) {
+            return null;
+        }
+        String base = normalizeAbsolute(projectBase);
+        if (base == null || base.isEmpty()) {
+            return null;
+        }
+        if (!isValidWorkingDirectory(cwd)) {
+            return projectBase;
+        }
+        String normalizedCwd = normalizeAbsolute(cwd);
+        if (normalizedCwd == null || !isWithinOrEqual(normalizedCwd, base)) {
+            return projectBase;
+        }
+        return cwd;
+    }
+
+    /** Non-null, non-empty, and not one of the sentinel strings the webview sends for "no cwd". */
+    private static boolean isValidWorkingDirectory(String cwd) {
+        return cwd != null && !cwd.isEmpty() && !"undefined".equals(cwd) && !"null".equals(cwd);
+    }
+
+    /** True when {@code path} equals {@code base} or is nested directly under it. */
+    private static boolean isWithinOrEqual(String path, String base) {
+        if (path.equals(base)) {
+            return true;
+        }
+        String prefix = base.endsWith(File.separator) ? base : base + File.separator;
+        return path.startsWith(prefix);
+    }
+
     /** True for the WSL UNC roots ({@code \\wsl.localhost\...}, {@code \\wsl$\...}) in either slash form. */
     private static boolean isWslUncPath(String path) {
         String p = path.replace('\\', '/');

--- a/src/test/java/com/github/claudecodegui/provider/common/DaemonBridgeTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/common/DaemonBridgeTest.java
@@ -484,7 +484,8 @@ public class DaemonBridgeTest {
                     return replacementProcess;
                 },
                 hooks,
-                5);
+                5,
+                null);
 
         assertTrue(bridge.start());
         assertTrue(heartbeatCheckReached.await(2, TimeUnit.SECONDS));

--- a/src/test/java/com/github/claudecodegui/service/NodeProcessRegistryHelpersTest.java
+++ b/src/test/java/com/github/claudecodegui/service/NodeProcessRegistryHelpersTest.java
@@ -87,6 +87,46 @@ public class NodeProcessRegistryHelpersTest {
         assertNull(NodeProcessRegistry.detectProviderFromCmd(null));
     }
 
+    // Grok/Gemini are the providers added by the persistent GrokSDKBridge /
+    // Gemini runtime work. Mislabeling their live channel-manager daemon as an
+    // orphan is exactly the "Kill all orphans tears down a live ACP turn"
+    // hazard, so their classification branches must stay pinned.
+
+    @Test
+    public void detectProviderClassifiesGrokChannelManager() {
+        // channel-manager fingerprint is the clearer signal than shared daemon.js
+        assertEquals("grok",
+                NodeProcessRegistry.detectProviderFromCmd("node /path/channel-manager.js grok send"));
+    }
+
+    @Test
+    public void detectProviderClassifiesBareGrokCommand() {
+        // grok appears without channel-manager (e.g. grok-agent stdio) — still grok
+        assertEquals("grok",
+                NodeProcessRegistry.detectProviderFromCmd("node /path/grok-agent.js --stdio"));
+    }
+
+    @Test
+    public void detectProviderClassifiesGeminiChannelManager() {
+        assertEquals("gemini",
+                NodeProcessRegistry.detectProviderFromCmd("node /path/channel-manager.js gemini send"));
+    }
+
+    @Test
+    public void detectProviderClassifiesBareGeminiCommand() {
+        assertEquals("gemini",
+                NodeProcessRegistry.detectProviderFromCmd("node /path/gemini-agent.js --stdio"));
+    }
+
+    @Test
+    public void detectProviderChannelManagerGrokBeatsDaemonJsAmbiguity() {
+        // A grok channel-manager invocation may also contain daemon.js in its
+        // argv; the channel-manager+grok check must win over the daemon.js→claude
+        // fallback, otherwise the live Grok daemon is mislabeled "claude".
+        assertEquals("grok",
+                NodeProcessRegistry.detectProviderFromCmd("node /path/daemon.js channel-manager grok"));
+    }
+
     // ============================================================================
     // Ownership check — prevents IDEA from claiming PyCharm's daemons as orphans
     // (and vice-versa) when both run CC GUI side-by-side.

--- a/src/test/java/com/github/claudecodegui/settings/CodemossSettingsServiceGrokAuthTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/CodemossSettingsServiceGrokAuthTest.java
@@ -1,0 +1,164 @@
+package com.github.claudecodegui.settings;
+
+import com.github.claudecodegui.util.PlatformUtils;
+import org.junit.After;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Pins the Grok auth-method normalization matrix and the auth-config persistence
+ * round-trip backing the {@code get_grok_auth_config}/{@code set_grok_auth_config}
+ * bridge + Settings UI (Grok provider runtime + auth settings PR).
+ *
+ * <p>Normalization is the non-trivial part: the raw value arriving from the webview
+ * (or legacy config) can be any of {@code api_key}/{@code xai.api_key}/{@code apikey},
+ * {@code oauth}/{@code cached_token}/{@code cli_login}/{@code grok.com}, or
+ * {@code auto}, in arbitrary case — all must collapse to the canonical tri-state the
+ * {@code GrokSDKBridge} environment wiring switches on. The round-trip proves the
+ * settings survive a fresh service instance (i.e. a real write→read through the
+ * config file), so a saved Grok API key still authenticates the next session.
+ */
+public class CodemossSettingsServiceGrokAuthTest {
+    private String originalHomeDir;
+
+    @After
+    public void tearDown() throws Exception {
+        if (originalHomeDir != null) {
+            setCachedHomeDirectory(originalHomeDir);
+            originalHomeDir = null;
+        }
+    }
+
+    // -- normalizeGrokAuthMethod ------------------------------------------------
+
+    @Test
+    public void normalizeDefaultsToOauthForBlankInput() {
+        assertEquals(CodemossSettingsService.DEFAULT_GROK_AUTH_METHOD,
+                CodemossSettingsService.normalizeGrokAuthMethod(null));
+        assertEquals(CodemossSettingsService.DEFAULT_GROK_AUTH_METHOD,
+                CodemossSettingsService.normalizeGrokAuthMethod(""));
+        assertEquals(CodemossSettingsService.DEFAULT_GROK_AUTH_METHOD,
+                CodemossSettingsService.normalizeGrokAuthMethod("   "));
+    }
+
+    @Test
+    public void normalizeMapsApiKeyAliases() {
+        // The webview may send any of these for the API-key auth method.
+        assertEquals(CodemossSettingsService.GROK_AUTH_METHOD_API_KEY,
+                CodemossSettingsService.normalizeGrokAuthMethod("api_key"));
+        assertEquals(CodemossSettingsService.GROK_AUTH_METHOD_API_KEY,
+                CodemossSettingsService.normalizeGrokAuthMethod("xai.api_key"));
+        assertEquals(CodemossSettingsService.GROK_AUTH_METHOD_API_KEY,
+                CodemossSettingsService.normalizeGrokAuthMethod("apikey"));
+    }
+
+    @Test
+    public void normalizeIsCaseInsensitive() {
+        assertEquals(CodemossSettingsService.GROK_AUTH_METHOD_API_KEY,
+                CodemossSettingsService.normalizeGrokAuthMethod("API_KEY"));
+        assertEquals(CodemossSettingsService.GROK_AUTH_METHOD_API_KEY,
+                CodemossSettingsService.normalizeGrokAuthMethod("XAI.API_KEY"));
+        assertEquals(CodemossSettingsService.GROK_AUTH_METHOD_OAUTH,
+                CodemossSettingsService.normalizeGrokAuthMethod("OAUTH"));
+        assertEquals(CodemossSettingsService.GROK_AUTH_METHOD_AUTO,
+                CodemossSettingsService.normalizeGrokAuthMethod("AUTO"));
+    }
+
+    @Test
+    public void normalizeMapsOauthAliases() {
+        // cached_token / cli_login / grok.com are all oauth-style flows the CLI
+        // surfaces under different names — they must select the oauth env wiring.
+        assertEquals(CodemossSettingsService.GROK_AUTH_METHOD_OAUTH,
+                CodemossSettingsService.normalizeGrokAuthMethod("oauth"));
+        assertEquals(CodemossSettingsService.GROK_AUTH_METHOD_OAUTH,
+                CodemossSettingsService.normalizeGrokAuthMethod("cached_token"));
+        assertEquals(CodemossSettingsService.GROK_AUTH_METHOD_OAUTH,
+                CodemossSettingsService.normalizeGrokAuthMethod("cli_login"));
+        assertEquals(CodemossSettingsService.GROK_AUTH_METHOD_OAUTH,
+                CodemossSettingsService.normalizeGrokAuthMethod("grok.com"));
+    }
+
+    @Test
+    public void normalizeAcceptsAuto() {
+        assertEquals(CodemossSettingsService.GROK_AUTH_METHOD_AUTO,
+                CodemossSettingsService.normalizeGrokAuthMethod("auto"));
+    }
+
+    @Test
+    public void normalizeFallsBackToDefaultForUnknown() {
+        assertEquals(CodemossSettingsService.DEFAULT_GROK_AUTH_METHOD,
+                CodemossSettingsService.normalizeGrokAuthMethod("garbage"));
+        assertEquals(CodemossSettingsService.DEFAULT_GROK_AUTH_METHOD,
+                CodemossSettingsService.normalizeGrokAuthMethod("password"));
+    }
+
+    // -- persistence round-trip -------------------------------------------------
+
+    @Test
+    public void authMethodDefaultsToOauthOnAFreshConfig() throws Exception {
+        Path tempHome = Files.createTempDirectory("grok-auth-default-home");
+        useTemporaryHomeDirectory(tempHome);
+
+        CodemossSettingsService service = new CodemossSettingsService();
+        assertEquals(CodemossSettingsService.DEFAULT_GROK_AUTH_METHOD, service.getGrokAuthMethod());
+    }
+
+    @Test
+    public void grokAuthConfigRoundTripsThroughTheConfigFile() throws Exception {
+        // Set on one instance, read back on a fresh one — proves a real write→read
+        // so a saved key/base URL still authenticates and routes the next session.
+        Path tempHome = Files.createTempDirectory("grok-auth-roundtrip-home");
+        useTemporaryHomeDirectory(tempHome);
+
+        CodemossSettingsService writer = new CodemossSettingsService();
+        writer.setGrokAuthMethod("xai.api_key"); // alias → normalized to api_key on store
+        writer.setGrokApiKey("xai-secret-key");
+        writer.setGrokApiBaseUrl("https://api.x.ai");
+        writer.setGrokOauthBaseUrl("https://oauth.x.ai");
+
+        CodemossSettingsService reader = new CodemossSettingsService();
+        assertEquals(CodemossSettingsService.GROK_AUTH_METHOD_API_KEY, reader.getGrokAuthMethod());
+        assertEquals("xai-secret-key", reader.getGrokApiKey());
+        assertEquals("https://api.x.ai", reader.getGrokApiBaseUrl());
+        assertEquals("https://oauth.x.ai", reader.getGrokOauthBaseUrl());
+    }
+
+    @Test
+    public void emptyApiKeyRemovesTheEntry() throws Exception {
+        Path tempHome = Files.createTempDirectory("grok-auth-empty-key-home");
+        useTemporaryHomeDirectory(tempHome);
+
+        CodemossSettingsService writer = new CodemossSettingsService();
+        writer.setGrokApiKey("then-removed");
+        writer.setGrokApiKey(""); // empty → entry removed, get returns ""
+
+        CodemossSettingsService reader = new CodemossSettingsService();
+        assertEquals("", reader.getGrokApiKey());
+    }
+
+    // -- temp-home isolation (mirrors CodemossSettingsServiceCodexCliLoginTest) --
+
+    private void useTemporaryHomeDirectory(Path tempHome) throws Exception {
+        if (originalHomeDir == null) {
+            originalHomeDir = getCachedHomeDirectory();
+        }
+        setCachedHomeDirectory(tempHome.toString());
+    }
+
+    private String getCachedHomeDirectory() throws Exception {
+        Field field = PlatformUtils.class.getDeclaredField("cachedRealHomeDir");
+        field.setAccessible(true);
+        return (String) field.get(null);
+    }
+
+    private void setCachedHomeDirectory(String homeDir) throws Exception {
+        Field field = PlatformUtils.class.getDeclaredField("cachedRealHomeDir");
+        field.setAccessible(true);
+        field.set(null, homeDir);
+    }
+}

--- a/src/test/java/com/github/claudecodegui/util/PathUtilsGuardWorkingDirectoryTest.java
+++ b/src/test/java/com/github/claudecodegui/util/PathUtilsGuardWorkingDirectoryTest.java
@@ -1,0 +1,77 @@
+package com.github.claudecodegui.util;
+
+import org.junit.Test;
+
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Pins {@link PathUtils#guardWorkingDirectory(String, String)} — the cwd clamp
+ * that keeps a provider daemon (e.g. the Grok ACP runtime) from being pointed
+ * outside the project base. A wrong answer here is either a security hole
+ * (daemon runs outside the project) or a broken UX (legit sub-directory cwd is
+ * rejected), so every branch is covered.
+ */
+public class PathUtilsGuardWorkingDirectoryTest {
+
+    private String tmpdir() {
+        return Paths.get(System.getProperty("java.io.tmpdir")).toAbsolutePath().toString();
+    }
+
+    @Test
+    public void returnsNullWhenNoProjectBaseToGuardAgainst() {
+        // null base ⇒ caller has no anchor to clamp to, so it must keep its own cwd.
+        assertNull(PathUtils.guardWorkingDirectory(Paths.get(tmpdir(), "anywhere").toString(), null));
+        assertNull(PathUtils.guardWorkingDirectory(Paths.get(tmpdir(), "anywhere").toString(), ""));
+    }
+
+    @Test
+    public void clampsMissingOrSentinelCwdToProjectBase() {
+        String project = Paths.get(tmpdir(), "proj").toString();
+        // The webview sends these sentinels when no cwd was chosen.
+        assertEquals(project, PathUtils.guardWorkingDirectory(null, project));
+        assertEquals(project, PathUtils.guardWorkingDirectory("", project));
+        assertEquals(project, PathUtils.guardWorkingDirectory("undefined", project));
+        assertEquals(project, PathUtils.guardWorkingDirectory("null", project));
+    }
+
+    @Test
+    public void acceptsCwdEqualToProjectBase() {
+        String project = Paths.get(tmpdir(), "proj").toString();
+        assertEquals(project, PathUtils.guardWorkingDirectory(project, project));
+    }
+
+    @Test
+    public void acceptsCwdNestedUnderProjectBase() {
+        String project = Paths.get(tmpdir(), "proj").toString();
+        String nested = Paths.get(project, "src", "deep").toString();
+        assertEquals(nested, PathUtils.guardWorkingDirectory(nested, project));
+    }
+
+    @Test
+    public void clampsCwdOutsideProjectBase() {
+        String project = Paths.get(tmpdir(), "proj").toString();
+        String outside = Paths.get(tmpdir(), "elsewhere").toString();
+        assertEquals(project, PathUtils.guardWorkingDirectory(outside, project));
+    }
+
+    @Test
+    public void clampsCwdThatEscapesViaDotDot() {
+        // /tmp/proj/../elsewhere normalizes to /tmp/elsewhere — outside the project.
+        String project = Paths.get(tmpdir(), "proj").toString();
+        String escape = project + java.io.File.separator + ".." + java.io.File.separator + "elsewhere";
+        assertEquals(project, PathUtils.guardWorkingDirectory(escape, project));
+    }
+
+    @Test
+    public void acceptsCwdThatStaysInsideAfterNormalizing() {
+        // /tmp/proj/sub/./file normalizes to /tmp/proj/sub/file — still inside — and
+        // the original (non-normalized) cwd form is returned verbatim.
+        String project = Paths.get(tmpdir(), "proj").toString();
+        String inside = project + java.io.File.separator + "sub" + java.io.File.separator + "."
+                + java.io.File.separator + "file";
+        assertEquals(inside, PathUtils.guardWorkingDirectory(inside, project));
+    }
+}

--- a/webview/src/components/settings/GrokProviderSection/index.tsx
+++ b/webview/src/components/settings/GrokProviderSection/index.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useState } from 'react';
+import styles from './style.module.less';
+
+export type GrokAuthMethod = 'oauth' | 'api_key' | 'auto';
+
+const GrokProviderSection = () => {
+  const [jsonConfig, setJsonConfig] = useState('');
+  const [jsonError, setJsonError] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const handler = (jsonStr: string) => {
+      try {
+        const data = typeof jsonStr === 'string' ? JSON.parse(jsonStr) : jsonStr;
+        const configObj = {
+          env: data?.env || {
+            GROK_API_KEY: data?.apiKey || '',
+            GROK_MODELS_BASE_URL: data?.apiBaseUrl || '',
+            GROK_CLI_CHAT_PROXY_BASE_URL: data?.oauthBaseUrl || '',
+          },
+          authMethod: data?.authMethod || 'oauth'
+        };
+        setJsonConfig(JSON.stringify(configObj, null, 2));
+      } catch {
+        // ignore parse errors
+      }
+    };
+    window.updateGrokAuthConfig = handler;
+    window.sendToJava?.('get_grok_auth_config:');
+    return () => {
+      if (window.updateGrokAuthConfig === handler) {
+        delete window.updateGrokAuthConfig;
+      }
+    };
+  }, []);
+
+  const handleJsonChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setJsonConfig(e.target.value);
+    setJsonError('');
+  };
+
+  const handleSave = useCallback(() => {
+    try {
+      const parsed = JSON.parse(jsonConfig);
+      const env = parsed.env || {};
+      const next = {
+        authMethod: parsed.authMethod || 'oauth',
+        apiKey: env.GROK_API_KEY || env.XAI_API_KEY || '',
+        apiBaseUrl: env.GROK_MODELS_BASE_URL || env.XAI_API_BASE_URL || env.GROK_XAI_API_BASE_URL || '',
+        oauthBaseUrl: env.GROK_CLI_CHAT_PROXY_BASE_URL || '',
+        gatewayOrigin: '',
+        env: env // send custom env down to backend
+      };
+      
+      setSaving(true);
+      window.sendToJava?.(`set_grok_auth_config:${JSON.stringify(next)}`);
+      setTimeout(() => setSaving(false), 400);
+      setJsonError('');
+    } catch (err) {
+      setJsonError('Invalid JSON format');
+    }
+  }, [jsonConfig]);
+
+  return (
+    <div className={styles.grokSection}>
+      <div className={styles.header}>
+        <h4 className={styles.title}>Grok JSON Configuration</h4>
+        <p className={styles.desc}>Configure Grok settings using JSON format.</p>
+      </div>
+
+      <div className={styles.card}>
+        <div className={styles.cardBody}>
+          <div style={{ marginBottom: '12px', fontSize: '12px', color: '#999' }}>
+            Edit your configuration below.
+          </div>
+          <div className="json-editor-wrapper">
+            <textarea
+              style={{
+                width: '100%',
+                height: '250px',
+                fontFamily: 'monospace',
+                fontSize: '13px',
+                padding: '12px',
+                backgroundColor: 'var(--vscode-input-background, #1e1e1e)',
+                color: 'var(--vscode-input-foreground, #cccccc)',
+                border: '1px solid var(--vscode-input-border, #3c3c3c)',
+                borderRadius: '4px',
+                resize: 'vertical'
+              }}
+              value={jsonConfig}
+              onChange={handleJsonChange}
+              placeholder={`{
+  "env": {
+    "GROK_API_KEY": "",
+    "GROK_MODELS_BASE_URL": "",
+    "GROK_CLI_CHAT_PROXY_BASE_URL": ""
+  },
+  "authMethod": "oauth"
+}`}
+            />
+            {jsonError && (
+              <p style={{ color: 'var(--vscode-errorForeground, #f48771)', marginTop: '8px', fontSize: '13px' }}>
+                <span className="codicon codicon-error" style={{ marginRight: '4px' }} />
+                {jsonError}
+              </p>
+            )}
+          </div>
+          
+          <div style={{ marginTop: '16px', display: 'flex', justifyContent: 'flex-end' }}>
+            <button
+              type="button"
+              className={styles.saveBtn}
+              onClick={handleSave}
+              disabled={saving}
+              style={{
+                padding: '6px 14px',
+                backgroundColor: 'var(--vscode-button-background, #0e639c)',
+                color: 'var(--vscode-button-foreground, #ffffff)',
+                border: 'none',
+                borderRadius: '2px',
+                cursor: 'pointer'
+              }}
+            >
+              {saving ? 'Saving...' : 'Save Configuration'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GrokProviderSection;

--- a/webview/src/components/settings/GrokProviderSection/index.tsx
+++ b/webview/src/components/settings/GrokProviderSection/index.tsx
@@ -12,9 +12,13 @@ const GrokProviderSection = () => {
     const handler = (jsonStr: string) => {
       try {
         const data = typeof jsonStr === 'string' ? JSON.parse(jsonStr) : jsonStr;
+        // XAI_API_KEY is the official xAI env; GROK_API_KEY is a compatible alias.
+        // Runtime accepts either (and usually writes both when injecting a key).
+        const apiKey = data?.apiKey || '';
         const configObj = {
           env: data?.env || {
-            GROK_API_KEY: data?.apiKey || '',
+            XAI_API_KEY: apiKey,
+            GROK_API_KEY: apiKey,
             GROK_MODELS_BASE_URL: data?.apiBaseUrl || '',
             GROK_CLI_CHAT_PROXY_BASE_URL: data?.oauthBaseUrl || '',
           },
@@ -45,8 +49,8 @@ const GrokProviderSection = () => {
       const env = parsed.env || {};
       const next = {
         authMethod: parsed.authMethod || 'oauth',
-        apiKey: env.GROK_API_KEY || env.XAI_API_KEY || '',
-        apiBaseUrl: env.GROK_MODELS_BASE_URL || env.XAI_API_BASE_URL || env.GROK_XAI_API_BASE_URL || '',
+        apiKey: env.XAI_API_KEY || env.GROK_API_KEY || '',
+        apiBaseUrl: env.XAI_API_BASE_URL || env.GROK_XAI_API_BASE_URL || env.GROK_MODELS_BASE_URL || '',
         oauthBaseUrl: env.GROK_CLI_CHAT_PROXY_BASE_URL || '',
         gatewayOrigin: '',
         env: env // send custom env down to backend
@@ -91,6 +95,7 @@ const GrokProviderSection = () => {
               onChange={handleJsonChange}
               placeholder={`{
   "env": {
+    "XAI_API_KEY": "",
     "GROK_API_KEY": "",
     "GROK_MODELS_BASE_URL": "",
     "GROK_CLI_CHAT_PROXY_BASE_URL": ""

--- a/webview/src/components/settings/GrokProviderSection/style.module.less
+++ b/webview/src/components/settings/GrokProviderSection/style.module.less
@@ -1,0 +1,141 @@
+.grokSection {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--vscode-foreground);
+}
+
+.desc {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--vscode-descriptionForeground);
+}
+
+.card {
+  border: 1px solid var(--vscode-widget-border, rgba(128, 128, 128, 0.35));
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: var(--vscode-editor-background);
+}
+
+.cardRow {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.cardRow .codicon {
+  margin-top: 2px;
+  font-size: 14px;
+  color: var(--vscode-textLink-foreground);
+}
+
+.cardBody {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.cardTitle {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.cardText {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--vscode-descriptionForeground);
+  white-space: pre-wrap;
+}
+
+.radioGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.radioRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.radioRow input {
+  margin: 0;
+}
+
+.apiKeyRow {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+  align-items: center;
+}
+
+.apiKeyInput {
+  flex: 1;
+  min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
+  height: 28px;
+  padding: 0 8px;
+  border-radius: 4px;
+  border: 1px solid var(--vscode-input-border, rgba(128,128,128,0.4));
+  background: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  font-size: 12px;
+}
+
+.saveBtn {
+  height: 28px;
+  padding: 0 10px;
+  border-radius: 4px;
+  border: 1px solid var(--vscode-button-border, transparent);
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.saveBtn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+
+.fieldLabel {
+  margin-top: 10px;
+  margin-bottom: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--vscode-foreground);
+}
+
+.warnText {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--vscode-inputValidation-warningForeground, #e2c08d);
+  background: var(--vscode-inputValidation-warningBackground, rgba(226, 192, 141, 0.12));
+  border: 1px solid var(--vscode-inputValidation-warningBorder, rgba(226, 192, 141, 0.4));
+  border-radius: 4px;
+  padding: 6px 8px;
+}

--- a/webview/src/components/settings/ProviderTabSection/index.tsx
+++ b/webview/src/components/settings/ProviderTabSection/index.tsx
@@ -5,6 +5,7 @@ import { STORAGE_KEYS } from '../../../types/provider';
 import ProviderManageSection from '../ProviderManageSection';
 import CodexProviderSection from '../CodexProviderSection';
 import CliSection from '../CliSection';
+import GrokProviderSection from '../GrokProviderSection';
 import CustomModelDialog from '../CustomModelDialog';
 import { usePluginModels } from '../hooks/usePluginModels';
 import { useConfiguredClaudeModelPricing } from '../hooks/useConfiguredModelPricing';
@@ -13,7 +14,7 @@ import styles from './style.module.less';
 const ICON_14_STYLE: React.CSSProperties = { fontSize: 14 };
 const FLEX_1_STYLE: React.CSSProperties = { flex: 1 };
 
-type ProviderManageTab = 'claude' | 'codex' | 'cli';
+type ProviderManageTab = 'claude' | 'codex' | 'cli' | 'grok';
 
 interface ProviderTabSectionProps {
   currentProvider: 'claude' | 'codex' | string;
@@ -57,9 +58,9 @@ const ProviderTabSection = ({
 
   const [activeTab, setActiveTab] = useState<ProviderManageTab>(() => {
     if (currentProvider === 'codex') return 'codex';
-    // Grok / Kimi / OpenCode / PI share the CLI management surface.
-    if (currentProvider === 'grok' || currentProvider === 'kimi'
-      || currentProvider === 'opencode' || currentProvider === 'pi') {
+    if (currentProvider === 'grok') return 'grok';
+    // Kimi / OpenCode / PI share the CLI management surface.
+    if (currentProvider === 'kimi' || currentProvider === 'opencode' || currentProvider === 'pi') {
       return 'cli';
     }
     return 'claude';
@@ -124,6 +125,16 @@ const ProviderTabSection = ({
         >
           <span className="codicon codicon-terminal-bash" aria-hidden="true" />
           {t('settings.providerTab.cli')}
+        </button>
+        <button
+          role="tab"
+          aria-selected={activeTab === 'grok'}
+          aria-controls="panel-grok-providers"
+          className={`${styles.tabBtn} ${activeTab === 'grok' ? styles.active : ''}`}
+          onClick={() => setActiveTab('grok')}
+        >
+          <span className="codicon codicon-rocket" aria-hidden="true" />
+          {t('settings.providerTab.grok')}
         </button>
       </div>
 
@@ -209,6 +220,10 @@ const ProviderTabSection = ({
           <CliSection addToast={addToast} />
         </div>
       )}
+
+      <div id="panel-grok-providers" role="tabpanel" style={activeTab === 'grok' ? BLOCK_STYLE : NONE_STYLE}>
+        <GrokProviderSection />
+      </div>
 
       {/* Shared model management dialog */}
       <CustomModelDialog

--- a/webview/src/components/settings/ProviderTabSection/index.tsx
+++ b/webview/src/components/settings/ProviderTabSection/index.tsx
@@ -13,6 +13,10 @@ import styles from './style.module.less';
 
 const ICON_14_STYLE: React.CSSProperties = { fontSize: 14 };
 const FLEX_1_STYLE: React.CSSProperties = { flex: 1 };
+// Display-toggle (not conditional render) so GrokProviderSection stays mounted
+// and keeps its form state when the user switches away from the Grok tab.
+const BLOCK_STYLE: React.CSSProperties = { display: 'block' };
+const NONE_STYLE: React.CSSProperties = { display: 'none' };
 
 type ProviderManageTab = 'claude' | 'codex' | 'cli' | 'grok';
 

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -6,6 +6,7 @@ interface Window {
    * Send message to Java backend
    */
   sendToJava?: (message: string) => void;
+  updateGrokAuthConfig?: (config: any) => void;
 
   /** Legacy windowed-JCEF repaint requested after its IntelliJ content tab is activated. */
   onTabActivated?: () => void;

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -546,7 +546,8 @@
     "providerTab": {
       "claude": "Claude Code",
       "codex": "Codex",
-      "cli": "CLI"
+      "cli": "CLI",
+      "grok": "Grok"
     },
     "cli": {
       "hint": "These CLIs must be installed and configured in your system terminal. The plugin only detects installation status and version — it will never install them for you. Confirm each CLI works in the terminal before coming back here to use it.",

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -348,7 +348,8 @@
     "providerTab": {
       "claude": "Claude Code",
       "codex": "Codex",
-      "cli": "CLI"
+      "cli": "CLI",
+      "grok": "Grok"
     },
     "pluginModels": {
       "title": "Modelos personalizados",

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -348,7 +348,8 @@
     "providerTab": {
       "claude": "Claude Code",
       "codex": "Codex",
-      "cli": "CLI"
+      "cli": "CLI",
+      "grok": "Grok"
     },
     "pluginModels": {
       "title": "Modèles personnalisés",

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -348,7 +348,8 @@
     "providerTab": {
       "claude": "Claude Code",
       "codex": "Codex",
-      "cli": "CLI"
+      "cli": "CLI",
+      "grok": "Grok"
     },
     "pluginModels": {
       "title": "कस्टम मॉडल",

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -348,7 +348,8 @@
     "providerTab": {
       "claude": "Claude Code",
       "codex": "Codex",
-      "cli": "CLI"
+      "cli": "CLI",
+      "grok": "Grok"
     },
     "pluginModels": {
       "title": "カスタムモデル",

--- a/webview/src/i18n/locales/ko.json
+++ b/webview/src/i18n/locales/ko.json
@@ -348,7 +348,8 @@
     "providerTab": {
       "claude": "Claude Code",
       "codex": "Codex",
-      "cli": "CLI"
+      "cli": "CLI",
+      "grok": "Grok"
     },
     "pluginModels": {
       "title": "사용자 지정 모델",

--- a/webview/src/i18n/locales/pt-BR.json
+++ b/webview/src/i18n/locales/pt-BR.json
@@ -375,7 +375,8 @@
     "providerTab": {
       "claude": "Claude Code",
       "codex": "Codex",
-      "cli": "CLI"
+      "cli": "CLI",
+      "grok": "Grok"
     },
     "pluginModels": {
       "title": "Modelos Personalizados",

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -348,7 +348,8 @@
     "providerTab": {
       "claude": "Claude Code",
       "codex": "Codex",
-      "cli": "CLI"
+      "cli": "CLI",
+      "grok": "Grok"
     },
     "pluginModels": {
       "title": "Пользовательские модели",

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -348,7 +348,8 @@
     "providerTab": {
       "claude": "Claude Code",
       "codex": "Codex",
-      "cli": "CLI"
+      "cli": "CLI",
+      "grok": "Grok"
     },
     "pluginModels": {
       "title": "自訂模型",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -546,7 +546,8 @@
     "providerTab": {
       "claude": "Claude Code",
       "codex": "Codex",
-      "cli": "CLI"
+      "cli": "CLI",
+      "grok": "Grok"
     },
     "cli": {
       "hint": "以下 CLI 需在系统终端自行安装并完成配置。插件只负责检测是否已安装及版本号，不会替你自动安装。请先在终端确认可正常使用，再回到此处使用。",


### PR DESCRIPTION
## TL;DR
Adds a **persistent Grok runtime** (Grok runs as a long-lived ACP daemon, like Claude does today, instead of a fresh CLI process per message) and a **Settings UI to configure Grok auth** (API key / OAuth / base URLs). Rebased onto current `feature/v0.5.3` head (includes upstream's grok-4.6 default — this PR does not touch model defaults, so they flow through as-is); **supersedes #1643**, which is now closed.

## Why one PR instead of two
#1643 was the runtime, this branch adds the settings UI on top. But the settings UI configures a bridge that **doesn't exist without the runtime** — so neither half was independently mergeable, and splitting them only added review overhead (the settings PR's diff included all the runtime commits anyway). They're one feature, so they land together.

## What's included

**1. Persistent Grok runtime** *(was #1643)*
- Grok is routed through `GrokSDKBridge` (an ACP daemon) instead of `MarkerCliBridge`, so multi-turn Grok chats reuse one process instead of spawning a new one each turn.
- New `EnvironmentConfigurator` centralizes env/proxy setup across providers (PATH, login-shell vars, HTTP proxy, permission dirs, WSL paths) — shared by Claude and Grok.
- The Node-process panel and "Kill all orphans" now correctly recognize the live Grok daemon (and Gemini/Codex) and **won't kill a Grok turn in progress**. PID and liveness guards prevent false positives.
- Session history respects `$GROK_HOME` (with fallbacks).

**2. Grok auth settings UI + persistence** *(unique to this PR)*
- A `GrokProviderSection` in Settings (JSON editor) for auth method, API key, and base URLs, persisted via `CodemossSettingsService`.
- `get_grok_auth_config` / `set_grok_auth_config` bridge.
- Accepts both `XAI_API_KEY` (official) and `GROK_API_KEY` (legacy alias); saves `XAI_*` first.

## Two build blockers fixed during the rebase
The branch merged cleanly into v0.5.3 textually, but **didn't compile** — GitHub's "mergeable" check doesn't build or type-check. Fixed both:
- **Webview didn't compile** (`:buildWebview`/tsc): `ProviderTabSection` referenced `BLOCK_STYLE`/`NONE_STYLE` that were never defined. Added them.
- **Java didn't compile** (`:compileJava`): `SessionSendService.sendToGrok` called `PathUtils.guardWorkingDirectory(...)`, a method that never existed. Implemented it in `PathUtils` — it clamps a working directory that's missing or escapes the project back to the project root (a security guard keeping the daemon inside the project), and leaves legitimate in-project directories alone.

## Tests *(the stack previously had almost none — one 2-line test touch)*
- **Grok/Gemini orphan classification** (`NodeProcessRegistryHelpersTest`): the existing tests only covered Claude/Codex; the Grok/Gemini branches — the ones that stop "Kill all orphans" from killing a live Grok daemon — were untested. Now pinned, including the priority of the Grok signal over the Claude fallback.
- **Grok auth normalization + persistence** (`CodemossSettingsServiceGrokAuthTest`): the auth-method alias matrix (`api_key` / `xai.api_key` / `apikey`, `oauth` / `cached_token` / `cli_login` / `grok.com`, `auto`, case-insensitive) and a full save→reload round-trip.
- **Cwd guard** (`PathUtilsGuardWorkingDirectoryTest`): every branch of the new clamp.

**40 tests added/pinned, 0 failures.** `:buildWebview` + `:compileJava` + `:test` all green on v0.5.3.

## Manual test plan *(not yet executed — needs a running IDE + Grok credentials)*
- [ ] Switch to Grok; a multi-turn chat reuses one daemon (no orphaned Node per turn)
- [ ] Interrupt / new session / load history with Grok selected
- [ ] Process panel labels the Grok daemon correctly; **"Kill all orphans" does not kill a live Grok turn**
- [ ] Proxy / env applied to the Grok ACP client
- [ ] Save auth method + API key + base URL → reload IDE → values persist → Grok chat works with API-key auth

