### PR TITLE
fix(vcs): use AWT EventQueue fallback for EDT detection in commit message

### DIFF
--- a/src/main/java/com/github/claudecodegui/service/GitCommitMessageService.java
+++ b/src/main/java/com/github/claudecodegui/service/GitCommitMessageService.java
@@ -112,11 +112,32 @@ public class GitCommitMessageService {
      * True when the current thread is the EDT and a real Application is available
      * so we can re-dispatch. Headless/unit-test environments without an
      * Application keep the synchronous path for deterministic assertions.
+     *
+     * <p>Both {@link Application#isDispatchThread()} and
+     * {@link java.awt.EventQueue#isDispatchThread()} are checked. The AWT
+     * fallback catches edge cases where an action's {@code actionPerformed}
+     * runs on the EDT via {@code WriteIntentReadAction} or {@code InvokeLater}
+     * but the IntelliJ Application reports the thread as non-dispatch (observed
+     * on some 2026.2 builds). Without this, {@code CommitDiffProvider} would
+     * call {@code GitRepositoryManager.getRepositoryForFile} synchronously on
+     * the EDT, triggering the "Do not call synchronous repository update in EDT"
+     * assertion.
      */
     private static boolean shouldOffloadToBackground() {
         try {
             Application app = ApplicationManager.getApplication();
-            return app != null && app.isDispatchThread();
+            if (app == null) {
+                return false;
+            }
+            // Primary: IntelliJ's own EDT detection.
+            if (app.isDispatchThread()) {
+                return true;
+            }
+            // Fallback: AWT EventQueue detection. This covers the edge case
+            // where the IntelliJ Application does not recognise the thread as
+            // its dispatch thread but AWT does (the action pipeline still runs
+            // on the AWT EDT).
+            return java.awt.EventQueue.isDispatchThread();
         } catch (Throwable t) {
             return false;
         }

--- a/src/main/java/com/github/claudecodegui/service/GitCommitMessageService.java
+++ b/src/main/java/com/github/claudecodegui/service/GitCommitMessageService.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vcs.changes.Change;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -113,30 +114,46 @@ public class GitCommitMessageService {
      * so we can re-dispatch. Headless/unit-test environments without an
      * Application keep the synchronous path for deterministic assertions.
      *
-     * <p>Both {@link Application#isDispatchThread()} and
-     * {@link java.awt.EventQueue#isDispatchThread()} are checked. The AWT
-     * fallback catches edge cases where an action's {@code actionPerformed}
-     * runs on the EDT via {@code WriteIntentReadAction} or {@code InvokeLater}
-     * but the IntelliJ Application reports the thread as non-dispatch (observed
-     * on some 2026.2 builds). Without this, {@code CommitDiffProvider} would
-     * call {@code GitRepositoryManager.getRepositoryForFile} synchronously on
-     * the EDT, triggering the "Do not call synchronous repository update in EDT"
-     * assertion.
+     * <p>This is defensive hardening: the primary check is
+     * {@link Application#isDispatchThread()}. The secondary
+     * {@link java.awt.EventQueue#isDispatchThread()} fallback guards a
+     * hypothetical edge case where a caller reaches this code on the AWT EDT
+     * while the IntelliJ Application does not report the thread as its
+     * dispatch thread. The fallback is harmless and cheap, but it is not a
+     * verified fix for any reported crash (see the PR discussion: the
+     * #1642 report predates the EDT offload entirely and was most likely
+     * already fixed by the v0.5.1 offload change).
      */
     private static boolean shouldOffloadToBackground() {
         try {
-            Application app = ApplicationManager.getApplication();
-            if (app == null) {
-                return false;
-            }
+            return shouldOffloadToBackground(ApplicationManager.getApplication());
+        } catch (Throwable t) {
+            // No Application (headless/unit tests) or lookup failure: stay inline.
+            return false;
+        }
+    }
+
+    /**
+     * Testable core of {@link #shouldOffloadToBackground()}: decides whether
+     * the caller must be re-dispatched to a pooled thread.
+     *
+     * @param app the current IntelliJ Application (null in headless tests)
+     * @return true when the caller runs on a dispatch thread (IntelliJ's own
+     *         EDT, or the AWT EDT via the defensive fallback)
+     */
+    @VisibleForTesting
+    static boolean shouldOffloadToBackground(@Nullable Application app) {
+        if (app == null) {
+            return false;
+        }
+        try {
             // Primary: IntelliJ's own EDT detection.
             if (app.isDispatchThread()) {
                 return true;
             }
-            // Fallback: AWT EventQueue detection. This covers the edge case
-            // where the IntelliJ Application does not recognise the thread as
-            // its dispatch thread but AWT does (the action pipeline still runs
-            // on the AWT EDT).
+            // Defensive fallback: AWT EventQueue detection, in case a caller
+            // runs on the AWT EDT that the IntelliJ Application does not
+            // recognise as its dispatch thread.
             return java.awt.EventQueue.isDispatchThread();
         } catch (Throwable t) {
             return false;

--- a/src/test/java/com/github/claudecodegui/service/GitCommitMessageServiceEdtFallbackTest.java
+++ b/src/test/java/com/github/claudecodegui/service/GitCommitMessageServiceEdtFallbackTest.java
@@ -1,0 +1,89 @@
+package com.github.claudecodegui.service;
+
+import com.intellij.openapi.application.Application;
+import org.junit.Test;
+
+import java.lang.reflect.Proxy;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the EDT-detection logic in
+ * {@link GitCommitMessageService#shouldOffloadToBackground(Application)}.
+ *
+ * <p>Covers the three branches of the defensive AWT fallback documented in
+ * PR #1645: no Application (headless), Application that recognises the EDT,
+ * and Application that does NOT recognise the thread while AWT does.
+ */
+public class GitCommitMessageServiceEdtFallbackTest {
+
+    /** Application stub answering isDispatchThread() with a fixed value. */
+    private static Application appWithDispatchFlag(final boolean isDispatch) {
+        return (Application) Proxy.newProxyInstance(
+                GitCommitMessageServiceEdtFallbackTest.class.getClassLoader(),
+                new Class<?>[]{Application.class},
+                (proxy, method, methodArgs) -> {
+                    if ("isDispatchThread".equals(method.getName())) {
+                        return isDispatch;
+                    }
+                    if ("hashCode".equals(method.getName())) {
+                        return System.identityHashCode(proxy);
+                    }
+                    if ("toString".equals(method.getName())) {
+                        return "ApplicationStub(isDispatchThread=" + isDispatch + ")";
+                    }
+                    return null;
+                });
+    }
+
+    /** Application stub whose isDispatchThread() throws, simulating a broken lookup. */
+    private static Application throwingApp() {
+        return (Application) Proxy.newProxyInstance(
+                GitCommitMessageServiceEdtFallbackTest.class.getClassLoader(),
+                new Class<?>[]{Application.class},
+                (proxy, method, methodArgs) -> {
+                    if ("isDispatchThread".equals(method.getName())) {
+                        throw new IllegalStateException("broken application");
+                    }
+                    return null;
+                });
+    }
+
+    @Test
+    public void nullApplicationStaysInline() {
+        // Headless/unit-test environment: no offload, synchronous path.
+        assertFalse(GitCommitMessageService.shouldOffloadToBackground(null));
+    }
+
+    @Test
+    public void intellijRecognisedEdtOffloads() {
+        // Primary branch: Application.isDispatchThread() == true.
+        assertTrue(GitCommitMessageService.shouldOffloadToBackground(appWithDispatchFlag(true)));
+    }
+
+    @Test
+    public void backgroundThreadStaysInline() {
+        // JUnit worker threads are neither the IntelliJ EDT nor the AWT EDT,
+        // so both checks are false and the caller stays inline.
+        assertFalse(GitCommitMessageService.shouldOffloadToBackground(appWithDispatchFlag(false)));
+    }
+
+    @Test
+    public void awtEdtFallsBackToOffload() throws Exception {
+        // Defensive fallback branch: the Application says "not my EDT", but we
+        // are on the real AWT EDT - the code must still offload. Run the
+        // assertion on the AWT EDT via SwingUtilities.invokeAndWait so
+        // EventQueue.isDispatchThread() is genuinely true here.
+        final boolean[] offloaded = new boolean[1];
+        java.awt.EventQueue.invokeAndWait(() ->
+                offloaded[0] = GitCommitMessageService.shouldOffloadToBackground(appWithDispatchFlag(false)));
+        assertTrue("AWT EDT with non-recognising Application should offload", offloaded[0]);
+    }
+
+    @Test
+    public void throwingApplicationStaysInline() {
+        // Broken Application: the internal try/catch keeps the caller inline.
+        assertFalse(GitCommitMessageService.shouldOffloadToBackground(throwingApp()));
+    }
+}


### PR DESCRIPTION
## Summary

**Defensive hardening** for EDT detection in AI commit-message generation: add `java.awt.EventQueue.isDispatchThread()` as a fallback to `shouldOffloadToBackground()`, plus unit tests covering every branch of the fallback.

> **Note on scope:** this is *not* a verified fix for #1642. As discussed in the review, the #1642 report was against plugin version `0.5-fix1`, which predates the EDT offload (`2f8b06c8`, first shipped in v0.5.1) entirely - the reporter's build ran `generateGitDiff` inline on the EDT unconditionally, which fully explains the crash without any new theory. The crash was most likely already fixed by the v0.5.1 offload change; the reporter has been asked to retest on 0.5.3+ in the issue thread.

## What this PR actually does

`shouldOffloadToBackground()` previously relied solely on `Application.isDispatchThread()`. This PR adds a secondary, defensive check:

```java
// Primary: IntelliJ's own EDT detection.
if (app.isDispatchThread()) {
    return true;
}
// Defensive fallback: AWT EventQueue detection, in case a caller
// runs on the AWT EDT that the IntelliJ Application does not
// recognise as its dispatch thread.
return java.awt.EventQueue.isDispatchThread();
```

This guards a **hypothetical** edge case (a caller reaching the code on the AWT EDT while the IntelliJ `Application` does not report the thread as its dispatch thread). The fallback is harmless and cheap; no reproducer exists for this scenario. Headless/unit-test environments without an Application keep the synchronous path.

## Tests

New `GitCommitMessageServiceEdtFallbackTest` (JUnit 4, no new dependencies) covers all five branches of `shouldOffloadToBackground(Application)` via a JDK dynamic-proxy `Application` stub:

1. `null` Application (headless) -> stays inline
2. Application recognises the EDT -> offloads (primary branch)
3. Background thread (neither IntelliJ EDT nor AWT EDT) -> stays inline
4. **AWT EDT with non-recognising Application -> offloads (the new fallback branch**, asserted on the real AWT EDT via `EventQueue.invokeAndWait`)
5. Throwing/broken Application -> stays inline (try/catch guard)

A `@VisibleForTesting` overload `shouldOffloadToBackground(Application)` was extracted with unchanged behavior so the branches are directly testable.

## Backward Compatibility

- No API, config, or behavior changes for existing callers; only the decision function gains an additional defensive check.
- Full Java test suite: 1229 tests, 0 failures, 0 errors.