### PR TITLE
fix(file): disambiguate same-named fuzzy file matches deterministically

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/file/OpenFileHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/file/OpenFileHandler.java
@@ -28,8 +28,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -243,36 +246,135 @@ class OpenFileHandler {
                 return null;
             }
 
-            // If there's a path hint (e.g., "utils/linkify.ts"), try to match by path suffix
-            if (pathSuffix != null && !pathSuffix.isBlank()) {
-                for (VirtualFile match : matches) {
-                    String matchPath = match.getPath();
-                    if (matchPath.endsWith(pathSuffix) || matchPath.contains(pathSuffix)) {
-                        return match;
-                    }
-                }
-            }
-
-            // If multiple matches, prefer files in common source directories
-            VirtualFile bestMatch = null;
+            // Disambiguate same-named files (e.g. every Django app has models.py)
+            // deterministically - see pickBestFuzzyMatchPath for the priority order.
+            Map<String, VirtualFile> matchesByPath = new LinkedHashMap<>();
             for (VirtualFile match : matches) {
-                String matchPath = match.getPath();
-                // Prefer src/, main/, or project root files
-                if (matchPath.contains("/src/") || matchPath.contains("\\src\\")) {
-                    if (bestMatch == null || !bestMatch.getPath().contains("/src/")) {
-                        bestMatch = match;
-                    }
-                } else if (matchPath.contains("/main/") || matchPath.contains("\\main\\")) {
-                    if (bestMatch == null) {
-                        bestMatch = match;
-                    }
-                } else if (bestMatch == null) {
-                    bestMatch = match;
+                matchesByPath.put(match.getPath(), match);
+            }
+            String bestPath = pickBestFuzzyMatchPath(matchesByPath.keySet(), pathSuffix, collectRecentOpenPaths(project));
+            return bestPath != null ? matchesByPath.get(bestPath) : null;
+        });
+    }
+
+    /**
+     * Collect the paths of files currently open in the editor, most recent first.
+     * Used to disambiguate fuzzy matches: the file under discussion in the chat is
+     * very likely one the user (or the AI tool window) has open right now.
+     */
+    private List<String> collectRecentOpenPaths(Project project) {
+        try {
+            VirtualFile[] openFiles = FileEditorManager.getInstance(project).getOpenFiles();
+            List<String> paths = new ArrayList<>(openFiles.length);
+            for (VirtualFile openFile : openFiles) {
+                paths.add(openFile.getPath());
+            }
+            return paths;
+        } catch (Exception e) {
+            LOG.debug("Failed to collect open files for fuzzy match disambiguation: " + e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Pick the best fuzzy-match candidate deterministically. Priority:
+     * <ol>
+     *   <li>A segment-aligned path-suffix match (unique) - "blog/models.py" only
+     *       matches ".../blog/models.py", never ".../myblog/models.py"</li>
+     *   <li>A candidate currently open in the editor (most recent first)</li>
+     *   <li>Common source-root heuristic (src/, main/)</li>
+     *   <li>Shortest path as the final deterministic tiebreaker</li>
+     * </ol>
+     * Previously the fallback returned whichever candidate the filename index
+     * happened to iterate first, which opened arbitrary same-named files (#1682).
+     *
+     * @param candidatePaths paths of all same-named candidates (unsorted)
+     * @param pathSuffix relative path hint from the message (may be null/blank)
+     * @param recentOpenPaths editor-open file paths, most recent first (may be empty)
+     * @return the best candidate path, or null when candidates is empty
+     */
+    // VisibleForTesting
+    static String pickBestFuzzyMatchPath(Collection<String> candidatePaths, String pathSuffix, List<String> recentOpenPaths) {
+        List<String> candidates = new ArrayList<>(candidatePaths);
+        if (candidates.isEmpty()) {
+            return null;
+        }
+
+        // 1. Narrow by segment-aligned path suffix
+        if (pathSuffix != null && !pathSuffix.isBlank()) {
+            List<String> suffixMatches = new ArrayList<>();
+            for (String candidate : candidates) {
+                if (isSegmentAlignedSuffixMatch(candidate, pathSuffix)) {
+                    suffixMatches.add(candidate);
                 }
             }
+            if (!suffixMatches.isEmpty()) {
+                candidates = suffixMatches;
+            }
+        }
+        if (candidates.size() == 1) {
+            return candidates.get(0);
+        }
 
-            return bestMatch;
-        });
+        // 2. Prefer a file currently open in the editor (most recent first)
+        for (String recentPath : recentOpenPaths) {
+            for (String candidate : candidates) {
+                if (candidate.equals(recentPath)) {
+                    return candidate;
+                }
+            }
+        }
+
+        // 3./4. Source-root heuristic, then shortest path as deterministic tiebreaker
+        String best = null;
+        int bestRank = -1;
+        for (String candidate : candidates) {
+            String normalized = candidate.replace('\\', '/');
+            int rank;
+            if (normalized.contains("/src/")) {
+                rank = 0;
+            } else if (normalized.contains("/main/")) {
+                rank = 1;
+            } else {
+                rank = 2;
+            }
+            if (best == null
+                    || rank < bestRank
+                    || (rank == bestRank && candidate.length() < best.length())) {
+                best = candidate;
+                bestRank = rank;
+            }
+        }
+        return best;
+    }
+
+    /**
+     * Check whether {@code candidatePath} ends with (or contains, on segment
+     * boundaries only) the given relative {@code suffix}. Both separators are
+     * normalized to '/'.
+     *
+     * <p>"/project/blog/models.py" matches "blog/models.py";
+     * "/project/myblog/models.py" does NOT - the occurrence must start right
+     * after a '/' so a directory named "myblog" cannot satisfy "blog".</p>
+     */
+    // VisibleForTesting
+    static boolean isSegmentAlignedSuffixMatch(String candidatePath, String suffix) {
+        String candidate = candidatePath.replace('\\', '/');
+        String target = suffix.replace('\\', '/');
+        if (candidate.equals(target) || candidate.endsWith("/" + target)) {
+            return true;
+        }
+        // Legacy "contains" behavior, restricted to segment-aligned occurrences
+        int idx = candidate.indexOf(target);
+        while (idx >= 0) {
+            int end = idx + target.length();
+            boolean startsOnSegment = idx == 0 || candidate.charAt(idx - 1) == '/';
+            if (startsOnSegment && end == candidate.length()) {
+                return true;
+            }
+            idx = candidate.indexOf(target, idx + 1);
+        }
+        return false;
     }
 
     /**

--- a/src/test/java/com/github/claudecodegui/handler/file/OpenFileHandlerTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/file/OpenFileHandlerTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import java.lang.reflect.Proxy;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -145,6 +146,76 @@ public class OpenFileHandlerTest {
     public void extractPathSuffix_singleSegment_returnsNull() {
         // Only one segment => no meaningful suffix.
         assertNull(OpenFileHandler.extractPathSuffix("Bar.java"));
+    }
+
+    // ---------- pickBestFuzzyMatchPath / isSegmentAlignedSuffixMatch (#1682) ----------
+
+    @Test
+    public void pickBestFuzzyMatchPath_prefersSegmentAlignedSuffixMatch() {
+        // Django-style project: several apps each have models.py. The message
+        // references "blog/models.py" - only the blog app must win.
+        List<String> candidates = List.of(
+                "/proj/accounts/models.py",
+                "/proj/blog/models.py",
+                "/proj/myblog/models.py"
+        );
+
+        String best = OpenFileHandler.pickBestFuzzyMatchPath(candidates, "blog/models.py", List.of());
+
+        assertEquals("/proj/blog/models.py", best);
+    }
+
+    @Test
+    public void pickBestFuzzyMatchPath_prefersRecentlyOpenFileWhenNoSuffix() {
+        // Bare filename "models.py" with two candidates and no path hint: the one
+        // currently open in the editor must win over index iteration order.
+        List<String> candidates = List.of(
+                "/proj/accounts/models.py",
+                "/proj/blog/models.py"
+        );
+        List<String> recentOpen = List.of("/proj/blog/models.py", "/proj/settings.py");
+
+        String best = OpenFileHandler.pickBestFuzzyMatchPath(candidates, null, recentOpen);
+
+        assertEquals("/proj/blog/models.py", best);
+    }
+
+    @Test
+    public void pickBestFuzzyMatchPath_fallsBackToShortestPathDeterministically() {
+        // No suffix, no open files: source-root heuristic is irrelevant for Django
+        // apps, so the shortest path must win - deterministically, not by index order.
+        List<String> candidates = List.of(
+                "/proj/verylongappname/models.py",
+                "/proj/app/models.py",
+                "/proj/another/models.py"
+        );
+
+        String best = OpenFileHandler.pickBestFuzzyMatchPath(candidates, null, List.of());
+
+        assertEquals("/proj/app/models.py", best);
+    }
+
+    @Test
+    public void pickBestFuzzyMatchPath_returnsNullForEmptyCandidates() {
+        assertNull(OpenFileHandler.pickBestFuzzyMatchPath(List.of(), "blog/models.py", List.of()));
+    }
+
+    @Test
+    public void segmentAlignedSuffixMatch_rejectsEmbeddedSegment() {
+        // "blog/models.py" must NOT match ".../myblog/models.py" - the occurrence
+        // has to start on a '/' boundary (#1682).
+        assertTrue(OpenFileHandler.isSegmentAlignedSuffixMatch(
+                "/proj/blog/models.py", "blog/models.py"));
+        assertFalse(OpenFileHandler.isSegmentAlignedSuffixMatch(
+                "/proj/myblog/models.py", "blog/models.py"));
+    }
+
+    @Test
+    public void segmentAlignedSuffixMatch_acceptsWindowsSeparators() {
+        assertTrue(OpenFileHandler.isSegmentAlignedSuffixMatch(
+                "D:\\proj\\blog\\models.py", "blog\\models.py"));
+        assertFalse(OpenFileHandler.isSegmentAlignedSuffixMatch(
+                "D:\\proj\\myblog\\models.py", "blog\\models.py"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #1682 - file links in the chat output frequently open the wrong file when several files share the same name (e.g. every Django app has a `models.py`; the link opens the `models.py` of an unrelated app).

### Root Cause

Bare-filename links resolve through `OpenFileHandler.resolveFileByFuzzyMatch()` (IDEA `FilenameIndex`). When multiple candidates share the filename:

1. **Path-suffix matching used unaligned `contains()`**: the loop returned the *first* candidate whose path contains the suffix - `blog/models.py` also matched `.../myblog/models.py`, and iteration order over index results is arbitrary.
2. **No context for bare filenames**: with no suffix at all, the `/src/` / `/main/` heuristic almost never applies to frameworks like Django, so the code fell back to whichever candidate the filename index happened to return first - effectively a random file.

### Fix

Extracted the disambiguation into a testable `pickBestFuzzyMatchPath(candidatePaths, pathSuffix, recentOpenPaths)` with a deterministic priority order:

1. **Segment-aligned path-suffix match** - `blog/models.py` now only matches `.../blog/models.py`, never `.../myblog/models.py` (the occurrence must start on a `/` boundary)
2. **Recently open file** - a candidate currently open in the editor (most recent first) wins; the file under discussion in the chat is very likely open right now
3. **Source-root heuristic** - `src/`, then `main/` (existing behavior, kept)
4. **Shortest path** as the final deterministic tiebreaker - no more index-order randomness

### Before / After

| Scenario (Django project) | Before | After |
|---|---|---|
| Link `blog/models.py` with apps `accounts`, `blog`, `myblog` | First `contains()` hit - arbitrary, may open `myblog/models.py` | Segment-aligned match opens `blog/models.py` |
| Bare link `models.py` | First index result - effectively random | Open-in-editor candidate wins; otherwise shortest path (deterministic) |
| Link with unique filename | Unchanged | Unchanged |

### Backward Compatibility

- Existing single-candidate and `/src/`-style resolutions keep working (verified by the retained heuristic)
- `endsWith` matches remain valid via the same segment-boundary rule
- Windows separators are normalized before matching

Closes #1682