### PR TITLE
fix(commit-ai): migrate retired default model in Commit AI / Prompt Enhancer

### DIFF
--- a/ai-bridge/services/prompt-enhancer.js
+++ b/ai-bridge/services/prompt-enhancer.js
@@ -48,7 +48,8 @@ const DEFAULT_PROMPT_ENHANCER_CONFIG = {
   effectiveProvider: 'claude',
   resolutionSource: 'auto',
   models: {
-    claude: 'claude-sonnet-4-6',
+    // claude-sonnet-4-6/4-7 are retired - defaults must stay on live models (#1678, #1693).
+    claude: 'claude-sonnet-5',
     codex: 'gpt-5.5',
     grok: 'grok',
     kimi: 'auto',

--- a/ai-bridge/services/prompt-enhancer.test.js
+++ b/ai-bridge/services/prompt-enhancer.test.js
@@ -17,7 +17,7 @@ test('resolvePromptEnhancerRuntimeConfig prefers Codex when auto mode has both p
       effectiveProvider: 'codex',
       resolutionSource: 'auto',
       models: {
-        claude: 'claude-sonnet-4-6',
+        claude: 'claude-sonnet-5',
         codex: 'gpt-5.5',
         grok: 'grok',
       },
@@ -40,7 +40,7 @@ test('resolvePromptEnhancerRuntimeConfig accepts Grok when effectiveProvider is 
       effectiveProvider: 'grok',
       resolutionSource: 'manual',
       models: {
-        claude: 'claude-sonnet-4-6',
+        claude: 'claude-sonnet-5',
         codex: 'gpt-5.5',
         grok: 'grok',
       },
@@ -64,7 +64,7 @@ test('resolvePromptEnhancerRuntimeConfig accepts Kimi / OpenCode / PI CLI provid
         effectiveProvider: provider,
         resolutionSource: 'manual',
         models: {
-          claude: 'claude-sonnet-4-6',
+          claude: 'claude-sonnet-5',
           codex: 'gpt-5.5',
           kimi: 'kimi-k2',
           opencode: 'opencode/gpt',
@@ -135,12 +135,12 @@ test('resolveAutoChatModel ignores chat model when provider differs', () => {
   assert.equal(
     resolveAutoChatModel({
       provider: 'claude',
-      configuredModel: 'claude-sonnet-4-6',
+      configuredModel: 'claude-sonnet-5',
       resolutionSource: 'auto',
       chatProvider: 'opencode',
       chatModel: 'opencode/deepseek-v4-flash-free',
     }),
-    'claude-sonnet-4-6'
+    'claude-sonnet-5'
   );
 });
 
@@ -151,7 +151,7 @@ test('resolvePromptEnhancerRuntimeConfig auto follows chat model for OpenCode', 
       effectiveProvider: 'opencode',
       resolutionSource: 'auto',
       models: {
-        claude: 'claude-sonnet-4-6',
+        claude: 'claude-sonnet-5',
         codex: 'gpt-5.5',
         opencode: 'opencode-default',
       },

--- a/src/main/java/com/github/claudecodegui/session/SessionState.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionState.java
@@ -230,7 +230,7 @@ public class SessionState {
      * @return the model id to store - retired ids mapped to their live replacement,
      *         anything else (including non-Claude ids) passed through unchanged
      */
-    static String normalizeRetiredModelId(String model) {
+    public static String normalizeRetiredModelId(String model) {
         if (model == null) {
             return null;
         }

--- a/src/main/java/com/github/claudecodegui/settings/CodemossSettingsService.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodemossSettingsService.java
@@ -7,6 +7,7 @@ import com.github.claudecodegui.i18n.ClaudeCodeGuiBundle;
 import com.github.claudecodegui.model.ConflictStrategy;
 import com.github.claudecodegui.model.DeleteResult;
 import com.github.claudecodegui.model.PromptScope;
+import com.github.claudecodegui.session.SessionState;
 import com.github.claudecodegui.dependency.DependencyManager;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -352,9 +353,10 @@ public class CodemossSettingsService {
     private static final String AI_FEATURE_RESOLUTION_MANUAL = "manual";
     private static final String AI_FEATURE_RESOLUTION_AUTO = "auto";
     private static final String AI_FEATURE_RESOLUTION_UNAVAILABLE = "unavailable";
-    private static final String DEFAULT_PROMPT_ENHANCER_CLAUDE_MODEL = "claude-sonnet-4-6";
+    // claude-sonnet-4-6/4-7 are retired - defaults must stay on live models (#1678, #1693).
+    private static final String DEFAULT_PROMPT_ENHANCER_CLAUDE_MODEL = "claude-sonnet-5";
     private static final String DEFAULT_PROMPT_ENHANCER_CODEX_MODEL = "gpt-5.5";
-    private static final String DEFAULT_COMMIT_AI_CLAUDE_MODEL = "claude-sonnet-4-6";
+    private static final String DEFAULT_COMMIT_AI_CLAUDE_MODEL = "claude-sonnet-5";
     private static final String DEFAULT_COMMIT_AI_CODEX_MODEL = "gpt-5.5";
     private static final String DEFAULT_AI_FEATURE_GROK_MODEL = "grok";
     private static final String DEFAULT_AI_FEATURE_KIMI_MODEL = "auto";
@@ -2301,6 +2303,12 @@ public class CodemossSettingsService {
                 } catch (Exception ignored) {
                     raw = null;
                 }
+            }
+            // Self-heal persisted retired Claude model ids (e.g. a config saved while
+            // the default was claude-sonnet-4-6 keeps that dead id forever; every
+            // generation then fails with an empty/failed response - #1693, see #1678).
+            if (AI_FEATURE_PROVIDER_CLAUDE.equals(provider)) {
+                raw = SessionState.normalizeRetiredModelId(raw);
             }
             models.addProperty(provider, normalizeAiFeatureModel(raw, fallback));
         }

--- a/src/test/java/com/github/claudecodegui/settings/CodemossSettingsServiceCommitAiConfigTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/CodemossSettingsServiceCommitAiConfigTest.java
@@ -43,7 +43,7 @@ public class CodemossSettingsServiceCommitAiConfigTest {
         assertEquals("auto", config.get("resolutionSource").getAsString());
         assertTrue(config.getAsJsonObject("availability").get("claude").getAsBoolean());
         assertTrue(config.getAsJsonObject("availability").get("codex").getAsBoolean());
-        assertEquals("claude-sonnet-4-6", config.getAsJsonObject("models").get("claude").getAsString());
+        assertEquals("claude-sonnet-5", config.getAsJsonObject("models").get("claude").getAsString());
         assertEquals("gpt-5.5", config.getAsJsonObject("models").get("codex").getAsString());
     }
 
@@ -134,6 +134,33 @@ public class CodemossSettingsServiceCommitAiConfigTest {
     }
 
     @Test
+    public void shouldMigratePersistedRetiredClaudeModelOnRead() throws Exception {
+        // A config saved while the default was the (now retired) claude-sonnet-4-6
+        // would pin Commit AI to a dead model forever - every generation then fails
+        // with an empty response (#1693). Reading must self-heal the stored id.
+        Path tempHome = Files.createTempDirectory("commit-ai-retired-home");
+        useTemporaryHomeDirectory(tempHome);
+        writeConfig(tempHome, "claude-a", "");
+
+        // Persist the retired id directly into the stored config, as an older
+        // plugin version would have written it.
+        JsonObject config = new JsonObject();
+        JsonObject commitAi = new JsonObject();
+        JsonObject models = new JsonObject();
+        models.addProperty("claude", "claude-sonnet-4-6");
+        commitAi.add("models", models);
+        config.add("commitAi", commitAi);
+        JsonObject root = readConfigJson(tempHome);
+        root.add("commitAi", config.get("commitAi"));
+        writeConfigJson(tempHome, root);
+
+        CodemossSettingsService service = new CodemossSettingsService();
+        JsonObject resolved = invokeGetCommitAiConfig(service);
+
+        assertEquals("claude-sonnet-5", resolved.getAsJsonObject("models").get("claude").getAsString());
+    }
+
+    @Test
     public void shouldNotMutatePromptEnhancerConfigWhenSavingCommitAiConfig() throws Exception {
         Path tempHome = Files.createTempDirectory("commit-ai-isolated-home");
         useTemporaryHomeDirectory(tempHome);
@@ -142,7 +169,7 @@ public class CodemossSettingsServiceCommitAiConfigTest {
         installSdk(tempHome, "codex-sdk", "@openai/codex-sdk", "0.117.0");
 
         CodemossSettingsService service = new CodemossSettingsService();
-        invokeSetPromptEnhancerConfig(service, "claude", "claude-opus-4-6", "gpt-5.4");
+        invokeSetPromptEnhancerConfig(service, "claude", "claude-opus-4-8", "gpt-5.4");
 
         invokeSetCommitAiConfig(service, "codex", "claude-opus-4-8", "gpt-5.5");
 
@@ -150,7 +177,7 @@ public class CodemossSettingsServiceCommitAiConfigTest {
         JsonObject commitAiConfig = invokeGetCommitAiConfig(service);
 
         assertEquals("claude", promptEnhancerConfig.get("provider").getAsString());
-        assertEquals("claude-opus-4-6", promptEnhancerConfig.getAsJsonObject("models").get("claude").getAsString());
+        assertEquals("claude-opus-4-8", promptEnhancerConfig.getAsJsonObject("models").get("claude").getAsString());
         assertEquals("gpt-5.4", promptEnhancerConfig.getAsJsonObject("models").get("codex").getAsString());
 
         assertEquals("codex", commitAiConfig.get("provider").getAsString());
@@ -264,6 +291,20 @@ public class CodemossSettingsServiceCommitAiConfigTest {
         Files.writeString(
                 tempHome.resolve(".codemoss").resolve("config.json"),
                 config.toString()
+        );
+    }
+
+    /** Read the stored config JSON for direct manipulation (e.g. injecting retired models). */
+    private JsonObject readConfigJson(Path tempHome) throws Exception {
+        String raw = Files.readString(tempHome.resolve(".codemoss").resolve("config.json"));
+        return com.google.gson.JsonParser.parseString(raw).getAsJsonObject();
+    }
+
+    /** Write a complete config JSON back to disk. */
+    private void writeConfigJson(Path tempHome, JsonObject root) throws Exception {
+        Files.writeString(
+                tempHome.resolve(".codemoss").resolve("config.json"),
+                root.toString()
         );
     }
 

--- a/src/test/java/com/github/claudecodegui/settings/CodemossSettingsServicePromptEnhancerConfigTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/CodemossSettingsServicePromptEnhancerConfigTest.java
@@ -43,7 +43,7 @@ public class CodemossSettingsServicePromptEnhancerConfigTest {
         assertEquals("auto", config.get("resolutionSource").getAsString());
         assertTrue(config.getAsJsonObject("availability").get("claude").getAsBoolean());
         assertTrue(config.getAsJsonObject("availability").get("codex").getAsBoolean());
-        assertEquals("claude-sonnet-4-6", config.getAsJsonObject("models").get("claude").getAsString());
+        assertEquals("claude-sonnet-5", config.getAsJsonObject("models").get("claude").getAsString());
         assertEquals("gpt-5.5", config.getAsJsonObject("models").get("codex").getAsString());
         // Same CLI set as the main chat selector
         assertEquals("grok", config.getAsJsonObject("models").get("grok").getAsString());
@@ -140,7 +140,7 @@ public class CodemossSettingsServicePromptEnhancerConfigTest {
 
         CodemossSettingsService service = new CodemossSettingsService();
         JsonObject models = new JsonObject();
-        models.addProperty("claude", "claude-sonnet-4-6");
+        models.addProperty("claude", "claude-sonnet-5");
         models.addProperty("codex", "gpt-5.5");
         models.addProperty("grok", "grok");
 


### PR DESCRIPTION
## Summary

Fixes #1693 - Generate Commit Message fails with `java.lang.RuntimeException: Claude commit response is empty` (also affects Prompt Enhance).

### Root Cause

Commit AI / Prompt Enhancer defaulted the Claude provider to **`claude-sonnet-4-6`**, which is retired (the same model family migrated for the chat path in #1678). Anyone who never changed the Commit AI model had that dead id persisted into their saved config (`commitAi.models.claude`). The default-constant change alone is not enough, because persisted configs are read back as-is, so every generation kept hitting the dead model:

- request pinned to a retired model -> the relay/API returns an error or empty body
- `commit-message.js` sees no streamed text -> throws `Claude commit response is empty`

This matches the reporter's observation: after importing a working model via Provider Management (so a live mapped model is used), generation succeeds.

### Fix

- `CodemossSettingsService`: Commit AI / Prompt Enhancer Claude defaults now `claude-sonnet-5` (live model)
- `getNormalizedAiFeatureModels`: self-heal persisted retired Claude model ids **on read** via `SessionState.normalizeRetiredModelId` (the exact same mapping used for chat tab restore in #1678: sonnet-4-6 / sonnet-4-7 -> sonnet-5, `[1m]` suffix preserved)
- `SessionState.normalizeRetiredModelId` made `public` for reuse (logic unchanged)
- `prompt-enhancer.js`: JS-side default config updated to `claude-sonnet-5` to stay consistent
- Tests: default assertions updated + new regression test that injects the retired id into a stored config and asserts it reads back as `claude-sonnet-5`

### Before / After

| Stored config `commitAi.models.claude` | Before | After |
|---|---|---|
| `claude-sonnet-4-6` (legacy persisted) | dead model -> empty response | migrated to `claude-sonnet-5` |
| `claude-sonnet-4-7[1m]` (legacy persisted) | dead model | migrated to `claude-sonnet-5[1m]` |
| user-chosen live/custom model | unchanged | unchanged |
| no saved config | default `claude-sonnet-4-6` (dead) | default `claude-sonnet-5` |

### Backward Compatibility

- Only retired Claude ids are rewritten; all other models (custom relay ids, codex, CLI providers) pass through unchanged
- The on-read self-heal does not rewrite the persisted config file; it only returns the migrated id for this generation
- Provider availability/resolution logic untouched

Closes #1693