### PR TITLE
fix(ime): repair OSR composition caret position and stale composing state for CJK IMEs

### DIFF
--- a/src/main/java/com/github/claudecodegui/ui/OsrImeCaretFix.java
+++ b/src/main/java/com/github/claudecodegui/ui/OsrImeCaretFix.java
@@ -1,0 +1,215 @@
+package com.github.claudecodegui.ui;
+
+import com.intellij.openapi.diagnostic.Logger;
+import org.cef.browser.CefBrowser;
+import org.cef.input.CefCompositionUnderline;
+import org.cef.misc.CefRange;
+
+import javax.swing.JComponent;
+import java.awt.Color;
+import java.awt.event.InputMethodEvent;
+import java.awt.event.InputMethodListener;
+import java.awt.font.TextHitInfo;
+import java.lang.reflect.Field;
+import java.text.AttributedCharacterIterator;
+import java.text.CharacterIterator;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Repairs IME composition handling on JCEF OSR components.
+ *
+ * <p>The platform's {@code JBCefInputMethodAdapter} (registered by
+ * {@code JBCefOsrComponent} as its {@link InputMethodListener}) has two defects
+ * that break CJK phrase-based IMEs such as Bopomofo (注音) and Pinyin:</p>
+ *
+ * <ol>
+ *   <li>It always passes {@code new CefRange(len, len)} as the selection range to
+ *       {@code CefBrowser#ImeSetComposition}, ignoring {@link InputMethodEvent#getCaret()}.
+ *       The rendered caret therefore sticks to the end of the pre-edit text while the
+ *       user moves the IME cursor to pick candidates for a specific character.</li>
+ *   <li>It silently drops events whose text is {@code null} or whose composed part is
+ *       empty, so a composition cancelled by switching the input source mid-composition
+ *       never reaches Blink: the page keeps stale pre-edit text and never receives
+ *       {@code compositionend}, leaving the webview's IME state stuck.</li>
+ * </ol>
+ *
+ * <p>{@link #install(JComponent)} swaps the platform listener for a fixed
+ * re-implementation. The platform adapter object stays in place as the component's
+ * {@code InputMethodRequests} implementation (candidate-window positioning), and is kept
+ * as a delegate fallback whenever the browser instance cannot be resolved.</p>
+ *
+ * <p>Only components carrying the known platform adapter are touched; if JetBrains
+ * renames or fixes the adapter, this class becomes a no-op. The fix can be disabled with
+ * {@code -Dccg.disable.osr.ime.fix=true}.</p>
+ */
+public final class OsrImeCaretFix {
+
+    private static final Logger LOG = Logger.getInstance(OsrImeCaretFix.class);
+
+    static final String PLATFORM_ADAPTER_CLASS = "com.intellij.ui.jcef.JBCefInputMethodAdapter";
+    private static final String DISABLE_PROPERTY = "ccg.disable.osr.ime.fix";
+
+    /** CEF's "no explicit range" sentinel, mirroring the platform adapter's DEFAULT_RANGE. */
+    private static final CefRange UNMARKED_RANGE = new CefRange(-1, -1);
+
+    /** Transparent color: tells Blink to draw the composition underline with its defaults. */
+    private static final Color TRANSPARENT = new Color(0, true);
+
+    private OsrImeCaretFix() {
+    }
+
+    /**
+     * Replaces the platform IME adapter on an OSR component with the fixed listener.
+     * Safe to call on any component; does nothing when the adapter is absent.
+     */
+    public static void install(JComponent component) {
+        if (component == null || Boolean.getBoolean(DISABLE_PROPERTY)) {
+            return;
+        }
+        for (InputMethodListener listener : component.getInputMethodListeners()) {
+            if (PLATFORM_ADAPTER_CLASS.equals(listener.getClass().getName())) {
+                component.removeInputMethodListener(listener);
+                component.addInputMethodListener(
+                        new FixedInputMethodListener(listener, new ReflectiveBrowserResolver(listener)));
+                LOG.info("Installed OSR IME caret fix on " + component.getClass().getName());
+                return;
+            }
+        }
+    }
+
+    /** Clamps the IME caret to a valid offset inside the composed text. */
+    static int caretPosition(TextHitInfo caret, int composedLength) {
+        if (caret == null) {
+            return composedLength;
+        }
+        return Math.max(0, Math.min(caret.getInsertionIndex(), composedLength));
+    }
+
+    /**
+     * Splits an input-method event's text into committed and composed parts.
+     * Returns {@code {committed, composed}}; both are empty when the event has no text
+     * (composition cancelled).
+     */
+    static String[] splitCommittedComposed(AttributedCharacterIterator text, int committedCount) {
+        if (text == null) {
+            return new String[]{"", ""};
+        }
+        StringBuilder all = new StringBuilder();
+        for (char c = text.first(); c != CharacterIterator.DONE; c = text.next()) {
+            all.append(c);
+        }
+        int committed = Math.max(0, Math.min(committedCount, all.length()));
+        return new String[]{all.substring(0, committed), all.substring(committed)};
+    }
+
+    /** Resolves the {@code CefBrowser} from the platform adapter's private field. */
+    private static final class ReflectiveBrowserResolver implements Supplier<CefBrowser> {
+        private final InputMethodListener platformAdapter;
+        private Field browserField;
+        private boolean broken;
+
+        ReflectiveBrowserResolver(InputMethodListener platformAdapter) {
+            this.platformAdapter = platformAdapter;
+        }
+
+        @Override
+        public CefBrowser get() {
+            if (broken) {
+                return null;
+            }
+            try {
+                if (browserField == null) {
+                    Field field = platformAdapter.getClass().getDeclaredField("myBrowser");
+                    field.setAccessible(true);
+                    browserField = field;
+                }
+                Object value = browserField.get(platformAdapter);
+                return value instanceof CefBrowser ? (CefBrowser) value : null;
+            } catch (ReflectiveOperationException | RuntimeException | LinkageError e) {
+                broken = true;
+                LOG.warn("OSR IME caret fix falling back to platform behaviour: "
+                        + "cannot access adapter browser field", e);
+                return null;
+            }
+        }
+    }
+
+    /**
+     * Fixed IME listener: forwards the real caret position to Blink and terminates the
+     * composition when the IME cancels it. Falls back to the platform adapter whenever
+     * the browser cannot be resolved.
+     */
+    static final class FixedInputMethodListener implements InputMethodListener {
+        private final InputMethodListener platformAdapter;
+        private final Supplier<CefBrowser> browserSupplier;
+        private String composedText = "";
+        private boolean composing;
+
+        FixedInputMethodListener(InputMethodListener platformAdapter, Supplier<CefBrowser> browserSupplier) {
+            this.platformAdapter = platformAdapter;
+            this.browserSupplier = browserSupplier;
+        }
+
+        @Override
+        public void inputMethodTextChanged(InputMethodEvent event) {
+            CefBrowser browser = browserSupplier.get();
+            if (browser == null) {
+                platformAdapter.inputMethodTextChanged(event);
+                return;
+            }
+
+            String[] parts = splitCommittedComposed(event.getText(), event.getCommittedCharacterCount());
+            String committed = parts[0];
+            String composed = parts[1];
+
+            if (!committed.isEmpty()) {
+                browser.ImeCommitText(committed, UNMARKED_RANGE, 0);
+                composing = false;
+                composedText = "";
+            }
+
+            if (composed.isEmpty()) {
+                // Empty composed text on an active composition means the IME aborted it
+                // (input source switched, Escape, ...). The platform adapter drops this
+                // case, leaving the page composing forever.
+                if (composing) {
+                    browser.ImeCancelComposing();
+                    composing = false;
+                    composedText = "";
+                }
+            } else {
+                setComposition(browser, composed, event.getCaret());
+            }
+            event.consume();
+        }
+
+        @Override
+        public void caretPositionChanged(InputMethodEvent event) {
+            // Fired when only the caret moves inside the pre-edit text (e.g. Bopomofo
+            // arrow-key navigation between characters). The platform adapter ignores it.
+            CefBrowser browser = composing && !composedText.isEmpty() ? browserSupplier.get() : null;
+            if (browser == null) {
+                platformAdapter.caretPositionChanged(event);
+                return;
+            }
+            setComposition(browser, composedText, event.getCaret());
+            event.consume();
+        }
+
+        private void setComposition(CefBrowser browser, String composed, TextHitInfo caret) {
+            int caretOffset = caretPosition(caret, composed.length());
+            CefCompositionUnderline underline = new CefCompositionUnderline(
+                    new CefRange(0, composed.length()),
+                    TRANSPARENT, TRANSPARENT, 0,
+                    CefCompositionUnderline.Style.SOLID);
+            browser.ImeSetComposition(
+                    composed,
+                    List.of(underline),
+                    UNMARKED_RANGE,
+                    new CefRange(caretOffset, caretOffset));
+            composing = true;
+            composedText = composed;
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/ui/SurfaceFrameFence.java
+++ b/src/main/java/com/github/claudecodegui/ui/SurfaceFrameFence.java
@@ -227,7 +227,9 @@ public final class SurfaceFrameFence {
         return new JBCefOSRHandlerFactory() {
             @Override
             public JComponent createComponent(boolean isTransparent) {
-                return delegateFactory.createComponent(isTransparent);
+                JComponent component = delegateFactory.createComponent(isTransparent);
+                OsrImeCaretFix.install(component);
+                return component;
             }
 
             @Override

--- a/src/test/java/com/github/claudecodegui/ui/OsrImeCaretFixTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/OsrImeCaretFixTest.java
@@ -1,0 +1,251 @@
+package com.github.claudecodegui.ui;
+
+import org.cef.browser.CefBrowser;
+import org.cef.misc.CefRange;
+import org.junit.Test;
+
+import javax.swing.JPanel;
+import java.awt.event.InputMethodEvent;
+import java.awt.event.InputMethodListener;
+import java.awt.font.TextHitInfo;
+import java.lang.reflect.Proxy;
+import java.text.AttributedString;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the OSR IME composition fix: caret propagation into ImeSetComposition,
+ * composition cancellation on empty/null composed text, committed-text passthrough,
+ * caret-only movement re-sends, and fallback delegation when no browser is available.
+ */
+public class OsrImeCaretFixTest {
+
+    /** Records every Ime* call reaching the fake CefBrowser. */
+    private static final class RecordedCall {
+        final String name;
+        final Object[] args;
+
+        RecordedCall(String name, Object[] args) {
+            this.name = name;
+            this.args = args;
+        }
+    }
+
+    private static CefBrowser recordingBrowser(List<RecordedCall> calls) {
+        return (CefBrowser) Proxy.newProxyInstance(
+                CefBrowser.class.getClassLoader(),
+                new Class<?>[]{CefBrowser.class},
+                (proxy, method, args) -> {
+                    calls.add(new RecordedCall(method.getName(), args));
+                    Class<?> rt = method.getReturnType();
+                    if (rt == boolean.class) return false;
+                    if (rt == int.class) return 0;
+                    if (rt == double.class) return 0.0;
+                    return null;
+                });
+    }
+
+    private static final class RecordingListener implements InputMethodListener {
+        int textChanged;
+        int caretChanged;
+
+        @Override
+        public void inputMethodTextChanged(InputMethodEvent event) {
+            textChanged++;
+        }
+
+        @Override
+        public void caretPositionChanged(InputMethodEvent event) {
+            caretChanged++;
+        }
+    }
+
+    private static InputMethodEvent textEvent(String text, int committedCount, TextHitInfo caret) {
+        return new InputMethodEvent(
+                new JPanel(),
+                InputMethodEvent.INPUT_METHOD_TEXT_CHANGED,
+                text == null ? null : new AttributedString(text).getIterator(),
+                committedCount,
+                caret,
+                null);
+    }
+
+    private static InputMethodEvent caretEvent(TextHitInfo caret) {
+        return new InputMethodEvent(
+                new JPanel(),
+                InputMethodEvent.CARET_POSITION_CHANGED,
+                null,
+                0,
+                caret,
+                null);
+    }
+
+    private static CefRange selectionRangeOf(RecordedCall call) {
+        // ImeSetComposition(text, underlines, replacementRange, selectionRange)
+        return (CefRange) call.args[3];
+    }
+
+    // --- caretPosition ---
+
+    @Test
+    public void caretPositionUsesInsertionIndex() {
+        assertEquals(2, OsrImeCaretFix.caretPosition(TextHitInfo.leading(2), 5));
+    }
+
+    @Test
+    public void caretPositionClampsToComposedLength() {
+        assertEquals(3, OsrImeCaretFix.caretPosition(TextHitInfo.leading(9), 3));
+        assertEquals(0, OsrImeCaretFix.caretPosition(TextHitInfo.trailing(-2), 3));
+    }
+
+    @Test
+    public void caretPositionDefaultsToEndWithoutCaret() {
+        assertEquals(4, OsrImeCaretFix.caretPosition(null, 4));
+    }
+
+    // --- splitCommittedComposed ---
+
+    @Test
+    public void splitReturnsEmptyPartsForNullText() {
+        String[] parts = OsrImeCaretFix.splitCommittedComposed(null, 0);
+        assertEquals("", parts[0]);
+        assertEquals("", parts[1]);
+    }
+
+    @Test
+    public void splitSeparatesCommittedAndComposed() {
+        String[] parts = OsrImeCaretFix.splitCommittedComposed(
+                new AttributedString("好注音").getIterator(), 1);
+        assertEquals("好", parts[0]);
+        assertEquals("注音", parts[1]);
+    }
+
+    @Test
+    public void splitClampsCommittedCount() {
+        String[] parts = OsrImeCaretFix.splitCommittedComposed(
+                new AttributedString("ab").getIterator(), 9);
+        assertEquals("ab", parts[0]);
+        assertEquals("", parts[1]);
+    }
+
+    // --- FixedInputMethodListener ---
+
+    @Test
+    public void compositionForwardsCaretPositionToBlink() {
+        List<RecordedCall> calls = new ArrayList<>();
+        CefBrowser browser = recordingBrowser(calls);
+        RecordingListener fallback = new RecordingListener();
+        OsrImeCaretFix.FixedInputMethodListener listener =
+                new OsrImeCaretFix.FixedInputMethodListener(fallback, () -> browser);
+
+        listener.inputMethodTextChanged(textEvent("注音輸入", 0, TextHitInfo.leading(2)));
+
+        assertEquals(1, calls.size());
+        assertEquals("ImeSetComposition", calls.get(0).name);
+        assertEquals("注音輸入", calls.get(0).args[0]);
+        CefRange selection = selectionRangeOf(calls.get(0));
+        assertEquals(2, selection.from);
+        assertEquals(2, selection.to);
+        assertEquals(0, fallback.textChanged);
+    }
+
+    @Test
+    public void caretOnlyMovementResendsCompositionWithNewCaret() {
+        List<RecordedCall> calls = new ArrayList<>();
+        CefBrowser browser = recordingBrowser(calls);
+        OsrImeCaretFix.FixedInputMethodListener listener =
+                new OsrImeCaretFix.FixedInputMethodListener(new RecordingListener(), () -> browser);
+
+        listener.inputMethodTextChanged(textEvent("注音", 0, TextHitInfo.leading(2)));
+        listener.caretPositionChanged(caretEvent(TextHitInfo.leading(1)));
+
+        assertEquals(2, calls.size());
+        assertEquals("ImeSetComposition", calls.get(1).name);
+        assertEquals("注音", calls.get(1).args[0]);
+        CefRange selection = selectionRangeOf(calls.get(1));
+        assertEquals(1, selection.from);
+        assertEquals(1, selection.to);
+    }
+
+    @Test
+    public void nullTextCancelsActiveComposition() {
+        List<RecordedCall> calls = new ArrayList<>();
+        CefBrowser browser = recordingBrowser(calls);
+        OsrImeCaretFix.FixedInputMethodListener listener =
+                new OsrImeCaretFix.FixedInputMethodListener(new RecordingListener(), () -> browser);
+
+        listener.inputMethodTextChanged(textEvent("ㄊㄞ", 0, null));
+        listener.inputMethodTextChanged(textEvent(null, 0, null));
+
+        assertEquals(2, calls.size());
+        assertEquals("ImeCancelComposing", calls.get(1).name);
+    }
+
+    @Test
+    public void emptyComposedTextWithoutActiveCompositionDoesNothing() {
+        List<RecordedCall> calls = new ArrayList<>();
+        CefBrowser browser = recordingBrowser(calls);
+        OsrImeCaretFix.FixedInputMethodListener listener =
+                new OsrImeCaretFix.FixedInputMethodListener(new RecordingListener(), () -> browser);
+
+        listener.inputMethodTextChanged(textEvent(null, 0, null));
+
+        assertTrue(calls.isEmpty());
+    }
+
+    @Test
+    public void committedTextIsCommittedAndEndsComposition() {
+        List<RecordedCall> calls = new ArrayList<>();
+        CefBrowser browser = recordingBrowser(calls);
+        OsrImeCaretFix.FixedInputMethodListener listener =
+                new OsrImeCaretFix.FixedInputMethodListener(new RecordingListener(), () -> browser);
+
+        listener.inputMethodTextChanged(textEvent("注音", 0, null));
+        listener.inputMethodTextChanged(textEvent("注音", 2, null));
+        // A later null-text event must not send a redundant cancel.
+        listener.inputMethodTextChanged(textEvent(null, 0, null));
+
+        assertEquals(2, calls.size());
+        assertEquals("ImeSetComposition", calls.get(0).name);
+        assertEquals("ImeCommitText", calls.get(1).name);
+        assertEquals("注音", calls.get(1).args[0]);
+    }
+
+    @Test
+    public void missingBrowserDelegatesToPlatformAdapter() {
+        RecordingListener fallback = new RecordingListener();
+        OsrImeCaretFix.FixedInputMethodListener listener =
+                new OsrImeCaretFix.FixedInputMethodListener(fallback, () -> null);
+
+        listener.inputMethodTextChanged(textEvent("注", 0, null));
+        listener.caretPositionChanged(caretEvent(TextHitInfo.leading(0)));
+
+        assertEquals(1, fallback.textChanged);
+        assertEquals(1, fallback.caretChanged);
+    }
+
+    // --- install ---
+
+    @Test
+    public void installIgnoresComponentsWithoutPlatformAdapter() {
+        JPanel panel = new JPanel();
+        RecordingListener listener = new RecordingListener();
+        panel.addInputMethodListener(listener);
+
+        OsrImeCaretFix.install(panel);
+
+        InputMethodListener[] listeners = panel.getInputMethodListeners();
+        assertEquals(1, listeners.length);
+        assertEquals(listener, listeners[0]);
+    }
+
+    @Test
+    public void installToleratesNullComponent() {
+        OsrImeCaretFix.install(null);
+        assertNull(null);
+    }
+}

--- a/webview/src/components/ChatInputBox/ChatInputBox.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBox.tsx
@@ -50,6 +50,19 @@ import { useContextMenu, copySelection, pasteAtCursor, insertNewline } from '../
 import './styles.css';
 
 /**
+ * InputEvent.inputType values that belong to an active IME composition.
+ * Any other inputType arriving while isComposingRef is set means JCEF lost the
+ * compositionEnd event (e.g. IME switched mid-composition) and the composing
+ * state is stale.
+ */
+const COMPOSITION_INPUT_TYPES = new Set([
+  'insertCompositionText',
+  'deleteCompositionText',
+  'insertFromComposition',
+  'deleteByComposition',
+]);
+
+/**
  * ChatInputBox - Chat input component
  * Uses contenteditable div with auto height adjustment, IME handling, @ file references, / slash commands
  *
@@ -279,9 +292,12 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
 
     /**
      * Handle input event (optimized: use debounce to reduce performance overhead)
+     *
+     * @param inputType - InputEvent.inputType of the triggering native event,
+     *   when available. Programmatic callers omit it.
      */
     const handleInput = useCallback(
-      () => {
+      (inputType?: string) => {
         const timer = perfTimer('handleInput');
 
         // Only trust our own isComposingRef for IME state detection.
@@ -290,7 +306,19 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
         // by compositionStart/End and keyCode 229 detection, making it the sole
         // reliable source of truth.
         if (isComposingRef.current) {
-          return;
+          // JCEF/OSR can drop compositionEnd entirely when the user switches the
+          // input source mid-composition (e.g. Bopomofo -> English via Shift).
+          // A non-composition input event while our flag is still set proves the
+          // composition is over — reset the refs so completion detection and
+          // parent sync are not blocked forever.
+          const staleComposition =
+            inputType !== undefined && !COMPOSITION_INPUT_TYPES.has(inputType);
+          if (!staleComposition) {
+            return;
+          }
+          isComposingRef.current = false;
+          sharedComposingRef.current = false;
+          lastCompositionEndTimeRef.current = Date.now();
         }
 
         // Cancel any pending compositionEnd fallback timeout.
@@ -663,11 +691,16 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
             spellCheck={false}
             data-placeholder={placeholder}
             data-completion-suffix={inlineCompletion.suffix || ''}
-            onInput={() => {
+            onInput={(e) => {
               // Don't pass browser's isComposing — it's unreliable in JCEF.
               // isComposingRef (set by compositionStart/End + keyCode 229) is the
-              // sole source of truth for IME state.
-              handleInput();
+              // sole source of truth for IME state. The inputType is forwarded so
+              // handleInput can detect a stale composing flag (lost compositionEnd).
+              const inputType =
+                'inputType' in e.nativeEvent
+                  ? (e.nativeEvent as InputEvent).inputType
+                  : undefined;
+              handleInput(inputType);
             }}
             onKeyDown={handleKeyDown}
             onKeyUp={handleKeyUp}

--- a/webview/src/components/ChatInputBox/hooks/useInputHistory.ts
+++ b/webview/src/components/ChatInputBox/hooks/useInputHistory.ts
@@ -52,7 +52,7 @@ type KeyEventLike = {
 export interface UseInputHistoryOptions {
   editableRef: EditableRef;
   getTextContent: () => string;
-  handleInput: (isComposingFromEvent?: boolean) => void;
+  handleInput: (inputType?: string) => void;
 }
 
 export interface UseInputHistoryReturn {
@@ -101,7 +101,7 @@ export function useInputHistory({
       } catch {
         // Defensive: JCEF/IME edge cases can throw on DOM selection APIs.
       } finally {
-        handleInput(false);
+        handleInput();
       }
     },
     [editableRef, handleInput]

--- a/webview/src/components/ChatInputBox/hooks/usePasteAndDrop.ts
+++ b/webview/src/components/ChatInputBox/hooks/usePasteAndDrop.ts
@@ -20,7 +20,7 @@ interface UsePasteAndDropOptions {
   setInternalAttachments: React.Dispatch<React.SetStateAction<Attachment[]>>;
   onInput?: (content: string) => void;
   closeAllCompletions: () => void;
-  handleInput: (isComposingFromEvent?: boolean) => void;
+  handleInput: (inputType?: string) => void;
   /** Immediately flush pending debounced onInput to sync parent state */
   flushInput: () => void;
 }
@@ -140,7 +140,7 @@ export function usePasteAndDrop({
                   // Insert full path using modern Selection API
                   insertTextAtCursor(fullPath, editableRef.current);
                   // Bypass IME guard (isComposingRef may be stale after recent compositionEnd)
-                  handleInput(false);
+                  handleInput();
                   // Immediately sync parent state without waiting for debounce
                   flushInput();
                 }
@@ -162,7 +162,7 @@ export function usePasteAndDrop({
 
           // Trigger input event to update state
           // Pass false to bypass IME guard (isComposingRef may be stale after recent compositionEnd)
-          handleInput(false);
+          handleInput();
           timer.mark('handleInput');
 
           // Immediately sync parent state without waiting for debounce

--- a/webview/src/components/ChatInputBox/hooks/useTriggerDetection.test.ts
+++ b/webview/src/components/ChatInputBox/hooks/useTriggerDetection.test.ts
@@ -1,0 +1,66 @@
+import { renderHook } from '@testing-library/react';
+import { useTriggerDetection } from './useTriggerDetection.js';
+
+const ZWSP = '\u200B'; // zero-width space
+const ZWNJ = '\u200C'; // zero-width non-joiner
+const BOM = '\uFEFF'; // byte order mark
+
+function detect(text: string, cursorPosition: number = text.length) {
+  const { result } = renderHook(() => useTriggerDetection());
+  return result.current.detectTrigger(text, cursorPosition);
+}
+
+describe('useTriggerDetection', () => {
+  describe('slash trigger line-start detection', () => {
+    it('triggers for / at the very start of input', () => {
+      const trigger = detect('/rev');
+      expect(trigger).toEqual({ trigger: '/', query: 'rev', start: 0, end: 4 });
+    });
+
+    it('triggers for / at the start of a new line', () => {
+      const trigger = detect('hello\n/rev');
+      expect(trigger?.trigger).toBe('/');
+      expect(trigger?.query).toBe('rev');
+    });
+
+    it('does not trigger for / preceded by visible text', () => {
+      expect(detect('abc/rev')).toBeNull();
+    });
+
+    it('triggers for / preceded only by zero-width IME residue', () => {
+      // A stale IME composition can leave invisible characters in the
+      // contenteditable; they must not block the slash menu.
+      const trigger = detect(`${ZWSP}/rev`);
+      expect(trigger?.trigger).toBe('/');
+      expect(trigger?.query).toBe('rev');
+    });
+
+    it('triggers for / preceded by multiple invisible characters', () => {
+      const trigger = detect(`${BOM}${ZWSP}${ZWNJ}/skill`);
+      expect(trigger?.trigger).toBe('/');
+      expect(trigger?.query).toBe('skill');
+    });
+
+    it('triggers for / after newline followed by invisible characters', () => {
+      const trigger = detect(`text\n${ZWSP}/cmd`);
+      expect(trigger?.trigger).toBe('/');
+      expect(trigger?.query).toBe('cmd');
+    });
+
+    it('does not trigger when visible text hides behind invisible characters', () => {
+      expect(detect(`a${ZWSP}/rev`)).toBeNull();
+    });
+  });
+
+  describe('hash trigger line-start detection', () => {
+    it('triggers for # preceded only by zero-width IME residue', () => {
+      const trigger = detect(`${ZWSP}#agent`);
+      expect(trigger?.trigger).toBe('#');
+      expect(trigger?.query).toBe('agent');
+    });
+
+    it('does not trigger for # preceded by visible text', () => {
+      expect(detect('abc#agent')).toBeNull();
+    });
+  });
+});

--- a/webview/src/components/ChatInputBox/hooks/useTriggerDetection.ts
+++ b/webview/src/components/ChatInputBox/hooks/useTriggerDetection.ts
@@ -246,6 +246,28 @@ function isWhitespace(char: string): boolean {
 }
 
 /**
+ * Invisible characters (zero-width space/joiner, BOM) that IME composition can
+ * leave behind in the contenteditable. They must not count as "content" when
+ * deciding whether a trigger sits at line start, otherwise a residual invisible
+ * character silently blocks the / and # menus.
+ */
+const INVISIBLE_CHAR_REGEX = /[\u200B-\u200D\uFEFF]/;
+
+/**
+ * Check whether position `index` is at the start of a line, treating invisible
+ * zero-width characters as transparent.
+ */
+function isLineStart(text: string, index: number): boolean {
+  for (let i = index - 1; i >= 0; i--) {
+    const char = text[i];
+    if (char === '\n') return true;
+    if (INVISIBLE_CHAR_REGEX.test(char)) continue;
+    return false;
+  }
+  return true;
+}
+
+/**
  * Detect @ file reference trigger
  * Note: Skip rendered file tags to avoid false triggers after file tags
  */
@@ -299,9 +321,8 @@ function detectSlashTrigger(text: string, cursorPosition: number): TriggerQuery 
 
     // Found /
     if (char === '/') {
-      // Check if / is at line start
-      const isLineStart = start === 0 || text[start - 1] === '\n';
-      if (isLineStart) {
+      // Check if / is at line start (invisible IME residue is transparent)
+      if (isLineStart(text, start)) {
         const query = text.slice(start + 1, cursorPosition);
         return {
           trigger: '/',
@@ -336,9 +357,8 @@ function detectHashTrigger(text: string, cursorPosition: number): TriggerQuery |
 
     // Found #
     if (char === '#') {
-      // Check if # is at line start
-      const isLineStart = start === 0 || text[start - 1] === '\n';
-      if (isLineStart) {
+      // Check if # is at line start (invisible IME residue is transparent)
+      if (isLineStart(text, start)) {
         const query = text.slice(start + 1, cursorPosition);
         return {
           trigger: '#',


### PR DESCRIPTION
## Problem / 問題

Two IME bugs affecting phrase-based CJK input methods (Bopomofo 注音 / Pinyin) in the chat input box, both reproducible with JCEF OSR rendering (forced by remote JCEF on recent IDEA builds):

1. **Composition caret pinned to the end** — while moving the IME cursor inside the pre-edit text to pick candidates (e.g. Bopomofo ←/→ navigation), the rendered caret always stays after the last character, so you cannot see which character you are editing.
2. **`/` skill menu stops working after switching input source mid-composition** — after typing Bopomofo halfway and toggling to English (Shift), typing `/` no longer opens the slash-command/skill autocomplete menu.

Related reports: #576 (candidate window / caret mismatch, pinyin residue), #1622 (input scrambled after toggling IME to English).

## Root cause / 根因

The platform's `JBCefInputMethodAdapter` (registered by `JBCefOsrComponent` on OSR components) has two defects, confirmed by inspecting the platform bytecode:

- It always passes `new CefRange(len, len)` as the selection range to `CefBrowser#ImeSetComposition`, ignoring `InputMethodEvent.getCaret()`, and its `caretPositionChanged` handler is a no-op — the composition caret can never move.
- It silently drops events whose text is `null` or whose composed part is empty, so a composition aborted by an input-source switch never reaches Blink: the page keeps stale pre-edit text and never receives `compositionend`. The webview's `sharedComposingRef` then stays `true` forever, and completion trigger detection (guarded during composition) is permanently blocked.

## Fix / 修復

**Plugin (Java, root cause):** new `OsrImeCaretFix` swaps the platform IME listener on OSR components for a fixed re-implementation that:
- forwards the real caret position from `InputMethodEvent.getCaret()` to `ImeSetComposition`
- handles caret-only input-method events (pre-edit cursor navigation)
- calls `ImeCancelComposing()` when the IME aborts the composition, so the page receives a proper `compositionend`

Safety: only installs when the known platform adapter class is present (no-op if JetBrains renames/fixes it), keeps the platform adapter as `InputMethodRequests` (candidate-window positioning untouched), falls back to the platform behaviour whenever the browser cannot be resolved, and can be disabled with `-Dccg.disable.osr.ime.fix=true`. Windowed-mode browsers are unaffected.

**Webview (defense in depth):**
- `handleInput` now receives `InputEvent.inputType`; a non-composition inputType arriving while the composing flag is still set proves `compositionend` was lost, and the stuck refs are reset — the `/` and `#` menus recover immediately.
- Trigger detection treats zero-width IME residue (U+200B–U+200D, U+FEFF) as transparent for the line-start rule, so invisible leftovers no longer block the `/` and `#` menus.

## Tests / 測試

- Java: new `OsrImeCaretFixTest` (14 tests: caret clamping, caret-only re-send, cancel-on-abort, commit flow, fallback delegation, install gating); `SurfaceFrameFenceTest` regression passes; checkstyle clean
- Webview: new `useTriggerDetection.test.ts` (9 cases); full suite 143 files / 1252 tests + `tsc` typecheck pass
- Manual: verified in IDEA with macOS Bopomofo — pre-edit caret follows ←/→ during candidate selection, and `/` opens the skill menu right after toggling to English mid-composition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

