### PR TITLE
fix(claude): stabilize rewinds, diagnostics, and long sessions

### DIFF
--- a/ai-bridge/services/claude/conversation-chain.js
+++ b/ai-bridge/services/claude/conversation-chain.js
@@ -74,7 +74,8 @@ export function selectConversationChain(entries) {
   if (chain.length === 0) {
     return entries;
   }
-  return recoverOrphanedParallelToolResults(byUuid, chain);
+  const chainWithAttachments = recoverOrphanedTerminalAttachments(byUuid, chain);
+  return recoverOrphanedParallelToolResults(byUuid, chainWithAttachments);
 }
 
 /**
@@ -83,24 +84,20 @@ export function selectConversationChain(entries) {
  * chain). The newest non-sidechain leaf is the tip of the live branch;
  * leaves of rewound branches are older by timestamp.
  *
- * When every leaf is a sidechain tail (the main branch ended in a
- * subagent call), sidechain rows are excluded and leaves are recomputed
- * so the main branch still resolves instead of degrading to line order.
+ * Sidechain rows are excluded before computing leaves so their main-thread
+ * parents remain candidates even when a subagent call is the newest row.
  */
 function selectNewestLeaf(byUuid) {
-  let tip = newestNonSidechainLeaf(byUuid, byUuid);
-  if (!tip) {
-    const mainThread = new Map();
-    for (const entry of byUuid.values()) {
-      if (!entry.isSidechain) {
-        mainThread.set(entry.uuid, entry);
-      }
-    }
-    if (mainThread.size > 0 && mainThread.size < byUuid.size) {
-      tip = newestNonSidechainLeaf(byUuid, mainThread);
+  // A sidechain child hides its main-thread parent from the full graph's
+  // leaf set. Exclude sidechains before finding leaves so a dead main branch
+  // cannot win merely because the live branch ends in a sidechain row.
+  const mainThread = new Map();
+  for (const entry of byUuid.values()) {
+    if (!entry.isSidechain) {
+      mainThread.set(entry.uuid, entry);
     }
   }
-  return tip;
+  return newestNonSidechainLeaf(byUuid, mainThread) ?? newestNonSidechainLeaf(byUuid, byUuid);
 }
 
 function newestNonSidechainLeaf(byUuid, graph) {
@@ -161,6 +158,37 @@ function walkParentChain(byUuid, tip) {
   }
   chain.reverse();
   return chain;
+}
+
+/**
+ * Recover terminal attachment rows that parent directly to the selected
+ * message. They are leaves in the JSONL graph, but their payload still
+ * belongs to the live turn and must reach the session-history transformer.
+ */
+function recoverOrphanedTerminalAttachments(byUuid, chain) {
+  const tip = chain[chain.length - 1];
+  if (!tip) {
+    return chain;
+  }
+
+  const onChain = new Set(chain.map((entry) => entry.uuid));
+  const attachments = [];
+  for (const entry of byUuid.values()) {
+    if (
+      entry.type === 'attachment' &&
+      !entry.isSidechain &&
+      !onChain.has(entry.uuid) &&
+      entry.parentUuid === tip.uuid
+    ) {
+      attachments.push(entry);
+    }
+  }
+  if (attachments.length === 0) {
+    return chain;
+  }
+
+  byTimestamp(attachments);
+  return [...chain, ...attachments];
 }
 
 /**

--- a/ai-bridge/services/claude/conversation-chain.js
+++ b/ai-bridge/services/claude/conversation-chain.js
@@ -1,0 +1,264 @@
+/**
+ * Effective-chain selection for Claude session JSONL transcripts.
+ *
+ * The CLI never deletes rewound messages from the transcript. Rewinding
+ * forks the conversation in place: subsequent messages get parentUuid
+ * pointing past the rewound span, so the discarded branch stays on disk
+ * as a dead chain. Reading the file line-by-line renders those dead
+ * branches as if they were live conversation.
+ *
+ * Mirrors Claude Code's loadMessagesFromJsonlPath + buildConversationChain:
+ * pick the newest non-sidechain leaf, walk parentUuid back to the root,
+ * then recover parallel-tool siblings the single-parent walk orphans
+ * (N parallel tool_uses stream as N assistant rows sharing one message.id;
+ * the parentUuid chain keeps only one branch of that DAG).
+ */
+
+/**
+ * Select the messages that form the effective conversation.
+ * @param {Array<any>} entries parsed JSONL entries in file order
+ * @returns {Array<any>} chain messages in conversation order; line order
+ *   when the transcript carries no parentUuid fields at all (the plugin's
+ *   direct-API fallback writer omits them, and chain-walking such a file
+ *   would collapse every message into isolated leaves)
+ */
+export function selectConversationChain(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return entries ?? [];
+  }
+
+  const byUuid = new Map();
+  for (const entry of entries) {
+    if (entry && typeof entry.uuid === 'string') {
+      byUuid.set(entry.uuid, entry);
+    }
+  }
+  if (byUuid.size === 0) {
+    return entries;
+  }
+
+  // The CLI writes parentUuid on every row (null for the root). If no row
+  // carries the field, this transcript was not written by the chain model
+  // and line order is the only meaningful order.
+  let hasParentField = false;
+  for (const entry of byUuid.values()) {
+    if ('parentUuid' in entry) {
+      hasParentField = true;
+      break;
+    }
+  }
+  if (!hasParentField) {
+    return entries;
+  }
+
+  // A row can lack the parentUuid KEY entirely: SDK-written roots, and rows
+  // the plugin's direct-API fallback appends to a CLI-written file. An
+  // explicit null stays a root (session start, compact boundary); a missing
+  // key inherits the previous uuid-carrying row as its parent so a hybrid
+  // transcript keeps its line-order continuity instead of collapsing the
+  // walk at the first such row.
+  let prevUuid = null;
+  for (const entry of byUuid.values()) {
+    if (!('parentUuid' in entry) && prevUuid !== null) {
+      byUuid.set(entry.uuid, { ...entry, parentUuid: prevUuid });
+    }
+    prevUuid = entry.uuid;
+  }
+
+  const leaf = selectNewestLeaf(byUuid);
+  if (!leaf) {
+    return entries;
+  }
+
+  const chain = walkParentChain(byUuid, leaf);
+  if (chain.length === 0) {
+    return entries;
+  }
+  return recoverOrphanedParallelToolResults(byUuid, chain);
+}
+
+/**
+ * A leaf is the nearest user/assistant ancestor of any childless message
+ * (attachments can trail a user/assistant message without continuing the
+ * chain). The newest non-sidechain leaf is the tip of the live branch;
+ * leaves of rewound branches are older by timestamp.
+ *
+ * When every leaf is a sidechain tail (the main branch ended in a
+ * subagent call), sidechain rows are excluded and leaves are recomputed
+ * so the main branch still resolves instead of degrading to line order.
+ */
+function selectNewestLeaf(byUuid) {
+  let tip = newestNonSidechainLeaf(byUuid, byUuid);
+  if (!tip) {
+    const mainThread = new Map();
+    for (const entry of byUuid.values()) {
+      if (!entry.isSidechain) {
+        mainThread.set(entry.uuid, entry);
+      }
+    }
+    if (mainThread.size > 0 && mainThread.size < byUuid.size) {
+      tip = newestNonSidechainLeaf(byUuid, mainThread);
+    }
+  }
+  return tip;
+}
+
+function newestNonSidechainLeaf(byUuid, graph) {
+  const parentUuids = new Set();
+  for (const entry of graph.values()) {
+    if (entry.parentUuid) {
+      parentUuids.add(entry.parentUuid);
+    }
+  }
+
+  const leafUuids = new Set();
+  for (const entry of graph.values()) {
+    if (parentUuids.has(entry.uuid)) {
+      continue;
+    }
+    let current = entry;
+    const seen = new Set();
+    while (current) {
+      if (seen.has(current.uuid)) {
+        break;
+      }
+      seen.add(current.uuid);
+      if (current.type === 'user' || current.type === 'assistant') {
+        leafUuids.add(current.uuid);
+        break;
+      }
+      current = current.parentUuid ? byUuid.get(current.parentUuid) : null;
+    }
+  }
+
+  let tip = null;
+  let tipTime = 0;
+  for (const uuid of leafUuids) {
+    const entry = byUuid.get(uuid);
+    if (entry.isSidechain) {
+      continue;
+    }
+    const time = Date.parse(entry.timestamp ?? '') || 0;
+    if (time > tipTime) {
+      tipTime = time;
+      tip = entry;
+    }
+  }
+  return tip;
+}
+
+function walkParentChain(byUuid, tip) {
+  const chain = [];
+  const seen = new Set();
+  let current = tip;
+  while (current) {
+    if (seen.has(current.uuid)) {
+      break;
+    }
+    seen.add(current.uuid);
+    chain.push(current);
+    current = current.parentUuid ? byUuid.get(current.parentUuid) : null;
+  }
+  chain.reverse();
+  return chain;
+}
+
+/**
+ * Post-pass for walkParentChain: recover sibling assistant rows and tool
+ * results that the single-parent walk orphaned. Siblings share message.id
+ * with an on-chain assistant; tool results attach to their source
+ * assistant via parentUuid. Both are spliced right after the last
+ * on-chain member of their sibling group so the group stays contiguous.
+ */
+function recoverOrphanedParallelToolResults(byUuid, chain) {
+  const onChain = new Set(chain.map((entry) => entry.uuid));
+  const chainAssistants = chain.filter(
+    (entry) => entry.type === 'assistant' && entry.message && entry.message.id
+  );
+  if (chainAssistants.length === 0) {
+    return chain;
+  }
+
+  const siblingsByMsgId = new Map();
+  const toolResultsByAsst = new Map();
+  for (const entry of byUuid.values()) {
+    if (entry.type === 'assistant' && entry.message && entry.message.id) {
+      const group = siblingsByMsgId.get(entry.message.id);
+      if (group) {
+        group.push(entry);
+      } else {
+        siblingsByMsgId.set(entry.message.id, [entry]);
+      }
+    } else if (
+      entry.type === 'user' &&
+      entry.parentUuid &&
+      Array.isArray(entry.message && entry.message.content) &&
+      entry.message.content.some((block) => block && block.type === 'tool_result')
+    ) {
+      const group = toolResultsByAsst.get(entry.parentUuid);
+      if (group) {
+        group.push(entry);
+      } else {
+        toolResultsByAsst.set(entry.parentUuid, [entry]);
+      }
+    }
+  }
+
+  // Anchor = last on-chain member of each sibling group, so the group stays
+  // contiguous and every recovered tool result lands after its tool_use.
+  const anchorByMsgId = new Map();
+  for (const assistant of chainAssistants) {
+    anchorByMsgId.set(assistant.message.id, assistant);
+  }
+
+  const inserts = new Map();
+  for (const assistant of chainAssistants) {
+    const msgId = assistant.message.id;
+    const anchor = anchorByMsgId.get(msgId);
+    if (anchor !== assistant) {
+      continue;
+    }
+
+    const group = siblingsByMsgId.get(msgId) ?? [assistant];
+    const orphanedSiblings = group.filter((sibling) => !onChain.has(sibling.uuid));
+    const orphanedToolResults = [];
+    for (const member of group) {
+      for (const toolResult of toolResultsByAsst.get(member.uuid) ?? []) {
+        if (!onChain.has(toolResult.uuid)) {
+          orphanedToolResults.push(toolResult);
+        }
+      }
+    }
+    if (orphanedSiblings.length === 0 && orphanedToolResults.length === 0) {
+      continue;
+    }
+
+    byTimestamp(orphanedSiblings);
+    byTimestamp(orphanedToolResults);
+    inserts.set(assistant.uuid, [...orphanedSiblings, ...orphanedToolResults]);
+  }
+
+  if (inserts.size === 0) {
+    return chain;
+  }
+
+  const result = [];
+  for (const entry of chain) {
+    result.push(entry);
+    const toInsert = inserts.get(entry.uuid);
+    if (toInsert) {
+      result.push(...toInsert);
+    }
+  }
+  return result;
+}
+
+// Stable timestamp sort keeps content-block order; equal timestamps (same
+// streamed second) fall back to file order because byUuid preserves it.
+function byTimestamp(entries) {
+  entries.sort((a, b) => {
+    const ta = Date.parse(a.timestamp ?? '') || 0;
+    const tb = Date.parse(b.timestamp ?? '') || 0;
+    return ta - tb;
+  });
+}

--- a/ai-bridge/services/claude/conversation-chain.test.mjs
+++ b/ai-bridge/services/claude/conversation-chain.test.mjs
@@ -205,6 +205,34 @@ test('ignores sidechain leaves when picking the chain tip', () => {
   assert.deepEqual(chainTexts(chain), ['main', 'main answer']);
 });
 
+test('prefers the live main branch when it ends with a sidechain entry', () => {
+  const firstQuestion = userEntry(null, 'first question', '2026-01-01T10:00:00Z');
+  const firstAnswer = assistantEntry(firstQuestion.uuid, 'first answer', '2026-01-01T10:00:01Z', 'm1');
+  const deadQuestion = userEntry(firstAnswer.uuid, 'dead question', '2026-01-01T10:00:02Z');
+  const deadAnswer = assistantEntry(deadQuestion.uuid, 'dead answer', '2026-01-01T10:00:03Z', 'm-dead');
+  const liveQuestion = userEntry(firstAnswer.uuid, 'live question', '2026-01-01T10:00:04Z');
+  const liveAnswer = assistantEntry(liveQuestion.uuid, 'live answer', '2026-01-01T10:00:05Z', 'm-live');
+  const sidechainAnswer = {
+    type: 'assistant',
+    uuid: uuid('a'),
+    parentUuid: liveAnswer.uuid,
+    isSidechain: true,
+    timestamp: '2026-01-01T10:00:06Z',
+    message: { id: 'm-side', role: 'assistant', content: [{ type: 'text', text: 'sidechain answer' }] },
+  };
+
+  const chain = selectConversationChain([
+    firstQuestion,
+    firstAnswer,
+    deadQuestion,
+    deadAnswer,
+    liveQuestion,
+    liveAnswer,
+    sidechainAnswer,
+  ]);
+  assert.deepEqual(chainTexts(chain), ['first question', 'first answer', 'live question', 'live answer']);
+});
+
 test('stops walking at a parentUuid cycle instead of looping forever', () => {
   const question = userEntry(null, 'first', '2026-01-01T10:00:00Z');
   const answer = assistantEntry(question.uuid, 'answer', '2026-01-01T10:00:05Z', 'm1');

--- a/ai-bridge/services/claude/conversation-chain.test.mjs
+++ b/ai-bridge/services/claude/conversation-chain.test.mjs
@@ -1,0 +1,226 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { selectConversationChain } from './conversation-chain.js';
+
+let uuidCounter = 0;
+function uuid(prefix) {
+  uuidCounter += 1;
+  return `${prefix}-${String(uuidCounter).padStart(4, '0')}`;
+}
+
+function userEntry(parentUuid, text, timestamp) {
+  return {
+    type: 'user',
+    uuid: uuid('u'),
+    parentUuid,
+    timestamp,
+    message: { role: 'user', content: text },
+  };
+}
+
+function assistantEntry(parentUuid, text, timestamp, messageId) {
+  return {
+    type: 'assistant',
+    uuid: uuid('a'),
+    parentUuid,
+    timestamp,
+    message: { id: messageId, role: 'assistant', content: [{ type: 'text', text }] },
+  };
+}
+
+function chainTexts(chain) {
+  return chain.map((entry) => {
+    const content = entry.message.content;
+    if (typeof content === 'string') {
+      return content;
+    }
+    return content[0].type === 'tool_result' ? 'tool_result' : content[0].text;
+  });
+}
+
+test('drops the rewound branch and keeps the forked continuation', () => {
+  // Rewind forks in place: after rewinding to u1's answer, the next user
+  // message parents onto a1, leaving the old u2/a2 branch dead on disk.
+  const first = userEntry(null, 'first', '2026-01-01T10:00:00Z');
+  const answerOne = assistantEntry(first.uuid, 'answer one', '2026-01-01T10:00:05Z', 'm1');
+  const rewoundQuestion = userEntry(answerOne.uuid, 'second (rewound)', '2026-01-01T10:01:00Z');
+  const rewoundAnswer = assistantEntry(rewoundQuestion.uuid, 'answer two (rewound)', '2026-01-01T10:01:05Z', 'm2');
+  const retry = userEntry(answerOne.uuid, 'second retry', '2026-01-01T10:02:00Z');
+  const retryAnswer = assistantEntry(retry.uuid, 'answer retry', '2026-01-01T10:02:05Z', 'm3');
+
+  const chain = selectConversationChain([
+    first, answerOne, rewoundQuestion, rewoundAnswer, retry, retryAnswer,
+  ]);
+  assert.deepEqual(chainTexts(chain), ['first', 'answer one', 'second retry', 'answer retry']);
+});
+
+test('keeps attachments that hang off the live chain and drops rewound ones', () => {
+  const first = userEntry(null, 'first', '2026-01-01T10:00:00Z');
+  const liveAttachment = {
+    type: 'attachment',
+    uuid: uuid('att'),
+    parentUuid: first.uuid,
+    timestamp: '2026-01-01T10:00:01Z',
+    attachment: { type: 'file' },
+  };
+  const answerOne = assistantEntry(liveAttachment.uuid, 'answer one', '2026-01-01T10:00:05Z', 'm1');
+  const rewound = userEntry(answerOne.uuid, 'rewound', '2026-01-01T10:01:00Z');
+  const rewoundAttachment = {
+    type: 'attachment',
+    uuid: uuid('att'),
+    parentUuid: rewound.uuid,
+    timestamp: '2026-01-01T10:01:01Z',
+    attachment: { type: 'file' },
+  };
+  const retry = userEntry(answerOne.uuid, 'retry', '2026-01-01T10:02:00Z');
+
+  const chain = selectConversationChain([
+    first, liveAttachment, answerOne, rewound, rewoundAttachment, retry,
+  ]);
+  assert.deepEqual(chain.map((entry) => entry.type), [
+    'user',
+    'attachment',
+    'assistant',
+    'user',
+  ]);
+});
+
+test('recovers parallel tool_use siblings and their tool results', () => {
+  // N parallel tool_uses stream as N assistant rows sharing one message.id;
+  // the parentUuid chain keeps only one, the recovery pass must splice the
+  // siblings and their tool results back in after the on-chain anchor.
+  const question = userEntry(null, 'run both', '2026-01-01T10:00:00Z');
+  const toolA = assistantEntry(question.uuid, 'tool A', '2026-01-01T10:00:01Z', 'msg-shared');
+  const toolB = {
+    type: 'assistant',
+    uuid: uuid('a'),
+    parentUuid: toolA.uuid,
+    timestamp: '2026-01-01T10:00:01Z',
+    message: { id: 'msg-shared', role: 'assistant', content: [{ type: 'text', text: 'tool B' }] },
+  };
+  const resultA = {
+    type: 'user',
+    uuid: uuid('u'),
+    parentUuid: toolB.uuid,
+    timestamp: '2026-01-01T10:00:02Z',
+    message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1' }] },
+  };
+  const resultB = {
+    type: 'user',
+    uuid: uuid('u'),
+    parentUuid: toolA.uuid,
+    timestamp: '2026-01-01T10:00:02Z',
+    message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't2' }] },
+  };
+  const done = assistantEntry(resultA.uuid, 'done', '2026-01-01T10:00:05Z', 'm-final');
+
+  const chain = selectConversationChain([
+    question, toolA, toolB, resultA, resultB, done,
+  ]);
+  assert.deepEqual(chainTexts(chain), [
+    'run both',
+    'tool A',
+    'tool B',
+    'tool_result',
+    'tool_result',
+    'done',
+  ]);
+});
+
+test('falls back to line order when no row carries parentUuid', () => {
+  // The plugin's direct-API fallback writer omits parentUuid entirely;
+  // chain-walking such a file would collapse every message into isolated
+  // leaves, so line order must win.
+  const entries = [
+    { type: 'user', uuid: uuid('u'), timestamp: '2026-01-01T10:00:00Z', message: { role: 'user', content: 'one' } },
+    { type: 'assistant', uuid: uuid('a'), timestamp: '2026-01-01T10:00:05Z', message: { role: 'assistant', content: 'two' } },
+    { type: 'user', uuid: uuid('u'), timestamp: '2026-01-01T10:01:00Z', message: { role: 'user', content: 'three' } },
+  ];
+
+  const chain = selectConversationChain(entries);
+  assert.equal(chain.length, 3);
+  assert.deepEqual(chainTexts(chain), ['one', 'two', 'three']);
+});
+
+test('chains through rows appended without the parentUuid key', () => {
+  // A hybrid transcript: CLI rows carry parentUuid, then the plugin's
+  // direct-API fallback appends rows with uuid but no parentUuid key. The
+  // walk must inherit the previous row as the implicit parent instead of
+  // stopping at the first such row and dropping all prior history. An
+  // explicit null (compact boundary / true root written by the CLI) stays
+  // a root.
+  const root = userEntry(null, 'root', '2026-01-01T10:00:00Z');
+  const answer = assistantEntry(root.uuid, 'answer', '2026-01-01T10:00:05Z', 'm1');
+  const fallbackUser = {
+    type: 'user',
+    uuid: uuid('u'),
+    timestamp: '2026-01-01T10:01:00Z',
+    message: { role: 'user', content: 'appended without the key' },
+  };
+  const fallbackAssistant = {
+    type: 'assistant',
+    uuid: uuid('a'),
+    timestamp: '2026-01-01T10:01:05Z',
+    message: { id: 'm2', role: 'assistant', content: [{ type: 'text', text: 'fallback answer' }] },
+  };
+
+  const chain = selectConversationChain([root, answer, fallbackUser, fallbackAssistant]);
+  assert.deepEqual(chainTexts(chain), ['root', 'answer', 'appended without the key', 'fallback answer']);
+});
+
+test('stops at a compact boundary root despite pre-compact rows above it', () => {
+  // Compaction writes a system compact_boundary row with parentUuid null;
+  // post-compact rows chain to it. The walk must stop at the boundary so
+  // the stale pre-compact span stays excluded.
+  const staleUser = userEntry(null, 'stale pre-compact', '2026-01-01T09:00:00Z');
+  const boundary = {
+    type: 'system',
+    subtype: 'compact_boundary',
+    uuid: uuid('sys'),
+    parentUuid: null,
+    timestamp: '2026-01-01T10:00:00Z',
+  };
+  const freshUser = userEntry(boundary.uuid, 'post-compact', '2026-01-01T10:01:00Z');
+
+  const chain = selectConversationChain([staleUser, boundary, freshUser]);
+  // The boundary row itself stays on the chain (system rows are filtered
+  // downstream); the stale pre-compact span must not.
+  assert.deepEqual(chain.map((entry) => entry.uuid), [boundary.uuid, freshUser.uuid]);
+});
+
+test('ignores sidechain leaves when picking the chain tip', () => {
+  const question = userEntry(null, 'main', '2026-01-01T10:00:00Z');
+  const answer = assistantEntry(question.uuid, 'main answer', '2026-01-01T10:00:05Z', 'm1');
+  const sidechainTail = {
+    type: 'assistant',
+    uuid: uuid('a'),
+    parentUuid: answer.uuid,
+    isSidechain: true,
+    timestamp: '2026-01-01T11:00:00Z',
+    message: { id: 'm-side', role: 'assistant', content: [{ type: 'text', text: 'sidechain tail' }] },
+  };
+
+  const chain = selectConversationChain([question, answer, sidechainTail]);
+  assert.deepEqual(chainTexts(chain), ['main', 'main answer']);
+});
+
+test('stops walking at a parentUuid cycle instead of looping forever', () => {
+  const question = userEntry(null, 'first', '2026-01-01T10:00:00Z');
+  const answer = assistantEntry(question.uuid, 'answer', '2026-01-01T10:00:05Z', 'm1');
+  // Self-referencing parentUuid: the walk must terminate, not hang.
+  answer.parentUuid = answer.uuid;
+
+  const chain = selectConversationChain([question, answer]);
+  assert.ok(chain.length > 0);
+  assert.ok(chain.length <= 2);
+});
+
+test('returns line order for empty or uuid-less input', () => {
+  assert.deepEqual(selectConversationChain([]), []);
+  const entries = [
+    { type: 'user', message: { role: 'user', content: 'no uuid here' } },
+    { type: 'file-history-snapshot', snapshot: {} },
+  ];
+  assert.equal(selectConversationChain(entries).length, 2);
+});

--- a/ai-bridge/services/claude/message-rewind.child.mjs
+++ b/ai-bridge/services/claude/message-rewind.child.mjs
@@ -59,4 +59,16 @@ const markerThenReal = await runCandidateResolution([
 assert.ok(markerThenReal.includes('real-3'), 'message after the marker must be picked');
 assert.ok(!markerThenReal.includes('interrupted-1'));
 
+// Rewind forks the transcript in place: rewound user rows stay on disk but
+// the live branch parented past them. Their ids must not become anchors.
+const rewoundFork = await runCandidateResolution([
+  { type: 'user', uuid: 'root-1', parentUuid: null, timestamp: '2026-01-01T10:00:00Z', message: { role: 'user', content: 'hello' } },
+  { type: 'assistant', uuid: 'root-1-answer', parentUuid: 'root-1', timestamp: '2026-01-01T10:00:05Z', message: { id: 'm1', role: 'assistant', content: 'hi' } },
+  { type: 'user', uuid: 'rewound-1', parentUuid: 'root-1-answer', timestamp: '2026-01-01T10:01:00Z', message: { role: 'user', content: 'rewound question' } },
+  { type: 'assistant', uuid: 'rewound-1-answer', parentUuid: 'rewound-1', timestamp: '2026-01-01T10:01:05Z', message: { id: 'm2', role: 'assistant', content: 'rewound answer' } },
+  { type: 'user', uuid: 'live-1', parentUuid: 'root-1-answer', timestamp: '2026-01-01T10:02:00Z', message: { role: 'user', content: 'retry question' } },
+]);
+assert.ok(rewoundFork.includes('live-1'), 'the live branch user message must be a candidate');
+assert.ok(!rewoundFork.includes('rewound-1'), 'a rewound user row must not be a rewind anchor');
+
 console.log('SCENARIO_OK');

--- a/ai-bridge/services/claude/message-rewind.child.mjs
+++ b/ai-bridge/services/claude/message-rewind.child.mjs
@@ -1,0 +1,62 @@
+// Child process for the "rewind candidates exclude interruption markers"
+// scenario driven by message-rewind.test.mjs.
+//
+// Why a separate process: importing message-rewind.js pulls in api-config.js,
+// which calls getRealHomeDir() at module load and caches the real home inside
+// path-utils. Setting HOME afterwards has no effect, so the transcript must be
+// resolved under a temp home BEFORE any module that touches getRealHomeDir is
+// imported. The parent spawns this script with HOME pointed at a temp dir it
+// owns and cleans up; this child must NOT create its own temp home or it
+// leaks (the parent only rmSync's the dir it created).
+//
+// On success prints SCENARIO_OK and exits 0; any assertion failure rejects the
+// top-level await, so Node exits non-zero and the parent surfaces it.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const tempHome = process.env.HOME;
+assert.ok(tempHome, 'parent must inject HOME');
+
+const { resolveRewindCandidateMessageIds } = await import('./message-rewind.js');
+const { getClaudeProjectKey } = await import('../../utils/path-utils.js');
+
+const sessionDir = path.join(tempHome, '.claude', 'projects', getClaudeProjectKey(tempHome));
+fs.mkdirSync(sessionDir, { recursive: true });
+
+function runCandidateResolution(rows) {
+  const file = path.join(sessionDir, 'rewind-candidates.jsonl');
+  fs.writeFileSync(file, rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+  return resolveRewindCandidateMessageIds('rewind-candidates', tempHome, null);
+}
+
+// A turn was aborted: the CLI persisted its synthetic marker user row after
+// the user's real message. It must not become a rewind anchor.
+const withMarker = await runCandidateResolution([
+  { type: 'user', uuid: 'real-1', message: { role: 'user', content: 'hello' } },
+  { type: 'assistant', uuid: 'asst-1', message: { role: 'assistant', content: 'hi' } },
+  { type: 'user', uuid: 'interrupted-1', message: { role: 'user', content: '[Request interrupted by user]' } },
+]);
+assert.ok(!withMarker.includes('interrupted-1'), 'marker row must not be a rewind anchor');
+assert.ok(withMarker.includes('real-1'), 'the real user message must remain a candidate');
+
+// Without a marker, the real last user message is still picked. (With no
+// providedMessageId the candidates are exactly the last user text message —
+// real-1 only enters via the provided-message ancestor chain.)
+const noMarker = await runCandidateResolution([
+  { type: 'user', uuid: 'real-1', message: { role: 'user', content: 'hello' } },
+  { type: 'assistant', uuid: 'asst-1', message: { role: 'assistant', content: 'hi' } },
+  { type: 'user', uuid: 'real-2', message: { role: 'user', content: 'follow up' } },
+]);
+assert.ok(noMarker.includes('real-2'), 'last real user message must be a candidate');
+assert.ok(!noMarker.includes('interrupted-1'));
+
+// A marker followed by the real message must still resolve to the real one.
+const markerThenReal = await runCandidateResolution([
+  { type: 'user', uuid: 'interrupted-1', message: { role: 'user', content: '[Request interrupted by user]' } },
+  { type: 'user', uuid: 'real-3', message: { role: 'user', content: 'after the interrupt' } },
+]);
+assert.ok(markerThenReal.includes('real-3'), 'message after the marker must be picked');
+assert.ok(!markerThenReal.includes('interrupted-1'));
+
+console.log('SCENARIO_OK');

--- a/ai-bridge/services/claude/message-rewind.js
+++ b/ai-bridge/services/claude/message-rewind.js
@@ -11,6 +11,7 @@ import { ensureClaudeSdk, hasClaudeProjectSessionFile, waitForClaudeProjectSessi
 import { getActiveQueryResult, getActiveSessionIds } from './message-session-registry.js';
 import { getClaudeCliPathOverride } from '../../utils/claude-cli-path.js';
 import { isUserTextMessage } from './session-service.js';
+import { selectConversationChain } from './conversation-chain.js';
 
 export async function rewindFiles(sessionId, userMessageId, cwd = null) {
   let result = null;
@@ -196,8 +197,13 @@ export async function resolveRewindCandidateMessageIds(sessionId, cwd, providedM
     return [];
   }
 
+  // Anchor candidates must come from the live parentUuid chain: rewound
+  // branches stay on disk, and anchoring on one would restore files to a
+  // state the live conversation no longer reflects.
+  const chainMessages = selectConversationChain(messages);
+
   const byId = new Map();
-  for (const m of messages) {
+  for (const m of chainMessages) {
     if (m && typeof m === 'object' && typeof m.uuid === 'string') {
       byId.set(m.uuid, m);
     }
@@ -223,7 +229,7 @@ export async function resolveRewindCandidateMessageIds(sessionId, cwd, providedM
     current = parent || null;
   }
 
-  const lastUserText = [...messages].reverse().find(isUserTextMessage);
+  const lastUserText = [...chainMessages].reverse().find(isUserTextMessage);
   if (lastUserText?.uuid) {
     candidates.push(lastUserText.uuid);
   }

--- a/ai-bridge/services/claude/message-rewind.js
+++ b/ai-bridge/services/claude/message-rewind.js
@@ -10,6 +10,7 @@ import { getClaudeProjectSessionFilePath, getRealHomeDir, selectWorkingDirectory
 import { ensureClaudeSdk, hasClaudeProjectSessionFile, waitForClaudeProjectSessionFile, isNoConversationFoundError } from './message-utils.js';
 import { getActiveQueryResult, getActiveSessionIds } from './message-session-registry.js';
 import { getClaudeCliPathOverride } from '../../utils/claude-cli-path.js';
+import { isUserTextMessage } from './session-service.js';
 
 export async function rewindFiles(sessionId, userMessageId, cwd = null) {
   let result = null;
@@ -189,7 +190,7 @@ export async function rewindFiles(sessionId, userMessageId, cwd = null) {
   }
 }
 
-async function resolveRewindCandidateMessageIds(sessionId, cwd, providedMessageId) {
+export async function resolveRewindCandidateMessageIds(sessionId, cwd, providedMessageId) {
   const messages = await readClaudeProjectSessionMessages(sessionId, cwd);
   if (!Array.isArray(messages) || messages.length === 0) {
     return [];
@@ -202,19 +203,9 @@ async function resolveRewindCandidateMessageIds(sessionId, cwd, providedMessageI
     }
   }
 
-  const isUserTextMessage = (m) => {
-    if (!m || m.type !== 'user') return false;
-    const content = m.message?.content;
-    if (!content) return false;
-    if (typeof content === 'string') {
-      return content.trim().length > 0;
-    }
-    if (Array.isArray(content)) {
-      return content.some((b) => b && b.type === 'text' && String(b.text || '').trim().length > 0);
-    }
-    return false;
-  };
-
+  // Reuse the canonical user-text-message predicate from session-service so
+  // the CLI's synthetic "[Request interrupted by user]" rows (which carry
+  // uuid + text and would otherwise qualify) never become rewind anchors.
   const candidates = [];
   const visited = new Set();
 

--- a/ai-bridge/services/claude/message-rewind.test.mjs
+++ b/ai-bridge/services/claude/message-rewind.test.mjs
@@ -1,0 +1,30 @@
+// Tests for the rewind candidate resolution used by file rewind.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+// getRealHomeDir() is cached at module load by api-config.js, so the scenario
+// runs in a child process with HOME pointed at a temp dir (same pattern as
+// the closed-runtime and [1m]-toggle child tests).
+test('rewind candidates exclude the CLI interruption marker rows', () => {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-rewind-'));
+  try {
+    const childPath = fileURLToPath(
+      new URL('./message-rewind.child.mjs', import.meta.url)
+    );
+    const output = execFileSync(process.execPath, [childPath], {
+      cwd: process.cwd(),
+      env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+      encoding: 'utf8',
+      timeout: 30000,
+    });
+
+    assert.match(output, /SCENARIO_OK/, `child scenario did not pass:\n${output}`);
+  } finally {
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+});

--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -75,7 +75,7 @@ function buildQueryOptions({ workingDirectory, permissionMode, sdkModelName, max
     cwd: workingDirectory,
     permissionMode,
     model: sdkModelName,
-    maxTurns: 100,
+    maxTurns: 1000,
     enableFileCheckpointing: true,
     env: buildCliEnv(),
     settings: buildWebviewControlledSettingsOverride(modelId),

--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -31,7 +31,8 @@ import {
   truncateString,
   truncateErrorContent,
   emitUsageTag,
-  buildConfigErrorPayload
+  buildConfigErrorPayload,
+  extractResultError
 } from './message-utils.js';
 import { createPreToolUseHook } from './permission-mode.js';
 import { loadMcpServersConfigAsRecord } from './mcp-status/config-loader.js';
@@ -276,7 +277,9 @@ function processStreamMessage(msg, state, logPrefix) {
   // Error result detection
   if (msg.type === 'result' && msg.is_error) {
     console.error(`[DEBUG]${logPrefix ? ` ${logPrefix}` : ''} Received error result:`, JSON.stringify(msg));
-    throw new Error(msg.result || msg.message || 'API request failed');
+    // The SDK reports the real error text in msg.errors (array); extractResultError
+    // reads it so the actual failure surfaces instead of a generic fallback.
+    throw new Error(extractResultError(msg));
   }
 }
 

--- a/ai-bridge/services/claude/message-utils.js
+++ b/ai-bridge/services/claude/message-utils.js
@@ -63,6 +63,7 @@ export const AUTO_RETRY_CONFIG = {
  */
 export function isRetryableError(error) {
   const msg = error?.message || String(error);
+  const normalizedMessage = msg.toLowerCase();
   const retryablePatterns = [
     'API request failed',
     'ECONNRESET',
@@ -75,9 +76,19 @@ export function isRetryableError(error) {
     'getaddrinfo',
     'connect EHOSTUNREACH',
     'No conversation found with session ID',
-    'conversation not found'
+    'conversation not found',
+    'rate_limit_error',
+    'rate limit',
+    'overloaded_error',
+    'temporarily unavailable'
   ];
-  return retryablePatterns.some(pattern => msg.toLowerCase().includes(pattern.toLowerCase()));
+  if (retryablePatterns.some(pattern => normalizedMessage.includes(pattern.toLowerCase()))) {
+    return true;
+  }
+
+  // Claude SDK errors may expose transient HTTP status codes without the
+  // generic "API request failed" prefix that the retry policy used before.
+  return /\b(?:429|500|502|503|504|529)\b/.test(msg);
 }
 
 export function isNoConversationFoundError(error) {

--- a/ai-bridge/services/claude/message-utils.js
+++ b/ai-bridge/services/claude/message-utils.js
@@ -161,6 +161,32 @@ export function truncateErrorContent(content, maxLen = 1000) {
 }
 
 /**
+ * Extract the human-readable error text from an SDK error result message.
+ * Mirrors the Claude Agent SDK's own precedence (see sdk.mjs): a result whose
+ * subtype is "success" carries its text in `result`, all other error results
+ * report in the `errors` array. Reading only `result`/`message` silently
+ * dropped the real failure and left users staring at a generic fallback.
+ * @param {object} msg - The SDK result message
+ * @returns {string} The best available error text, or a generic fallback
+ */
+export function extractResultError(msg) {
+  if (!msg) return 'API request failed';
+  // Mirror the SDK's own precedence (sdk.mjs): an error result whose subtype is
+  // "success" carries its text in `result`; every other error result reports in
+  // the `errors` array. Reading the wrong field silently lost the real failure.
+  if (msg.subtype === 'success') {
+    return msg.result || msg.message || 'API request failed';
+  }
+  if (Array.isArray(msg.errors) && msg.errors.length > 0) {
+    // The SDK joins with `|| void 0`, so an all-blank errors array must not
+    // surface as an empty string — fall through to the generic fallback.
+    const joined = msg.errors.map((r) => String(r).trim()).filter(Boolean).join('; ');
+    if (joined) return joined;
+  }
+  return msg?.result || msg?.message || 'API request failed';
+}
+
+/**
  * Emit [USAGE] tag for Java-side token tracking.
  * NOTE: Uses process.stdout.write for consistent buffering with other IPC messages.
  * The Java backend parses stdout lines starting with "[USAGE]" to extract token metrics.

--- a/ai-bridge/services/claude/message-utils.test.js
+++ b/ai-bridge/services/claude/message-utils.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { extractResultError } from './message-utils.js';
+import { extractResultError, isRetryableError } from './message-utils.js';
 
 // Regression guard for the "API request failed" masking bug: the Claude Agent
 // SDK reports the real error text in the `errors` array (or in `result` when
@@ -49,4 +49,18 @@ test('extractResultError: falls back to the generic text for an empty message', 
   assert.equal(extractResultError({ type: 'result', is_error: true }), 'API request failed');
   assert.equal(extractResultError(null), 'API request failed');
   assert.equal(extractResultError(undefined), 'API request failed');
+});
+
+test('isRetryableError recognizes retryable SDK errors after detailed extraction', () => {
+  const rateLimitError = new Error(extractResultError({
+    subtype: 'error_during_execution',
+    errors: ['rate_limit_error: 429 Too Many Requests'],
+  }));
+  const overloadedError = new Error(extractResultError({
+    subtype: 'error_during_execution',
+    errors: ['overloaded_error: service temporarily unavailable'],
+  }));
+
+  assert.equal(isRetryableError(rateLimitError), true);
+  assert.equal(isRetryableError(overloadedError), true);
 });

--- a/ai-bridge/services/claude/message-utils.test.js
+++ b/ai-bridge/services/claude/message-utils.test.js
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { extractResultError } from './message-utils.js';
+
+// Regression guard for the "API request failed" masking bug: the Claude Agent
+// SDK reports the real error text in the `errors` array (or in `result` when
+// subtype is "success"), never in a generic message. These cases pin down the
+// exact precedence so a real failure can no longer be silently dropped.
+
+test('extractResultError: reads the errors array for a normal error result', () => {
+  const msg = {
+    type: 'result',
+    is_error: true,
+    subtype: 'error',
+    errors: ['rate_limit_error: 429 Too Many Requests', 'Retry after 60s'],
+    result: 'ignored generic text',
+  };
+  assert.equal(extractResultError(msg), 'rate_limit_error: 429 Too Many Requests; Retry after 60s');
+});
+
+test('extractResultError: trims and drops blank entries from the errors array', () => {
+  const msg = { type: 'result', is_error: true, subtype: 'error', errors: ['  auth failed  ', '', '  '] };
+  assert.equal(extractResultError(msg), 'auth failed');
+});
+
+test('extractResultError: falls back when the errors array is entirely blank', () => {
+  const msg = { type: 'result', is_error: true, subtype: 'error', errors: ['', '   '] };
+  assert.equal(extractResultError(msg), 'API request failed');
+});
+
+test('extractResultError: prefers `result` when subtype is "success" (SDK precedence)', () => {
+  const msg = {
+    type: 'result',
+    is_error: true,
+    subtype: 'success',
+    errors: ['must-not-win'],
+    result: 'the real message',
+  };
+  assert.equal(extractResultError(msg), 'the real message');
+});
+
+test('extractResultError: falls back to `result` then `message` when no errors array', () => {
+  assert.equal(extractResultError({ type: 'result', is_error: true, result: 'from result' }), 'from result');
+  assert.equal(extractResultError({ type: 'result', is_error: true, message: 'from message' }), 'from message');
+});
+
+test('extractResultError: falls back to the generic text for an empty message', () => {
+  assert.equal(extractResultError({ type: 'result', is_error: true }), 'API request failed');
+  assert.equal(extractResultError(null), 'API request failed');
+  assert.equal(extractResultError(undefined), 'API request failed');
+});

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -23,6 +23,7 @@ import { buildQuickFixPrompt } from '../quickfix-prompts.js';
 import { registerActiveQueryResult, removeSession } from './message-service.js';
 import { normalizePermissionMode } from './permission-mode.js';
 import { redactSecrets, truncateString } from './message-output-filter.js';
+import { extractResultError } from './message-utils.js';
 import {
   beginRuntimeTurn,
   cleanupStaleAnonymousRuntimes,
@@ -370,7 +371,10 @@ _sessionCleanupTimer.unref();
 
       if (msg?.type === 'result') {
         if (msg.is_error) {
-          throw new Error(msg.result || msg.message || 'API request failed');
+          // The SDK puts the real error text in msg.errors (array), not in
+          // result/message — extractResultError covers all three so the true
+          // failure reaches the UI instead of a generic fallback.
+          throw new Error(extractResultError(msg));
         }
         // A task_notification for a background (run_in_background) Agent that
         // settles AFTER this result cannot ride the in-turn [MESSAGE] stream:

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -130,7 +130,7 @@ function buildQueryOptions(workingDirectory, sdkModelName, permissionMode, maxTh
     cwd: workingDirectory,
     permissionMode,
     model: sdkModelName,
-    maxTurns: 100,
+    maxTurns: 1000,
     enableFileCheckpointing: true,
     env: buildCliEnv(),
     settings: buildWebviewControlledSettingsOverride(modelId),

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -269,6 +269,12 @@ _sessionCleanupTimer.unref();
 
   try {
     beginRuntimeTurn(runtime);
+    // Scope the abort flag to the turn that aborted: it is set by
+    // abortCurrentTurn and must not carry into a fresh turn started right
+    // after an interrupt, or sendInternal would misclassify the new turn's
+    // failures (e.g. "Runtime is closed" on a disposed runtime) as a graceful
+    // "User interrupted" and silently swallow the user's message.
+    runtime.abortRequested = false;
 
     // Create and register turnSink after beginRuntimeTurn to avoid race
     // (ensures executeTurn is ready to consume before perpetual reader can push)

--- a/ai-bridge/services/claude/persistent-query-service.test.js
+++ b/ai-bridge/services/claude/persistent-query-service.test.js
@@ -1,5 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { __testing } from './persistent-query-service.js';
 import { createTurnSink } from './runtime-lifecycle.js';
 
@@ -301,3 +306,80 @@ test('messages route to turnSink when active, not when null', () => {
 });
 
 console.log('\n✅ All persistent-query-service tests updated with turnSink coverage');
+
+// ============================================================================
+// Regression: fresh turn after an abort must not inherit abortRequested
+// ============================================================================
+
+test('executeTurn resets abortRequested at the start of a new turn', async () => {
+  // abortCurrentTurn leaves abortRequested=true on the runtime. If a fresh
+  // turn then fails (e.g. the runtime was disposed mid-abort), sendInternal's
+  // wasAborted check would swallow the failure as a graceful "User
+  // interrupted" and silently drop the user's message. The reset scopes the
+  // flag to the turn that actually aborted.
+  const runtime = {
+    closed: false,
+    abortRequested: true,
+    sessionId: null,
+    runtimeSessionEpoch: null,
+    activeTurnCount: 0,
+    inputStream: { enqueue() {}, done() {} },
+    query: { close() {} },
+  };
+
+  // Start the turn; executeTurn blocks on turnSink.take() until the sink is
+  // failed (as abortCurrentTurn does to unblock a live turn).
+  const failSink = __testing.executeTurn(runtime, {
+    requestedSessionId: null,
+    runtimeSessionEpoch: null,
+    options: { cwd: '/tmp' },
+    permissionMode: 'default',
+    streamingEnabled: false,
+    userMessage: { type: 'user', message: { role: 'user', content: 'hi' } },
+  });
+
+  // Simulate the CLI closing the stream out from under the turn.
+  runtime.turnSink.fail(new Error('stream ended'));
+  runtime.closed = true;
+
+  await assert.rejects(failSink, /stream ended/);
+  assert.equal(runtime.abortRequested, false);
+});
+
+// ============================================================================
+// Regression: a fresh send must never reuse a closed runtime
+// ============================================================================
+
+test('acquireRuntime discards a closed runtime still registered from an abort', () => {
+  // abortCurrentTurn marks the runtime closed but only removes it from the
+  // registry after its async query.close() completes. A send that races that
+  // window used to reuse the closed runtime, hit "Runtime is closed", and —
+  // because abortRequested was still true — have the failure swallowed as a
+  // graceful "User interrupted": the user's message was silently eaten.
+  //
+  // Runs in a child process with a mock SDK (mirroring the [1m]-toggle test)
+  // so acquireRuntime never touches the real SDK loader or credentials.
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-closed-runtime-'));
+  try {
+    fs.mkdirSync(path.join(tempHome, '.codemoss'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempHome, '.codemoss', 'config.json'),
+      JSON.stringify({ claude: { current: '__cli_login__', providers: {} } }),
+      'utf8'
+    );
+
+    const childPath = fileURLToPath(
+      new URL('./runtime-lifecycle.closed-runtime.child.mjs', import.meta.url)
+    );
+    const output = execFileSync(process.execPath, [childPath], {
+      cwd: process.cwd(),
+      env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+      encoding: 'utf8',
+      timeout: 30000,
+    });
+
+    assert.match(output, /SCENARIO_OK/, `child scenario did not pass:\n${output}`);
+  } finally {
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+});

--- a/ai-bridge/services/claude/runtime-lifecycle.closed-runtime.child.mjs
+++ b/ai-bridge/services/claude/runtime-lifecycle.closed-runtime.child.mjs
@@ -1,0 +1,78 @@
+// Child process for the "closed runtime must not be reused" scenario driven by
+// persistent-query-service.test.js.
+//
+// Why a separate process: acquireRuntime() may call buildRequestContext()
+// paths that hit setupApiKey(), which resolves credentials only from
+// ~/.codemoss + ~/.claude under the real home dir. The parent spawns this
+// script with HOME pointed at a temp dir carrying a CLI-login config (same
+// pattern as runtime-lifecycle.1m-toggle.child.mjs). A mock SDK keeps
+// createRuntime off the real SDK loader.
+//
+// On success prints SCENARIO_OK and exits 0; any assertion failure rejects the
+// top-level await, so Node exits non-zero and the parent surfaces it.
+import assert from 'node:assert/strict';
+import { __testing } from './persistent-query-service.js';
+
+/**
+ * Create a fake SDK query whose message iterator is a REAL native async
+ * generator. It pends until close() is called (the real iterator stays open
+ * between turns), so the perpetual reader neither spins nor tears the runtime
+ * down mid-test.
+ */
+function createHangingQuery({ prompt, options }) {
+  let closeResolve;
+  const closedSignal = new Promise((resolve) => { closeResolve = resolve; });
+  async function* messages() {
+    await closedSignal;
+  }
+  const generator = messages();
+  return {
+    prompt,
+    options,
+    closed: false,
+    setPermissionMode: async () => {},
+    setModel: async () => {},
+    setMaxThinkingTokens: async () => {},
+    close() {
+      this.closed = true;
+      closeResolve();
+    },
+    next: () => generator.next(),
+  };
+}
+
+let created = 0;
+__testing.setQueryFn((args) => {
+  created += 1;
+  return createHangingQuery(args);
+});
+
+const baseParams = {
+  sessionId: '',
+  runtimeSessionEpoch: 'epoch-closed-runtime',
+  cwd: process.cwd(),
+  message: 'hello',
+};
+// Settings override keeps the resolved model deterministic regardless of the
+// developer's real ~/.claude/settings.json.
+const overrides = { settings: { env: {} } };
+
+const ctx = await __testing.buildRequestContext(
+  { ...baseParams, model: 'claude-sonnet-4-6' }, false, overrides
+);
+const first = await __testing.acquireRuntime(ctx);
+assert.equal(created, 1);
+
+// Simulate the abort's disposeRuntime window: the runtime is closed but still
+// registered (removeRuntime runs only after the async query.close() that is
+// still in flight), and the abort left its flag set.
+first.closed = true;
+first.abortRequested = true;
+
+const second = await __testing.acquireRuntime(ctx);
+assert.notEqual(second, first, 'closed runtime must not be reused');
+assert.equal(second.closed, false, 'replacement runtime must be alive');
+assert.equal(created, 2, 'a fresh runtime must be created');
+
+await __testing.resetState();
+console.log('SCENARIO_OK');

--- a/ai-bridge/services/claude/runtime-lifecycle.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.js
@@ -516,6 +516,21 @@ export async function acquireRuntime(requestContext, callbacks) {
 
   let runtime = findRuntimeForRequest(requestContext);
 
+  // Never reuse a runtime that is closed but somehow still registered. If it
+  // reached acquireRuntime, executeTurn would immediately throw "Runtime is
+  // closed", and the prior abort left abortRequested=true on it, so sendInternal
+  // would swallow that failure as a graceful "User interrupted" — silently
+  // eating the message the user just sent. Evict it from the registry and treat
+  // it as absent so a fresh runtime is created instead. (disposeRuntime removes
+  // the runtime from the registry synchronously, so this branch is a defensive
+  // invariant, not a common path.)
+  if (runtime && runtime.closed) {
+    console.log('[LIFECYCLE] discardClosedRuntime sessionId=' + (runtime.sessionId || '(new)')
+      + ' epoch=' + (runtime.runtimeSessionEpoch || '(none)'));
+    removeRuntime(runtime, callbacks?.removeSession);
+    runtime = null;
+  }
+
   if (runtime && runtime.runtimeSignature !== requestContext.runtimeSignature) {
     await disposeRuntime(runtime, callbacks);
     runtime = null;

--- a/ai-bridge/services/claude/session-service.js
+++ b/ai-bridge/services/claude/session-service.js
@@ -8,6 +8,7 @@ import { dirname } from 'path';
 import { randomUUID } from 'crypto';
 import { createInterface } from 'readline';
 import { getClaudeProjectSessionFilePath } from '../../utils/path-utils.js';
+import { selectConversationChain } from './conversation-chain.js';
 import { extractTaskNotificationXml } from './task-notification-parser.js';
 
 /**
@@ -55,6 +56,24 @@ export function persistJsonlMessage(sessionId, cwd, obj) {
 }
 
 /**
+ * Parse raw JSONL file content into entries, skipping blank and malformed
+ * lines. Shared by every reader that consumes a session transcript.
+ */
+function parseJsonlContent(content) {
+  return content
+    .split('\n')
+    .filter(line => line.trim())
+    .map(line => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(msg => msg !== null);
+}
+
+/**
  * Load session history messages (used to maintain context when resuming a session).
  * Returns an array of messages in the Anthropic Messages API format.
  */
@@ -66,28 +85,16 @@ export function loadSessionHistory(sessionId, cwd) {
       return [];
     }
 
-    const content = readFileSync(sessionFile, 'utf8');
-    const lines = content.split('\n').filter(line => line.trim());
-    const messages = [];
-
-    for (const line of lines) {
-      try {
-        const msg = JSON.parse(line);
-        if (msg.type === 'user' && msg.message && msg.message.content) {
-          messages.push({
-            role: 'user',
-            content: msg.message.content
-          });
-        } else if (msg.type === 'assistant' && msg.message && msg.message.content) {
-          messages.push({
-            role: 'assistant',
-            content: msg.message.content
-          });
-        }
-      } catch (e) {
-        // Skip lines that fail to parse
-      }
-    }
+    // Rewind keeps dead branches on disk; only the parentUuid chain from the
+    // newest leaf is the live conversation the API should see.
+    const messages = selectConversationChain(parseJsonlContent(readFileSync(sessionFile, 'utf8')))
+      .filter(msg =>
+        (msg.type === 'user' || msg.type === 'assistant') &&
+        msg.message && msg.message.content)
+      .map(msg => ({
+        role: msg.type,
+        content: msg.message.content
+      }));
 
     // Exclude the last user message (since we already persisted the current user message before calling this function)
     if (messages.length > 0 && messages[messages.length - 1].role === 'user') {
@@ -113,17 +120,7 @@ export function buildSessionMessagesPayload(sessionFile) {
     return { success: true, messages: [] };
   }
   const content = readFileSync(sessionFile, 'utf8');
-  const messages = content
-    .split('\n')
-    .filter(line => line.trim())
-    .map(line => {
-      try {
-        return JSON.parse(line);
-      } catch {
-        return null;
-      }
-    })
-    .filter(msg => msg !== null)
+  const messages = selectConversationChain(parseJsonlContent(content))
     // Drop the CLI's synthetic "[Request interrupted by user]" user rows.
     // They are turn-abort bookkeeping the CLI persists into the transcript,
     // not real user input: rendered in the chat they read as a phantom

--- a/ai-bridge/services/claude/session-service.js
+++ b/ai-bridge/services/claude/session-service.js
@@ -124,6 +124,15 @@ export function buildSessionMessagesPayload(sessionFile) {
       }
     })
     .filter(msg => msg !== null)
+    // Drop the CLI's synthetic "[Request interrupted by user]" user rows.
+    // They are turn-abort bookkeeping the CLI persists into the transcript,
+    // not real user input: rendered in the chat they read as a phantom
+    // message, and their uuid makes getLatestUserMessage return them as the
+    // "latest user message", starving the rewind uuid-sync for the user's
+    // real last message. The live stream never carries them (the daemon
+    // consumes them inter-turn), so dropping them here keeps reloaded
+    // history consistent with the live view.
+    .filter(msg => !(msg.type === 'user' && isInterruptionMarker(msg)))
     // A background Agent's terminal report can land as a queued_command
     // attachment (type:"attachment") rather than a user message. Java's
     // MessageParser only forwards user/assistant rows, so the attachment row
@@ -215,13 +224,28 @@ export async function getLatestUserMessage(sessionId, cwd = null) {
   }
 }
 
-function isUserTextMessage(message) {
+export function isUserTextMessage(message) {
   return Boolean(
     message &&
     message.type === 'user' &&
     typeof message.uuid === 'string' &&
+    !isInterruptionMarker(message) &&
     extractTextContent(message)?.trim()
   );
+}
+
+/**
+ * Detect the CLI's synthetic user rows for an aborted turn, matching the
+ * transcript markers it persists: "[Request interrupted by user]" (stream
+ * abort) and "[Request interrupted by user for tool use]" (tool-use abort).
+ * Mirrors the filter Java's SessionLiteReader already applies.
+ */
+export function isInterruptionMarker(message) {
+  if (!message || message.type !== 'user') {
+    return false;
+  }
+  const text = extractTextContent(message);
+  return typeof text === 'string' && text.startsWith('[Request interrupted');
 }
 
 function extractTextContent(message) {

--- a/ai-bridge/services/claude/session-service.test.mjs
+++ b/ai-bridge/services/claude/session-service.test.mjs
@@ -122,6 +122,31 @@ test('buildSessionMessagesPayload keeps a user message that merely mentions the 
   }
 });
 
+test('buildSessionMessagesPayload drops rewound branches of the transcript', () => {
+  // Rewind never deletes rows: the CLI forks in place, so the next user
+  // message parents onto the pre-rewind assistant and the discarded span
+  // stays on disk as a dead branch. Reading line-by-line would render it;
+  // only the parentUuid chain from the newest leaf is live.
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-claude-session-'));
+  try {
+    const file = path.join(tempDir, 'session.jsonl');
+    fs.writeFileSync(file, [
+      JSON.stringify({ type: 'user', uuid: 'u1', parentUuid: null, timestamp: '2026-01-01T10:00:00Z', message: { role: 'user', content: 'first' } }),
+      JSON.stringify({ type: 'assistant', uuid: 'a1', parentUuid: 'u1', timestamp: '2026-01-01T10:00:05Z', message: { id: 'm1', role: 'assistant', content: 'answer one' } }),
+      JSON.stringify({ type: 'user', uuid: 'u2', parentUuid: 'a1', timestamp: '2026-01-01T10:01:00Z', message: { role: 'user', content: 'rewound question' } }),
+      JSON.stringify({ type: 'assistant', uuid: 'a2', parentUuid: 'u2', timestamp: '2026-01-01T10:01:05Z', message: { id: 'm2', role: 'assistant', content: 'rewound answer' } }),
+      JSON.stringify({ type: 'user', uuid: 'u3', parentUuid: 'a1', timestamp: '2026-01-01T10:02:00Z', message: { role: 'user', content: 'retry question' } }),
+      JSON.stringify({ type: 'assistant', uuid: 'a3', parentUuid: 'u3', timestamp: '2026-01-01T10:02:05Z', message: { id: 'm3', role: 'assistant', content: 'retry answer' } }),
+    ].join('\n') + '\n');
+
+    const { success, messages } = buildSessionMessagesPayload(file);
+    assert.equal(success, true);
+    assert.deepEqual(messages.map((m) => m.uuid), ['u1', 'a1', 'u3', 'a3']);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test('isUserTextMessage rejects the interruption markers', () => {
   // getLatestUserMessage feeds the rewind uuid-sync: the interruption row must
   // never be picked as the "latest user message", or the user's real last

--- a/ai-bridge/services/claude/session-service.test.mjs
+++ b/ai-bridge/services/claude/session-service.test.mjs
@@ -55,6 +55,41 @@ test('buildSessionMessagesPayload rewrites a queued_command attachment carrier i
   }
 });
 
+test('buildSessionMessagesPayload keeps a parent-linked queued command attachment on the effective chain', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-claude-session-'));
+  try {
+    const file = path.join(tempDir, 'session.jsonl');
+    const xml = '<task-notification>do the thing</task-notification>';
+    fs.writeFileSync(file, [
+      JSON.stringify({
+        type: 'user',
+        uuid: 'u1',
+        timestamp: '2026-01-01T10:00:00Z',
+        message: { role: 'user', content: 'start' },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        uuid: 'a1',
+        parentUuid: 'u1',
+        timestamp: '2026-01-01T10:00:01Z',
+        message: { role: 'assistant', content: 'working' },
+      }),
+      JSON.stringify({
+        type: 'attachment',
+        uuid: 'attachment-1',
+        parentUuid: 'a1',
+        timestamp: '2026-01-01T10:00:02Z',
+        attachment: { type: 'queued_command', commandMode: 'task-notification', prompt: xml },
+      }),
+    ].join('\n') + '\n');
+
+    const { messages } = buildSessionMessagesPayload(file);
+    assert.deepEqual(messages.map((message) => message.message.content), ['start', 'working', xml]);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test('buildSessionMessagesPayload leaves a non-task-notification queued_command attachment untouched', () => {
   // An enqueued user prompt is also a queued_command attachment but not a
   // task-notification carrier; it must not be rewritten into a user message.

--- a/ai-bridge/services/claude/session-service.test.mjs
+++ b/ai-bridge/services/claude/session-service.test.mjs
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { buildSessionMessagesPayload } from './session-service.js';
+import { buildSessionMessagesPayload, isUserTextMessage, isInterruptionMarker } from './session-service.js';
 
 test('buildSessionMessagesPayload returns an empty history when the session file is missing', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-claude-session-'));
@@ -74,4 +74,88 @@ test('buildSessionMessagesPayload leaves a non-task-notification queued_command 
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
+});
+
+test('buildSessionMessagesPayload drops the CLI interruption marker rows', () => {
+  // The CLI persists synthetic "[Request interrupted by user]" user rows when
+  // a turn is aborted. They are turn-abort bookkeeping, not real input: if
+  // they reach the chat they render as a phantom user message, and their uuid
+  // hijacks getLatestUserMessage so the rewind uuid-sync starves the user's
+  // real last message. Both marker variants must be dropped.
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-claude-session-'));
+  try {
+    const file = path.join(tempDir, 'session.jsonl');
+    fs.writeFileSync(file, [
+      JSON.stringify({ type: 'user', uuid: 'u1', message: { role: 'user', content: 'hi' } }),
+      JSON.stringify({ type: 'user', uuid: 'u2', message: { role: 'user', content: '[Request interrupted by user]' } }),
+      JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: 'ok' } }),
+      JSON.stringify({ type: 'user', uuid: 'u3', message: { role: 'user', content: '[Request interrupted by user for tool use]' } }),
+    ].join('\n') + '\n');
+
+    const { success, messages } = buildSessionMessagesPayload(file);
+    assert.equal(success, true);
+    assert.deepEqual(messages.map((m) => m.uuid), ['u1', undefined]);
+    assert.equal(messages[0].type, 'user');
+    assert.equal(messages[1].type, 'assistant');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('buildSessionMessagesPayload keeps a user message that merely mentions the marker text', () => {
+  // Only whole content exactly equal to the marker is synthetic; a real user
+  // prompt that mentions it must survive.
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-claude-session-'));
+  try {
+    const file = path.join(tempDir, 'session.jsonl');
+    fs.writeFileSync(file, JSON.stringify({
+      type: 'user',
+      uuid: 'u1',
+      message: { role: 'user', content: 'why did you print [Request interrupted by user]?' },
+    }) + '\n');
+
+    const { messages } = buildSessionMessagesPayload(file);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].uuid, 'u1');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('isUserTextMessage rejects the interruption markers', () => {
+  // getLatestUserMessage feeds the rewind uuid-sync: the interruption row must
+  // never be picked as the "latest user message", or the user's real last
+  // message keeps its uuid unpatched and rewind loses the anchor.
+  assert.equal(isUserTextMessage({
+    type: 'user',
+    uuid: 'u1',
+    message: { role: 'user', content: '[Request interrupted by user]' },
+  }), false);
+  assert.equal(isUserTextMessage({
+    type: 'user',
+    uuid: 'u2',
+    message: { role: 'user', content: [{ type: 'text', text: '[Request interrupted by user for tool use]' }] },
+  }), false);
+  assert.equal(isUserTextMessage({
+    type: 'user',
+    uuid: 'u3',
+    message: { role: 'user', content: 'hi' },
+  }), true);
+});
+
+test('isInterruptionMarker matches only the synthetic markers', () => {
+  assert.equal(isInterruptionMarker({
+    type: 'user',
+    message: { role: 'user', content: '[Request interrupted by user]' },
+  }), true);
+  assert.equal(isInterruptionMarker({
+    type: 'user',
+    message: { role: 'user', content: '[Request interrupted by user for tool use]' },
+  }), true);
+  assert.equal(isInterruptionMarker({
+    type: 'user',
+    message: { role: 'user', content: 'why did you print [Request interrupted by user]?' },
+  }), false);
+  assert.equal(isInterruptionMarker({ type: 'assistant', message: { role: 'assistant', content: '[Request interrupted by user]' } }), false);
+  assert.equal(isInterruptionMarker(null), false);
 });

--- a/webview/src/components/AskUserQuestionDialog.css
+++ b/webview/src/components/AskUserQuestionDialog.css
@@ -6,8 +6,12 @@
   border: 1px solid var(--border-secondary);
   border-radius: 8px;
   padding: 24px;
-  width: 100%;
-  max-width: 100%;
+  /* Float as a card instead of hugging the tool-window edges: the full border
+     and rounded corners must stay visible, otherwise the left border line is
+     clipped by the plugin's display boundary. Stretch within the overlay minus
+     these insets, including while collapsed mode aligns its children to the end. */
+  align-self: stretch;
+  margin: 0 8px 8px;
   box-shadow: var(--shadow-lg);
   display: flex;
   flex-direction: column;

--- a/webview/src/components/ChatScreen.tsx
+++ b/webview/src/components/ChatScreen.tsx
@@ -236,6 +236,11 @@ export const ChatScreen = ({
     setSearchOpen(false);
   }, [setSearchOpen]);
 
+  const handleNavigateToDependencySettings = useCallback(() => {
+    setSettingsInitialTab('dependencies');
+    setCurrentView('settings');
+  }, [setCurrentView, setSettingsInitialTab]);
+
   return (
     <>
       <div className="messages-shell">
@@ -284,10 +289,7 @@ export const ChatScreen = ({
                   onMessageNodeRef={onMessageNodeRef}
                   onCollapsedCountChange={setAnchorCollapsedCount}
                   onNavigateToProviderSettings={onNavigateToProviderSettings}
-                  onNavigateToDependencySettings={() => {
-                    setSettingsInitialTab('dependencies');
-                    setCurrentView('settings');
-                  }}
+                  onNavigateToDependencySettings={handleNavigateToDependencySettings}
                   currentProvider={currentProvider}
                   currentSessionId={currentSessionId}
                 />

--- a/webview/src/components/MessageItem/MessageItem.test.tsx
+++ b/webview/src/components/MessageItem/MessageItem.test.tsx
@@ -16,6 +16,7 @@ vi.mock('../toolBlocks', () => ({
   BashToolBlock: () => <div data-testid="bash-tool-block">bash</div>,
   BashToolGroupBlock: () => <div data-testid="bash-tool-group-block">bash-group</div>,
   SearchToolGroupBlock: () => <div data-testid="search-tool-group-block">search-group</div>,
+  AgentGroupBlock: () => <div data-testid="agent-group-block">agent</div>,
 }));
 
 vi.mock('./ContentBlockRenderer', () => ({
@@ -161,6 +162,42 @@ describe('MessageItem copy button visibility', () => {
 
     expect(screen.getByTestId('bash-tool-group-block')).toBeTruthy();
     expect(screen.queryAllByTestId('content-block-tool_use')).toHaveLength(0);
+  });
+  it('keeps the Agent block mounted when its tool id arrives later', () => {
+    const makeMessage = (id?: string): ClaudeMessage => ({
+      type: 'assistant',
+      raw: {
+        content: [{
+          type: 'tool_use',
+          ...(id ? { id } : {}),
+          name: 'Task',
+          input: { description: 'Inspect the project' },
+        }],
+      },
+    } as unknown as ClaudeMessage);
+
+    const renderAgentMessage = (message: ClaudeMessage) => (
+      <MessageItem
+        message={message}
+        messageIndex={0}
+        messageKey="message-0"
+        isLast
+        streamingActive
+        isThinking={false}
+        t={t}
+        getMessageText={getMessageText}
+        getContentBlocks={getContentBlocks}
+        findToolResult={findToolResult}
+        extractMarkdownContent={extractMarkdownContent}
+      />
+    );
+
+    const { rerender } = render(renderAgentMessage(makeMessage()));
+    const initialBlock = screen.getByTestId('agent-group-block');
+
+    rerender(renderAgentMessage(makeMessage('tool-1')));
+
+    expect(screen.getByTestId('agent-group-block')).toBe(initialBlock);
   });
 });
 

--- a/webview/src/components/MessageItem/MessageItem.tsx
+++ b/webview/src/components/MessageItem/MessageItem.tsx
@@ -734,9 +734,8 @@ export const MessageItem = memo(function MessageItem({
       }
 
       if (grouped.type === 'agent_group') {
-        const agentToolId = grouped.agentBlock.type === 'tool_use' ? grouped.agentBlock.id : undefined;
         return (
-          <div key={`agentgroup-${agentToolId ?? grouped.startIndex}`} className="content-block">
+          <div key={`${messageKey}-agentgroup-${grouped.startIndex}`} className="content-block">
             <AgentGroupBlock
               agentBlock={grouped.agentBlock}
               followingBlocks={grouped.followingBlocks}

--- a/webview/src/components/PlanApprovalDialog.css
+++ b/webview/src/components/PlanApprovalDialog.css
@@ -7,9 +7,12 @@
   border-radius: 8px;
   padding: 24px;
   padding-top: 28px; /* extra space for resize handle */
-  /* Set to 100% width */
-  max-width: 100%;
-  width: 100%;
+  /* Float as a card instead of hugging the tool-window edges: the full border
+     and rounded corners must stay visible, otherwise the left border line is
+     clipped by the plugin's display boundary. Stretch within the overlay minus
+     these insets (align-items: stretch on the overlay does the filling). */
+  align-self: stretch;
+  margin: 0 8px 8px;
   max-height: 80vh;
   overflow-y: auto;
   box-shadow: var(--shadow-lg);
@@ -197,8 +200,11 @@
   border: 1px solid var(--border-secondary);
   border-radius: 8px;
   box-shadow: var(--shadow-md);
-  width: 100%;
-  max-width: 100%;
+  /* Same edge inset as the expanded card so the collapsed bar never hugs the
+     tool-window edge either. Override the overlay's end alignment to retain
+     the full-width compact layout. */
+  align-self: stretch;
+  margin: 0 8px 8px;
 }
 
 .collapsed-header {
@@ -403,7 +409,6 @@
 @media (max-width: 600px) {
   .plan-approval-dialog {
     padding: 16px;
-    width: 100%;
   }
 
   .plan-approval-dialog-title {


### PR DESCRIPTION
## Summary

Three related fixes make Claude session recovery and diagnostics reliable:

**1. Hide rewound dead branches when reading session transcripts**

Rewinding forks the CLI transcript in place: rewound rows are never deleted
from the `.jsonl`, and later messages `parentUuid` past the discarded span.
Line-order readers therefore render the dead branch as live conversation —
both in the chat window and in the context sent to the API.

Mirror Claude Code's own loader (`loadMessagesFromJsonlPath` +
`buildConversationChain`):
- pick the newest non-sidechain leaf of the parentUuid graph
- walk back to the root, recovering parallel-tool siblings the
  single-parent walk orphans (N parallel tool_uses stream as N assistant
  rows sharing one `message.id`)
- rows missing the `parentUuid` key inherit the previous row as implicit
  parent (SDK-written roots, plugin-appended rows); transcripts with no
  `parentUuid` at all fall back to line order
- explicit `null` stays a root (session start, compact boundary)

**2. Keep rewind anchors on the live chain**

- drop CLI synthetic "[Request interrupted by user]" user rows from
  reloaded history and reject them in `isUserTextMessage`
- rewind anchor candidates (`resolveRewindCandidateMessageIds`) now come
  from the same effective chain, so a rewound user row can never be picked
  as the restore target
- clear `abortRequested` when a new turn starts so it never leaks across
  turns
- discard closed-but-registered runtimes in `acquireRuntime` so a fresh
  runtime is built instead of reusing a dead query

**3. Surface Claude Agent SDK error details**

The SDK puts ordinary error-result text in the `errors` array, while
`subtype: "success"` uses `result`. The previous error paths only read
`result` or `message`, replacing actionable API diagnostics with the generic
`API request failed` text. Centralize the SDK-compatible precedence and cover
blank entries and fallback behavior with regression tests.

## Changes

- `ai-bridge/services/claude/conversation-chain.js` (new): effective-chain
  selection, mirrors the official CLI loader
- `ai-bridge/services/claude/session-service.js`: `buildSessionMessagesPayload`
  and `loadSessionHistory` filter through the chain before the marker drop /
  API shaping; shared `parseJsonlContent` helper
- `ai-bridge/services/claude/message-rewind.js`: rewind candidates built
  from the live chain only
- `ai-bridge/services/claude/persistent-query-service.js`,
  `runtime-lifecycle.js`: abort-flag reset, closed-runtime discard, and
  SDK error extraction for persistent turns
- `ai-bridge/services/claude/message-sender.js`,
  `message-utils.js`: SDK error extraction for the non-persistent path
- `ai-bridge/services/claude/message-utils.test.js`: error precedence and
  fallback regression coverage

## Test plan

- `conversation-chain.test.mjs` (new): fork-branch exclusion, attachment
  handling, parallel-sibling recovery, compact-boundary roots, hybrid
  transcripts, sidechain tips, cycle guard, no-parentUuid fallback
- `session-service.test.mjs`: rewound-branch exclusion through
  `buildSessionMessagesPayload`
- `message-rewind.child.mjs`: rewound rows excluded from rewind anchors
- `message-utils.test.js`: SDK error precedence, blank-entry filtering, and
  generic fallback behavior
- Full Claude-service suite before the latest change: 186 tests pass
- Targeted regression suite after the latest change: 104 tests pass

## Latest update

**4. Keep streaming Agent tool blocks visually stable**

- derive Agent group React keys from the stable message key and structural block index instead of a tool id that may arrive after the initial streaming snapshot
- memoize the dependency-settings navigation callback so `MessageList` can retain its shallow-equality bailout
- add a regression test proving that an Agent block keeps the same DOM instance when its tool id is filled in later

Additional validation:

- `npm run test`
- `npx vitest run src/components/MessageItem/MessageItem.test.tsx src/components/MessageList.test.tsx`
- `npx tsc -p tsconfig.test.json --noEmit`

**5. Allow long Claude sessions to reach 1000 turns**

- raise maxTurns from 100 to 1000 in both normal Claude Agent SDK query paths
- keep the deliberate one-turn limits for rewind and prompt-enhancement operations
- verify Claude lifecycle and persistent-runtime coverage: 43 tests passed
- verify persistent query context and helper coverage: all tests passed

**6. Keep action-dialog borders visible at tool-window edges**

- inset AskUserQuestion and PlanApproval cards by 8px so JCEF cannot clip their rounded left borders
- keep expanded and collapsed cards stretched across the available overlay width; collapsed overlays use end alignment, which would otherwise shrink cards to their content width

Additional validation:

- headless layout check: Ask/Plan cards in both expanded and collapsed modes retain an 8px inset on each side
- `npx vitest run src/components/AskUserQuestionDialog.test.tsx src/components/PlanApprovalDialog.test.tsx` (15 tests passed)
- `npx tsc -p tsconfig.test.json --noEmit`
