### PR TITLE
fix(streaming): let in-flight message frames reach the webview instead of starving them

### DIFF
--- a/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
@@ -76,9 +76,20 @@ public class ClaudeSession {
         }
 
         public Type type;
-        public String content;
+        // The streaming handler thread reassigns these on every assistant update
+        // (e.g. `raw = mergedRaw`, `content = builder.toString()`) while
+        // StreamMessageCoalescer serializes the same Message off-EDT — enqueue only
+        // shallow-copies the list, so elements are shared across threads. Without
+        // volatile the serializer could read a stale reference and publish a snapshot
+        // predating a just-reassigned tool_use block, which the frontend's structural
+        // merge (it takes blocks from the new snapshot only) would then freeze as
+        // missing.
+        // This covers the reassignment race, the dominant mutation pattern. Note:
+        // a few call sites still mutate the JsonObject in place (turnUsage / uuid /
+        // usage stamps in ClaudeMessageHandler); those are a separate concern.
+        public volatile String content;
         public long timestamp;
-        public JsonObject raw; // Raw message data from SDK
+        public volatile JsonObject raw; // Raw message data from SDK
 
         public Message(Type type, String content) {
             this.type = type;

--- a/src/main/java/com/github/claudecodegui/session/StreamMessageCoalescer.java
+++ b/src/main/java/com/github/claudecodegui/session/StreamMessageCoalescer.java
@@ -68,6 +68,10 @@ public class StreamMessageCoalescer {
     // lock-protected fields.  This is intentional: a one-cycle stale read only means the
     // interval adapts one push later — acceptable for a best-effort throttling heuristic.
     private volatile int lastPayloadChars = 0;
+    // Highest sequence actually handed to the webview. Ordering is enforced against THIS,
+    // not against updateSequence: updateSequence only means "newer data is queued", which
+    // is not a reason to drop the in-flight frame. See sendToWebView for why that matters.
+    private volatile long lastPushedSequence = 0L;
     private volatile List<ClaudeSession.Message> pendingMessages = null;
     private volatile List<ClaudeSession.Message> lastSnapshot = null;
     private volatile List<ClaudeSession.Message> lastDeliveredSnapshot = null;
@@ -172,7 +176,10 @@ public class StreamMessageCoalescer {
             lastDeliveredSnapshot = null;
             lastUpdateAtMs = 0L;
             lastPayloadChars = 0;
-            return ++updateSequence;
+            // Raise the ordering floor as well: frames still in flight from the previous
+            // session carry a smaller sequence and must not repopulate the list we cleared.
+            lastPushedSequence = ++updateSequence;
+            return lastPushedSequence;
         }
     }
 
@@ -368,33 +375,35 @@ public class StreamMessageCoalescer {
 
                 final long pushSequence;
                 synchronized (lock) {
-                    if (sequence != updateSequence) {
-                        // Stale snapshot: a newer one is pending or was just pushed,
-                        // so normally we skip this push. Force-push ONLY on the flush
-                        // path (afterSendOnEdt != null) - that is the onStreamEnd flush
-                        // carrying the turn's FINAL snapshot, and when a late enqueue
-                        // has advanced updateSequence past it, no newer snapshot will
-                        // compensate, so the turn's tail content would be lost for good.
-                        // The alarm path (afterSendOnEdt == null) holds a possibly
-                        // outdated snapshot; force-pushing it would advance the sequence
-                        // and let a stale frame overwrite the final one once its
-                        // (large-payload-delayed) invokeLater lands after the flush.
-                        // Advancing the sequence on force-push keeps the frontend's
-                        // minAcceptedUpdateSequence barrier accepting the frame.
-                        if (streamActive || afterSendOnEdt == null) {
-                            if (afterSendOnEdt != null) {
-                                afterSendOnEdt.accept(sequence);
-                            }
-                            return;
+                    // Drop ONLY genuinely out-of-order frames: a snapshot whose
+                    // (large-payload-delayed) invokeLater lands after a newer one already
+                    // reached the webview would roll the list backwards.
+                    //
+                    // A frame that is merely older than `updateSequence` is NOT stale.
+                    // Snapshots grow monotonically within a turn, so a frame whose
+                    // sequence is >= the last pushed one carries content that is a
+                    // superset of whatever the webview already shows — pushing it is
+                    // forward progress, never a regression, even if a newer one is still
+                    // queued. The previous `sequence != updateSequence` check treated
+                    // "newer data is queued" as "this frame is obsolete" and dropped it.
+                    // Because the payload serializes off-EDT, any enqueue arriving in
+                    // that window advanced updateSequence, so frame after frame was
+                    // discarded during dense streaming and structural blocks
+                    // (tool_use / tool_result) never reached the frontend until the
+                    // stream-end flush. Meanwhile onContentDelta kept flowing, so text
+                    // was appended to whichever assistant message the frontend last knew
+                    // about.
+                    //
+                    // The frontend's __minAcceptedUpdateSequence guard applies the same
+                    // ordering rule on its side, so this is not the only line of defence.
+                    if (sequence < lastPushedSequence) {
+                        if (afterSendOnEdt != null) {
+                            afterSendOnEdt.accept(sequence);
                         }
-                        pushSequence = ++updateSequence;
-                        LOG.info("[StreamMessageCoalescer] Force-pushing stale final snapshot after"
-                                + " stream end (stale sequence=" + sequence
-                                + ", pushed=" + pushSequence
-                                + ") to avoid losing the turn's final content");
-                    } else {
-                        pushSequence = sequence;
+                        return;
                     }
+                    pushSequence = sequence;
+                    lastPushedSequence = sequence;
                 }
 
                 // FIX: Wrap callJavaScript in try-catch so that a JCEF failure
@@ -412,9 +421,13 @@ public class StreamMessageCoalescer {
                         callbackTarget.callJavaScript("updateMessages", escapedMessagesJson, String.valueOf(pushSequence));
                     }
                     synchronized (lock) {
-                        if (pushSequence == updateSequence) {
-                            lastDeliveredSnapshot = messages;
-                        }
+                        // Unconditional: this frame reached the webview, so it becomes the
+                        // prefix baseline for tail transport. Gating this on
+                        // `pushSequence == updateSequence` froze the baseline for as long as
+                        // newer data stayed queued, so hasSamePrefix never matched, tail
+                        // updates never engaged on long conversations, and every push kept
+                        // paying full-payload serialization cost.
+                        lastDeliveredSnapshot = messages;
                     }
                     MessageJsonConverter.pushUsageUpdateFromMessages(
                             messages,


### PR DESCRIPTION
Streaming tool_use / tool_result blocks intermittently failed to render during active streaming, with text appending to the wrong assistant message; both symptoms recovered after the turn ended.

Root cause: StreamMessageCoalescer dropped every frame whose sequence differed from the latest updateSequence. Because schedulePush bumps updateSequence on every dispatch and JSON serialization runs off-EDT, any enqueue arriving during the serialization window made the in-flight frame look stale, so updateMessages frames were discarded one after another during dense streaming. Structural blocks only travel via updateMessages, while text deltas (onContentDelta) keep flowing unthrottled and carry no segment routing, so the frontend appended them to whichever assistant it last knew about. Only the onStreamEnd flush escaped the drop, which is why everything looked correct again once the turn finished.

Fix: order frames against the highest sequence actually pushed, not against updateSequence. A frame whose sequence is >= the last pushed one carries a monotonic superset of what the webview already shows, so pushing it is always forward progress; only genuinely out-of-order frames (a late invokeLater landing after a newer push) are dropped. This matches the frontend __minAcceptedUpdateSequence guard, which already applies the same rule on its side.

Also unblock tail transport on long conversations: lastDeliveredSnapshot was gated on pushSequence == updateSequence, a condition that almost never held while newer data stayed queued, so the tail prefix baseline froze, tail updates never engaged, and every push kept paying full- payload serialization cost. Now updated unconditionally on every successful push.

Finally mark ClaudeSession.Message.content / raw volatile: the streaming handler reassigns them on every assistant update while the coalescer serializes the same Message off-EDT (enqueue only shallow-copies the list), so without volatile the serializer could publish a snapshot predating a just-reassigned tool_use block.