### PR TITLE
fix(settings): stop stripping user-configured API_TIMEOUT_MS on provider sync

### DIFF
--- a/src/main/java/com/github/claudecodegui/settings/ClaudeSettingsSyncPlan.java
+++ b/src/main/java/com/github/claudecodegui/settings/ClaudeSettingsSyncPlan.java
@@ -25,6 +25,12 @@ public final class ClaudeSettingsSyncPlan {
     /**
      * Env keys the plugin owns when syncing a managed provider.
      * Aligned with vscode-cc-gui {@code CLAUDE_MANAGED_ENV_KEYS}.
+     *
+     * <p>Deliberately excludes {@code API_TIMEOUT_MS}: it is a user-tunable
+     * performance knob, not a plugin-managed credential. Removing it from the
+     * managed set lets users extend the timeout for slow local-model backends
+     * (e.g. Ollama with 80k+ token contexts) that exceed the CLI default
+     * (#1307). When unset, the Claude CLI keeps its own default.
      */
     public static final Set<String> CLAUDE_MANAGED_ENV_KEYS = Set.of(
             "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN",
@@ -33,7 +39,7 @@ public final class ClaudeSettingsSyncPlan {
             "ANTHROPIC_DEFAULT_HAIKU_MODEL", "ANTHROPIC_DEFAULT_SONNET_MODEL",
             "ANTHROPIC_DEFAULT_OPUS_MODEL", "ANTHROPIC_DEFAULT_FABLE_MODEL",
             "CLAUDE_CODE_USE_BEDROCK",
-            "API_TIMEOUT_MS", "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
             "CCGUI_CLI_LOGIN_AUTHORIZED"
     );
 

--- a/src/test/java/com/github/claudecodegui/settings/ClaudeSettingsSyncPlanTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/ClaudeSettingsSyncPlanTest.java
@@ -110,4 +110,42 @@ public class ClaudeSettingsSyncPlanTest {
         assertTrue(d.reason.contains("cli-login"));
         assertNull(d.nextSettings);
     }
+
+    /**
+     * Regression for #1307: API_TIMEOUT_MS is a user-tunable performance knob,
+     * not a plugin-managed credential. It must survive provider sync so users
+     * can extend the timeout for slow local backends (e.g. Ollama with 80k+
+     * token contexts that exceed the CLI's built-in default).
+     */
+    @Test
+    public void preservesUserConfiguredApiTimeoutMs() {
+        JsonObject current = new JsonObject();
+        JsonObject env = new JsonObject();
+        env.addProperty("ANTHROPIC_AUTH_TOKEN", "old");
+        env.addProperty("ANTHROPIC_BASE_URL", "http://localhost:11434");
+        // User explicitly raised the timeout for a slow local Ollama backend.
+        env.addProperty("API_TIMEOUT_MS", "900000");
+        current.add("env", env);
+
+        JsonObject active = new JsonObject();
+        active.addProperty("id", "proxy-ollama");
+        active.addProperty("isActive", true);
+        JsonObject settingsConfig = new JsonObject();
+        JsonObject newEnv = new JsonObject();
+        newEnv.addProperty("ANTHROPIC_AUTH_TOKEN", "new");
+        newEnv.addProperty("ANTHROPIC_BASE_URL", "http://localhost:11434");
+        settingsConfig.add("env", newEnv);
+        active.add("settingsConfig", settingsConfig);
+
+        ClaudeSettingsSyncPlan.Decision d = ClaudeSettingsSyncPlan.plan(current, active);
+        assertEquals(ClaudeSettingsSyncPlan.Action.WRITE, d.action);
+        assertNotNull(d.nextSettings);
+        JsonObject outEnv = d.nextSettings.getAsJsonObject("env");
+        // Managed credentials are replaced by the provider payload...
+        assertEquals("new", outEnv.get("ANTHROPIC_AUTH_TOKEN").getAsString());
+        // ...but the user's API_TIMEOUT_MS is NOT stripped (#1307).
+        assertTrue("API_TIMEOUT_MS must survive provider sync",
+                outEnv.has("API_TIMEOUT_MS"));
+        assertEquals("900000", outEnv.get("API_TIMEOUT_MS").getAsString());
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #1307 — users running local Ollama with large contexts (80k+ tokens) cannot extend the Claude Code CLI request timeout because the plugin deletes any `API_TIMEOUT_MS` they set in `~/.claude/settings.json` on every provider sync.

### Root Cause

`ClaudeSettingsSyncPlan.CLAUDE_MANAGED_ENV_KEYS` included `API_TIMEOUT_MS`, so `plan()` stripped it from `env` before writing `~/.claude/settings.json` — treating a user-tunable performance knob as if it were a plugin-managed credential like `ANTHROPIC_API_KEY`. With the timeout unconfigurable, the CLI's built-in default severed the connection mid-generation on slow local backends.

### Fix

Remove `API_TIMEOUT_MS` from `CLAUDE_MANAGED_ENV_KEYS`. The plugin never sets it, never needs to own it, and clearing it serves no isolation purpose. A user-configured value now survives provider syncs; when unset, the Claude CLI keeps its own default.

### Before / After

| Scenario | Before | After |
|---|---|---|
| User sets `API_TIMEOUT_MS=900000` in `settings.json`, then switches provider | key silently deleted; long Ollama generations time out at the CLI default | key preserved; CLI uses 900s timeout |
| User does not set `API_TIMEOUT_MS` | CLI default applies | unchanged (CLI default applies) |

### Backward Compatibility

- Users who never set `API_TIMEOUT_MS` see zero behavior change.
- Users who did set it and wondered why it kept disappearing now get the expected behavior.
- No new env writes, no migration needed.

Closes #1307