### PR TITLE
fix(subagent): deliver async agent reports and the original task brief

### DIFF
--- a/ai-bridge/services/claude/persistent-query-service.context.test.mjs
+++ b/ai-bridge/services/claude/persistent-query-service.context.test.mjs
@@ -4,6 +4,25 @@ import assert from 'node:assert/strict';
 import { __testing, getContextUsagePersistent } from './persistent-query-service.js';
 
 /**
+ * Make a mock query.next() idle like a real SDK stream: block while idle,
+ * settle only when close() runs. Returning {done:true} immediately makes the
+ * perpetual reader treat the stream as ended out-of-band and evict the runtime
+ * via disposeRuntime - which races acquireRuntime's ownership check (the
+ * runtime can be closed between createRuntime and the assert). The reader
+ * always awaits next(), so the close rejection is handled by its catch rather
+ * than surfacing as an unhandled rejection.
+ * @returns {{ next: () => Promise, onClose: () => void }}
+ */
+function createIdleNext() {
+  let closeReject;
+  const idle = new Promise((_, reject) => { closeReject = reject; });
+  return {
+    next: () => idle,
+    onClose: () => closeReject(new Error('runtime closed')),
+  };
+}
+
+/**
  * Create a query factory whose runtimes have getContextUsage() and setModel().
  * The runtime's currentModel is set from options.model at creation time.
  * Also stores modelId to track [1m] suffix state for context window changes.
@@ -16,6 +35,7 @@ function createContextAwareQueryFactory(contextUsageResult = { totalTokens: 1000
     queryFn({ prompt, options }) {
       // Set currentModel from options.model (matches SDK behavior)
       // Also store the original modelId for [1m] suffix tracking
+      const idle = createIdleNext();
       const runtime = {
         prompt,
         options,
@@ -30,10 +50,9 @@ function createContextAwareQueryFactory(contextUsageResult = { totalTokens: 1000
         getContextUsage: async () => contextUsageResult,
         close() {
           this.closed = true;
+          idle.onClose();
         },
-        async next() {
-          return { done: true, value: undefined };
-        }
+        next: idle.next
       };
       runtimes.push(runtime);
       return runtime;
@@ -212,6 +231,7 @@ test('getContextUsagePersistent throws when getContextUsage is not available', a
   // Create a factory WITHOUT getContextUsage on the runtime
   const factory = {
     queryFn({ prompt, options }) {
+      const idle = createIdleNext();
       return {
         prompt,
         options,
@@ -219,8 +239,8 @@ test('getContextUsagePersistent throws when getContextUsage is not available', a
         setPermissionMode: async () => {},
         setModel: async () => {},
         setMaxThinkingTokens: async () => {},
-        close() { this.closed = true; },
-        async next() { return { done: true }; }
+        close() { this.closed = true; idle.onClose(); },
+        next: idle.next
       };
     }
   };
@@ -328,6 +348,7 @@ test('getContextUsagePersistent temporarily disables 1M context when model has n
   const observedValues = [];
   const factory = {
     queryFn({ prompt, options }) {
+      const idle = createIdleNext();
       return {
         prompt,
         options,
@@ -343,10 +364,9 @@ test('getContextUsagePersistent temporarily disables 1M context when model has n
         },
         close() {
           this.closed = true;
+          idle.onClose();
         },
-        async next() {
-          return { done: true, value: undefined };
-        }
+        next: idle.next
       };
     }
   };
@@ -382,6 +402,7 @@ test('getContextUsagePersistent temporarily clears 1M disable override for expli
   const observedValues = [];
   const factory = {
     queryFn({ prompt, options }) {
+      const idle = createIdleNext();
       return {
         prompt,
         options,
@@ -397,10 +418,9 @@ test('getContextUsagePersistent temporarily clears 1M disable override for expli
         },
         close() {
           this.closed = true;
+          idle.onClose();
         },
-        async next() {
-          return { done: true, value: undefined };
-        }
+        next: idle.next
       };
     }
   };

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -39,7 +39,7 @@ import {
   createTurnSink,
   emitTaskEvent,
 } from './runtime-lifecycle.js';
-import { parseTaskNotificationXml, buildTaskNotificationEvent, extractUserMessageTaskNotificationXml } from './task-notification-parser.js';
+import { parseTaskNotificationXml, buildTaskNotificationEvent, extractTaskNotificationXml } from './task-notification-parser.js';
 import {
   SESSION_CLEANUP_INTERVAL_MS,
   clearActiveTurnRuntime,
@@ -314,23 +314,24 @@ _sessionCleanupTimer.unref();
       }
 
       // In-turn task-notification: a background agent that finishes while the
-      // main turn is still live delivers its report as a <task-notification> XML
-      // in the content of a plain user message, not as an SDK event. Synthesize
-      // the task_notification the SDK no longer emits and continue, so the
-      // report reaches the frontend subagent card and the raw XML never leaks
-      // into the [MESSAGE] stream (which would only render as an opaque user
-      // message). The frontend also recovers these from history on its own.
-      const taskNotificationXml = extractUserMessageTaskNotificationXml(msg);
+      // main turn is still live delivers its report as a <task-notification>
+      // XML, either in a plain user message's content or a queued_command
+      // attachment's prompt — not as an SDK event. Synthesize the
+      // task_notification the SDK no longer emits and continue, so the report
+      // reaches the frontend subagent card and the raw XML never leaks into the
+      // [MESSAGE] stream (which would only render as an opaque user message).
+      // The frontend also recovers these from history on its own.
+      const taskNotificationXml = extractTaskNotificationXml(msg);
       if (taskNotificationXml !== null) {
         const parsed = parseTaskNotificationXml(taskNotificationXml);
         const event = buildTaskNotificationEvent(parsed);
         if (event && runtime.sessionId) {
-          console.log('[LIFECYCLE] In-turn task-notification user message for sessionId=' + runtime.sessionId + ', toolUseId=' + parsed.toolUseId + ', status=' + event.status);
+          console.log('[LIFECYCLE] In-turn task-notification message for sessionId=' + runtime.sessionId + ', toolUseId=' + parsed.toolUseId + ', status=' + event.status);
           emitTaskEvent(runtime.sessionId, event);
         } else if (!event) {
-          console.log('[LIFECYCLE] In-turn task-notification user message could not be parsed (no tool_use_id or non-terminal status), consuming silently');
+          console.log('[LIFECYCLE] In-turn task-notification message could not be parsed (no tool_use_id or non-terminal status), consuming silently');
         } else {
-          console.log('[LIFECYCLE] In-turn task-notification user message for anonymous runtime, consuming silently');
+          console.log('[LIFECYCLE] In-turn task-notification message for anonymous runtime, consuming silently');
         }
         continue;
       }

--- a/ai-bridge/services/claude/persistent-query-service.test.mjs
+++ b/ai-bridge/services/claude/persistent-query-service.test.mjs
@@ -22,6 +22,15 @@ function createQueryFactory() {
   return {
     runtimes,
     queryFn({ prompt, options }) {
+      // A real SDK query stream blocks on next() while idle and only ends when
+      // the runtime is torn down. Returning {done:true} immediately makes the
+      // perpetual reader treat the stream as ended out-of-band and evict the
+      // runtime via disposeRuntime - which races acquireRuntime's ownership
+      // check (the runtime can be closed between createRuntime and the assert).
+      // Block on a promise that settles only when close() runs, so the reader
+      // idles like the real SDK between turns.
+      let closeReject;
+      const idle = new Promise((_, reject) => { closeReject = reject; });
       const runtime = {
         prompt,
         options,
@@ -31,9 +40,10 @@ function createQueryFactory() {
         setMaxThinkingTokens: async () => {},
         close() {
           this.closed = true;
+          closeReject(new Error('runtime closed'));
         },
-        async next() {
-          return { done: true, value: undefined };
+        next() {
+          return idle;
         }
       };
       runtimes.push(runtime);
@@ -351,6 +361,9 @@ test('abortCurrentTurn still disposes an active runtime explicitly', async () =>
   await __testing.abortCurrentTurn();
   nextDeferred.reject(new Error('runtime terminated'));
 
-  await assert.rejects(turnPromise, /runtime terminated/);
+  // abortCurrentTurn fails the turnSink with 'Turn aborted' before the reader's
+  // next() rejects, so the turn promise settles on the abort signal rather than
+  // the downstream 'runtime terminated' rejection.
+  await assert.rejects(turnPromise, /Turn aborted/);
   assert.equal(runtime.closed, true);
 });

--- a/ai-bridge/services/claude/runtime-lifecycle.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.js
@@ -1,7 +1,7 @@
 import { AsyncStream } from '../../utils/async-stream.js';
 import { loadClaudeSdk } from '../../utils/sdk-loader.js';
 import { createPreToolUseHook, normalizePermissionMode } from './permission-mode.js';
-import { parseTaskNotificationXml, buildTaskNotificationEvent, extractUserMessageTaskNotificationXml } from './task-notification-parser.js';
+import { parseTaskNotificationXml, buildTaskNotificationEvent, extractTaskNotificationXml } from './task-notification-parser.js';
 import {
   beginRuntimeTurn,
   cleanupStaleAnonymousRuntimes as cleanupAnonymousFromRegistry,
@@ -382,28 +382,29 @@ export function startPerpetualReader(runtime, callbacks) {
             }
           }
           // Recent Claude Code terminates a background Agent by injecting a
-          // <task-notification> XML as the CONTENT of a plain user message in
-          // the main session, not as a queued_command attachment and not as an
-          // SDK task_notification event. The user message carries the agent's
+          // <task-notification> XML into the main session, not as an SDK
+          // task_notification event. The XML arrives as either a plain user
+          // message (content) or a queued_command attachment (prompt); both are
+          // recognized by extractTaskNotificationXml. It carries the agent's
           // full <result> report; inter-turn it is otherwise silently consumed
           // (the frontend only sees it after a reload). Parse the XML and
           // synthesize the task_notification event the SDK no longer emits, so
           // window.onTaskEvent can surface the report without waiting for a
           // reload. (The frontend also recovers these from history on its own —
           // see collectTaskEventsFromMessages — so this is the live fast-path.)
-          const taskNotificationXml = extractUserMessageTaskNotificationXml(msg);
+          const taskNotificationXml = extractTaskNotificationXml(msg);
           if (taskNotificationXml !== null) {
             if (runtime.sessionId) {
               const parsed = parseTaskNotificationXml(taskNotificationXml);
               const event = buildTaskNotificationEvent(parsed);
               if (event) {
-                console.log('[PERPETUAL_READER] Inter-turn task-notification user message for sessionId=' + runtime.sessionId + ', toolUseId=' + parsed.toolUseId + ', status=' + event.status);
+                console.log('[PERPETUAL_READER] Inter-turn task-notification message for sessionId=' + runtime.sessionId + ', toolUseId=' + parsed.toolUseId + ', status=' + event.status);
                 emitTaskEvent(runtime.sessionId, event);
               } else {
-                console.log('[PERPETUAL_READER] Inter-turn task-notification user message could not be parsed (no tool_use_id or non-terminal status), consuming silently');
+                console.log('[PERPETUAL_READER] Inter-turn task-notification message could not be parsed (no tool_use_id or non-terminal status), consuming silently');
               }
             } else {
-              console.log('[PERPETUAL_READER] Inter-turn task-notification user message for anonymous runtime, consuming silently');
+              console.log('[PERPETUAL_READER] Inter-turn task-notification message for anonymous runtime, consuming silently');
             }
           }
           // For other message types during inter-turn, we silently consume

--- a/ai-bridge/services/claude/session-service.js
+++ b/ai-bridge/services/claude/session-service.js
@@ -4,11 +4,11 @@
  */
 
 import { existsSync, createReadStream, mkdirSync, readFileSync, appendFileSync, statSync } from 'fs';
-import { readFile } from 'fs/promises';
 import { dirname } from 'path';
 import { randomUUID } from 'crypto';
 import { createInterface } from 'readline';
 import { getClaudeProjectSessionFilePath } from '../../utils/path-utils.js';
+import { extractTaskNotificationXml } from './task-notification-parser.js';
 
 /**
  * Write a JSON payload as a single stdout line and await the flush.
@@ -102,40 +102,59 @@ export function loadSessionHistory(sessionId, cwd) {
 }
 
 /**
+ * Build the getSessionMessages response payload by reading a JSONL session
+ * file. Exported (not just inlined) so the parse + carrier-rewrite logic is
+ * unit-testable without going through process.stdout: the test only needs a
+ * temp file, not an stdout spy. Returns { success, messages } - empty messages
+ * when the file is missing.
+ */
+export function buildSessionMessagesPayload(sessionFile) {
+  if (!existsSync(sessionFile)) {
+    return { success: true, messages: [] };
+  }
+  const content = readFileSync(sessionFile, 'utf8');
+  const messages = content
+    .split('\n')
+    .filter(line => line.trim())
+    .map(line => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(msg => msg !== null)
+    // A background Agent's terminal report can land as a queued_command
+    // attachment (type:"attachment") rather than a user message. Java's
+    // MessageParser only forwards user/assistant rows, so the attachment row
+    // would be dropped on history reload and the subagent card would stay
+    // stuck on the launch ack text. Re-shape it into a user message whose
+    // content is the task-notification XML - the same shape the user-message
+    // carrier already has - so MessageParser forwards it and the frontend's
+    // collectTaskEventsFromMessages recovers the report. User-message and
+    // non-task-notification attachments pass through unchanged.
+    .flatMap(msg => {
+      if (msg.type === 'attachment' && extractTaskNotificationXml(msg) !== null) {
+        return [{
+          type: 'user',
+          message: { role: 'user', content: extractTaskNotificationXml(msg) },
+        }];
+      }
+      return [msg];
+    });
+
+  return { success: true, messages };
+}
+
+/**
  * Get session history messages.
  * Reads from the ~/.claude/projects/ directory.
+ * Writes the result as a single NDJSON line to stdout.
  */
 export async function getSessionMessages(sessionId, cwd = null) {
   try {
     const sessionFile = resolveSessionFile(sessionId, cwd);
-
-    if (!existsSync(sessionFile)) {
-      await writeJsonResponse({
-        success: true,
-        messages: []
-      });
-      return;
-    }
-
-    // Read the JSONL file
-    const content = await readFile(sessionFile, 'utf8');
-    const messages = content
-      .split('\n')
-      .filter(line => line.trim())
-      .map(line => {
-        try {
-          return JSON.parse(line);
-        } catch {
-          return null;
-        }
-      })
-      .filter(msg => msg !== null);
-
-    await writeJsonResponse({
-      success: true,
-      messages
-    });
-
+    await writeJsonResponse(buildSessionMessagesPayload(sessionFile));
   } catch (error) {
     console.error('[GET_SESSION_ERROR]', error.message);
     await writeJsonResponse({

--- a/ai-bridge/services/claude/session-service.test.mjs
+++ b/ai-bridge/services/claude/session-service.test.mjs
@@ -4,31 +4,74 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { getSessionMessages } from './session-service.js';
+import { buildSessionMessagesPayload } from './session-service.js';
 
-test('getSessionMessages returns an empty history when the session file is missing', async () => {
-  const originalHome = process.env.HOME;
-  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-claude-session-'));
-  const output = [];
-  const originalLog = console.log;
-
-  process.env.HOME = tempHome;
-  console.log = (message) => output.push(message);
+test('buildSessionMessagesPayload returns an empty history when the session file is missing', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-claude-session-'));
   try {
-    await getSessionMessages('missing-session', '/workspace/missing-history');
+    const missing = path.join(tempDir, 'does-not-exist.jsonl');
+    assert.deepEqual(buildSessionMessagesPayload(missing), {
+      success: true,
+      messages: [],
+    });
   } finally {
-    console.log = originalLog;
-    if (originalHome === undefined) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = originalHome;
-    }
-    fs.rmSync(tempHome, { recursive: true, force: true });
+    fs.rmSync(tempDir, { recursive: true, force: true });
   }
+});
 
-  assert.equal(output.length, 1);
-  assert.deepEqual(JSON.parse(output[0]), {
-    success: true,
-    messages: []
-  });
+test('buildSessionMessagesPayload rewrites a queued_command attachment carrier into a user message', () => {
+  // A background Agent's terminal report can land as a queued_command
+  // attachment rather than a user message. Java's MessageParser drops
+  // non-user/assistant rows, so the reader must reshape it into a user message
+  // or the subagent card stays stuck on the launch ack text after a reload.
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-claude-session-'));
+  try {
+    const file = path.join(tempDir, 'session.jsonl');
+    const xml = '<task-notification>\n<tool-use-id>toolu_att</tool-use-id>\n<status>completed</status>\n<result>the report</result>\n</task-notification>';
+    fs.writeFileSync(file, [
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'hi' } }),
+      JSON.stringify({
+        type: 'attachment',
+        attachment: { type: 'queued_command', commandMode: 'task-notification', prompt: xml },
+      }),
+      JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: 'ok' } }),
+    ].join('\n') + '\n');
+
+    const { success, messages } = buildSessionMessagesPayload(file);
+    assert.equal(success, true);
+    // The attachment row is reshaped into a user message carrying the XML, so
+    // it survives MessageParser's user/assistant-only filter and reaches the
+    // frontend's collectTaskEventsFromMessages.
+    assert.equal(messages.length, 3);
+    assert.deepEqual(messages[1], {
+      type: 'user',
+      message: { role: 'user', content: xml },
+    });
+    // User-message and assistant rows pass through unchanged.
+    assert.equal(messages[0].type, 'user');
+    assert.equal(messages[2].type, 'assistant');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('buildSessionMessagesPayload leaves a non-task-notification queued_command attachment untouched', () => {
+  // An enqueued user prompt is also a queued_command attachment but not a
+  // task-notification carrier; it must not be rewritten into a user message.
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-claude-session-'));
+  try {
+    const file = path.join(tempDir, 'session.jsonl');
+    const queuedPrompt = {
+      type: 'attachment',
+      attachment: { type: 'queued_command', commandMode: 'user-prompt', prompt: 'do something' },
+    };
+    fs.writeFileSync(file, JSON.stringify(queuedPrompt) + '\n');
+
+    const { messages } = buildSessionMessagesPayload(file);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].type, 'attachment');
+    assert.equal(messages[0].attachment.commandMode, 'user-prompt');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
 });

--- a/ai-bridge/services/claude/task-notification-parser.js
+++ b/ai-bridge/services/claude/task-notification-parser.js
@@ -2,12 +2,18 @@
  * Parse a Claude Code task-notification XML string.
  *
  * Recent Claude Code terminates a background (run_in_background) Agent by
- * injecting a <task-notification> XML as the content of a plain user message
- * in the main session, NOT by emitting a task_notification SDK event. The
- * <result> tag carries the agent's finalMessage (its full report); the
- * <summary> tag is only a one-liner like `Agent "desc" finished`. Without
- * parsing this XML the frontend subagent card never sees the report and stays
- * stuck on the launch ack text ("Async agent launched successfully.").
+ * injecting a <task-notification> XML into the main session instead of
+ * emitting a task_notification SDK event. The XML's <result> tag carries the
+ * agent's finalMessage (its full report); the <summary> tag is only a one-liner
+ * like `Agent "desc" finished`. Without parsing this XML the frontend subagent
+ * card never sees the report and stays stuck on the launch ack text ("Async
+ * agent launched successfully.").
+ *
+ * The carrier varies by Claude Code version/scene: the XML arrives either as
+ * the content of a plain user message, or wrapped in a queued_command
+ * attachment (attachment.type === 'queued_command', commandMode ===
+ * 'task-notification', XML in attachment.prompt). extractTaskNotificationXml
+ * recognizes both.
  *
  * The XML body is escaped with a minimal escaper (only & < >), so a
  * non-greedy indexOf scan for the closing tag is safe — the escaped report
@@ -37,21 +43,36 @@ export function parseTaskNotificationXml(xml) {
 }
 
 /**
- * If `msg` is a main-session user message whose content carries a
- * <task-notification> XML, return that XML string; otherwise return null. The
- * content may be a plain string or an array of text blocks (Claude Code uses
- * the string form, but both are accepted). Returning null for "not a carrier"
- * lets the caller keep processing a normal user message (in-turn) or silently
- * consume it (inter-turn) without conflating it with an unparseable payload.
+ * If `msg` carries a <task-notification> XML, return that XML string; otherwise
+ * return null. Two carriers are recognized:
+ *  - a main-session user message whose content is the XML (string, or an array
+ *    of text blocks joined);
+ *  - a queued_command attachment (attachment.type === 'queued_command',
+ *    commandMode === 'task-notification') with the XML in attachment.prompt.
+ * Both forms appear in the wild depending on Claude Code version/scene, so the
+ * caller must handle both or the report is lost on one path. Returning null for
+ * "not a carrier" lets the caller keep processing a normal user message
+ * (in-turn) or silently consume it (inter-turn) without conflating it with an
+ * unparseable payload.
  */
-export function extractUserMessageTaskNotificationXml(msg) {
-  if (!msg || msg.type !== 'user') return null;
-  const rawContent = msg.message?.content ?? msg.content;
-  const xml = typeof rawContent === 'string' ? rawContent
-    : (Array.isArray(rawContent)
-      ? rawContent.map((b) => (b && typeof b.text === 'string' ? b.text : '')).join('')
-      : '');
-  return xml.includes('<task-notification') ? xml : null;
+export function extractTaskNotificationXml(msg) {
+  if (!msg) return null;
+  if (msg.type === 'user') {
+    const rawContent = msg.message?.content ?? msg.content;
+    const xml = typeof rawContent === 'string' ? rawContent
+      : (Array.isArray(rawContent)
+        ? rawContent.map((b) => (b && typeof b.text === 'string' ? b.text : '')).join('')
+        : '');
+    return xml.includes('<task-notification') ? xml : null;
+  }
+  if (msg.type === 'attachment'
+    && msg.attachment?.type === 'queued_command'
+    && msg.attachment?.commandMode === 'task-notification'
+    && typeof msg.attachment?.prompt === 'string'
+    && msg.attachment.prompt.includes('<task-notification')) {
+    return msg.attachment.prompt;
+  }
+  return null;
 }
 
 function extractTag(xml, tag) {

--- a/ai-bridge/services/claude/task-notification-parser.test.js
+++ b/ai-bridge/services/claude/task-notification-parser.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { parseTaskNotificationXml, buildTaskNotificationEvent } from './task-notification-parser.js';
+import { parseTaskNotificationXml, buildTaskNotificationEvent, extractTaskNotificationXml } from './task-notification-parser.js';
 
 // Mirrors the user-message content Claude Code injects when a background Agent
 // terminates (built by enqueueAgentNotification). The <result> body is escaped
@@ -130,4 +130,45 @@ test('buildTaskNotificationEvent omits summary when both result and summary are 
   // No summary key at all, so the frontend falls all the way back to the
   // launch ack text rather than rendering an empty report.
   assert.strictEqual('summary' in event, false);
+});
+
+test('extractTaskNotificationXml recognizes a queued_command attachment carrier', () => {
+  // Claude Code sometimes delivers the report as a queued_command attachment
+  // (attachment.commandMode === 'task-notification', XML in attachment.prompt)
+  // rather than a user message. Both carriers must be recognized or the report
+  // is lost on one path.
+  const msg = {
+    type: 'attachment',
+    attachment: { type: 'queued_command', commandMode: 'task-notification', prompt: FULL_XML },
+  };
+  assert.strictEqual(extractTaskNotificationXml(msg), FULL_XML);
+});
+
+test('extractTaskNotificationXml recognizes a user-message carrier', () => {
+  const msg = { type: 'user', message: { role: 'user', content: FULL_XML } };
+  assert.strictEqual(extractTaskNotificationXml(msg), FULL_XML);
+  // Array-of-text-blocks content form is also accepted.
+  const arrayMsg = {
+    type: 'user',
+    message: { role: 'user', content: [{ type: 'text', text: FULL_XML }] },
+  };
+  assert.strictEqual(extractTaskNotificationXml(arrayMsg), FULL_XML);
+});
+
+test('extractTaskNotificationXml rejects non-carriers', () => {
+  // A queued_command that is NOT a task-notification (e.g. an enqueued user
+  // prompt) must not be mistaken for one.
+  assert.strictEqual(extractTaskNotificationXml(null), null);
+  assert.strictEqual(extractTaskNotificationXml({ type: 'assistant', message: { content: 'hi' } }), null);
+  assert.strictEqual(
+    extractTaskNotificationXml({
+      type: 'attachment',
+      attachment: { type: 'queued_command', commandMode: 'user-prompt', prompt: 'do something' },
+    }),
+    null,
+  );
+  assert.strictEqual(
+    extractTaskNotificationXml({ type: 'user', message: { role: 'user', content: 'a normal prompt' } }),
+    null,
+  );
 });

--- a/webview/src/components/StatusPanel/StatusPanel.less
+++ b/webview/src/components/StatusPanel/StatusPanel.less
@@ -496,7 +496,8 @@
 }
 
 .subagent-note-card,
-.subagent-result-card {
+.subagent-result-card,
+.subagent-prompt-card {
   padding: 10px;
   border: 1px solid var(--border-primary);
   border-radius: 7px;

--- a/webview/src/components/StatusPanel/SubagentList.tsx
+++ b/webview/src/components/StatusPanel/SubagentList.tsx
@@ -55,6 +55,7 @@ const SubagentRow = memo(({ subagent, isExpanded, history, canLoad, onToggle, t 
           totalTokens={subagent.totalTokens}
           totalToolUseCount={subagent.totalToolUseCount}
           resultText={subagent.resultText}
+          prompt={subagent.prompt}
           history={history}
           canLoad={canLoad}
         />

--- a/webview/src/components/StatusPanel/SubagentProcessDetails.test.tsx
+++ b/webview/src/components/StatusPanel/SubagentProcessDetails.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import SubagentProcessDetails from './SubagentProcessDetails';
+import type { SubagentHistoryResponse } from '../../types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const history: SubagentHistoryResponse = {
+  success: true,
+  completed: true,
+  messages: [
+    {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'thinking', thinking: 'first reasoning step' }],
+      },
+    },
+  ],
+};
+
+afterEach(() => cleanup());
+
+describe('SubagentProcessDetails', () => {
+  it('renders the prompt section above the thought section', () => {
+    const { container } = render(
+      <SubagentProcessDetails prompt="investigate the bug" history={history} canLoad />,
+    );
+    const sections = Array.from(container.querySelectorAll('.subagent-process-section'));
+    const promptIdx = sections.findIndex((s) => s.querySelector('.subagent-prompt-card'));
+    const thoughtIdx = sections.findIndex((s) => s.textContent?.includes('first reasoning step'));
+    expect(promptIdx).toBeGreaterThanOrEqual(0);
+    expect(thoughtIdx).toBeGreaterThan(promptIdx);
+  });
+
+  it('omits the prompt section when no prompt is provided', () => {
+    const { container } = render(<SubagentProcessDetails history={history} canLoad />);
+    expect(container.querySelector('.subagent-prompt-card')).toBeNull();
+  });
+});

--- a/webview/src/components/StatusPanel/SubagentProcessDetails.tsx
+++ b/webview/src/components/StatusPanel/SubagentProcessDetails.tsx
@@ -10,6 +10,8 @@ interface SubagentProcessDetailsProps {
   totalTokens?: number;
   totalToolUseCount?: number;
   resultText?: string;
+  /** The original prompt the user sent the agent off with (tool_use input.prompt). */
+  prompt?: string;
   history?: SubagentHistoryResponse;
   canLoad: boolean;
 }
@@ -27,6 +29,7 @@ const SubagentProcessDetails = memo(function SubagentProcessDetails({
   totalTokens,
   totalToolUseCount,
   resultText,
+  prompt,
   history,
   canLoad,
 }: SubagentProcessDetailsProps) {
@@ -42,7 +45,8 @@ const SubagentProcessDetails = memo(function SubagentProcessDetails({
   ].filter(Boolean).join(' · ');
   const process = buildSubagentProcessModel(history);
   const finalSummary = firstMeaningfulLine(resultText, t);
-  const hasContent = process.notes.length > 0 || process.readFiles.length > 0 || process.toolCalls.length > 0 || Boolean(finalSummary);
+  const hasPrompt = Boolean(prompt && prompt.trim());
+  const hasContent = hasPrompt || process.notes.length > 0 || process.readFiles.length > 0 || process.toolCalls.length > 0 || Boolean(finalSummary);
 
   return (
     <div className="subagent-details subagent-process-card">
@@ -58,6 +62,16 @@ const SubagentProcessDetails = memo(function SubagentProcessDetails({
 
       {hasContent ? (
         <div className="subagent-process-sections">
+          {hasPrompt && (
+            <section className="subagent-process-section">
+              <div className="subagent-section-heading">
+                <span className="codicon codicon-comment" />
+                {t('subagent.process.prompt')}
+              </div>
+              <div className="subagent-prompt-card">{prompt}</div>
+            </section>
+          )}
+
           {process.notes.length > 0 && (
             <section className="subagent-process-section">
               <div className="subagent-section-heading">

--- a/webview/src/components/StatusPanel/subagentProcess.test.ts
+++ b/webview/src/components/StatusPanel/subagentProcess.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { buildSubagentProcessModel } from './subagentProcess';
+import type { SubagentHistoryResponse } from '../../types';
+
+function assistantMessage(blocks: unknown[]) {
+  return { type: 'assistant', message: { role: 'assistant', content: blocks } };
+}
+
+function userMessage(blocks: unknown[]) {
+  return { type: 'user', message: { role: 'user', content: blocks } };
+}
+
+describe('buildSubagentProcessModel', () => {
+  it('collects assistant thinking blocks into notes, not terminal text output', () => {
+    const history: SubagentHistoryResponse = {
+      success: true,
+      completed: true,
+      messages: [
+        assistantMessage([
+          { type: 'thinking', thinking: 'First reasoning step' },
+        ]),
+        assistantMessage([
+          { type: 'thinking', thinking: 'Second reasoning step' },
+        ]),
+        assistantMessage([
+          // The final assistant text block is the agent's terminal report; it
+          // must not leak into the thought section (which would duplicate the
+          // result section).
+          { type: 'text', text: 'The investigation conclusion' },
+        ]),
+      ],
+    };
+
+    const model = buildSubagentProcessModel(history);
+    expect(model.notes).toEqual(['First reasoning step', 'Second reasoning step']);
+  });
+
+  it('still extracts read files and tool calls alongside notes', () => {
+    const history: SubagentHistoryResponse = {
+      success: true,
+      completed: true,
+      messages: [
+        assistantMessage([
+          { type: 'thinking', thinking: 'Plan first' },
+          { type: 'tool_use', id: 'call-1', name: 'Read', input: { file_path: '/a/b/c/File.java' } },
+          { type: 'tool_use', id: 'call-2', name: 'Grep', input: { pattern: 'foo' } },
+        ]),
+      ],
+    };
+
+    const model = buildSubagentProcessModel(history);
+    expect(model.notes).toEqual(['Plan first']);
+    expect(model.readFiles).toEqual(['/a/b/c/File.java']);
+    expect(model.toolCalls).toEqual([{ id: '0-2', name: 'Grep', detail: 'foo' }]);
+  });
+
+  it('ignores user-message text blocks', () => {
+    const history: SubagentHistoryResponse = {
+      success: true,
+      completed: true,
+      messages: [
+        userMessage([{ type: 'text', text: 'User prompt' }]),
+      ],
+    };
+
+    const model = buildSubagentProcessModel(history);
+    expect(model.notes).toEqual([]);
+  });
+});

--- a/webview/src/components/StatusPanel/subagentProcess.ts
+++ b/webview/src/components/StatusPanel/subagentProcess.ts
@@ -60,8 +60,16 @@ export function buildSubagentProcessModel(history?: SubagentHistoryResponse): Su
     getRawContent(message).forEach((block, blockIndex) => {
       if (!block || typeof block !== 'object') return;
       const item = block as Record<string, any>;
-      if (item.type === 'text' && raw.type === 'assistant' && typeof item.text === 'string' && item.text.trim()) {
-        model.notes.push(item.text.trim());
+      if (item.type === 'thinking'
+        && raw.type === 'assistant'
+        && typeof item.thinking === 'string'
+        && item.thinking.trim()) {
+        // The "thought" section must show the agent's actual reasoning, not
+        // its output. A sidechain transcript's assistant messages carry
+        // thinking blocks throughout and a single final text block with the
+        // terminal report — collecting text here would surface the report in
+        // the thought section, duplicating the result section.
+        model.notes.push(item.thinking.trim());
         return;
       }
       if (item.type !== 'tool_use') return;

--- a/webview/src/components/toolBlocks/AgentGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/AgentGroupBlock.tsx
@@ -212,6 +212,7 @@ const AgentGroupBlock = memo(function AgentGroupBlock({
             totalTokens={(isAsync ? taskEvent?.totalTokens : undefined) ?? agentToolMeta.totalTokens}
             totalToolUseCount={(isAsync ? taskEvent?.totalToolUseCount : undefined) ?? agentToolMeta.totalToolUseCount}
             resultText={(isAsync ? taskEvent?.summary : undefined) ?? extractResultText(result)}
+            prompt={typeof input?.prompt === 'string' ? input.prompt : undefined}
             history={history}
             canLoad={Boolean(currentSessionId)}
           />

--- a/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
+++ b/webview/src/components/toolBlocks/TaskExecutionBlock.tsx
@@ -232,6 +232,7 @@ const TaskExecutionBlock = memo(function TaskExecutionBlock({ name, input, resul
                 totalTokens={detailTokens}
                 totalToolUseCount={detailToolUseCount}
                 resultText={detailResultText}
+                prompt={typeof prompt === 'string' ? prompt : undefined}
                 history={history}
                 canLoad={Boolean(currentSessionId)}
               />

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -1685,6 +1685,7 @@
   "subagent": {
     "process": {
       "title": "Agent process",
+      "prompt": "Prompt",
       "thought": "Thought",
       "filesRead_one": "Read {{count}} file",
       "filesRead_other": "Read {{count}} files",

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -1336,6 +1336,25 @@
     "stopped": "Detenido",
     "progress": "{{completed}} de {{total}} tareas completadas"
   },
+  "subagent": {
+    "process": {
+      "title": "Proceso del agente",
+      "prompt": "Indicación",
+      "thought": "Razonamiento",
+      "filesRead_one": "Leer {{count}} archivo",
+      "filesRead_other": "Leer {{count}} archivos",
+      "otherTools": "Otras herramientas",
+      "result": "Resultado",
+      "showFullOutput": "Ver salida completa",
+      "loading": "Cargando proceso del agente…",
+      "unavailable": "El registro del proceso no está disponible hasta que la sesión tenga un id.",
+      "reportGenerated": "Informe de análisis estructurado generado",
+      "unitMs": "ms",
+      "unitS": "s",
+      "unitTools": "herramientas",
+      "unitTokens": "tokens"
+    }
+  },
   "statusPanel": {
     "todoTab": "Plan",
     "tasksTab": "Tareas",

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -1336,6 +1336,25 @@
     "stopped": "Arrêté",
     "progress": "{{completed}} sur {{total}} tâches terminées"
   },
+  "subagent": {
+    "process": {
+      "title": "Processus de l'agent",
+      "prompt": "Invite",
+      "thought": "Raisonnement",
+      "filesRead_one": "Lire {{count}} fichier",
+      "filesRead_other": "Lire {{count}} fichiers",
+      "otherTools": "Autres outils",
+      "result": "Résultat",
+      "showFullOutput": "Afficher la sortie complète",
+      "loading": "Chargement du processus de l'agent…",
+      "unavailable": "Le journal du processus n'est pas disponible tant que la session n'a pas d'identifiant.",
+      "reportGenerated": "Rapport d'analyse structuré généré",
+      "unitMs": "ms",
+      "unitS": "s",
+      "unitTools": "outils",
+      "unitTokens": "tokens"
+    }
+  },
   "statusPanel": {
     "todoTab": "Plan",
     "tasksTab": "Tâches",

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -1335,6 +1335,25 @@
     "allCompleted": "{{completed}}/{{total}} कार्य पूर्ण",
     "stopped": "रुका हुआ"
   },
+  "subagent": {
+    "process": {
+      "title": "एजेंट प्रक्रिया",
+      "prompt": "प्रॉम्प्ट",
+      "thought": "विचार",
+      "filesRead_one": "{{count}} फ़ाइल पढ़ें",
+      "filesRead_other": "{{count}} फ़ाइलें पढ़ें",
+      "otherTools": "अन्य उपकरण",
+      "result": "परिणाम",
+      "showFullOutput": "पूरा आउटपुट देखें",
+      "loading": "एजेंट प्रक्रिया लोड हो रही है…",
+      "unavailable": "जब तक सत्र का id नहीं है, प्रक्रिया लॉग उपलब्ध नहीं है।",
+      "reportGenerated": "संरचित विश्लेषण रिपोर्ट तैयार की गई",
+      "unitMs": "मि॰से॰",
+      "unitS": "से॰",
+      "unitTools": "उपकरण",
+      "unitTokens": "टोकन"
+    }
+  },
   "statusPanel": {
     "todoTab": "योजना",
     "tasksTab": "कार्य",

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -1341,6 +1341,25 @@
     "stopped": "停止",
     "progress": "{{total}} 件中 {{completed}} 件完了"
   },
+  "subagent": {
+    "process": {
+      "title": "エージェントプロセス",
+      "prompt": "プロンプト",
+      "thought": "思考",
+      "filesRead_one": "{{count}} 件のファイルを読む",
+      "filesRead_other": "{{count}} 件のファイルを読む",
+      "otherTools": "その他ツール",
+      "result": "結果",
+      "showFullOutput": "出力全体を表示",
+      "loading": "エージェントプロセスを読み込み中…",
+      "unavailable": "セッションに id ができるまでプロセスログは利用できません。",
+      "reportGenerated": "構造化分析レポートを生成しました",
+      "unitMs": "ミリ秒",
+      "unitS": "秒",
+      "unitTools": "ツール",
+      "unitTokens": "トークン"
+    }
+  },
   "statusPanel": {
     "todoTab": "計画",
     "tasksTab": "タスク",

--- a/webview/src/i18n/locales/ko.json
+++ b/webview/src/i18n/locales/ko.json
@@ -1431,6 +1431,25 @@
     "allCompleted": "모두 완료 {{completed}}/{{total}} 작업",
     "stopped": "중단됨"
   },
+  "subagent": {
+    "process": {
+      "title": "에이전트 프로세스",
+      "prompt": "프롬프트",
+      "thought": "생각",
+      "filesRead_one": "파일 {{count}}개 읽기",
+      "filesRead_other": "파일 {{count}}개 읽기",
+      "otherTools": "기타 도구",
+      "result": "결과",
+      "showFullOutput": "전체 출력 보기",
+      "loading": "에이전트 프로세스 로드 중…",
+      "unavailable": "세션에 id가 생기기 전까지 프로세스 로그를 사용할 수 없습니다.",
+      "reportGenerated": "구조화된 분석 보고서가 생성됨",
+      "unitMs": "ms",
+      "unitS": "초",
+      "unitTools": "도구",
+      "unitTokens": "토큰"
+    }
+  },
   "statusPanel": {
     "todoTab": "계획",
     "tasksTab": "작업",

--- a/webview/src/i18n/locales/pt-BR.json
+++ b/webview/src/i18n/locales/pt-BR.json
@@ -1486,6 +1486,25 @@
     "allCompleted": "Todas Concluídas {{completed}}/{{total}} tarefas",
     "stopped": "Parado"
   },
+  "subagent": {
+    "process": {
+      "title": "Processo do agente",
+      "prompt": "Prompt",
+      "thought": "Raciocínio",
+      "filesRead_one": "Ler {{count}} arquivo",
+      "filesRead_other": "Ler {{count}} arquivos",
+      "otherTools": "Outras ferramentas",
+      "result": "Resultado",
+      "showFullOutput": "Ver saída completa",
+      "loading": "Carregando processo do agente…",
+      "unavailable": "O log do processo não está disponível até que a sessão tenha um id.",
+      "reportGenerated": "Relatório de análise estruturada gerado",
+      "unitMs": "ms",
+      "unitS": "s",
+      "unitTools": "ferramentas",
+      "unitTokens": "tokens"
+    }
+  },
   "statusPanel": {
     "todoTab": "Plano",
     "tasksTab": "Tarefas",

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -1362,6 +1362,25 @@
     "allCompleted": "Все завершены {{completed}}/{{total}} задач",
     "stopped": "Остановлено"
   },
+  "subagent": {
+    "process": {
+      "title": "Процесс агента",
+      "prompt": "Промпт",
+      "thought": "Размышление",
+      "filesRead_one": "Прочитан {{count}} файл",
+      "filesRead_other": "Прочитано {{count}} файлов",
+      "otherTools": "Другие инструменты",
+      "result": "Результат",
+      "showFullOutput": "Показать полный вывод",
+      "loading": "Загрузка процесса агента…",
+      "unavailable": "Журнал процесса недоступен, пока у сессии нет id.",
+      "reportGenerated": "Сформирован структурированный аналитический отчёт",
+      "unitMs": "мс",
+      "unitS": "с",
+      "unitTools": "инструментов",
+      "unitTokens": "токенов"
+    }
+  },
   "statusPanel": {
     "todoTab": "План",
     "tasksTab": "Задачи",

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -1341,6 +1341,25 @@
     "stopped": "已停止",
     "progress": "已完成 {{completed}}/{{total}} 個任務"
   },
+  "subagent": {
+    "process": {
+      "title": "Agent 程序",
+      "prompt": "提示詞",
+      "thought": "思考",
+      "filesRead_one": "讀取 {{count}} 個檔案",
+      "filesRead_other": "讀取 {{count}} 個檔案",
+      "otherTools": "其他工具",
+      "result": "結果",
+      "showFullOutput": "檢視完整輸出",
+      "loading": "正在載入 Agent 程序…",
+      "unavailable": "本次工作階段未產生程序記錄（需要工作階段 ID）。",
+      "reportGenerated": "已產生結構化分析報告",
+      "unitMs": "毫秒",
+      "unitS": "秒",
+      "unitTools": "個工具",
+      "unitTokens": "tokens"
+    }
+  },
   "statusPanel": {
     "todoTab": "計畫",
     "tasksTab": "任務",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -1690,6 +1690,7 @@
   "subagent": {
     "process": {
       "title": "Agent 进程",
+      "prompt": "提示词",
       "thought": "思考",
       "filesRead_one": "读取 {{count}} 个文件",
       "filesRead_other": "读取 {{count}} 个文件",


### PR DESCRIPTION
## Summary

A background Agent's terminal report lands as `<task-notification>` XML in either a plain user message or a `queued_command` attachment (commandMode `task-notification`), depending on the Claude Code version. The reader only saw the user-message form, so attachment-carried reports never surfaced — the subagent card stayed stuck on the launch ack text. The thought section also collected assistant text blocks (the sidechain's terminal report) into notes, duplicating the result section, and the card never showed the task brief that kicked the agent off.

## Changes

### Report delivery (ai-bridge)

- `extractTaskNotificationXml` recognizes both carriers in the in-turn and inter-turn interception paths.
- Session-history replay reshapes attachment rows into user messages so Java's `MessageParser` forwards them to the frontend's `collectTaskEventsFromMessages`.

### Thought section (webview)

- `buildSubagentProcessModel` collects `thinking` blocks instead of assistant `text` blocks, so the thought section shows the agent's actual reasoning, not its terminal report.

### Task brief (webview)

- `SubagentProcessDetails` shows the agent's original prompt (tool_use `input.prompt`) above the thought section; `TaskExecutionBlock`, `AgentGroupBlock` and `SubagentList` pass it through.
- `subagent.process.prompt` is translated across all 10 locales, filling in the rest of the `subagent.process` block for the eight locales that previously fell back to English.

### Tests

- New coverage: task-notification dual-carrier parsing, session-history carrier rewrite, `buildSubagentProcessModel` notes/read-files/tool-calls, and prompt placement in `SubagentProcessDetails`.
- Heal the pre-existing `persistent-query-service` tests: their mock `next()` reported stream-end immediately, which made the perpetual reader evict the runtime and race `acquireRuntime`'s ownership check. The mock now idles like the real SDK until `close()`, and the abort test asserts the actual `'Turn aborted'` signal.