### PR TITLE
feat(codex): add context window selector

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/CodexContextWindowHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/CodexContextWindowHandler.java
@@ -1,0 +1,119 @@
+package com.github.claudecodegui.handler;
+
+import com.github.claudecodegui.handler.core.HandlerContext;
+import com.github.claudecodegui.settings.CodexContextWindowConfigService;
+import com.github.claudecodegui.settings.CodexSettingsManager;
+import com.google.gson.Gson;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+
+/**
+ * 处理 WebView 与 Codex 全局上下文窗口配置之间的桥接。
+ */
+public final class CodexContextWindowHandler {
+
+    private static final Logger LOG = Logger.getInstance(CodexContextWindowHandler.class);
+    private static final String CALLBACK_NAME = "window.updateCodexContextWindowConfig";
+
+    private final HandlerContext context;
+    private final Gson gson = new Gson();
+    private final CodexContextWindowConfigService configService;
+    private CodexContextWindowConfigService.RegisteredCallback callbackHandle;
+
+    public CodexContextWindowHandler(HandlerContext context) {
+        this(context, CodexContextWindowConfigService.getInstance());
+    }
+
+    CodexContextWindowHandler(
+            HandlerContext context,
+            CodexContextWindowConfigService configService
+    ) {
+        this.context = context;
+        this.configService = configService;
+        this.callbackHandle = configService.registerCallback(config -> pushConfig(config, true, null));
+    }
+
+    /**
+     * 将当前磁盘配置返回给 WebView。
+     */
+    public void handleGet() {
+        pushResult(configService.readCurrent());
+    }
+
+    /**
+     * 校验并写入用户选择的上下文预设。
+     *
+     * @param content JSON 负载，格式为 {@code {"preset":"default|500k|1m"}}
+     */
+    public void handleSet(String content) {
+        String preset = null;
+        try {
+            JsonObject payload = gson.fromJson(content, JsonObject.class);
+            if (payload != null && payload.has("preset") && !payload.get("preset").isJsonNull()) {
+                preset = payload.get("preset").getAsString();
+            }
+        } catch (Exception e) {
+            LOG.warn("[CodexContextWindow] Invalid set payload", e);
+        }
+        CodexContextWindowConfigService.OperationResult result = configService.updatePreset(preset);
+        if (!result.isSuccess()) {
+            pushResult(result);
+        }
+    }
+
+    /**
+     * 注销全局回调，防止窗口销毁后继续接收广播。
+     */
+    public void dispose() {
+        if (callbackHandle != null) {
+            configService.unregisterCallback(callbackHandle);
+            callbackHandle = null;
+        }
+    }
+
+    private void pushResult(CodexContextWindowConfigService.OperationResult result) {
+        if (result.isSuccess()) {
+            pushConfig(result.getConfig(), true, null);
+            return;
+        }
+        pushConfig(result.getConfig(), false, result.getError());
+    }
+
+    private void pushConfig(
+            CodexSettingsManager.CodexContextWindowConfig config,
+            boolean success,
+            String error
+    ) {
+        JsonObject response = new JsonObject();
+        response.addProperty("success", success);
+        if (config != null) {
+            response.addProperty("preset", config.getPreset());
+            if (config.getContextWindow() != null) {
+                response.addProperty("contextWindow", config.getContextWindow());
+            } else {
+                response.add("contextWindow", JsonNull.INSTANCE);
+            }
+            if (config.getAutoCompactTokenLimit() != null) {
+                response.addProperty("autoCompactTokenLimit", config.getAutoCompactTokenLimit());
+            } else {
+                response.add("autoCompactTokenLimit", JsonNull.INSTANCE);
+            }
+            response.addProperty("custom", config.isCustom());
+        }
+        if (error != null && !error.isBlank()) {
+            response.addProperty("error", error);
+        }
+
+        Runnable push = () -> context.callJavaScript(
+                CALLBACK_NAME,
+                context.escapeJs(response.toString())
+        );
+        if (ApplicationManager.getApplication() != null) {
+            ApplicationManager.getApplication().invokeLater(push);
+        } else {
+            push.run();
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/SettingsHandler.java
@@ -25,6 +25,7 @@ public class SettingsHandler extends BaseMessageHandler {
     private final UsagePushService usagePushService;
     private final PermissionModeHandler permissionModeHandler;
     private final ModelProviderHandler modelProviderHandler;
+    private final CodexContextWindowHandler codexContextWindowHandler;
     private final NodePathHandler nodePathHandler;
     private final ClaudeCliPathHandler claudeCliPathHandler;
     private final ProjectConfigHandler projectConfigHandler;
@@ -43,6 +44,8 @@ public class SettingsHandler extends BaseMessageHandler {
         "set_provider",
         "set_reasoning_effort",
         "set_codex_fast_mode",
+        "get_codex_context_window",
+        "set_codex_context_window",
         "set_dsh_preset",
         "get_node_path",
         "set_node_path",
@@ -120,6 +123,7 @@ public class SettingsHandler extends BaseMessageHandler {
         this.usagePushService = new UsagePushService(context);
         this.permissionModeHandler = new PermissionModeHandler(context);
         this.modelProviderHandler = new ModelProviderHandler(context, usagePushService);
+        this.codexContextWindowHandler = new CodexContextWindowHandler(context);
         this.nodePathHandler = new NodePathHandler(context);
         this.claudeCliPathHandler = new ClaudeCliPathHandler(context);
         this.projectConfigHandler = new ProjectConfigHandler(context);
@@ -149,6 +153,7 @@ public class SettingsHandler extends BaseMessageHandler {
      * Should be called when the owning ClaudeChatWindow is disposed.
      */
     public void dispose() {
+        codexContextWindowHandler.dispose();
         if (themeCallbackHandle != null) {
             ThemeConfigService.unregisterThemeChangeListener(themeCallbackHandle);
             themeCallbackHandle = null;
@@ -182,6 +187,12 @@ public class SettingsHandler extends BaseMessageHandler {
                 return true;
             case "set_codex_fast_mode":
                 modelProviderHandler.handleSetCodexFastMode(content);
+                return true;
+            case "get_codex_context_window":
+                codexContextWindowHandler.handleGet();
+                return true;
+            case "set_codex_context_window":
+                codexContextWindowHandler.handleSet(content);
                 return true;
             case "set_dsh_preset":
                 dshPresetHandler.handleSetDshPreset(content);

--- a/src/main/java/com/github/claudecodegui/settings/CodexContextWindowConfigService.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodexContextWindowConfigService.java
@@ -1,0 +1,186 @@
+package com.github.claudecodegui.settings;
+
+import com.google.gson.Gson;
+import com.intellij.openapi.diagnostic.Logger;
+import org.jetbrains.annotations.TestOnly;
+
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Codex 全局上下文窗口配置服务。
+ *
+ * <p>所有 CC GUI 窗口共享同一个实例。服务串行化 {@code config.toml} 更新，并在
+ * 成功写入后把重新读取的权威配置广播给每个已注册窗口。</p>
+ */
+public final class CodexContextWindowConfigService {
+
+    private static final Logger LOG = Logger.getInstance(CodexContextWindowConfigService.class);
+    private static volatile CodexContextWindowConfigService instance;
+
+    private final CodexSettingsManager settingsManager;
+    private final Object writeLock = new Object();
+    private final CopyOnWriteArraySet<RegisteredCallback> callbacks = new CopyOnWriteArraySet<>();
+    private final AtomicLong callbackIdSequence = new AtomicLong();
+
+    private CodexContextWindowConfigService(CodexSettingsManager settingsManager) {
+        this.settingsManager = settingsManager;
+    }
+
+    public static CodexContextWindowConfigService getInstance() {
+        CodexContextWindowConfigService local = instance;
+        if (local == null) {
+            synchronized (CodexContextWindowConfigService.class) {
+                local = instance;
+                if (local == null) {
+                    local = new CodexContextWindowConfigService(new CodexSettingsManager(new Gson()));
+                    instance = local;
+                }
+            }
+        }
+        return local;
+    }
+
+    @TestOnly
+    static CodexContextWindowConfigService createForTests(CodexSettingsManager settingsManager) {
+        return new CodexContextWindowConfigService(settingsManager);
+    }
+
+    /**
+     * 读取当前全局配置。
+     *
+     * @return 成功时包含权威快照；失败时包含错误信息
+     */
+    public OperationResult readCurrent() {
+        try {
+            return OperationResult.success(settingsManager.readContextWindowConfig());
+        } catch (Exception e) {
+            LOG.warn("[CodexContextWindow] Failed to read config: " + e.getMessage(), e);
+            return OperationResult.failure(null, e.getMessage());
+        }
+    }
+
+    /**
+     * 更新全局预设并广播最终配置。
+     *
+     * @param preset default、500k 或 1m
+     * @return 更新结果
+     */
+    public OperationResult updatePreset(String preset) {
+        synchronized (writeLock) {
+            if (preset == null || preset.isBlank()) {
+                OperationResult current = readCurrent();
+                return OperationResult.failure(current.getConfig(), "Missing Codex context window preset");
+            }
+            try {
+                CodexSettingsManager.CodexContextWindowConfig config =
+                        settingsManager.updateContextWindowPreset(preset);
+                notifyCallbacks(config);
+                return OperationResult.success(config);
+            } catch (Exception e) {
+                LOG.warn("[CodexContextWindow] Failed to update preset: " + preset, e);
+                OperationResult current = readCurrent();
+                return OperationResult.failure(current.getConfig(), e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * 注册窗口配置回调。
+     *
+     * @param callback 配置成功变化时调用
+     * @return 用于注销的句柄
+     */
+    public RegisteredCallback registerCallback(ConfigChangedCallback callback) {
+        if (callback == null) {
+            return null;
+        }
+        RegisteredCallback handle = new RegisteredCallback(
+                callbackIdSequence.incrementAndGet(),
+                callback
+        );
+        callbacks.add(handle);
+        return handle;
+    }
+
+    /**
+     * 注销窗口配置回调，防止向已销毁 WebView 推送消息。
+     *
+     * @param handle 注册时返回的句柄
+     */
+    public void unregisterCallback(RegisteredCallback handle) {
+        if (handle != null) {
+            callbacks.remove(handle);
+        }
+    }
+
+    private void notifyCallbacks(CodexSettingsManager.CodexContextWindowConfig config) {
+        for (RegisteredCallback callback : callbacks) {
+            try {
+                callback.callback.onConfigChanged(config);
+            } catch (Exception e) {
+                LOG.warn("[CodexContextWindow] Failed to notify callback id=" + callback.id, e);
+            }
+        }
+    }
+
+    public interface ConfigChangedCallback {
+        void onConfigChanged(CodexSettingsManager.CodexContextWindowConfig config);
+    }
+
+    /**
+     * 不透明的窗口回调句柄。
+     */
+    public static final class RegisteredCallback {
+        private final long id;
+        private final ConfigChangedCallback callback;
+
+        private RegisteredCallback(long id, ConfigChangedCallback callback) {
+            this.id = id;
+            this.callback = callback;
+        }
+    }
+
+    /**
+     * 配置读写结果。
+     */
+    public static final class OperationResult {
+        private final boolean success;
+        private final CodexSettingsManager.CodexContextWindowConfig config;
+        private final String error;
+
+        private OperationResult(
+                boolean success,
+                CodexSettingsManager.CodexContextWindowConfig config,
+                String error
+        ) {
+            this.success = success;
+            this.config = config;
+            this.error = error;
+        }
+
+        static OperationResult success(CodexSettingsManager.CodexContextWindowConfig config) {
+            return new OperationResult(true, config, null);
+        }
+
+        static OperationResult failure(
+                CodexSettingsManager.CodexContextWindowConfig config,
+                String error
+        ) {
+            String message = error == null || error.isBlank() ? "Unknown configuration error" : error;
+            return new OperationResult(false, config, message);
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public CodexSettingsManager.CodexContextWindowConfig getConfig() {
+            return config;
+        }
+
+        public String getError() {
+            return error;
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/settings/CodexSettingsManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodexSettingsManager.java
@@ -43,6 +43,14 @@ public class CodexSettingsManager {
     private static final String PROVIDER_CONFIG_BASELINE_FILE_NAME = "config.toml.provider_backup";
     private static final Set<String> GLOBAL_CONFIG_KEYS = Set.of("mcp_servers", "skills");
     private static final Object CONFIG_FILE_LOCK = new Object();
+    private static final String MODEL_CONTEXT_WINDOW_KEY = "model_context_window";
+    private static final String MODEL_AUTO_COMPACT_TOKEN_LIMIT_KEY = "model_auto_compact_token_limit";
+    private static final int DEFAULT_CONTEXT_WINDOW = 272_000;
+    private static final int DEFAULT_AUTO_COMPACT_TOKEN_LIMIT = 244_800;
+    private static final int MEDIUM_CONTEXT_WINDOW = 500_000;
+    private static final int MEDIUM_AUTO_COMPACT_TOKEN_LIMIT = 450_000;
+    private static final int LARGE_CONTEXT_WINDOW = 1_000_000;
+    private static final int LARGE_AUTO_COMPACT_TOKEN_LIMIT = 900_000;
 
     // Pattern to validate TOML bare keys (letters, digits, hyphens, underscores)
     private static final Pattern TOML_KEY_PATTERN = Pattern.compile("^[a-zA-Z0-9_-]+$");
@@ -54,6 +62,11 @@ public class CodexSettingsManager {
         this.gson = gson;
         String userHome = NodeDetector.resolveHomeForFileOps();
         this.codexDir = Paths.get(userHome, ".codex");
+    }
+
+    CodexSettingsManager(Gson gson, Path codexDir) {
+        this.gson = gson;
+        this.codexDir = codexDir;
     }
 
     /**
@@ -176,6 +189,343 @@ public class CodexSettingsManager {
     boolean isConfigLockHeldByCurrentThread() {
         return Thread.holdsLock(CONFIG_FILE_LOCK);
     }
+
+    /**
+     * 读取 Codex 顶层上下文窗口配置，并映射为 CC GUI 支持的预设。
+     *
+     * <p>这里只读取第一个 TOML section 之前的顶层标量，避免把同名的 Provider
+     * 子项误判为全局配置。与预设不完全匹配的已有配置会作为 custom 返回，供前端
+     * 如实展示而不会在读取时改写用户文件。</p>
+     *
+     * @return 当前权威配置快照
+     * @throws IOException 读取配置文件失败时抛出
+     */
+    public CodexContextWindowConfig readContextWindowConfig() throws IOException {
+        synchronized (CONFIG_FILE_LOCK) {
+            return readContextWindowConfigUnlocked();
+        }
+    }
+
+    private CodexContextWindowConfig readContextWindowConfigUnlocked() throws IOException {
+        Path configPath = getConfigTomlPath();
+        if (!Files.exists(configPath)) {
+            return CodexContextWindowConfig.defaultConfig();
+        }
+
+        String content = Files.readString(configPath, StandardCharsets.UTF_8);
+        Integer contextWindow = readTopLevelInteger(content, MODEL_CONTEXT_WINDOW_KEY);
+        Integer autoCompactTokenLimit = readTopLevelInteger(content, MODEL_AUTO_COMPACT_TOKEN_LIMIT_KEY);
+
+        if (contextWindow == null && autoCompactTokenLimit == null) {
+            return CodexContextWindowConfig.defaultConfig();
+        }
+        if (Integer.valueOf(DEFAULT_CONTEXT_WINDOW).equals(contextWindow)
+                && (autoCompactTokenLimit == null
+                    || Integer.valueOf(DEFAULT_AUTO_COMPACT_TOKEN_LIMIT).equals(autoCompactTokenLimit))) {
+            return CodexContextWindowConfig.defaultConfig();
+        }
+        if (Integer.valueOf(MEDIUM_CONTEXT_WINDOW).equals(contextWindow)
+                && (autoCompactTokenLimit == null
+                    || Integer.valueOf(MEDIUM_AUTO_COMPACT_TOKEN_LIMIT).equals(autoCompactTokenLimit))) {
+            return new CodexContextWindowConfig(
+                    CodexContextWindowConfig.PRESET_500K,
+                    MEDIUM_CONTEXT_WINDOW,
+                    autoCompactTokenLimit != null ? autoCompactTokenLimit : MEDIUM_AUTO_COMPACT_TOKEN_LIMIT,
+                    false
+            );
+        }
+        if (Integer.valueOf(LARGE_CONTEXT_WINDOW).equals(contextWindow)
+                && (autoCompactTokenLimit == null
+                    || Integer.valueOf(LARGE_AUTO_COMPACT_TOKEN_LIMIT).equals(autoCompactTokenLimit))) {
+            return new CodexContextWindowConfig(
+                    CodexContextWindowConfig.PRESET_1M,
+                    LARGE_CONTEXT_WINDOW,
+                    autoCompactTokenLimit != null ? autoCompactTokenLimit : LARGE_AUTO_COMPACT_TOKEN_LIMIT,
+                    false
+            );
+        }
+
+        return new CodexContextWindowConfig(
+                CodexContextWindowConfig.PRESET_CUSTOM,
+                contextWindow,
+                autoCompactTokenLimit,
+                true
+        );
+    }
+
+    /**
+     * 原子更新 Codex 顶层上下文窗口配置，保留其余 TOML 文本、注释和 section。
+     *
+     * <p>default 会移除两个覆盖项；500k 和 1m 会写入窗口值以及 90% 自动压缩线。
+     * 此方法不会修改 model、Provider 或压缩 scope。</p>
+     *
+     * @param preset default、500k 或 1m
+     * @return 写入后重新读取的权威配置
+     * @throws IOException 读取或写入失败时抛出
+     * @throws IllegalArgumentException 预设非法时抛出
+     */
+    public CodexContextWindowConfig updateContextWindowPreset(String preset) throws IOException {
+        synchronized (CONFIG_FILE_LOCK) {
+            return updateContextWindowPresetUnlocked(preset);
+        }
+    }
+
+    private CodexContextWindowConfig updateContextWindowPresetUnlocked(String preset) throws IOException {
+        int contextWindow;
+        int autoCompactTokenLimit;
+        boolean restoreDefault;
+        switch (preset) {
+            case CodexContextWindowConfig.PRESET_DEFAULT:
+                contextWindow = DEFAULT_CONTEXT_WINDOW;
+                autoCompactTokenLimit = DEFAULT_AUTO_COMPACT_TOKEN_LIMIT;
+                restoreDefault = true;
+                break;
+            case CodexContextWindowConfig.PRESET_500K:
+                contextWindow = MEDIUM_CONTEXT_WINDOW;
+                autoCompactTokenLimit = MEDIUM_AUTO_COMPACT_TOKEN_LIMIT;
+                restoreDefault = false;
+                break;
+            case CodexContextWindowConfig.PRESET_1M:
+                contextWindow = LARGE_CONTEXT_WINDOW;
+                autoCompactTokenLimit = LARGE_AUTO_COMPACT_TOKEN_LIMIT;
+                restoreDefault = false;
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported Codex context window preset: " + preset);
+        }
+
+        Path configPath = getConfigTomlPath();
+        if (restoreDefault && !Files.exists(configPath)) {
+            return CodexContextWindowConfig.defaultConfig();
+        }
+
+        String original = Files.exists(configPath)
+                ? Files.readString(configPath, StandardCharsets.UTF_8)
+                : "";
+        String patched = patchTopLevelContextWindow(
+                original,
+                restoreDefault ? null : contextWindow,
+                restoreDefault ? null : autoCompactTokenLimit
+        );
+
+        if (!patched.equals(original)) {
+            writeStringAtomically(configPath, patched);
+            LOG.info("[CodexSettingsManager] Updated Codex context window preset to: " + preset);
+        }
+        return readContextWindowConfigUnlocked();
+    }
+
+    private Integer readTopLevelInteger(String content, String key) {
+        String normalized = stripBom(content);
+        String[] lines = normalized.split("\\r?\\n", -1);
+        Pattern assignmentPattern = Pattern.compile(
+                "^\\s*" + exactTomlKeyPattern(key)
+                        + "\\s*=\\s*([0-9][0-9_]*)\\s*(?:#.*)?$"
+        );
+        for (String line : lines) {
+            if (isTomlSectionHeader(line)) {
+                break;
+            }
+            java.util.regex.Matcher matcher = assignmentPattern.matcher(line);
+            if (!matcher.matches()) {
+                continue;
+            }
+            try {
+                long parsed = Long.parseLong(matcher.group(1).replace("_", ""));
+                if (parsed > 0 && parsed <= Integer.MAX_VALUE) {
+                    return (int) parsed;
+                }
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private String patchTopLevelContextWindow(
+            String original,
+            Integer contextWindow,
+            Integer autoCompactTokenLimit
+    ) throws IOException {
+        boolean hasBom = original.startsWith("\uFEFF");
+        String body = stripBom(original);
+        String newline = body.contains("\r\n") ? "\r\n" : "\n";
+        boolean endedWithNewline = body.endsWith("\n") || body.endsWith("\r");
+        String[] sourceLines = body.split("\\r?\\n", -1);
+        List<String> topLevel = new ArrayList<>();
+        List<String> sections = new ArrayList<>();
+        boolean inSection = false;
+        boolean contextWritten = false;
+        boolean autoCompactWritten = false;
+
+        Pattern contextPattern = topLevelAssignmentPattern(MODEL_CONTEXT_WINDOW_KEY);
+        Pattern autoCompactPattern = topLevelAssignmentPattern(MODEL_AUTO_COMPACT_TOKEN_LIMIT_KEY);
+
+        for (String line : sourceLines) {
+            if (!inSection && isTomlSectionHeader(line)) {
+                inSection = true;
+            }
+            if (inSection) {
+                sections.add(line);
+                continue;
+            }
+
+            if (contextPattern.matcher(line).matches()) {
+                if (contextWindow != null && !contextWritten) {
+                    topLevel.add(MODEL_CONTEXT_WINDOW_KEY + " = " + contextWindow);
+                    contextWritten = true;
+                }
+                continue;
+            }
+            if (autoCompactPattern.matcher(line).matches()) {
+                if (autoCompactTokenLimit != null && !autoCompactWritten) {
+                    topLevel.add(MODEL_AUTO_COMPACT_TOKEN_LIMIT_KEY + " = " + autoCompactTokenLimit);
+                    autoCompactWritten = true;
+                }
+                continue;
+            }
+            topLevel.add(line);
+        }
+
+        if (contextWindow != null && !contextWritten) {
+            insertBeforeTrailingBlankLines(topLevel, MODEL_CONTEXT_WINDOW_KEY + " = " + contextWindow);
+        }
+        if (autoCompactTokenLimit != null && !autoCompactWritten) {
+            int insertionIndex = indexBeforeTrailingBlankLines(topLevel);
+            topLevel.add(insertionIndex, MODEL_AUTO_COMPACT_TOKEN_LIMIT_KEY + " = " + autoCompactTokenLimit);
+        }
+
+        if (!sections.isEmpty() && !topLevel.isEmpty()
+                && !topLevel.get(topLevel.size() - 1).isEmpty()) {
+            topLevel.add("");
+        }
+
+        List<String> resultLines = new ArrayList<>(topLevel.size() + sections.size());
+        resultLines.addAll(topLevel);
+        resultLines.addAll(sections);
+
+        // split(..., -1) already represents a trailing newline as an empty last line.
+        // New files should also end with a newline, matching standard config.toml formatting.
+        if (body.isEmpty() && contextWindow != null) {
+            endedWithNewline = true;
+        }
+        while (resultLines.size() > 1
+                && resultLines.get(resultLines.size() - 1).isEmpty()
+                && resultLines.get(resultLines.size() - 2).isEmpty()
+                && !endedWithNewline) {
+            resultLines.remove(resultLines.size() - 1);
+        }
+
+        String patched = String.join(newline, resultLines);
+        if (endedWithNewline && !patched.endsWith(newline)) {
+            patched += newline;
+        }
+        if (hasBom) {
+            patched = "\uFEFF" + patched;
+        }
+
+        validatePatchedContextWindow(patched, contextWindow, autoCompactTokenLimit);
+        return patched;
+    }
+
+    private void validatePatchedContextWindow(
+            String patched,
+            Integer expectedContextWindow,
+            Integer expectedAutoCompactTokenLimit
+    ) throws IOException {
+        Integer actualContextWindow = readTopLevelInteger(patched, MODEL_CONTEXT_WINDOW_KEY);
+        Integer actualAutoCompactTokenLimit = readTopLevelInteger(
+                patched,
+                MODEL_AUTO_COMPACT_TOKEN_LIMIT_KEY
+        );
+        if (!java.util.Objects.equals(expectedContextWindow, actualContextWindow)
+                || !java.util.Objects.equals(expectedAutoCompactTokenLimit, actualAutoCompactTokenLimit)) {
+            throw new IOException("Failed to validate patched Codex context window configuration");
+        }
+    }
+
+    private Pattern topLevelAssignmentPattern(String key) {
+        return Pattern.compile("^\\s*" + exactTomlKeyPattern(key) + "\\s*=.*$");
+    }
+
+    private String exactTomlKeyPattern(String key) {
+        String quoted = Pattern.quote(key);
+        return "(?:" + quoted + "|\\\"" + quoted + "\\\"|'" + quoted + "')";
+    }
+
+    private boolean isTomlSectionHeader(String line) {
+        String trimmed = line == null ? "" : line.trim();
+        return trimmed.startsWith("[");
+    }
+
+    private String stripBom(String content) {
+        return content != null && content.startsWith("\uFEFF") ? content.substring(1) : content;
+    }
+
+    private void insertBeforeTrailingBlankLines(List<String> lines, String value) {
+        lines.add(indexBeforeTrailingBlankLines(lines), value);
+    }
+
+    private int indexBeforeTrailingBlankLines(List<String> lines) {
+        int index = lines.size();
+        while (index > 0 && lines.get(index - 1).trim().isEmpty()) {
+            index--;
+        }
+        return index;
+    }
+
+    /**
+     * Codex 上下文窗口的权威配置快照。
+     */
+    public static final class CodexContextWindowConfig {
+        public static final String PRESET_DEFAULT = "default";
+        public static final String PRESET_500K = "500k";
+        public static final String PRESET_1M = "1m";
+        public static final String PRESET_CUSTOM = "custom";
+
+        private final String preset;
+        private final Integer contextWindow;
+        private final Integer autoCompactTokenLimit;
+        private final boolean custom;
+
+        CodexContextWindowConfig(
+                String preset,
+                Integer contextWindow,
+                Integer autoCompactTokenLimit,
+                boolean custom
+        ) {
+            this.preset = preset;
+            this.contextWindow = contextWindow;
+            this.autoCompactTokenLimit = autoCompactTokenLimit;
+            this.custom = custom;
+        }
+
+        static CodexContextWindowConfig defaultConfig() {
+            return new CodexContextWindowConfig(
+                    PRESET_DEFAULT,
+                    DEFAULT_CONTEXT_WINDOW,
+                    DEFAULT_AUTO_COMPACT_TOKEN_LIMIT,
+                    false
+            );
+        }
+
+        public String getPreset() {
+            return preset;
+        }
+
+        public Integer getContextWindow() {
+            return contextWindow;
+        }
+
+        public Integer getAutoCompactTokenLimit() {
+            return autoCompactTokenLimit;
+        }
+
+        public boolean isCustom() {
+            return custom;
+        }
+    }
+
 
     /**
      * Read auth.json

--- a/src/test/java/com/github/claudecodegui/settings/CodexContextWindowConfigTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/CodexContextWindowConfigTest.java
@@ -1,0 +1,220 @@
+package com.github.claudecodegui.settings;
+
+import com.google.gson.Gson;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class CodexContextWindowConfigTest {
+
+    @Test
+    public void defaultPresetDoesNotCreateMissingConfig() throws Exception {
+        Path codexDir = Files.createTempDirectory("codex-context-default");
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson(), codexDir);
+
+        CodexSettingsManager.CodexContextWindowConfig config =
+                manager.updateContextWindowPreset("default");
+
+        assertEquals("default", config.getPreset());
+        assertEquals(Integer.valueOf(272_000), config.getContextWindow());
+        assertEquals(Integer.valueOf(244_800), config.getAutoCompactTokenLimit());
+        assertFalse(Files.exists(codexDir.resolve("config.toml")));
+    }
+
+    @Test
+    public void writes500kAndPreservesBomCrLfCommentsAndSections() throws Exception {
+        Path codexDir = Files.createTempDirectory("codex-context-500k");
+        Path configPath = codexDir.resolve("config.toml");
+        String original = "\uFEFF# keep this comment\r\n"
+                + "model_context_window = 1000000 # old\r\n"
+                + "model_context_window = 900000 # duplicate\r\n"
+                + "model_auto_compact_token_limit = 900000\r\n"
+                + "custom_key = \"keep\"\r\n"
+                + "\r\n"
+                + "[profiles.work]\r\n"
+                + "model_context_window = 123456\r\n";
+        Files.writeString(configPath, original, StandardCharsets.UTF_8);
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson(), codexDir);
+
+        CodexSettingsManager.CodexContextWindowConfig config =
+                manager.updateContextWindowPreset("500k");
+
+        String written = Files.readString(configPath, StandardCharsets.UTF_8);
+        assertTrue(written.startsWith("\uFEFF# keep this comment\r\n"));
+        assertTrue(written.contains("model_context_window = 500000\r\n"));
+        assertTrue(written.contains("model_auto_compact_token_limit = 450000\r\n"));
+        assertTrue(written.contains("custom_key = \"keep\"\r\n"));
+        assertTrue(written.contains("[profiles.work]\r\nmodel_context_window = 123456\r\n"));
+        assertEquals(2, countOccurrences(written, "model_context_window ="));
+        assertEquals("500k", config.getPreset());
+        assertFalse(config.isCustom());
+    }
+
+    @Test
+    public void writes1mPresetWithNinetyPercentCompaction() throws Exception {
+        Path codexDir = Files.createTempDirectory("codex-context-1m");
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson(), codexDir);
+
+        CodexSettingsManager.CodexContextWindowConfig config =
+                manager.updateContextWindowPreset("1m");
+
+        String written = Files.readString(codexDir.resolve("config.toml"), StandardCharsets.UTF_8);
+        assertEquals("model_context_window = 1000000\n"
+                + "model_auto_compact_token_limit = 900000\n", written);
+        assertEquals("1m", config.getPreset());
+        assertEquals(Integer.valueOf(1_000_000), config.getContextWindow());
+        assertEquals(Integer.valueOf(900_000), config.getAutoCompactTokenLimit());
+    }
+
+    @Test
+    public void replacesQuotedTopLevelKeysWithoutCreatingTomlDuplicates() throws Exception {
+        Path codexDir = Files.createTempDirectory("codex-context-quoted");
+        Path configPath = codexDir.resolve("config.toml");
+        Files.writeString(
+                configPath,
+                "\"model_context_window\" = 1000000\n"
+                        + "'model_auto_compact_token_limit' = 900000\n",
+                StandardCharsets.UTF_8
+        );
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson(), codexDir);
+
+        CodexSettingsManager.CodexContextWindowConfig before = manager.readContextWindowConfig();
+        CodexSettingsManager.CodexContextWindowConfig after =
+                manager.updateContextWindowPreset("500k");
+
+        String written = Files.readString(configPath, StandardCharsets.UTF_8);
+        assertEquals("1m", before.getPreset());
+        assertEquals("500k", after.getPreset());
+        assertEquals("model_context_window = 500000\n"
+                + "model_auto_compact_token_limit = 450000\n", written);
+        assertFalse(written.contains("\"model_context_window\""));
+        assertFalse(written.contains("'model_auto_compact_token_limit'"));
+    }
+
+    @Test
+    public void defaultRemovesOnlyTopLevelOverrides() throws Exception {
+        Path codexDir = Files.createTempDirectory("codex-context-remove");
+        Path configPath = codexDir.resolve("config.toml");
+        Files.writeString(
+                configPath,
+                "# context settings\n"
+                        + "model_context_window = 500000\n"
+                        + "model_auto_compact_token_limit = 450000\n"
+                        + "model = \"gpt-5.6-sol\"\n"
+                        + "\n"
+                        + "[profiles.large]\n"
+                        + "model_context_window = 1000000\n"
+                        + "model_auto_compact_token_limit = 900000\n",
+                StandardCharsets.UTF_8
+        );
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson(), codexDir);
+
+        CodexSettingsManager.CodexContextWindowConfig config =
+                manager.updateContextWindowPreset("default");
+
+        String written = Files.readString(configPath, StandardCharsets.UTF_8);
+        String topLevel = written.substring(0, written.indexOf("[profiles.large]"));
+        assertFalse(topLevel.contains("model_context_window"));
+        assertFalse(topLevel.contains("model_auto_compact_token_limit"));
+        assertTrue(written.contains("model = \"gpt-5.6-sol\""));
+        assertTrue(written.contains("[profiles.large]\nmodel_context_window = 1000000"));
+        assertEquals("default", config.getPreset());
+    }
+
+    @Test
+    public void readsMismatchedValuesAsCustomWithoutChangingFile() throws Exception {
+        Path codexDir = Files.createTempDirectory("codex-context-custom");
+        Path configPath = codexDir.resolve("config.toml");
+        String original = "model_context_window = 640000\n"
+                + "model_auto_compact_token_limit = 500000\n";
+        Files.writeString(configPath, original, StandardCharsets.UTF_8);
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson(), codexDir);
+
+        CodexSettingsManager.CodexContextWindowConfig config = manager.readContextWindowConfig();
+
+        assertEquals("custom", config.getPreset());
+        assertTrue(config.isCustom());
+        assertEquals(Integer.valueOf(640_000), config.getContextWindow());
+        assertEquals(Integer.valueOf(500_000), config.getAutoCompactTokenLimit());
+        assertEquals(original, Files.readString(configPath, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void invalidPresetLeavesConfigUnchanged() throws Exception {
+        Path codexDir = Files.createTempDirectory("codex-context-invalid");
+        Path configPath = codexDir.resolve("config.toml");
+        String original = "model_context_window = 500000\n"
+                + "model_auto_compact_token_limit = 450000\n";
+        Files.writeString(configPath, original, StandardCharsets.UTF_8);
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson(), codexDir);
+
+        try {
+            manager.updateContextWindowPreset("2m");
+            fail("Expected invalid preset to be rejected");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("2m"));
+        }
+
+        assertEquals(original, Files.readString(configPath, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void serviceBroadcastsSuccessfulWritesAndUnregistersCallbacks() throws Exception {
+        Path codexDir = Files.createTempDirectory("codex-context-service");
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson(), codexDir);
+        CodexContextWindowConfigService service =
+                CodexContextWindowConfigService.createForTests(manager);
+        AtomicInteger firstCalls = new AtomicInteger();
+        AtomicInteger secondCalls = new AtomicInteger();
+        CodexContextWindowConfigService.RegisteredCallback first =
+                service.registerCallback(config -> firstCalls.incrementAndGet());
+        service.registerCallback(config -> secondCalls.incrementAndGet());
+
+        CodexContextWindowConfigService.OperationResult firstResult = service.updatePreset("500k");
+        service.unregisterCallback(first);
+        CodexContextWindowConfigService.OperationResult secondResult = service.updatePreset("1m");
+
+        assertTrue(firstResult.isSuccess());
+        assertTrue(secondResult.isSuccess());
+        assertEquals(1, firstCalls.get());
+        assertEquals(2, secondCalls.get());
+        assertNull(secondResult.getError());
+        assertEquals("1m", service.readCurrent().getConfig().getPreset());
+    }
+
+    @Test
+    public void serviceRejectsInvalidPresetWithoutBroadcasting() throws Exception {
+        Path codexDir = Files.createTempDirectory("codex-context-service-invalid");
+        CodexSettingsManager manager = new CodexSettingsManager(new Gson(), codexDir);
+        CodexContextWindowConfigService service =
+                CodexContextWindowConfigService.createForTests(manager);
+        AtomicInteger calls = new AtomicInteger();
+        service.registerCallback(config -> calls.incrementAndGet());
+
+        CodexContextWindowConfigService.OperationResult result = service.updatePreset("invalid");
+
+        assertFalse(result.isSuccess());
+        assertEquals(0, calls.get());
+        assertFalse(Files.exists(codexDir.resolve("config.toml")));
+        assertEquals("default", result.getConfig().getPreset());
+    }
+
+    private int countOccurrences(String value, String needle) {
+        int count = 0;
+        int index = 0;
+        while ((index = value.indexOf(needle, index)) >= 0) {
+            count++;
+            index += needle.length();
+        }
+        return count;
+    }
+}

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -161,7 +161,10 @@ const App = () => {
     claudeSdkMeetsMinimum,
     currentProviderRef,
     activeProviderConfig, claudeSettingsAlwaysThinkingEnabled,
-    reasoningEffort, codexFastMode, dshPreset, streamingEnabledSetting, sendShortcut, autoOpenFileEnabled,
+    reasoningEffort, codexFastMode,
+    codexContextWindow, codexContextWindowTokens,
+    codexContextWindowLoading, codexContextWindowSaving,
+    dshPreset, streamingEnabledSetting, sendShortcut, autoOpenFileEnabled,
     longContextEnabled,
     usagePercentage, usageUsedTokens, usageMaxTokens,
     setPermissionMode, setCurrentProvider,
@@ -178,7 +181,8 @@ const App = () => {
     setUsagePercentage, setUsageUsedTokens, setUsageMaxTokens,
     syncActiveProviderModelMapping,
     handleModeSelect, handleModelSelect, handleProviderSelect,
-    handleReasoningChange, handleCodexFastModeChange, handleDshPresetChange, handleAgentSelect, handleToggleThinking,
+    handleReasoningChange, handleCodexFastModeChange, handleCodexContextWindowChange,
+    refreshCodexContextWindow, handleDshPresetChange, handleAgentSelect, handleToggleThinking,
     handleStreamingEnabledChange, handleSendShortcutChange,
     handleAutoOpenFileEnabledChange, handleLongContextChange,
   } = useModelProviderState({ addToast, t });
@@ -649,6 +653,10 @@ const App = () => {
               claudeSettingsAlwaysThinkingEnabled={claudeSettingsAlwaysThinkingEnabled}
               reasoningEffort={reasoningEffort}
               codexFastMode={codexFastMode}
+              codexContextWindow={codexContextWindow}
+              codexContextWindowTokens={codexContextWindowTokens}
+              codexContextWindowLoading={codexContextWindowLoading}
+              codexContextWindowSaving={codexContextWindowSaving}
               dshPreset={dshPreset}
               streamingEnabledSetting={streamingEnabledSetting}
               sendShortcut={sendShortcut}
@@ -662,6 +670,8 @@ const App = () => {
               onAgentSelect={handleAgentSelect}
               onReasoningChange={handleReasoningChange}
               onCodexFastModeChange={handleCodexFastModeChange}
+              onCodexContextWindowChange={handleCodexContextWindowChange}
+              onCodexContextWindowRefresh={refreshCodexContextWindow}
               onDshPresetChange={handleDshPresetChange}
               onToggleThinking={handleToggleThinking}
               onStreamingEnabledChange={handleStreamingEnabledChange}

--- a/webview/src/components/ChatInputBox/ButtonArea.codexContextWindow.test.tsx
+++ b/webview/src/components/ChatInputBox/ButtonArea.codexContextWindow.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ButtonArea } from './ButtonArea';
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (_key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? _key,
+    }),
+  };
+});
+
+describe('ButtonArea Codex context-window placement', () => {
+  it('shows the context selector immediately after speed only for Codex', () => {
+    const props = {
+      selectedModel: 'gpt-5.6-sol',
+      currentProvider: 'codex',
+      onModelSelect: vi.fn(),
+      onProviderSelect: vi.fn(),
+      onCodexContextWindowChange: vi.fn(),
+      onCodexContextWindowRefresh: vi.fn(),
+    } as const;
+    const { rerender } = render(<ButtonArea {...props} />);
+
+    const speedButton = screen.getByTitle('Select Codex speed mode');
+    const contextSelector = screen.getByTestId('codex-context-window-select');
+    expect(speedButton.parentElement?.nextElementSibling).toBe(contextSelector);
+
+    rerender(<ButtonArea {...props} currentProvider="claude" />);
+    expect(screen.queryByTestId('codex-context-window-select')).toBeNull();
+  });
+});

--- a/webview/src/components/ChatInputBox/ButtonArea.tsx
+++ b/webview/src/components/ChatInputBox/ButtonArea.tsx
@@ -2,7 +2,16 @@ import { useCallback, useMemo, useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { ButtonAreaProps, CodexFastMode, ModelInfo, PermissionMode, ReasoningEffort } from './types';
 import { DEFAULT_CLAUDE_MODEL_ID } from './types';
-import { CodexFastModeSelect, ConfigSelect, DshPresetSelect, ModelSelect, ModeSelect, ProviderSelect, ReasoningSelect } from './selectors';
+import {
+  CodexContextWindowSelect,
+  CodexFastModeSelect,
+  ConfigSelect,
+  DshPresetSelect,
+  ModelSelect,
+  ModeSelect,
+  ProviderSelect,
+  ReasoningSelect,
+} from './selectors';
 import { STORAGE_KEYS, validateCodexCustomModels } from '../../types/provider';
 import type { CodexCustomModel } from '../../types/provider';
 import { readClaudeModelMapping } from '../../utils/claudeModelMapping';
@@ -80,6 +89,10 @@ export const ButtonArea = ({
   reasoningEffort = 'high',
   dshPreset = '',
   codexFastMode = 'normal',
+  codexContextWindow = 'default',
+  codexContextWindowTokens = 272_000,
+  codexContextWindowLoading = false,
+  codexContextWindowSaving = false,
   onSubmit,
   onStop,
   onModeSelect,
@@ -87,6 +100,8 @@ export const ButtonArea = ({
   onProviderSelect,
   onReasoningChange,
   onCodexFastModeChange,
+  onCodexContextWindowChange,
+  onCodexContextWindowRefresh,
   onDshPresetChange,
   onEnhancePrompt,
   alwaysThinkingEnabled = false,
@@ -259,6 +274,9 @@ export const ButtonArea = ({
     permissionMode,
     reasoningEffort,
     codexFastMode,
+    codexContextWindow,
+    codexContextWindowLoading ? 'context-loading' : 'context-ready',
+    codexContextWindowSaving ? 'context-saving' : 'context-saved',
     dshPreset,
     selectedAgent?.id ?? '',
     cliModelsLoading ? 'loading' : 'ready',
@@ -308,7 +326,19 @@ export const ButtonArea = ({
         />
         <ReasoningSelect value={reasoningEffort} onChange={handleReasoningChange} selectedModel={selectedModel} currentProvider={currentProvider} />
         {currentProvider === 'codex' && (
-          <CodexFastModeSelect value={codexFastMode} onChange={handleCodexFastModeChange} />
+          <>
+            <CodexFastModeSelect value={codexFastMode} onChange={handleCodexFastModeChange} />
+            {onCodexContextWindowChange ? (
+              <CodexContextWindowSelect
+                value={codexContextWindow}
+                contextWindowTokens={codexContextWindowTokens}
+                loading={codexContextWindowLoading}
+                saving={codexContextWindowSaving}
+                onChange={onCodexContextWindowChange}
+                onRefresh={onCodexContextWindowRefresh}
+              />
+            ) : null}
+          </>
         )}
         {currentProvider === 'dsh' && (
           <DshPresetSelect value={dshPreset} onChange={handleDshPresetChange} />

--- a/webview/src/components/ChatInputBox/ChatInputBox.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBox.tsx
@@ -100,6 +100,12 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
       onReasoningChange,
       codexFastMode = 'normal',
       onCodexFastModeChange,
+      codexContextWindow = 'default',
+      codexContextWindowTokens = 272_000,
+      codexContextWindowLoading = false,
+      codexContextWindowSaving = false,
+      onCodexContextWindowChange,
+      onCodexContextWindowRefresh,
       dshPreset,
       onDshPresetChange,
       activeFile,
@@ -453,6 +459,7 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
       sdkStatusLoading,
       sdkInstalled,
       currentProvider,
+      submitBlocked: currentProvider === 'codex' && codexContextWindowSaving,
       clearInput,
       cancelPendingInput: () => {
         debouncedOnInput.cancel();
@@ -779,6 +786,10 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
           currentProvider={currentProvider}
           reasoningEffort={reasoningEffort}
           codexFastMode={codexFastMode}
+          codexContextWindow={codexContextWindow}
+          codexContextWindowTokens={codexContextWindowTokens}
+          codexContextWindowLoading={codexContextWindowLoading}
+          codexContextWindowSaving={codexContextWindowSaving}
           dshPreset={dshPreset}
           onSubmit={handleSubmit}
           onStop={onStop}
@@ -787,6 +798,8 @@ export const ChatInputBox = memo(forwardRef<ChatInputBoxHandle, ChatInputBoxProp
           onProviderSelect={onProviderSelect}
           onReasoningChange={onReasoningChange}
           onCodexFastModeChange={onCodexFastModeChange}
+          onCodexContextWindowChange={onCodexContextWindowChange}
+          onCodexContextWindowRefresh={onCodexContextWindowRefresh}
           onDshPresetChange={onDshPresetChange}
           onEnhancePrompt={handleEnhancePrompt}
           alwaysThinkingEnabled={alwaysThinkingEnabled}

--- a/webview/src/components/ChatInputBox/ChatInputBoxFooter.tsx
+++ b/webview/src/components/ChatInputBox/ChatInputBoxFooter.tsx
@@ -1,5 +1,14 @@
 import type { TFunction } from 'i18next';
-import type { CodexFastMode, DropdownItemData, DropdownPosition, PermissionMode, ReasoningEffort, SelectedAgent } from './types.js';
+import type {
+  CodexContextWindowPreset,
+  CodexContextWindowValue,
+  CodexFastMode,
+  DropdownItemData,
+  DropdownPosition,
+  PermissionMode,
+  ReasoningEffort,
+  SelectedAgent,
+} from './types.js';
 import type { TooltipState } from './hooks/useTooltip.js';
 import { ButtonArea } from './ButtonArea.js';
 import { CompletionDropdown } from './Dropdown/index.js';
@@ -26,6 +35,10 @@ export function ChatInputBoxFooter({
   currentProvider,
   reasoningEffort,
   codexFastMode,
+  codexContextWindow,
+  codexContextWindowTokens,
+  codexContextWindowLoading,
+  codexContextWindowSaving,
   dshPreset,
   onSubmit,
   onStop,
@@ -34,6 +47,8 @@ export function ChatInputBoxFooter({
   onProviderSelect,
   onReasoningChange,
   onCodexFastModeChange,
+  onCodexContextWindowChange,
+  onCodexContextWindowRefresh,
   onDshPresetChange,
   onEnhancePrompt,
   alwaysThinkingEnabled,
@@ -65,6 +80,10 @@ export function ChatInputBoxFooter({
   currentProvider: string;
   reasoningEffort: ReasoningEffort;
   codexFastMode?: CodexFastMode;
+  codexContextWindow?: CodexContextWindowValue;
+  codexContextWindowTokens?: number | null;
+  codexContextWindowLoading?: boolean;
+  codexContextWindowSaving?: boolean;
   dshPreset?: string;
   onSubmit: () => void;
   onStop?: () => void;
@@ -73,6 +92,8 @@ export function ChatInputBoxFooter({
   onProviderSelect?: (providerId: string) => void;
   onReasoningChange?: (effort: ReasoningEffort) => void;
   onCodexFastModeChange?: (mode: CodexFastMode) => void;
+  onCodexContextWindowChange?: (preset: CodexContextWindowPreset) => void;
+  onCodexContextWindowRefresh?: () => void;
   onDshPresetChange?: (preset: string) => void;
   onEnhancePrompt: () => void;
   alwaysThinkingEnabled?: boolean;
@@ -113,7 +134,7 @@ export function ChatInputBoxFooter({
     <>
       {/* Bottom button area */}
       <ButtonArea
-        disabled={disabled || isLoading}
+        disabled={disabled || isLoading || codexContextWindowSaving}
         hasInputContent={hasInputContent}
         isLoading={isLoading}
         isEnhancing={isEnhancing}
@@ -122,6 +143,10 @@ export function ChatInputBoxFooter({
         currentProvider={currentProvider}
         reasoningEffort={reasoningEffort}
         codexFastMode={codexFastMode}
+        codexContextWindow={codexContextWindow}
+        codexContextWindowTokens={codexContextWindowTokens}
+        codexContextWindowLoading={codexContextWindowLoading}
+        codexContextWindowSaving={codexContextWindowSaving}
         dshPreset={dshPreset}
         onSubmit={onSubmit}
         onStop={onStop}
@@ -130,6 +155,8 @@ export function ChatInputBoxFooter({
         onProviderSelect={onProviderSelect}
         onReasoningChange={onReasoningChange}
         onCodexFastModeChange={onCodexFastModeChange}
+        onCodexContextWindowChange={onCodexContextWindowChange}
+        onCodexContextWindowRefresh={onCodexContextWindowRefresh}
         onDshPresetChange={onDshPresetChange}
         onEnhancePrompt={onEnhancePrompt}
         alwaysThinkingEnabled={alwaysThinkingEnabled}

--- a/webview/src/components/ChatInputBox/hooks/useSubmitHandler.test.ts
+++ b/webview/src/components/ChatInputBox/hooks/useSubmitHandler.test.ts
@@ -7,6 +7,43 @@ function createAttachment(id: string): Attachment {
 }
 
 describe('useSubmitHandler', () => {
+  it('blocks keyboard and button submission while Codex context config is saving', () => {
+    const addToast = vi.fn();
+    const clearInput = vi.fn();
+    const onSubmit = vi.fn();
+
+    const { result } = renderHook(() =>
+      useSubmitHandler({
+        getTextContent: () => 'hello',
+        invalidateCache: vi.fn(),
+        attachments: [],
+        isLoading: false,
+        sdkStatusLoading: false,
+        sdkInstalled: true,
+        currentProvider: 'codex',
+        submitBlocked: true,
+        clearInput,
+        cancelPendingInput: vi.fn(),
+        externalAttachments: undefined,
+        setInternalAttachments: vi.fn(),
+        fileCompletion: { close: vi.fn() },
+        commandCompletion: { close: vi.fn() },
+        agentCompletion: { close: vi.fn() },
+        promptCompletion: { close: vi.fn() },
+        dollarCommandCompletion: { close: vi.fn() },
+        recordInputHistory: vi.fn(),
+        onSubmit,
+        addToast,
+        t: (key) => key,
+      })
+    );
+
+    result.current();
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(clearInput).not.toHaveBeenCalled();
+    expect(addToast).toHaveBeenCalledWith('codexContextWindow.savingBlocked', 'info');
+  });
+
   it('does nothing when input is empty and no attachments', () => {
     const clearInput = vi.fn();
     const close = vi.fn();

--- a/webview/src/components/ChatInputBox/hooks/useSubmitHandler.ts
+++ b/webview/src/components/ChatInputBox/hooks/useSubmitHandler.ts
@@ -13,6 +13,7 @@ export interface UseSubmitHandlerOptions {
   sdkStatusLoading: boolean;
   sdkInstalled: boolean;
   currentProvider: string;
+  submitBlocked?: boolean;
   clearInput: () => void;
   /** Cancel any pending debounced input callbacks to prevent stale values from refilling the input */
   cancelPendingInput: () => void;
@@ -49,6 +50,7 @@ export function useSubmitHandler({
   sdkStatusLoading,
   sdkInstalled,
   currentProvider,
+  submitBlocked = false,
   clearInput,
   cancelPendingInput,
   invalidateCache,
@@ -67,6 +69,16 @@ export function useSubmitHandler({
   t,
 }: UseSubmitHandlerOptions) {
   return useCallback(() => {
+    if (submitBlocked) {
+      addToast?.(
+        t('codexContextWindow.savingBlocked', {
+          defaultValue: 'Please wait for the Codex context setting to finish saving',
+        }),
+        'info',
+      );
+      return;
+    }
+
     // Force fresh DOM read to avoid stale cache (e.g., after paste)
     invalidateCache();
     const content = getTextContent();
@@ -126,6 +138,7 @@ export function useSubmitHandler({
     sdkStatusLoading,
     sdkInstalled,
     currentProvider,
+    submitBlocked,
     clearInput,
     cancelPendingInput,
     externalAttachments,

--- a/webview/src/components/ChatInputBox/selectors/CodexContextWindowSelect.test.tsx
+++ b/webview/src/components/ChatInputBox/selectors/CodexContextWindowSelect.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CodexContextWindowSelect } from './CodexContextWindowSelect';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: { defaultValue?: string; value?: string }) => {
+      const fallback = options?.defaultValue ?? _key;
+      return fallback.replace('{{value}}', options?.value ?? '');
+    },
+  }),
+}));
+
+describe('CodexContextWindowSelect', () => {
+  it('shows exactly three presets and refreshes when opened', () => {
+    const onChange = vi.fn();
+    const onRefresh = vi.fn();
+    render(
+      <CodexContextWindowSelect
+        value="default"
+        contextWindowTokens={272_000}
+        onChange={onChange}
+        onRefresh={onRefresh}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+    expect(screen.getAllByText('Default 272K').length).toBeGreaterThan(0);
+    expect(screen.getByText('500K')).toBeTruthy();
+    expect(screen.getByText('1M')).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('codex-context-option-500k'));
+    expect(onChange).toHaveBeenCalledWith('500k');
+  });
+
+  it('shows a non-selectable custom value without adding a fourth option', () => {
+    render(
+      <CodexContextWindowSelect
+        value="custom"
+        contextWindowTokens={640_000}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Custom 640K')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+  });
+
+  it('disables interaction while loading or saving', () => {
+    const { rerender } = render(
+      <CodexContextWindowSelect
+        value="default"
+        loading
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button')).toHaveProperty('disabled', true);
+
+    rerender(
+      <CodexContextWindowSelect
+        value="1m"
+        saving
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button')).toHaveProperty('disabled', true);
+  });
+});

--- a/webview/src/components/ChatInputBox/selectors/CodexContextWindowSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/CodexContextWindowSelect.tsx
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { CodexContextWindowPreset, CodexContextWindowValue } from '../types';
+
+const RELATIVE_INLINE_BLOCK_STYLE: React.CSSProperties = { position: 'relative', display: 'inline-block' };
+const CHEVRON_ICON_STYLE: React.CSSProperties = { fontSize: '10px', marginLeft: '2px' };
+const DROPDOWN_STYLE: React.CSSProperties = {
+  position: 'absolute',
+  bottom: '100%',
+  left: 0,
+  marginBottom: '4px',
+  zIndex: 10000,
+  minWidth: '230px',
+};
+const OPTION_INFO_STYLE: React.CSSProperties = { display: 'flex', flexDirection: 'column', flex: 1 };
+
+interface CodexContextWindowSelectProps {
+  value: CodexContextWindowValue;
+  contextWindowTokens?: number | null;
+  loading?: boolean;
+  saving?: boolean;
+  onChange: (preset: CodexContextWindowPreset) => void;
+  onRefresh?: () => void;
+}
+
+const CONTEXT_WINDOW_OPTIONS: Array<{
+  id: CodexContextWindowPreset;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: 'default',
+    label: 'Default 272K',
+    description: 'Remove overrides and use the Codex default context window',
+  },
+  {
+    id: '500k',
+    label: '500K',
+    description: 'Request 500K context with compaction around 450K',
+  },
+  {
+    id: '1m',
+    label: '1M',
+    description: 'Request 1M context; the actual window depends on the model and Codex runtime',
+  },
+];
+
+function formatTokenCount(tokens?: number | null): string {
+  if (typeof tokens !== 'number' || !Number.isFinite(tokens) || tokens <= 0) {
+    return '';
+  }
+  if (tokens >= 1_000_000) {
+    const value = tokens / 1_000_000;
+    return `${Number.isInteger(value) ? value.toFixed(0) : value.toFixed(2).replace(/0+$/, '').replace(/\.$/, '')}M`;
+  }
+  const value = tokens / 1_000;
+  return `${Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1).replace(/\.0$/, '')}K`;
+}
+
+export const CodexContextWindowSelect = ({
+  value,
+  contextWindowTokens,
+  loading = false,
+  saving = false,
+  onChange,
+  onRefresh,
+}: CodexContextWindowSelectProps) => {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const disabled = loading || saving;
+
+  const getOptionText = useCallback((
+    option: typeof CONTEXT_WINDOW_OPTIONS[number],
+    field: 'label' | 'description',
+  ) => t(`codexContextWindow.${option.id}.${field}`, { defaultValue: option[field] }), [t]);
+
+  const getCurrentLabel = () => {
+    if (loading) {
+      return t('codexContextWindow.loading', { defaultValue: 'Context…' });
+    }
+    if (value === 'custom') {
+      const formatted = formatTokenCount(contextWindowTokens);
+      return t('codexContextWindow.customLabel', {
+        value: formatted || '?',
+        defaultValue: 'Custom {{value}}',
+      });
+    }
+    const current = CONTEXT_WINDOW_OPTIONS.find(option => option.id === value)
+      || CONTEXT_WINDOW_OPTIONS[0];
+    return getOptionText(current, 'label');
+  };
+
+  const handleToggle = useCallback((event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (disabled) return;
+    setIsOpen(current => {
+      const next = !current;
+      if (next) onRefresh?.();
+      return next;
+    });
+  }, [disabled, onRefresh]);
+
+  const handleSelect = useCallback((preset: CodexContextWindowPreset) => {
+    if (saving) return;
+    onChange(preset);
+    setIsOpen(false);
+  }, [onChange, saving]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (
+        dropdownRef.current && !dropdownRef.current.contains(target)
+        && buttonRef.current && !buttonRef.current.contains(target)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    const timer = setTimeout(() => document.addEventListener('mousedown', handleClickOutside), 0);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
+
+  return (
+    <div style={RELATIVE_INLINE_BLOCK_STYLE} data-testid="codex-context-window-select">
+      <button
+        ref={buttonRef}
+        className="selector-button"
+        onClick={handleToggle}
+        disabled={disabled}
+        title={t('codexContextWindow.title', { defaultValue: 'Select Codex context window' })}
+      >
+        <span className={`codicon ${saving || loading ? 'codicon-loading codicon-modifier-spin' : 'codicon-symbol-number'}`} />
+        <span className="selector-button-text">{getCurrentLabel()}</span>
+        <span className={`codicon codicon-chevron-${isOpen ? 'up' : 'down'}`} style={CHEVRON_ICON_STYLE} />
+      </button>
+
+      {isOpen ? (
+        <div ref={dropdownRef} className="selector-dropdown" style={DROPDOWN_STYLE} role="listbox">
+          {CONTEXT_WINDOW_OPTIONS.map(option => (
+            <div
+              key={option.id}
+              className={`selector-option ${option.id === value ? 'selected' : ''}`}
+              onClick={() => handleSelect(option.id)}
+              title={getOptionText(option, 'description')}
+              role="option"
+              aria-selected={option.id === value}
+              data-testid={`codex-context-option-${option.id}`}
+            >
+              <span className="codicon codicon-symbol-number" />
+              <div style={OPTION_INFO_STYLE}>
+                <span>{getOptionText(option, 'label')}</span>
+                <span className="mode-description">{getOptionText(option, 'description')}</span>
+              </div>
+              {option.id === value ? <span className="codicon codicon-check check-mark" /> : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default CodexContextWindowSelect;

--- a/webview/src/components/ChatInputBox/selectors/index.ts
+++ b/webview/src/components/ChatInputBox/selectors/index.ts
@@ -5,5 +5,6 @@ export { RuntimeProviderSelect } from './RuntimeProviderSelect';
 export { ConfigSelect } from './ConfigSelect';
 export { ReasoningSelect } from './ReasoningSelect';
 export { CodexFastModeSelect } from './CodexFastModeSelect';
+export { CodexContextWindowSelect } from './CodexContextWindowSelect';
 export { LongContextToggle } from './LongContextToggle';
 export { default as DshPresetSelect } from './DshPresetSelect';

--- a/webview/src/components/ChatInputBox/types.ts
+++ b/webview/src/components/ChatInputBox/types.ts
@@ -670,6 +670,12 @@ export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
  */
 export type CodexFastMode = 'normal' | 'fast';
 
+/** Codex global context-window presets exposed by CC GUI. */
+export type CodexContextWindowPreset = 'default' | '500k' | '1m';
+
+/** A persisted config may contain values outside the three selectable presets. */
+export type CodexContextWindowValue = CodexContextWindowPreset | 'custom';
+
 /**
  * Reasoning level information
  */
@@ -823,10 +829,22 @@ export interface ChatInputBoxProps {
   onReasoningChange?: (effort: ReasoningEffort) => void;
   /** Codex speed mode */
   codexFastMode?: CodexFastMode;
+  /** Current Codex context-window selection */
+  codexContextWindow?: CodexContextWindowValue;
+  /** Raw configured context-window tokens (used for custom display) */
+  codexContextWindowTokens?: number | null;
+  /** Whether the global Codex context config is loading */
+  codexContextWindowLoading?: boolean;
+  /** Whether the global Codex context config is being saved */
+  codexContextWindowSaving?: boolean;
   /** DSH agent preset */
   dshPreset?: string;
   /** Switch Codex speed mode callback */
   onCodexFastModeChange?: (mode: CodexFastMode) => void;
+  /** Switch Codex context-window preset */
+  onCodexContextWindowChange?: (preset: CodexContextWindowPreset) => void;
+  /** Refresh Codex context-window config from disk */
+  onCodexContextWindowRefresh?: () => void;
   /** Switch DSH agent preset callback */
   onDshPresetChange?: (preset: string) => void;
   /** Toggle thinking mode */
@@ -912,6 +930,14 @@ export interface ButtonAreaProps {
   reasoningEffort?: ReasoningEffort;
   /** Codex speed mode */
   codexFastMode?: CodexFastMode;
+  /** Current Codex context-window selection */
+  codexContextWindow?: CodexContextWindowValue;
+  /** Raw configured context-window tokens (used for custom display) */
+  codexContextWindowTokens?: number | null;
+  /** Whether the global Codex context config is loading */
+  codexContextWindowLoading?: boolean;
+  /** Whether the global Codex context config is being saved */
+  codexContextWindowSaving?: boolean;
   /** DSH agent preset */
   dshPreset?: string;
 
@@ -925,6 +951,10 @@ export interface ButtonAreaProps {
   onReasoningChange?: (effort: ReasoningEffort) => void;
   /** Switch Codex speed mode callback */
   onCodexFastModeChange?: (mode: CodexFastMode) => void;
+  /** Switch Codex context-window preset */
+  onCodexContextWindowChange?: (preset: CodexContextWindowPreset) => void;
+  /** Refresh Codex context-window config from disk */
+  onCodexContextWindowRefresh?: () => void;
   /** Switch DSH agent preset callback */
   onDshPresetChange?: (preset: string) => void;
   /** Enhance prompt callback */

--- a/webview/src/components/ChatScreen.tsx
+++ b/webview/src/components/ChatScreen.tsx
@@ -96,6 +96,10 @@ export interface ChatScreenProps {
   claudeSettingsAlwaysThinkingEnabled: ProviderState['claudeSettingsAlwaysThinkingEnabled'];
   reasoningEffort: ProviderState['reasoningEffort'];
   codexFastMode: ProviderState['codexFastMode'];
+  codexContextWindow: ProviderState['codexContextWindow'];
+  codexContextWindowTokens: ProviderState['codexContextWindowTokens'];
+  codexContextWindowLoading: ProviderState['codexContextWindowLoading'];
+  codexContextWindowSaving: ProviderState['codexContextWindowSaving'];
   dshPreset: ProviderState['dshPreset'];
   streamingEnabledSetting: ProviderState['streamingEnabledSetting'];
   sendShortcut: ProviderState['sendShortcut'];
@@ -111,6 +115,8 @@ export interface ChatScreenProps {
   onAgentSelect: ProviderState['handleAgentSelect'];
   onReasoningChange: ProviderState['handleReasoningChange'];
   onCodexFastModeChange: ProviderState['handleCodexFastModeChange'];
+  onCodexContextWindowChange: ProviderState['handleCodexContextWindowChange'];
+  onCodexContextWindowRefresh: ProviderState['refreshCodexContextWindow'];
   onDshPresetChange: ProviderState['handleDshPresetChange'];
   onToggleThinking: ProviderState['handleToggleThinking'];
   onStreamingEnabledChange: ProviderState['handleStreamingEnabledChange'];
@@ -144,9 +150,13 @@ export const ChatScreen = ({
   currentProvider, selectedModel, permissionMode, selectedAgent,
   sdkStatusLoading, sdkStatusError, onRetrySdkStatus, currentSdkInstalled,
   activeProviderConfig, claudeSettingsAlwaysThinkingEnabled,
-  reasoningEffort, codexFastMode, dshPreset, streamingEnabledSetting, sendShortcut, autoOpenFileEnabled,
+  reasoningEffort, codexFastMode,
+  codexContextWindow, codexContextWindowTokens,
+  codexContextWindowLoading, codexContextWindowSaving,
+  dshPreset, streamingEnabledSetting, sendShortcut, autoOpenFileEnabled,
   longContextEnabled, usagePercentage, usageUsedTokens, usageMaxTokens,
-  onModeSelect, onModelSelect, onAgentSelect, onReasoningChange, onCodexFastModeChange, onDshPresetChange, onToggleThinking,
+  onModeSelect, onModelSelect, onAgentSelect, onReasoningChange, onCodexFastModeChange,
+  onCodexContextWindowChange, onCodexContextWindowRefresh, onDshPresetChange, onToggleThinking,
   onStreamingEnabledChange,
   onAutoOpenFileEnabledChange, onLongContextChange,
   messageQueue, onRemoveFromQueue,
@@ -364,6 +374,12 @@ export const ChatScreen = ({
           onReasoningChange={onReasoningChange}
           codexFastMode={codexFastMode}
           onCodexFastModeChange={onCodexFastModeChange}
+          codexContextWindow={codexContextWindow}
+          codexContextWindowTokens={codexContextWindowTokens}
+          codexContextWindowLoading={codexContextWindowLoading}
+          codexContextWindowSaving={codexContextWindowSaving}
+          onCodexContextWindowChange={onCodexContextWindowChange}
+          onCodexContextWindowRefresh={onCodexContextWindowRefresh}
           onDshPresetChange={onDshPresetChange}
           onToggleThinking={onToggleThinking}
           streamingEnabled={streamingEnabledSetting}

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -1121,6 +1121,23 @@ interface Window {
   /** Buffers backend tab state when Java responds before React callbacks mount. */
   __pendingBackendTabState?: string;
 
+  /** Global Codex context-window config pushed by the Java backend. */
+  updateCodexContextWindowConfig?: (
+    dataOrStr:
+      | string
+      | {
+          success?: boolean;
+          preset?: string;
+          contextWindow?: number | null;
+          autoCompactTokenLimit?: number | null;
+          custom?: boolean;
+          error?: string;
+        }
+  ) => void;
+
+  /** Buffers Codex context config when Java responds before the provider hook mounts. */
+  __pendingCodexContextWindowConfig?: string;
+
   // ============================================================================
   // Provider settings panel callbacks (registered by ProviderList)
   // ============================================================================

--- a/webview/src/hooks/providers/useCodexProvider.contextWindow.test.ts
+++ b/webview/src/hooks/providers/useCodexProvider.contextWindow.test.ts
@@ -1,0 +1,166 @@
+import { act, renderHook } from '@testing-library/react';
+import type { TFunction } from 'i18next';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCodexProvider } from './useCodexProvider';
+
+const sendBridgeEventMock = vi.hoisted(() => vi.fn(
+  (_event: string, _content?: string) => true,
+));
+
+vi.mock('../../utils/bridge', () => ({
+  sendBridgeEvent: (event: string, content?: string) => sendBridgeEventMock(event, content),
+}));
+
+const t = ((_key: string, options?: { defaultValue?: string }) =>
+  options?.defaultValue ?? _key) as unknown as TFunction;
+
+describe('useCodexProvider context-window config', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sendBridgeEventMock.mockClear();
+    sendBridgeEventMock.mockReturnValue(true);
+    delete window.updateCodexContextWindowConfig;
+    delete window.__pendingCodexContextWindowConfig;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete window.updateCodexContextWindowConfig;
+    delete window.__pendingCodexContextWindowConfig;
+  });
+
+  it('loads the authoritative 1m config and refreshes when Codex is active', () => {
+    const { result } = renderHook(() => useCodexProvider({
+      currentProvider: 'codex',
+      addToast: vi.fn(),
+      t,
+    }));
+
+    expect(sendBridgeEventMock).toHaveBeenCalledWith('get_codex_context_window', undefined);
+    act(() => {
+      window.updateCodexContextWindowConfig?.(JSON.stringify({
+        success: true,
+        preset: '1m',
+        contextWindow: 1_000_000,
+        autoCompactTokenLimit: 900_000,
+        custom: false,
+      }));
+    });
+
+    expect(result.current.codexContextWindow).toBe('1m');
+    expect(result.current.codexContextWindowTokens).toBe(1_000_000);
+    expect(result.current.codexAutoCompactTokenLimit).toBe(900_000);
+    expect(result.current.codexContextWindowLoading).toBe(false);
+  });
+
+  it('saves a preset optimistically and settles from the broadcast snapshot', () => {
+    const addToast = vi.fn();
+    const { result } = renderHook(() => useCodexProvider({
+      currentProvider: 'codex',
+      addToast,
+      t,
+    }));
+
+    act(() => result.current.handleCodexContextWindowChange('500k'));
+    expect(result.current.codexContextWindow).toBe('500k');
+    expect(result.current.codexContextWindowSaving).toBe(true);
+    expect(sendBridgeEventMock).toHaveBeenCalledWith(
+      'set_codex_context_window',
+      JSON.stringify({ preset: '500k' }),
+    );
+
+    act(() => {
+      window.updateCodexContextWindowConfig?.({
+        success: true,
+        preset: '500k',
+        contextWindow: 500_000,
+        autoCompactTokenLimit: 450_000,
+        custom: false,
+      });
+    });
+
+    expect(result.current.codexContextWindowSaving).toBe(false);
+    expect(result.current.codexContextWindowTokens).toBe(500_000);
+    expect(addToast).toHaveBeenCalledWith(
+      'Codex context window updated; the next message will use it',
+      'success',
+    );
+  });
+
+  it('rolls back to the authoritative config after a write failure', () => {
+    const addToast = vi.fn();
+    const { result } = renderHook(() => useCodexProvider({
+      currentProvider: 'codex',
+      addToast,
+      t,
+    }));
+
+    act(() => {
+      window.updateCodexContextWindowConfig?.({
+        success: true,
+        preset: '1m',
+        contextWindow: 1_000_000,
+        autoCompactTokenLimit: 900_000,
+      });
+    });
+    act(() => result.current.handleCodexContextWindowChange('default'));
+    act(() => {
+      window.updateCodexContextWindowConfig?.({
+        success: false,
+        preset: '1m',
+        contextWindow: 1_000_000,
+        autoCompactTokenLimit: 900_000,
+        error: 'config.toml is read-only',
+      });
+    });
+
+    expect(result.current.codexContextWindow).toBe('1m');
+    expect(result.current.codexContextWindowSaving).toBe(false);
+    expect(addToast).toHaveBeenCalledWith('config.toml is read-only', 'error');
+  });
+
+  it('unblocks submission and refreshes after a missing save callback times out', () => {
+    const addToast = vi.fn();
+    const { result } = renderHook(() => useCodexProvider({
+      currentProvider: 'codex',
+      addToast,
+      t,
+    }));
+
+    act(() => result.current.handleCodexContextWindowChange('1m'));
+    expect(result.current.codexContextWindowSaving).toBe(true);
+
+    act(() => vi.advanceTimersByTime(10_000));
+
+    expect(result.current.codexContextWindow).toBe('default');
+    expect(result.current.codexContextWindowSaving).toBe(false);
+    expect(addToast).toHaveBeenCalledWith(
+      'Timed out while saving the Codex context setting',
+      'error',
+    );
+    expect(sendBridgeEventMock).toHaveBeenCalledWith('get_codex_context_window', undefined);
+  });
+
+  it('drains an early custom config and unregisters its callback on unmount', () => {
+    window.__pendingCodexContextWindowConfig = JSON.stringify({
+      success: true,
+      preset: 'custom',
+      contextWindow: 640_000,
+      autoCompactTokenLimit: 500_000,
+      custom: true,
+    });
+
+    const { result, unmount } = renderHook(() => useCodexProvider({
+      currentProvider: 'claude',
+      addToast: vi.fn(),
+      t,
+    }));
+
+    expect(result.current.codexContextWindow).toBe('custom');
+    expect(result.current.codexContextWindowTokens).toBe(640_000);
+    expect(window.__pendingCodexContextWindowConfig).toBeUndefined();
+
+    unmount();
+    expect(window.updateCodexContextWindowConfig).toBeUndefined();
+  });
+});

--- a/webview/src/hooks/providers/useCodexProvider.ts
+++ b/webview/src/hooks/providers/useCodexProvider.ts
@@ -1,18 +1,185 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { TFunction } from 'i18next';
 import { sendBridgeEvent } from '../../utils/bridge';
 import { CODEX_MODELS } from '../../components/ChatInputBox/types';
-import type { CodexFastMode, PermissionMode, ReasoningEffort } from '../../components/ChatInputBox/types';
+import type {
+  CodexContextWindowPreset,
+  CodexContextWindowValue,
+  CodexFastMode,
+  PermissionMode,
+  ReasoningEffort,
+} from '../../components/ChatInputBox/types';
+
+const CONTEXT_CONFIG_RETRY_LIMIT = 30;
+const CONTEXT_CONFIG_SAVE_TIMEOUT_MS = 10_000;
+
+interface UseCodexProviderOptions {
+  currentProvider: string;
+  addToast: (message: string, type?: 'info' | 'success' | 'warning' | 'error') => void;
+  t: TFunction;
+}
+
+interface CodexContextWindowPayload {
+  success?: boolean;
+  preset?: unknown;
+  contextWindow?: unknown;
+  autoCompactTokenLimit?: unknown;
+  custom?: unknown;
+  error?: unknown;
+}
+
+interface ConfirmedContextWindowConfig {
+  value: CodexContextWindowValue;
+  contextWindowTokens: number | null;
+  autoCompactTokenLimit: number | null;
+}
+
+const DEFAULT_CONTEXT_WINDOW_CONFIG: ConfirmedContextWindowConfig = {
+  value: 'default',
+  contextWindowTokens: 272_000,
+  autoCompactTokenLimit: 244_800,
+};
+
+const isContextWindowValue = (value: unknown): value is CodexContextWindowValue =>
+  value === 'default' || value === '500k' || value === '1m' || value === 'custom';
+
+const readPositiveNumber = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
+
+const parseContextWindowPayload = (
+  dataOrString: string | CodexContextWindowPayload,
+): CodexContextWindowPayload | null => {
+  if (typeof dataOrString === 'string') {
+    try {
+      return JSON.parse(dataOrString) as CodexContextWindowPayload;
+    } catch {
+      return null;
+    }
+  }
+  return dataOrString && typeof dataOrString === 'object' ? dataOrString : null;
+};
 
 /**
  * Codex-specific selectable state. `reasoningEffort` lives here because the
  * value set is a Codex/OpenAI concept (low/medium/high/xhigh/max). The change
  * handler forwards directly to the backend via bridge event.
  */
-export function useCodexProvider() {
+export function useCodexProvider({ currentProvider, addToast, t }: UseCodexProviderOptions) {
   const [selectedCodexModel, setSelectedCodexModel] = useState(CODEX_MODELS[0].id);
   const [codexPermissionMode, setCodexPermissionMode] = useState<PermissionMode>('default');
   const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort>('high');
   const [codexFastMode, setCodexFastMode] = useState<CodexFastMode>('normal');
+  const [codexContextWindow, setCodexContextWindow] = useState<CodexContextWindowValue>('default');
+  const [codexContextWindowTokens, setCodexContextWindowTokens] = useState<number | null>(272_000);
+  const [codexAutoCompactTokenLimit, setCodexAutoCompactTokenLimit] = useState<number | null>(244_800);
+  const [codexContextWindowLoading, setCodexContextWindowLoading] = useState(true);
+  const [codexContextWindowSaving, setCodexContextWindowSaving] = useState(false);
+  const lastConfirmedContextRef = useRef<ConfirmedContextWindowConfig>(DEFAULT_CONTEXT_WINDOW_CONFIG);
+  const pendingPresetRef = useRef<CodexContextWindowPreset | null>(null);
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearSaveTimeout = useCallback(() => {
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+      saveTimeoutRef.current = null;
+    }
+  }, []);
+
+  const applyConfirmedContext = useCallback((config: ConfirmedContextWindowConfig) => {
+    lastConfirmedContextRef.current = config;
+    setCodexContextWindow(config.value);
+    setCodexContextWindowTokens(config.contextWindowTokens);
+    setCodexAutoCompactTokenLimit(config.autoCompactTokenLimit);
+  }, []);
+
+  const refreshCodexContextWindow = useCallback(() => {
+    return sendBridgeEvent('get_codex_context_window');
+  }, []);
+
+  useEffect(() => {
+    const handleConfig = (dataOrString: string | CodexContextWindowPayload) => {
+      const payload = parseContextWindowPayload(dataOrString);
+      if (!payload) return;
+
+      const value = isContextWindowValue(payload.preset) ? payload.preset : null;
+      const authoritativeConfig = value ? {
+        value,
+        contextWindowTokens: readPositiveNumber(payload.contextWindow),
+        autoCompactTokenLimit: readPositiveNumber(payload.autoCompactTokenLimit),
+      } satisfies ConfirmedContextWindowConfig : null;
+
+      if (payload.success === false) {
+        if (authoritativeConfig) applyConfirmedContext(authoritativeConfig);
+        else applyConfirmedContext(lastConfirmedContextRef.current);
+        setCodexContextWindowLoading(false);
+        setCodexContextWindowSaving(false);
+        pendingPresetRef.current = null;
+        clearSaveTimeout();
+        const error = typeof payload.error === 'string' && payload.error.trim()
+          ? payload.error.trim()
+          : t('codexContextWindow.saveFailed', { defaultValue: 'Failed to update Codex context window' });
+        addToast(error, 'error');
+        return;
+      }
+
+      if (!authoritativeConfig) return;
+      applyConfirmedContext(authoritativeConfig);
+      setCodexContextWindowLoading(false);
+      if (pendingPresetRef.current) {
+        if (authoritativeConfig.value !== pendingPresetRef.current) {
+          // Another open window may have written first. Keep this request pending
+          // until its own authoritative broadcast arrives from the serialized backend.
+          return;
+        }
+        pendingPresetRef.current = null;
+        setCodexContextWindowSaving(false);
+        clearSaveTimeout();
+        addToast(
+          t('codexContextWindow.saved', {
+            value: authoritativeConfig.value,
+            defaultValue: 'Codex context window updated; the next message will use it',
+          }),
+          'success',
+        );
+      } else {
+        setCodexContextWindowSaving(false);
+      }
+    };
+
+    window.updateCodexContextWindowConfig = handleConfig;
+    if (window.__pendingCodexContextWindowConfig) {
+      const pending = window.__pendingCodexContextWindowConfig;
+      delete window.__pendingCodexContextWindowConfig;
+      handleConfig(pending);
+    }
+
+    let retryCount = 0;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    const requestInitialConfig = () => {
+      if (refreshCodexContextWindow()) return;
+      retryCount += 1;
+      if (retryCount < CONTEXT_CONFIG_RETRY_LIMIT) {
+        retryTimer = setTimeout(requestInitialConfig, 100);
+      } else {
+        setCodexContextWindowLoading(false);
+      }
+    };
+    retryTimer = setTimeout(requestInitialConfig, 200);
+
+    return () => {
+      if (retryTimer) clearTimeout(retryTimer);
+      clearSaveTimeout();
+      if (window.updateCodexContextWindowConfig === handleConfig) {
+        delete window.updateCodexContextWindowConfig;
+      }
+    };
+  }, [addToast, applyConfirmedContext, clearSaveTimeout, refreshCodexContextWindow, t]);
+
+  useEffect(() => {
+    if (currentProvider === 'codex') {
+      refreshCodexContextWindow();
+    }
+  }, [currentProvider, refreshCodexContextWindow]);
 
   const handleReasoningChange = useCallback((effort: ReasoningEffort) => {
     setReasoningEffort(effort);
@@ -24,6 +191,54 @@ export function useCodexProvider() {
     sendBridgeEvent('set_codex_fast_mode', mode);
   }, []);
 
+  const handleCodexContextWindowChange = useCallback((preset: CodexContextWindowPreset) => {
+    if (codexContextWindowSaving) return;
+
+    pendingPresetRef.current = preset;
+    setCodexContextWindowSaving(true);
+    setCodexContextWindow(preset);
+    if (preset === 'default') setCodexContextWindowTokens(272_000);
+    if (preset === '500k') setCodexContextWindowTokens(500_000);
+    if (preset === '1m') setCodexContextWindowTokens(1_000_000);
+
+    const sent = sendBridgeEvent('set_codex_context_window', JSON.stringify({ preset }));
+    if (!sent) {
+      pendingPresetRef.current = null;
+      applyConfirmedContext(lastConfirmedContextRef.current);
+      setCodexContextWindowSaving(false);
+      clearSaveTimeout();
+      addToast(
+        t('codexContextWindow.bridgeUnavailable', {
+          defaultValue: 'Codex context settings are not available yet',
+        }),
+        'error',
+      );
+      return;
+    }
+
+    clearSaveTimeout();
+    saveTimeoutRef.current = setTimeout(() => {
+      pendingPresetRef.current = null;
+      saveTimeoutRef.current = null;
+      applyConfirmedContext(lastConfirmedContextRef.current);
+      setCodexContextWindowSaving(false);
+      addToast(
+        t('codexContextWindow.saveTimeout', {
+          defaultValue: 'Timed out while saving the Codex context setting',
+        }),
+        'error',
+      );
+      refreshCodexContextWindow();
+    }, CONTEXT_CONFIG_SAVE_TIMEOUT_MS);
+  }, [
+    addToast,
+    applyConfirmedContext,
+    clearSaveTimeout,
+    codexContextWindowSaving,
+    refreshCodexContextWindow,
+    t,
+  ]);
+
   return {
     selectedCodexModel,
     setSelectedCodexModel,
@@ -33,8 +248,15 @@ export function useCodexProvider() {
     setReasoningEffort,
     codexFastMode,
     setCodexFastMode,
+    codexContextWindow,
+    codexContextWindowTokens,
+    codexAutoCompactTokenLimit,
+    codexContextWindowLoading,
+    codexContextWindowSaving,
     handleReasoningChange,
     handleCodexFastModeChange,
+    handleCodexContextWindowChange,
+    refreshCodexContextWindow,
   };
 }
 

--- a/webview/src/hooks/useModelProviderState.ts
+++ b/webview/src/hooks/useModelProviderState.ts
@@ -58,7 +58,7 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
 
   // ── Provider-specific sub-hooks ──
   const claude = useClaudeProvider();
-  const codex = useCodexProvider();
+  const codex = useCodexProvider({ currentProvider, addToast, t });
   const grok = useGrokProvider();
   const kimi = useKimiProvider();
   const openCode = useOpenCodeProvider();

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -2341,6 +2341,28 @@
       "description": "Codex fast response mode (uses additional credits)"
     }
   },
+  "codexContextWindow": {
+    "title": "Select Codex context window",
+    "loading": "Context…",
+    "customLabel": "Custom {{value}}",
+    "saved": "Codex context updated; the next message will use it",
+    "saveFailed": "Failed to update Codex context window",
+    "saveTimeout": "Timed out while saving the Codex context setting",
+    "bridgeUnavailable": "Codex context settings are not available yet",
+    "savingBlocked": "Please wait for the Codex context setting to finish saving",
+    "default": {
+      "label": "Default 272K",
+      "description": "Remove overrides and use the official Codex default context window"
+    },
+    "500k": {
+      "label": "500K",
+      "description": "Request 500K context with automatic compaction around 450K"
+    },
+    "1m": {
+      "label": "1M",
+      "description": "Request 1M context; the actual window depends on the model and Codex runtime"
+    }
+  },
   "dshPresets": {
     "title": "Select DeepSeek Harness agent preset",
     "none": { "label": "Default", "description": "dsh default headless composition (full toolset)" },

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -1861,6 +1861,28 @@
       "description": "Codex 快速回應模式（會產生額外消耗）"
     }
   },
+  "codexContextWindow": {
+    "title": "選擇 Codex 上下文視窗",
+    "loading": "上下文…",
+    "customLabel": "自訂 {{value}}",
+    "saved": "Codex 上下文已更新，下一則訊息生效",
+    "saveFailed": "更新 Codex 上下文失敗",
+    "saveTimeout": "儲存 Codex 上下文設定逾時",
+    "bridgeUnavailable": "Codex 上下文設定尚不可用",
+    "savingBlocked": "請等待 Codex 上下文設定儲存完成",
+    "default": {
+      "label": "預設 272K",
+      "description": "移除覆寫項目，使用 Codex 官方預設上下文視窗"
+    },
+    "500k": {
+      "label": "500K",
+      "description": "要求 500K 上下文，約在 450K 時自動壓縮"
+    },
+    "1m": {
+      "label": "1M",
+      "description": "要求 1M 上下文；實際視窗受模型與 Codex 執行環境限制"
+    }
+  },
   "dshPresets": {
     "title": "選擇 DeepSeek Harness Agent 預設",
     "none": { "label": "預設", "description": "dsh 預設 headless 組合（完整工具集）" },

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -2346,6 +2346,28 @@
       "description": "Codex快速响应模式（会产生额外消耗）"
     }
   },
+  "codexContextWindow": {
+    "title": "选择 Codex 上下文窗口",
+    "loading": "上下文…",
+    "customLabel": "自定义 {{value}}",
+    "saved": "Codex 上下文已更新，下一条消息生效",
+    "saveFailed": "更新 Codex 上下文失败",
+    "saveTimeout": "保存 Codex 上下文设置超时",
+    "bridgeUnavailable": "Codex 上下文设置尚不可用",
+    "savingBlocked": "请等待 Codex 上下文设置保存完成",
+    "default": {
+      "label": "默认 272K",
+      "description": "移除覆盖项，使用 Codex 官方默认上下文窗口"
+    },
+    "500k": {
+      "label": "500K",
+      "description": "请求 500K 上下文，约在 450K 时自动压缩"
+    },
+    "1m": {
+      "label": "1M",
+      "description": "请求 1M 上下文；实际窗口受模型和 Codex 运行时限制"
+    }
+  },
   "dshPresets": {
     "title": "选择 DeepSeek Harness Agent 预设",
     "none": { "label": "默认", "description": "dsh 默认 headless 组合（完整工具集）" },

--- a/webview/src/main.tsx
+++ b/webview/src/main.tsx
@@ -659,6 +659,16 @@ if (typeof window !== 'undefined' && !window.applyBackendTabState) {
   };
 }
 
+// Keep the latest global Codex context config if Java answers before the
+// provider hook has registered its authoritative callback.
+if (typeof window !== 'undefined' && !window.updateCodexContextWindowConfig) {
+  window.updateCodexContextWindowConfig = (dataOrString) => {
+    window.__pendingCodexContextWindowConfig = typeof dataOrString === 'string'
+      ? dataOrString
+      : JSON.stringify(dataOrString);
+  };
+}
+
 if (typeof window !== 'undefined' && !window.showPermissionDialog) {
   debugLog('[Main] Pre-registering showPermissionDialog placeholder');
   window.showPermissionDialog = (json: string) => {


### PR DESCRIPTION
## Summary

- add a Codex-only context-window selector beside the existing speed selector
- expose three choices: **Default 272K**, **500K**, and **1M**
- update the global `~/.codex/config.toml` so the next Codex turn and newly opened Codex clients use the selection without restarting IDEA
- synchronize the authoritative value across all open CC GUI windows and handle existing custom values, write failures, and missing callbacks

## Configuration mapping

| Selection | `model_context_window` | `model_auto_compact_token_limit` |
|---|---:|---:|
| Default 272K | remove override | remove override |
| 500K | 500000 | 450000 |
| 1M | 1000000 | 900000 |

The 1M option is a requested limit. The effective window may still be clamped by the selected model or Codex runtime; the existing `token_count.model_context_window` event remains authoritative for usage display.

## Config safety

- patch only the two top-level context keys
- preserve unrelated keys, comments, quoted keys, BOM, CRLF/LF line endings, and TOML sections
- validate the patched values before using the existing atomic file replacement path
- serialize reads and writes through the existing shared Codex config lock
- do not change the selected model, provider, or compaction scope
- restore the last confirmed UI value and unblock submission if a write fails or times out

## Verification

- manually verified in IDEA: changing the selector takes effect on the next Codex message without restarting the IDE
- `npm test` (168 test files, 1447 tests)
- targeted Codex context Java tests (9 tests)
- TypeScript production and test type checks
- Java 17 `compileJava` and `checkstyleMain`
- Java 17 `buildPlugin`
- `git diff --check`