### PR TITLE
fix(terminal): register context-menu actions dynamically to support 2023.3

### DIFF
--- a/src/main/java/com/github/claudecodegui/terminal/SendTerminalSelectionToInputAction.java
+++ b/src/main/java/com/github/claudecodegui/terminal/SendTerminalSelectionToInputAction.java
@@ -127,17 +127,34 @@ public class SendTerminalSelectionToInputAction extends AnAction implements Dumb
     }
 
     static boolean registerForReworkedTerminalContextMenu(@NotNull ActionManager actionManager) {
+        return registerForTerminalContextMenu(actionManager, TERMINAL_REWORKED_CONTEXT_MENU);
+    }
+
+    /**
+     * Register the send action into a terminal context-menu group at runtime, only
+     * when that group exists in the current IDE build.
+     *
+     * <p>{@code Terminal.OutputContextMenu} and {@code Terminal.PromptContextMenu} were
+     * introduced in later IDE versions and are absent from 2023.3 (build 233), so they
+     * must NOT be referenced statically in terminal-features.xml — doing so raises a
+     * PluginException at startup. Registering them here (guarded by an existence check)
+     * keeps the action available in newer builds while staying silent on older ones.</p>
+     *
+     * @return true if the action was newly added to the group, false otherwise (group
+     *         missing, action missing, not a DefaultActionGroup, or already registered)
+     */
+    static boolean registerForTerminalContextMenu(@NotNull ActionManager actionManager, @NotNull String groupId) {
         synchronized (SendTerminalSelectionToInputAction.class) {
             AnAction action = actionManager.getAction(ACTION_ID);
             if (action == null) {
-                LOG.warn("[TerminalSend] Cannot register reworked terminal menu action because the action is missing: " + ACTION_ID);
+                LOG.warn("[TerminalSend] Cannot register terminal menu action because the action is missing: " + ACTION_ID);
                 return false;
             }
 
-            AnAction groupAction = actionManager.getAction(TERMINAL_REWORKED_CONTEXT_MENU);
+            AnAction groupAction = actionManager.getAction(groupId);
             if (!(groupAction instanceof DefaultActionGroup)) {
                 if (groupAction instanceof ActionGroup) {
-                    LOG.debug("[TerminalSend] Reworked terminal context menu is not a DefaultActionGroup: "
+                    LOG.debug("[TerminalSend] Terminal context menu is not a DefaultActionGroup: "
                             + groupAction.getClass().getName());
                 }
                 return false;

--- a/src/main/java/com/github/claudecodegui/terminal/TerminalMonitorService.java
+++ b/src/main/java/com/github/claudecodegui/terminal/TerminalMonitorService.java
@@ -673,12 +673,17 @@ public class TerminalMonitorService implements ProjectActivity {
     private static void ensureReworkedTerminalMenuRegistration() {
         try {
             ActionManager actionManager = ActionManager.getInstance();
-            boolean added = SendTerminalSelectionToInputAction.registerForReworkedTerminalContextMenu(actionManager);
-            if (added) {
-                LOG.info("[TerminalSend] Registered send action into Terminal.ReworkedTerminalContextMenu at runtime");
+            boolean addedOutput = SendTerminalSelectionToInputAction.registerForTerminalContextMenu(
+                    actionManager, SendTerminalSelectionToInputAction.TERMINAL_OUTPUT_CONTEXT_MENU);
+            boolean addedPrompt = SendTerminalSelectionToInputAction.registerForTerminalContextMenu(
+                    actionManager, SendTerminalSelectionToInputAction.TERMINAL_PROMPT_CONTEXT_MENU);
+            boolean addedReworked = SendTerminalSelectionToInputAction.registerForTerminalContextMenu(
+                    actionManager, SendTerminalSelectionToInputAction.TERMINAL_REWORKED_CONTEXT_MENU);
+            if (addedOutput || addedPrompt || addedReworked) {
+                LOG.info("[TerminalSend] Registered send action into terminal context menus at runtime");
             }
         } catch (Exception | LinkageError e) {
-            LOG.debug("[TerminalSend] Failed to register reworked terminal context menu action", e);
+            LOG.debug("[TerminalSend] Failed to register terminal context menu action", e);
         }
     }
 

--- a/src/main/resources/META-INF/terminal-features.xml
+++ b/src/main/resources/META-INF/terminal-features.xml
@@ -12,8 +12,12 @@
         <action id="ClaudeCodeGUI.SendTerminalSelectionToInputAction"
                 class="com.github.claudecodegui.terminal.SendTerminalSelectionToInputAction"
                 icon="/icons/cc-gui-icon.svg">
-            <add-to-group group-id="Terminal.OutputContextMenu" anchor="last"/>
-            <add-to-group group-id="Terminal.PromptContextMenu" anchor="last"/>
+            <!-- Only the EditorPopupMenu is registered statically because it exists
+                 across all supported IDE builds. Terminal.OutputContextMenu and
+                 Terminal.PromptContextMenu were introduced in later IDE versions and
+                 are absent from 2023.3 (build 233), so registering them here raises a
+                 PluginException at startup. They are registered dynamically at runtime
+                 instead — see SendTerminalSelectionToInputAction.registerForTerminalContextMenu. -->
             <add-to-group group-id="EditorPopupMenu" anchor="last"/>
         </action>
     </actions>

--- a/src/test/java/com/github/claudecodegui/terminal/SendTerminalSelectionToInputActionTest.java
+++ b/src/test/java/com/github/claudecodegui/terminal/SendTerminalSelectionToInputActionTest.java
@@ -103,12 +103,40 @@ public class SendTerminalSelectionToInputActionTest {
     }
 
     @Test
-    public void terminalFeaturesDoNotRegisterActionForReworkedTerminalContextMenuStatically() throws IOException {
+    public void terminalFeaturesDoNotRegisterVersionSpecificContextMenusStatically() throws IOException {
         try (InputStream stream = getClass().getClassLoader().getResourceAsStream("META-INF/terminal-features.xml")) {
             Assert.assertNotNull("terminal-features.xml should be on the test classpath", stream);
             String xml = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+            // These groups only exist in newer IDE builds (2024.1+/2024.3+); static
+            // registration would raise PluginException on 2023.3 (build 233).
+            Assert.assertFalse(xml.contains("group-id=\"Terminal.OutputContextMenu\""));
+            Assert.assertFalse(xml.contains("group-id=\"Terminal.PromptContextMenu\""));
             Assert.assertFalse(xml.contains("group-id=\"Terminal.ReworkedTerminalContextMenu\""));
         }
+    }
+
+    @Test
+    public void outputContextMenuIsRegisteredOnlyWhenGroupExists() {
+        TestActionManager actionManager = new TestActionManager();
+        DefaultActionGroup group = new DefaultActionGroup();
+        actionManager.registerAction(SendTerminalSelectionToInputAction.ACTION_ID, new SendTerminalSelectionToInputAction());
+        actionManager.registerAction(SendTerminalSelectionToInputAction.TERMINAL_OUTPUT_CONTEXT_MENU, group);
+
+        Assert.assertTrue(SendTerminalSelectionToInputAction.registerForTerminalContextMenu(
+                actionManager, SendTerminalSelectionToInputAction.TERMINAL_OUTPUT_CONTEXT_MENU));
+        Assert.assertEquals(
+                Collections.singletonList(SendTerminalSelectionToInputAction.ACTION_ID),
+                childIds(actionManager, group)
+        );
+    }
+
+    @Test
+    public void outputContextMenuRegistrationIsSkippedWhenGroupIsMissing() {
+        TestActionManager actionManager = new TestActionManager();
+        actionManager.registerAction(SendTerminalSelectionToInputAction.ACTION_ID, new SendTerminalSelectionToInputAction());
+
+        Assert.assertFalse(SendTerminalSelectionToInputAction.registerForTerminalContextMenu(
+                actionManager, SendTerminalSelectionToInputAction.TERMINAL_OUTPUT_CONTEXT_MENU));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #1668 - opening IntelliJ IDEA 2023.3 raises a `PluginException` at startup because the terminal send-selection action is registered into context-menu groups that do not exist in that IDE build.

```
com.intellij.diagnostic.PluginException:
SendTerminalSelectionToInputAction (ClaudeCodeGUI.SendTerminalSelectionToInputAction):
group with id "Terminal.OutputContextMenu" isn't registered so the action won't be added to it
```

### Root Cause

`terminal-features.xml` statically registered `SendTerminalSelectionToInputAction` into three groups:

```xml
<add-to-group group-id="Terminal.OutputContextMenu" anchor="last"/>
<add-to-group group-id="Terminal.PromptContextMenu" anchor="last"/>
<add-to-group group-id="EditorPopupMenu" anchor="last"/>
```

`Terminal.OutputContextMenu` and `Terminal.PromptContextMenu` were introduced in later IDE versions (2024.1+) and do not exist in 2023.3 (build 233). The plugin declares `sinceBuild = '233'`, so IntelliJ reports a `PluginException` for the missing groups.

The project already handled the newest group (`Terminal.ReworkedTerminalContextMenu`, 2024.3+) with a runtime registration guarded by an existence check (`registerForReworkedTerminalContextMenu`). The two intermediate groups were left as static registrations, which breaks 2023.3.

### Fix

1. `terminal-features.xml`: keep only `EditorPopupMenu` (present in every supported build) as a static registration; remove the two version-specific groups.
2. `SendTerminalSelectionToInputAction`: extract a generic `registerForTerminalContextMenu(actionManager, groupId)` that checks the group exists before adding the action, and delegate `registerForReworkedTerminalContextMenu` to it.
3. `TerminalMonitorService.ensureReworkedTerminalMenuRegistration`: register all three version-specific groups (`OutputContextMenu`, `PromptContextMenu`, `ReworkedTerminalContextMenu`) at runtime.
4. Added tests: the static-registration test now asserts none of the three version-specific groups are in the XML, plus two tests covering runtime registration of `Terminal.OutputContextMenu`.

### Before / After

| IDE build | Before | After |
|---|---|---|
| 2023.3 (233) | PluginException at startup | No exception; action available via EditorPopupMenu |
| 2024.1+ | Action in Output/Prompt context menus | Action still in Output/Prompt context menus (runtime registration) |
| 2024.3+ | Action in reworked context menu | Action still in reworked context menu (unchanged) |

Closes #1668