### PR TITLE
docs: restore Star History chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ Thank you for [AtomGit](https://atomgit.com/zhukunpenglinyutong/idea-claude-code
 
 Recently, many bloggers have recommended this project on their own initiative, and I am deeply grateful. Thanks again to bloggers including "沉默的王二", "macrozheng", "JavaGuide", "Java知音", "鲲鹏talk 公众号", and "程序员青戈" for recommending this project. I will keep iterating to make it more comfortable for everyone to use.
 
+---
+
+## Star History
+
+[![Star History](https://star-history.dera.page/svg?repos=zhukunpenglinyutong/jetbrains-cc-gui&type=date&legend=top-left)](https://star-history.dera.page/#zhukunpenglinyutong/jetbrains-cc-gui&type=date&legend=top-left)
+
 <!-- LINK GROUP -->
 
 [github-contributors-shield]: https://img.shields.io/github/contributors/zhukunpenglinyutong/idea-claude-code-gui?color=c4f042&labelColor=black&style=flat-square

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -151,6 +151,12 @@ https://atomgit.com/zhukunpenglinyutong/idea-claude-code-gui
 
 最近有很多博主自发推荐本项目，心中十分感激，再次感谢《沉默的王二》《macrozheng》《JavaGuide》《Java知音》《鲲鹏talk 公众号》《程序员青戈》等博主推荐本项目，我会继续努力迭代，让大家用起来更舒适。
 
+---
+
+## Star History
+
+[![Star History](https://star-history.dera.page/svg?repos=zhukunpenglinyutong/jetbrains-cc-gui&type=date&legend=top-left)](https://star-history.dera.page/#zhukunpenglinyutong/jetbrains-cc-gui&type=date&legend=top-left)
+
 <!-- LINK GROUP -->
 
 [github-contributors-shield]: https://img.shields.io/github/contributors/zhukunpenglinyutong/idea-claude-code-gui?color=c4f042&labelColor=black&style=flat-square


### PR DESCRIPTION
The Star History chart was removed when the README credits were simplified (5c78e9ec), and the original star-history.com rendering is currently broken because of GitHub stargazer API restrictions. This change restores the chart in both README.md and README.zh-CN.md at its previous location so contributors can see the project's growth again, updated to the current repository name.