### PR TITLE
fix(input): preserve existing content when inserting external snippets with a stale selection

### DIFF
--- a/webview/src/components/ChatInputBox/hooks/useGlobalCallbacks.test.ts
+++ b/webview/src/components/ChatInputBox/hooks/useGlobalCallbacks.test.ts
@@ -143,4 +143,45 @@ describe('useGlobalCallbacks', () => {
 
     expect(getTextContent()).toBe('draft question\n@/path/to/file ');
   });
+
+  it('does not wipe existing content when a stale non-collapsed selection exists (#1700)', () => {
+    const editable = createEditable();
+    editable.appendChild(document.createTextNode('existing draft'));
+    const { getTextContent } = renderUseGlobalCallbacks(editable);
+
+    // Simulate the real repro: user selected text inside the box earlier, then went
+    // back to the IDE editor and triggered "Add selection to CC GUI". The webview's
+    // stale select-all range is still non-collapsed and still anchored in editable.
+    editable.blur();
+    const selectAll = document.createRange();
+    selectAll.selectNodeContents(editable);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(selectAll);
+
+    window.insertCodeSnippetAtCursor?.('@src/file.ts#L10-20');
+    vi.runAllTimers();
+
+    // The snippet is appended at the end; the pre-existing draft must survive.
+    expect(getTextContent()).toBe('existing draft\n@src/file.ts#L10-20 ');
+  });
+
+  it('handleFilePathFromJava does not wipe content on stale non-collapsed selection (#1700)', () => {
+    const editable = createEditable();
+    editable.appendChild(document.createTextNode('existing draft'));
+    const { getTextContent } = renderUseGlobalCallbacks(editable);
+
+    editable.blur();
+    const selectAll = document.createRange();
+    selectAll.selectNodeContents(editable);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(selectAll);
+
+    window.handleFilePathFromJava?.('/abs/path/Helper.ts');
+    vi.runAllTimers();
+
+    expect(getTextContent()).toContain('existing draft');
+    expect(getTextContent()).toContain('@/abs/path/Helper.ts ');
+  });
 });

--- a/webview/src/components/ChatInputBox/hooks/useGlobalCallbacks.ts
+++ b/webview/src/components/ChatInputBox/hooks/useGlobalCallbacks.ts
@@ -63,15 +63,29 @@ export function useGlobalCallbacks({
       ) {
         // Cursor inside input box, insert at cursor position
         const range = selection.getRangeAt(0);
-        range.deleteContents();
-        const textNode = document.createTextNode(pathToInsert);
-        range.insertNode(textNode);
+        // File paths arrive from IDE actions (project tree / right-click), not
+        // from typing. A stale non-collapsed selection must not be replaced by
+        // deleteContents() - that wiped the existing content (#1700). Only a
+        // collapsed caret is a real insertion point; otherwise append at end.
+        if (!range.collapsed) {
+          const textNode = document.createTextNode(pathToInsert);
+          editableRef.current.appendChild(textNode);
+          const appendRange = document.createRange();
+          appendRange.setStartAfter(textNode);
+          appendRange.collapse(true);
+          selection.removeAllRanges();
+          selection.addRange(appendRange);
+        } else {
+          range.deleteContents();
+          const textNode = document.createTextNode(pathToInsert);
+          range.insertNode(textNode);
 
-        // Move cursor after inserted text
-        range.setStartAfter(textNode);
-        range.collapse(true);
-        selection.removeAllRanges();
-        selection.addRange(range);
+          // Move cursor after inserted text
+          range.setStartAfter(textNode);
+          range.collapse(true);
+          selection.removeAllRanges();
+          selection.addRange(range);
+        }
       } else {
         // Cursor not inside input box, append to end
         // Use appendChild instead of innerText to avoid breaking existing file tags
@@ -203,6 +217,15 @@ export function useGlobalCallbacks({
       }
 
       const range = selection.getRangeAt(0);
+      // External snippets come from IDE actions (editor selection), never from
+      // typing inside the input. A stale NON-collapsed selection (user last
+      // selected text in the box, then went back to the editor) must not be
+      // replaced by deleteContents() - that wiped the existing content (#1700).
+      // Only a collapsed caret is a real insertion point; otherwise fall back
+      // to appending at the end.
+      if (!range.collapsed) {
+        return false;
+      }
       range.deleteContents();
       const fragment = createTextFragment(`${selectionInfo} `);
       const lastChild = fragment.lastChild;
@@ -279,13 +302,27 @@ export function useGlobalCallbacks({
 
         if (insertAtCaret) {
           const range = selection.getRangeAt(0);
-          range.deleteContents();
-          const tokenNode = document.createTextNode(token);
-          range.insertNode(tokenNode);
-          range.setStartAfter(tokenNode);
-          range.collapse(true);
-          selection.removeAllRanges();
-          selection.addRange(range);
+          // Quote chips arrive from external actions, not from typing. A stale
+          // non-collapsed selection must not be replaced by deleteContents() -
+          // that wiped the existing content (#1700). Fall back to appending.
+          if (!range.collapsed) {
+            editableRef.current.focus();
+            const tokenNode = document.createTextNode(token);
+            editableRef.current.appendChild(tokenNode);
+            const appendRange = document.createRange();
+            appendRange.setStartAfter(tokenNode);
+            appendRange.collapse(true);
+            selection?.removeAllRanges();
+            selection?.addRange(appendRange);
+          } else {
+            range.deleteContents();
+            const tokenNode = document.createTextNode(token);
+            range.insertNode(tokenNode);
+            range.setStartAfter(tokenNode);
+            range.collapse(true);
+            selection.removeAllRanges();
+            selection.addRange(range);
+          }
         } else {
           editableRef.current.focus();
           const tokenNode = document.createTextNode(token);


### PR DESCRIPTION
## Summary

Fixes #1700 - when the chat input already contains text, selecting code in the editor and adding it to CC GUI makes the previously typed content disappear.

### Root Cause

Reproduced deterministically in a unit test (jsdom):

```
final text: "@src/file.ts#L10-20 "   ← "existing draft" was deleted
```

The caret-insertion path in `useGlobalCallbacks` checks whether the webview's current selection is anchored inside the editable div. The JCEF webview is a separate document, so selecting text in the IDE editor does **not** touch the webview's Selection. The trigger sequence is:

1. User types a draft in the chat input and at some point selects part of it (Ctrl+A, drag-select, double-click word...)
2. User goes back to the editor, selects code, triggers *Add Selection to CC GUI*
3. The webview's stale **non-collapsed** select-all range is still anchored in the editable → `tryInsertExternalSnippetAtCaret` takes the "insert at caret" branch
4. `range.deleteContents()` runs on that stale range → the entire existing draft is deleted before the snippet is inserted

The same pattern exists in all three Java-interop insertion paths (`insertCodeSnippetAtCursor`, `handleFilePathFromJava`, `addQuotedSnippet`), each calling `range.deleteContents()` on whatever selection happens to exist.

### Fix

External content arrives from IDE actions, never from typing inside the box - so a non-collapsed range can never be a meaningful insertion point. All three paths now treat only a **collapsed caret** as an insertion position; a stale non-collapsed selection falls back to appending at the end, preserving existing content.

### Before / After

| Scenario | Before | After |
|---|---|---|
| Stale non-collapsed selection + add selection | existing content deleted, only snippet remains | existing content preserved, snippet appended on new line |
| Stale non-collapsed selection + add file path | existing content deleted | existing content preserved, `@path` appended |
| Collapsed caret inside input + add selection | inserts at caret | unchanged - inserts at caret |
| Caret outside input + add selection | appends at end | unchanged - appends at end |

### Backward Compatibility

- Collapsed-caret insertion (the normal flow) is byte-for-byte unchanged
- Appending-when-caret-outside behavior unchanged
- Only the previously destructive stale-selection case changes behavior

### Verification

- New regression tests reproduce the exact select-all stale-selection scenario for both the snippet path and the file-path path; both fail on the old code and pass with the fix
- `useGlobalCallbacks.test.ts`: 6/6 pass
- Full webview suite: 1252 tests pass (4 unrelated test files fail to load with a pre-existing local `transform` error, identical on the base branch)

Closes #1700