### PR TITLE
fix(daemon): signal ready before SDK preload to unblock Java startup

### DIFF
--- a/ai-bridge/daemon.js
+++ b/ai-bridge/daemon.js
@@ -580,18 +580,28 @@ async function runDaemonMain() {
     platform: process.platform,
   });
 
-  // Pre-load SDK
-  await preloadSdks();
+  // Signal ready BEFORE pre-loading the SDK so the Java side can start sending
+  // heartbeats and status queries immediately. The SDK load is moved to
+  // background: acquireRuntime() already lazy-loads via ensureQueryFn() with
+  // its own caching, so the first send will simply wait for the in-flight load
+  // instead of blocking daemon startup. (#performance)
+  sendDaemonEvent('ready', {
+    pid: process.pid,
+    sdkPreloaded: false, // SDK is loading in the background
+  });
+
+  // Pre-load SDK in the background (non-blocking). Errors are logged but do
+  // not affect daemon readiness — a failed preload is retried lazily on the
+  // first send via ensureQueryFn().
+  preloadSdks().then(() => {
+    sendDaemonEvent('sdk_ready', { pid: process.pid });
+  }).catch((e) => {
+    _originalStderrWrite(`[daemon] Background SDK preload failed: ${e?.message || e}\n`, 'utf8');
+  });
 
   // Best-effort cleanup of stale temp image files (>24h). Fire-and-forget so
   // it doesn't block daemon readiness.
   cleanupStaleTempImages().catch(() => {});
-
-  // Signal ready
-  sendDaemonEvent('ready', {
-    pid: process.pid,
-    sdkPreloaded,
-  });
 
   // --- Listen for requests on stdin ---
   const rl = createInterface({


### PR DESCRIPTION
## Summary

The daemon previously blocked on `await preloadSdks()` before sending the `ready` event, causing the Java plugin's `DaemonBridge` startup to wait for the full Claude Agent SDK import (potentially seconds on slow disks or cold caches).

### Root Cause

`daemon.js` startup sequence was:
1. `starting` event
2. `await preloadSdks()` — **blocking**
3. `ready` event

The SDK load (`await import()` of the Claude Agent SDK) is CPU/IO intensive. During this window the Java side could not even send heartbeats or status queries.

### Fix

Send `ready` **before** `preloadSdks()`, and run the preload in the background:

```javascript
sendDaemonEvent('ready', { pid: process.pid, sdkPreloaded: false });
preloadSdks().then(() => sendDaemonEvent('sdk_ready', { pid })).catch(...);
```

The first `send` request is unaffected: `acquireRuntime()` → `ensureQueryFn()` → `loadClaudeSdk()` already lazy-loads with its own promise cache (`loadingPromises`). If the background preload is still in flight, the first send simply joins the same promise; if preload failed, it retries.

### Benefits

- Java plugin startup is no longer blocked by SDK import.
- Heartbeat and status commands respond immediately.
- No protocol changes; `sdkPreloaded: false` in `ready` is informational (Java logs it but does not gate on it).
- A new `sdk_ready` event is emitted when background preload completes for diagnostics.

### Backward Compatibility

- No Java-side changes needed.
- `sdkPreloaded: false` in the `ready` event is safe: `DaemonBridge` only logs it (`LOG.info("SDK preloaded: " + ...)`), it does not block requests.
- If preload fails, the first send retries the load lazily and surfaces the error then, same as before.