### PR TITLE
feat(dsh): add agent preset switching

### DIFF
--- a/ai-bridge/channels/dsh-channel.js
+++ b/ai-bridge/channels/dsh-channel.js
@@ -34,6 +34,7 @@ export async function handleDshCommand(command, args, stdinData) {
           model: stdinData.model || '',
           reasoningEffort: stdinData.reasoningEffort || '',
           attachments: stdinData.attachments || [],
+          preset: stdinData.preset || '',
         });
       } else {
         await dshSendMessage({
@@ -43,6 +44,7 @@ export async function handleDshCommand(command, args, stdinData) {
           model: args[3],
           reasoningEffort: args[4],
           attachments: [],
+          preset: '',
         });
       }
       break;

--- a/ai-bridge/services/dsh/message-service.js
+++ b/ai-bridge/services/dsh/message-service.js
@@ -332,6 +332,7 @@ function settlePendingBridges(pendingBridges) {
  * @param {string} [options.model] "<provider>/<model>" or empty for host default
  * @param {string} [options.reasoningEffort]
  * @param {Array} [options.attachments] base64 {fileName, mediaType, data}
+ * @param {string} [options.preset] DSH agent preset id ('' = default composition)
  */
 export async function sendMessage(options = {}) {
   const {
@@ -341,9 +342,12 @@ export async function sendMessage(options = {}) {
     model = '',
     reasoningEffort = '',
     attachments = [],
+    preset = '',
   } = options;
 
   const settings = runtimeSettingsFromEnv();
+  // Scope the preset to this turn; do not mutate process.env across tabs.
+  settings.dshPreset = preset;
   const workCwd = cwd && cwd !== 'undefined' && cwd !== 'null' ? cwd : process.cwd();
 
   const session = await ensureSession(settings, workCwd, incomingSessionId);

--- a/ai-bridge/services/dsh/preset-overlay.js
+++ b/ai-bridge/services/dsh/preset-overlay.js
@@ -1,0 +1,487 @@
+/**
+ * DSH agent-preset → headless patch overlay conversion.
+ *
+ * The DeepSeek Harness web app offers four agent presets (标准/极简/PTC/创造)
+ * that are composed per-session by the `dsh-agent-presets` plugin. The CC GUI
+ * dsh integration runs `dsh --profile headless`, whose base composition ships
+ * the full standard toolset and has no `agent-presets` row — so the presets
+ * are NOT available to it out of the box.
+ *
+ * This module emulates preset mounting by converting a preset's
+ * `agent.cordis.yml` composition into a `--patch` overlay that the headless
+ * profile can apply:
+ *
+ * - Rows whose id already exists in the headless base tree are emitted as
+ *   plain patch entries (override the base row, last-wins).
+ * - Rows with new ids are wrapped in an `insert:` block (the loader drops
+ *   plain entries with unknown ids — `--patch` only patches known rows).
+ * - The `minimal` preset additionally emits `disabled: true` overrides for the
+ *   base capability rows it is defined to remove, so the agent really ends up
+ *   with only its persistent shell + str-replace-editor.
+ *
+ * The base-row id set is discovered once per process via
+ * `dsh --profile headless --dump-config` and cached, so per-message spawns
+ * stay cheap after the first run.
+ */
+
+import { spawnSync } from 'child_process';
+import { homedir } from 'os';
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { enrichPathWithBinDirs, commonCliBinDirs } from '../../utils/cli-path.js';
+
+/**
+ * The shipped DSH agent presets plus user-installed ones curated by the CC
+ * GUI (they get localized labels/descriptions on the frontend). Ids =
+ * directory names under the dsh installation (config/agent-presets/<id>) or
+ * under the user preset root (<dshHome>/.agent-presets/<id>, e.g. the
+ * dsh-routing-suite router-standard preset).
+ *
+ * Any OTHER preset the user drops into <dshHome>/.agent-presets/ is picked
+ * up dynamically via {@link discoverUserPresetIds} — no code change needed
+ * (see {@link getKnownDshPresetIds} / {@link isKnownDshPresetId}).
+ */
+export const DSH_PRESET_IDS = ['standard', 'code', 'minimal', 'cordis', 'router-standard'];
+
+/**
+ * Discover user-installed preset ids under <dshHome>/.agent-presets/<id>/.
+ *
+ * dshHome is `${DSH_HOME:-$HOME/.dsh}` — the same root the
+ * `dsh-agent-presets` plugin scans, so anything the DSH web app can select
+ * (e.g. the dsh-routing-suite router-standard/router-flash presets) is found
+ * here too. A directory counts as a preset when it ships an
+ * `agent.cordis.yml` composition. Missing/unreadable roots yield an empty
+ * list. Scanned on every call so presets installed while the IDE is running
+ * take effect on the next send.
+ *
+ * @returns {string[]} sorted preset ids
+ */
+export function discoverUserPresetIds() {
+  const dshHome = process.env.DSH_HOME || join(homedir(), '.dsh');
+  const root = join(dshHome, '.agent-presets');
+  const ids = [];
+  try {
+    for (const dirent of readdirSync(root, { withFileTypes: true })) {
+      if (!dirent.isDirectory()) continue;
+      try {
+        if (existsSync(join(root, dirent.name, 'agent.cordis.yml'))) {
+          ids.push(dirent.name);
+        }
+      } catch {
+        // Unreadable subdir — skip.
+      }
+    }
+  } catch {
+    // Root missing or unreadable — no user presets.
+  }
+  return ids.sort();
+}
+/**
+ * All preset ids the CC GUI accepts: the shipped/curated set plus whatever
+ * the user has installed under <dshHome>/.agent-presets/ (deduplicated).
+ *
+ * @returns {string[]}
+ */
+export function getKnownDshPresetIds() {
+  return [...new Set([...DSH_PRESET_IDS, ...discoverUserPresetIds()])];
+}
+
+/**
+ * Whether a preset id is known to the CC GUI (shipped, curated, or
+ * user-installed under <dshHome>/.agent-presets/).
+ *
+ * @param {string} presetId
+ * @returns {boolean}
+ */
+export function isKnownDshPresetId(presetId) {
+  return typeof presetId === 'string' && presetId !== '' && getKnownDshPresetIds().includes(presetId);
+}
+
+/**
+ * Headless base rows that the `minimal` preset is defined to NOT have (the
+ * standard toolset). The preset file only adds its two tools; emulating
+ * "minimal" on top of the full headless base requires disabling these rows.
+ * Curated from the headless bundle composition; unknown ids are skipped.
+ */
+const MINIMAL_DISABLED_BASE_IDS = [
+  'agent-instructions',
+  'tool-bash',
+  'tool-pwsh',
+  'tool-jobs',
+  'tool-fs',
+  'tool-fs-search',
+  'tool-skill',
+  'skill',
+  'skill-filesystem',
+  'skill-badge',
+  'tool-goal',
+  'command-goal',
+  'plan-mode',
+  'compaction-basic',
+  'command-compact',
+  'tool-result-pruner',
+  'subagent',
+  'subagent-spawn-in-process',
+  'subagent-fork-in-process',
+  'tool-subagent-control',
+  'tool-subagent-list-agents',
+  'tool-subagent',
+  'tool-subagent-fork',
+  'tool-subagent-report',
+  'workflow-worker-thread',
+  'tool-workflow',
+  'tool-ralph',
+  'tool-todo',
+  'tool-web',
+];
+
+/** Cached headless base row ids (Set). */
+let cachedBaseIds = null;
+
+function logDebug(...args) {
+  console.error('[DEBUG][Dsh][Preset]', ...args);
+}
+
+/**
+ * Parse a preset's `agent.cordis.yml` into top-level entry blocks.
+ *
+ * A block starts at a column-0 `- ` line and runs until the next column-0
+ * `- ` line. Pure column-0 comment lines are skipped. Returns
+ * `[{ id: string|null, block: string[] }]` — `id` is the entry's 2-space
+ * indented `id:` value, or null when the block has none.
+ *
+ * @param {string} text
+ * @returns {Array<{ id: string|null, block: string[] }>}
+ */
+export function parsePresetEntries(text) {
+  const lines = String(text || '').split(/\r?\n/);
+  const entries = [];
+  let current = null;
+  for (const line of lines) {
+    if (/^- /.test(line)) {
+      if (current) entries.push(current);
+      current = { id: null, block: [line] };
+      continue;
+    }
+    if (current) {
+      current.block.push(line);
+      continue;
+    }
+    // Lines before the first entry (file header comments) are dropped.
+  }
+  if (current) entries.push(current);
+  for (const entry of entries) {
+    for (const line of entry.block) {
+      // `- id: persona` (id inline with the list dash) or `  id: persona`.
+      const inline = /^- id: (\S+)/.exec(line);
+      const own = /^ {2}id: (\S+)/.exec(line);
+      if (inline || own) {
+        entry.id = (inline || own)[1];
+        break;
+      }
+    }
+  }
+  return entries;
+}
+
+/**
+ * Extract the persona text from a preset `persona` entry block.
+ *
+ * The presets declare their persona as
+ * `- id: persona / name: '@deepseek-ai/dsh-persona' / config: { text: <scalar> }`.
+ * The headless base has no `persona` row — it owns `system-prompt` with
+ * `config.persona` — and inserting a second persona plugin row makes the
+ * system-prompt registry throw (`deployment:persona already registered`), so
+ * the text is remapped onto the `system-prompt` row instead.
+ *
+ * @param {string[]} block
+ * @returns {string|null} the persona text, or null when the block has none
+ */
+export function extractPersonaText(block) {
+  const textIdx = block.findIndex((line) => /^ {4}text: /.test(line));
+  if (textIdx < 0) return null;
+  const header = block[textIdx];
+  const inline = /^ {4}text: (.+)$/.exec(header);
+  if (inline && !/^(>-|>\||\|-|\|)/.test(inline[1])) {
+    return inline[1].trim();
+  }
+  // Multi-line scalar: content lines follow at ≥6 spaces; the style tag
+  // (`>-` folded / `|-` literal) is preserved.
+  const style = /^ {4}text: (\|[-+]?|>[-+]?)/.exec(header);
+  const styleTag = style ? style[1] : '>-';
+  const content = [];
+  for (let i = textIdx + 1; i < block.length; i++) {
+    const line = block[i];
+    if (/^ {2}\S/.test(line) && !/^ {4}\S/.test(line)) break; // next key at 2-space indent
+    if (line.trim() === '' || /^ {6}/.test(line)) {
+      content.push(line.replace(/^ {6}/, ''));
+    } else {
+      break;
+    }
+  }
+  if (content.length === 0) return null;
+  return `${styleTag}\n${content.map((l) => (l === '' ? '' : `      ${l}`)).join('\n')}`;
+}
+
+/**
+ * Preset-specific conversion tweaks for the headless base.
+ *
+ * - `minimal`: its `filesystem` group embeds a `str-replace-editor` entry, but
+ *   the headless base already registers the `str_replace_editor` tool — a
+ *   second registration throws. The base copy is kept (it is the same tool).
+ * - `cordis`: `tool-cordis` waits for host services (`dynamicCordisRunner`,
+ *   `cordisInspect`) that the headless host composition does not provide, so
+ *   the row can never activate and would fail the whole boot. It is dropped;
+ *   the rest of the preset (persona, skills, standard toolset) still applies.
+ *
+ * @param {string} presetId
+ * @returns {{ dropEntryIds?: string[], stripNestedIds?: string[] }}
+ */
+function presetOverlayOptions(presetId) {
+  if (presetId === 'minimal') return { stripNestedIds: ['str-replace-editor'] };
+  if (presetId === 'cordis') return { dropEntryIds: ['tool-cordis'] };
+  return {};
+}
+
+/**
+ * Remove nested entries (4-space indented `- id:` lines inside a group's
+ * `config:`) whose id is listed, together with their sub-lines.
+ *
+ * @param {string[]} block
+ * @param {Set<string>} stripIds
+ * @returns {string[]}
+ */
+function stripNestedEntryLines(block, stripIds) {
+  const out = [];
+  let skipping = false;
+  for (const line of block) {
+    const nested = /^ {4}- (?:id: )?(\S+)/.exec(line);
+    if (nested && stripIds.has(nested[1])) {
+      skipping = true;
+      continue;
+    }
+    if (skipping) {
+      // Nested entry body lines are indented ≥6 spaces; a 4-space `- ` (next
+      // sibling) or a 2-space key (group keys like `isolate:`) ends the skip.
+      if (/^ {4}- /.test(line) || /^ {2}\S/.test(line)) skipping = false;
+      else continue;
+    }
+    out.push(line);
+  }
+  return out;
+}
+
+/**
+ * Build the patch overlay text for a preset against a known base id set.
+ *
+ * Conversion rules (headless base owns the full standard toolset at root):
+ * - `persona` → override the base `system-prompt` row's persona text (the
+ *   preset persona plugin cannot be inserted — see {@link extractPersonaText}).
+ * - Rows whose id already exists in the base tree → plain patch entries
+ *   (override, last-wins).
+ * - Rows with new ids → wrapped in an `insert:` block (the loader drops plain
+ *   entries with unknown ids).
+ * - `minimal` → `disabled: true` overrides for the base capability rows it is
+ *   defined to remove.
+ * - `cordis` → the `tool-cordis` row is dropped (host services missing).
+ *
+ * @param {object} options
+ * @param {string} options.presetId - a known preset id (see {@link isKnownDshPresetId})
+ * @param {string} options.presetText - raw agent.cordis.yml content
+ * @param {Set<string>} options.baseIds - headless base row ids
+ * @param {string} [options.presetDir] - absolute path of the preset dir; when
+ *   set, `baseUrl`-relative config values (the cordis preset's skill roots)
+ *   are rewritten to absolute paths into that directory.
+ * @returns {string} YAML entries to append to a `--patch` overlay file
+ */
+export function buildPresetOverlay({ presetId, presetText, baseIds, presetDir = '' }) {
+  const { dropEntryIds = [], stripNestedIds = [] } = presetOverlayOptions(presetId);
+  const dropIds = new Set(dropEntryIds);
+  const stripIds = new Set(stripNestedIds);
+  const presetDirUrl = presetDir ? `file:///${presetDir.replace(/\\/g, '/')}/` : '';
+  const entries = parsePresetEntries(presetText);
+  const overrides = [];
+  const inserts = [];
+  for (const entry of entries) {
+    if (entry.id !== null && dropIds.has(entry.id)) {
+      continue;
+    }
+    let block = entry.block;
+    if (stripIds.size > 0) {
+      block = stripNestedEntryLines(block, stripIds);
+    }
+    if (presetDirUrl) {
+      block = block.map((line) => {
+        // Relative plugin rows (`name: ./router-bootstrap.mjs`) in user
+        // presets resolve against the headless PROFILE dir, not the patch
+        // file — the loader would fail to find them. Rewrite to absolute
+        // file:// URLs into the preset dir (the router-standard preset ships
+        // its local plugin files next to the composition; the plugin's own
+        // ESM imports then resolve relative to that URL).
+        const relName = /^(\s*)name: (\.\/\S+)\s*$/.exec(line);
+        if (relName) {
+          return `${relName[1]}name: ${presetDirUrl}${relName[2].slice(2)}`;
+        }
+        // `- !!js "... fileURLToPath(new URL('skills/', baseUrl))"` — emit the
+        // resolved path directly instead of a JS expression (a URL string
+        // inside the quoted expression would break the YAML scalar).
+        if (line.includes('skills/') && line.includes('baseUrl')) {
+          const indent = /^\s*/.exec(line)[0];
+          return `${indent}- ${presetDir.replace(/\\/g, '/')}/skills`;
+        }
+        return line.replace(/\bbaseUrl\b/g, JSON.stringify(presetDirUrl));
+      });
+    }
+    if (entry.id === 'persona') {
+      const personaText = extractPersonaText(block);
+      if (personaText) {
+        overrides.push(
+          `- id: system-prompt\n  config:\n    persona: ${personaText}`
+        );
+      }
+      continue;
+    }
+    if (entry.id !== null && baseIds.has(entry.id)) {
+      overrides.push(block.join('\n'));
+    } else {
+      inserts.push(block);
+    }
+  }
+
+  const parts = [];
+  if (overrides.length > 0) {
+    parts.push(overrides.join('\n'));
+  }
+  if (inserts.length > 0) {
+    const nested = inserts.flatMap((block) => block.map((line) => `    ${line}`));
+    parts.push(`- insert:\n${nested.join('\n')}`);
+  }
+
+  if (presetId === 'minimal') {
+    const disabled = MINIMAL_DISABLED_BASE_IDS.filter((id) => baseIds.has(id));
+    if (disabled.length > 0) {
+      parts.push(disabled.map((id) => `- id: ${id}\n  disabled: true`).join('\n'));
+    }
+  }
+
+  return parts.join('\n');
+}
+
+/**
+ * Locate the preset directory in the dsh installation or the user preset root.
+ *
+ * The npm global install layout is `<prefix>/node_modules/@deepseek-ai/dsh/`
+ * with `config/agent-presets/<id>/`. User-installed presets (e.g. the
+ * dsh-routing-suite router-standard preset) live under
+ * `<dshHome>/.agent-presets/<id>/` where dshHome is `${DSH_HOME:-$HOME/.dsh}`
+ * — the same root the `dsh-agent-presets` plugin scans, so anything the DSH
+ * web app can select is found here too. From the resolved spawn command:
+ * - Windows `.cmd` shim: `resolveDshSpawnCommand` yields `node <pkgRoot>/lib/bin.js`
+ *   → pkgRoot = dirname(dirname(script)).
+ * - POSIX: try `dirname(dirname(bin))` (bin under `<pkgRoot>/bin/`) and the
+ *   npm prefix layout `<prefix>/lib/node_modules/@deepseek-ai/dsh`.
+ *
+ * @param {string} presetId
+ * @param {{ bin: string, args: string[], shell: boolean }} spawnCmd
+ * @returns {string|null} absolute path of the preset directory
+ */
+export function resolveDshPresetDir(presetId, spawnCmd) {
+  if (!isKnownDshPresetId(presetId)) return null;
+  const candidates = [];
+  const scriptPath = spawnCmd && Array.isArray(spawnCmd.args) && spawnCmd.args[0]
+    ? spawnCmd.args[0]
+    : null;
+  if (scriptPath && /[\\/]lib[\\/][^\\/]+\.js$/.test(scriptPath)) {
+    // <pkgRoot>/lib/<file>.js → pkgRoot = dirname(dirname(script))
+    candidates.push(join(dirname(dirname(scriptPath)), 'config', 'agent-presets', presetId));
+  }
+  const bin = spawnCmd ? spawnCmd.bin : '';
+  if (bin) {
+    candidates.push(join(dirname(dirname(bin)), 'config', 'agent-presets', presetId));
+    // npm global layout on POSIX: <prefix>/lib/node_modules/@deepseek-ai/dsh
+    candidates.push(join(dirname(dirname(bin)), 'lib', 'node_modules', '@deepseek-ai', 'dsh', 'config', 'agent-presets', presetId));
+  }
+  // User preset root: <dshHome>/.agent-presets/<id> (shipped presets shadow
+  // same-named home directories, matching dsh-agent-presets' precedence).
+  const dshHome = process.env.DSH_HOME || join(homedir(), '.dsh');
+  candidates.push(join(dshHome, '.agent-presets', presetId));
+  for (const candidate of candidates) {
+    try {
+      if (existsSync(join(candidate, 'agent.cordis.yml'))) return candidate;
+    } catch {
+      // fall through
+    }
+  }
+  return null;
+}
+
+/**
+ * Discover the headless base row ids (cached per process).
+ *
+ * @param {{ bin: string, args: string[], shell: boolean }} spawnCmd
+ * @param {{ refresh?: boolean }} [options]
+ * @returns {Set<string>|null} base row ids, or null when the dump failed
+ */
+export function getHeadlessBaseIds(spawnCmd, options = {}) {
+  if (cachedBaseIds && !options.refresh) return cachedBaseIds;
+  const bin = spawnCmd ? spawnCmd.bin : '';
+  if (!bin) return null;
+  const env = { ...process.env };
+  const home = process.env.HOME || process.env.USERPROFILE || homedir();
+  enrichPathWithBinDirs(env, commonCliBinDirs(home));
+  try {
+    const result = spawnSync(bin, [...(spawnCmd.args || []), '--profile', 'headless', '--dump-config'], {
+      encoding: 'utf8',
+      env,
+      timeout: 60_000,
+      maxBuffer: 32 * 1024 * 1024,
+      shell: spawnCmd.shell === true,
+    });
+    if (result.error || result.status !== 0) {
+      logDebug('dump-config failed:', result.error?.message || `status ${result.status}`);
+      return null;
+    }
+    const ids = new Set();
+    const output = String(result.stdout || '');
+    for (const line of output.split(/\r?\n/)) {
+      const m = /^\s*- id: (\S+)/.exec(line);
+      if (m) ids.add(m[1]);
+    }
+    cachedBaseIds = ids;
+    return ids;
+  } catch (error) {
+    logDebug('dump-config threw:', error?.message || error);
+    return null;
+  }
+}
+
+/**
+ * Resolve a preset's agent.cordis.yml path (null when unavailable).
+ *
+ * @param {string} presetId
+ * @param {{ bin: string, args: string[], shell: boolean }} spawnCmd
+ * @returns {string|null}
+ */
+export function resolveDshPresetFile(presetId, spawnCmd) {
+  const dir = resolveDshPresetDir(presetId, spawnCmd);
+  if (!dir) return null;
+  return join(dir, 'agent.cordis.yml');
+}
+
+/**
+ * Read a preset's composition text (null when unavailable).
+ *
+ * @param {string} presetId
+ * @param {{ bin: string, args: string[], shell: boolean }} spawnCmd
+ * @returns {string|null}
+ */
+export function readDshPresetFile(presetId, spawnCmd) {
+  const file = resolveDshPresetFile(presetId, spawnCmd);
+  if (!file) return null;
+  try {
+    return readFileSync(file, 'utf8');
+  } catch (error) {
+    logDebug('failed to read preset file', file, error?.message || error);
+    return null;
+  }
+}

--- a/ai-bridge/services/dsh/supervisor.js
+++ b/ai-bridge/services/dsh/supervisor.js
@@ -19,18 +19,30 @@ import {
   resolveCliSpawn,
   resolveWindowsSpawnableBin,
 } from '../../utils/cli-path.js';
+import {
+  buildPresetOverlay,
+  getHeadlessBaseIds,
+  isKnownDshPresetId,
+  readDshPresetFile,
+  resolveDshPresetDir,
+} from './preset-overlay.js';
 import { DshHostClient, DshTransportError, originFromHostPort, probeDescribe } from './host.js';
 
 const SPAWN_READY_TIMEOUT_MS = process.platform === 'win32' ? 45_000 : 20_000;
 const SPAWN_POLL_MS = 250;
 const VERSION_PROBE_TIMEOUT_MS = 5_000;
 
+function logDebug(...args) {
+  console.error('[DEBUG][DSH]', ...args);
+}
+
 export function runtimeSettingsFromEnv(env = process.env) {
   const host = (env.DSH_HOST || '').trim() || '127.0.0.1';
   const port = Number(env.DSH_PORT) > 0 ? Number(env.DSH_PORT) : 3080;
   const autoStart = (env.DSH_AUTO_START || '').trim().toLowerCase() !== 'false';
   const binPath = (env.DSH_BIN || '').trim() || null;
-  return { binPath, host, port, autoStart };
+  const dshPreset = (env.DSH_PRESET || '').trim();
+  return { binPath, host, port, autoStart, dshPreset };
 }
 
 function stateFilePath() {
@@ -67,6 +79,20 @@ function removeStateFile() {
   } catch {
     // ignore
   }
+}
+
+function normalizeDshPreset(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function presetNeedsReload(remembered, requestedPreset) {
+  const requested = normalizeDshPreset(requestedPreset);
+  // State files written by older bridge versions have no preset field. They
+  // are known to be the default only when the caller also requests default.
+  if (!remembered || typeof remembered.preset !== 'string') {
+    return requested !== '';
+  }
+  return normalizeDshPreset(remembered.preset) !== requested;
 }
 
 function isPidAlive(pid) {
@@ -213,7 +239,7 @@ export function probeDshVersion(bin) {
   return 'unknown';
 }
 
-function spawnDshWeb(bin, host, port) {
+function spawnDshWeb(bin, host, port, preset = '') {
   const args = ['web', '--host', host, '--port', String(port)];
   // One stable log next to the state file, truncated per spawn — avoids
   // accumulating dsh-web-spawn-*.log files in tmpdir.
@@ -230,6 +256,26 @@ function spawnDshWeb(bin, host, port) {
   const env = { ...process.env };
   const home = process.env.HOME || process.env.USERPROFILE || homedir();
   enrichPathWithBinDirs(env, [...dshHomeBinDirs(), ...commonCliBinDirs(home)]);
+  if (preset && isKnownDshPresetId(preset)) {
+    try {
+      const baseIds = getHeadlessBaseIds({ bin, args: [], shell: false });
+      const presetText = readDshPresetFile(preset, { bin, args: [], shell: false });
+      const presetDir = resolveDshPresetDir(preset, { bin, args: [], shell: false });
+      const overlay = presetText && baseIds
+        ? buildPresetOverlay({ presetId: preset, presetText, baseIds, presetDir: presetDir || '' })
+        : null;
+      if (overlay) {
+        const patchFile = join(dirname(stateFilePath()), `dsh-preset-${Date.now()}.patch`);
+        writeFileSync(patchFile, overlay, 'utf8');
+        args.push('--patch', patchFile);
+        logDebug(`preset=${preset} overlay=${overlay.length} chars`);
+      } else {
+        console.error(`[DEBUG][DSH] preset=${preset} skipped: composition unavailable`);
+      }
+    } catch (error) {
+      console.error(`[DEBUG][DSH] preset=${preset} failed: ${error?.message || error}`);
+    }
+  }
   const invocation = resolveCliSpawn(bin, args, {
     detached: true,
     stdio: ['ignore', logFd === 'ignore' ? 'ignore' : logFd, logFd === 'ignore' ? 'ignore' : logFd],
@@ -278,14 +324,40 @@ export async function connectExisting(settings) {
  */
 export async function ensureHost(settings) {
   const origin = originFromHostPort(settings.host, settings.port);
+  const remembered = readStateFile();
+  let existing = null;
+  let reloaded = false;
   try {
-    return await connectExisting(settings);
+    existing = await connectExisting(settings);
   } catch {
-    // host not up yet — fall through
+    // Host not up yet — fall through.
   }
 
-  const remembered = readStateFile();
-  if (remembered && remembered.origin === origin && isPidAlive(remembered.pid)) {
+  if (existing) {
+    const canReload = remembered
+      && remembered.origin === origin
+      && isPidAlive(remembered.pid)
+      && isDshHostProcess(remembered.pid, remembered.bin)
+      && presetNeedsReload(remembered, settings.dshPreset);
+    if (!canReload) {
+      return existing;
+    }
+
+    logDebug(
+      `reloading spawned host for preset change: ${normalizeDshPreset(remembered.preset) || 'default'} -> `
+      + `${normalizeDshPreset(settings.dshPreset) || 'default'}`
+    );
+    const stopped = await stopSpawnedHost(settings);
+    if (!stopped.success) {
+      throw new DshTransportError(`Failed to reload DSH host: ${stopped.error || 'stop failed'}`);
+    }
+    reloaded = stopped.stopped;
+    // The host was ours and is now stopped; fall through to spawn it with the
+    // requested preset. If it disappeared concurrently, the same path is safe.
+  }
+
+  const refreshedRemembered = readStateFile();
+  if (refreshedRemembered && refreshedRemembered.origin === origin && isPidAlive(refreshedRemembered.pid)) {
     try {
       const describe = await waitForDescribe(origin, SPAWN_READY_TIMEOUT_MS);
       return {
@@ -301,14 +373,19 @@ export async function ensureHost(settings) {
     }
   }
 
-  if (!settings.autoStart) {
+  if (!settings.autoStart && !reloaded) {
     throw new DshTransportError(
       `DSH host is not running at ${origin}. Start \`dsh web\` or enable auto-start.`
     );
   }
 
   const bin = resolveDshBin(settings.binPath);
-  const { child, logFile } = spawnDshWeb(bin, settings.host, settings.port);
+  const { child, logFile } = spawnDshWeb(
+    bin,
+    settings.host,
+    settings.port,
+    settings.dshPreset || '',
+  );
   writeStateFile({
     pid: child.pid,
     origin,
@@ -316,6 +393,7 @@ export async function ensureHost(settings) {
     port: settings.port,
     bin,
     logFile,
+    preset: normalizeDshPreset(settings.dshPreset),
     startedAt: new Date().toISOString(),
   });
 

--- a/src/main/java/com/github/claudecodegui/handler/DshPresetHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/DshPresetHandler.java
@@ -1,0 +1,38 @@
+package com.github.claudecodegui.handler;
+
+import com.github.claudecodegui.handler.core.HandlerContext;
+import com.github.claudecodegui.session.SessionState;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+
+public class DshPresetHandler {
+    private static final Logger LOG = Logger.getInstance(DshPresetHandler.class);
+
+    private static final Gson GSON = new Gson();
+    private final HandlerContext context;
+
+    public DshPresetHandler(HandlerContext context) {
+        this.context = context;
+    }
+
+    public void handleSetDshPreset(String content) {
+        try {
+            String preset = content;
+            if (content != null && !content.isEmpty()) {
+                JsonObject payload = GSON.fromJson(content, JsonObject.class);
+                if (payload != null && payload.has("preset") && !payload.get("preset").isJsonNull()) {
+                    preset = payload.get("preset").getAsString();
+                }
+            }
+            if (!SessionState.isValidDshPreset(preset)) {
+                return;
+            }
+            if (context.getSession() != null) {
+                context.getSession().getState().setDshPreset(preset.trim());
+            }
+        } catch (Exception e) {
+            LOG.warn("[DSH] Failed to set DSH agent preset: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/handler/SessionHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SessionHandler.java
@@ -124,6 +124,7 @@ public class SessionHandler extends BaseMessageHandler {
         String requestedPermissionMode = null;
         String requestedReasoningEffort = null;
         String requestedCodexFastMode = null;
+        String requestedDshPreset = null;
         try {
             Gson gson = new Gson();
             JsonObject payload = gson.fromJson(content, JsonObject.class);
@@ -171,6 +172,7 @@ public class SessionHandler extends BaseMessageHandler {
             if (payload != null && payload.has("codexFastMode") && !payload.get("codexFastMode").isJsonNull()) {
                 requestedCodexFastMode = payload.get("codexFastMode").getAsString();
             }
+            requestedDshPreset = extractDshPreset(payload);
         } catch (Exception e) {
             // If parsing fails, treat content as plain text (backward compatibility)
             LOG.debug("[SessionHandler] Message is plain text, not JSON: " + e.getMessage());
@@ -183,6 +185,7 @@ public class SessionHandler extends BaseMessageHandler {
         final String finalRequestedPermissionMode = requestedPermissionMode;
         final String finalRequestedReasoningEffort = requestedReasoningEffort;
         final String finalRequestedCodexFastMode = requestedCodexFastMode;
+        final String finalRequestedDshPreset = requestedDshPreset;
 
         CompletableFuture.runAsync(() -> {
             String currentWorkingDir = determineWorkingDirectory();
@@ -201,7 +204,8 @@ public class SessionHandler extends BaseMessageHandler {
 
             // [FIX] Pass agent prompt and file tags directly to session
             context.getSession().send(finalPrompt, finalAgentPrompt, finalFileTagPaths,
-                            finalRequestedPermissionMode, finalRequestedReasoningEffort, finalRequestedCodexFastMode)
+                            finalRequestedPermissionMode, finalRequestedReasoningEffort,
+                            finalRequestedCodexFastMode, finalRequestedDshPreset)
                 .thenRun(() -> {
                     // Claude now triggers success on actual stream_end callback.
                     // Codex has no stream_end event, keep success trigger at completion.
@@ -263,6 +267,7 @@ public class SessionHandler extends BaseMessageHandler {
             String requestedPermissionMode = null;
             String requestedReasoningEffort = null;
             String requestedCodexFastMode = null;
+            String requestedDshPreset = null;
             if (payload != null && payload.has("agent") && !payload.get("agent").isJsonNull()) {
                 JsonObject agent = payload.getAsJsonObject("agent");
                 if (agent.has("prompt") && !agent.get("prompt").isJsonNull()) {
@@ -302,9 +307,10 @@ public class SessionHandler extends BaseMessageHandler {
             if (payload != null && payload.has("codexFastMode") && !payload.get("codexFastMode").isJsonNull()) {
                 requestedCodexFastMode = payload.get("codexFastMode").getAsString();
             }
+            requestedDshPreset = extractDshPreset(payload);
 
             sendMessageWithAttachments(text, atts, agentPrompt, fileTagPaths, requestedPermissionMode,
-                    requestedReasoningEffort, requestedCodexFastMode);
+                    requestedReasoningEffort, requestedCodexFastMode, requestedDshPreset);
         } catch (Exception e) {
             LOG.error("[SessionHandler] 解析附件负载失败: " + e.getMessage(), e);
             handleSendMessage(content);
@@ -322,7 +328,8 @@ public class SessionHandler extends BaseMessageHandler {
         java.util.List<String> fileTagPaths,
         String requestedPermissionMode,
         String requestedReasoningEffort,
-        String requestedCodexFastMode
+        String requestedCodexFastMode,
+        String requestedDshPreset
     ) {
         // Version check (consistent with handleSendMessage)
         String nodeVersion = this.resolveNodeVersion();
@@ -346,6 +353,7 @@ public class SessionHandler extends BaseMessageHandler {
         final String finalRequestedPermissionMode = requestedPermissionMode;
         final String finalRequestedReasoningEffort = requestedReasoningEffort;
         final String finalRequestedCodexFastMode = requestedCodexFastMode;
+        final String finalRequestedDshPreset = requestedDshPreset;
 
         CompletableFuture.runAsync(() -> {
             String currentWorkingDir = determineWorkingDirectory();
@@ -363,7 +371,8 @@ public class SessionHandler extends BaseMessageHandler {
 
             // [FIX] Pass agent prompt and file tags directly to session
             context.getSession().send(prompt, attachments, finalAgentPrompt, finalFileTagPaths,
-                            finalRequestedPermissionMode, finalRequestedReasoningEffort, finalRequestedCodexFastMode)
+                            finalRequestedPermissionMode, finalRequestedReasoningEffort,
+                            finalRequestedCodexFastMode, finalRequestedDshPreset)
                 .thenRun(() -> {
                     // Claude now triggers success on actual stream_end callback.
                     // Codex has no stream_end event, keep success trigger at completion.
@@ -458,6 +467,14 @@ public class SessionHandler extends BaseMessageHandler {
             return null;
         }
         return payload.get("reasoningEffort").getAsString();
+    }
+
+    private String extractDshPreset(JsonObject payload) {
+        if (payload == null || !payload.has("dshPreset") || payload.get("dshPreset").isJsonNull()) {
+            return null;
+        }
+        String preset = payload.get("dshPreset").getAsString();
+        return SessionState.isValidDshPreset(preset) ? preset.trim() : null;
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
@@ -34,6 +34,7 @@ public class SettingsHandler extends BaseMessageHandler {
     private ThemeConfigService.RegisteredCallback themeCallbackHandle;
     private final CodexSubscriptionQuotaHandler codexSubscriptionQuotaHandler;
     private final TokenTrackerHandler tokenTrackerHandler;
+    private final DshPresetHandler dshPresetHandler;
 
     private static final String[] SUPPORTED_TYPES = {
         "get_mode",
@@ -42,6 +43,7 @@ public class SettingsHandler extends BaseMessageHandler {
         "set_provider",
         "set_reasoning_effort",
         "set_codex_fast_mode",
+        "set_dsh_preset",
         "get_node_path",
         "set_node_path",
         "get_claude_cli_path",
@@ -123,6 +125,7 @@ public class SettingsHandler extends BaseMessageHandler {
         this.projectConfigHandler = new ProjectConfigHandler(context);
         this.codexSubscriptionQuotaHandler = new CodexSubscriptionQuotaHandler(context);
         this.tokenTrackerHandler = new TokenTrackerHandler(context);
+        this.dshPresetHandler = new DshPresetHandler(context);
         // Register theme change listener to automatically notify frontend when IDE theme changes
         registerThemeChangeListener();
     }
@@ -179,6 +182,9 @@ public class SettingsHandler extends BaseMessageHandler {
                 return true;
             case "set_codex_fast_mode":
                 modelProviderHandler.handleSetCodexFastMode(content);
+                return true;
+            case "set_dsh_preset":
+                dshPresetHandler.handleSetDshPreset(content);
                 return true;
             // Node path
             case "get_node_path":

--- a/src/main/java/com/github/claudecodegui/provider/common/MarkerCliBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/MarkerCliBridge.java
@@ -153,7 +153,8 @@ public abstract class MarkerCliBridge extends BaseSDKBridge {
             String reasoningEffort,
             MessageCallback callback
     ) {
-        return sendMessage(channelId, message, sessionId, cwd, model, reasoningEffort, null, null, callback);
+        return sendMessage(channelId, message, sessionId, cwd, model, reasoningEffort,
+                null, null, null, callback);
     }
 
     /**
@@ -173,7 +174,8 @@ public abstract class MarkerCliBridge extends BaseSDKBridge {
             List<ClaudeSession.Attachment> attachments,
             MessageCallback callback
     ) {
-        return sendMessage(channelId, message, sessionId, cwd, model, reasoningEffort, attachments, null, callback);
+        return sendMessage(channelId, message, sessionId, cwd, model, reasoningEffort,
+                attachments, null, null, callback);
     }
 
     /**
@@ -192,6 +194,7 @@ public abstract class MarkerCliBridge extends BaseSDKBridge {
             String reasoningEffort,
             List<ClaudeSession.Attachment> attachments,
             String permissionMode,
+            String dshPreset,
             MessageCallback callback
     ) {
         JsonObject stdinInput = new JsonObject();
@@ -204,6 +207,9 @@ public abstract class MarkerCliBridge extends BaseSDKBridge {
         // fall back to an implicit default that ignores the UI mode selection.
         String mode = permissionMode != null && !permissionMode.isBlank() ? permissionMode.trim() : "default";
         stdinInput.addProperty("permissionMode", mode);
+        if (dshPreset != null) {
+            stdinInput.addProperty("preset", dshPreset);
+        }
         if (attachments != null && !attachments.isEmpty()) {
             stdinInput.add("attachments", buildAttachmentArray(attachments));
         }

--- a/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
@@ -449,7 +449,24 @@ public class ClaudeSession {
             String requestedReasoningEffort,
             String requestedCodexFastMode
     ) {
-        return send(input, null, agentPrompt, fileTagPaths, requestedPermissionMode, requestedReasoningEffort, requestedCodexFastMode);
+        return send(input, null, agentPrompt, fileTagPaths, requestedPermissionMode,
+                requestedReasoningEffort, requestedCodexFastMode, null);
+    }
+
+    /**
+     * Send a message with an optional DSH agent preset.
+     */
+    public CompletableFuture<Void> send(
+            String input,
+            String agentPrompt,
+            List<String> fileTagPaths,
+            String requestedPermissionMode,
+            String requestedReasoningEffort,
+            String requestedCodexFastMode,
+            String requestedDshPreset
+    ) {
+        return send(input, null, agentPrompt, fileTagPaths, requestedPermissionMode,
+                requestedReasoningEffort, requestedCodexFastMode, requestedDshPreset);
     }
 
     /**
@@ -518,6 +535,23 @@ public class ClaudeSession {
             String requestedReasoningEffort,
             String requestedCodexFastMode
     ) {
+        return send(input, attachments, agentPrompt, fileTagPaths, requestedPermissionMode,
+                requestedReasoningEffort, requestedCodexFastMode, null);
+    }
+
+    /**
+     * Send a message with attachments and an optional DSH agent preset.
+     */
+    public CompletableFuture<Void> send(
+            String input,
+            List<Attachment> attachments,
+            String agentPrompt,
+            List<String> fileTagPaths,
+            String requestedPermissionMode,
+            String requestedReasoningEffort,
+            String requestedCodexFastMode,
+            String requestedDshPreset
+    ) {
         lastTurnStartedAtMillis = System.currentTimeMillis();
         // Reset the manual-interrupt flag at the start of a new turn so that
         // a fresh send is not mistaken for a user-initiated stop.
@@ -531,6 +565,7 @@ public class ClaudeSession {
         final String finalRequestedPermissionMode = requestedPermissionMode;
         final String finalRequestedReasoningEffort = requestedReasoningEffort;
         final String finalRequestedCodexFastMode = requestedCodexFastMode;
+        final String finalRequestedDshPreset = requestedDshPreset;
 
         return launchClaude().thenCompose(chId -> {
             sendService.prepareContextCollector(contextCollector);
@@ -545,7 +580,8 @@ public class ClaudeSession {
                             finalFileTagPaths,
                             finalRequestedPermissionMode,
                             finalRequestedReasoningEffort,
-                            finalRequestedCodexFastMode
+                            finalRequestedCodexFastMode,
+                            finalRequestedDshPreset
                     )
             ).thenCompose(v -> syncUserMessageUuidsAfterSend());
         }).exceptionally(ex -> {

--- a/src/main/java/com/github/claudecodegui/session/SessionSendService.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionSendService.java
@@ -116,7 +116,8 @@ public class SessionSendService {
             List<String> fileTagPaths,
             String requestedPermissionMode,
             String requestedReasoningEffort,
-            String requestedCodexFastMode
+            String requestedCodexFastMode,
+            String requestedDshPreset
     ) {
         String agentPrompt = externalAgentPrompt;
         if (agentPrompt == null) {
@@ -176,6 +177,9 @@ public class SessionSendService {
         }
 
         if (cliBridges.containsKey(currentProvider) && !"grok".equals(currentProvider)) {
+            if ("dsh".equals(currentProvider) && requestedDshPreset != null) {
+                state.setDshPreset(requestedDshPreset);
+            }
             return sendToCliProvider(
                     currentProvider,
                     channelId,
@@ -451,6 +455,7 @@ public class SessionSendService {
                 effort,
                 attachments,
                 effectiveMode,
+                "dsh".equals(provider) ? state.getDshPreset() : null,
                 handler
         ).thenApply(result -> null);
     }

--- a/src/main/java/com/github/claudecodegui/session/SessionState.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionState.java
@@ -1,6 +1,7 @@
 package com.github.claudecodegui.session;
 
 
+import com.github.claudecodegui.util.PlatformUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -61,6 +62,40 @@ public class SessionState {
         return effort != null && VALID_REASONING_EFFORTS.contains(effort.trim());
     }
 
+    /**
+     * Check whether the given DSH agent preset id is recognized.
+     */
+    public static boolean isValidDshPreset(String preset) {
+        if (preset == null) {
+            return false;
+        }
+        String normalized = preset.trim();
+        return normalized.isEmpty()
+                || Set.of("standard", "code", "minimal", "cordis").contains(normalized)
+                || discoverUserDshPresetIds().contains(normalized);
+    }
+
+    public static List<String> discoverUserDshPresetIds() {
+        List<String> ids = new ArrayList<>();
+        String dshHome = System.getenv("DSH_HOME");
+        java.nio.file.Path dshRoot = dshHome != null && !dshHome.trim().isEmpty()
+                ? java.nio.file.Paths.get(dshHome.trim())
+                : java.nio.file.Paths.get(PlatformUtils.getHomeDirectory(), ".dsh");
+        java.nio.file.Path root = dshRoot.resolve(".agent-presets");
+        try (java.nio.file.DirectoryStream<java.nio.file.Path> stream =
+                     java.nio.file.Files.newDirectoryStream(root)) {
+            for (java.nio.file.Path entry : stream) {
+                if (java.nio.file.Files.isDirectory(entry)
+                        && java.nio.file.Files.isRegularFile(entry.resolve("agent.cordis.yml"))) {
+                    ids.add(entry.getFileName().toString());
+                }
+            }
+        } catch (Exception ignored) {
+        }
+        java.util.Collections.sort(ids);
+        return ids;
+    }
+
     // Session identifiers
     private volatile String sessionId;
     private volatile String channelId;
@@ -93,6 +128,7 @@ public class SessionState {
     private volatile String reasoningEffort = null;
     // Codex service tier: null = use Codex defaults, "fast" = Codex /fast.
     private volatile String codexServiceTier = null;
+    private volatile String dshPreset = "";
 
     // Slash commands — volatile for cross-thread visibility (same reason as permissionMode/model/provider)
     private volatile List<String> slashCommands = new ArrayList<>();
@@ -159,6 +195,10 @@ public class SessionState {
 
     public String getCodexServiceTier() {
         return codexServiceTier;
+    }
+
+    public String getDshPreset() {
+        return dshPreset;
     }
 
     public String getRuntimeSessionEpoch() {
@@ -281,6 +321,12 @@ public class SessionState {
 
     public void setCodexServiceTier(String codexServiceTier) {
         this.codexServiceTier = codexServiceTier;
+    }
+
+    public void setDshPreset(String preset) {
+        if (isValidDshPreset(preset)) {
+            this.dshPreset = preset.trim();
+        }
     }
 
     public void setRuntimeSessionEpoch(String runtimeSessionEpoch) {

--- a/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
@@ -9,6 +9,7 @@ import com.github.claudecodegui.provider.codex.CodexSDKBridge;
 import com.github.claudecodegui.provider.common.MarkerCliBridge;
 import java.util.Map;
 import com.github.claudecodegui.session.ClaudeSession;
+import com.github.claudecodegui.session.SessionState;
 import com.github.claudecodegui.startup.BridgePreloader;
 import com.github.claudecodegui.util.FontConfigService;
 import com.github.claudecodegui.util.HtmlLoader;
@@ -1310,7 +1311,10 @@ public class WebviewInitializer {
         String tabProvider = session != null ? session.getProvider() : null;
         String tabModel = session != null ? session.getModel() : null;
         String htmlWithTabState = htmlLoader.injectInitialTabState(htmlContent, tabProvider, tabModel);
-        return htmlLoader.injectPageContextBootstrap(htmlWithTabState);
+        String htmlWithDshPresets = htmlLoader.injectInitialDshPresets(
+                htmlWithTabState,
+                SessionState.discoverUserDshPresetIds());
+        return htmlLoader.injectPageContextBootstrap(htmlWithDshPresets);
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/util/HtmlLoader.java
+++ b/src/main/java/com/github/claudecodegui/util/HtmlLoader.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
 
 /**
  * HTML loader.
@@ -124,6 +125,41 @@ public class HtmlLoader {
             }
         } catch (Exception e) {
             LOG.error("Failed to inject initial tab state: " + e.getMessage(), e);
+        }
+        return html;
+    }
+
+    /**
+     * Inject locally installed DSH preset ids before the frontend bundle starts.
+     */
+    public String injectInitialDshPresets(String html, List<String> presetIds) {
+        try {
+            StringBuilder values = new StringBuilder("[");
+            if (presetIds != null) {
+                boolean first = true;
+                for (String presetId : presetIds) {
+                    if (presetId == null || presetId.isBlank()) {
+                        continue;
+                    }
+                    if (!first) {
+                        values.append(',');
+                    }
+                    values.append('\'')
+                            .append(escapeForSingleQuotedJs(presetId.trim()))
+                            .append('\'');
+                    first = false;
+                }
+            }
+            values.append(']');
+            String scriptInjection = "\n    <script>window.__INITIAL_DSH_PRESETS__ = "
+                    + values + ";</script>";
+            int headIndex = html.indexOf("<head>");
+            if (headIndex != -1) {
+                int insertPos = headIndex + "<head>".length();
+                return html.substring(0, insertPos) + scriptInjection + html.substring(insertPos);
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to inject initial DSH presets: " + e.getMessage(), e);
         }
         return html;
     }

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -161,7 +161,7 @@ const App = () => {
     claudeSdkMeetsMinimum,
     currentProviderRef,
     activeProviderConfig, claudeSettingsAlwaysThinkingEnabled,
-    reasoningEffort, codexFastMode, streamingEnabledSetting, sendShortcut, autoOpenFileEnabled,
+    reasoningEffort, codexFastMode, dshPreset, streamingEnabledSetting, sendShortcut, autoOpenFileEnabled,
     longContextEnabled,
     usagePercentage, usageUsedTokens, usageMaxTokens,
     setPermissionMode, setCurrentProvider,
@@ -178,7 +178,7 @@ const App = () => {
     setUsagePercentage, setUsageUsedTokens, setUsageMaxTokens,
     syncActiveProviderModelMapping,
     handleModeSelect, handleModelSelect, handleProviderSelect,
-    handleReasoningChange, handleCodexFastModeChange, handleAgentSelect, handleToggleThinking,
+    handleReasoningChange, handleCodexFastModeChange, handleDshPresetChange, handleAgentSelect, handleToggleThinking,
     handleStreamingEnabledChange, handleSendShortcutChange,
     handleAutoOpenFileEnabledChange, handleLongContextChange,
   } = useModelProviderState({ addToast, t });
@@ -428,7 +428,7 @@ const App = () => {
     interruptSession,
   } = useMessageSender({
     t, addToast,
-    currentProvider, selectedModel, permissionMode, reasoningEffort, selectedAgent, codexFastMode,
+    currentProvider, selectedModel, permissionMode, reasoningEffort, selectedAgent, codexFastMode, dshPreset,
     sdkStatusLoading, currentSdkInstalled,
     sentAttachmentsRef, chatInputRef, messagesContainerRef,
     isUserAtBottomRef, userPausedRef, isStreamingRef,
@@ -649,6 +649,7 @@ const App = () => {
               claudeSettingsAlwaysThinkingEnabled={claudeSettingsAlwaysThinkingEnabled}
               reasoningEffort={reasoningEffort}
               codexFastMode={codexFastMode}
+              dshPreset={dshPreset}
               streamingEnabledSetting={streamingEnabledSetting}
               sendShortcut={sendShortcut}
               autoOpenFileEnabled={autoOpenFileEnabled}
@@ -661,6 +662,7 @@ const App = () => {
               onAgentSelect={handleAgentSelect}
               onReasoningChange={handleReasoningChange}
               onCodexFastModeChange={handleCodexFastModeChange}
+              onDshPresetChange={handleDshPresetChange}
               onToggleThinking={handleToggleThinking}
               onStreamingEnabledChange={handleStreamingEnabledChange}
               onAutoOpenFileEnabledChange={handleAutoOpenFileEnabledChange}

--- a/webview/src/components/ChatInputBox/ButtonArea.tsx
+++ b/webview/src/components/ChatInputBox/ButtonArea.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ButtonAreaProps, CodexFastMode, ModelInfo, PermissionMode, ReasoningEffort } from './types';
 import { DEFAULT_CLAUDE_MODEL_ID } from './types';
-import { CodexFastModeSelect, ConfigSelect, ModelSelect, ModeSelect, ProviderSelect, ReasoningSelect } from './selectors';
+import { CodexFastModeSelect, ConfigSelect, DshPresetSelect, ModelSelect, ModeSelect, ProviderSelect, ReasoningSelect } from './selectors';
 import { STORAGE_KEYS, validateCodexCustomModels } from '../../types/provider';
 import type { CodexCustomModel } from '../../types/provider';
 import { readClaudeModelMapping } from '../../utils/claudeModelMapping';
@@ -78,6 +78,7 @@ export const ButtonArea = ({
   permissionMode = 'default',
   currentProvider = 'claude',
   reasoningEffort = 'high',
+  dshPreset = '',
   codexFastMode = 'normal',
   onSubmit,
   onStop,
@@ -86,6 +87,7 @@ export const ButtonArea = ({
   onProviderSelect,
   onReasoningChange,
   onCodexFastModeChange,
+  onDshPresetChange,
   onEnhancePrompt,
   alwaysThinkingEnabled = false,
   onToggleThinking,
@@ -235,6 +237,10 @@ export const ButtonArea = ({
     onCodexFastModeChange?.(mode);
   }, [onCodexFastModeChange]);
 
+  const handleDshPresetChange = useCallback((preset: string) => {
+    onDshPresetChange?.(preset);
+  }, [onDshPresetChange]);
+
   /**
    * Handle enhance prompt button click
    */
@@ -253,6 +259,7 @@ export const ButtonArea = ({
     permissionMode,
     reasoningEffort,
     codexFastMode,
+    dshPreset,
     selectedAgent?.id ?? '',
     cliModelsLoading ? 'loading' : 'ready',
   ].join('|');
@@ -302,6 +309,9 @@ export const ButtonArea = ({
         <ReasoningSelect value={reasoningEffort} onChange={handleReasoningChange} selectedModel={selectedModel} currentProvider={currentProvider} />
         {currentProvider === 'codex' && (
           <CodexFastModeSelect value={codexFastMode} onChange={handleCodexFastModeChange} />
+        )}
+        {currentProvider === 'dsh' && (
+          <DshPresetSelect value={dshPreset} onChange={handleDshPresetChange} />
         )}
       </div>
 

--- a/webview/src/components/ChatInputBox/ChatInputBox.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBox.tsx
@@ -100,6 +100,8 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
       onReasoningChange,
       codexFastMode = 'normal',
       onCodexFastModeChange,
+      dshPreset,
+      onDshPresetChange,
       activeFile,
       selectedLines,
       onClearContext,
@@ -775,6 +777,7 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
           currentProvider={currentProvider}
           reasoningEffort={reasoningEffort}
           codexFastMode={codexFastMode}
+          dshPreset={dshPreset}
           onSubmit={handleSubmit}
           onStop={onStop}
           onModeSelect={handleModeSelect}
@@ -782,6 +785,7 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
           onProviderSelect={onProviderSelect}
           onReasoningChange={onReasoningChange}
           onCodexFastModeChange={onCodexFastModeChange}
+          onDshPresetChange={onDshPresetChange}
           onEnhancePrompt={handleEnhancePrompt}
           alwaysThinkingEnabled={alwaysThinkingEnabled}
           onToggleThinking={onToggleThinking}

--- a/webview/src/components/ChatInputBox/ChatInputBoxFooter.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBoxFooter.tsx
@@ -26,6 +26,7 @@ export function ChatInputBoxFooter({
   currentProvider,
   reasoningEffort,
   codexFastMode,
+  dshPreset,
   onSubmit,
   onStop,
   onModeSelect,
@@ -33,6 +34,7 @@ export function ChatInputBoxFooter({
   onProviderSelect,
   onReasoningChange,
   onCodexFastModeChange,
+  onDshPresetChange,
   onEnhancePrompt,
   alwaysThinkingEnabled,
   onToggleThinking,
@@ -63,6 +65,7 @@ export function ChatInputBoxFooter({
   currentProvider: string;
   reasoningEffort: ReasoningEffort;
   codexFastMode?: CodexFastMode;
+  dshPreset?: string;
   onSubmit: () => void;
   onStop?: () => void;
   onModeSelect?: (mode: PermissionMode) => void;
@@ -70,6 +73,7 @@ export function ChatInputBoxFooter({
   onProviderSelect?: (providerId: string) => void;
   onReasoningChange?: (effort: ReasoningEffort) => void;
   onCodexFastModeChange?: (mode: CodexFastMode) => void;
+  onDshPresetChange?: (preset: string) => void;
   onEnhancePrompt: () => void;
   alwaysThinkingEnabled?: boolean;
   onToggleThinking?: (enabled: boolean) => void;
@@ -118,6 +122,7 @@ export function ChatInputBoxFooter({
         currentProvider={currentProvider}
         reasoningEffort={reasoningEffort}
         codexFastMode={codexFastMode}
+        dshPreset={dshPreset}
         onSubmit={onSubmit}
         onStop={onStop}
         onModeSelect={onModeSelect}
@@ -125,6 +130,7 @@ export function ChatInputBoxFooter({
         onProviderSelect={onProviderSelect}
         onReasoningChange={onReasoningChange}
         onCodexFastModeChange={onCodexFastModeChange}
+        onDshPresetChange={onDshPresetChange}
         onEnhancePrompt={onEnhancePrompt}
         alwaysThinkingEnabled={alwaysThinkingEnabled}
         onToggleThinking={onToggleThinking}

--- a/webview/src/components/ChatInputBox/selectors/DshPresetSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/DshPresetSelect.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { DSH_PRESETS, getUserDshPresetOptions } from '../types';
+import { useDropdownPosition } from '../../../hooks/useDropdownPosition';
+
+const CHEVRON_ICON_STYLE: React.CSSProperties = { fontSize: '10px', marginLeft: '2px' };
+const DROPDOWN_STYLE: React.CSSProperties = {
+  position: 'absolute',
+  bottom: '100%',
+  marginBottom: '4px',
+  zIndex: 10000,
+  maxWidth: 'calc(100vw - 16px)',
+  overflowX: 'hidden',
+};
+const MODE_INFO_STYLE: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+  minWidth: 0,
+  overflow: 'hidden',
+};
+const MODE_TEXT_STYLE: React.CSSProperties = {
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+};
+
+interface DshPresetSelectProps {
+  value: string;
+  onChange: (preset: string) => void;
+}
+
+export const DshPresetSelect = ({ value, onChange }: DshPresetSelectProps) => {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const { positionedStyle, recalculate } = useDropdownPosition({
+    buttonRef,
+    dropdownRef,
+    minWidth: 260,
+  });
+
+  const options = useMemo(
+    () => [...DSH_PRESETS, ...getUserDshPresetOptions()],
+    [],
+  );
+  const currentPreset = options.find((preset) => preset.id === value) || options[0];
+
+  const getPresetText = (presetId: string, field: 'label' | 'description') => {
+    const preset = options.find((item) => item.id === presetId);
+    if (!preset) return '';
+    if (field === 'label' && preset.label) return preset.label;
+    const key = field === 'label' ? preset.labelKey : preset.descriptionKey;
+    if (!key) return presetId;
+    return t(key, { defaultValue: presetId });
+  };
+
+  const handleToggle = useCallback((event: React.MouseEvent) => {
+    event.stopPropagation();
+    const nextOpen = !isOpen;
+    setIsOpen(nextOpen);
+    if (nextOpen) recalculate();
+  }, [isOpen, recalculate]);
+
+  const handleSelect = useCallback((presetId: string) => {
+    onChange(presetId);
+    setIsOpen(false);
+  }, [onChange]);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current
+        && !dropdownRef.current.contains(event.target as Node)
+        && buttonRef.current
+        && !buttonRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    const timer = setTimeout(() => document.addEventListener('mousedown', handleClickOutside), 0);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
+
+  return (
+    <div style={{ position: 'relative', display: 'inline-block' }}>
+      <button
+        ref={buttonRef}
+        className="selector-button"
+        onClick={handleToggle}
+        title={t('dshPresets.title', { defaultValue: getPresetText(currentPreset.id, 'description') })}
+      >
+        <span className="codicon codicon-robot" />
+        <span className="selector-button-text">{getPresetText(currentPreset.id, 'label')}</span>
+        <span className={`codicon codicon-chevron-${isOpen ? 'up' : 'down'}`} style={CHEVRON_ICON_STYLE} />
+      </button>
+
+      {isOpen && (
+        <div
+          ref={dropdownRef}
+          className="selector-dropdown"
+          style={{ ...DROPDOWN_STYLE, ...positionedStyle }}
+        >
+          {options.map((preset) => (
+            <div
+              key={preset.id}
+              data-testid={`dsh-preset-option-${preset.id || 'none'}`}
+              className={`selector-option ${preset.id === value ? 'selected' : ''}`}
+              onClick={() => handleSelect(preset.id)}
+              title={getPresetText(preset.id, 'description')}
+            >
+              <span className={`codicon ${preset.id === '' ? 'codicon-circle-outline' : 'codicon-symbol-class'}`} />
+              <div style={MODE_INFO_STYLE}>
+                <span style={MODE_TEXT_STYLE}>{getPresetText(preset.id, 'label')}</span>
+                <span className="mode-description" style={MODE_TEXT_STYLE}>
+                  {getPresetText(preset.id, 'description')}
+                </span>
+              </div>
+              {preset.id === value && <span className="codicon codicon-check check-mark" />}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DshPresetSelect;

--- a/webview/src/components/ChatInputBox/selectors/index.ts
+++ b/webview/src/components/ChatInputBox/selectors/index.ts
@@ -6,3 +6,4 @@ export { ConfigSelect } from './ConfigSelect';
 export { ReasoningSelect } from './ReasoningSelect';
 export { CodexFastModeSelect } from './CodexFastModeSelect';
 export { LongContextToggle } from './LongContextToggle';
+export { default as DshPresetSelect } from './DshPresetSelect';

--- a/webview/src/components/ChatInputBox/types.ts
+++ b/webview/src/components/ChatInputBox/types.ts
@@ -549,6 +549,40 @@ export const DSH_MODELS: ModelInfo[] = [
   },
 ];
 
+/** No DSH agent preset: use the default headless composition. */
+export const DSH_PRESET_NONE = '';
+
+export interface DshPresetOption {
+  id: string;
+  label?: string;
+  labelKey?: string;
+  descriptionKey?: string;
+}
+
+export const DSH_PRESETS: DshPresetOption[] = [
+  { id: DSH_PRESET_NONE, labelKey: 'dshPresets.none.label', descriptionKey: 'dshPresets.none.description' },
+  { id: 'standard', labelKey: 'dshPresets.standard.label', descriptionKey: 'dshPresets.standard.description' },
+  { id: 'code', labelKey: 'dshPresets.code.label', descriptionKey: 'dshPresets.code.description' },
+  { id: 'minimal', labelKey: 'dshPresets.minimal.label', descriptionKey: 'dshPresets.minimal.description' },
+  { id: 'cordis', labelKey: 'dshPresets.cordis.label', descriptionKey: 'dshPresets.cordis.description' },
+];
+
+export const getUserDshPresetOptions = (): DshPresetOption[] => {
+  const injected = window.__INITIAL_DSH_PRESETS__;
+  if (!Array.isArray(injected)) return [];
+  const curated = new Set(DSH_PRESETS.map((preset) => preset.id));
+  return injected
+    .filter((id): id is string => typeof id === 'string' && id.trim() !== '' && !curated.has(id))
+    .map((id) => ({ id, label: id, descriptionKey: 'dshPresets.user.description' }));
+};
+
+export type DshPreset = string;
+
+export const isValidDshPreset = (value: unknown): value is DshPreset =>
+  typeof value === 'string'
+  && (DSH_PRESETS.some((preset) => preset.id === value)
+    || getUserDshPresetOptions().some((preset) => preset.id === value));
+
 /**
  * Available models (backward compatibility)
  */
@@ -789,8 +823,12 @@ export interface ChatInputBoxProps {
   onReasoningChange?: (effort: ReasoningEffort) => void;
   /** Codex speed mode */
   codexFastMode?: CodexFastMode;
+  /** DSH agent preset */
+  dshPreset?: string;
   /** Switch Codex speed mode callback */
   onCodexFastModeChange?: (mode: CodexFastMode) => void;
+  /** Switch DSH agent preset callback */
+  onDshPresetChange?: (preset: string) => void;
   /** Toggle thinking mode */
   onToggleThinking?: (enabled: boolean) => void;
   /** Whether streaming is enabled */
@@ -874,6 +912,8 @@ export interface ButtonAreaProps {
   reasoningEffort?: ReasoningEffort;
   /** Codex speed mode */
   codexFastMode?: CodexFastMode;
+  /** DSH agent preset */
+  dshPreset?: string;
 
   // Event callbacks
   onSubmit?: () => void;
@@ -885,6 +925,8 @@ export interface ButtonAreaProps {
   onReasoningChange?: (effort: ReasoningEffort) => void;
   /** Switch Codex speed mode callback */
   onCodexFastModeChange?: (mode: CodexFastMode) => void;
+  /** Switch DSH agent preset callback */
+  onDshPresetChange?: (preset: string) => void;
   /** Enhance prompt callback */
   onEnhancePrompt?: () => void;
   /** Whether always thinking enabled */

--- a/webview/src/components/ChatScreen.tsx
+++ b/webview/src/components/ChatScreen.tsx
@@ -96,6 +96,7 @@ export interface ChatScreenProps {
   claudeSettingsAlwaysThinkingEnabled: ProviderState['claudeSettingsAlwaysThinkingEnabled'];
   reasoningEffort: ProviderState['reasoningEffort'];
   codexFastMode: ProviderState['codexFastMode'];
+  dshPreset: ProviderState['dshPreset'];
   streamingEnabledSetting: ProviderState['streamingEnabledSetting'];
   sendShortcut: ProviderState['sendShortcut'];
   autoOpenFileEnabled: ProviderState['autoOpenFileEnabled'];
@@ -110,6 +111,7 @@ export interface ChatScreenProps {
   onAgentSelect: ProviderState['handleAgentSelect'];
   onReasoningChange: ProviderState['handleReasoningChange'];
   onCodexFastModeChange: ProviderState['handleCodexFastModeChange'];
+  onDshPresetChange: ProviderState['handleDshPresetChange'];
   onToggleThinking: ProviderState['handleToggleThinking'];
   onStreamingEnabledChange: ProviderState['handleStreamingEnabledChange'];
   onAutoOpenFileEnabledChange: ProviderState['handleAutoOpenFileEnabledChange'];
@@ -142,9 +144,9 @@ export const ChatScreen = ({
   currentProvider, selectedModel, permissionMode, selectedAgent,
   sdkStatusLoading, sdkStatusError, onRetrySdkStatus, currentSdkInstalled,
   activeProviderConfig, claudeSettingsAlwaysThinkingEnabled,
-  reasoningEffort, codexFastMode, streamingEnabledSetting, sendShortcut, autoOpenFileEnabled,
+  reasoningEffort, codexFastMode, dshPreset, streamingEnabledSetting, sendShortcut, autoOpenFileEnabled,
   longContextEnabled, usagePercentage, usageUsedTokens, usageMaxTokens,
-  onModeSelect, onModelSelect, onAgentSelect, onReasoningChange, onCodexFastModeChange, onToggleThinking,
+  onModeSelect, onModelSelect, onAgentSelect, onReasoningChange, onCodexFastModeChange, onDshPresetChange, onToggleThinking,
   onStreamingEnabledChange,
   onAutoOpenFileEnabledChange, onLongContextChange,
   messageQueue, onRemoveFromQueue,
@@ -358,9 +360,11 @@ export const ChatScreen = ({
           onModelSelect={onModelSelect}
           onProviderSelect={onProviderSelect}
           reasoningEffort={reasoningEffort}
+          dshPreset={dshPreset}
           onReasoningChange={onReasoningChange}
           codexFastMode={codexFastMode}
           onCodexFastModeChange={onCodexFastModeChange}
+          onDshPresetChange={onDshPresetChange}
           onToggleThinking={onToggleThinking}
           streamingEnabled={streamingEnabledSetting}
           onStreamingEnabledChange={onStreamingEnabledChange}

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -1091,6 +1091,9 @@ interface Window {
    */
   __INITIAL_TAB_MODEL__?: string;
 
+  /** User-installed DSH agent preset ids discovered from the DSH home. */
+  __INITIAL_DSH_PRESETS__?: string[];
+
   /** Runtime page generation established by Java before exposing the bridge. */
   __CCG_PAGE_GENERATION__?: number;
 

--- a/webview/src/hooks/providers/useDshProvider.ts
+++ b/webview/src/hooks/providers/useDshProvider.ts
@@ -1,4 +1,5 @@
-import { DSH_DEFAULT_MODEL_ID } from '../../components/ChatInputBox/types';
+import { useState } from 'react';
+import { DSH_DEFAULT_MODEL_ID, DSH_PRESET_NONE } from '../../components/ChatInputBox/types';
 import { useCliProviderState } from './useCliProviderState';
 
 /**
@@ -8,11 +9,14 @@ import { useCliProviderState } from './useCliProviderState';
  */
 export function useDshProvider() {
   const state = useCliProviderState(DSH_DEFAULT_MODEL_ID);
+  const [dshPreset, setDshPreset] = useState(DSH_PRESET_NONE);
   return {
     selectedDshModel: state.selectedModel,
     setSelectedDshModel: state.setSelectedModel,
     dshPermissionMode: state.permissionMode,
     setDshPermissionMode: state.setPermissionMode,
+    dshPreset,
+    setDshPreset,
   };
 }
 

--- a/webview/src/hooks/providers/useModelStatePersistence.test.ts
+++ b/webview/src/hooks/providers/useModelStatePersistence.test.ts
@@ -33,6 +33,7 @@ function makeOptions(overrides: Partial<UseModelStatePersistenceOptions> = {}): 
     setLongContextEnabled: vi.fn(),
     setReasoningEffort: vi.fn(),
     setCodexFastMode: vi.fn(),
+    setDshPreset: vi.fn(),
     currentProvider: 'claude',
     selectedClaudeModel: 'claude-sonnet-4-5',
     selectedCodexModel: 'gpt-5-codex',
@@ -53,6 +54,7 @@ function makeOptions(overrides: Partial<UseModelStatePersistenceOptions> = {}): 
     longContextEnabled: false,
     reasoningEffort: 'medium',
     codexFastMode: 'normal',
+    dshPreset: '',
     ...overrides,
   };
 }

--- a/webview/src/hooks/providers/useModelStatePersistence.ts
+++ b/webview/src/hooks/providers/useModelStatePersistence.ts
@@ -10,6 +10,8 @@ import {
   OPENCODE_DEFAULT_MODEL_ID,
   PI_DEFAULT_MODEL_ID,
   DSH_DEFAULT_MODEL_ID,
+  DSH_PRESET_NONE,
+  isValidDshPreset,
   isValidPermissionMode,
   normalizeClaudeModelId,
   apply1MContextSuffix,
@@ -69,6 +71,7 @@ export interface UseModelStatePersistenceOptions {
   setLongContextEnabled: (value: boolean) => void;
   setReasoningEffort: (value: ReasoningEffort) => void;
   setCodexFastMode: (value: CodexFastMode) => void;
+  setDshPreset: (value: string) => void;
   // Cross-slice save deps (re-saves on any change)
   currentProvider: string;
   selectedClaudeModel: string;
@@ -90,6 +93,7 @@ export interface UseModelStatePersistenceOptions {
   longContextEnabled: boolean;
   reasoningEffort: ReasoningEffort;
   codexFastMode: CodexFastMode;
+  dshPreset: string;
 }
 
 /**
@@ -125,6 +129,7 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
     setLongContextEnabled,
     setReasoningEffort,
     setCodexFastMode,
+    setDshPreset,
     currentProvider,
     selectedClaudeModel,
     selectedCodexModel,
@@ -145,6 +150,7 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
     longContextEnabled,
     reasoningEffort,
     codexFastMode,
+    dshPreset,
   } = options;
 
   // Hydrate from localStorage and sync to backend (mount only).
@@ -189,6 +195,7 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
       let restoredDshPermissionMode: PermissionMode = 'default';
       let restoredLongContextEnabled = true;
       let restoredCodexFastMode: CodexFastMode = 'normal';
+      let restoredDshPreset = DSH_PRESET_NONE;
 
       // Model validation helpers — close over the restored* lets so both
       // branches (saved localStorage / fresh backend-only) share the same logic
@@ -297,6 +304,10 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
         if (isCodexFastMode(state.codexFastMode)) {
           restoredCodexFastMode = state.codexFastMode;
           setCodexFastMode(restoredCodexFastMode);
+        }
+        if (isValidDshPreset(state.dshPreset)) {
+          restoredDshPreset = state.dshPreset;
+          setDshPreset(restoredDshPreset);
         }
 
         const claudeModelCandidate = hasBackendModel && restoredProvider === 'claude'
@@ -429,6 +440,9 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
           // The mode is only sent to Java on an explicit user switch
           // (handleModeSelect → set_mode).
           sendBridgeEvent('set_codex_fast_mode', restoredCodexFastMode);
+          if (restoredProvider === 'dsh') {
+            sendBridgeEvent('set_dsh_preset', restoredDshPreset);
+          }
         } else {
           syncRetryCount++;
           if (syncRetryCount < MAX_SYNC_RETRIES) {
@@ -488,6 +502,7 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
           longContextEnabled,
           reasoningEffort,
           codexFastMode,
+          dshPreset,
         }));
       } catch {
         // Failed to save model selection state — non-fatal.
@@ -521,5 +536,6 @@ export function useModelStatePersistence(options: UseModelStatePersistenceOption
     longContextEnabled,
     reasoningEffort,
     codexFastMode,
+    dshPreset,
   ]);
 }

--- a/webview/src/hooks/useMessageSender.ts
+++ b/webview/src/hooks/useMessageSender.ts
@@ -43,6 +43,7 @@ export interface UseMessageSenderOptions {
   permissionMode: PermissionMode;
   reasoningEffort: ReasoningEffort;
   codexFastMode: CodexFastMode;
+  dshPreset?: string;
   selectedAgent: SelectedAgent | null;
   sdkStatusLoading: boolean;
   currentSdkInstalled: boolean;
@@ -76,6 +77,7 @@ export function useMessageSender({
   permissionMode,
   reasoningEffort,
   codexFastMode,
+  dshPreset,
   selectedAgent,
   sdkStatusLoading,
   currentSdkInstalled,
@@ -281,6 +283,7 @@ export function useMessageSender({
           fileTags: fileTagsInfo,
           permissionMode: effectivePermissionMode,
           ...reasoningEffortPayload,
+          ...(currentProvider === 'dsh' ? { dshPreset: dshPreset || '' } : {}),
           codexFastMode,
         });
         sendBridgeEvent('send_message_with_attachments', payload);
@@ -292,6 +295,7 @@ export function useMessageSender({
           fileTags: fileTagsInfo,
           permissionMode: effectivePermissionMode,
           ...reasoningEffortPayload,
+          ...(currentProvider === 'dsh' ? { dshPreset: dshPreset || '' } : {}),
           codexFastMode,
         });
         sendBridgeEvent('send_message', fallbackPayload);
@@ -303,11 +307,12 @@ export function useMessageSender({
         fileTags: fileTagsInfo,
         permissionMode: effectivePermissionMode,
         ...reasoningEffortPayload,
+        ...(currentProvider === 'dsh' ? { dshPreset: dshPreset || '' } : {}),
         codexFastMode,
       });
       sendBridgeEvent('send_message', payload);
     }
-  }, [codexFastMode, currentProvider, selectedModel, reasoningEffort]);
+  }, [codexFastMode, currentProvider, dshPreset, selectedModel, reasoningEffort]);
 
   /**
    * Execute message sending (from queue or directly)
@@ -402,6 +407,7 @@ export function useMessageSender({
     sdkStatusLoading,
     currentSdkInstalled,
     currentProvider,
+    dshPreset,
     permissionMode,
     selectedAgent,
     buildUserContentBlocks,

--- a/webview/src/hooks/useModelProviderState.ts
+++ b/webview/src/hooks/useModelProviderState.ts
@@ -3,6 +3,7 @@ import type { TFunction } from 'i18next';
 import { sendBridgeEvent } from '../utils/bridge';
 import {
   apply1MContextSuffix,
+  isValidDshPreset,
   isValidPermissionMode,
   normalizeClaudeModelId,
   strip1MContextSuffix,
@@ -105,6 +106,7 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
   const {
     selectedDshModel, setSelectedDshModel,
     dshPermissionMode, setDshPermissionMode,
+    dshPreset, setDshPreset,
   } = dsh;
 
   // ── Persistence: load on mount + save on change ──
@@ -130,6 +132,7 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
     setLongContextEnabled,
     setReasoningEffort,
     setCodexFastMode,
+    setDshPreset,
     currentProvider,
     selectedClaudeModel,
     selectedCodexModel,
@@ -150,6 +153,7 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
     longContextEnabled,
     reasoningEffort,
     codexFastMode,
+    dshPreset,
   });
 
   // ── Computed values ──
@@ -350,6 +354,14 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
     }
   }, [currentProvider, selectedClaudeModel, setLongContextEnabled]);
 
+  const handleDshPresetChange = useCallback((preset: string) => {
+    if (!isValidDshPreset(preset)) return;
+    setDshPreset(preset);
+    if (currentProvider === 'dsh') {
+      sendBridgeEvent('set_dsh_preset', preset);
+    }
+  }, [currentProvider, setDshPreset]);
+
   const handleToggleThinking = useCallback((enabled: boolean) => {
     const config = settings.activeProviderConfig;
     const isSpecialProvider = isSpecialProviderId(config?.id || '');
@@ -411,6 +423,7 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
     handleModeSelect,
     handleModelSelect,
     handleProviderSelect,
+    handleDshPresetChange,
     handleLongContextChange,
     handleToggleThinking,
   };

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -2341,6 +2341,15 @@
       "description": "Codex fast response mode (uses additional credits)"
     }
   },
+  "dshPresets": {
+    "title": "Select DeepSeek Harness agent preset",
+    "none": { "label": "Default", "description": "dsh default headless composition (full toolset)" },
+    "standard": { "label": "Standard", "description": "Full coding agent with the standard toolset" },
+    "code": { "label": "PTC", "description": "Standard capabilities with Code Mode" },
+    "minimal": { "label": "Minimal", "description": "Bash and str_replace_editor only" },
+    "cordis": { "label": "Creator", "description": "Standard capabilities plus composition authoring" },
+    "user": { "description": "Custom preset installed under the DSH home" }
+  },
   "error": {
     "providerNotConfigured": "Provider Not Configured",
     "providerNotConfiguredDesc": "No AI provider is configured yet, or access to the local configuration has not been authorized. Please complete setup in Provider Management settings before starting a conversation.",

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -1861,6 +1861,15 @@
       "description": "Codex 快速回應模式（會產生額外消耗）"
     }
   },
+  "dshPresets": {
+    "title": "選擇 DeepSeek Harness Agent 預設",
+    "none": { "label": "預設", "description": "dsh 預設 headless 組合（完整工具集）" },
+    "standard": { "label": "標準模式", "description": "功能完整的標準編碼工具集" },
+    "code": { "label": "PTC 模式", "description": "標準能力加 Code Mode" },
+    "minimal": { "label": "極簡模式", "description": "僅提供 bash 與 str_replace_editor" },
+    "cordis": { "label": "創造模式", "description": "標準能力加組合編排能力" },
+    "user": { "description": "安裝在 DSH 主目錄中的自訂預設" }
+  },
   "error": {
     "providerNotConfigured": "供應商未設定",
     "providerNotConfiguredDesc": "尚未設定 AI 供應商或未授權使用本機設定，請先在供應商管理設定中完成設定後再開始對話。",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -2346,6 +2346,15 @@
       "description": "Codex快速响应模式（会产生额外消耗）"
     }
   },
+  "dshPresets": {
+    "title": "选择 DeepSeek Harness Agent 预设",
+    "none": { "label": "默认", "description": "dsh 默认 headless 组合（完整工具集）" },
+    "standard": { "label": "标准模式", "description": "功能完整的标准编码工具集" },
+    "code": { "label": "PTC 模式", "description": "标准能力加 Code Mode" },
+    "minimal": { "label": "极简模式", "description": "仅提供 bash 与 str_replace_editor" },
+    "cordis": { "label": "创造模式", "description": "标准能力加组合编排能力" },
+    "user": { "description": "安装在 DSH 主目录中的自定义预设" }
+  },
   "error": {
     "providerNotConfigured": "供应商未配置",
     "providerNotConfiguredDesc": "尚未配置 AI 供应商或未授权使用本地配置，请先在供应商管理设置中完成配置后再开始对话。",


### PR DESCRIPTION
## What
Adds DSH agent preset switching to the chat toolbar, including built-in and user-installed presets.

## How
- adds a DSH preset selector with per-tab persistence
- passes the selected preset through the Java and Node DSH bridge
- applies preset compositions to spawned headless DSH hosts and reloads owned hosts when the preset changes

## Testing
- `gradlew compileJava --no-daemon -x buildWebview` — passed
- Node syntax checks for DSH bridge files — passed
- locale JSON parsing — passed
- webview `tsc` could not run in the clean worktree because `webview/node_modules` is not installed

This PR contains only DSH agent preset changes and targets `feature/v0.5.4`.