### PR TITLE
fix(bugId:#1600): show '100%+' when percentage exceeds 100%

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/UsagePushService.java
+++ b/src/main/java/com/github/claudecodegui/handler/UsagePushService.java
@@ -101,9 +101,13 @@ public class UsagePushService {
 
     /**
      * Send usage update to the frontend.
+     *
+     * <p>Does not clamp percentage to 100: send the true value so the frontend
+     * can distinguish "exactly 100" from "100 and counting" via
+     * {@code formatUsagePercentageLabel} (which appends a "+" when overflowing).
      */
     public void sendUsageUpdate(int usedTokens, int maxTokens) {
-        int percentage = Math.min(100, maxTokens > 0 ? (int) ((usedTokens * 100.0) / maxTokens) : 0);
+        int percentage = maxTokens > 0 ? (int) ((usedTokens * 100.0) / maxTokens) : 0;
 
         LOG.info("[UsagePushService] Sending usage update: usedTokens=" + usedTokens + ", maxTokens=" + maxTokens + ", percentage=" + percentage + "%");
 

--- a/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
@@ -360,12 +360,14 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         if (isInactive()) {
             return;
         }
+        final int safeMaxTokens = normalizeUsageValue(maxTokens);
+        final int safeUsedTokens = normalizeUsageValue(usedTokens);
         ApplicationManager.getApplication().invokeLater(() -> {
             if (isInactive()) {
                 return;
             }
-            int safeUsedTokens = normalizeUsageValue(usedTokens);
-            int safeMaxTokens = normalizeUsageValue(maxTokens);
+            // Don't clamp to 100: send the true percentage so the frontend can
+            // distinguish "exactly 100" from "100 and counting".
             double percentage = calculateUsagePercentage(safeUsedTokens, safeMaxTokens);
             String json = String.format("{\"percentage\":%.2f,\"usedTokens\":%d,\"maxTokens\":%d}",
                     percentage, safeUsedTokens, safeMaxTokens);
@@ -391,7 +393,9 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
             return 0.0;
         }
         double percentage = usedTokens * 100.0 / maxTokens;
-        return Math.max(0.0, Math.min(100.0, percentage));
+        // Don't clamp to 100: send the true percentage so the frontend can
+        // distinguish "exactly 100" from "100 and counting".
+        return Math.max(0.0, percentage);
     }
 
     @Override

--- a/src/main/java/com/github/claudecodegui/util/MessageJsonConverter.java
+++ b/src/main/java/com/github/claudecodegui/util/MessageJsonConverter.java
@@ -343,7 +343,9 @@ public class MessageJsonConverter {
             int fallbackMaxTokens = SettingsHandler.getModelContextLimit(
                     currentProvider, handlerContext.getCurrentModel());
             int maxTokens = TokenUsageUtils.extractMaxTokens(lastUsage, fallbackMaxTokens);
-            int percentage = Math.min(100, maxTokens > 0 ? (int) ((usedTokens * 100.0) / maxTokens) : 0);
+            // Don't clamp: send the true percentage so the frontend can distinguish
+            // "exactly 100" from "100 and counting" via formatUsagePercentageLabel.
+            int percentage = maxTokens > 0 ? (int) ((usedTokens * 100.0) / maxTokens) : 0;
 
             LOG.debug("Pushing usage update: provider=" + currentProvider + ", usedTokens=" + usedTokens + ", max=" + maxTokens + ", percentage=" + percentage + "%");
 

--- a/webview/src/components/ChatInputBox/TokenIndicator.test.tsx
+++ b/webview/src/components/ChatInputBox/TokenIndicator.test.tsx
@@ -9,12 +9,37 @@ vi.mock('react-i18next', () => ({
 }));
 
 describe('TokenIndicator', () => {
-  it('clamps labels and ring geometry above 100 percent', () => {
-    const { container } = render(<TokenIndicator percentage={145} usedTokens={2900} maxTokens={2000} />);
+  it('renders normal percentages as a percentage string', () => {
+    render(<TokenIndicator percentage={45} usedTokens={900} maxTokens={2000} />);
+    expect(screen.getByText('45%')).toBeTruthy();
+  });
 
+  it('shows 100% (no plus) when percentage is exactly 100', () => {
+    render(<TokenIndicator percentage={100} usedTokens={2000} maxTokens={2000} />);
     expect(screen.getByText('100%')).toBeTruthy();
+  });
+
+  // ★ KEY REGRESSION TEST: shows "+" suffix when percentage exceeds 100
+  it('shows 100%+ when percentage exceeds 100', () => {
+    render(<TokenIndicator percentage={145} usedTokens={2900} maxTokens={2000} />);
+    expect(screen.getByText('100%+')).toBeTruthy();
+  });
+
+  it('clamps the ring fill geometry but preserves raw used tokens', () => {
+    const { container } = render(
+      <TokenIndicator percentage={145} usedTokens={2900} maxTokens={2000} />
+    );
     const progressCircle = container.querySelector('.token-indicator-fill');
     expect(progressCircle?.getAttribute('stroke-dashoffset')).toBe('0');
+    // Real values preserved on tooltip — front end must not lose overflow info
     expect(screen.getByText(/2.9k \/ 2k/)).toBeTruthy();
+  });
+
+  it('shows the bug scenario from the issue: 100.0% + 2043.6k/1050k', () => {
+    const { container } = render(
+      <TokenIndicator percentage={194.6} usedTokens={2043600} maxTokens={1050000} />
+    );
+    expect(screen.getByText('100%+')).toBeTruthy();
+    expect(screen.getByText(/2.0M \/ 1.0M/)).toBeTruthy();
   });
 });

--- a/webview/src/components/ChatInputBox/TokenIndicator.tsx
+++ b/webview/src/components/ChatInputBox/TokenIndicator.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import type { TokenIndicatorProps } from './types';
-import { clampUsagePercentage } from '../../utils/usagePercentage';
+import { clampUsagePercentage, formatUsagePercentageLabel, formatUsagePercentageTooltip } from '../../utils/usagePercentage';
 
 /**
  * TokenIndicator - Usage ring progress bar component
@@ -24,10 +24,10 @@ export const TokenIndicator = ({
   // Calculate offset (fill clockwise from top)
   const strokeOffset = circumference * (1 - safePercentage / 100);
 
-  // Indicator label: integer percentage (no decimal)
-  const labelPercentage = `${Math.round(safePercentage)}%`;
-  // Tooltip: one decimal place for precision
-  const tooltipPercentage = `${(Math.round(safePercentage * 10) / 10).toFixed(1)}%`;
+  // Indicator label: integer percentage (no decimal). Adds "+" when overflowing the model window.
+  const labelPercentage = formatUsagePercentageLabel(percentage);
+  // Tooltip: one decimal place for precision. Adds "+" when overflowing the model window.
+  const tooltipPercentage = formatUsagePercentageTooltip(percentage);
 
   const formatTokens = (value?: number) => {
     if (typeof value !== 'number' || !isFinite(value)) return undefined;
@@ -65,7 +65,7 @@ export const TokenIndicator = ({
           />
           {/* Progress arc */}
           <circle
-            className="token-indicator-fill"
+            className={`token-indicator-fill ${percentage > 100 ? 'overflowing' : ''}`}
             cx={center}
             cy={center}
             r={radius}
@@ -78,7 +78,11 @@ export const TokenIndicator = ({
           {tooltip}
         </div>
       </div>
-      <span className="token-percentage-label">{labelPercentage}</span>
+      <span
+        className={`token-percentage-label ${percentage > 100 ? 'overflowing' : ''}`}
+      >
+        {labelPercentage}
+      </span>
     </div>
   );
 };

--- a/webview/src/components/ChatInputBox/styles/selectors.css
+++ b/webview/src/components/ChatInputBox/styles/selectors.css
@@ -403,6 +403,16 @@
   transition: stroke-dashoffset 0.3s;
 }
 
+/* Over-limit: usage exceeds model context window. Turns the ring and label red. */
+.token-indicator-fill.overflowing {
+  stroke: var(--vscode-errorForeground, #ef4444);
+}
+
+.token-percentage-label.overflowing {
+  color: var(--vscode-errorForeground, #ef4444);
+  font-weight: 600;
+}
+
 /* Usage hover tooltip bubble */
 .token-tooltip {
   position: absolute;

--- a/webview/src/components/ContextUsageDialog.test.tsx
+++ b/webview/src/components/ContextUsageDialog.test.tsx
@@ -111,7 +111,22 @@ describe('ContextUsageDialog', () => {
       />,
     );
 
-    expect(container.querySelector('.context-usage-tokens')?.textContent).toBe('2.4k / 2.0k (100%)');
+    // ★ Changed from "100%" to "100.0%+" since the test exercises an overflowing case
+    expect(container.querySelector('.context-usage-tokens')?.textContent).toBe('2.4k / 2.0k (100.0%+)');
+  });
+
+  it('shows the overflow warning when percentage exceeds 100', () => {
+    render(
+      <ContextUsageDialog
+        isOpen
+        isLoading={false}
+        data={{ ...sampleData, totalTokens: 2400, percentage: 120 }}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(/上下文已超出/)).toBeTruthy();
+  });
   });
 
   it('uses a finite fallback opacity for invalid square fullness', () => {

--- a/webview/src/components/ContextUsageDialog.tsx
+++ b/webview/src/components/ContextUsageDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useMemo, useCallback, useId, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import './ContextUsageDialog.css';
-import { clampUsagePercentage } from '../utils/usagePercentage';
+import { clampUsagePercentage, formatUsagePercentageTooltip, isOverflowing } from '../utils/usagePercentage';
 
 export interface ContextUsageData {
   categories: Array<{
@@ -269,7 +269,6 @@ const ContextUsageDialog = memo(function ContextUsageDialog({
     isAutoCompactEnabled = false,
     autoCompactThreshold,
   } = data;
-  const safePercentage = clampUsagePercentage(percentage);
 
   return (
     <div className="context-usage-overlay" onMouseDown={handleCloseMouseDown}>
@@ -305,7 +304,7 @@ const ContextUsageDialog = memo(function ContextUsageDialog({
         <div id={descriptionId} className="context-usage-summary">
           <span className="context-usage-model">{model}</span>
           <span className="context-usage-tokens">
-            {formatTokens(totalTokens)} / {formatTokens(rawMaxTokens)} ({safePercentage}%)
+            {formatTokens(totalTokens)} / {formatTokens(rawMaxTokens)} ({formatUsagePercentageTooltip(percentage)})
           </span>
           {isAutoCompactEnabled && (
             <span className="context-usage-autocompact">
@@ -317,6 +316,13 @@ const ContextUsageDialog = memo(function ContextUsageDialog({
                 : t('contextUsage.autoCompactEnabled', {
                     defaultValue: 'Auto-compact: enabled',
                   })}
+            </span>
+          )}
+          {isOverflowing(percentage) && (
+            <span className="context-usage-overflow-warning">
+              ⚠ {t('contextUsage.overflowWarning', {
+                defaultValue: 'Context exceeded: consider running /compact',
+              })}
             </span>
           )}
         </div>

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/usageModeCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/usageModeCallbacks.ts
@@ -66,7 +66,9 @@ export function registerUsageModeCallbacks(options: UseWindowCallbacksOptions): 
           );
         }
 
-        const safePercentage = Math.max(0, Math.min(100, data.percentage));
+        // Don't clamp percentage to 100: send the true value so TokenIndicator
+        // can distinguish "exactly 100" from "100 and counting".
+        const safePercentage = Math.max(0, data.percentage);
         setUsagePercentage(safePercentage);
         setUsageUsedTokens(used);
         setUsageMaxTokens(max);

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -2080,6 +2080,7 @@
     "loading": "Loading context usage...",
     "autoCompactEnabled": "Auto-compact: enabled",
     "autoCompactEnabledWithThreshold": "Auto-compact: enabled ({{threshold}}%)",
+    "overflowWarning": "Context exceeded: consider running /compact",
     "notAvailable": "N/A",
     "categories": {
       "systemPrompt": "System prompt",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -2085,6 +2085,7 @@
     "loading": "正在加载上下文使用情况...",
     "autoCompactEnabled": "自动压缩已启用",
     "autoCompactEnabledWithThreshold": "自动压缩已启用 ({{threshold}}%)",
+    "overflowWarning": "上下文已超出：建议执行 /compact 进行压缩",
     "notAvailable": "不可用",
     "categories": {
       "systemPrompt": "系统提示词",

--- a/webview/src/utils/usagePercentage.test.ts
+++ b/webview/src/utils/usagePercentage.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { clampUsagePercentage } from './usagePercentage';
+import {
+  clampUsagePercentage,
+  formatUsagePercentageLabel,
+  formatUsagePercentageTooltip,
+  isOverflowing,
+} from './usagePercentage';
 
 describe('clampUsagePercentage', () => {
   it('keeps visual percentages within the supported range', () => {
@@ -9,5 +14,51 @@ describe('clampUsagePercentage', () => {
     expect(clampUsagePercentage(Number.NaN)).toBe(0);
     expect(clampUsagePercentage(Number.POSITIVE_INFINITY)).toBe(0);
     expect(clampUsagePercentage(Number.NEGATIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe('isOverflowing', () => {
+  it('is true when percentage > 100', () => {
+    expect(isOverflowing(100.1)).toBe(true);
+    expect(isOverflowing(145.6)).toBe(true);
+    expect(isOverflowing(194.6)).toBe(true);
+  });
+  it('is false when percentage <= 100', () => {
+    expect(isOverflowing(100)).toBe(false);
+    expect(isOverflowing(99.9)).toBe(false);
+    expect(isOverflowing(0)).toBe(false);
+  });
+  it('is false for non-finite values', () => {
+    expect(isOverflowing(Number.NaN)).toBe(false);
+    expect(isOverflowing(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+});
+
+describe('formatUsagePercentageLabel', () => {
+  it('rounds to integer for normal values', () => {
+    expect(formatUsagePercentageLabel(0)).toBe('0%');
+    expect(formatUsagePercentageLabel(45.4)).toBe('45%');
+    expect(formatUsagePercentageLabel(99.6)).toBe('100%');
+  });
+  it('adds + suffix when overflowing', () => {
+    expect(formatUsagePercentageLabel(100.1)).toBe('100%+');
+    expect(formatUsagePercentageLabel(145.6)).toBe('100%+');
+    expect(formatUsagePercentageLabel(194.6)).toBe('100%+');
+  });
+  it('handles invalid values', () => {
+    expect(formatUsagePercentageLabel(Number.NaN)).toBe('0%');
+    expect(formatUsagePercentageLabel(-5)).toBe('0%');
+  });
+});
+
+describe('formatUsagePercentageTooltip', () => {
+  it('uses one decimal for normal values', () => {
+    expect(formatUsagePercentageTooltip(99.4)).toBe('99.4%');
+    expect(formatUsagePercentageTooltip(100)).toBe('100.0%');
+  });
+  it('uses 100.0%+ when overflowing', () => {
+    expect(formatUsagePercentageTooltip(100.1)).toBe('100.0%+');
+    expect(formatUsagePercentageTooltip(145.6)).toBe('100.0%+');
+    expect(formatUsagePercentageTooltip(194.6)).toBe('100.0%+');
   });
 });

--- a/webview/src/utils/usagePercentage.ts
+++ b/webview/src/utils/usagePercentage.ts
@@ -2,3 +2,37 @@ export function clampUsagePercentage(value: number): number {
   if (!Number.isFinite(value)) return 0;
   return Math.max(0, Math.min(100, value));
 }
+
+/**
+ * Whether a usage percentage exceeds the model's context window.
+ * Used to disambiguate "exactly 100" from "100 and counting".
+ */
+export function isOverflowing(percentage: number): boolean {
+  return Number.isFinite(percentage) && percentage > 100;
+}
+
+/**
+ * Format a percentage for display as a label (no decimal places).
+ * - 99.4   -> "99%"
+ * - 100.0  -> "100%"
+ * - 145.6  -> "100%+"
+ */
+export function formatUsagePercentageLabel(percentage: number): string {
+  if (!Number.isFinite(percentage)) return '0%';
+  const clamped = Math.max(0, Math.min(100, percentage));
+  const rounded = Math.round(clamped);
+  return isOverflowing(percentage) ? `${rounded}%+` : `${rounded}%`;
+}
+
+/**
+ * Format a percentage for tooltip-style display (one decimal place).
+ * - 99.4   -> "99.4%"
+ * - 100.0  -> "100.0%"
+ * - 145.6  -> "100.0%+"
+ */
+export function formatUsagePercentageTooltip(percentage: number): string {
+  if (!Number.isFinite(percentage)) return '0.0%';
+  const clamped = Math.max(0, Math.min(100, percentage));
+  const rounded = Math.round(clamped * 10) / 10;
+  return isOverflowing(percentage) ? `${rounded.toFixed(1)}%+` : `${rounded.toFixed(1)}%`;
+}


### PR DESCRIPTION
优化超出模型上下文百分比显示 
修改前 100%
[
<img width="262" height="62" alt="before" src="https://github.com/user-attachments/assets/4457eae1-76e2-499f-ab31-db9b9d8ce30a" />
](url)
修改后 100%+
[
<img width="784" height="176" alt="after" src="https://github.com/user-attachments/assets/b125d130-4175-401d-80b8-779552e7340d" />
](url)

Fixes https://github.com/zhukunpenglinyutong/jetbrains-cc-gui/issues/1600 - The context indicator previously displayed '100%' for any value at or above 100%, which made the over-limit state indistinguishable from a session that was exactly full. Users saw a misleading ring (e.g. '100.0% - 2043.6k / 1050k context') and could not tell they were already overflowing the model context window.

Changes:

* New utility functions in webview/src/utils/usagePercentage.ts:
  - isOverflowing(): true when percentage > 100
  - formatUsagePercentageLabel(): adds '+' suffix when overflowing
  - formatUsagePercentageTooltip(): one-decimal '+' tooltip format

* TokenIndicator.tsx: uses the new formatters and renders in red with font-weight 600 when overflowing (selectors.css).

* ContextUsageDialog.tsx: uses formatUsagePercentageTooltip and adds a 'Context exceeded: consider running /compact' warning banner when isOverflowing() is true. New i18n strings (overflowWarning) in en.json and zh.json.

* usageModeCallbacks.ts: do not clamp percentage to 100 on the way into React state so the true value reaches the formatter.

* Java side (UsagePushService, MessageJsonConverter, SessionCallbackAdapter): remove Math.min(100, ...) on the percentage calculation so the frontend receives the real percentage (>100) and can decide how to render it.

Real token counts (e.g. 287.0k / 1k context) are preserved in the tooltip and detail dialog so users can tell how much they have exceeded the model window, and decide whether to /compact or start a new session.

Tests: updated TokenIndicator / ContextUsageDialog tests and added unit tests for the new utility functions in
webview/src/utils/usagePercentage.test.ts.