### PR TITLE
fix(mcp): expand ${VAR} placeholders in .mcp.json env from settings files

### DIFF
--- a/ai-bridge/services/claude/mcp-status/config-loader.js
+++ b/ai-bridge/services/claude/mcp-status/config-loader.js
@@ -10,6 +10,100 @@ import { getRealHomeDir } from '../../../utils/path-utils.js';
 import { log } from './logger.js';
 
 /**
+ * Expand ${VAR} placeholders in an MCP server env value
+ *
+ * Claude Code resolves these from the `env` section of
+ * `.claude/settings.local.json` (project) and `.claude/settings.json`
+ * (user), falling back to the process environment. The plugin passed the
+ * literal placeholder through to the spawned MCP server, so containers
+ * received e.g. DATABASE_URI=${NEXUS_MCP_DB_URI} verbatim (#1722).
+ *
+ * Lookup order (first hit wins): project settings.local env -> user
+ * settings env -> process.env. Unresolvable placeholders are left as-is so
+ * misconfiguration stays visible in logs instead of becoming empty strings.
+ *
+ * @param {string} value - Raw env value that may contain ${VAR} placeholders
+ * @param {Object} projectEnv - env map from .claude/settings.local.json
+ * @param {Object} userEnv - env map from .claude/settings.json
+ * @returns {string} Value with all resolvable ${VAR} placeholders expanded
+ */
+function expandEnvPlaceholders(value, projectEnv, userEnv) {
+  if (typeof value !== 'string' || !value.includes('${')) return value;
+  // ${VAR} only - no command substitution, nesting, or defaults syntax
+  return value.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (match, name) => {
+    if (Object.prototype.hasOwnProperty.call(projectEnv, name)) {
+      return String(projectEnv[name]);
+    }
+    if (Object.prototype.hasOwnProperty.call(userEnv, name)) {
+      return String(userEnv[name]);
+    }
+    if (Object.prototype.hasOwnProperty.call(process.env, name)) {
+      return process.env[name];
+    }
+    log('warn', `[MCP Config] Unresolved \${${name}} placeholder left as-is in MCP env`);
+    return match;
+  });
+}
+
+/**
+ * Load the env override maps used for ${VAR} expansion
+ *
+ * Reads the `env` section of .claude/settings.local.json (project-local,
+ * git-ignored, where secrets live) and .claude/settings.json (user-level),
+ * matching the resolution order Claude Code uses for .mcp.json placeholders.
+ * Files that are missing, unparseable, or have no env section produce {}.
+ *
+ * @param {string} cwd - Current working directory (project root)
+ * @returns {Promise<{projectEnv: Object, userEnv: Object}>} env maps
+ */
+async function loadEnvExpansionSources(cwd) {
+  const projectEnv = {};
+  const userEnv = {};
+
+  const sources = [
+    { label: 'project settings.local.json', file: cwd ? join(cwd, '.claude', 'settings.local.json') : null, into: projectEnv },
+    { label: 'user settings.json', file: join(getRealHomeDir(), '.claude', 'settings.json'), into: userEnv }
+  ];
+
+  for (const source of sources) {
+    if (!source.file || !existsSync(source.file)) continue;
+    try {
+      const parsed = JSON.parse(await readFile(source.file, 'utf8'));
+      if (parsed && typeof parsed.env === 'object' && parsed.env !== null) {
+        Object.assign(source.into, parsed.env);
+      }
+    } catch (e) {
+      log('warn', `[MCP Config] Failed to read ${source.label} for env expansion:`, e.message);
+    }
+  }
+
+  return { projectEnv, userEnv };
+}
+
+/**
+ * Apply ${VAR} expansion to every env value of every server config
+ * @param {Object} mcpServers - Server name -> config map
+ * @param {Object} projectEnv - env map from .claude/settings.local.json
+ * @param {Object} userEnv - env map from .claude/settings.json
+ * @returns {Object} New map with expanded env values (input is not mutated)
+ */
+function expandMcpServersEnv(mcpServers, projectEnv, userEnv) {
+  const expanded = {};
+  for (const [name, config] of Object.entries(mcpServers)) {
+    if (config && typeof config === 'object' && config.env && typeof config.env === 'object') {
+      const env = {};
+      for (const [key, value] of Object.entries(config.env)) {
+        env[key] = expandEnvPlaceholders(value, projectEnv, userEnv);
+      }
+      expanded[name] = { ...config, env };
+    } else {
+      expanded[name] = config;
+    }
+  }
+  return expanded;
+}
+
+/**
  * Validate the basic structure of an MCP server configuration
  * @param {Object} serverConfig - Server configuration object
  * @returns {boolean} Whether the configuration is valid
@@ -143,6 +237,12 @@ async function parseMcpConfig(cwd = null) {
     mcpServers = config.mcpServers || {};
     disabledServers = new Set(config.disabledMcpServers || []);
   }
+
+  // Expand ${VAR} placeholders in server env values (e.g. from
+  // .claude/settings.local.json) so spawned servers receive real values,
+  // matching Claude Code's behaviour for the same config (#1722).
+  const { projectEnv, userEnv } = await loadEnvExpansionSources(cwd);
+  mcpServers = expandMcpServersEnv(mcpServers, projectEnv, userEnv);
 
   return { mcpServers, disabledServers };
 }

--- a/ai-bridge/services/claude/mcp-status/config-loader.test.mjs
+++ b/ai-bridge/services/claude/mcp-status/config-loader.test.mjs
@@ -91,3 +91,91 @@ test('loadMcpServersConfig still returns an array (empty on missing config)', as
   assert.ok(Array.isArray(list));
   assert.equal(list.length, 0);
 });
+
+test('loadMcpServersConfigAsRecord expands ${VAR} from .claude/settings.local.json env', async () => {
+  // Regression test for #1722: Claude Code expands ${VAR} in .mcp.json env
+  // values from .claude/settings.local.json; the plugin passed them through
+  // literally, so containers received DATABASE_URI=${NEXUS_MCP_DB_URI}.
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccg-mcp-env-'));
+  try {
+    fs.mkdirSync(path.join(projectDir, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, '.claude', 'settings.local.json'), JSON.stringify({
+      env: { NEXUS_MCP_DB_URI: 'postgres://user:pass@localhost/db' }
+    }));
+
+    writeConfig({
+      mcpServers: {
+        postgres: {
+          command: 'docker',
+          args: ['run', '-i', '--rm', 'postgres-mcp'],
+          env: { DATABASE_URI: '${NEXUS_MCP_DB_URI}', STATIC: 'plain' }
+        }
+      }
+    });
+
+    const result = await loadMcpServersConfigAsRecord(projectDir);
+    assert.ok(result, 'expected a non-null record');
+    assert.equal(result.postgres.env.DATABASE_URI, 'postgres://user:pass@localhost/db');
+    assert.equal(result.postgres.env.STATIC, 'plain');
+  } finally {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  }
+});
+
+test('loadMcpServersConfigAsRecord falls back to process env then leaves unresolved placeholders as-is', async () => {
+  process.env.CCG_TEST_MCP_FALLBACK = 'from-process-env';
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccg-mcp-env2-'));
+  try {
+    writeConfig({
+      mcpServers: {
+        mixed: {
+          command: 'docker',
+          args: ['run', '-i', '--rm', 'some-mcp'],
+          env: {
+            FROM_PROCESS: '${CCG_TEST_MCP_FALLBACK}',
+            UNRESOLVED: '${CCG_TEST_MCP_MISSING_VAR}'
+          }
+        }
+      }
+    });
+
+    const result = await loadMcpServersConfigAsRecord(projectDir);
+    assert.ok(result, 'expected a non-null record');
+    assert.equal(result.mixed.env.FROM_PROCESS, 'from-process-env');
+    // Unresolvable placeholders stay literal so misconfig is visible
+    assert.equal(result.mixed.env.UNRESOLVED, '${CCG_TEST_MCP_MISSING_VAR}');
+  } finally {
+    delete process.env.CCG_TEST_MCP_FALLBACK;
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  }
+});
+
+test('loadMcpServersConfigAsRecord prefers project env over user settings.json env', async () => {
+  // user settings env map
+  fs.mkdirSync(path.join(tempHome, '.claude'), { recursive: true });
+  fs.writeFileSync(path.join(tempHome, '.claude', 'settings.json'), JSON.stringify({
+    env: { SHARED_VAR: 'user-value', USER_ONLY: 'user-only-value' }
+  }));
+
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccg-mcp-env3-'));
+  try {
+    fs.mkdirSync(path.join(projectDir, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, '.claude', 'settings.local.json'), JSON.stringify({
+      env: { SHARED_VAR: 'project-value' }
+    }));
+
+    writeConfig({
+      mcpServers: {
+        layered: { command: 'docker', env: { A: '${SHARED_VAR}', B: '${USER_ONLY}' } }
+      }
+    });
+
+    const result = await loadMcpServersConfigAsRecord(projectDir);
+    assert.ok(result, 'expected a non-null record');
+    assert.equal(result.layered.env.A, 'project-value');
+    assert.equal(result.layered.env.B, 'user-only-value');
+  } finally {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(path.join(tempHome, '.claude'), { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #1722 - `${VAR}` placeholders in `.mcp.json` were passed through literally to the spawned MCP server instead of being expanded from `.claude/settings.local.json`.

### Root Cause

Claude Code expands `${VAR}` placeholders found in `.mcp.json` env values using the `env` section of `.claude/settings.local.json` (project) and `.claude/settings.json` (user), falling back to the process environment. The plugin reads the same config (`config-loader.js`) but never performs any expansion, so containers received e.g. `DATABASE_URI=${NEXUS_MCP_DB_URI}` verbatim (confirmed via `docker inspect`). Worse, `postgres-mcp` does not exit on an invalid connection string - it logs a warning and keeps running, feeding the container leak described in #1721.

### Fix

`config-loader.js` now expands `${VAR}` placeholders in every server's `env` values after resolving global/project `mcpServers`:

- **Lookup order (first hit wins)**: project `.claude/settings.local.json` `env` -> user `~/.claude/settings.json` `env` -> `process.env`
- **Unresolvable placeholders stay as-is** so misconfiguration remains visible (in logs and server errors) instead of silently becoming empty strings
- Only plain `${VAR}` (identifier) placeholders are expanded - no command substitution, nesting, or default-value syntax
- Original config objects are not mutated; expansion happens on a copy
- Unparseable/missing settings files are logged and treated as empty

### Before / After

| `.mcp.json` env value | Before | After |
|---|---|---|
| `DATABASE_URI: "${NEXUS_MCP_DB_URI}"` (defined in settings.local.json) | literal `${NEXUS_MCP_DB_URI}` | expanded value |
| `${SOME_VAR}` (defined only in process env) | literal | expanded from process env |
| `${UNDEFINED_VAR}` | literal | literal (left as-is, warned in log) |
| plain value / server without env | unchanged | unchanged |

### Backward Compatibility

- Configs without `${` in env values are byte-identical after loading (early return)
- No file is written back - expansion happens in-memory at load time only
- Server configs without an `env` object are passed through untouched

Closes #1722