### PR TITLE
fix(skills): echo skill name in Codex toggle result to clear spinner

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/SkillHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SkillHandler.java
@@ -264,6 +264,15 @@ public class SkillHandler extends BaseMessageHandler {
                         } else {
                             result = CodexSkillService.toggleSkill(skillPath, currentEnabled, workspaceRoot);
                         }
+                        // The frontend's skillToggleResult handler clears its in-progress
+                        // set by matching on result.name. CodexSkillService.toggleSkill only
+                        // returns success/enabled and omits name, which would leave the row
+                        // stuck in the spinning state forever. Echo the requested skill name
+                        // so the frontend can clear the in-progress flag (mirrors the Claude
+                        // SkillService.enableSkill/disableSkill contract).
+                        if (!result.has("name") && skillName != null && !skillName.isEmpty()) {
+                            result.addProperty("name", skillName);
+                        }
                     } else {
                         result = SkillService.toggleSkill(skillName, scope, currentEnabled, workspaceRoot);
                     }


### PR DESCRIPTION
## Summary

Fixes the toggle-spinner issue reported in #1438: in the skills management page, after clicking to disable/enable a Codex skill, the checkbox keeps spinning and cannot be re-clicked until leaving and re-entering the settings page.

### Root Cause

The frontend `skillToggleResult` handler (in `SkillsSettingsSection.tsx`) clears its in-progress `togglingSkills` set by matching on `result.name`:

```js
if (result.name) {
  newSet.forEach(id => {
    if (id.includes(result.name)) newSet.delete(id);
  });
}
```

But `CodexSkillService.toggleSkill` only returns `success` / `enabled` / `error` and **omits `name`**. So the in-progress flag is never cleared, the checkbox spins forever, and the `if (togglingSkills.has(skill.id)) return;` guard in `handleToggle` blocks any further clicks on that row.

The Claude path (`SkillService.enableSkill` / `disableSkill`) already includes `name` in its success result, so Claude skills work correctly - only Codex skills are affected.

### Fix

In `SkillHandler.handleToggleSkill`, echo the requested skill name back into the Codex toggle result when it is missing, mirroring the Claude `SkillService` contract:

```java
result = CodexSkillService.toggleSkill(skillPath, currentEnabled, workspaceRoot);
if (!result.has("name") && skillName != null && !skillName.isEmpty()) {
    result.addProperty("name", skillName);
}
```

This lets the frontend correctly remove the row from the in-progress set so the checkbox stops spinning and can be toggled again.

### Behavior

| Before | After |
|---|---|
| Codex skill checkbox spins forever after toggle | Checkbox clears immediately after toggle result |
| Must leave/re-enter settings page to toggle again | Can re-toggle immediately |
| Claude skills unaffected | Claude skills unchanged (already worked) |

Closes #1438