### PR TITLE
fix(mcp): close stdin before signalling stdio servers to stop container leaks

### DIFF
--- a/ai-bridge/services/claude/mcp-status/process-manager.js
+++ b/ai-bridge/services/claude/mcp-status/process-manager.js
@@ -8,21 +8,67 @@ import { parseServerInfo } from './server-info-parser.js';
 import { hasValidMcpResponse, createInitializeRequest } from './mcp-protocol.js';
 
 /**
+ * Grace period between closing stdin and falling back to signals.
+ * Gives stdin EOF time to propagate so `docker run -i --rm` containers can
+ * exit on their own (and --rm can clean them up) before the Docker CLI
+ * client is signalled (#1721).
+ */
+const STDIN_EOF_GRACE_MS = 500;
+
+/**
  * Safely terminate a child process
+ *
+ * stdin is closed FIRST, then signals are used only as a fallback:
+ * for `docker run -i --rm ...` MCP servers, a signal only reaches the
+ * Docker *client*, not the container - the container keeps running and
+ * `--rm` never fires, leaking one container per status refresh (#1721).
+ * Closing stdin delivers EOF on the container's stdin, so a well-behaved
+ * MCP server exits on its own and `--rm` cleans up. Signalling too early
+ * would kill the client before the EOF propagates, recreating the leak,
+ * hence the grace period before SIGTERM/SIGKILL.
+ *
  * @param {import('child_process').ChildProcess | null} child - Child process
  * @param {string} serverName - Server name (for logging)
  */
 export function safeKillProcess(child, serverName) {
   if (!child) return;
+  // Already exited - nothing to clean up
+  if (child.exitCode !== null || child.signalCode !== null) return;
 
+  // Close stdin first: EOF lets docker run -i --rm containers (and any
+  // child reading stdin) terminate gracefully instead of being leaked.
   try {
+    if (child.stdin && !child.stdin.destroyed && !child.stdin.writableEnded) {
+      child.stdin.end();
+    }
+  } catch (e) {
+    log('debug', `Failed to close stdin for ${serverName}:`, e.message);
+  }
+
+  // After the grace period, fall back to signals for children that do not
+  // react to stdin EOF. unref() so these timers never block process exit.
+  const signalTimer = setTimeout(() => terminateWithSignals(child, serverName), STDIN_EOF_GRACE_MS);
+  signalTimer.unref();
+}
+
+/**
+ * Signal-based termination fallback for children still alive after the
+ * stdin-EOF grace period (e.g. local processes that never read stdin).
+ * @param {import('child_process').ChildProcess} child - Child process
+ * @param {string} serverName - Server name (for logging)
+ */
+function terminateWithSignals(child, serverName) {
+  try {
+    // Exited on its own after stdin EOF - nothing to signal
+    if (child.exitCode !== null || child.signalCode !== null) return;
+
     if (!child.killed) {
       child.kill('SIGTERM');
       // If SIGTERM doesn't kill it, send SIGKILL after 500ms
       // Use unref() so this timer won't prevent the parent process from exiting
       const killTimer = setTimeout(() => {
         try {
-          if (!child.killed) {
+          if (child.exitCode === null && child.signalCode === null && !child.killed) {
             child.kill('SIGKILL');
             log('debug', `Force killed process for ${serverName}`);
           }

--- a/ai-bridge/services/claude/mcp-status/process-manager.test.js
+++ b/ai-bridge/services/claude/mcp-status/process-manager.test.js
@@ -1,0 +1,76 @@
+/**
+ * Tests for safeKillProcess in process-manager.js
+ *
+ * Regression test for #1721: killing the client process is not enough for
+ * `docker run -i --rm` MCP servers - the container only terminates when its
+ * stdin receives EOF. safeKillProcess must close stdin FIRST and give EOF a
+ * grace period to propagate before falling back to signals.
+ */
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import test from 'node:test';
+
+import { safeKillProcess } from './process-manager.js';
+
+/**
+ * Spawn a child that mimics a `docker run -i --rm` MCP server:
+ * it ignores SIGTERM (the signal can't reach the container anyway) and only
+ * exits when its stdin reaches EOF - exactly like a dockerised MCP server
+ * whose CLI client closed the stream (which makes --rm fire).
+ */
+function spawnStdinDrivenChild() {
+  return spawn(process.execPath, ['-e', `
+    process.on('SIGTERM', () => { /* ignore: mimic docker client dying */ });
+    process.stdin.on('end', () => process.exit(0));
+    process.stdin.on('data', () => { /* keep reading */ });
+    // Stay alive until stdin EOF
+    setInterval(() => {}, 1000);
+  `], { stdio: ['pipe', 'pipe', 'pipe'] });
+}
+
+/**
+ * Resolve when the child exits, or reject after the timeout.
+ * @returns {Promise<number>} exit code (null when killed by a signal)
+ */
+function waitForExit(child, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('child did not exit in time')), timeoutMs);
+    child.on('exit', (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+}
+
+test('safeKillProcess closes stdin so stdin-driven children exit gracefully', async () => {
+  const child = spawnStdinDrivenChild();
+  assert.ok(child.stdin, 'child should have a piped stdin');
+
+  const exited = waitForExit(child, 10000);
+  safeKillProcess(child, 'test-server');
+  const code = await exited;
+
+  // Exit code 0 = the child observed stdin EOF and exited by itself,
+  // exactly like a `docker run -i --rm` container cleaning up.
+  assert.equal(code, 0);
+});
+
+test('safeKillProcess is a no-op for null/already-dead children', async () => {
+  // null child must not throw
+  safeKillProcess(null, 'null-server');
+
+  // stdin already destroyed must not throw
+  const child = spawnStdinDrivenChild();
+  child.stdin.destroy();
+  safeKillProcess(child, 'dead-server');
+  assert.ok(true);
+});
+
+test('safeKillProcess is idempotent when called twice', async () => {
+  const child = spawnStdinDrivenChild();
+  const exited = waitForExit(child, 10000);
+  safeKillProcess(child, 'double-server');
+  safeKillProcess(child, 'double-server');
+  const code = await exited;
+  assert.equal(code, 0);
+});


### PR DESCRIPTION
## Summary

Fixes #1721 - every MCP connection-status refresh leaked one permanently running `docker run -i --rm ...` container (67 containers / 4.2 GB RAM after ~12h on the reporter's machine).

### Root Cause

`safeKillProcess()` terminates the **client** process with SIGTERM → SIGKILL. For `docker run -i`, the CLI is only a client attached to the container's streams through the daemon: the signal never reaches the container, its stdin never receives EOF, and `--rm` only fires when the *container* exits. Result: one leaked `Up` container per status refresh.

`stdio-verifier.js` never called `child.stdin.end()` at all, even though `process-manager.js`'s own `sendInitializeRequest()` doc states "Caller is responsible for closing stdin when appropriate."

### Fix

`safeKillProcess()` now:

1. **Closes stdin first** - EOF propagates to the container's stdin, so a well-behaved dockerised MCP server exits on its own and `--rm` cleans it up
2. **Signals only as fallback** - SIGTERM (→ SIGKILL after 500ms) fires only after a 500ms grace period, for local processes that don't react to EOF. Signalling earlier would kill the Docker client before EOF propagates and recreate the leak
3. **Early-exit guards** (`exitCode` / `signalCode` / `writableEnded`) make repeated calls and racing with natural exit safe

Both call sites (`stdio-verifier.js` finalize, `stdio-tools-getter.js` finalize) go through `safeKillProcess`, so both the status verifier and the tools fetcher are fixed.

### Before / After

| Scenario | Before | After |
|---|---|---|
| `docker run -i --rm` MCP server, status refresh | SIGTERM kills CLI client; container stays `Up` forever | stdin EOF → container exits, `--rm` removes it |
| Local stdio MCP server ignoring EOF | SIGTERM → SIGKILL after 500ms | same fallback after 500ms grace |
| Child already exited / stdin already closed | kill attempted anyway | no-op (guards) |

### Backward Compatibility

- Public API unchanged (`safeKillProcess(child, serverName)`)
- Verification timing: worst case adds ~500ms before the signal fallback; successful verifications resolve as soon as the server responds (unchanged)

Closes #1721