### PR TITLE
fix: offload Node.js auto-detection off the EDT to prevent IDE freeze

### DIFF
--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -187,23 +187,33 @@ public class ChatWindowDelegate {
                 claudeSDKBridge.verifyAndCacheNodePath(path);
                 LOG.info("Using manually configured Node.js path: " + path);
             } else {
-                LOG.info("No saved Node.js path found, attempting auto-detection...");
-                com.github.claudecodegui.model.NodeDetectionResult detected =
-                    claudeSDKBridge.detectNodeWithDetails();
+                // Auto-detection spawns shell processes which block the calling thread for several
+                // seconds per attempt. Running this on the EDT freezes the entire IDE. Offload to
+                // a pooled thread; the bridges fall back to invoking "node" by name until the
+                // detection completes and updates them.
+                LOG.info("No saved Node.js path found, scheduling auto-detection on background thread...");
+                ApplicationManager.getApplication().executeOnPooledThread(() -> {
+                    try {
+                        com.github.claudecodegui.model.NodeDetectionResult detected =
+                            claudeSDKBridge.detectNodeWithDetails();
 
-                if (detected != null && detected.isFound() && detected.getNodePath() != null) {
-                    String detectedPath = detected.getNodePath();
-                    String detectedVersion = detected.getNodeVersion();
+                        if (detected != null && detected.isFound() && detected.getNodePath() != null) {
+                            String detectedPath = detected.getNodePath();
+                            String detectedVersion = detected.getNodeVersion();
 
-                    props.setValue(NODE_PATH_PROPERTY_KEY, detectedPath);
-                    applyNodePathToBridges(detectedPath);
-                    claudeSDKBridge.verifyAndCacheNodePath(detectedPath);
+                            props.setValue(NODE_PATH_PROPERTY_KEY, detectedPath);
+                            applyNodePathToBridges(detectedPath);
+                            claudeSDKBridge.verifyAndCacheNodePath(detectedPath);
 
-                    LOG.info("Auto-detected Node.js: " + detectedPath + " (" + detectedVersion + ")");
-                } else {
-                    LOG.warn("Failed to auto-detect Node.js path. Error: " +
-                        (detected != null ? detected.getErrorMessage() : "Unknown error"));
-                }
+                            LOG.info("Auto-detected Node.js: " + detectedPath + " (" + detectedVersion + ")");
+                        } else {
+                            LOG.warn("Failed to auto-detect Node.js path. Error: " +
+                                (detected != null ? detected.getErrorMessage() : "Unknown error"));
+                        }
+                    } catch (Exception e) {
+                        LOG.error("Failed to auto-detect Node.js path: " + e.getMessage(), e);
+                    }
+                });
             }
         } catch (Exception e) {
             LOG.error("Failed to load Node.js path: " + e.getMessage(), e);


### PR DESCRIPTION
I'm running CLion and CC-GUI in a virtual environment (a docker container).  When I try to start cc-gui it hangs CLion.  I asked claude to look at the problem, and it came up with this fix, which seems to work on my machine, anyway.  Here is Claude's explanation:

detectNodeWithDetails() spawns multiple shell processes (zsh/bash which, known paths, fallback) each with a 5-second waitFor. Calling this synchronously from the ClaudeChatWindow constructor on the EDT freezes the entire IDE until all probes time out — permanently in VM environments where the subprocesses hang rather than exit.

Moves the auto-detection branch to executeOnPooledThread. The bridges fall back to invoking "node" by name until detection completes. The fast path (saved node path already configured) is unchanged and stays synchronous.