### PR TITLE
fix(jcef): one-click workaround for out-of-process JCEF NPE (JBR-9234)

### DIFF
--- a/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
@@ -999,14 +999,32 @@ public class WebviewInitializer {
 
     private void showJcefRemoteModeErrorPanel() {
         // Terminal state: the remote CefServer process is unhealthy, so every
-        // reload/recreate against it will keep throwing the same NPE. Stop the
-        // watchdog so it does not loop back into recreate every cooldown and
-        // re-flash this panel. Recovery requires an IDE restart.
+        // reload/recreate against it will keep throwing the same NPE (JBR-9234,
+        // out-of-process JCEF on IntelliJ 2025.2+ / JCEF 144). Stop the watchdog
+        // so it does not loop back into recreate every cooldown and re-flash this
+        // panel. The offered action disables out-of-process JCEF in the Registry
+        // — the documented workaround — after which an IDE restart initialises
+        // JCEF in-process and the message router stops throwing.
         host.getWebviewWatchdog().stop();
         JPanel panel = ErrorPanelBuilder.buildCenteredPanel(
             "⚠️",
             ClaudeCodeGuiBundle.message("toolwindow.jcefRemoteError"),
-            ClaudeCodeGuiBundle.message("toolwindow.jcefRemoteSolution")
+            ClaudeCodeGuiBundle.message("toolwindow.jcefRemoteSolution"),
+            ClaudeCodeGuiBundle.message("toolwindow.jcefRemoteAction"),
+            this::disableOutOfProcessJcefAndShowRestartPanel
+        );
+        replaceMainContent(panel);
+    }
+
+    private void disableOutOfProcessJcefAndShowRestartPanel() {
+        if (!JBCefBrowserFactory.disableOutOfProcessJcefInRegistry()) {
+            LOG.warn("Could not disable out-of-process JCEF in the IDE registry");
+            return;
+        }
+        JPanel panel = ErrorPanelBuilder.buildCenteredPanel(
+                "✓",
+                ClaudeCodeGuiBundle.message("toolwindow.jcefRestartRequired"),
+                ClaudeCodeGuiBundle.message("toolwindow.jcefRestartRequiredSolution")
         );
         replaceMainContent(panel);
     }

--- a/src/main/java/com/github/claudecodegui/util/JBCefBrowserFactory.java
+++ b/src/main/java/com/github/claudecodegui/util/JBCefBrowserFactory.java
@@ -36,6 +36,12 @@ public final class JBCefBrowserFactory {
     private static final Logger LOG = Logger.getInstance(JBCefBrowserFactory.class);
     private static final int CONTROL_CHAR_MAX = 0x1F;
     private static final String JCEF_ENABLED_REGISTRY_KEY = "ide.browser.jcef.enabled";
+    /**
+     * Toggles JCEF's out-of-process (remote CEF server) mode. On by default from
+     * IntelliJ 2025.2 / JCEF 144, where it triggers JBR-9234: an NPE in
+     * RemoteMessageRouterImpl when a JBCefJSQuery message router is created.
+     */
+    private static final String JCEF_OUT_OF_PROCESS_REGISTRY_KEY = "ide.browser.jcef.out-of-process.enabled";
     private static final ConcurrentMap<Class<?>, Optional<Method>> IS_CLOSED_METHODS = new ConcurrentHashMap<>();
 
     /**
@@ -390,6 +396,28 @@ public final class JBCefBrowserFactory {
             return Registry.is(JCEF_ENABLED_REGISTRY_KEY, true);
         } catch (Exception | LinkageError e) {
             LOG.warn("Failed to enable JCEF in IDE registry: " + e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
+     * Disable the IDE registry flag that runs JCEF in out-of-process (remote CEF
+     * server) mode. That mode throws {@code NullPointerException} in
+     * {@code RemoteMessageRouterImpl} on the JCEF builds bundled with IntelliJ
+     * 2025.2+ (JCEF 144) whenever a {@code JBCefJSQuery} message router is
+     * created — <a href="https://youtrack.jetbrains.com/issue/JBR-9234">JBR-9234</a>.
+     * Flipping it off is the documented workaround; the flag is read during
+     * JBCefApp initialization, so an IDE restart is required for it to take effect.
+     *
+     * @return true when the registry value was updated successfully
+     */
+    public static boolean disableOutOfProcessJcefInRegistry() {
+        try {
+            Registry.get(JCEF_OUT_OF_PROCESS_REGISTRY_KEY).setValue(false);
+            // The key defaults to true, so a successful write must read back false.
+            return !Registry.is(JCEF_OUT_OF_PROCESS_REGISTRY_KEY, true);
+        } catch (Exception | LinkageError e) {
+            LOG.warn("Failed to disable out-of-process JCEF in IDE registry: " + e.getMessage(), e);
             return false;
         }
     }

--- a/src/main/resources/messages/ClaudeCodeGuiBundle.properties
+++ b/src/main/resources/messages/ClaudeCodeGuiBundle.properties
@@ -258,7 +258,8 @@ toolwindow.jcefPluginMissingSolution=Open Settings > Plugins > Marketplace.\nIns
 toolwindow.jcefOutdatedJbr=IDE's bundled Java Runtime (JBR) is too old for JCEF
 toolwindow.jcefOutdatedJbrSolution=This IDE (e.g. Android Studio 2026.x) ships a JBR that lacks the JCEF API\nrequired by the platform (JCefAppConfig.isRemoteEnabled).\nSolution:\nDouble-click Shift, search for "Choose Boot Java Runtime for the IDE"\nSelect or add a JetBrains Runtime with JCEF b1373 or newer.\nManual download: https://cache-redirector.jetbrains.com/intellij-jbr/\n(e.g. jbr_jcef-21.0.10-windows-x64-b1373.tar.gz)\nThen restart the IDE.
 toolwindow.jcefRemoteError=JCEF module error in editor
-toolwindow.jcefRemoteSolution=Solution:\nCompletely exit your editor and restart it.\nNote: You must fully exit, not just go back to the project selection page.
+toolwindow.jcefRemoteSolution=Known JCEF bug (JBR-9234) in IntelliJ's out-of-process JCEF mode on 2025.2+.\nUse the button below to apply the fix, then fully restart the IDE (you must exit completely, not just return to the project selection page).\nManual alternative: in Help - Edit Custom VM Options add:\n-Dide.browser.jcef.out-of-process.enabled=false
+toolwindow.jcefRemoteAction=Disable out-of-process JCEF
 toolwindow.extractingTitle=Preparing AI Bridge...
 toolwindow.extractingDesc=First-time setup: extracting AI Bridge components.\nThis only happens on first install/update (approx. 10-30s).
 

--- a/src/main/resources/messages/ClaudeCodeGuiBundle_en.properties
+++ b/src/main/resources/messages/ClaudeCodeGuiBundle_en.properties
@@ -232,7 +232,8 @@ toolwindow.jcefPluginMissingSolution=Open Settings > Plugins > Marketplace.\nIns
 toolwindow.jcefOutdatedJbr=IDE's bundled Java Runtime (JBR) is too old for JCEF
 toolwindow.jcefOutdatedJbrSolution=This IDE (e.g. Android Studio 2026.x) ships a JBR that lacks the JCEF API\nrequired by the platform (JCefAppConfig.isRemoteEnabled).\nSolution:\nDouble-click Shift, search for "Choose Boot Java Runtime for the IDE"\nSelect or add a JetBrains Runtime with JCEF b1373 or newer.\nManual download: https://cache-redirector.jetbrains.com/intellij-jbr/\n(e.g. jbr_jcef-21.0.10-windows-x64-b1373.tar.gz)\nThen restart the IDE.
 toolwindow.jcefRemoteError=JCEF module error in editor
-toolwindow.jcefRemoteSolution=Solution:\nCompletely exit your editor and restart it.\nNote: You must fully exit, not just go back to the project selection page.
+toolwindow.jcefRemoteSolution=Known JCEF bug (JBR-9234) in IntelliJ's out-of-process JCEF mode on 2025.2+.\nUse the button below to apply the fix, then fully restart the IDE (you must exit completely, not just return to the project selection page).\nManual alternative: in Help - Edit Custom VM Options add:\n-Dide.browser.jcef.out-of-process.enabled=false
+toolwindow.jcefRemoteAction=Disable out-of-process JCEF
 toolwindow.extractingTitle=Preparing AI Bridge...
 toolwindow.extractingDesc=First-time setup: extracting AI Bridge components.\nThis only happens on first install/update (approx. 10-30s).
 

--- a/src/main/resources/messages/ClaudeCodeGuiBundle_es.properties
+++ b/src/main/resources/messages/ClaudeCodeGuiBundle_es.properties
@@ -228,7 +228,8 @@ toolwindow.jcefPluginMissingSolution=Abra Settings > Plugins > Marketplace.\nIns
 toolwindow.jcefOutdatedJbr=El Java Runtime (JBR) incluido en el IDE es demasiado antiguo para JCEF
 toolwindow.jcefOutdatedJbrSolution=Este IDE (p. ej. Android Studio 2026.x) incluye un JBR sin la API JCEF\nrequerida por la plataforma (JCefAppConfig.isRemoteEnabled).\nSolución:\nPresione Shift dos veces, busque "Choose Boot Java Runtime for the IDE"\nSeleccione o agregue un JetBrains Runtime con JCEF b1373 o más reciente.\nDescarga manual: https://cache-redirector.jetbrains.com/intellij-jbr/\n(p. ej. jbr_jcef-21.0.10-windows-x64-b1373.tar.gz)\nLuego reinicie el IDE.
 toolwindow.jcefRemoteError=Error del módulo JCEF en el editor
-toolwindow.jcefRemoteSolution=Solución:\nCierre completamente el editor y reinícielo.\nNota: debe cerrar completamente, no solo volver a la página de selección de proyecto.
+toolwindow.jcefRemoteSolution=Error conocido de JCEF (JBR-9234) en el modo out-of-process de JCEF en IntelliJ 2025.2+.\nUse el botón siguiente para aplicar la corrección y luego reinicie completamente el IDE (debe salir completamente, no solo volver a la página de selección de proyecto).\nAlternativa manual: en Help - Edit Custom VM Options añada:\n-Dide.browser.jcef.out-of-process.enabled=false
+toolwindow.jcefRemoteAction=Desactivar JCEF out-of-process
 toolwindow.extractingTitle=Preparando AI Bridge...
 toolwindow.extractingDesc=Configuración inicial: extrayendo componentes de AI Bridge.\nEsto solo ocurre en la primera instalación/actualización (aprox. 10-30s).
 

--- a/src/main/resources/messages/ClaudeCodeGuiBundle_fr.properties
+++ b/src/main/resources/messages/ClaudeCodeGuiBundle_fr.properties
@@ -228,7 +228,8 @@ toolwindow.jcefPluginMissingSolution=Ouvrez Settings > Plugins > Marketplace.\nI
 toolwindow.jcefOutdatedJbr=Le Java Runtime (JBR) fourni avec l'IDE est trop ancien pour JCEF
 toolwindow.jcefOutdatedJbrSolution=Cet IDE (p. ex. Android Studio 2026.x) inclut un JBR dépourvu de l'API JCEF\nrequise par la plateforme (JCefAppConfig.isRemoteEnabled).\nSolution :\nAppuyez deux fois sur Shift, recherchez "Choose Boot Java Runtime for the IDE"\nSélectionnez ou ajoutez un JetBrains Runtime avec JCEF b1373 ou plus récent.\nTéléchargement manuel : https://cache-redirector.jetbrains.com/intellij-jbr/\n(p. ex. jbr_jcef-21.0.10-windows-x64-b1373.tar.gz)\nPuis redémarrez l'IDE.
 toolwindow.jcefRemoteError=Erreur du module JCEF dans l'éditeur
-toolwindow.jcefRemoteSolution=Solution :\nQuittez complètement l'éditeur et redémarrez-le.\nNote : vous devez quitter complètement, pas simplement revenir à la page de sélection du projet.
+toolwindow.jcefRemoteSolution=Bogue JCEF connu (JBR-9234) dans le mode out-of-process de JCEF sur IntelliJ 2025.2+.\nCliquez sur le bouton ci-dessous pour appliquer le correctif, puis redémarrez complètement l'IDE (vous devez quitter complètement, pas seulement revenir à la page de sélection du projet).\nAlternative manuelle : dans Help - Edit Custom VM Options ajoutez :\n-Dide.browser.jcef.out-of-process.enabled=false
+toolwindow.jcefRemoteAction=Désactiver JCEF out-of-process
 toolwindow.extractingTitle=Préparation de AI Bridge...
 toolwindow.extractingDesc=Configuration initiale : extraction des composants AI Bridge.\nCela ne se produit qu'à la première installation/mise à jour (environ 10-30s).
 

--- a/src/main/resources/messages/ClaudeCodeGuiBundle_hi.properties
+++ b/src/main/resources/messages/ClaudeCodeGuiBundle_hi.properties
@@ -228,7 +228,8 @@ toolwindow.jcefPluginMissingSolution=Settings > Plugins > Marketplace खोल�
 toolwindow.jcefOutdatedJbr=IDE के साथ आया Java Runtime (JBR) JCEF के लिए बहुत पुराना है
 toolwindow.jcefOutdatedJbrSolution=यह IDE (जैसे Android Studio 2026.x) ऐसा JBR शामिल करता है जिसमें प्लेटफ़ॉर्म के लिए\nआवश्यक JCEF API (JCefAppConfig.isRemoteEnabled) नहीं है।\nसमाधान:\nShift दो बार दबाएं, "Choose Boot Java Runtime for the IDE" खोजें\nJCEF b1373 या नया JetBrains Runtime चुनें या जोड़ें।\nमैनुअल डाउनलोड: https://cache-redirector.jetbrains.com/intellij-jbr/\n(जैसे jbr_jcef-21.0.10-windows-x64-b1373.tar.gz)\nफिर IDE पुनर्प्रारंभ करें।
 toolwindow.jcefRemoteError=संपादक में JCEF मॉड्यूल त्रुटि
-toolwindow.jcefRemoteSolution=समाधान:\nसंपादक को पूरी तरह से बंद करें और पुनर्प्रारंभ करें।\nनोट: आपको पूरी तरह से बाहर निकलना होगा, केवल प्रोजेक्ट चयन पृष्ठ पर वापस जाना पर्याप्त नहीं है।
+toolwindow.jcefRemoteSolution=यह IntelliJ 2025.2+ पर out-of-process JCEF मोड में एक ज्ञात JCEF बग (JBR-9234) है।\nसुधार लागू करने के लिए नीचे दिए गए बटन पर क्लिक करें, फिर IDE को पूरी तरह पुनर्प्रारंभ करें (आपको पूरी तरह बाहर निकलना होगा, केवल प्रोजेक्ट चयन पृष्ठ पर वापस जाना पर्याप्त नहीं है)।\nमैन्युअल विकल्प: Help - Edit Custom VM Options में जोड़ें:\n-Dide.browser.jcef.out-of-process.enabled=false
+toolwindow.jcefRemoteAction=out-of-process JCEF अक्षम करें
 toolwindow.extractingTitle=AI Bridge तैयार हो रहा है...
 toolwindow.extractingDesc=प्रथम सेटअप: AI Bridge घटकों को निकाला जा रहा है।\nयह केवल प्रथम इंस्टॉल/अपडेट पर होता है (लगभग 10-30 सेकंड)।
 

--- a/src/main/resources/messages/ClaudeCodeGuiBundle_ja.properties
+++ b/src/main/resources/messages/ClaudeCodeGuiBundle_ja.properties
@@ -228,7 +228,8 @@ toolwindow.jcefPluginMissingSolution=Settings > Plugins > Marketplace を開き�
 toolwindow.jcefOutdatedJbr=IDE 同梱の Java ランタイム（JBR）が古く、JCEF を起動できません
 toolwindow.jcefOutdatedJbrSolution=この IDE（例: Android Studio 2026.x）に同梱の JBR には、プラットフォームが必要とする\nJCEF API（JCefAppConfig.isRemoteEnabled）がありません。\n解決方法:\nShift を2回押して、"Choose Boot Java Runtime for the IDE" を検索\nJCEF b1373 以降の JetBrains Runtime を選択または追加してください。\n手動ダウンロード: https://cache-redirector.jetbrains.com/intellij-jbr/\n（例: jbr_jcef-21.0.10-windows-x64-b1373.tar.gz）\nその後 IDE を再起動してください。
 toolwindow.jcefRemoteError=エディターで JCEF モジュールエラーが発生しました
-toolwindow.jcefRemoteSolution=解決方法:\nエディターを完全に終了して再起動してください。\n注意：完全に終了する必要があります。プロジェクト選択画面に戻るだけでは不十分です。
+toolwindow.jcefRemoteSolution=IntelliJ 2025.2+ の out-of-process JCEF モードにおける既知の JCEF 不具合 (JBR-9234) です。\n下のボタンをクリックして修正を適用し、IDE を完全に再起動してください（プロジェクト選択画面に戻るだけではなく、完全に終了する必要があります）。\n手動の代替案：Help - Edit Custom VM Options に以下を追加：\n-Dide.browser.jcef.out-of-process.enabled=false
+toolwindow.jcefRemoteAction=out-of-process JCEF を無効化
 toolwindow.extractingTitle=AI Bridge を準備中...
 toolwindow.extractingDesc=初回セットアップ：AI Bridge コンポーネントを展開中。\nこの処理は初回インストール/更新時のみ発生します（約 10-30 秒）。
 

--- a/src/main/resources/messages/ClaudeCodeGuiBundle_ru.properties
+++ b/src/main/resources/messages/ClaudeCodeGuiBundle_ru.properties
@@ -228,7 +228,8 @@ toolwindow.jcefPluginMissingSolution=Откройте Settings > Plugins > Marke
 toolwindow.jcefOutdatedJbr=Встроенная в IDE Java Runtime (JBR) слишком старая для JCEF
 toolwindow.jcefOutdatedJbrSolution=Эта IDE (например, Android Studio 2026.x) поставляется с JBR без JCEF API,\nтребуемого платформой (JCefAppConfig.isRemoteEnabled).\nРешение:\nДважды нажмите Shift, найдите "Choose Boot Java Runtime for the IDE"\nВыберите или добавьте JetBrains Runtime с JCEF b1373 или новее.\nЗагрузка вручную: https://cache-redirector.jetbrains.com/intellij-jbr/\n(например, jbr_jcef-21.0.10-windows-x64-b1373.tar.gz)\nЗатем перезапустите IDE.
 toolwindow.jcefRemoteError=Ошибка модуля JCEF в редакторе
-toolwindow.jcefRemoteSolution=Решение:\nПолностью закройте редактор и перезапустите его.\nПримечание: необходимо полностью выйти, а не просто вернуться на страницу выбора проекта.
+toolwindow.jcefRemoteSolution=Известный баг JCEF (JBR-9234) в out-of-process режиме JCEF на IntelliJ 2025.2+.\nНажмите кнопку ниже, чтобы применить исправление, затем полностью перезапустите IDE (нужно именно полностью выйти, а не вернуться на страницу выбора проекта).\nРучной вариант: в Help - Edit Custom VM Options добавьте:\n-Dide.browser.jcef.out-of-process.enabled=false
+toolwindow.jcefRemoteAction=Отключить out-of-process JCEF
 toolwindow.extractingTitle=Подготовка AI Bridge...
 toolwindow.extractingDesc=Первоначальная настройка: извлечение компонентов AI Bridge.\nЭто происходит только при первой установке/обновлении (прибл. 10-30 сек).
 

--- a/src/main/resources/messages/ClaudeCodeGuiBundle_zh.properties
+++ b/src/main/resources/messages/ClaudeCodeGuiBundle_zh.properties
@@ -237,7 +237,8 @@ toolwindow.jcefPluginMissingSolution=打开 Settings > Plugins > Marketplace。\
 toolwindow.jcefOutdatedJbr=IDE 自带的 Java 运行时（JBR）过旧，无法启动 JCEF
 toolwindow.jcefOutdatedJbrSolution=当前 IDE（如 Android Studio 2026.x）自带的 JBR 缺少平台所需的 JCEF API\n（JCefAppConfig.isRemoteEnabled）。\n解决方案:\n双击 Shift，搜索 "Choose Boot Java Runtime for the IDE"\n选择或添加 JCEF b1373 及更新版本的 JetBrains Runtime。\n手动下载: https://cache-redirector.jetbrains.com/intellij-jbr/\n（例如 jbr_jcef-21.0.10-windows-x64-b1373.tar.gz）\n完成后重启 IDE。
 toolwindow.jcefRemoteError=编辑器中 JCEF 模块出错
-toolwindow.jcefRemoteSolution=解决方案:\n完全退出编辑器并重新启动。\n注意：必须完全退出，不能只是返回到项目选择页面。
+toolwindow.jcefRemoteSolution=这是 IntelliJ 2025.2+ 的 out-of-process JCEF 模式中已知的 JCEF 缺陷 (JBR-9234)。\n点击下方按钮应用修复，然后完全重启 IDE（必须完全退出，不能只是返回到项目选择页面）。\n手动替代方案：在 Help - Edit Custom VM Options 中添加：\n-Dide.browser.jcef.out-of-process.enabled=false
+toolwindow.jcefRemoteAction=禁用 out-of-process JCEF
 toolwindow.extractingTitle=正在准备 AI Bridge...
 toolwindow.extractingDesc=首次设置：正在提取 AI Bridge 组件。\n此过程仅在首次安装/更新时发生（约 10-30 秒）。
 

--- a/src/main/resources/messages/ClaudeCodeGuiBundle_zh_TW.properties
+++ b/src/main/resources/messages/ClaudeCodeGuiBundle_zh_TW.properties
@@ -228,7 +228,8 @@ toolwindow.jcefPluginMissingSolution=開啟 Settings > Plugins > Marketplace。\
 toolwindow.jcefOutdatedJbr=IDE 內建的 Java 執行階段（JBR）過舊，無法啟動 JCEF
 toolwindow.jcefOutdatedJbrSolution=當前 IDE（如 Android Studio 2026.x）內建的 JBR 缺少平台所需的 JCEF API\n（JCefAppConfig.isRemoteEnabled）。\n解決方案:\n雙擊 Shift，搜尋 "Choose Boot Java Runtime for the IDE"\n選擇或新增 JCEF b1373 及更新版本的 JetBrains Runtime。\n手動下載: https://cache-redirector.jetbrains.com/intellij-jbr/\n（例如 jbr_jcef-21.0.10-windows-x64-b1373.tar.gz）\n完成後重新啟動 IDE。
 toolwindow.jcefRemoteError=編輯器中 JCEF 模組出錯
-toolwindow.jcefRemoteSolution=解決方案:\n完全退出編輯器並重新啟動。\n注意：必須完全退出，不能只是返回到專案選擇頁面。
+toolwindow.jcefRemoteSolution=這是 IntelliJ 2025.2+ 的 out-of-process JCEF 模式中已知的 JCEF 缺陷 (JBR-9234)。\n點擊下方按鈕套用修復，然後完全重新啟動 IDE（必須完全退出，不能只是返回到專案選擇頁面）。\n手動替代方案：在 Help - Edit Custom VM Options 中新增：\n-Dide.browser.jcef.out-of-process.enabled=false
+toolwindow.jcefRemoteAction=停用 out-of-process JCEF
 toolwindow.extractingTitle=正在準備 AI Bridge...
 toolwindow.extractingDesc=首次設定：正在提取 AI Bridge 元件。\n此過程僅在首次安裝/更新時發生（約 10-30 秒）。
 


### PR DESCRIPTION
## Problem
On IntelliJ 2025.2+ / JCEF 144, JCEF runs in **out-of-process (remote CEF server) mode**. Creating a `JBCefJSQuery` message router throws `NullPointerException: Cannot read field "isNull" because "robj" is null` in `RemoteMessageRouterImpl` — [JBR-9234](https://youtrack.jetbrains.com/issue/JBR-9234). This kills the webview, which relies on `JBCefJSQuery` for the JS↔Java bridge.

The plugin already caught this NPE and showed a static "restart the IDE" panel, but a plain restart doesn't stop it recurring — out-of-process mode stays enabled, so the next webview recreation throws the same NPE.

## Fix
Mirrors the existing `enableJcefInRegistry()` one-click flow:

- **`JBCefBrowserFactory.disableOutOfProcessJcefInRegistry()`** — flips the IDE registry key `ide.browser.jcef.out-of-process.enabled=false` (the [documented workaround](https://youtrack.jetbrains.com/issue/IJPL-186252)).
- **`showJcefRemoteModeErrorPanel()`** — gains an action button that applies the fix and shows the standard "Registry updated → restart IDE" panel (same UX as the existing JCEF-disabled flow).
- **i18n** — `toolwindow.jcefRemoteSolution` updated in all 9 locales (explains the bug + manual VM-option fallback); new key `toolwindow.jcefRemoteAction`.

**UX:** when the NPE fires, the panel now offers *Disable out-of-process JCEF* → click → *restart IDE* → after restart JCEF runs in-process and the router no longer throws.

## Testing
- `compileJava` + `compileTestJava` pass on `feature/v0.5.3`.
- `JBCefBrowserFactoryTest` passes (existing factory logic untouched).
- Reuses the plugin's already-established JCEF registry-write mechanism (`enableJcefInRegistry` writes `ide.browser.jcef.enabled` the same way).

## Refs
- [JBR-9234](https://youtrack.jetbrains.com/issue/JBR-9234) — root platform bug
- [IJPL-186252](https://youtrack.jetbrains.com/issue/IJPL-186252) — official workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)
