### PR TITLE
fix(claude): route persistent-runtime turns by CLI accounting, not sink existence

### DIFF
--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -38,6 +38,7 @@ import {
   touchRuntime,
   createTurnSink,
   emitTaskEvent,
+  waitForReaderQuiescent,
 } from './runtime-lifecycle.js';
 import { parseTaskNotificationXml, buildTaskNotificationEvent, extractTaskNotificationXml } from './task-notification-parser.js';
 import {
@@ -270,6 +271,19 @@ _sessionCleanupTimer.unref();
   try {
     beginRuntimeTurn(runtime);
 
+    // Wait until the perpetual reader has drained the SDK pipe and parked with
+    // no CLI run in flight BEFORE opening the sink or sending the user message.
+    // Because the user message is not enqueued yet, nothing in the pipe can be a
+    // response to it, so anything still buffered is prior-turn tail (a still-
+    // in-flight background run_in_background, #1305) and routes inter-turn
+    // instead of into this turn's sink — where its output, and worse its closing
+    // result, would be misattributed and seed the one-behind shift (#1410). The
+    // CLI would queue our send behind an in-flight run anyway, so this adds no
+    // latency; it only aligns the daemon's accounting with the CLI's order.
+    // Resolves on quiescence, on dispose (abort stays responsive), or a 120s
+    // protocol-anomaly backstop.
+    await waitForReaderQuiescent(runtime);
+
     // Create and register turnSink after beginRuntimeTurn to avoid race
     // (ensures executeTurn is ready to consume before perpetual reader can push)
     runtime.turnSink = createTurnSink();
@@ -336,6 +350,17 @@ _sessionCleanupTimer.unref();
         continue;
       }
 
+      // Substantive output (assistant / user / stream_event) belongs to THIS
+      // turn, so a later result is ours. A bare SUCCESS result arriving with
+      // sawTurnMessage still false is provably foreign (a real run emits output
+      // before its result) and is skipped below rather than ending the turn
+      // empty and seeding the one-behind shift. system/control messages are NOT
+      // counted: a turn almost always opens with a system session_id message,
+      // so counting it would defang the foreign-result skip in production.
+      if (msg?.type === 'assistant' || msg?.type === 'user' || msg?.type === 'stream_event') {
+        turnState.sawTurnMessage = true;
+      }
+
       if (msg?.type === 'stream_event' && turnState.streamingEnabled) {
         turnState.hasStreamEvents = true;
         processStreamEvent(msg, turnState);
@@ -365,6 +390,17 @@ _sessionCleanupTimer.unref();
       if (msg?.type === 'result') {
         if (msg.is_error) {
           throw new Error(msg.result || msg.message || 'API request failed');
+        }
+        // Defense in depth for the boundary the quiescence gate cannot close: a
+        // foreign run whose closing SUCCESS result is read only AFTER this sink
+        // opened. With no prior turn output (sawTurnMessage still false) it is
+        // provably not ours — a real run always emits output before its result —
+        // so skip it instead of ending the turn empty and seeding the one-behind
+        // shift. The background run still renders via the inter-turn
+        // session_updated path (#1305).
+        if (!turnState.sawTurnMessage) {
+          console.log('[LIFECYCLE] Skipping foreign bare-success result (no prior turn output this turn)');
+          continue;
         }
         // A task_notification for a background (run_in_background) Agent that
         // settles AFTER this result cannot ride the in-turn [MESSAGE] stream:

--- a/ai-bridge/services/claude/runtime-lifecycle.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.js
@@ -223,6 +223,11 @@ async function createRuntime(requestContext, callbacks) {
     createdAt: Date.now(),
     lastUsedAt: Date.now(),
     activeTurnCount: 0,
+    // CLI turn accounting for the quiescence gate — see waitForReaderQuiescent.
+    // cliTurnInFlight: a run whose output we have seen but whose closing result
+    // has not. readerProgress: ticks per message the perpetual reader routes.
+    cliTurnInFlight: false,
+    readerProgress: 0,
     stderrLines: [],
     query: null,
     inputStream: new AsyncStream(),
@@ -286,6 +291,52 @@ async function createRuntime(requestContext, callbacks) {
 }
 
 /**
+ * Wait until the perpetual reader has drained the SDK pipe and parked on
+ * query.next() with no CLI run in flight. Called by executeTurn BEFORE it opens
+ * the turn sink and enqueues the user message, so anything still buffered in the
+ * pipe is prior-turn tail (e.g. a still-in-flight background run_in_background,
+ * #1305) and routes inter-turn instead of into the new turn's sink — where its
+ * output, and worse its closing result, would be misattributed and seed the
+ * sticky "answered my previous message" / one-behind shift (#1410).
+ *
+ * Quiescence = a full macrotask with no reader progress (the reader is parked on
+ * a pending query.next()) AND cliTurnInFlight === false. An idle pipe therefore
+ * returns after one macrotask — the CLI would queue our send behind an in-flight
+ * run anyway, so this adds no latency on the common path; it only aligns the
+ * daemon's accounting with the CLI's actual order. Resolves on quiescence, on
+ * dispose (runtime.closed is checked each tick so abort stays responsive and the
+ * turn fails fast), or a loud 120s protocol-anomaly backstop so a stuck CLI
+ * cannot wedge the daemon silently.
+ */
+export async function waitForReaderQuiescent(runtime) {
+  if (!runtime || runtime.closed) {
+    throw new Error('Runtime closed while waiting for the CLI to become quiet');
+  }
+  const deadline = Date.now() + 120_000;
+  let lastProgress = runtime.readerProgress || 0;
+  for (;;) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    if (runtime.closed) {
+      throw new Error('Runtime closed while waiting for the CLI to become quiet');
+    }
+    // Normalize: readerProgress is undefined until the reader processes its
+    // first message, and undefined !== 0 would otherwise read as perpetual
+    // progress and wedge the gate on a fresh/parked reader.
+    const progress = runtime.readerProgress || 0;
+    const progressed = progress !== lastProgress;
+    lastProgress = progress;
+    if (!progressed && !runtime.cliTurnInFlight) {
+      return;
+    }
+    if (Date.now() > deadline) {
+      console.warn('[LIFECYCLE] waitForReaderQuiescent timed out after 120s'
+        + ' (protocol anomaly; proceeding) cliTurnInFlight=' + !!runtime.cliTurnInFlight);
+      return;
+    }
+  }
+}
+
+/**
  * Start the perpetual reader for a runtime.
  * The reader continuously consumes runtime.query.next() for the runtime's lifetime,
  * routing messages to either the active turn (via turnSink) or inter-turn handling.
@@ -339,6 +390,24 @@ export function startPerpetualReader(runtime, callbacks) {
         // messages are also touched by executeTurn; touching here is idempotent and
         // additionally covers the inter-turn path executeTurn cannot see.
         touchRuntime(runtime);
+
+        // CLI turn accounting for executeTurn's quiescence gate. Substantive
+        // output (assistant / user / stream_event) means a CLI run is in flight;
+        // its closing result clears it (output always precedes its result on the
+        // pipe). system and other control messages leave the flag untouched, so
+        // prewarmed/idle runtimes stay quiet. This lets a new user turn wait for
+        // a still-in-flight run (e.g. a run_in_background completion, #1305)
+        // instead of absorbing its output — and worse, its result — which is the
+        // sticky "answered my previous message" / one-behind shift (#1410).
+        if (msg?.type === 'result') {
+          runtime.cliTurnInFlight = false;
+        } else if (msg?.type === 'assistant' || msg?.type === 'user' || msg?.type === 'stream_event') {
+          runtime.cliTurnInFlight = true;
+        }
+        // readerProgress ticks once per processed message so waitForReaderQuiescent
+        // can tell a parked reader (no progress across a macrotask) from one still
+        // draining the pipe.
+        runtime.readerProgress = (runtime.readerProgress || 0) + 1;
 
         // Dual-mode routing: check if we're in an active turn or inter-turn period
         if (runtime.turnSink) {
@@ -394,6 +463,11 @@ export function startPerpetualReader(runtime, callbacks) {
           // see collectTaskEventsFromMessages — so this is the live fast-path.)
           const taskNotificationXml = extractTaskNotificationXml(msg);
           if (taskNotificationXml !== null) {
+            // A <task-notification> XML carries a background agent's terminal
+            // result report (recent CLI emits no separate `result` for it), so it
+            // IS the run's completion — clear the in-flight flag so the next user
+            // turn's quiescence gate does not wait on a run that already ended.
+            runtime.cliTurnInFlight = false;
             if (runtime.sessionId) {
               const parsed = parseTaskNotificationXml(taskNotificationXml);
               const event = buildTaskNotificationEvent(parsed);

--- a/ai-bridge/services/claude/stale-turn-isolation.test.js
+++ b/ai-bridge/services/claude/stale-turn-isolation.test.js
@@ -1,0 +1,416 @@
+// Redirect HOME to a temp CLI-login config BEFORE importing modules that call
+// setupApiKey(), so buildRequestContext() does not throw on a credential-less CI
+// runner. Must stay the first import (see testing/cli-login-home.js).
+import './testing/cli-login-home.js';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __testing } from './persistent-query-service.js';
+import {
+  createScriptedQuery,
+  assistantText,
+  streamTextDelta,
+  messageStart,
+  RESULT_OK,
+  settleReader,
+} from './testing/scripted-query.js';
+
+/**
+ * Regression suite for stale-event isolation between turns on a persistent
+ * runtime — the "AI answered the previous question" bug (#1410).
+ *
+ * On a reused runtime the SDK iterator lives across turns, so events the CLI
+ * emits after a turn's result message (late snapshots, trailing deltas,
+ * stream cleanup) are still in flight when the next turn starts. These tests
+ * pin down the intended routing: the perpetual reader (the iterator's ONLY
+ * consumer) must absorb those stragglers between turns, and every event of a
+ * new turn — including the very first one — must reach that turn's sink.
+ *
+ * The fake SDK query is a native async generator over a single-slot queue,
+ * the same shape as the SDK's readSdkMessages() (see testing/scripted-query.js
+ * for why plain-function mocks cannot catch this class of bug).
+ */
+
+const OVERRIDES = { settings: { env: {} } };
+
+function baseParams(tag) {
+  return {
+    sessionId: `session-${tag}`,
+    runtimeSessionEpoch: `epoch-${tag}`,
+    cwd: process.cwd(),
+    streaming: true,
+  };
+}
+
+test.beforeEach(async () => {
+  await __testing.resetState();
+});
+
+test.after(async () => {
+  await __testing.resetState();
+});
+
+test('post-result stragglers from turn 1 are consumed between turns and never reach turn 2', async () => {
+  const turn1 = [
+    messageStart(),
+    streamTextDelta('turn 1 reply'),
+    assistantText('turn 1 reply'),
+    RESULT_OK,
+    // A CLI-initiated follow-up run right after the turn (e.g. a background
+    // task notification): its messages arrive after executeTurn already broke
+    // out of its loop, and per protocol it closes with its own result.
+    assistantText('STALE turn 1 trailing snapshot that must never surface again'),
+    streamTextDelta('STALE tail'),
+    RESULT_OK,
+  ];
+  const turn2 = [
+    messageStart(),
+    streamTextDelta('turn 2 reply'),
+    assistantText('turn 2 reply'),
+    RESULT_OK,
+  ];
+
+  let query;
+  __testing.setQueryFn((args) => {
+    query = createScriptedQuery(args, [turn1, turn2]);
+    return query;
+  });
+
+  const params = baseParams('straggler');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'first question' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+  const meta1 = { state: null };
+  await __testing.executeTurn(runtime, ctx1, meta1);
+  assert.equal(meta1.state.lastAssistantContent, 'turn 1 reply');
+
+  // Inter-turn gap: the perpetual reader must drain the stragglers here.
+  await settleReader();
+
+  const ctx2 = await __testing.buildRequestContext({ ...params, message: 'second question' }, false, OVERRIDES);
+  const runtime2 = await __testing.acquireRuntime(ctx2);
+  assert.equal(runtime2, runtime, 'the persistent runtime must be reused across turns');
+
+  const meta2 = { state: null };
+  await __testing.executeTurn(runtime2, ctx2, meta2);
+
+  assert.equal(meta2.state.lastAssistantContent, 'turn 2 reply');
+  assert.ok(
+    !meta2.state.lastAssistantContent.includes('STALE'),
+    'previous-turn straggler content must not be re-emitted in the new turn'
+  );
+});
+
+test('the first event of a new turn is delivered to that turn, never swallowed', async () => {
+  // Regression for the abandoned-next() failure mode: a stray consumer left
+  // waiting on the iterator between turns would receive (and lose) the new
+  // turn's first event. message_start is that first event, and it drives the
+  // [BLOCK_RESET] emission — so its arrival is observable on stdout.
+  const turn1 = [
+    messageStart(),
+    streamTextDelta('first answer'),
+    assistantText('first answer'),
+    RESULT_OK,
+  ];
+  const turn2 = [
+    messageStart(),
+    streamTextDelta('Hello'),
+    streamTextDelta(' world'),
+    assistantText('Hello world'),
+    RESULT_OK,
+  ];
+
+  __testing.setQueryFn((args) => createScriptedQuery(args, [turn1, turn2]));
+
+  const params = baseParams('first-event');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+  await __testing.executeTurn(runtime, ctx1, { state: null });
+
+  // Idle inter-turn gap with nothing buffered — the exact scenario where a
+  // timed-out drain used to leave an abandoned next() queued on the iterator.
+  await settleReader();
+
+  const ctx2 = await __testing.buildRequestContext({ ...params, message: 'q2' }, false, OVERRIDES);
+  const runtime2 = await __testing.acquireRuntime(ctx2);
+  const meta2 = { state: null };
+
+  const written = [];
+  const originalWrite = process.stdout.write;
+  process.stdout.write = function capture(chunk, ...rest) {
+    written.push(String(chunk));
+    return originalWrite.call(this, chunk, ...rest);
+  };
+  try {
+    await __testing.executeTurn(runtime2, ctx2, meta2);
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+
+  assert.ok(
+    written.some((line) => line.includes('[BLOCK_RESET]')),
+    'turn 2 must observe its message_start (first event) — it drives [BLOCK_RESET]'
+  );
+  assert.equal(meta2.state.lastAssistantContent, 'Hello world',
+    'every delta of the new turn must arrive, starting from the first event');
+});
+
+test('a turn ending in is_error leaves the runtime reusable and the next turn clean', async () => {
+  const turn1 = [
+    { type: 'result', is_error: true, result: 'rate limited' },
+    // CLI-initiated follow-up run after the errored result; closes with its
+    // own result per protocol.
+    assistantText('STALE post-error snapshot'),
+    RESULT_OK,
+  ];
+  const turn2 = [
+    messageStart(),
+    streamTextDelta('recovered'),
+    assistantText('recovered'),
+    RESULT_OK,
+  ];
+
+  __testing.setQueryFn((args) => createScriptedQuery(args, [turn1, turn2]));
+
+  const params = baseParams('is-error');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+
+  await assert.rejects(
+    __testing.executeTurn(runtime, ctx1, { state: null }),
+    /rate limited/
+  );
+  assert.equal(runtime.closed, false, 'an is_error result must not tear the runtime down');
+
+  await settleReader();
+
+  const ctx2 = await __testing.buildRequestContext({ ...params, message: 'q2' }, false, OVERRIDES);
+  const runtime2 = await __testing.acquireRuntime(ctx2);
+  assert.equal(runtime2, runtime, 'the runtime must be reused after an is_error turn');
+
+  const meta2 = { state: null };
+  await __testing.executeTurn(runtime2, ctx2, meta2);
+  assert.equal(meta2.state.lastAssistantContent, 'recovered');
+  assert.ok(!meta2.state.lastAssistantContent.includes('STALE'));
+});
+
+test('a new turn waits for an in-flight CLI-initiated turn and never absorbs its result', async () => {
+  // Reproduces the "answer to the previous phrase" ratchet trigger: a
+  // CLI-initiated run (e.g. a background-task completion notification) is
+  // still streaming when the user sends the next message. Without the
+  // in-flight gate, the new turn's sink absorbs that run's output and breaks
+  // on its result; the real answer then completes unobserved between turns
+  // and every later answer shifts back by one.
+  const turn1 = [messageStart(), streamTextDelta('answer one'), assistantText('answer one'), RESULT_OK];
+  const turn2 = [messageStart(), streamTextDelta('answer two'), assistantText('answer two'), RESULT_OK];
+
+  let query;
+  __testing.setQueryFn((args) => {
+    query = createScriptedQuery(args, [turn1, turn2]);
+    return query;
+  });
+
+  const params = baseParams('inflight-gate');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+  await __testing.executeTurn(runtime, ctx1, { state: null });
+  await settleReader();
+
+  // A CLI-initiated run starts between turns: output arrives, no result yet.
+  query.channel.enqueue(assistantText('background notification body'));
+  await settleReader();
+  assert.equal(runtime.cliTurnInFlight, true, 'reader must mark the CLI busy after un-closed output');
+
+  const ctx2 = await __testing.buildRequestContext({ ...params, message: 'q2' }, false, OVERRIDES);
+  const meta2 = { state: null };
+  const turn2Promise = __testing.executeTurn(runtime, ctx2, meta2);
+  await settleReader();
+
+  assert.equal(query.inputs.length, 1,
+    'the new turn must not enqueue its user message while a CLI turn is in flight');
+
+  // The in-flight run closes; only now may the new turn proceed.
+  query.channel.enqueue(RESULT_OK);
+  await settleReader();
+  assert.equal(query.inputs.length, 2, 'the gated turn must proceed once the result arrives');
+
+  await turn2Promise;
+  assert.equal(meta2.state.lastAssistantContent, 'answer two');
+  assert.ok(!meta2.state.lastAssistantContent.includes('background notification'));
+});
+
+test('a foreign success result arriving first in a new turn is skipped, not treated as the turn end', async () => {
+  // The boundary straddle the gate cannot see: the background run's closing
+  // result is read only AFTER the new turn's sink opened. Consuming it as the
+  // new turn's own result would end the turn with empty output and seed the
+  // one-behind shift.
+  const turn1 = [messageStart(), streamTextDelta('answer one'), assistantText('answer one'), RESULT_OK];
+  const turn2 = []; // driven manually below
+
+  let query;
+  __testing.setQueryFn((args) => {
+    query = createScriptedQuery(args, [turn1, turn2]);
+    return query;
+  });
+
+  const params = baseParams('foreign-result');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+  await __testing.executeTurn(runtime, ctx1, { state: null });
+  await settleReader();
+
+  const ctx2 = await __testing.buildRequestContext({ ...params, message: 'q2' }, false, OVERRIDES);
+  const meta2 = { state: null };
+  const turn2Promise = __testing.executeTurn(runtime, ctx2, meta2);
+  await settleReader();
+  assert.equal(query.inputs.length, 2, 'gate must not trigger: the CLI was quiet at turn start');
+
+  // Foreign result lands in the fresh sink before any of this turn's output.
+  query.channel.enqueue({ type: 'result', is_error: false });
+  await settleReader();
+
+  // The real answer follows — the turn must still be alive to receive it.
+  query.channel.enqueue(messageStart());
+  query.channel.enqueue(streamTextDelta('real answer two'));
+  query.channel.enqueue(assistantText('real answer two'));
+  query.channel.enqueue(RESULT_OK);
+
+  await turn2Promise;
+  assert.equal(meta2.state.lastAssistantContent, 'real answer two',
+    'a bare foreign success result must not terminate the turn');
+});
+
+test('an error result as the first message of a turn still fails the turn (not treated as foreign)', async () => {
+  // Immediately-failing requests (auth, rate limit, invalid model) produce a
+  // bare error result with no prior output — that is OUR turn's result and
+  // must keep surfacing as an error, not be skipped by the foreign check.
+  const turn1 = [{ type: 'result', is_error: true, result: 'invalid api key' }];
+
+  __testing.setQueryFn((args) => createScriptedQuery(args, [turn1]));
+
+  const params = baseParams('bare-error');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+
+  await assert.rejects(
+    __testing.executeTurn(runtime, ctx1, { state: null }),
+    /invalid api key/
+  );
+});
+
+test('abort while gated on an in-flight CLI turn fails the turn instead of hanging', async () => {
+  const turn1 = [messageStart(), assistantText('answer one'), RESULT_OK];
+
+  let query;
+  __testing.setQueryFn((args) => {
+    query = createScriptedQuery(args, [turn1]);
+    return query;
+  });
+
+  const params = baseParams('gate-abort');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+  await __testing.executeTurn(runtime, ctx1, { state: null });
+  await settleReader();
+
+  // Arm the gate: CLI output with no closing result.
+  query.channel.enqueue(assistantText('background run output'));
+  await settleReader();
+
+  const ctx2 = await __testing.buildRequestContext({ ...params, message: 'q2' }, false, OVERRIDES);
+  const turn2Promise = __testing.executeTurn(runtime, ctx2, { state: null });
+  await settleReader();
+  assert.equal(query.inputs.length, 1, 'turn must be parked in the gate');
+
+  // User hits stop: dispose resolves the gate, the turn fails fast.
+  await __testing.abortCurrentTurn();
+  await assert.rejects(turn2Promise, /Runtime closed while waiting/);
+  assert.equal(runtime.closed, true);
+});
+
+test('a background-turn tail already in the pipe does not contaminate the next user turn', async () => {
+  // The scheduler-race that survives the level-triggered in-flight gate: turn 1
+  // ends, then the CLI emits a background turn (assistant + its OWN result,
+  // #1305) whose events are already buffered in the pipe — but the reader has
+  // not yet been scheduled to consume them into the inter-turn path. Turn 2
+  // starts in that window.
+  //
+  // Without deferring the sink until the pipe is quiet, turn 2 would open its
+  // sink, receive the background assistant (arming sawTurnMessage), then take
+  // the background *result* as its own — ending turn 2 before its real answer,
+  // which then completes unobserved between turns. Every later answer shifts
+  // back by one ("answer to the previous / pre-previous phrase").
+  const turn1 = [messageStart(), streamTextDelta('answer ONE'), assistantText('answer ONE'), RESULT_OK];
+
+  let query;
+  __testing.setQueryFn((args) => {
+    query = createScriptedQuery(args, [turn1]);
+    return query;
+  });
+
+  const params = baseParams('bg-tail');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+  const meta1 = { state: null };
+  await __testing.executeTurn(runtime, ctx1, meta1);
+  assert.equal(meta1.state.lastAssistantContent, 'answer ONE');
+  await query.waitForInput(); // consume turn 1's user message from the FIFO tracker
+
+  // A complete CLI-initiated background turn lands in the pipe.
+  query.channel.enqueue(assistantText('BACKGROUND task summary — not an answer the user asked for'));
+  query.channel.enqueue(RESULT_OK);
+
+  // Turn 2 begins immediately — NO settleReader, so the reader has not drained
+  // the background turn yet. executeTurn must defer its sink until quiescent.
+  const ctx2 = await __testing.buildRequestContext({ ...params, message: 'q2' }, false, OVERRIDES);
+  const runtime2 = await __testing.acquireRuntime(ctx2);
+  assert.equal(runtime2, runtime, 'runtime is reused across turns');
+  const meta2 = { state: null };
+  const turn2 = __testing.executeTurn(runtime2, ctx2, meta2);
+
+  // Deliver turn 2's real answer only AFTER the CLI has read our user message —
+  // mirroring real ordering, where a response cannot precede its request.
+  await query.waitForInput();
+  query.channel.enqueue(messageStart());
+  query.channel.enqueue(streamTextDelta('answer TWO'));
+  query.channel.enqueue(assistantText('answer TWO'));
+  query.channel.enqueue(RESULT_OK);
+
+  await turn2;
+
+  assert.equal(meta2.state.lastAssistantContent, 'answer TWO');
+  assert.ok(
+    !meta2.state.lastAssistantContent.includes('BACKGROUND'),
+    'the background turn must not be attributed to turn 2'
+  );
+});
+
+test('the perpetual reader is the only query.next() consumer across turns', async () => {
+  // Architectural invariant that makes swallowed events impossible: native
+  // async generators serve queued next() callers in FIFO order, so ANY second
+  // concurrent consumer (a drain, a probe, an abandoned racing read) steals
+  // events from the reader. maxInflight > 1 is that second consumer.
+  const turn1 = [messageStart(), assistantText('one'), RESULT_OK, assistantText('straggler'), RESULT_OK];
+  const turn2 = [messageStart(), assistantText('two'), RESULT_OK];
+
+  let query;
+  __testing.setQueryFn((args) => {
+    query = createScriptedQuery(args, [turn1, turn2]);
+    return query;
+  });
+
+  const params = baseParams('single-consumer');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+  await __testing.executeTurn(runtime, ctx1, { state: null });
+
+  await settleReader();
+
+  const ctx2 = await __testing.buildRequestContext({ ...params, message: 'q2' }, false, OVERRIDES);
+  await __testing.executeTurn(await __testing.acquireRuntime(ctx2), ctx2, { state: null });
+
+  assert.ok(query.stats.nextCalls > 0);
+  assert.equal(
+    query.stats.maxInflight, 1,
+    'exactly one consumer may read the SDK iterator; a second one loses events'
+  );
+});

--- a/ai-bridge/services/claude/stream-event-processor.js
+++ b/ai-bridge/services/claude/stream-event-processor.js
@@ -25,6 +25,11 @@ export function createTurnState(requestContext, runtime) {
     streamStarted: false,
     streamEnded: false,
     hasStreamEvents: false,
+    // True once any non-result message has been processed this turn. A closing
+    // SUCCESS result arriving with this still false is provably foreign (a real
+    // run emits output before its result) and is skipped rather than ending the
+    // turn empty — see the foreign-result skip in executeTurn (#1410).
+    sawTurnMessage: false,
     lastAssistantContent: '',
     lastThinkingContent: '',
     textBlockContentByIndex: new Map(),

--- a/ai-bridge/services/claude/testing/cli-login-home.js
+++ b/ai-bridge/services/claude/testing/cli-login-home.js
@@ -1,0 +1,46 @@
+/**
+ * Test setup side-effect: point HOME at a throwaway temp dir carrying a
+ * CLI-login config, so buildRequestContext() -> setupApiKey() resolves as
+ * "cli_login" instead of throwing "API Key not configured" on a clean CI
+ * runner that has no ~/.codemoss / ~/.claude credentials.
+ *
+ * Why this shape:
+ * - setupApiKey() reads credentials ONLY from ~/.codemoss + ~/.claude under the
+ *   real home dir (it deliberately ignores shell env vars), and getRealHomeDir()
+ *   CACHES that path on its first call. So HOME must be redirected BEFORE any
+ *   code calls getRealHomeDir(). Importing this module first — above the import
+ *   of persistent-query-service.js — guarantees that: ES module imports execute
+ *   in source order, and this file has no dependency that touches the home dir.
+ * - It is the lightweight, single-process equivalent of the child-process
+ *   harness used by runtime-lifecycle.test.js / api-config.test.js for the same
+ *   reason. Test-only; no production code is involved.
+ *
+ * A `claude.current === "__cli_login__"` config makes getClaudeRuntimeState()
+ * report access === 'cli_login', which setupApiKey() treats as a valid auth
+ * mode and returns without throwing.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-test-home-'));
+fs.mkdirSync(path.join(tempHome, '.codemoss'), { recursive: true });
+fs.writeFileSync(
+  path.join(tempHome, '.codemoss', 'config.json'),
+  JSON.stringify({ claude: { current: '__cli_login__', providers: {} } }),
+  'utf8'
+);
+
+process.env.HOME = tempHome;
+process.env.USERPROFILE = tempHome;
+
+// Best-effort cleanup when the test process exits.
+process.on('exit', () => {
+  try {
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  } catch {
+    // ignore — OS will reclaim the temp dir
+  }
+});
+
+export const testHomeDir = tempHome;

--- a/ai-bridge/services/claude/testing/scripted-query.js
+++ b/ai-bridge/services/claude/testing/scripted-query.js
@@ -1,0 +1,160 @@
+/**
+ * Test doubles for the SDK query object used by persistent-runtime tests.
+ *
+ * The message iterator here is a NATIVE async generator over a single-slot
+ * message queue — the same shape as the SDK's readSdkMessages() in sdk.mjs:
+ *
+ *   async *readSdkMessages() {
+ *     try { for await (const e of this.inputStream) yield e; }
+ *     finally { await this.cleanup(); }
+ *   }
+ *
+ * The shape matters. Native async generators queue concurrent next() callers
+ * and hand each queued caller a distinct value in FIFO order, so an abandoned
+ * next() (e.g. from a timeout race) invisibly consumes the next produced
+ * value. Plain-function mocks whose next() independently returns a fresh
+ * value cannot express that failure mode — which is exactly how the
+ * swallowed-first-event bug in the original drain approach slipped past its
+ * tests (PR #1410 review).
+ */
+
+export class MessageQueue {
+  queue = [];
+  readResolve = null;
+  isDone = false;
+
+  next() {
+    if (this.queue.length > 0) {
+      return Promise.resolve({ done: false, value: this.queue.shift() });
+    }
+    if (this.isDone) {
+      return Promise.resolve({ done: true, value: undefined });
+    }
+    return new Promise((resolve) => { this.readResolve = resolve; });
+  }
+
+  enqueue(value) {
+    if (this.readResolve) {
+      const resolve = this.readResolve;
+      this.readResolve = null;
+      resolve({ done: false, value });
+    } else {
+      this.queue.push(value);
+    }
+  }
+
+  end() {
+    this.isDone = true;
+    if (this.readResolve) {
+      const resolve = this.readResolve;
+      this.readResolve = null;
+      resolve({ done: true, value: undefined });
+    }
+  }
+
+  [Symbol.asyncIterator]() { return this; }
+}
+
+/**
+ * Fake SDK query that consumes the runtime's input stream and answers the
+ * i-th user message with turnScripts[i] (an array of SDK messages, enqueued
+ * in order). Events listed after a result message model post-result
+ * stragglers. With an empty script list the query simply pends — the real
+ * iterator's behavior between turns — until close() ends the stream.
+ *
+ * Also records next() concurrency: maxInflight > 1 means something other
+ * than the perpetual reader consumed the iterator concurrently, which is the
+ * exact condition that loses events on the real SDK.
+ */
+export function createScriptedQuery({ prompt, options }, turnScripts = []) {
+  const channel = new MessageQueue();
+  const inputs = [];
+  const inputWaiters = [];
+  let waitIndex = 0;
+
+  (async () => {
+    for await (const userMessage of prompt) {
+      inputs.push(userMessage);
+      const waiter = inputWaiters.shift();
+      if (waiter) waiter(userMessage);
+      const script = turnScripts[inputs.length - 1] || [];
+      for (const event of script) {
+        channel.enqueue(event);
+      }
+    }
+  })().catch(() => { /* input stream errored on dispose — irrelevant to tests */ });
+
+  // Same shape as the SDK's readSdkMessages(): a native async generator over
+  // the internal message stream.
+  async function* readMessages() {
+    for await (const event of channel) yield event;
+  }
+  const generator = readMessages();
+
+  const stats = { nextCalls: 0, inflight: 0, maxInflight: 0 };
+
+  return {
+    options,
+    channel,
+    inputs,
+    stats,
+    /** Resolves with the next not-yet-awaited user message (FIFO). */
+    waitForInput() {
+      if (waitIndex < inputs.length) {
+        const message = inputs[waitIndex];
+        waitIndex += 1;
+        return Promise.resolve(message);
+      }
+      return new Promise((resolve) => {
+        inputWaiters.push((message) => {
+          waitIndex += 1;
+          resolve(message);
+        });
+      });
+    },
+    setPermissionMode: async () => {},
+    setModel: async () => {},
+    setMaxThinkingTokens: async () => {},
+    close() {
+      channel.end();
+    },
+    next() {
+      stats.nextCalls += 1;
+      stats.inflight += 1;
+      stats.maxInflight = Math.max(stats.maxInflight, stats.inflight);
+      return generator.next().finally(() => { stats.inflight -= 1; });
+    },
+  };
+}
+
+/** Common SDK message shapes. */
+export function assistantText(text) {
+  return { type: 'assistant', message: { content: [{ type: 'text', text }] } };
+}
+
+export function streamTextDelta(text) {
+  return {
+    type: 'stream_event',
+    event: { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } },
+  };
+}
+
+export function messageStart() {
+  return {
+    type: 'stream_event',
+    event: { type: 'message_start', message: { usage: { input_tokens: 1, output_tokens: 0 } } },
+  };
+}
+
+export const RESULT_OK = { type: 'result', is_error: false };
+
+/**
+ * Let the perpetual reader run: it pulls from the iterator across macrotask
+ * boundaries (an I/O boundary in production), so inter-turn stragglers need a
+ * few ticks to be consumed.
+ */
+export async function settleReader(ticks = 5) {
+  for (let i = 0; i < ticks; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}


### PR DESCRIPTION
## Supersedes #1410

This is the ai-bridge turn-attribution fix from #1410, reborn on `feature/v0.5.3`. #1410 was based on `feature/v0.4.7` and went stale behind ~60 commits; the perpetual reader's inter-turn path also grew since (async subagents, `<task-notification>` XML), so the accounting had to be **re-derived against the current code rather than rebased** — the old `cliTurnInFlight` logic predated that new inter-turn taxonomy and couldn't be ported mechanically. Closing #1410 in favor of this.

## Symptom

A Claude response arrives, is buffered, but attributed to the *wrong* turn — the chat appears to answer the previous (or pre-previous) message. Users re-send, which feeds Claude redundant prompts. Open issue: **#1305**.

## Root cause

The perpetual reader routes SDK messages by a single temporal signal — *does a `turnSink` exist right now* — with no identity on the messages (`runtime-lifecycle.js`):

```js
if (runtime.turnSink) { runtime.turnSink.push(msg); }   // in-turn
else { /* inter-turn */ }
```

Any CLI output read after the next turn's sink opens is therefore attributed to that turn. A still-in-flight run — including a CLI-initiated one such as a `run_in_background` completion (#1305) — then has its output, and worse its closing `result`, consumed by the new turn. Consuming a foreign `result` ends the new turn early; the real answer completes unobserved between turns, and every later answer shifts back by one — the sticky "answered my previous message" ratchet.

Messages carry no per-turn identity (`session_id` is per-session, not per-turn; `parent_tool_use_id` marks subagents), so this can't be solved by inspecting a message — only by accounting for the run's lifecycle.

## Fix — three layers, all ai-bridge

**1. CLI turn accounting in the reader.** Substantive output (`assistant` / `user` / `stream_event`) arms `cliTurnInFlight`; its closing `result` clears it (output always precedes its result on the pipe). `system`/control messages never arm it, so prewarmed/idle runtimes stay quiet. `readerProgress` ticks once per routed message.
*v0.5.3-specific:* a `<task-notification>` XML is a background agent's terminal report (recent CLI emits no separate `result` for it), so it **also clears the flag** — otherwise the next turn's gate would wait on a run that already ended. This is the main thing that had to be added beyond #1410's v0.4.7 logic.

**2. Quiescence gate in `executeTurn` (`waitForReaderQuiescent`).** Before opening the sink **and** before enqueuing the user message, wait until the reader has drained the pipe and parked on `query.next()` with no run in flight. Because the user message isn't sent yet, nothing in the pipe can be a response to it — anything buffered is prior-turn tail and routes inter-turn where it belongs. The CLI would queue our send behind an in-flight run anyway, so this adds no latency on the common path (idle pipe returns after one macrotask); it only aligns the daemon's accounting with the CLI's actual order. Resolves on quiescence, on dispose (abort stays responsive, turn fails fast), or a loud 120s protocol-anomaly backstop.

**3. Foreign-result skip** (defense in depth for the boundary the gate cannot close). A bare *success* `result` with no prior substantive turn output (`sawTurnMessage` still false) is provably foreign (a real run always emits output before its result) and is **skipped**, not treated as turn-end. Bare *error* results keep failing the turn (immediately-failing requests legitimately produce them).

## Known residual

A foreign run whose events arrive from the network strictly *after* this turn's message is enqueued (a true send/receive race, not a scheduling artifact) can still interleave. Fully closing that needs message-level turn identity from the CLI/SDK.

## Tests

All isolation tests use a fake SDK query built on a **native async generator** over a single-slot queue — the SDK's `readSdkMessages()` shape, and the only mock shape that surfaces stolen-read / misattribution bugs (the flaw that sank the original drain approach in #1410's review).

`stale-turn-isolation.test.js` — 9/9 green:
- post-result stragglers consumed between turns, never reach the next turn
- the first event of a new turn is delivered, never swallowed
- a turn ending in `is_error` leaves the runtime reusable
- a new turn waits for an in-flight CLI run and never absorbs its result
- a background-turn tail already in the pipe does not contaminate the next turn
- a foreign bare-success result is skipped, not treated as turn-end
- a bare error result still fails the turn
- abort while gated fails fast
- the perpetual reader stays the only iterator consumer (`maxInflight === 1`)

Full `ai-bridge/services/claude/*.test.js`: **139/139**. The 3 failures in the wider `ai-bridge/**/*.test.js` glob (MCP-server cwd, grok `makeRuntimeKey` auth, image-only prompt fallback) are pre-existing on `feature/v0.5.3` and unrelated — verified by stashing this change and reproducing the same 3 on a clean checkout.
