### PR TITLE
fix(dsh): preserve configured model in picker

### DIFF
--- a/ai-bridge/services/dsh/models-service.js
+++ b/ai-bridge/services/dsh/models-service.js
@@ -7,25 +7,55 @@
 import { connectExisting, runtimeSettingsFromEnv } from './supervisor.js';
 import { defaultDshModel, flattenLlmModels, loadModels } from './session.js';
 
+function withDefaultModel(models, defaultModel) {
+  if (!defaultModel || models.some((model) => model.id === defaultModel)) {
+    return models;
+  }
+  const [provider = 'unknown', ...modelParts] = defaultModel.split('/');
+  const modelId = modelParts.join('/');
+  if (!modelId) {
+    return models;
+  }
+  return [
+    {
+      id: defaultModel,
+      label: `${provider} / ${modelId}`,
+      description: provider,
+    },
+    ...models,
+  ];
+}
+
+function configuredDefaultFromDescribe(describe) {
+  const provider = describe && typeof describe.provider === 'string' ? describe.provider : '';
+  const model = describe && typeof describe.model === 'string' ? describe.model : '';
+  return provider && model ? `${provider}/${model}` : null;
+}
+
 export async function listModels() {
   const settings = runtimeSettingsFromEnv();
+  let configuredDefaultModel = null;
   try {
     const { client, describe } = await connectExisting(settings);
+    configuredDefaultModel = configuredDefaultFromDescribe(describe);
     const catalog = await loadModels(client);
-    const models = flattenLlmModels(catalog);
+    const defaultModel = defaultDshModel(catalog, describe);
+    const models = withDefaultModel(flattenLlmModels(catalog), defaultModel);
     console.log(JSON.stringify({
       success: true,
       provider: 'dsh',
-      defaultModel: defaultDshModel(catalog, describe),
+      defaultModel,
       models,
     }));
   } catch (error) {
-    // Host down / CLI missing: empty catalog + error for diagnostics. The
-    // webview falls back to its static entry and the settings card shows why.
+    // Host down / CLI missing: preserve the configured default from
+    // host.describe when the probe reached a live host before failing. The
+    // webview otherwise keeps its static Auto entry while showing why no
+    // full catalog is available.
     console.log(JSON.stringify({
       success: true,
       provider: 'dsh',
-      defaultModel: null,
+      defaultModel: configuredDefaultModel,
       models: [],
       error: error.message,
     }));


### PR DESCRIPTION
## What
Fixes the DSH model picker dropping the model configured in the DeepSeek Harness Web UI when the runtime catalog omits that exact route.

## How
- Resolve the configured provider/model from host.describe.
- Insert the configured route at the top of the picker if llm.models does not advertise it.
- Preserve the configured default even when the catalog request fails, while retaining the diagnostic error.