### PR TITLE
fix: restore full pre-compact history in compacted transcripts

### DIFF
--- a/ai-bridge/services/claude/conversation-chain.js
+++ b/ai-bridge/services/claude/conversation-chain.js
@@ -17,16 +17,20 @@
 /**
  * Select the messages that form the effective conversation.
  * @param {Array<any>} entries parsed JSONL entries in file order
+ * @param {Object} options chain selection options
+ * @param {boolean} options.includePreCompactHistory keep the GUI-visible
+ *   compact prefix; disable it when building model context
  * @returns {Array<any>} chain messages in conversation order; line order
  *   when the transcript carries no parentUuid fields at all (the plugin's
  *   direct-API fallback writer omits them, and chain-walking such a file
  *   would collapse every message into isolated leaves)
  */
-export function selectConversationChain(entries) {
+export function selectConversationChain(entries, options = {}) {
   if (!Array.isArray(entries) || entries.length === 0) {
     return entries ?? [];
   }
 
+  const includePreCompactHistory = options.includePreCompactHistory !== false;
   const byUuid = new Map();
   for (const entry of entries) {
     if (entry && typeof entry.uuid === 'string') {
@@ -74,15 +78,21 @@ export function selectConversationChain(entries) {
   if (chain.length === 0) {
     return entries;
   }
-  const chainWithAttachments = recoverOrphanedTerminalAttachments(byUuid, chain);
+  const chainWithCompactHistory = includePreCompactHistory
+    ? recoverCompactHistory(byUuid, chain)
+    : recoverCompactModelHistory(byUuid, chain);
+  const chainWithAttachments = recoverOrphanedTerminalAttachments(
+    byUuid,
+    chainWithCompactHistory
+  );
   return recoverOrphanedParallelToolResults(byUuid, chainWithAttachments);
 }
 
 /**
- * A leaf is the nearest user/assistant ancestor of any childless message
- * (attachments can trail a user/assistant message without continuing the
- * chain). The newest non-sidechain leaf is the tip of the live branch;
- * leaves of rewound branches are older by timestamp.
+ * A leaf is the nearest real user/assistant ancestor of any childless message
+ * (attachments and local command metadata can trail a conversation message
+ * without continuing the chain). The newest non-sidechain leaf is the tip of
+ * the live branch; leaves of rewound branches are older by timestamp.
  *
  * Sidechain rows are excluded before computing leaves so their main-thread
  * parents remain candidates even when a subagent call is the newest row.
@@ -120,7 +130,8 @@ function newestNonSidechainLeaf(byUuid, graph) {
         break;
       }
       seen.add(current.uuid);
-      if (current.type === 'user' || current.type === 'assistant') {
+      if ((current.type === 'user' || current.type === 'assistant')
+          && !isSyntheticUserMessage(current)) {
         leafUuids.add(current.uuid);
         break;
       }
@@ -144,6 +155,21 @@ function newestNonSidechainLeaf(byUuid, graph) {
   return tip;
 }
 
+/**
+ * Local command caveats and stdout are CLI metadata, not conversation turns.
+ * They may be written after compacting while still pointing to the pre-compact
+ * branch, so they must not hide a newer compact summary leaf.
+ */
+function isSyntheticUserMessage(entry) {
+  if (entry.type !== 'user' || typeof entry.message?.content !== 'string') {
+    return false;
+  }
+  const content = entry.message.content;
+  return content.includes('<local-command-caveat>')
+      || content.includes('<local-command-stdout>')
+      || content.includes('<command-name>');
+}
+
 function walkParentChain(byUuid, tip) {
   const chain = [];
   const seen = new Set();
@@ -158,6 +184,255 @@ function walkParentChain(byUuid, tip) {
   }
   chain.reverse();
   return chain;
+}
+
+function walkPreservedSegment(byUuid, segment) {
+  const uuids = [];
+  const seen = new Set();
+  let current = byUuid.get(segment.tailUuid);
+  while (current && !seen.has(current.uuid)) {
+    seen.add(current.uuid);
+    uuids.push(current.uuid);
+    if (current.uuid === segment.headUuid) {
+      uuids.reverse();
+      return uuids;
+    }
+    current = current.parentUuid ? byUuid.get(current.parentUuid) : null;
+  }
+  return null;
+}
+
+/**
+ * Keep the compact summary and preserved tail for model context without
+ * replaying the pre-compact prefix that Claude Code already summarized.
+ */
+function recoverCompactModelHistory(byUuid, chain) {
+  const compact = findRelevantCompactBoundary(byUuid, chain);
+  if (!compact) {
+    return chain;
+  }
+
+  const { boundary, preservedUuids } = compact;
+  const summary = findCompactSummary(byUuid, boundary);
+  const preservedEntries = preservedUuids
+    .map((uuid) => byUuid.get(uuid))
+    .filter(Boolean);
+  const boundaryIndex = chain.findIndex((entry) => entry.uuid === boundary.uuid);
+
+  if (boundaryIndex >= 0) {
+    const summaryIndex = summary.length > 0
+      ? chain.findIndex((entry) => entry.uuid === summary[0].uuid)
+      : -1;
+    const insertAfter = summaryIndex >= boundaryIndex ? summaryIndex : boundaryIndex;
+    const onChain = new Set(chain.map((entry) => entry.uuid));
+    const inserts = [
+      ...summary.filter((entry) => !onChain.has(entry.uuid)),
+      ...preservedEntries.filter((entry) => !onChain.has(entry.uuid)),
+    ];
+    if (inserts.length === 0) {
+      return chain;
+    }
+    return [
+      ...chain.slice(0, insertAfter + 1),
+      ...inserts,
+      ...chain.slice(insertAfter + 1),
+    ];
+  }
+
+  const continuationIndex = findCompactContinuationIndex(chain, boundary, preservedUuids);
+  if (continuationIndex < 0) {
+    return chain;
+  }
+  const block = [boundary, ...summary, ...preservedEntries];
+  const compactUuids = new Set(block.map((entry) => entry.uuid));
+  return [
+    ...block,
+    ...chain.slice(continuationIndex + 1).filter((entry) => !compactUuids.has(entry.uuid)),
+  ];
+}
+
+/**
+ * Keep the effective pre-compact conversation visible before the boundary.
+ * Claude Code's loader prunes this prefix because it is only needed as model
+ * context, but the GUI is a transcript viewer and must show the messages that
+ * led to the compact summary. The preserved UUID carrier bridges the physical
+ * gap between the last pre-compact assistant and the boundary; standard
+ * Claude Code metadata can derive the same suffix from preservedSegment.
+ */
+function recoverCompactHistory(byUuid, chain) {
+  const compact = findRelevantCompactBoundary(byUuid, chain);
+  if (!compact) {
+    return chain;
+  }
+  return recoverCompactHistoryForBoundary(byUuid, chain, compact.boundary, compact.preservedUuids);
+}
+
+/**
+ * Recover one pinned boundary. Boundary selection must not re-run inside the
+ * recursion: a pre-compact chain always contains the newest boundary's
+ * preserved uuids, so re-selecting would keep picking that boundary and loop
+ * forever on sessions compacted more than once. The nested boundary handed in
+ * by buildPreCompactPrefix is strictly older, so the recursion terminates.
+ */
+function recoverCompactHistoryForBoundary(byUuid, chain, boundary, preservedUuids) {
+  const boundaryInChain = chain.some((entry) => entry.uuid === boundary.uuid);
+  const prefix = buildPreCompactPrefix(byUuid, boundary, preservedUuids);
+  if (boundaryInChain) {
+    const onChain = new Set(chain.map((entry) => entry.uuid));
+    const uniquePrefix = prefix.filter((entry) => !onChain.has(entry.uuid));
+    return uniquePrefix.length === 0 ? chain : [...uniquePrefix, ...chain];
+  }
+
+  const block = [
+    ...prefix,
+    boundary,
+    ...findCompactSummary(byUuid, boundary),
+  ];
+  const compactUuids = new Set(block.map((entry) => entry.uuid));
+  const continuationIndex = findCompactContinuationIndex(chain, boundary, preservedUuids);
+  if (continuationIndex < 0) {
+    return chain;
+  }
+  return [
+    ...block,
+    ...chain.slice(continuationIndex + 1).filter((entry) => !compactUuids.has(entry.uuid)),
+  ];
+}
+
+function getCompactPreservedUuids(byUuid, boundary) {
+  const preserved = boundary.compactMetadata?.preservedMessages;
+  const segment = boundary.compactMetadata?.preservedSegment;
+  let preservedUuids = Array.isArray(preserved?.allUuids)
+    ? preserved.allUuids
+    : preserved?.uuids;
+  if (!Array.isArray(preservedUuids) && segment) {
+    preservedUuids = walkPreservedSegment(byUuid, segment);
+  }
+  return Array.isArray(preservedUuids) ? preservedUuids : [];
+}
+
+function buildPreCompactPrefix(byUuid, boundary, preservedUuids) {
+  const segment = boundary.compactMetadata?.preservedSegment;
+  const headUuid = segment?.headUuid ?? preservedUuids.find((uuid) => byUuid.has(uuid));
+  let preCompactChain = headUuid && byUuid.has(headUuid)
+    ? walkParentChain(byUuid, byUuid.get(headUuid))
+    : findPreCompactChain(byUuid, boundary.uuid);
+
+  const nestedBoundary = preCompactChain.find((entry) => (
+    entry.subtype === 'compact_boundary' && entry.uuid !== boundary.uuid
+  ));
+  if (nestedBoundary) {
+    preCompactChain = recoverCompactHistoryForBoundary(
+      byUuid,
+      preCompactChain,
+      nestedBoundary,
+      getCompactPreservedUuids(byUuid, nestedBoundary)
+    );
+  }
+
+  const onChain = new Set([boundary.uuid]);
+  const prefix = [];
+  for (const entry of preCompactChain) {
+    if (!onChain.has(entry.uuid)) {
+      prefix.push(entry);
+      onChain.add(entry.uuid);
+    }
+  }
+  for (const uuid of preservedUuids) {
+    const entry = byUuid.get(uuid);
+    if (entry && !onChain.has(uuid)) {
+      prefix.push(entry);
+      onChain.add(uuid);
+    }
+  }
+  return prefix;
+}
+
+function findLatestCompactBoundary(byUuid) {
+  let boundary = null;
+  for (const entry of byUuid.values()) {
+    if (entry.subtype === 'compact_boundary') {
+      boundary = entry;
+    }
+  }
+  return boundary;
+}
+
+function findRelevantCompactBoundary(byUuid, chain) {
+  const chainBoundary = chain.find((entry) => entry.subtype === 'compact_boundary');
+  const latestBoundary = findLatestCompactBoundary(byUuid);
+  const latestPreservedUuids = latestBoundary
+    ? getCompactPreservedUuids(byUuid, latestBoundary)
+    : [];
+  const boundary = latestBoundary && (
+    !chainBoundary
+    || chainBoundary.uuid === latestBoundary.uuid
+    || hasCompactContinuation(chain, latestBoundary, latestPreservedUuids)
+  )
+    ? latestBoundary
+    : chainBoundary;
+  if (!boundary) {
+    return null;
+  }
+
+  const preservedUuids = boundary.uuid === latestBoundary?.uuid
+    ? latestPreservedUuids
+    : getCompactPreservedUuids(byUuid, boundary);
+  if (
+    chain.some((entry) => entry.uuid === boundary.uuid)
+    || hasCompactContinuation(chain, boundary, preservedUuids)
+  ) {
+    return { boundary, preservedUuids };
+  }
+  return null;
+}
+
+function findCompactSummary(byUuid, boundary) {
+  const summaries = [];
+  for (const entry of byUuid.values()) {
+    if (entry.parentUuid === boundary.uuid && (entry.type === 'user' || entry.type === 'assistant')) {
+      summaries.push(entry);
+    }
+  }
+  const marked = summaries.find((entry) => entry.isCompactSummary);
+  return marked ? [marked] : summaries.slice(0, 1);
+}
+
+function hasCompactContinuation(chain, boundary, preservedUuids) {
+  const compactUuids = new Set([
+    boundary.uuid,
+    ...preservedUuids,
+    boundary.compactMetadata?.preservedSegment?.headUuid,
+    boundary.compactMetadata?.preservedSegment?.tailUuid,
+  ]);
+  return chain.some((entry) => compactUuids.has(entry.uuid));
+}
+
+function findCompactContinuationIndex(chain, boundary, preservedUuids) {
+  const compactUuids = new Set([
+    ...preservedUuids,
+    boundary.compactMetadata?.preservedSegment?.headUuid,
+    boundary.compactMetadata?.preservedSegment?.tailUuid,
+  ]);
+  let index = -1;
+  for (let i = 0; i < chain.length; i++) {
+    if (compactUuids.has(chain[i].uuid)) {
+      index = i;
+    }
+  }
+  return index;
+}
+
+function findPreCompactChain(byUuid, boundaryUuid) {
+  const beforeBoundary = new Map();
+  for (const [uuid, entry] of byUuid) {
+    if (uuid === boundaryUuid) {
+      break;
+    }
+    beforeBoundary.set(uuid, entry);
+  }
+  const leaf = selectNewestLeaf(beforeBoundary);
+  return leaf ? walkParentChain(beforeBoundary, leaf) : [];
 }
 
 /**

--- a/ai-bridge/services/claude/conversation-chain.test.mjs
+++ b/ai-bridge/services/claude/conversation-chain.test.mjs
@@ -169,10 +169,9 @@ test('chains through rows appended without the parentUuid key', () => {
   assert.deepEqual(chainTexts(chain), ['root', 'answer', 'appended without the key', 'fallback answer']);
 });
 
-test('stops at a compact boundary root despite pre-compact rows above it', () => {
-  // Compaction writes a system compact_boundary row with parentUuid null;
-  // post-compact rows chain to it. The walk must stop at the boundary so
-  // the stale pre-compact span stays excluded.
+test('keeps pre-compact history before the compact boundary', () => {
+  // The GUI keeps the effective pre-compact prefix visible even though the
+  // boundary starts a new parent chain for Claude Code's model loader.
   const staleUser = userEntry(null, 'stale pre-compact', '2026-01-01T09:00:00Z');
   const boundary = {
     type: 'system',
@@ -184,9 +183,362 @@ test('stops at a compact boundary root despite pre-compact rows above it', () =>
   const freshUser = userEntry(boundary.uuid, 'post-compact', '2026-01-01T10:01:00Z');
 
   const chain = selectConversationChain([staleUser, boundary, freshUser]);
-  // The boundary row itself stays on the chain (system rows are filtered
-  // downstream); the stale pre-compact span must not.
-  assert.deepEqual(chain.map((entry) => entry.uuid), [boundary.uuid, freshUser.uuid]);
+  assert.deepEqual(chain.map((entry) => entry.uuid), [staleUser.uuid, boundary.uuid, freshUser.uuid]);
+});
+
+test('keeps a compact summary ahead of trailing local command output', () => {
+  const previousUser = userEntry(null, 'before compact', '2026-01-01T09:00:00Z');
+  const previousAnswer = assistantEntry(
+    previousUser.uuid,
+    'previous answer',
+    '2026-01-01T09:00:05Z',
+    'm-previous'
+  );
+  const compactCommand = userEntry(
+    previousAnswer.uuid,
+    '<command-name>/compact</command-name>\n<command-args></command-args>',
+    '2026-01-01T09:01:00Z'
+  );
+  const boundary = {
+    type: 'system',
+    subtype: 'compact_boundary',
+    uuid: uuid('sys'),
+    parentUuid: null,
+    timestamp: '2026-01-01T10:00:00Z',
+  };
+  const summary = userEntry(boundary.uuid, 'compacted summary', '2026-01-01T10:00:01Z');
+  summary.isCompactSummary = true;
+  const stdout = userEntry(
+    compactCommand.uuid,
+    '<local-command-stdout>Compacted Tip</local-command-stdout>',
+    '2026-01-01T10:00:02Z'
+  );
+
+  const chain = selectConversationChain([
+    previousUser,
+    previousAnswer,
+    compactCommand,
+    boundary,
+    summary,
+    stdout,
+  ]);
+
+  assert.deepEqual(chain.map((entry) => entry.uuid), [
+    previousUser.uuid,
+    previousAnswer.uuid,
+    boundary.uuid,
+    summary.uuid,
+  ]);
+});
+
+test('restores compact-preserved messages before the summary', () => {
+  // The GUI keeps the pre-compact tail before the compact summary, rather
+  // than inheriting Claude Code's internal post-summary splice order.
+  const previousUser = userEntry(null, 'before compact', '2026-01-01T09:00:00Z');
+  const preservedAssistant = assistantEntry(
+    previousUser.uuid,
+    'long assistant summary',
+    '2026-01-01T09:01:00Z',
+    'm-preserved'
+  );
+  const boundary = {
+    type: 'system',
+    subtype: 'compact_boundary',
+    uuid: uuid('sys'),
+    parentUuid: null,
+    timestamp: '2026-01-01T10:00:00Z',
+    compactMetadata: {
+      preservedSegment: {
+        headUuid: preservedAssistant.uuid,
+        anchorUuid: 'anchor-summary',
+        tailUuid: preservedAssistant.uuid,
+      },
+      preservedMessages: {
+        anchorUuid: 'anchor-summary',
+        allUuids: [preservedAssistant.uuid],
+      },
+    },
+  };
+  const summary = userEntry(boundary.uuid, 'compacted summary', '2026-01-01T10:00:01Z');
+  summary.uuid = 'anchor-summary';
+  summary.isCompactSummary = true;
+
+  const chain = selectConversationChain([
+    previousUser,
+    preservedAssistant,
+    boundary,
+    summary,
+  ]);
+
+  assert.deepEqual(chain.map((entry) => entry.uuid), [
+    previousUser.uuid,
+    preservedAssistant.uuid,
+    boundary.uuid,
+    summary.uuid,
+  ]);
+});
+
+test('restores compact-preserved messages from segment metadata alone', () => {
+  // Claude Code's standard compact boundary carries preservedSegment without
+  // the optional UUID carrier; recover the segment by walking tail to head.
+  const previousUser = userEntry(null, 'before compact', '2026-01-01T09:00:00Z');
+  const preservedAssistant = assistantEntry(
+    previousUser.uuid,
+    'kept answer',
+    '2026-01-01T09:01:00Z',
+    'm-preserved'
+  );
+  const preservedQuestion = userEntry(
+    preservedAssistant.uuid,
+    'kept question',
+    '2026-01-01T09:01:30Z'
+  );
+  const preservedAnswer = assistantEntry(
+    preservedQuestion.uuid,
+    'kept follow-up',
+    '2026-01-01T09:02:00Z',
+    'm-preserved-follow-up'
+  );
+  const boundary = {
+    type: 'system',
+    subtype: 'compact_boundary',
+    uuid: uuid('sys'),
+    parentUuid: null,
+    timestamp: '2026-01-01T10:00:00Z',
+    compactMetadata: {
+      preservedSegment: {
+        headUuid: preservedAssistant.uuid,
+        anchorUuid: 'anchor-summary',
+        tailUuid: preservedAnswer.uuid,
+      },
+    },
+  };
+  const summary = userEntry(boundary.uuid, 'compacted summary', '2026-01-01T10:00:01Z');
+  summary.uuid = 'anchor-summary';
+  summary.isCompactSummary = true;
+
+  const chain = selectConversationChain([
+    previousUser,
+    preservedAssistant,
+    preservedQuestion,
+    preservedAnswer,
+    boundary,
+    summary,
+  ]);
+
+  assert.deepEqual(chain.map((entry) => entry.uuid), [
+    previousUser.uuid,
+    preservedAssistant.uuid,
+    preservedQuestion.uuid,
+    preservedAnswer.uuid,
+    boundary.uuid,
+    summary.uuid,
+  ]);
+});
+
+test('keeps compact-preserved messages before the summary when the anchor is off-chain', () => {
+  // The UUID carrier still identifies the pre-compact tail even when its
+  // anchor is absent; the GUI places that tail before the compact summary.
+  const previousUser = userEntry(null, 'before compact', '2026-01-01T09:00:00Z');
+  const preservedAssistant = assistantEntry(
+    previousUser.uuid,
+    'kept tail',
+    '2026-01-01T09:01:00Z',
+    'm-preserved'
+  );
+  const boundary = {
+    type: 'system',
+    subtype: 'compact_boundary',
+    uuid: uuid('sys'),
+    parentUuid: null,
+    timestamp: '2026-01-01T10:00:00Z',
+    compactMetadata: {
+      preservedMessages: {
+        anchorUuid: 'missing-anchor',
+        allUuids: [preservedAssistant.uuid],
+      },
+    },
+  };
+  const summary = userEntry(boundary.uuid, 'compacted summary', '2026-01-01T10:00:01Z');
+  summary.isCompactSummary = true;
+
+  const chain = selectConversationChain([
+    previousUser,
+    preservedAssistant,
+    boundary,
+    summary,
+  ]);
+
+  assert.deepEqual(chain.map((entry) => entry.uuid), [
+    previousUser.uuid,
+    preservedAssistant.uuid,
+    boundary.uuid,
+    summary.uuid,
+  ]);
+});
+
+test('reconnects continuation attached to the preserved tail after compact', () => {
+  const previousUser = userEntry(null, 'before compact', '2026-01-01T09:00:00Z');
+  const preservedAssistant = assistantEntry(
+    previousUser.uuid,
+    'last answer before compact',
+    '2026-01-01T09:01:00Z',
+    'm-preserved'
+  );
+  const preservedTail = {
+    type: 'system',
+    subtype: 'stop_hook_summary',
+    uuid: uuid('sys'),
+    parentUuid: preservedAssistant.uuid,
+    timestamp: '2026-01-01T09:01:01Z',
+  };
+  const boundary = {
+    type: 'system',
+    subtype: 'compact_boundary',
+    uuid: uuid('sys'),
+    parentUuid: null,
+    timestamp: '2026-01-01T10:00:00Z',
+    compactMetadata: {
+      preservedSegment: {
+        headUuid: preservedAssistant.uuid,
+        anchorUuid: 'compact-summary',
+        tailUuid: preservedTail.uuid,
+      },
+      preservedMessages: {
+        allUuids: [preservedAssistant.uuid, preservedTail.uuid],
+      },
+    },
+  };
+  const summary = userEntry(boundary.uuid, 'compacted summary', '2026-01-01T10:00:01Z');
+  summary.uuid = 'compact-summary';
+  summary.isCompactSummary = true;
+  const command = userEntry(
+    preservedTail.uuid,
+    '<command-name>/compact</command-name>\n<command-args></command-args>',
+    '2026-01-01T10:00:02Z'
+  );
+  const continuation = userEntry(command.uuid, 'Continue from where you left off.', '2026-01-01T10:00:03Z');
+  const answer = assistantEntry(continuation.uuid, 'continued answer', '2026-01-01T10:00:04Z', 'm-next');
+
+  const chain = selectConversationChain([
+    previousUser,
+    preservedAssistant,
+    preservedTail,
+    boundary,
+    summary,
+    command,
+    continuation,
+    answer,
+  ]);
+
+  assert.deepEqual(chain.map((entry) => entry.uuid), [
+    previousUser.uuid,
+    preservedAssistant.uuid,
+    preservedTail.uuid,
+    boundary.uuid,
+    summary.uuid,
+    command.uuid,
+    continuation.uuid,
+    answer.uuid,
+  ]);
+
+  const modelChain = selectConversationChain([
+    previousUser,
+    preservedAssistant,
+    preservedTail,
+    boundary,
+    summary,
+    command,
+    continuation,
+    answer,
+  ], { includePreCompactHistory: false });
+  assert.deepEqual(modelChain.map((entry) => entry.uuid), [
+    boundary.uuid,
+    summary.uuid,
+    preservedAssistant.uuid,
+    preservedTail.uuid,
+    command.uuid,
+    continuation.uuid,
+    answer.uuid,
+  ]);
+});
+
+test('unwinds nested compacts without recursing forever', () => {
+  // Two /compact runs in one session: the second boundary's pre-compact
+  // walk crosses the first boundary, and re-running boundary selection
+  // inside that recursion would keep picking the newest boundary forever.
+  const rootUser = userEntry(null, 'root question', '2026-01-01T09:00:00Z');
+  const rootAnswer = assistantEntry(rootUser.uuid, 'root answer', '2026-01-01T09:00:05Z', 'm1');
+  const firstBoundary = {
+    type: 'system',
+    subtype: 'compact_boundary',
+    uuid: uuid('sys'),
+    parentUuid: null,
+    timestamp: '2026-01-01T09:01:00Z',
+    compactMetadata: {
+      preservedSegment: {
+        headUuid: rootAnswer.uuid,
+        anchorUuid: 'summary-1',
+        tailUuid: rootAnswer.uuid,
+      },
+    },
+  };
+  const firstSummary = userEntry(firstBoundary.uuid, 'first summary', '2026-01-01T09:01:01Z');
+  firstSummary.uuid = 'summary-1';
+  firstSummary.isCompactSummary = true;
+  const midQuestion = userEntry(firstSummary.uuid, 'mid question', '2026-01-01T09:02:00Z');
+  const midAnswer = assistantEntry(midQuestion.uuid, 'mid answer', '2026-01-01T09:02:05Z', 'm2');
+  const secondBoundary = {
+    type: 'system',
+    subtype: 'compact_boundary',
+    uuid: uuid('sys'),
+    parentUuid: null,
+    timestamp: '2026-01-01T09:03:00Z',
+    compactMetadata: {
+      preservedSegment: {
+        headUuid: midAnswer.uuid,
+        anchorUuid: 'summary-2',
+        tailUuid: midAnswer.uuid,
+      },
+    },
+  };
+  const secondSummary = userEntry(secondBoundary.uuid, 'second summary', '2026-01-01T09:03:01Z');
+  secondSummary.uuid = 'summary-2';
+  secondSummary.isCompactSummary = true;
+  const postUser = userEntry(secondSummary.uuid, 'after both compacts', '2026-01-01T09:04:00Z');
+
+  const entries = [
+    rootUser,
+    rootAnswer,
+    firstBoundary,
+    firstSummary,
+    midQuestion,
+    midAnswer,
+    secondBoundary,
+    secondSummary,
+    postUser,
+  ];
+
+  const chain = selectConversationChain(entries);
+  assert.deepEqual(chain.map((entry) => entry.uuid), [
+    rootUser.uuid,
+    rootAnswer.uuid,
+    firstBoundary.uuid,
+    firstSummary.uuid,
+    midQuestion.uuid,
+    midAnswer.uuid,
+    secondBoundary.uuid,
+    secondSummary.uuid,
+    postUser.uuid,
+  ]);
+
+  const modelChain = selectConversationChain(entries, { includePreCompactHistory: false });
+  assert.deepEqual(modelChain.map((entry) => entry.uuid), [
+    secondBoundary.uuid,
+    secondSummary.uuid,
+    midAnswer.uuid,
+    postUser.uuid,
+  ]);
 });
 
 test('ignores sidechain leaves when picking the chain tip', () => {

--- a/ai-bridge/services/claude/session-service.js
+++ b/ai-bridge/services/claude/session-service.js
@@ -87,7 +87,12 @@ export function loadSessionHistory(sessionId, cwd) {
 
     // Rewind keeps dead branches on disk; only the parentUuid chain from the
     // newest leaf is the live conversation the API should see.
-    const messages = selectConversationChain(parseJsonlContent(readFileSync(sessionFile, 'utf8')))
+    // Keep the model context compact: the UI reader intentionally restores the
+    // pre-compact transcript, but the API must rely on Claude's summary instead.
+    const messages = selectConversationChain(
+      parseJsonlContent(readFileSync(sessionFile, 'utf8')),
+      { includePreCompactHistory: false }
+    )
       .filter(msg =>
         (msg.type === 'user' || msg.type === 'assistant') &&
         msg.message && msg.message.content)

--- a/src/main/java/com/github/claudecodegui/session/MessageParser.java
+++ b/src/main/java/com/github/claudecodegui/session/MessageParser.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.diagnostic.Logger;
  */
 public class MessageParser {
     private static final Logger LOG = Logger.getInstance(MessageParser.class);
+    private static final String NO_RESPONSE_REQUESTED = "No response requested.";
 
     /**
      * Parse a server-returned message.
@@ -43,6 +44,12 @@ public class MessageParser {
         // lives under "raw", is inspected the same way as a live SDK message; for live
         // messages resolveRawMessage returns msg unchanged, so this is a no-op there.
         if (shouldFilterCommandMessage(rawMessage, type)) {
+            return null;
+        }
+
+        // Claude Code uses this assistant placeholder for commands that do not need a response.
+        if ("assistant".equals(type)
+                && NO_RESPONSE_REQUESTED.equals(extractMessageContent(msg).trim())) {
             return null;
         }
 

--- a/src/test/java/com/github/claudecodegui/session/MessageParserTest.java
+++ b/src/test/java/com/github/claudecodegui/session/MessageParserTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class MessageParserTest {
 
@@ -96,5 +97,26 @@ public class MessageParserTest {
         assertEquals(ClaudeSession.Message.Type.USER, parsed.type);
         assertEquals("", parsed.content);
         assertEquals(normalizedRaw, parsed.raw);
+    }
+
+    @Test
+    public void parseServerMessageDropsNoResponseRequestedAssistantPlaceholder() {
+        MessageParser parser = new MessageParser();
+
+        JsonObject contentBlock = new JsonObject();
+        contentBlock.addProperty("type", "text");
+        contentBlock.addProperty("text", "No response requested.");
+
+        JsonArray content = new JsonArray();
+        content.add(contentBlock);
+
+        JsonObject message = new JsonObject();
+        message.add("content", content);
+
+        JsonObject raw = new JsonObject();
+        raw.addProperty("type", "assistant");
+        raw.add("message", message);
+
+        assertNull(parser.parseServerMessage(raw));
     }
 }


### PR DESCRIPTION
## What

The GUI was discarding large parts of compacted Claude sessions. When a transcript contains a `/compact` boundary, the parent-chain walk stops at it and the effective pre-compact conversation disappears from the UI — including the last assistant's long summary that /compact summarizes. Continuations that happen to parent onto the compact's preserved tail also bypassed the boundary and summary entirely.

This PR fixes the transcript chain selection so compacted sessions render the way the user actually experienced them, without inflating the model context.

## Changes

- **`selectConversationChain`** now recovers the effective pre-compact history ahead of a compact boundary, so the UI shows:
  `pre-compact history → last assistant summary → compact_boundary → compact summary → continuation`
- Works with both compact metadata carriers Claude Code emits:
  - `compactMetadata.preservedSegment` (head/anchor/tail uuid walk)
  - `compactMetadata.preservedMessages` (`allUuids` / `uuids`)
- Re-splices boundary + summary back into the chain when the live continuation is attached to the preserved tail (the CLI writes continuation this way after some compacts)
- Handles **nested compacts** (multiple `/compact` runs in one session): recovery unwinds each boundary without re-running global boundary selection, which previously overflowed the stack
- **UI vs model context split**: the history reader keeps the full pre-compact transcript for display, while `loadSessionHistory` passes `includePreCompactHistory: false` so the Anthropic fallback path relies on Claude's compact summary instead of replaying the whole summarized prefix
- Hides Claude Code's internal `No response requested.` assistant placeholder (official UI renders it as nothing)

## Verification

- `node --test ai-bridge/services/claude/conversation-chain.test.mjs ai-bridge/services/claude/session-service.test.mjs` — pass, including regressions for nested compacts, off-chain continuations, preserved-segment-only metadata, and the model/UI split
- `./gradlew test --tests com.github.claudecodegui.session.MessageParserTest checkstyleMain` — pass
- Validated against real local transcripts containing 1 and 2 compact boundaries: boundary precedes summary, and the model chain stays compact (1075 UI rows vs 6 model rows on a twice-compacted session)