### PR TITLE
fix(ime): prevent file tag DOM rebuilds during composition

### DIFF
--- a/webview/src/components/ChatInputBox/ChatInputBox.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBox.tsx
@@ -38,6 +38,7 @@ import {
   useOpenSourceBannerState,
   useResetAttachmentsOnSessionChange,
   useSpaceKeyListener,
+  useCompositionSafeTagRendering,
   useResizableChatInputBox,
 } from './hooks/index.js';
 import { debounce } from './utils/debounce.js';
@@ -224,11 +225,15 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
       el.style.overflowY = 'hidden';
     }, []);
 
-    // Create debounced version of renderFileTags
-    const debouncedRenderFileTags = useMemo(
-      () => debounce(renderTags, DEBOUNCE_TIMING.FILE_TAG_RENDERING_MS),
-      [renderTags]
-    );
+    const {
+      scheduleTagRendering,
+      cancelTagRendering,
+      renderTagsNowIfSafe,
+    } = useCompositionSafeTagRendering({
+      isComposingRef: sharedComposingRef,
+      renderTags,
+      delay: DEBOUNCE_TIMING.FILE_TAG_RENDERING_MS,
+    });
 
     const {
       fileCompletion,
@@ -284,11 +289,11 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
       () => {
         const timer = perfTimer('handleInput');
 
-        // Only trust our own isComposingRef for IME state detection.
+        // Only trust our composition-event-backed ref for IME state detection.
         // JCEF's InputEvent.isComposing is unreliable (can be false during active
-        // composition, or true after compositionEnd). Our ref is set synchronously
-        // by compositionStart/End and keyCode 229 detection, making it the sole
-        // reliable source of truth.
+        // composition, or true after compositionEnd). The ref is set synchronously
+        // by compositionStart/End. Do not restore persistent keyCode 229 state: it
+        // can get stuck for Korean IMEs when no matching compositionEnd arrives.
         if (isComposingRef.current) {
           return;
         }
@@ -331,10 +336,10 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
         // If determined empty (only zero-width characters), pass empty string to parent
         debouncedOnInput(isEmpty ? '' : text);
 
-        // Trigger file tag rendering so @path text is converted to chips.
+        // Schedule file/quote tag rendering after the input DOM becomes stable.
         // Covers non-keyboard input paths (history restore, paste, etc.)
         // that don't fire the space-key listener.
-        debouncedRenderFileTags();
+        scheduleTagRendering();
 
         timer.end();
       },
@@ -343,7 +348,7 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
         adjustHeight,
         debouncedDetectCompletion,
         debouncedOnInput,
-        debouncedRenderFileTags,
+        scheduleTagRendering,
         invalidateCache,
         syncInlineCompletion,
       ]
@@ -367,9 +372,10 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
     // Wrap composition handlers to sync sharedComposingRef (used by completion detection)
     // Both refs are now set synchronously — no RAF, no race conditions.
     const handleCompositionStart = useCallback(() => {
-      rawHandleCompositionStart();
       sharedComposingRef.current = true;
-    }, [rawHandleCompositionStart]);
+      cancelTagRendering();
+      rawHandleCompositionStart();
+    }, [cancelTagRendering, rawHandleCompositionStart]);
 
     const handleCompositionEnd = useCallback(() => {
       rawHandleCompositionEnd();
@@ -377,8 +383,8 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
     }, [rawHandleCompositionEnd]);
 
     useEffect(() => {
-      setRenderFileTags(renderTags);
-    }, [renderTags, setRenderFileTags]);
+      setRenderFileTags(renderTagsNowIfSafe);
+    }, [renderTagsNowIfSafe, setRenderFileTags]);
 
     const { record: recordInputHistory, handleKeyDown: handleHistoryKeyDown } = useInputHistory({
       editableRef,
@@ -393,17 +399,17 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
     });
 
     /**
-     * Handle keyboard down event (for detecting space to trigger file tag rendering)
+     * Handle keyboard down event (for detecting space to trigger tag rendering)
      * Optimized: use debounce for delayed rendering
      */
     const handleKeyDownForTagRendering = useCallback(
       (e: KeyboardEvent) => {
-        // If space key pressed, use debounce for delayed file tag rendering
-        if (e.key === ' ') {
-          debouncedRenderFileTags();
+        // IME candidate confirmation also uses Space, so never schedule while composing.
+        if (e.key === ' ' && !sharedComposingRef.current) {
+          scheduleTagRendering();
         }
       },
-      [debouncedRenderFileTags]
+      [scheduleTagRendering]
     );
 
     const handleSubmit = useSubmitHandler({
@@ -549,7 +555,7 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
       pathMappingRef,
       getTextContent,
       adjustHeight,
-      renderFileTags: renderTags,
+      renderFileTags: renderTagsNowIfSafe,
       setHasContent,
       setInternalAttachments,
       onInput,
@@ -586,7 +592,7 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
       pathMappingRef,
       getTextContent,
       adjustHeight,
-      renderFileTags: renderTags,
+      renderFileTags: renderTagsNowIfSafe,
       renderQuoteTags,
       setHasContent,
       onInput,

--- a/webview/src/components/ChatInputBox/hooks/index.ts
+++ b/webview/src/components/ChatInputBox/hooks/index.ts
@@ -39,6 +39,7 @@ export { useChatInputSelectionController } from './useChatInputSelectionControll
 export { useOpenSourceBannerState } from './useOpenSourceBannerState.js';
 export { useResetAttachmentsOnSessionChange } from './useResetAttachmentsOnSessionChange.js';
 export { useSpaceKeyListener } from './useSpaceKeyListener.js';
+export { useCompositionSafeTagRendering } from './useCompositionSafeTagRendering.js';
 export { useResizableChatInputBox, computeResize } from './useResizableChatInputBox.js';
 export { useInlineHistoryCompletion } from './useInlineHistoryCompletion.js';
 export {

--- a/webview/src/components/ChatInputBox/hooks/useCompositionSafeTagRendering.test.ts
+++ b/webview/src/components/ChatInputBox/hooks/useCompositionSafeTagRendering.test.ts
@@ -1,0 +1,96 @@
+import { act, renderHook } from '@testing-library/react';
+import { useCompositionSafeTagRendering } from './useCompositionSafeTagRendering.js';
+
+describe('useCompositionSafeTagRendering', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders after the delay when no composition is active', () => {
+    const renderTags = vi.fn();
+    const isComposingRef = { current: false };
+    const { result } = renderHook(() =>
+      useCompositionSafeTagRendering({ isComposingRef, renderTags, delay: 300 })
+    );
+
+    act(() => {
+      result.current.scheduleTagRendering();
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(renderTags).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not schedule rendering while composition is active', () => {
+    const renderTags = vi.fn();
+    const isComposingRef = { current: true };
+    const { result } = renderHook(() =>
+      useCompositionSafeTagRendering({ isComposingRef, renderTags, delay: 300 })
+    );
+
+    act(() => {
+      result.current.scheduleTagRendering();
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(renderTags).not.toHaveBeenCalled();
+  });
+
+  it('drops pending rendering when composition starts before the callback runs', () => {
+    const renderTags = vi.fn();
+    const isComposingRef = { current: false };
+    const { result } = renderHook(() =>
+      useCompositionSafeTagRendering({ isComposingRef, renderTags, delay: 300 })
+    );
+
+    act(() => {
+      result.current.scheduleTagRendering();
+      isComposingRef.current = true;
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(renderTags).not.toHaveBeenCalled();
+  });
+
+  it('cancels pending rendering explicitly and on unmount', () => {
+    const renderTags = vi.fn();
+    const isComposingRef = { current: false };
+    const { result, unmount } = renderHook(() =>
+      useCompositionSafeTagRendering({ isComposingRef, renderTags, delay: 300 })
+    );
+
+    act(() => {
+      result.current.scheduleTagRendering();
+      result.current.cancelTagRendering();
+      vi.advanceTimersByTime(300);
+      result.current.scheduleTagRendering();
+    });
+    unmount();
+    act(() => vi.advanceTimersByTime(300));
+
+    expect(renderTags).not.toHaveBeenCalled();
+  });
+
+  it('renders immediately only when safe and cancels pending debounced work', () => {
+    const renderTags = vi.fn();
+    const isComposingRef = { current: false };
+    const { result } = renderHook(() =>
+      useCompositionSafeTagRendering({ isComposingRef, renderTags, delay: 300 })
+    );
+
+    act(() => {
+      result.current.scheduleTagRendering();
+      result.current.renderTagsNowIfSafe();
+      vi.advanceTimersByTime(300);
+    });
+    expect(renderTags).toHaveBeenCalledTimes(1);
+
+    isComposingRef.current = true;
+    act(() => result.current.renderTagsNowIfSafe());
+    expect(renderTags).toHaveBeenCalledTimes(1);
+  });
+});

--- a/webview/src/components/ChatInputBox/hooks/useCompositionSafeTagRendering.ts
+++ b/webview/src/components/ChatInputBox/hooks/useCompositionSafeTagRendering.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import type { MutableRefObject } from 'react';
+import { debounce } from '../utils/debounce.js';
+
+interface UseCompositionSafeTagRenderingOptions {
+  isComposingRef: MutableRefObject<boolean>;
+  renderTags: () => void;
+  delay: number;
+}
+
+interface UseCompositionSafeTagRenderingReturn {
+  scheduleTagRendering: () => void;
+  cancelTagRendering: () => void;
+  renderTagsNowIfSafe: () => void;
+}
+
+/**
+ * Schedules tag rendering without allowing delayed DOM mutations to cross an
+ * IME composition boundary.
+ *
+ * The composing ref is checked both when work is scheduled and when the
+ * debounced callback executes. The second check protects against work queued
+ * by the previous input turn firing after the next composition has started.
+ */
+export function useCompositionSafeTagRendering({
+  isComposingRef,
+  renderTags,
+  delay,
+}: UseCompositionSafeTagRenderingOptions): UseCompositionSafeTagRenderingReturn {
+  const debouncedRenderTags = useMemo(
+    () => debounce(() => {
+      if (isComposingRef.current) return;
+      renderTags();
+    }, delay),
+    [delay, isComposingRef, renderTags]
+  );
+
+  useEffect(() => () => debouncedRenderTags.cancel(), [debouncedRenderTags]);
+
+  const scheduleTagRendering = useCallback(() => {
+    if (isComposingRef.current) return;
+    debouncedRenderTags();
+  }, [debouncedRenderTags, isComposingRef]);
+
+  const cancelTagRendering = useCallback(() => {
+    debouncedRenderTags.cancel();
+  }, [debouncedRenderTags]);
+
+  const renderTagsNowIfSafe = useCallback(() => {
+    if (isComposingRef.current) return;
+    debouncedRenderTags.cancel();
+    renderTags();
+  }, [debouncedRenderTags, isComposingRef, renderTags]);
+
+  return { scheduleTagRendering, cancelTagRendering, renderTagsNowIfSafe };
+}

--- a/webview/src/components/ChatInputBox/hooks/useFileTags.test.ts
+++ b/webview/src/components/ChatInputBox/hooks/useFileTags.test.ts
@@ -81,6 +81,103 @@ describe('useFileTags', () => {
     expect(editable.querySelectorAll('.file-tag').length).toBe(0);
   });
 
+  it('preserves an existing file tag when only unrelated raw @ text remains', () => {
+    const editable = createEditable();
+    const existingTag = document.createElement('span');
+    existingTag.className = 'file-tag';
+    existingTag.setAttribute('data-file-path', 'README.md');
+    existingTag.textContent = 'README.md';
+    editable.append(existingTag, document.createTextNode(' @GetMapping("/test")'));
+    const onCloseCompletions = vi.fn();
+
+    const { result } = renderHook(() =>
+      useFileTags({
+        editableRef: { current: editable },
+        // Mirrors useTextContent: existing chips are serialized into @path.
+        getTextContent: () => '@README.md @GetMapping("/test")',
+        onCloseCompletions,
+      })
+    );
+    result.current.pathMappingRef.current.set('README.md', '/project/README.md');
+
+    result.current.renderFileTags();
+
+    expect(editable.querySelector('.file-tag')).toBe(existingTag);
+    expect(onCloseCompletions).not.toHaveBeenCalled();
+  });
+
+  it('renders a new valid raw reference alongside an existing file tag', () => {
+    const editable = createEditable();
+    const existingTag = document.createElement('span');
+    existingTag.className = 'file-tag';
+    existingTag.setAttribute('data-file-path', 'README.md');
+    existingTag.textContent = 'README.md';
+    editable.append(existingTag, document.createTextNode(' @src/a.ts '));
+    mockSelection();
+
+    const { result } = renderHook(() =>
+      useFileTags({
+        editableRef: { current: editable },
+        getTextContent: () => '@README.md @src/a.ts ',
+        onCloseCompletions: vi.fn(),
+      })
+    );
+    result.current.pathMappingRef.current.set('README.md', '/project/README.md');
+    result.current.pathMappingRef.current.set('src/a.ts', '/project/src/a.ts');
+
+    result.current.renderFileTags();
+
+    const paths = Array.from(editable.querySelectorAll('.file-tag'))
+      .map((tag) => tag.getAttribute('data-file-path'));
+    expect(paths).toEqual(['README.md', 'src/a.ts']);
+  });
+
+  it('recognizes a valid raw reference split across adjacent inline elements', () => {
+    const editable = createEditable();
+    const firstPart = document.createElement('span');
+    firstPart.textContent = '@src/';
+    const secondPart = document.createElement('span');
+    secondPart.textContent = 'a.ts ';
+    editable.append(firstPart, secondPart);
+    mockSelection();
+
+    const { result } = renderHook(() =>
+      useFileTags({
+        editableRef: { current: editable },
+        getTextContent: () => '@src/a.ts ',
+        onCloseCompletions: vi.fn(),
+      })
+    );
+    result.current.pathMappingRef.current.set('src/a.ts', '/project/src/a.ts');
+
+    result.current.renderFileTags();
+
+    expect(editable.querySelector('.file-tag')?.getAttribute('data-file-path')).toBe('src/a.ts');
+  });
+
+  it('does not let quote chip decoration authorize a file-tag rebuild', () => {
+    const editable = createEditable();
+    const quoteTag = document.createElement('span');
+    quoteTag.className = 'quote-tag';
+    quoteTag.textContent = '@README.md';
+    editable.append(quoteTag, document.createTextNode(' @GetMapping("/test")'));
+    const onCloseCompletions = vi.fn();
+
+    const { result } = renderHook(() =>
+      useFileTags({
+        editableRef: { current: editable },
+        getTextContent: () => '@README.md @GetMapping("/test")',
+        onCloseCompletions,
+      })
+    );
+    result.current.pathMappingRef.current.set('README.md', '/project/README.md');
+
+    result.current.renderFileTags();
+
+    expect(editable.querySelector('.quote-tag')).toBe(quoteTag);
+    expect(onCloseCompletions).not.toHaveBeenCalled();
+  });
+
   it('renders file tags for paths with spaces', () => {
     const editable = createEditable();
     editable.textContent = '@my file.ts ';
@@ -145,4 +242,3 @@ describe('useFileTags', () => {
     expect(editable.querySelectorAll('.file-tag').length).toBe(1);
   });
 });
-

--- a/webview/src/components/ChatInputBox/hooks/useFileTags.ts
+++ b/webview/src/components/ChatInputBox/hooks/useFileTags.ts
@@ -131,20 +131,22 @@ export function useFileTags({
      * L = average path length (for startsWith checks). Acceptable for input box text
      * (typically < 10 '@' references) and moderate project sizes (< 1000 path entries).
      */
-    const matches: FileMatch[] = [];
+    const findMatches = (text: string): FileMatch[] => {
+      const matches: FileMatch[] = [];
 
-    // First pass: Find @ positions and try to match against pathMappingRef
-    for (let i = 0; i < currentText.length; i++) {
-      if (currentText[i] === '@') {
+      // Find @ positions and try to match against pathMappingRef.
+      for (let i = 0; i < text.length; i++) {
+        if (text[i] !== '@') continue;
+
         let longestMatch: { path: string; length: number } | null = null;
 
         // Try to find the longest matching path from pathMappingRef
         // Uses startsWith(str, position) to avoid creating substrings
         for (const [key] of pathMappingRef.current) {
           // Check if the text at position i matches "@key"
-          if (currentText.startsWith(key, i + 1)) {
+          if (text.startsWith(key, i + 1)) {
             // Match must be followed by whitespace or end of string
-            const afterChar = currentText[i + 1 + key.length];
+            const afterChar = text[i + 1 + key.length];
             if (afterChar === undefined || afterChar === ' ' || afterChar === '\n' || afterChar === '\t' || afterChar === '\r') {
               if (!longestMatch || key.length > longestMatch.length) {
                 longestMatch = { path: key, length: key.length };
@@ -155,7 +157,7 @@ export function useFileTags({
 
         if (longestMatch) {
           // Found a match from pathMappingRef
-          const afterChar = currentText[i + 1 + longestMatch.length];
+          const afterChar = text[i + 1 + longestMatch.length];
           const spacer = afterChar === ' ' ? ' ' : '';
           matches.push({
             index: i,
@@ -171,7 +173,7 @@ export function useFileTags({
         // This handles absolute paths and paths with line numbers.
         // The helper scans forward allowing spaces when the next segment
         // looks like a path continuation (contains a path separator: \ or /).
-        const remainingText = currentText.substring(i);
+        const remainingText = text.substring(i);
         const afterAt = remainingText.slice(1); // text after '@'
         let endPos = 0;
         while (endPos < afterAt.length) {
@@ -208,7 +210,25 @@ export function useFileTags({
           i += simpleMatch[0].length - 1;
         }
       }
-    }
+
+      return matches;
+    };
+
+    const isValidFileReference = (filePath: string): boolean => {
+      const hashIndex = filePath.indexOf('#');
+      const pureFilePath = hashIndex !== -1 ? filePath.substring(0, hashIndex) : filePath;
+      const pureFileName = pureFilePath.split(/[/\\]/).pop() || pureFilePath;
+      const hasLineNumber = /#L\d+/.test(filePath);
+      const isAbsolutePath = /^[a-zA-Z]:[/\\]/.test(filePath) || filePath.startsWith('/');
+
+      return pathMappingRef.current.has(pureFilePath)
+        || pathMappingRef.current.has(pureFileName)
+        || pathMappingRef.current.has(filePath)
+        || hasLineNumber
+        || isAbsolutePath;
+    };
+
+    const matches = findMatches(currentText);
 
     timer.mark('smart-matching');
 
@@ -224,29 +244,55 @@ export function useFileTags({
         ? matches.slice(0, RENDERING_LIMITS.MAX_FILE_TAGS_PER_RENDER)
         : matches;
 
-    // Check if there are plain text @filepath in DOM that need conversion
-    // Traverse all text nodes, looking for text containing @
-    let hasUnrenderedReferences = false;
+    // Only an actually renderable reference in a raw text node may authorize a
+    // root DOM rebuild. getTextContent() serializes an existing .file-tag back
+    // to @path, so validating the virtual currentText alone would mistake an
+    // already-rendered chip for pending work whenever unrelated raw @ text is
+    // also present (for example, @GetMapping).
+    const rawTextSegments: string[] = [''];
+    const appendRawText = (text: string) => {
+      rawTextSegments[rawTextSegments.length - 1] += text;
+    };
+    const breakRawTextSegment = () => {
+      if (rawTextSegments[rawTextSegments.length - 1] !== '') {
+        rawTextSegments.push('');
+      }
+    };
     const walk = (node: Node) => {
-      if (hasUnrenderedReferences) return; // Early exit if found
       if (node.nodeType === Node.TEXT_NODE) {
-        const text = node.textContent || '';
-        if (text.includes('@')) {
-          hasUnrenderedReferences = true;
-        }
+        appendRawText(node.textContent || '');
       } else if (node.nodeType === Node.ELEMENT_NODE) {
         const element = node as HTMLElement;
-        // Skip already rendered file tags
-        if (!element.classList.contains('file-tag')) {
-          node.childNodes.forEach(walk);
+        // Existing chips are serialized by getTextContent but are not raw text
+        // waiting for conversion. Their decorative children must not drive a
+        // rebuild either.
+        if (element.classList.contains('file-tag') || element.classList.contains('quote-tag')) {
+          breakRawTextSegment();
+          return;
         }
+
+        const tagName = element.tagName.toLowerCase();
+        if (tagName === 'br') {
+          appendRawText('\n');
+          return;
+        }
+        if (tagName === 'div' || tagName === 'p') {
+          breakRawTextSegment();
+          node.childNodes.forEach(walk);
+          breakRawTextSegment();
+          return;
+        }
+        node.childNodes.forEach(walk);
       }
     };
     editableRef.current.childNodes.forEach(walk);
 
-    // If no unrendered references, no need to re-render
-    if (!hasUnrenderedReferences) {
-      timer.mark('no-unrendered');
+    const hasRenderableRawReference = rawTextSegments.some((text) =>
+      text.includes('@') && findMatches(text).some((match) => isValidFileReference(match.path))
+    );
+
+    if (!hasRenderableRawReference) {
+      timer.mark('no-renderable-raw-reference');
       timer.end();
       return;
     }
@@ -281,14 +327,7 @@ export function useFileTags({
       // Validate if path is a valid reference (must exist in pathMappingRef)
       // Only files selected from dropdown list are recorded in pathMappingRef
       // Also allow paths with line numbers (e.g. #L10-20) or absolute paths
-      const hasLineNumber = /#L\d+/.test(filePath);
-      const isAbsolutePath = /^[a-zA-Z]:[/\\]/.test(filePath) || filePath.startsWith('/');
-      const isValidReference =
-        pathMappingRef.current.has(pureFilePath) ||
-        pathMappingRef.current.has(pureFileName) ||
-        pathMappingRef.current.has(filePath) ||
-        hasLineNumber ||
-        isAbsolutePath;
+      const isValidReference = isValidFileReference(filePath);
 
       // If not a valid reference, keep original text, don't render as tag
       if (!isValidReference) {


### PR DESCRIPTION
## Summary

- Prevent delayed file and quote tag rendering from mutating the `contentEditable` root during an active IME composition.
- Rebuild file-tag DOM only when raw editable text contains an actually renderable file reference.
- Preserve references split across adjacent inline text nodes while treating file chips, quote chips, and block elements as boundaries.

## Root cause

`useTextContent()` serializes an existing file chip back to an `@path` token. With a rendered `README.md` chip and unrelated raw Java annotations such as `@GetMapping`, `useFileTags` previously treated the raw `@` as pending work, matched the serialized `@README.md` as a valid file reference, and replaced the entire editable `innerHTML`.

Tag rendering is debounced after input and Space. A callback scheduled by the previous input turn could therefore rebuild the root DOM after the next IME composition had started, disrupting the JCEF/Blink pre-edit DOM and selection and leaking `w`, `q`, or `wq` into the committed text.

## Changes

- Add a composition-safe tag-rendering hook that checks the composing ref both when work is scheduled and when it executes.
- Cancel pending debounced work on `compositionstart`, explicit immediate rendering, and unmount.
- Route file selection, file drop, and IDE file/code injection through the same execution-time composition guard.
- Require a valid file reference in raw editable text before allowing a root DOM rebuild; ignore existing file and quote chip decoration.
- Keep the ref-only IME state model and do not restore the persistent `keyCode === 229` fallback.

## Verification

- Focused regression tests: 16/16 passed.
- Full webview suite: 143 files and 1,252 tests passed, including the test TypeScript check.
- Production TypeScript and Vite build passed.
- `./gradlew test`: `BUILD SUCCESSFUL`.
- `git diff --check` passed.
- Manual verification passed on macOS Apple Silicon, IntelliJ IDEA Ultimate 2025.2.6.2, and Baidu Wubi. With a rendered `README.md` chip, Java annotations, and a long input, repeated fast `wq` + Space input no longer leaked Latin pre-edit text.

## Related work

This complements but does not duplicate #1648. That PR repairs the JCEF OSR composition caret and stale composition state; this PR prevents the file-tag renderer from rebuilding the editable root during composition and removes the deterministic mixed-chip false-positive path.

Fixes #1650