### PR TITLE
fix(chat): allow slash and hash triggers after whitespace in input

### DIFF
--- a/webview/src/components/ChatInputBox/hooks/useTriggerDetection.ts
+++ b/webview/src/components/ChatInputBox/hooks/useTriggerDetection.ts
@@ -268,6 +268,19 @@ function isLineStart(text: string, index: number): boolean {
 }
 
 /**
+ * Check whether a character is *visible* whitespace (space, tab, NBSP, etc.).
+ * Zero-width invisible characters (ZWSP/ZWNJ/BOM) are NOT visible whitespace —
+ * they are treated transparently by isLineStart, and must not count as a
+ * "space before /" here. Otherwise `a\u200B/rev` would wrongly trigger the
+ * slash menu because the zero-width space between the visible text and the
+ * slash gets mistaken for an ordinary space.
+ */
+function isVisibleWhitespace(char: string): boolean {
+  return isWhitespace(char) && !INVISIBLE_CHAR_REGEX.test(char);
+}
+
+
+/**
  * Detect @ file reference trigger
  * Note: Skip rendered file tags to avoid false triggers after file tags
  */
@@ -321,8 +334,10 @@ function detectSlashTrigger(text: string, cursorPosition: number): TriggerQuery 
 
     // Found /
     if (char === '/') {
-      // Check if / is at line start (invisible IME residue is transparent)
-      if (isLineStart(text, start)) {
+      // Allow / at line start (invisible IME residue is transparent),
+      // or preceded by visible whitespace, so users can type content then /
+      // to invoke a slash command — matches the ! and $ triggers and the CLI.
+      if (isLineStart(text, start) || isVisibleWhitespace(text[start - 1])) {
         const query = text.slice(start + 1, cursorPosition);
         return {
           trigger: '/',
@@ -357,8 +372,9 @@ function detectHashTrigger(text: string, cursorPosition: number): TriggerQuery |
 
     // Found #
     if (char === '#') {
-      // Check if # is at line start (invisible IME residue is transparent)
-      if (isLineStart(text, start)) {
+      // Allow # at line start (invisible IME residue is transparent),
+      // or preceded by visible whitespace, matching the / ! $ triggers.
+      if (isLineStart(text, start) || isVisibleWhitespace(text[start - 1])) {
         const query = text.slice(start + 1, cursorPosition);
         return {
           trigger: '#',


### PR DESCRIPTION
## Summary

Fixes #1661 - slash commands (`/`) and agent mentions (`#`) can only be invoked when the input box is empty. Once any text is typed, `/` and `#` no longer trigger the suggestion dropdown, so the user must clear the input or insert a newline first.

### Root Cause

`detectSlashTrigger` and `detectHashTrigger` in `useTriggerDetection.ts` only fired when the trigger character was at the **absolute line start**:

```js
const isLineStart = start === 0 || text[start - 1] === '\n';
```

The `!` (prompt) and `$` (Codex skill) triggers already used a more permissive check that also allows the preceding character to be whitespace:

```js
const isValidPosition = start === 0 || text[start - 1] === '\n' || isWhitespace(text[start - 1]);
```

This inconsistency meant `text /` or `text #` (content + space + trigger) worked for `!` and `$` but **not** for `/` and `#`.

### Fix

Apply the same `isWhitespace(text[start - 1])` allowance to `detectSlashTrigger` and `detectHashTrigger`, so all four triggers (`/`, `#`, `!`, `$`) behave consistently:

```js
const isLineStart = start === 0 || text[start - 1] === '\n' || isWhitespace(text[start - 1]);
```

Now users can type content, press space, then type `/` to invoke a slash command or `#` to mention an agent - matching the CLI and the existing `!` / `$` behaviour.

### Before / After

| Input | Before | After |
|---|---|---|
| `/` (empty box) | ✅ triggers | ✅ triggers |
| `hello /` | ❌ no trigger | ✅ triggers |
| `hello #` | ❌ no trigger | ✅ triggers |
| `hello !` | ✅ triggers | ✅ triggers (unchanged) |
| `hello $` | ✅ triggers | ✅ triggers (unchanged) |

Closes #1661