### PR TITLE
fix(cli): quote CLI paths containing spaces when shell-spawning on Windows

### DIFF
--- a/ai-bridge/services/opencode/models-service.js
+++ b/ai-bridge/services/opencode/models-service.js
@@ -9,6 +9,7 @@ import {
   commonCliBinDirs,
   enrichPathWithBinDirs,
   isWindowsCmdShim,
+  quoteWindowsShellBin,
   resolveOpenCodeCliPath,
 } from '../../utils/cli-path.js';
 
@@ -66,13 +67,15 @@ export function listModels() {
 
   let result;
   try {
-    result = spawnSync(bin, ['models'], {
+    // Quote spaced paths for the shell spawn (see quoteWindowsShellBin, #1665).
+    const needsShell = isWindowsCmdShim(bin);
+    result = spawnSync(needsShell ? quoteWindowsShellBin(bin) : bin, ['models'], {
       encoding: 'utf8',
       env,
       timeout: 45_000,
       maxBuffer: 8 * 1024 * 1024,
       // Windows npm `.cmd` shims require a shell to spawn.
-      shell: isWindowsCmdShim(bin),
+      shell: needsShell,
     });
   } catch (error) {
     console.log(JSON.stringify({

--- a/ai-bridge/services/pi/models-service.js
+++ b/ai-bridge/services/pi/models-service.js
@@ -11,6 +11,7 @@ import {
   commonCliBinDirs,
   enrichPathWithBinDirs,
   isWindowsCmdShim,
+  quoteWindowsShellBin,
   resolvePiCliPath,
 } from '../../utils/cli-path.js';
 
@@ -64,13 +65,15 @@ export function listModels() {
 
   let result;
   try {
-    result = spawnSync(bin, ['--list-models'], {
+    // Quote spaced paths for the shell spawn (see quoteWindowsShellBin, #1665).
+    const needsShell = isWindowsCmdShim(bin);
+    result = spawnSync(needsShell ? quoteWindowsShellBin(bin) : bin, ['--list-models'], {
       encoding: 'utf8',
       env,
       timeout: 45_000,
       maxBuffer: 8 * 1024 * 1024,
       // Windows npm `.cmd` shims require a shell to spawn.
-      shell: isWindowsCmdShim(bin),
+      shell: needsShell,
     });
   } catch (error) {
     console.log(JSON.stringify({

--- a/ai-bridge/utils/cli-path.js
+++ b/ai-bridge/utils/cli-path.js
@@ -34,6 +34,32 @@ export function isWindowsCmdShim(bin) {
 }
 
 /**
+ * Quote a binary path for shell spawning on Windows (#1665).
+ *
+ * Node's `spawn(bin, args, { shell: true })` concatenates `bin` and `args`
+ * into a single `cmd.exe /d /s /c "<bin> <args...>"` command line WITHOUT
+ * quoting `bin`. When the resolved CLI path contains spaces (e.g.
+ * `D:\Program Files\nodejs\opencode.cmd`), cmd.exe splits it at the first
+ * space and the spawn fails with garbled "not recognized as an internal or
+ * external command" errors.
+ *
+ * Wrapping the whole command in quotes makes cmd.exe (with `/s` semantics)
+ * strip only the outer quotes and pass `bin` through as one token.
+ *
+ * @param {string} bin - resolved binary path or bare name
+ * @returns {string} quoted bin, or the input unchanged when no quoting needed
+ */
+export function quoteWindowsShellBin(bin) {
+  const value = String(bin || '');
+  if (!value) return value;
+  // Only quote when it contains a space; quoting a bare name would break cmd lookup.
+  if (!/\s/.test(value)) return value;
+  // Already fully quoted.
+  if (/^".*"$/s.test(value)) return value;
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+/**
  * Pick the best match from `where` output lines on Windows.
  * Prefer `.exe` / `.cmd` / `.bat` over extensionless npm bash shims.
  *

--- a/ai-bridge/utils/cli-path.test.js
+++ b/ai-bridge/utils/cli-path.test.js
@@ -4,6 +4,7 @@ import {
   isWindowsCmdShim,
   selectWindowsWhereMatch,
   resolveWindowsSpawnableBin,
+  quoteWindowsShellBin,
 } from './cli-path.js';
 
 test('isWindowsCmdShim detects .cmd/.bat only on win32-style paths', () => {
@@ -104,4 +105,38 @@ test('resolveWindowsSpawnableBin handles paths with spaces', () => {
   const exists = (p) => p === `${base}.cmd`;
   const resolved = resolveWindowsSpawnableBin(base, exists, true);
   assert.equal(resolved, `${base}.cmd`);
+});
+
+// ---------- quoteWindowsShellBin (#1665) ----------
+
+test('quoteWindowsShellBin wraps spaced paths in double quotes', () => {
+  assert.equal(
+    quoteWindowsShellBin('D:\\Program Files\\nodejs\\opencode.cmd'),
+    '"D:\\Program Files\\nodejs\\opencode.cmd"',
+  );
+});
+
+test('quoteWindowsShellBin leaves space-free paths untouched', () => {
+  // Bare names must stay unquoted: quoting would break cmd's PATH lookup.
+  assert.equal(quoteWindowsShellBin('opencode.cmd'), 'opencode.cmd');
+  assert.equal(quoteWindowsShellBin('C:\\npm\\opencode.cmd'), 'C:\\npm\\opencode.cmd');
+  assert.equal(quoteWindowsShellBin('pi'), 'pi');
+});
+
+test('quoteWindowsShellBin does not double-quote already quoted values', () => {
+  const quoted = '"D:\\Program Files\\nodejs\\opencode.cmd"';
+  assert.equal(quoteWindowsShellBin(quoted), quoted);
+});
+
+test('quoteWindowsShellBin escapes embedded quotes by doubling them', () => {
+  assert.equal(
+    quoteWindowsShellBin('C:\\weird "path"\\opencode.cmd'),
+    '"C:\\weird ""path""\\opencode.cmd"',
+  );
+});
+
+test('quoteWindowsShellBin handles empty and falsy input', () => {
+  assert.equal(quoteWindowsShellBin(''), '');
+  assert.equal(quoteWindowsShellBin(null), '');
+  assert.equal(quoteWindowsShellBin(undefined), '');
 });

--- a/ai-bridge/utils/cli-spawn.js
+++ b/ai-bridge/utils/cli-spawn.js
@@ -5,7 +5,7 @@
 import { spawn } from 'child_process';
 import { createInterface } from 'readline';
 import { emitSendError, endStream } from './marker-protocol.js';
-import { isWindowsCmdShim } from './cli-path.js';
+import { isWindowsCmdShim, quoteWindowsShellBin } from './cli-path.js';
 
 function killChildTree(child, label) {
   if (!child || child.killed) return;
@@ -88,14 +88,16 @@ export function runCliStreaming({
 
     let child;
     try {
-      child = spawn(bin, args, {
+      // Windows .cmd/.bat shims must be spawned via a shell, and Node does not
+      // quote `bin` in shell mode - quote paths containing spaces ourselves so
+      // cmd.exe does not split them at the first space (#1665).
+      const needsShell = isWindowsCmdShim(bin);
+      child = spawn(needsShell ? quoteWindowsShellBin(bin) : bin, args, {
         cwd,
         env,
         stdio: ['ignore', 'pipe', 'pipe'],
         detached: process.platform !== 'win32',
-        // Windows npm `.cmd`/`.bat` shims cannot be spawned without a shell
-        // (Node >= 18.20 / 20.12, CVE-2024-27980).
-        shell: isWindowsCmdShim(bin),
+        shell: needsShell,
       });
     } catch (error) {
       hadError = true;


### PR DESCRIPTION
## Summary

Fixes #1665 - when Node.js is installed under a path containing spaces (e.g. `D:\Program Files\nodejs`), the plugin spawns OpenCode CLI with a broken command line and every session fails immediately with exit code 1 and garbled characters:

```
'D:Program' 不是内部或外部命令  ("not recognized as an internal or external command" in a GBK-mojibake rendering)
```

OpenCode becomes completely unusable from the plugin.

### Root Cause

On Windows, npm-installed CLIs are `.cmd` shims that Node can only spawn with `shell: true` (CVE-2024-27980). In shell mode Node concatenates `bin` and `args` into a single `cmd.exe /d /s /c "<bin> <args...>"` command line **without quoting `bin`**. When the resolved CLI path contains spaces, cmd.exe splits it at the first space and tries to run `D:\Program` - the session dies instantly.

The same unquoted-shim spawn pattern exists in three places:

1. `ai-bridge/utils/cli-spawn.js` `runCliStreaming()` - the chat message path for **Grok / Kimi / OpenCode / PI**
2. `ai-bridge/services/opencode/models-service.js` `spawnSync()` - OpenCode models listing
3. `ai-bridge/services/pi/models-service.js` `spawnSync()` - PI models listing

So the bug affects all four headless CLI providers, not just OpenCode - it is just most visible there because OpenCode's installer commonly lands in `nodejs` dirs with spaces.

### Fix

Add `quoteWindowsShellBin()` to `ai-bridge/utils/cli-path.js` and apply it at every shell-spawn site:

- `cli-spawn.js` `runCliStreaming()` quotes `bin` before spawning when `isWindowsCmdShim(bin)` is true
- both `models-service.js` files quote `bin` for their `spawnSync` calls the same way

Quoting rules:
- Only paths containing spaces get quoted; bare names (`opencode.cmd`) stay untouched so cmd's PATH/PATHEXT lookup still works
- Already-quoted values pass through unchanged
- Embedded `"` are escaped by doubling (`""`), matching cmd.exe conventions

Wrapping in plain double quotes works because Node spawns via `cmd.exe /d /s /c` - with `/s`, cmd strips only the outer quote pair and passes the inner content through as a single token.

### Before / After

| Spawn input | Before | After |
|---|---|---|
| `D:\Program Files\nodejs\opencode.cmd` + `shell:true` | cmd runs `D:\Program` -> exit 1, garbled errors | quoted -> shim runs correctly |
| `C:\npm\opencode.cmd` (no spaces) | works | works (unchanged - not quoted) |
| bare `opencode.cmd` via PATH | works | works (unchanged - not quoted) |
| Linux / macOS | no shell spawn | no change |

### Backward Compatibility

- Space-free paths and bare names are byte-for-byte unchanged, so existing working setups see zero difference
- Non-Windows platforms are untouched (`isWindowsCmdShim` gates everything)

### Verification

- New unit tests in `cli-path.test.js` (17/17 pass): spaced paths get quoted, space-free/already-quoted/bare names untouched, embedded quotes escaped, empty input handled
- End-to-end check with a real spaced-path `.cmd` shim on Windows: unquoted spawn exits 1 with no output; quoted spawn exits 0 and emits the expected marker - confirming both the repro and the fix
- Full ai-bridge suite: 351/354 (3 failures are a pre-existing Windows-only `/bin/bash` assertion in `acp-terminal-host.test.js`, identical on the base branch; Linux CI passes them)

Closes #1665