### PR TITLE
fix(test): wait for the asynchronous turn sink

### DIFF
--- a/ai-bridge/services/claude/persistent-query-service.test.js
+++ b/ai-bridge/services/claude/persistent-query-service.test.js
@@ -217,7 +217,8 @@ test('turnSink creation happens after beginRuntimeTurn', () => {
   // This test verifies the order documented in the fix
   // Actual executeTurn flow:
   // 1. beginRuntimeTurn(runtime)
-  // 2. runtime.turnSink = createTurnSink()
+  // 2. await waitForReaderQuiescent(runtime)
+  // 3. runtime.turnSink = createTurnSink()
   // This ensures executeTurn is ready to consume before perpetual reader can push
 
   const runtime = {
@@ -327,8 +328,9 @@ test('executeTurn resets abortRequested at the start of a new turn', async () =>
     query: { close() {} },
   };
 
-  // Start the turn; executeTurn blocks on turnSink.take() until the sink is
-  // failed (as abortCurrentTurn does to unblock a live turn).
+  // Start the turn; executeTurn waits for reader quiescence before creating
+  // turnSink, then blocks on turnSink.take() until the sink is failed (as
+  // abortCurrentTurn does to unblock a live turn).
   const failSink = __testing.executeTurn(runtime, {
     requestedSessionId: null,
     runtimeSessionEpoch: null,
@@ -338,7 +340,10 @@ test('executeTurn resets abortRequested at the start of a new turn', async () =>
     userMessage: { type: 'user', message: { role: 'user', content: 'hi' } },
   });
 
-  // Simulate the CLI closing the stream out from under the turn.
+  // Wait for the quiescence gate to create the sink before simulating the CLI
+  // closing the stream out from under the turn.
+  await new Promise(resolve => setTimeout(resolve, 0));
+  assert.ok(runtime.turnSink);
   runtime.turnSink.fail(new Error('stream ended'));
   runtime.closed = true;
 


### PR DESCRIPTION
## Summary

- Wait for `executeTurn`'s quiescence gate before failing `runtime.turnSink` in the abort regression test.
- Update the lifecycle comments to document the asynchronous sink creation step.
- Prevent the test from dereferencing `undefined` after the runtime lifecycle changed.

## Test plan

- [x] `node --test ai-bridge/services/claude/persistent-query-service.test.js`
- [x] `node --test \"ai-bridge/**/*.test.js\"`
- [x] `git diff --check`