### PR TITLE
feat(claude): plan usage bar via SDK rate_limit_event

### DIFF
--- a/docs/images/claude-plan-usage-overview.svg
+++ b/docs/images/claude-plan-usage-overview.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="472" viewBox="0 0 960 472" font-family="-apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">
+  <!-- Overview of the chat input area: the plan-usage bar lives in the
+       ContextBar's right tool cluster (next to the status-panel toggle and
+       rewind button), above the message textarea. Faithful to the plugin's
+       dark theme; the highlighted bar is the same element as in the
+       states/windows mockups. Text positions computed from measured widths. -->
+
+  <!-- callout: what this PR adds -->
+  <text x="613" y="64" font-size="22" font-weight="600" fill="#e8e8e8" text-anchor="middle">Claude plan usage — this PR</text>
+
+  <!-- input card -->
+  <rect x="12" y="88" width="936" height="356" rx="12" fill="#1e1e1e" stroke="#2a2a2e"/>
+  <!-- callout arrow (after the card so the panel does not paint over it) -->
+  <line x1="613" y1="72" x2="613" y2="102" stroke="#9d9d9d" stroke-width="1.5"/>
+  <polygon points="613,117 607,105 619,105" fill="#9d9d9d"/>
+
+  <!-- ============ ContextBar row ============ -->
+  <!-- attach (codicon-attach, paperclip) -->
+  <path d="M 59 156 V 139 A 5 5 0 0 1 69 139 V 153 A 10 10 0 0 1 49 153 V 130 A 15 15 0 0 1 79 130"
+        fill="none" stroke="#c8c8c8" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- token indicator ring (~40% used) -->
+  <circle cx="112" cy="140" r="11" fill="none" stroke="#3e3e42" stroke-width="3.5"/>
+  <circle cx="112" cy="140" r="11" fill="none" stroke="#3ba55d" stroke-width="3.5"
+          stroke-dasharray="27.6 69.1" transform="rotate(-90 112 140)"/>
+  <!-- divider -->
+  <line x1="142" y1="126" x2="142" y2="154" stroke="#3e3e42" stroke-width="2"/>
+  <!-- selected-agent chip -->
+  <rect x="158" y="124" width="96" height="32" rx="6" fill="#26262a" stroke="#3e3e42"/>
+  <rect x="168" y="133" width="14" height="10" rx="2" fill="none" stroke="#c8c8c8" stroke-width="2"/>
+  <circle cx="172.5" cy="138" r="1.3" fill="#c8c8c8"/>
+  <circle cx="177.5" cy="138" r="1.3" fill="#c8c8c8"/>
+  <line x1="175" y1="133" x2="175" y2="130" stroke="#c8c8c8" stroke-width="2"/>
+  <circle cx="175" cy="128.5" r="1.5" fill="#c8c8c8"/>
+  <text x="188" y="140" font-size="20" fill="#c8c8c8" dominant-baseline="central">fix</text>
+
+  <!-- right tool cluster: [plan usage] [status panel] [rewind] -->
+  <!-- rewind (codicon-discard, undo arrow) -->
+  <path d="M 902 138 A 8 8 0 1 0 894 132" fill="none" stroke="#c8c8c8" stroke-width="2.5" stroke-linecap="round"/>
+  <polygon points="894,132 902,128 902,136" fill="#c8c8c8"/>
+  <!-- status-panel toggle (codicon-layers) -->
+  <polygon points="838,128 852,135 838,142 824,135" fill="none" stroke="#c8c8c8" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M 824 141 L 838 148 L 852 141" fill="none" stroke="#c8c8c8" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M 824 147 L 838 154 L 852 147" fill="none" stroke="#c8c8c8" stroke-width="2" stroke-linejoin="round"/>
+
+  <!-- the plan-usage indicator itself (green state, 34% / 5h) -->
+  <g>
+    <rect x="436" y="136" width="72" height="8" rx="4" fill="#3e3e42"/>
+    <rect x="436" y="136" width="25" height="8" rx="4" fill="#3ba55d"/>
+    <text x="518" y="146" font-size="24" font-weight="600" fill="#3ba55d">34%</text>
+    <rect x="582" y="125" width="48" height="30" rx="6" fill="none" stroke="#3e3e42"/>
+    <text x="606" y="141" font-size="22" fill="#c8c8c8" text-anchor="middle" dominant-baseline="central">5h</text>
+    <text x="642" y="146" font-size="22" fill="#888888">23 Aug 03:00</text>
+    <circle cx="788" cy="140" r="7" fill="#3ba55d"/>
+  </g>
+  <!-- highlight around the indicator -->
+  <rect x="422" y="118" width="382" height="44" rx="10" fill="none" stroke="#9d9d9d"
+        stroke-width="1.5" stroke-dasharray="7 5" opacity="0.9"/>
+
+  <!-- ============ message textarea (placeholder) ============ -->
+  <text x="36" y="216" font-size="24" fill="#6f6f78">@reference files, #invoke agents, !insert prompts, Enter to send</text>
+
+  <!-- ============ ButtonArea row ============ -->
+  <rect x="36" y="372" width="100" height="36" rx="8" fill="#26262a" stroke="#3e3e42"/>
+  <text x="86" y="390" font-size="20" fill="#c8c8c8" text-anchor="middle" dominant-baseline="central">Claude ▾</text>
+  <rect x="148" y="372" width="104" height="36" rx="8" fill="#26262a" stroke="#3e3e42"/>
+  <text x="200" y="390" font-size="20" fill="#c8c8c8" text-anchor="middle" dominant-baseline="central">default ▾</text>
+  <rect x="264" y="372" width="126" height="36" rx="8" fill="#26262a" stroke="#3e3e42"/>
+  <text x="327" y="390" font-size="20" fill="#c8c8c8" text-anchor="middle" dominant-baseline="central">opus-4-6 ▾</text>
+  <rect x="402" y="372" width="80" height="36" rx="8" fill="#26262a" stroke="#3e3e42"/>
+  <text x="442" y="390" font-size="20" fill="#c8c8c8" text-anchor="middle" dominant-baseline="central">high ▾</text>
+
+  <line x1="758" y1="380" x2="758" y2="400" stroke="#3e3e42" stroke-width="2"/>
+  <!-- enhance prompt (codicon-sparkle) -->
+  <path d="M 786 380 L 789 389 L 798 392 L 789 395 L 786 404 L 783 395 L 774 392 L 783 389 Z" fill="#c8c8c8"/>
+  <!-- send (codicon-send in a primary button) -->
+  <rect x="828" y="374" width="56" height="36" rx="8" fill="#007fd4"/>
+  <polygon points="846,385 880,392 846,399 853,392" fill="#ffffff"/>
+</svg>

--- a/docs/images/claude-plan-usage-states.svg
+++ b/docs/images/claude-plan-usage-states.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="352" viewBox="0 0 960 352" font-family="-apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">
+  <!-- Claude plan usage indicator — the three pace states, faithful to the
+       plugin's dark theme (#1e1e1e panel, bar 36x4 scaled 2x, colors from
+       context-bar.css: green #3ba55d, yellow #d4a017, red #e34850).
+       Element x-positions computed from measured text widths (system font). -->
+
+  <!-- ============ state 1: green = on pace ============ -->
+  <g>
+    <rect x="12" y="24" width="936" height="92" rx="10" fill="#1e1e1e" stroke="#2a2a2e"/>
+    <!-- bar -->
+    <rect x="36" y="66" width="72" height="8" rx="4" fill="#3e3e42"/>
+    <rect x="36" y="66" width="25" height="8" rx="4" fill="#3ba55d"/>
+    <text x="118" y="76" font-size="24" font-weight="600" fill="#3ba55d">34%</text>
+    <!-- window chip -->
+    <rect x="194" y="55" width="48" height="30" rx="6" fill="none" stroke="#3e3e42"/>
+    <text x="218" y="71" font-size="22" fill="#c8c8c8" text-anchor="middle" dominant-baseline="central">5h</text>
+    <!-- short reset (no trailing period — matches formatShortReset) -->
+    <text x="252" y="76" font-size="22" fill="#888888">23 Aug 03:00</text>
+    <!-- worst-window dot -->
+    <circle cx="416" cy="70" r="7" fill="#3ba55d"/>
+    <!-- label -->
+    <text x="460" y="62" font-size="23" font-weight="600" fill="#e8e8e8">On pace</text>
+    <text x="460" y="90" font-size="19" fill="#909090">Usage below the time budget — lasts to reset.</text>
+  </g>
+
+  <!-- ============ state 2: yellow = near the budget line ============ -->
+  <g>
+    <rect x="12" y="130" width="936" height="92" rx="10" fill="#1e1e1e" stroke="#2a2a2e"/>
+    <rect x="36" y="172" width="72" height="8" rx="4" fill="#3e3e42"/>
+    <rect x="36" y="172" width="56" height="8" rx="4" fill="#d4a017"/>
+    <text x="118" y="182" font-size="24" font-weight="600" fill="#d4a017">78%</text>
+    <rect x="194" y="161" width="48" height="30" rx="6" fill="none" stroke="#3e3e42"/>
+    <text x="218" y="177" font-size="22" fill="#c8c8c8" text-anchor="middle" dominant-baseline="central">7d</text>
+    <text x="252" y="182" font-size="22" fill="#888888">1 Sep 00:00</text>
+    <circle cx="416" cy="176" r="7" fill="#d4a017"/>
+    <text x="460" y="168" font-size="23" font-weight="600" fill="#e8e8e8">Near the budget line</text>
+    <text x="460" y="196" font-size="19" fill="#909090">Within 5 pp of the time budget — borderline.</text>
+  </g>
+
+  <!-- ============ state 3: red = over pace ============ -->
+  <g>
+    <rect x="12" y="236" width="936" height="92" rx="10" fill="#1e1e1e" stroke="#2a2a2e"/>
+    <rect x="36" y="278" width="72" height="8" rx="4" fill="#3e3e42"/>
+    <rect x="36" y="278" width="69" height="8" rx="4" fill="#e34850"/>
+    <text x="118" y="288" font-size="24" font-weight="600" fill="#e34850">96%</text>
+    <rect x="194" y="267" width="48" height="30" rx="6" fill="none" stroke="#3e3e42"/>
+    <text x="218" y="283" font-size="22" fill="#c8c8c8" text-anchor="middle" dominant-baseline="central">5h</text>
+    <text x="252" y="288" font-size="22" fill="#888888">23 Aug 21:30</text>
+    <circle cx="416" cy="282" r="7" fill="#e34850"/>
+    <text x="460" y="274" font-size="23" font-weight="600" fill="#e8e8e8">Over pace</text>
+    <text x="460" y="302" font-size="19" fill="#909090">Past the time budget — limits hit before reset.</text>
+  </g>
+</svg>

--- a/docs/images/claude-plan-usage-windows.svg
+++ b/docs/images/claude-plan-usage-windows.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="456" viewBox="0 0 960 456" font-family="-apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">
+  <!-- Claude plan usage indicator — multi-window switching (5h / 7d from rate_limit_event)
+       and the worst-window dot. Same snapshot in both cards; tooltip bubble
+       mirrors the component's real tooltip lines. x-positions computed from
+       measured text widths. -->
+
+  <!-- ============ tooltip bubble (hovering the indicator) ============ -->
+  <g>
+    <rect x="48" y="24" width="400" height="120" rx="8" fill="#2d2d30" stroke="#3e3e42"/>
+    <path d="M 206 143 L 218 162 L 230 143 Z" fill="#2d2d30"/>
+    <rect x="207" y="142" width="20" height="3" fill="#2d2d30"/>
+    <text x="68" y="56" font-size="20" fill="#d8d8d8">5h 92% &#183; Resets 23 Aug 03:00</text>
+    <text x="68" y="84" font-size="20" fill="#d8d8d8">5h 92% &#183; 7d 21%</text>
+    <text x="68" y="112" font-size="20" fill="#a8a8a8">Click period label to switch window</text>
+    </g>
+
+  <!-- ============ card A: 5h selected (red) ============ -->
+  <g>
+    <rect x="12" y="200" width="936" height="92" rx="10" fill="#1e1e1e" stroke="#2a2a2e"/>
+    <rect x="36" y="242" width="72" height="8" rx="4" fill="#3e3e42"/>
+    <rect x="36" y="242" width="66" height="8" rx="4" fill="#e34850"/>
+    <text x="118" y="252" font-size="24" font-weight="600" fill="#e34850">92%</text>
+    <!-- window chip — highlighted as the clickable switcher -->
+    <rect x="194" y="231" width="48" height="30" rx="6" fill="#26262a" stroke="#4d4d55"/>
+    <text x="218" y="247" font-size="22" fill="#e0e0e0" text-anchor="middle" dominant-baseline="central">5h</text>
+    <text x="252" y="252" font-size="22" fill="#888888">23 Aug 03:00</text>
+    <circle cx="416" cy="246" r="7" fill="#e34850"/>
+    <text x="460" y="240" font-size="23" font-weight="600" fill="#e8e8e8">5h window selected</text>
+    <text x="460" y="268" font-size="19" fill="#909090">Chip = switcher: click to cycle 5h / 7d.</text>
+  </g>
+
+  <!-- ============ card B: same snapshot, 7d selected ============ -->
+  <g>
+    <rect x="12" y="330" width="936" height="92" rx="10" fill="#1e1e1e" stroke="#2a2a2e"/>
+    <rect x="36" y="372" width="72" height="8" rx="4" fill="#3e3e42"/>
+    <rect x="36" y="372" width="15" height="8" rx="4" fill="#3ba55d"/>
+    <text x="118" y="382" font-size="24" font-weight="600" fill="#3ba55d">21%</text>
+    <rect x="194" y="361" width="48" height="30" rx="6" fill="none" stroke="#3e3e42"/>
+    <text x="218" y="377" font-size="22" fill="#c8c8c8" text-anchor="middle" dominant-baseline="central">7d</text>
+    <text x="252" y="382" font-size="22" fill="#888888">1 Sep 00:00</text>
+    <!-- worst-window dot stays RED even though the selected window is green -->
+    <circle cx="416" cy="376" r="7" fill="#e34850"/>
+    <text x="460" y="370" font-size="23" font-weight="600" fill="#e8e8e8">7d selected — bar green, dot red</text>
+    <text x="460" y="398" font-size="19" fill="#909090">Dot tracks the worst window — 5h is over pace.</text>
+  </g>
+</svg>

--- a/src/main/java/com/github/claudecodegui/handler/provider/claude/ClaudePlanUsageHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/provider/claude/ClaudePlanUsageHandler.java
@@ -1,0 +1,51 @@
+package com.github.claudecodegui.handler.provider.claude;
+
+import com.github.claudecodegui.handler.core.BaseMessageHandler;
+import com.github.claudecodegui.handler.core.HandlerContext;
+import com.github.claudecodegui.provider.claude.ClaudePlanUsageService;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.application.ApplicationManager;
+
+/**
+ * Bridges the webview's {@code get_claude_plan_usage} poll to
+ * {@link ClaudePlanUsageService} and pushes the snapshot back via
+ * {@code window.updateClaudePlanUsage}. Mirrors {@code GeminiPlanUsageHandler}.
+ */
+public class ClaudePlanUsageHandler extends BaseMessageHandler {
+
+    private static final String[] SUPPORTED_TYPES = {
+            "get_claude_plan_usage"
+    };
+
+    public ClaudePlanUsageHandler(HandlerContext context) {
+        super(context);
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return SUPPORTED_TYPES;
+    }
+
+    @Override
+    public boolean handle(String type, String content) {
+        if ("get_claude_plan_usage".equals(type)) {
+            ApplicationManager.getApplication().executeOnPooledThread(() -> {
+                try {
+                    JsonObject usage = ClaudePlanUsageService.resolvePlanUsagePayload();
+                    if (usage == null) {
+                        usage = new JsonObject();
+                        usage.addProperty("error", true);
+                    }
+                    context.callJavaScript("window.updateClaudePlanUsage", context.escapeJs(usage.toString()));
+                } catch (Exception e) {
+                    JsonObject error = new JsonObject();
+                    error.addProperty("error", true);
+                    error.addProperty("message", e.getMessage());
+                    context.callJavaScript("window.updateClaudePlanUsage", context.escapeJs(error.toString()));
+                }
+            });
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudePlanUsageService.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudePlanUsageService.java
@@ -1,0 +1,169 @@
+package com.github.claudecodegui.provider.claude;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.time.Instant;
+
+/**
+ * Claude plan-usage snapshot builder + cache.
+ *
+ * <p>Feeds the ContextBar plan-usage indicator using the same payload shape as
+ * Gemini/Codex ({@code capacity_pct} + {@code windows[]}), so the shared
+ * {@code GeminiPlanUsageIndicator} renders it unchanged.
+ *
+ * <p>Data source on a real Anthropic (OAuth subscription) backend: the SDK emits
+ * {@code rate_limit_event} messages ({@code rate_limit_info: {status, resetsAt, utilization}})
+ * during turns. {@link com.github.claudecodegui.session.ClaudeMessageHandler} extracts the
+ * {@code rate_limit_info} and calls {@link #cacheRateLimitInfo(JsonObject)} here. The webview
+ * polls {@code get_claude_plan_usage} (~every 120s, like Gemini) and this service returns the
+ * freshest cached snapshot.
+ *
+ * <p>Note: {@code rate_limit_event} only fires on real Anthropic (OAuth subscription)
+ * backends — third-party proxies do not emit it, so the bar stays hidden there.
+ */
+public final class ClaudePlanUsageService {
+    private static final Logger LOG = Logger.getInstance(ClaudePlanUsageService.class);
+
+    /** Last rate_limit_event snapshot (real Anthropic). Null until the first event arrives. */
+    private static volatile JsonObject cachedRateLimit;
+
+    private ClaudePlanUsageService() {
+    }
+
+    /**
+     * Cache a {@code rate_limit_event} snapshot from the SDK stream (real Anthropic).
+     * Called by {@code ClaudeMessageHandler.handleRateLimit}.
+     *
+     * @param rateLimitInfo the {@code rate_limit_info} object
+     *                      ({@code {status, resetsAt?, utilization?}})
+     */
+    public static void cacheRateLimitInfo(JsonObject rateLimitInfo) {
+        if (rateLimitInfo == null) {
+            return;
+        }
+        try {
+            JsonObject payload = buildCapacityPayload(rateLimitInfo);
+            if (payload != null) {
+                cachedRateLimit = payload;
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to cache Claude rate_limit_event: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Resolve the plan-usage payload for the webview poll. Returns the cached
+     * rate_limit snapshot if one is available, otherwise an unavailable marker.
+     */
+    public static JsonObject resolvePlanUsagePayload() {
+        JsonObject cached = cachedRateLimit;
+        if (cached != null) {
+            return cached.deepCopy();
+        }
+        return unavailable("Claude usage unavailable");
+    }
+
+    /**
+     * Build the Gemini/Codex-compatible capacity payload from a single
+     * {@code rate_limit_info} object.
+     *
+     * <p>{@code utilization} is a 0–1 fraction on Anthropic subscriptions; values &gt; 1 are
+     * treated defensively as already-percent. {@code resetsAt} is epoch milliseconds.
+     */
+    static JsonObject buildCapacityPayload(JsonObject rateLimitInfo) {
+        Double utilization = asDouble(rateLimitInfo, "utilization");
+        if (utilization == null || !Double.isFinite(utilization)) {
+            return null;
+        }
+        double pct = clampPct(utilization <= 1.0 ? utilization * 100.0 : utilization);
+
+        Long resetsAtMs = asLong(rateLimitInfo, "resetsAt", "resets_at", "resetAt");
+        String resetAt = resetsAtMs != null ? Instant.ofEpochMilli(resetsAtMs).toString() : null;
+        String periodType = resetsAtMs != null ? periodTypeFromResetMs(resetsAtMs) : "5h";
+
+        JsonObject window = new JsonObject();
+        window.addProperty("id", periodType);
+        window.addProperty("used_pct", pct);
+        if (resetAt != null) {
+            window.addProperty("reset_at", resetAt);
+        }
+        window.addProperty("period_type", periodType);
+        JsonArray windows = new JsonArray();
+        windows.add(window);
+
+        JsonObject out = new JsonObject();
+        out.addProperty("ok", true);
+        out.addProperty("present", true);
+        out.addProperty("provider", "claude");
+        out.addProperty("source", "sdk-rate-limit");
+        out.addProperty("capacity_pct", pct);
+        if (resetAt != null) {
+            out.addProperty("reset_at", resetAt);
+        }
+        out.addProperty("period_type", periodType);
+        out.add("windows", windows);
+        String status = asString(rateLimitInfo, "status");
+        if (status != null) {
+            out.addProperty("rate_limit_status", status);
+        }
+        return out;
+    }
+
+    /** Derive a 5h/7d window label from the reset timestamp's distance from now. */
+    static String periodTypeFromResetMs(long resetsAtMs) {
+        long deltaMs = resetsAtMs - System.currentTimeMillis();
+        if (deltaMs <= 6L * 60 * 60 * 1000) {
+            return "5h";
+        }
+        return "7d";
+    }
+
+    static double clampPct(double v) {
+        if (!Double.isFinite(v)) {
+            return 0;
+        }
+        return Math.max(0, Math.min(100, v));
+    }
+
+    static JsonObject unavailable(String message) {
+        JsonObject out = new JsonObject();
+        out.addProperty("present", false);
+        out.addProperty("unavailable", true);
+        out.addProperty("provider", "claude");
+        out.addProperty("message", message);
+        return out;
+    }
+
+    private static Double asDouble(JsonObject o, String... keys) {
+        for (String k : keys) {
+            if (o.has(k) && o.get(k).isJsonPrimitive() && !o.get(k).isJsonNull()) {
+                try {
+                    return o.get(k).getAsDouble();
+                } catch (RuntimeException ignored) {
+                }
+            }
+        }
+        return null;
+    }
+
+    private static Long asLong(JsonObject o, String... keys) {
+        for (String k : keys) {
+            if (o.has(k) && o.get(k).isJsonPrimitive() && !o.get(k).isJsonNull()) {
+                try {
+                    return o.get(k).getAsLong();
+                } catch (RuntimeException ignored) {
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String asString(JsonObject o, String key) {
+        if (o.has(key) && o.get(key).isJsonPrimitive() && !o.get(key).isJsonNull()) {
+            return o.get(key).getAsString();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeMessageHandler.java
@@ -7,6 +7,7 @@ import com.github.claudecodegui.notifications.ClaudeNotifier;
 import com.github.claudecodegui.provider.common.MessageCallback;
 import com.github.claudecodegui.settings.CodemossSettingsService;
 import com.github.claudecodegui.provider.common.SDKResult;
+import com.github.claudecodegui.provider.claude.ClaudePlanUsageService;
 import com.github.claudecodegui.util.TokenUsageUtils;
 import com.github.claudecodegui.util.UsageCostCalculator;
 import com.google.gson.Gson;
@@ -163,6 +164,9 @@ public class ClaudeMessageHandler implements MessageCallback {
                 break;
             case "system":
                 handleSystemMessage(content);
+                break;
+            case "rate_limit_event":
+                handleRateLimit(content);
                 break;
             case "node_log":
                 // Forward Node.js logs to frontend console
@@ -750,6 +754,30 @@ public class ClaudeMessageHandler implements MessageCallback {
             }
         } catch (Exception e) {
             LOG.warn("Failed to parse system message: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Handle a {@code rate_limit_event} from the SDK stream (real Anthropic subscription).
+     * Extracts {@code rate_limit_info} and caches it so the plan-usage poll
+     * ({@code get_claude_plan_usage}) can surface utilization + reset in the ContextBar.
+     * Only fires on real Anthropic (OAuth subscription) backends.
+     */
+    private void handleRateLimit(String content) {
+        if (content == null || !content.startsWith("{")) {
+            return;
+        }
+        try {
+            JsonObject msg = gson.fromJson(content, JsonObject.class);
+            if (msg == null
+                    || !msg.has("rate_limit_info")
+                    || !msg.get("rate_limit_info").isJsonObject()) {
+                return;
+            }
+            ClaudePlanUsageService.cacheRateLimitInfo(msg.getAsJsonObject("rate_limit_info"));
+            LOG.debug("Cached Claude rate_limit_event");
+        } catch (Exception e) {
+            LOG.warn("Failed to parse rate_limit_event: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -25,6 +25,7 @@ import com.github.claudecodegui.handler.PromptHandler;
 import com.github.claudecodegui.handler.provider.CustomModelPricingHandler;
 import com.github.claudecodegui.handler.provider.ModelProviderHandler;
 import com.github.claudecodegui.handler.provider.ProviderHandler;
+import com.github.claudecodegui.handler.provider.claude.ClaudePlanUsageHandler;
 import com.github.claudecodegui.handler.RewindHandler;
 import com.github.claudecodegui.handler.SessionHandler;
 import com.github.claudecodegui.handler.SettingsHandler;
@@ -337,6 +338,7 @@ public class ChatWindowDelegate {
         host.setMessageDispatcher(messageDispatcher);
 
         messageDispatcher.registerHandler(new ProviderHandler(handlerContext));
+        messageDispatcher.registerHandler(new ClaudePlanUsageHandler(handlerContext));
         messageDispatcher.registerHandler(new CustomModelPricingHandler(handlerContext, settingsService));
         messageDispatcher.registerHandler(new McpServerHandler(handlerContext));
         messageDispatcher.registerHandler(new McpMarketplaceHandler(handlerContext));

--- a/src/test/java/com/github/claudecodegui/provider/claude/ClaudePlanUsageServiceTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/ClaudePlanUsageServiceTest.java
@@ -1,0 +1,72 @@
+package com.github.claudecodegui.provider.claude;
+
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ClaudePlanUsageServiceTest {
+
+    private static JsonObject info(double utilization, long resetsAtMs, String status) {
+        JsonObject o = new JsonObject();
+        o.addProperty("utilization", utilization);
+        o.addProperty("resetsAt", resetsAtMs);
+        if (status != null) {
+            o.addProperty("status", status);
+        }
+        return o;
+    }
+
+    @Test
+    public void buildCapacityPayload_fractionUtilization_mapsToPercentWith5hWindow() {
+        long resetsAt = System.currentTimeMillis() + 3L * 60 * 60 * 1000; // ~3h out → 5h bucket
+        JsonObject payload = ClaudePlanUsageService.buildCapacityPayload(info(0.42, resetsAt, "allowed_warning"));
+
+        assertEquals(42.0, payload.get("capacity_pct").getAsDouble(), 0.01);
+        assertEquals("claude", payload.get("provider").getAsString());
+        assertEquals("sdk-rate-limit", payload.get("source").getAsString());
+        assertTrue(payload.get("present").getAsBoolean());
+        assertEquals("5h", payload.get("period_type").getAsString());
+        assertEquals("allowed_warning", payload.get("rate_limit_status").getAsString());
+        assertTrue(payload.has("reset_at"));
+
+        JsonObject window = payload.getAsJsonArray("windows").get(0).getAsJsonObject();
+        assertEquals("5h", window.get("id").getAsString());
+        assertEquals(42.0, window.get("used_pct").getAsDouble(), 0.01);
+        assertEquals("5h", window.get("period_type").getAsString());
+    }
+
+    @Test
+    public void buildCapacityPayload_percentUtilizationAboveOne_treatedAsPercent() {
+        long resetsAt = System.currentTimeMillis() + 5L * 24 * 60 * 60 * 1000; // ~5d → 7d bucket
+        JsonObject payload = ClaudePlanUsageService.buildCapacityPayload(info(87.0, resetsAt, "rejected"));
+
+        assertEquals(87.0, payload.get("capacity_pct").getAsDouble(), 0.01);
+        assertEquals("7d", payload.get("period_type").getAsString());
+        assertEquals("rejected", payload.get("rate_limit_status").getAsString());
+    }
+
+    @Test
+    public void buildCapacityPayload_missingUtilization_returnsNull() {
+        JsonObject noUtil = new JsonObject();
+        noUtil.addProperty("resetsAt", System.currentTimeMillis() + 1000L);
+        assertNull(ClaudePlanUsageService.buildCapacityPayload(noUtil));
+    }
+
+    @Test
+    public void clampPct_boundsZeroToHundred() {
+        assertEquals(0.0, ClaudePlanUsageService.clampPct(-5), 0.001);
+        assertEquals(100.0, ClaudePlanUsageService.clampPct(144), 0.001);
+        assertEquals(50.0, ClaudePlanUsageService.clampPct(50), 0.001);
+    }
+
+    @Test
+    public void periodTypeFromResetMs_classifies5hAnd7d() {
+        long now = System.currentTimeMillis();
+        assertEquals("5h", ClaudePlanUsageService.periodTypeFromResetMs(now + 2L * 60 * 60 * 1000));
+        assertEquals("5h", ClaudePlanUsageService.periodTypeFromResetMs(now + 6L * 60 * 60 * 1000));
+        assertEquals("7d", ClaudePlanUsageService.periodTypeFromResetMs(now + 2L * 24 * 60 * 60 * 1000));
+    }
+}

--- a/webview/src/components/ChatInputBox/ContextBar.tsx
+++ b/webview/src/components/ChatInputBox/ContextBar.tsx
@@ -1,6 +1,8 @@
 import React, { useRef, useState, useEffect, useCallback, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getFileIcon } from '../../utils/fileIcons';
+import { useClaudePlanUsage } from '../../hooks/useClaudePlanUsage';
+import { PlanUsageIndicator } from './PlanUsageIndicator';
 import { TokenIndicator } from './TokenIndicator';
 import type { SelectedAgent } from './types';
 
@@ -63,6 +65,8 @@ export const ContextBar: React.FC<ContextBarProps> = memo(({
 }) => {
   const { t } = useTranslation();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const isClaude = currentProvider === 'claude';
+  const claudePlanUsage = useClaudePlanUsage(currentProvider);
   const popoverRef = useRef<HTMLDivElement>(null);
   const [showEnablePopover, setShowEnablePopover] = useState(false);
 
@@ -265,6 +269,13 @@ export const ContextBar: React.FC<ContextBarProps> = memo(({
 
       {/* Right side tools - StatusPanel toggle and Rewind button */}
       <div className="context-tools-right">
+        {isClaude && (
+          <PlanUsageIndicator
+            snapshot={claudePlanUsage.snapshot}
+            status={claudePlanUsage.status}
+          />
+        )}
+
         {/* StatusPanel expand/collapse toggle - always visible */}
         {onToggleStatusPanel && (
           <button

--- a/webview/src/components/ChatInputBox/PlanUsageIndicator.test.tsx
+++ b/webview/src/components/ChatInputBox/PlanUsageIndicator.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PlanUsageIndicator } from './PlanUsageIndicator';
+
+describe('PlanUsageIndicator', () => {
+  it('shows Usage — when unavailable', () => {
+    render(
+      <PlanUsageIndicator
+        status="unavailable"
+        snapshot={{ present: false, message: 'down' }}
+      />,
+    );
+    expect(screen.getByText(/Usage/)).toBeTruthy();
+  });
+
+  it('renders bar percent and short reset on happy path', () => {
+    const { container } = render(
+      <PlanUsageIndicator
+        status="ready"
+        snapshot={{
+          present: true,
+          capacityPct: 47,
+          resetAt: '2026-07-28T00:00:00Z',
+          periodType: '7d',
+        }}
+      />,
+    );
+    expect(screen.getByText('47%')).toBeTruthy();
+    expect(container.querySelector('.plan-usage-bar')).toBeTruthy();
+    expect(container.querySelector('.plan-usage-fill')).toBeTruthy();
+  });
+
+  it('applies pace color class from TP vs TT', () => {
+    // end far future, start far past → TT high → TP low → green
+    const far = new Date();
+    far.setDate(far.getDate() + 3);
+    const start = new Date();
+    start.setDate(start.getDate() - 4);
+    const { container } = render(
+      <PlanUsageIndicator
+        status="ready"
+        snapshot={{
+          present: true,
+          capacityPct: 10,
+          resetAt: far.toISOString(),
+          periodStart: start.toISOString(),
+        }}
+      />,
+    );
+    expect(container.querySelector('.pace-green')).toBeTruthy();
+  });
+
+  it('returns null when idle', () => {
+    const { container } = render(<PlanUsageIndicator status="idle" snapshot={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/webview/src/components/ChatInputBox/PlanUsageIndicator.tsx
+++ b/webview/src/components/ChatInputBox/PlanUsageIndicator.tsx
@@ -1,0 +1,195 @@
+import React, { memo, useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  clampPercent,
+  formatFullReset,
+  formatShortReset,
+  nextWindowId,
+  paceColor,
+  readStoredWindowId,
+  resolveDisplayWindow,
+  resolveTimeBudget,
+  windowShortLabel,
+  worstPaceColor,
+  writeStoredWindowId,
+  type PlanUsageSnapshot,
+} from '../../utils/planUsagePace';
+
+export interface PlanUsageIndicatorProps {
+  snapshot: PlanUsageSnapshot | null;
+  status: 'idle' | 'loading' | 'ready' | 'unavailable';
+}
+
+/**
+ * Layout D: mini progress bar + % + window switcher + short reset.
+ * Click the window chip (5h / 7d) to cycle between windows.
+ */
+export const PlanUsageIndicator: React.FC<PlanUsageIndicatorProps> = memo(({
+  snapshot,
+  status,
+}) => {
+  const { t, i18n } = useTranslation();
+  const [windowId, setWindowId] = useState<string | null>(() => readStoredWindowId());
+
+  const display = useMemo(() => {
+    if (!snapshot?.present) return null;
+    return resolveDisplayWindow(snapshot, windowId);
+  }, [snapshot, windowId]);
+
+  const windows = snapshot?.windows ?? [];
+  const canSwitch = windows.length > 1;
+
+  const onCycleWindow = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!canSwitch) return;
+    const next = nextWindowId(windows, display?.windowId ?? windowId);
+    if (!next) return;
+    setWindowId(next);
+    writeStoredWindowId(next);
+  }, [canSwitch, windows, display?.windowId, windowId]);
+
+  const present = !!display && typeof display.capacityPct === 'number' && !!snapshot?.present;
+  const tp = present ? clampPercent(display!.capacityPct) : 0;
+  const tt = present
+    ? resolveTimeBudget({
+      resetAt: display!.resetAt,
+      periodStart: snapshot?.periodStart,
+      periodType: display!.periodType,
+    })
+    : null;
+  // Bar/% = selected window; trailing dot = worst across all windows.
+  const color = present ? paceColor(tp, tt) : 'neutral';
+  const worstColor = present && snapshot ? worstPaceColor(snapshot) : 'neutral';
+  const shortReset = present ? formatShortReset(display!.resetAt, i18n.language) : '';
+  const fullReset = present ? formatFullReset(display!.resetAt, i18n.language) : '';
+  const winLabel = windowShortLabel(display?.windowId || display?.periodType);
+
+  const tooltip = useMemo(() => {
+    if (!present) {
+      return snapshot?.message
+        || t('chat.planUsage.unavailable', { defaultValue: 'Usage unavailable' });
+    }
+    const pct = Math.round(tp);
+    const period = display?.periodType || display?.windowId || 'limit';
+    const lines: string[] = [];
+    if (fullReset) {
+      lines.push(
+        t('chat.planUsage.tooltipWindowWithReset', {
+          period,
+          percent: pct,
+          value: fullReset,
+          defaultValue: '{{period}} {{percent}}% · Resets {{value}}',
+        }),
+      );
+    } else {
+      lines.push(
+        t('chat.planUsage.tooltipWindow', {
+          period,
+          percent: pct,
+          defaultValue: '{{period}} {{percent}}%',
+        }),
+      );
+    }
+    if (windows.length > 1) {
+      const others = windows
+        .map((w) => `${w.id} ${Math.round(w.usedPct)}%`)
+        .join(' · ');
+      lines.push(others);
+      if (worstColor !== color && worstColor !== 'neutral' && worstColor !== 'green') {
+        lines.push(
+          t('chat.planUsage.worstHint', {
+            color: worstColor,
+            defaultValue: 'Dot shows worst window ({{color}})',
+          }),
+        );
+      }
+      lines.push(
+        t('chat.planUsage.clickToSwitch', {
+          defaultValue: 'Click period label to switch window',
+        }),
+      );
+    }
+    return lines.join('\n');
+  }, [present, snapshot?.message, tp, fullReset, display, windows, worstColor, color, t]);
+
+  if (status === 'idle') return null;
+
+  if (!present && status === 'loading') {
+    return (
+      <div
+        className="plan-usage loading has-tooltip"
+        data-tooltip={t('chat.planUsage.loading', { defaultValue: 'Loading usage…' })}
+        aria-label={t('chat.planUsage.loading', { defaultValue: 'Loading usage…' })}
+      >
+        <span className="plan-usage-label">…</span>
+      </div>
+    );
+  }
+
+  if (!present) {
+    return (
+      <div
+        className="plan-usage unavailable has-tooltip"
+        data-tooltip={tooltip}
+        aria-label={tooltip}
+      >
+        <span className="plan-usage-label">
+          {t('chat.planUsage.dash', { defaultValue: 'Usage —' })}
+        </span>
+      </div>
+    );
+  }
+
+  const fillWidth = `${tp}%`;
+  const rounded = Math.round(tp);
+  const labelPct = tp > 0 && rounded === 0 ? '<1%' : `${rounded}%`;
+
+  return (
+    <div
+      className={`plan-usage pace-${color} has-tooltip`}
+      data-tooltip={tooltip}
+      aria-label={tooltip}
+    >
+      <div className="plan-usage-bar" aria-hidden>
+        <div className="plan-usage-fill" style={{ width: fillWidth }} />
+      </div>
+      <span className="plan-usage-pct">{labelPct}</span>
+      {canSwitch || winLabel !== '·' ? (
+        <button
+          type="button"
+          className={`plan-usage-window${canSwitch ? ' switchable' : ''}`}
+          onClick={onCycleWindow}
+          disabled={!canSwitch}
+          title={
+            canSwitch
+              ? t('chat.planUsage.clickToSwitch', {
+                defaultValue: 'Click to switch between windows',
+              })
+              : undefined
+          }
+        >
+          {winLabel}
+        </button>
+      ) : null}
+      {shortReset ? (
+        <span className="plan-usage-reset">{shortReset}</span>
+      ) : null}
+      {/* Worst pace across all windows — after reset date */}
+      <span
+        className={`plan-usage-worst-dot pace-${worstColor}`}
+        aria-hidden
+        title={
+          worstColor !== 'neutral'
+            ? t('chat.planUsage.worstDot', {
+              color: worstColor,
+              defaultValue: 'Worst window: {{color}}',
+            })
+            : undefined
+        }
+      />
+    </div>
+  );
+});
+
+PlanUsageIndicator.displayName = 'PlanUsageIndicator';

--- a/webview/src/components/ChatInputBox/styles/context-bar.css
+++ b/webview/src/components/ChatInputBox/styles/context-bar.css
@@ -365,3 +365,131 @@ button.context-file-placeholder:focus-visible {
   }
 }
 
+/* Plan usage indicator (layout D: mini-bar + % + window + short reset) */
+.plan-usage {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  max-width: 200px;
+  min-width: 0;
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1;
+  flex-shrink: 1;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+/* Leading dot = worst pace across all windows (not just selected). */
+.plan-usage-worst-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--text-secondary);
+  opacity: 0.85;
+}
+.plan-usage-worst-dot.pace-green {
+  background: #3ba55d;
+  opacity: 1;
+}
+.plan-usage-worst-dot.pace-yellow {
+  background: #d4a017;
+  opacity: 1;
+}
+.plan-usage-worst-dot.pace-red {
+  background: #e34850;
+  opacity: 1;
+}
+.plan-usage-worst-dot.pace-neutral {
+  background: var(--text-secondary);
+  opacity: 0.5;
+}
+
+.plan-usage-bar {
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--input-border);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.plan-usage-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--text-secondary);
+  transition: width 0.25s ease, background 0.2s ease;
+}
+
+.plan-usage-pct {
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+.plan-usage-reset {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-secondary);
+  opacity: 0.9;
+}
+
+/* 5h/7d window switcher */
+.plan-usage-window {
+  flex-shrink: 0;
+  margin: 0;
+  padding: 1px 4px;
+  border: 1px solid var(--input-border);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+  cursor: default;
+}
+.plan-usage-window.switchable {
+  cursor: pointer;
+}
+.plan-usage-window.switchable:hover {
+  background: var(--button-hover);
+  color: var(--text-primary);
+}
+.plan-usage-window:disabled {
+  opacity: 0.85;
+}
+
+.plan-usage.pace-green .plan-usage-fill {
+  background: #3ba55d;
+}
+.plan-usage.pace-green .plan-usage-pct {
+  color: #3ba55d;
+}
+
+.plan-usage.pace-yellow .plan-usage-fill {
+  background: #d4a017;
+}
+.plan-usage.pace-yellow .plan-usage-pct {
+  color: #d4a017;
+}
+
+.plan-usage.pace-red .plan-usage-fill {
+  background: #e34850;
+}
+.plan-usage.pace-red .plan-usage-pct {
+  color: #e34850;
+}
+
+.plan-usage.unavailable {
+  opacity: 0.75;
+}
+
+.plan-usage-label {
+  font-size: 11px;
+  color: var(--text-secondary);
+}

--- a/webview/src/hooks/useClaudePlanUsage.test.tsx
+++ b/webview/src/hooks/useClaudePlanUsage.test.tsx
@@ -1,0 +1,73 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useClaudePlanUsage } from './useClaudePlanUsage';
+
+const w = window as unknown as {
+  sendToJava?: (cmd: string) => void;
+  updateClaudePlanUsage?: (json: string) => void;
+};
+
+const unavailablePayload = {
+  present: false,
+  unavailable: true,
+  message: 'Claude usage unavailable',
+};
+
+const presentPayload = {
+  ok: true,
+  present: true,
+  provider: 'claude',
+  source: 'sdk-rate-limit',
+  capacity_pct: 42,
+  reset_at: '2026-08-23T03:00:00Z',
+  period_type: '5h',
+  windows: [
+    { id: '5h', used_pct: 42, reset_at: '2026-08-23T03:00:00Z', period_type: '5h' },
+  ],
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete w.sendToJava;
+  delete w.updateClaudePlanUsage;
+});
+
+describe('useClaudePlanUsage', () => {
+  it('stays hidden (idle) while no event has ever arrived', () => {
+    w.sendToJava = vi.fn();
+    const { result } = renderHook(() => useClaudePlanUsage('claude'));
+    expect(w.sendToJava).toHaveBeenCalledWith('get_claude_plan_usage:');
+
+    act(() => {
+      w.updateClaudePlanUsage?.(JSON.stringify(unavailablePayload));
+    });
+    expect(result.current.status).toBe('idle');
+    expect(result.current.snapshot).toBeNull();
+  });
+
+  it('becomes ready on the first present payload, then keeps data visible', () => {
+    w.sendToJava = vi.fn();
+    const { result } = renderHook(() => useClaudePlanUsage('claude'));
+
+    act(() => {
+      w.updateClaudePlanUsage?.(JSON.stringify(presentPayload));
+    });
+    expect(result.current.status).toBe('ready');
+    expect(result.current.snapshot?.capacityPct).toBe(42);
+
+    // Later unavailable poll after data was seen → dash, not hidden.
+    act(() => {
+      w.updateClaudePlanUsage?.(JSON.stringify(unavailablePayload));
+    });
+    expect(result.current.status).toBe('unavailable');
+    expect(result.current.snapshot?.present).toBe(false);
+  });
+
+  it('is empty for non-claude providers and never polls', () => {
+    w.sendToJava = vi.fn();
+    const { result } = renderHook(() => useClaudePlanUsage('gemini'));
+    expect(result.current.status).toBe('idle');
+    expect(result.current.snapshot).toBeNull();
+    expect(w.sendToJava).not.toHaveBeenCalled();
+  });
+});

--- a/webview/src/hooks/useClaudePlanUsage.ts
+++ b/webview/src/hooks/useClaudePlanUsage.ts
@@ -9,6 +9,24 @@ export type ClaudePlanUsageState = {
 const EMPTY: ClaudePlanUsageState = { status: 'idle', snapshot: null };
 
 /**
+ * Apply one poll result. Until the first present payload the bar stays hidden:
+ * backends that never emit {@code rate_limit_event} (API keys, proxies) would
+ * otherwise show a permanent "Usage —" dash.
+ */
+function applySnapshot(
+  prev: ClaudePlanUsageState,
+  snap: PlanUsageSnapshot,
+): ClaudePlanUsageState {
+  if (snap.present) {
+    return { status: 'ready', snapshot: snap };
+  }
+  if (!prev.snapshot?.present) {
+    return EMPTY;
+  }
+  return { status: 'unavailable', snapshot: snap };
+}
+
+/**
  * Claude plan usage for ContextBar via Java bridge
  * ({@code get_claude_plan_usage} → cached SDK rate_limit_event snapshot).
  */
@@ -23,10 +41,8 @@ export function useClaudePlanUsage(currentProvider: string) {
       return;
     }
     const gen = ++genRef.current;
-    setState((prev) => ({
-      status: prev.snapshot?.present ? 'ready' : 'loading',
-      snapshot: prev.snapshot,
-    }));
+    // Keep the last data while re-polling; stay hidden until the first event.
+    setState((prev) => (prev.snapshot?.present ? prev : EMPTY));
 
     const w = window as unknown as {
       updateClaudePlanUsage?: (json: string) => void;
@@ -37,17 +53,10 @@ export function useClaudePlanUsage(currentProvider: string) {
       if (gen !== genRef.current) return;
       try {
         const data = typeof jsonStr === 'string' ? JSON.parse(jsonStr) : jsonStr;
-        const snap = parseCapacityPayload(data);
-        if (snap.present) {
-          setState({ status: 'ready', snapshot: snap });
-        } else {
-          setState({ status: 'unavailable', snapshot: snap });
-        }
+        setState((prev) => applySnapshot(prev, parseCapacityPayload(data)));
       } catch {
-        setState({
-          status: 'unavailable',
-          snapshot: { present: false, message: 'Usage unavailable' },
-        });
+        setState((prev) =>
+          applySnapshot(prev, { present: false, message: 'Usage unavailable' }));
       }
     };
 
@@ -62,10 +71,8 @@ export function useClaudePlanUsage(currentProvider: string) {
       w.sendToJava?.('get_claude_plan_usage:');
     } catch {
       if (gen === genRef.current) {
-        setState({
-          status: 'unavailable',
-          snapshot: { present: false, message: 'Usage unavailable' },
-        });
+        setState((prev) =>
+          applySnapshot(prev, { present: false, message: 'Usage unavailable' }));
       }
     }
   }, [currentProvider]);

--- a/webview/src/hooks/useClaudePlanUsage.ts
+++ b/webview/src/hooks/useClaudePlanUsage.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { parseCapacityPayload, type PlanUsageSnapshot } from '../utils/planUsagePace';
+
+export type ClaudePlanUsageState = {
+  status: 'idle' | 'loading' | 'ready' | 'unavailable';
+  snapshot: PlanUsageSnapshot | null;
+};
+
+const EMPTY: ClaudePlanUsageState = { status: 'idle', snapshot: null };
+
+/**
+ * Claude plan usage for ContextBar via Java bridge
+ * ({@code get_claude_plan_usage} → cached SDK rate_limit_event snapshot).
+ */
+export function useClaudePlanUsage(currentProvider: string) {
+  const [state, setState] = useState<ClaudePlanUsageState>(EMPTY);
+  const genRef = useRef(0);
+  const handlerRef = useRef<((json: string) => void) | null>(null);
+
+  const refresh = useCallback(() => {
+    if (currentProvider !== 'claude') {
+      setState(EMPTY);
+      return;
+    }
+    const gen = ++genRef.current;
+    setState((prev) => ({
+      status: prev.snapshot?.present ? 'ready' : 'loading',
+      snapshot: prev.snapshot,
+    }));
+
+    const w = window as unknown as {
+      updateClaudePlanUsage?: (json: string) => void;
+      sendToJava?: (cmd: string) => void;
+    };
+
+    const handler = (jsonStr: string) => {
+      if (gen !== genRef.current) return;
+      try {
+        const data = typeof jsonStr === 'string' ? JSON.parse(jsonStr) : jsonStr;
+        const snap = parseCapacityPayload(data);
+        if (snap.present) {
+          setState({ status: 'ready', snapshot: snap });
+        } else {
+          setState({ status: 'unavailable', snapshot: snap });
+        }
+      } catch {
+        setState({
+          status: 'unavailable',
+          snapshot: { present: false, message: 'Usage unavailable' },
+        });
+      }
+    };
+
+    handlerRef.current = handler;
+    w.updateClaudePlanUsage = (json: string) => {
+      if (handlerRef.current) {
+        handlerRef.current(json);
+      }
+    };
+
+    try {
+      w.sendToJava?.('get_claude_plan_usage:');
+    } catch {
+      if (gen === genRef.current) {
+        setState({
+          status: 'unavailable',
+          snapshot: { present: false, message: 'Usage unavailable' },
+        });
+      }
+    }
+  }, [currentProvider]);
+
+  useEffect(() => {
+    void refresh();
+    if (currentProvider !== 'claude') {
+      return () => {
+        genRef.current += 1;
+      };
+    }
+    const id = window.setInterval(() => {
+      void refresh();
+    }, 120_000);
+    return () => {
+      window.clearInterval(id);
+      genRef.current += 1;
+    };
+  }, [currentProvider, refresh]);
+
+  return { ...state, refresh };
+}
+
+export type UseClaudePlanUsageReturn = ReturnType<typeof useClaudePlanUsage>;

--- a/webview/src/utils/planUsagePace.test.ts
+++ b/webview/src/utils/planUsagePace.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatShortReset,
+  nextWindowId,
+  paceColor,
+  parseCapacityPayload,
+  resolveDisplayWindow,
+  windowShortLabel,
+  worstPaceColor,
+} from './planUsagePace';
+
+const claudePayload = {
+  ok: true,
+  present: true,
+  provider: 'claude',
+  source: 'sdk-rate-limit',
+  capacity_pct: 92,
+  reset_at: '2026-08-23T03:00:00Z',
+  period_type: '5h',
+  windows: [
+    { id: '5h', used_pct: 92, reset_at: '2026-08-23T03:00:00Z', period_type: '5h' },
+    { id: '7d', used_pct: 21, reset_at: '2026-08-25T00:00:00Z', period_type: '7d' },
+  ],
+};
+
+describe('parseCapacityPayload', () => {
+  it('normalizes snake_case windows into a snapshot', () => {
+    const snap = parseCapacityPayload(claudePayload);
+    expect(snap.present).toBe(true);
+    expect(snap.capacityPct).toBe(92);
+    expect(snap.provider).toBe('claude');
+    expect(snap.windows?.map((w) => w.id)).toEqual(['5h', '7d']);
+    expect(snap.windows?.[1].usedPct).toBe(21);
+  });
+
+  it('marks unavailable payloads not present', () => {
+    const snap = parseCapacityPayload({ present: false, unavailable: true, message: 'no data' });
+    expect(snap.present).toBe(false);
+    expect(snap.message).toBe('no data');
+  });
+
+  it('falls back to the first window when top-level pct is missing', () => {
+    const snap = parseCapacityPayload({
+      windows: [{ id: '5h', used_pct: 42, reset_at: '2026-08-23T03:00:00Z' }],
+    });
+    expect(snap.present).toBe(true);
+    expect(snap.capacityPct).toBe(42);
+    expect(snap.periodType).toBeNull();
+  });
+});
+
+describe('paceColor', () => {
+  it('green below budget, yellow within +5, red past it, neutral without budget', () => {
+    expect(paceColor(30, 50)).toBe('green');
+    expect(paceColor(52, 50)).toBe('yellow');
+    expect(paceColor(56, 50)).toBe('red');
+    expect(paceColor(30, null)).toBe('neutral');
+  });
+});
+
+describe('worstPaceColor', () => {
+  it('takes the worst window, not the selected one', () => {
+    // now chosen so 5h is far past its time budget (red) while 7d is far under (green)
+    const now = new Date('2026-08-22T22:30:00Z');
+    const snap = parseCapacityPayload(claudePayload);
+    expect(worstPaceColor(snap, now)).toBe('red');
+  });
+});
+
+describe('window switching', () => {
+  const snap = parseCapacityPayload(claudePayload);
+  const windows = snap.windows ?? [];
+
+  it('cycles 5h → 7d → 5h', () => {
+    expect(nextWindowId(windows, '5h')).toBe('7d');
+    expect(nextWindowId(windows, '7d')).toBe('5h');
+  });
+
+  it('prefers the stored window id and falls back to top-level binding', () => {
+    expect(resolveDisplayWindow(snap, '7d')).toMatchObject({ windowId: '7d', capacityPct: 21 });
+    expect(resolveDisplayWindow(snap, null).capacityPct).toBe(92);
+  });
+
+  it('labels raw ids compactly', () => {
+    expect(windowShortLabel('5h')).toBe('5h');
+    expect(windowShortLabel('7d')).toBe('7d');
+    expect(windowShortLabel('WEEKLY')).toBe('7d');
+    expect(windowShortLabel(null)).toBe('·');
+  });
+});
+
+describe('formatShortReset', () => {
+  it('emits day + short month + 24h time with no trailing period', () => {
+    const label = formatShortReset('2026-08-23T03:00:00Z', 'en-GB');
+    expect(label).not.toMatch(/\.$/);
+    // timezone-agnostic structure: "23 Aug 03:00" (locale day/time vary by TZ)
+    expect(label.trim()).toMatch(/^\d{1,2} [A-Za-z]{3,4} \d{2}:\d{2}$/);
+  });
+
+  it('returns empty string for missing dates', () => {
+    expect(formatShortReset(null)).toBe('');
+  });
+});

--- a/webview/src/utils/planUsagePace.ts
+++ b/webview/src/utils/planUsagePace.ts
@@ -1,0 +1,359 @@
+/**
+ * Plan-usage pace coloring for the ContextBar usage bar.
+ * TP = actual usage %, TT = linear time budget through the reset window.
+ */
+
+export type PaceColor = 'green' | 'yellow' | 'red' | 'neutral';
+
+/** One rate/billing window from a capacity payload windows[]. */
+export interface CapacityWindow {
+  id: string;
+  usedPct: number;
+  resetAt?: string | null;
+  periodType?: string | null;
+}
+
+export interface PlanUsageSnapshot {
+  present: boolean;
+  /** Usage percent 0–100 (TP) — binding/worst-case at top level. */
+  capacityPct?: number;
+  /** Period end / next reset (ISO or parseable date string). */
+  resetAt?: string | null;
+  /** Period start when known. */
+  periodStart?: string | null;
+  /** 5h | 7d | … */
+  periodType?: string | null;
+  /** All known windows (e.g. 5h/7d). */
+  windows?: CapacityWindow[];
+  /** Provider from capacity payload (claude | …). */
+  provider?: string;
+  source?: string;
+  message?: string;
+}
+
+export const PLAN_USAGE_WINDOW_STORAGE_KEY = 'ccgui.planUsage.windowId';
+
+const YELLOW_BAND = 5;
+
+/** Clamp number to [0, 100]. */
+export function clampPercent(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(100, n));
+}
+
+/**
+ * Derive period start from end + period_type when start is missing.
+ * 5H → end − 5h; 7D/WEEKLY → end − 7d; MONTHLY → end − 30d.
+ */
+export function derivePeriodStart(
+  resetAt: Date,
+  periodType?: string | null,
+): Date | null {
+  // Accept raw enums too, e.g. USAGE_PERIOD_TYPE_WEEKLY from xAI billing.
+  const t = (periodType || '').toUpperCase();
+  if (t === '5H' || t === '5HR' || t.includes('5H')) {
+    return new Date(resetAt.getTime() - 5 * 60 * 60 * 1000);
+  }
+  if (t === '7D' || t === '7DAY' || (t.includes('7D') && !t.includes('WEEK'))) {
+    return new Date(resetAt.getTime() - 7 * 24 * 60 * 60 * 1000);
+  }
+  if (t === 'WEEKLY' || t === 'WEEK' || t.includes('WEEK')) {
+    return new Date(resetAt.getTime() - 7 * 24 * 60 * 60 * 1000);
+  }
+  if (t === 'MONTHLY' || t === 'MONTH' || t.includes('MONTH')) {
+    return new Date(resetAt.getTime() - 30 * 24 * 60 * 60 * 1000);
+  }
+  return null;
+}
+
+export function parseDate(value?: string | null): Date | null {
+  if (!value || typeof value !== 'string') return null;
+  const d = new Date(value);
+  return Number.isFinite(d.getTime()) ? d : null;
+}
+
+/**
+ * TT = linear time progress through [start, end], 0–100.
+ * Returns null when window cannot be determined.
+ */
+export function computeTimeBudgetPercent(
+  now: Date,
+  periodStart?: Date | null,
+  periodEnd?: Date | null,
+): number | null {
+  if (!periodStart || !periodEnd) return null;
+  const start = periodStart.getTime();
+  const end = periodEnd.getTime();
+  if (!(end > start)) return null;
+  const t = now.getTime();
+  return clampPercent(((t - start) / (end - start)) * 100);
+}
+
+/**
+ * Resolve TT from snapshot fields (explicit start or period_type).
+ */
+export function resolveTimeBudget(
+  snapshot: Pick<PlanUsageSnapshot, 'resetAt' | 'periodStart' | 'periodType'>,
+  now: Date = new Date(),
+): number | null {
+  const end = parseDate(snapshot.resetAt ?? null);
+  if (!end) return null;
+  let start = parseDate(snapshot.periodStart ?? null);
+  if (!start) {
+    start = derivePeriodStart(end, snapshot.periodType);
+  }
+  return computeTimeBudgetPercent(now, start, end);
+}
+
+/**
+ * Pace color: TP < TT green; TT ≤ TP ≤ TT+5 yellow; TP > TT+5 red; no TT → neutral.
+ */
+export function paceColor(tp: number, tt: number | null): PaceColor {
+  if (tt === null || !Number.isFinite(tt)) return 'neutral';
+  const usage = clampPercent(tp);
+  const budget = clampPercent(tt);
+  if (usage < budget) return 'green';
+  if (usage <= budget + YELLOW_BAND) return 'yellow';
+  return 'red';
+}
+
+const PACE_RANK: Record<PaceColor, number> = {
+  neutral: 0,
+  green: 1,
+  yellow: 2,
+  red: 3,
+};
+
+/** Worse of two pace colors (red > yellow > green > neutral). */
+export function worsePace(a: PaceColor, b: PaceColor): PaceColor {
+  return PACE_RANK[a] >= PACE_RANK[b] ? a : b;
+}
+
+/**
+ * Worst pace across all windows (or single top-level snapshot when no windows[]).
+ * Used for the leading status dot so a green selected window cannot hide a red other.
+ */
+export function worstPaceColor(
+  snapshot: PlanUsageSnapshot,
+  now: Date = new Date(),
+): PaceColor {
+  if (!snapshot.present) return 'neutral';
+  const windows = snapshot.windows ?? [];
+  if (windows.length === 0) {
+    const tt = resolveTimeBudget(snapshot, now);
+    return paceColor(snapshot.capacityPct ?? 0, tt);
+  }
+  let worst: PaceColor = 'neutral';
+  for (const w of windows) {
+    const tt = resolveTimeBudget(
+      {
+        resetAt: w.resetAt,
+        periodStart: snapshot.periodStart,
+        periodType: w.periodType ?? w.id,
+      },
+      now,
+    );
+    worst = worsePace(worst, paceColor(w.usedPct, tt));
+  }
+  return worst;
+}
+
+/**
+ * Compact reset label for the bar: day + short month + 24h time in local TZ.
+ * Example (Europe/Moscow): "1 Aug 03:00".
+ */
+export function formatShortReset(resetAt?: string | null, locale?: string): string {
+  const d = parseDate(resetAt ?? null);
+  if (!d) return '';
+  try {
+    const datePart = d.toLocaleDateString(locale, { day: 'numeric', month: 'short' });
+    const timePart = d.toLocaleTimeString(locale, {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+    // Some locales still emit 24h with a trailing day-period; strip common noise.
+    const time = timePart.replace(/\u202f/g, ' ').trim();
+    // Drop locale abbreviations' trailing dots (e.g. "июл.") — no period after reset.
+    const date = datePart.replace(/\./g, '').trim();
+    return `${date} ${time} `;
+  } catch {
+    const hh = String(d.getHours()).padStart(2, '0');
+    const mm = String(d.getMinutes()).padStart(2, '0');
+    return `${d.getDate()} ${d.getMonth() + 1} ${hh}:${mm} `;
+  }
+}
+
+/** Full datetime for tooltip. */
+export function formatFullReset(resetAt?: string | null, locale?: string): string {
+  const d = parseDate(resetAt ?? null);
+  if (!d) return '';
+  try {
+    return d.toLocaleString(locale);
+  } catch {
+    return d.toISOString();
+  }
+}
+
+function parseWindows(raw: unknown): CapacityWindow[] {
+  if (!Array.isArray(raw)) return [];
+  const out: CapacityWindow[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const w = item as Record<string, unknown>;
+    const id = typeof w.id === 'string' ? w.id.trim() : '';
+    if (!id) continue;
+    const pctRaw = w.used_pct ?? w.usedPct ?? w.capacity_pct ?? w.capacityPct;
+    const pct = typeof pctRaw === 'number' ? pctRaw : Number(pctRaw);
+    if (!Number.isFinite(pct)) continue;
+    out.push({
+      id,
+      usedPct: clampPercent(pct),
+      resetAt:
+        typeof w.reset_at === 'string'
+          ? w.reset_at
+          : typeof w.resetAt === 'string'
+            ? w.resetAt
+            : null,
+      periodType:
+        typeof w.period_type === 'string'
+          ? w.period_type
+          : typeof w.periodType === 'string'
+            ? w.periodType
+            : id,
+    });
+  }
+  return out;
+}
+
+/** Normalize a capacity JSON payload (snake_case or camelCase) into a snapshot. */
+export function parseCapacityPayload(data: unknown): PlanUsageSnapshot {
+  if (!data || typeof data !== 'object') {
+    return { present: false, message: 'invalid capacity payload' };
+  }
+  const o = data as Record<string, unknown>;
+  if (o.present === false || o.unavailable === true) {
+    return {
+      present: false,
+      message: typeof o.message === 'string' ? o.message : 'capacity unavailable',
+      source: typeof o.source === 'string' ? o.source : undefined,
+    };
+  }
+  const windows = parseWindows(o.windows);
+  const pctRaw = o.capacity_pct ?? o.used_pct ?? o.capacityPct;
+  const pct = typeof pctRaw === 'number' ? pctRaw : Number(pctRaw);
+  if (!Number.isFinite(pct) && windows.length === 0) {
+    return {
+      present: false,
+      message: 'capacity missing capacity_pct',
+      source: typeof o.source === 'string' ? o.source : undefined,
+    };
+  }
+  const topPct = Number.isFinite(pct)
+    ? clampPercent(pct)
+    : windows[0]?.usedPct;
+  return {
+    present: true,
+    capacityPct: topPct,
+    resetAt: typeof o.reset_at === 'string' ? o.reset_at : typeof o.resetAt === 'string' ? o.resetAt : null,
+    periodType: typeof o.period_type === 'string' ? o.period_type : typeof o.periodType === 'string' ? o.periodType : null,
+    periodStart: typeof o.period_start === 'string' ? o.period_start : null,
+    windows: windows.length > 0 ? windows : undefined,
+    provider: typeof o.provider === 'string' ? o.provider : undefined,
+    source: typeof o.source === 'string' ? o.source : 'gateway',
+  };
+}
+
+/** Prefer stored window id if present; else binding top-level; else first window. */
+export function resolveDisplayWindow(
+  snapshot: PlanUsageSnapshot,
+  preferredWindowId?: string | null,
+): {
+  windowId: string | null;
+  capacityPct: number;
+  resetAt: string | null | undefined;
+  periodType: string | null | undefined;
+} {
+  const windows = snapshot.windows ?? [];
+  const preferred = (preferredWindowId || '').trim();
+  const hit = preferred ? windows.find((w) => w.id === preferred) : undefined;
+  if (hit) {
+    return {
+      windowId: hit.id,
+      capacityPct: hit.usedPct,
+      resetAt: hit.resetAt ?? snapshot.resetAt,
+      periodType: hit.periodType ?? hit.id,
+    };
+  }
+  // No preferred match: keep binding top-level fields when present
+  if (typeof snapshot.capacityPct === 'number') {
+    const bindingId =
+      windows.find(
+        (w) =>
+          Math.abs(w.usedPct - snapshot.capacityPct!) < 0.05
+          && (w.resetAt === snapshot.resetAt || !snapshot.resetAt),
+      )?.id
+      ?? (snapshot.periodType
+        ? windows.find((w) =>
+          (w.periodType || w.id).toLowerCase().includes(String(snapshot.periodType).toLowerCase())
+          || String(snapshot.periodType).toLowerCase().includes((w.periodType || w.id).toLowerCase()),
+        )?.id
+        : null)
+      ?? null;
+    return {
+      windowId: bindingId,
+      capacityPct: snapshot.capacityPct,
+      resetAt: snapshot.resetAt,
+      periodType: snapshot.periodType,
+    };
+  }
+  if (windows[0]) {
+    return {
+      windowId: windows[0].id,
+      capacityPct: windows[0].usedPct,
+      resetAt: windows[0].resetAt,
+      periodType: windows[0].periodType ?? windows[0].id,
+    };
+  }
+  return { windowId: null, capacityPct: 0, resetAt: null, periodType: null };
+}
+
+/** Compact label for window switcher: weekly→7d, monthly→mo, 5h, 7d. */
+export function windowShortLabel(idOrType?: string | null): string {
+  const t = (idOrType || '').toLowerCase();
+  if (!t) return '·';
+  if (t === '5h' || t.includes('5h')) return '5h';
+  if (t === '7d' || t === '7day' || t.includes('7d')) return '7d';
+  if (t.includes('week')) return '7d';
+  if (t.includes('month')) return 'mo';
+  return t.length > 4 ? t.slice(0, 4) : t;
+}
+
+export function readStoredWindowId(): string | null {
+  try {
+    const v = localStorage.getItem(PLAN_USAGE_WINDOW_STORAGE_KEY);
+    return v && v.trim() ? v.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredWindowId(id: string): void {
+  try {
+    localStorage.setItem(PLAN_USAGE_WINDOW_STORAGE_KEY, id);
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+/** Next window id in list (cycle). If preferred missing, start from first. */
+export function nextWindowId(
+  windows: CapacityWindow[],
+  currentId?: string | null,
+): string | null {
+  if (windows.length === 0) return null;
+  if (windows.length === 1) return windows[0].id;
+  const idx = windows.findIndex((w) => w.id === currentId);
+  const next = idx < 0 ? 0 : (idx + 1) % windows.length;
+  return windows[next].id;
+}


### PR DESCRIPTION
Adds a plan-usage bar for the **Claude** provider in the chat input area, fed by the SDK's `rate_limit_event` messages (real Anthropic subscription backends).

### Where it lives

![overview](https://raw.githubusercontent.com/toxeh/jetbrains-cc-gui/feat/claude-plan-usage/docs/images/claude-plan-usage-overview.svg)

The bar sits in the ContextBar's right tool cluster — next to the status-panel toggle and rewind button, above the message input.

### The bar — three pace states

![three states](https://raw.githubusercontent.com/toxeh/jetbrains-cc-gui/feat/claude-plan-usage/docs/images/claude-plan-usage-states.svg)

Color = usage pace vs. the elapsed-time budget of the selected window:

- **green** — usage below the budget, will last to the reset
- **yellow** — within 5 pp of the budget line
- **red** — past the budget, limits hit before the reset

### Window switching & the worst-window dot

![windows](https://raw.githubusercontent.com/toxeh/jetbrains-cc-gui/feat/claude-plan-usage/docs/images/claude-plan-usage-windows.svg)

Click the window chip (`5h` / `7d`) to switch windows; hover for all windows and reset time. The dot after the reset date tracks the **worst** window — a green weekly bar can't hide a red 5h window (second card: `7d` at 21% selected, dot stays red).

*(Images are vector mockups drawn from the component's exact CSS colors and geometry.)*

### How it works (2 commits)

- **`planUsagePace` + `PlanUsageIndicator`** — provider-agnostic webview infra: pace coloring (usage % vs. linear time budget), capacity payload normalization, 5h/7d window resolution/switching with persisted selection, and the indicator component with its CSS and unit tests.
- **Claude wiring** — `rate_limit_event` already arrives from the SDK as a message: `ClaudeMessageHandler` forwards `rate_limit_info` into a TTL cache (`ClaudePlanUsageService`), and the new `ClaudePlanUsageHandler` answers the webview's `get_claude_plan_usage` polls (120 s). Webview side: `useClaudePlanUsage` hook + `ContextBar` renders the indicator when the provider is `claude`. No SDK/bridge changes.

Note: `rate_limit_event` only fires on real Anthropic (OAuth subscription) backends. On proxies and API-key sessions it never arrives, so the bar stays **hidden** — it only appears once the first event comes in (no permanent dash).

### Testing

- `ClaudePlanUsageServiceTest`: `rate_limit_event` parsing + cache behavior (new)
- webview: unit tests for the pace utils, the indicator, and the usage hook (hidden until first event); `tsc` clean; vitest **152 files / 1322 tests** green
- gradle `test`: **1079 tests, 0 failures** (14 skipped)
