### PR TITLE
feat(history): add turn-based pagination for Claude session restore

### DIFF
--- a/ai-bridge/channels/claude-channel.js
+++ b/ai-bridge/channels/claude-channel.js
@@ -14,6 +14,7 @@ import {
 } from '../services/claude/persistent-query-service.js';
 import {
   getSessionMessages as claudeGetSessionMessages,
+  getSessionMessagesPage as claudeGetSessionMessagesPage,
   getLatestUserMessage as claudeGetLatestUserMessage
 } from '../services/claude/session-service.js';
 
@@ -68,6 +69,18 @@ export async function handleClaudeCommand(command, args, stdinData) {
     case 'getSession':
       await claudeGetSessionMessages(args[0], args[1]);
       break;
+
+    case 'getSessionPage': {
+      // Paginated history load. Falls back to the full-history getSession
+      // path on the Java side when the page request fails, so a malformed
+      // cursor never leaves the user with an empty chat.
+      const sessionId = stdinData?.sessionId || args[0];
+      const cwd = stdinData?.cwd || args[1] || null;
+      const beforeTurn = stdinData?.beforeTurn !== undefined ? stdinData.beforeTurn : null;
+      const limit = stdinData?.limit || 30;
+      await claudeGetSessionMessagesPage(sessionId, cwd, beforeTurn, limit);
+      break;
+    }
 
     case 'getLatestUserMessage':
       await claudeGetLatestUserMessage(args[0], args[1]);

--- a/ai-bridge/services/claude/session-service.js
+++ b/ai-bridge/services/claude/session-service.js
@@ -271,8 +271,144 @@ function extractTextContent(message) {
 }
 
 function resolveSessionFile(sessionId, cwd = null) {
-  if (!sessionId || /[\/\\]/.test(sessionId)) {
+  if (!sessionId || /[\\/\\\\]/.test(sessionId)) {
     throw new Error('Invalid session ID');
   }
   return getClaudeProjectSessionFilePath(sessionId, cwd);
+}
+
+/**
+ * A Claude "turn" is a contiguous block of messages starting with a user
+ * message (the prompt) followed by any assistant/tool messages until the
+ * next user message. Pagination is turn-based so a page boundary never
+ * splits an assistant reply from its tool calls or a tool result from its
+ * originating call.
+ */
+function isTurnStart(message) {
+  return Boolean(
+    message &&
+    message.type === 'user' &&
+    typeof message.uuid === 'string' &&
+    !isInterruptionMarker(message)
+  );
+}
+
+/**
+ * Build a paginated getSessionMessages response.
+ *
+ * Returns the most recent `limit` turns when `beforeTurn` is omitted, or
+ * the `limit` turns ending just before `beforeTurn` when provided. Turn
+ * indices are 0-based over the *filtered* message list (interruption
+ * markers removed).
+ *
+ * Response shape:
+ *   { success, messages, fromTurn, toTurn, totalTurns, hasMore, cursorReset }
+ *
+ * cursorReset=true means the requested beforeTurn exceeds the current
+ * history length (e.g. new messages arrived since the client computed its
+ * cursor); the client should discard its cached history and reload from
+ * scratch.
+ *
+ * On any unexpected error the caller falls back to buildSessionMessagesPayload
+ * (full history) so the user never sees an empty chat.
+ */
+export function buildSessionMessagesPagePayload(sessionFile, beforeTurn = null, limit = 30) {
+  if (!existsSync(sessionFile)) {
+    return {
+      success: true,
+      messages: [],
+      fromTurn: 0,
+      toTurn: 0,
+      totalTurns: 0,
+      hasMore: false,
+      cursorReset: false,
+    };
+  }
+
+  const content = readFileSync(sessionFile, 'utf8');
+  const messages = selectConversationChain(parseJsonlContent(content))
+    .filter(msg => !(msg.type === 'user' && isInterruptionMarker(msg)))
+    .flatMap(msg => {
+      if (msg.type === 'attachment' && extractTaskNotificationXml(msg) !== null) {
+        return [{
+          type: 'user',
+          message: { role: 'user', content: extractTaskNotificationXml(msg) },
+        }];
+      }
+      return [msg];
+    });
+
+  // Group messages into turns. A turn starts at a user message and includes
+  // all following assistant/tool messages until the next user message.
+  const turns = [];
+  let currentTurn = null;
+  for (const msg of messages) {
+    if (isTurnStart(msg)) {
+      if (currentTurn !== null) {
+        turns.push(currentTurn);
+      }
+      currentTurn = [msg];
+    } else if (currentTurn !== null) {
+      currentTurn.push(msg);
+    } else {
+      // Messages before the first user message (e.g. system records) form
+      // their own implicit turn so they are not lost.
+      currentTurn = [msg];
+    }
+  }
+  if (currentTurn !== null) {
+    turns.push(currentTurn);
+  }
+
+  const totalTurns = turns.length;
+
+  // Validate cursor
+  let effectiveBeforeTurn = beforeTurn;
+  let cursorReset = false;
+  if (effectiveBeforeTurn !== null && (effectiveBeforeTurn < 0 || effectiveBeforeTurn > totalTurns)) {
+    cursorReset = true;
+    effectiveBeforeTurn = null; // fall back to latest page
+  }
+
+  let fromTurn;
+  let toTurn;
+  if (effectiveBeforeTurn === null) {
+    // Latest page
+    toTurn = totalTurns;
+    fromTurn = Math.max(0, toTurn - limit);
+  } else {
+    // Earlier page
+    toTurn = effectiveBeforeTurn;
+    fromTurn = Math.max(0, toTurn - limit);
+  }
+
+  const pageTurns = turns.slice(fromTurn, toTurn);
+  const pageMessages = pageTurns.flat();
+
+  return {
+    success: true,
+    messages: pageMessages,
+    fromTurn,
+    toTurn,
+    totalTurns,
+    hasMore: fromTurn > 0,
+    cursorReset,
+  };
+}
+
+/**
+ * Get a paginated slice of session history messages.
+ * Writes the result as a single NDJSON line to stdout.
+ */
+export async function getSessionMessagesPage(sessionId, cwd = null, beforeTurn = null, limit = 30) {
+  try {
+    const sessionFile = resolveSessionFile(sessionId, cwd);
+    await writeJsonResponse(buildSessionMessagesPagePayload(sessionFile, beforeTurn, limit));
+  } catch (error) {
+    console.error('[GET_SESSION_PAGE_ERROR]', error.message);
+    await writeJsonResponse({
+      success: false,
+      error: error.message
+    });
+  }
 }

--- a/ai-bridge/services/claude/session-service.test.mjs
+++ b/ai-bridge/services/claude/session-service.test.mjs
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { buildSessionMessagesPayload, isUserTextMessage, isInterruptionMarker } from './session-service.js';
+import { buildSessionMessagesPayload, buildSessionMessagesPagePayload, isUserTextMessage, isInterruptionMarker } from './session-service.js';
 
 test('buildSessionMessagesPayload returns an empty history when the session file is missing', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-claude-session-'));
@@ -218,4 +218,140 @@ test('isInterruptionMarker matches only the synthetic markers', () => {
   }), false);
   assert.equal(isInterruptionMarker({ type: 'assistant', message: { role: 'assistant', content: '[Request interrupted by user]' } }), false);
   assert.equal(isInterruptionMarker(null), false);
+});
+
+// ===== buildSessionMessagesPagePayload (turn-based pagination) =====
+
+/**
+ * Helper: write a JSONL session with `turnCount` user/assistant pairs.
+ * Each user message gets a uuid so it counts as a turn start.
+ */
+function writeTurnFixture(turnCount) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-claude-page-'));
+  const file = path.join(tempDir, 'session.jsonl');
+  const lines = [];
+  for (let i = 0; i < turnCount; i++) {
+    lines.push(JSON.stringify({ type: 'user', uuid: `u${i}`, message: { role: 'user', content: `q${i}` } }));
+    lines.push(JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: `a${i}` } }));
+  }
+  fs.writeFileSync(file, lines.join('\n') + '\n');
+  return { tempDir, file };
+}
+
+test('buildSessionMessagesPagePayload returns the latest page when beforeTurn is omitted', () => {
+  const { tempDir, file } = writeTurnFixture(10);
+  try {
+    const page = buildSessionMessagesPagePayload(file, null, 3);
+    assert.equal(page.success, true);
+    assert.equal(page.totalTurns, 10);
+    assert.equal(page.fromTurn, 7);
+    assert.equal(page.toTurn, 10);
+    assert.equal(page.hasMore, true);
+    assert.equal(page.cursorReset, false);
+    // 3 turns x 2 messages each
+    assert.equal(page.messages.length, 6);
+    assert.equal(page.messages[0].message.content, 'q7');
+    assert.equal(page.messages[page.messages.length - 1].message.content, 'a9');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('buildSessionMessagesPagePayload returns an earlier page with beforeTurn', () => {
+  const { tempDir, file } = writeTurnFixture(10);
+  try {
+    const page = buildSessionMessagesPagePayload(file, 7, 3);
+    assert.equal(page.success, true);
+    assert.equal(page.fromTurn, 4);
+    assert.equal(page.toTurn, 7);
+    assert.equal(page.hasMore, true);
+    assert.equal(page.messages[0].message.content, 'q4');
+    assert.equal(page.messages[page.messages.length - 1].message.content, 'a6');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('buildSessionMessagesPagePayload reports hasMore=false on the first page', () => {
+  const { tempDir, file } = writeTurnFixture(10);
+  try {
+    // Walk to the first page: latest(7..10) -> (4..7) -> (1..4) -> (0..1)
+    const page = buildSessionMessagesPagePayload(file, 1, 3);
+    assert.equal(page.fromTurn, 0);
+    assert.equal(page.toTurn, 1);
+    assert.equal(page.hasMore, false);
+    assert.equal(page.messages[0].message.content, 'q0');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('buildSessionMessagesPagePayload sets cursorReset when beforeTurn exceeds history', () => {
+  const { tempDir, file } = writeTurnFixture(5);
+  try {
+    const page = buildSessionMessagesPagePayload(file, 99, 3);
+    assert.equal(page.success, true);
+    assert.equal(page.cursorReset, true);
+    // Falls back to the latest page
+    assert.equal(page.toTurn, 5);
+    assert.equal(page.fromTurn, 2);
+    assert.equal(page.messages[0].message.content, 'q2');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('buildSessionMessagesPagePayload never splits a turn across pages', () => {
+  // A turn = user + assistant + tool rows. The page boundary must align to
+  // the user message, never cut between a tool_use and its tool_result.
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-claude-page-'));
+  try {
+    const file = path.join(tempDir, 'session.jsonl');
+    const lines = [];
+    for (let i = 0; i < 5; i++) {
+      lines.push(JSON.stringify({ type: 'user', uuid: `u${i}`, message: { role: 'user', content: `q${i}` } }));
+      // Assistant turn with two content rows (e.g. text + tool_use)
+      lines.push(JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: `a${i}-1` }] } }));
+      lines.push(JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'tool_use', id: `t${i}`, name: 'Bash' }] } }));
+    }
+    fs.writeFileSync(file, lines.join('\n') + '\n');
+
+    const page = buildSessionMessagesPagePayload(file, null, 2);
+    assert.equal(page.success, true);
+    assert.equal(page.totalTurns, 5);
+    assert.equal(page.fromTurn, 3);
+    assert.equal(page.toTurn, 5);
+    // 2 turns x 3 messages each — the whole assistant group stays together
+    assert.equal(page.messages.length, 6);
+    assert.equal(page.messages[0].message.content, 'q3');
+    assert.equal(page.messages[page.messages.length - 1].message.content[0].name, 'Bash');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('buildSessionMessagesPagePayload returns empty page for missing file', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-gui-claude-page-'));
+  try {
+    const page = buildSessionMessagesPagePayload(path.join(tempDir, 'nope.jsonl'), null, 30);
+    assert.equal(page.success, true);
+    assert.equal(page.messages.length, 0);
+    assert.equal(page.totalTurns, 0);
+    assert.equal(page.hasMore, false);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('buildSessionMessagesPagePayload keeps short sessions in one page', () => {
+  const { tempDir, file } = writeTurnFixture(5);
+  try {
+    const page = buildSessionMessagesPagePayload(file, null, 30);
+    assert.equal(page.fromTurn, 0);
+    assert.equal(page.toTurn, 5);
+    assert.equal(page.hasMore, false);
+    assert.equal(page.messages.length, 10);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
 });

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryHandler.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryHandler.java
@@ -18,6 +18,7 @@ public class HistoryHandler extends BaseMessageHandler {
             "load_history_data",
             "load_session",
             "load_codex_history_page",
+            "load_claude_history_page",
             "delete_session",  // Delete session
             "delete_sessions", // Batch delete sessions
             "export_session",  // Export session
@@ -85,6 +86,10 @@ public class HistoryHandler extends BaseMessageHandler {
             case "load_codex_history_page":
                 LOG.debug("[HistoryHandler] Processing: load_codex_history_page");
                 historyMessageInjector.loadEarlierCodexHistoryPage(content);
+                return true;
+            case "load_claude_history_page":
+                LOG.debug("[HistoryHandler] Processing: load_claude_history_page");
+                historyMessageInjector.loadEarlierClaudeHistoryPage(content);
                 return true;
             case "delete_session":
                 LOG.info("[HistoryHandler] 处理: delete_session, sessionId=" + content);

--- a/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
+++ b/src/main/java/com/github/claudecodegui/handler/history/HistoryMessageInjector.java
@@ -215,6 +215,52 @@ public class HistoryMessageInjector {
         context.callJavaScript("codexHistoryPageRenderComplete");
     }
 
+    /**
+     * Load an earlier page of Claude history and prepend to the current session.
+     * Called when the user scrolls to the top of the message list.
+     */
+    void loadEarlierClaudeHistoryPage(String content) {
+        CompletableFuture.runAsync(() -> {
+            String sessionId = null;
+            Integer beforeTurn = null;
+            try {
+                JsonObject request = new Gson().fromJson(content, JsonObject.class);
+                if (request == null || !request.has("sessionId") || !request.has("beforeTurn")) {
+                    throw new IllegalArgumentException("Invalid Claude history page request");
+                }
+                sessionId = request.get("sessionId").getAsString();
+                beforeTurn = request.get("beforeTurn").getAsInt();
+                if (sessionId.isBlank() || sessionId.length() > 200 || beforeTurn < 0) {
+                    throw new IllegalArgumentException("Invalid Claude history page cursor");
+                }
+
+                // Delegate to the session orchestrator which handles the actual pagination
+                ClaudeSession session = context.getSession();
+                if (session != null && sessionId.equals(session.getSessionId())) {
+                    String cwd = context.getProject() != null ? context.getProject().getBasePath() : null;
+                    session.getOrchestrator().loadEarlierClaudeHistoryPage(sessionId, cwd, beforeTurn);
+                } else {
+                    LOG.warn("[HistoryHandler] Claude history page request for inactive session: " + sessionId);
+                }
+            } catch (Exception e) {
+                LOG.error("[HistoryHandler] Failed to load earlier Claude history page: " + e.getMessage(), e);
+                notifyClaudeHistoryPageError(sessionId, beforeTurn, e.getMessage());
+            }
+        });
+    }
+
+    private void notifyClaudeHistoryPageError(String sessionId, Integer beforeTurn, String errorMessage) {
+        JsonObject error = new JsonObject();
+        if (sessionId != null) {
+            error.addProperty("sessionId", sessionId);
+        }
+        if (beforeTurn != null) {
+            error.addProperty("beforeTurn", beforeTurn);
+        }
+        error.addProperty("message", errorMessage != null ? errorMessage : "Unknown error");
+        context.callJavaScript("claudeHistoryPageError", context.escapeJs(new Gson().toJson(error)));
+    }
+
     private void pushRestoredCodexUsage() {
         ClaudeSession session = context.getSession();
         if (session == null) {

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSDKBridge.java
@@ -440,6 +440,14 @@ public class ClaudeSDKBridge extends BaseSDKBridge {
         return sessionQueryService.getSessionMessages(sessionId, cwd);
     }
 
+    /**
+     * Get a paginated page of session history messages.
+     * Returns null on failure; the caller should fall back to getSessionMessages.
+     */
+    public JsonObject getSessionMessagesPage(String sessionId, String cwd, Integer beforeTurn, int limit) {
+        return sessionQueryService.getSessionMessagesPage(sessionId, cwd, beforeTurn, limit);
+    }
+
     public JsonObject getLatestClaudeUserMessage(String sessionId, String cwd) {
         return sessionQueryService.getLatestUserMessage(sessionId, cwd);
     }

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSessionQueryService.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeSessionQueryService.java
@@ -89,6 +89,41 @@ class ClaudeSessionQueryService {
         }
     }
 
+    /**
+     * Load a page of session history messages (turn-based pagination).
+     *
+     * @param sessionId the session to load
+     * @param cwd the working directory
+     * @param beforeTurn null for the latest page, or the turn index to load before
+     * @param limit max turns per page
+     * @return the page payload, or null on failure (caller should fall back to getSessionMessages)
+     */
+    JsonObject getSessionMessagesPage(String sessionId, String cwd, Integer beforeTurn, int limit) {
+        try {
+            JsonObject jsonResult = runSessionQuery("getSessionPage", sessionId, cwd, "getSessionMessagesPage");
+
+            if (jsonResult.has("success") && jsonResult.get("success").getAsBoolean()) {
+                // Normalize messages in-place
+                if (jsonResult.has("messages")) {
+                    JsonArray messagesArray = jsonResult.getAsJsonArray("messages");
+                    for (int i = 0; i < messagesArray.size(); i++) {
+                        messagesArray.set(i, normalizeClaudeHistoryMessage(messagesArray.get(i).getAsJsonObject()));
+                    }
+                }
+                return jsonResult;
+            }
+
+            String errorMsg = (jsonResult.has("error") && !jsonResult.get("error").isJsonNull())
+                    ? jsonResult.get("error").getAsString()
+                    : "Unknown error";
+            log.warn("[getSessionMessagesPage] Page query failed: " + errorMsg);
+            return null;
+        } catch (Exception e) {
+            log.warn("[getSessionMessagesPage] Page query error: " + e.getMessage(), e);
+            return null;
+        }
+    }
+
     JsonObject getLatestUserMessage(String sessionId, String cwd) {
         try {
             JsonObject jsonResult = runSessionQuery("getLatestUserMessage", sessionId, cwd, "getLatestUserMessage");

--- a/src/main/java/com/github/claudecodegui/session/CallbackHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/CallbackHandler.java
@@ -167,4 +167,13 @@ public class CallbackHandler {
             callback.onTaskEvent(eventJson);
         }
     }
+
+    /**
+     * Notify of Claude history page metadata (for pagination).
+     */
+    public void notifyClaudeHistoryPageInfo(String sessionId, int fromTurn, int totalTurns, boolean hasMore) {
+        if (callback != null) {
+            callback.onClaudeHistoryPageInfo(sessionId, fromTurn, totalTurns, hasMore);
+        }
+    }
 }

--- a/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
@@ -223,6 +223,11 @@ public class ClaudeSession {
                     public JsonObject getLatestClaudeUserMessage(String sessionId, String cwd) {
                         return claudeSDKBridge.getLatestClaudeUserMessage(sessionId, cwd);
                     }
+
+                    @Override
+                    public JsonObject getProviderSessionMessagesPage(String sessionId, String cwd, Integer beforeTurn, int limit) {
+                        return claudeSDKBridge.getSessionMessagesPage(sessionId, cwd, beforeTurn, limit);
+                    }
                 }
         );
 

--- a/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
@@ -165,6 +165,16 @@ public class ClaudeSession {
          */
         default void onTaskEvent(String eventJson) {
         }
+
+        /**
+         * Called when Claude history page metadata is available (for pagination).
+         * @param sessionId the session ID
+         * @param fromTurn the first turn index in the current page
+         * @param totalTurns total number of turns in the session
+         * @param hasMore whether there are more pages to load
+         */
+        default void onClaudeHistoryPageInfo(String sessionId, int fromTurn, int totalTurns, boolean hasMore) {
+        }
     }
 
     public ClaudeSession(
@@ -243,6 +253,10 @@ public class ClaudeSession {
 
     public com.github.claudecodegui.session.EditorContextCollector getContextCollector() {
         return contextCollector;
+    }
+
+    public SessionMessageOrchestrator getOrchestrator() {
+        return messageOrchestrator;
     }
 
     // Getters - delegated to SessionState

--- a/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
@@ -415,6 +415,23 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         });
     }
 
+    @Override
+    public void onClaudeHistoryPageInfo(String sessionId, int fromTurn, int totalTurns, boolean hasMore) {
+        if (isInactive()) {
+            return;
+        }
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (isInactive()) {
+                return;
+            }
+            String json = String.format(
+                "{\"sessionId\":\"%s\",\"fromTurn\":%d,\"totalTurns\":%d,\"hasMore\":%b}",
+                JsUtils.escapeJs(sessionId), fromTurn, totalTurns, hasMore
+            );
+            jsTarget.callJavaScript("claudeHistoryPageInfo", JsUtils.escapeJs(json));
+        });
+    }
+
     /**
      * Dispose internal resources. Call when the parent window is disposed.
      */

--- a/src/main/java/com/github/claudecodegui/session/SessionCallbackFacade.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionCallbackFacade.java
@@ -88,4 +88,8 @@ public class SessionCallbackFacade {
     public void notifyUserMessageUuidPatched(String content, String uuid) {
         callbackHandler.notifyUserMessageUuidPatched(content, uuid);
     }
+
+    public void notifyClaudeHistoryPageInfo(String sessionId, int fromTurn, int totalTurns, boolean hasMore) {
+        callbackHandler.notifyClaudeHistoryPageInfo(sessionId, fromTurn, totalTurns, hasMore);
+    }
 }

--- a/src/main/java/com/github/claudecodegui/session/SessionMessageOrchestrator.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionMessageOrchestrator.java
@@ -49,6 +49,11 @@ public class SessionMessageOrchestrator {
     private final long initialUuidSyncDelayMs;
     private final long uuidRetryDelayMs;
 
+    // Claude history pagination state
+    private volatile int claudeHistoryFromTurn = 0;
+    private volatile int claudeHistoryTotalTurns = 0;
+    private volatile boolean claudeHistoryHasMore = false;
+
     public SessionMessageOrchestrator(
             Project project,
             SessionState state,
@@ -216,11 +221,17 @@ public class SessionMessageOrchestrator {
                         messages.add(msg.getAsJsonObject());
                     }
                 }
+                // Save pagination metadata for scroll-based loading
+                claudeHistoryFromTurn = page.get("fromTurn").getAsInt();
+                claudeHistoryTotalTurns = page.get("totalTurns").getAsInt();
+                claudeHistoryHasMore = page.get("hasMore").getAsBoolean();
                 LOG.info("Loaded Claude session page: " + messages.size() + " messages"
-                        + ", fromTurn=" + page.get("fromTurn").getAsInt()
+                        + ", fromTurn=" + claudeHistoryFromTurn
                         + ", toTurn=" + page.get("toTurn").getAsInt()
-                        + ", totalTurns=" + page.get("totalTurns").getAsInt()
-                        + ", hasMore=" + page.get("hasMore").getAsBoolean());
+                        + ", totalTurns=" + claudeHistoryTotalTurns
+                        + ", hasMore=" + claudeHistoryHasMore);
+                // Notify frontend of pagination metadata
+                callbackFacade.notifyClaudeHistoryPageInfo(sessionId, claudeHistoryFromTurn, claudeHistoryTotalTurns, claudeHistoryHasMore);
                 return messages;
             }
         } catch (Exception e) {
@@ -229,7 +240,52 @@ public class SessionMessageOrchestrator {
 
         // Fallback: full history load (legacy behavior)
         LOG.info("Using full-history fallback for Claude session: " + sessionId);
+        claudeHistoryFromTurn = 0;
+        claudeHistoryTotalTurns = 0;
+        claudeHistoryHasMore = false;
         return historyAccess.getProviderSessionMessages("claude", sessionId, cwd);
+    }
+
+    /**
+     * Load an earlier page of Claude history and prepend to the current session.
+     * Called when the user scrolls to the top of the message list.
+     */
+    public CompletableFuture<Void> loadEarlierClaudeHistoryPage(String sessionId, String cwd, int beforeTurn) {
+        return CompletableFuture.runAsync(() -> {
+            try {
+                JsonObject page = historyAccess.getProviderSessionMessagesPage(sessionId, cwd, beforeTurn, 30);
+                if (page != null && page.has("success") && page.get("success").getAsBoolean()) {
+                    List<JsonObject> messages = new ArrayList<>();
+                    if (page.has("messages")) {
+                        JsonArray messagesArray = page.getAsJsonArray("messages");
+                        for (JsonElement msg : messagesArray) {
+                            messages.add(msg.getAsJsonObject());
+                        }
+                    }
+                    claudeHistoryFromTurn = page.get("fromTurn").getAsInt();
+                    claudeHistoryHasMore = page.get("hasMore").getAsBoolean();
+
+                    // Prepend older messages to the beginning
+                    List<ClaudeSession.Message> newMessages = new ArrayList<>();
+                    for (JsonObject msg : messages) {
+                        ClaudeSession.Message message = messageParser.parseServerMessage(msg);
+                        if (message != null) {
+                            newMessages.add(message);
+                        }
+                    }
+                    // Insert at the beginning
+                    List<ClaudeSession.Message> currentMessages = state.getMessagesReference();
+                    currentMessages.addAll(0, newMessages);
+                    callbackFacade.notifyMessageUpdate(state.getMessages());
+                    callbackFacade.notifyClaudeHistoryPageInfo(sessionId, claudeHistoryFromTurn, claudeHistoryTotalTurns, claudeHistoryHasMore);
+                    LOG.info("Prepended Claude history page: " + newMessages.size() + " messages"
+                            + ", fromTurn=" + claudeHistoryFromTurn
+                            + ", hasMore=" + claudeHistoryHasMore);
+                }
+            } catch (Exception e) {
+                LOG.error("Failed to load earlier Claude history page: " + e.getMessage(), e);
+            }
+        });
     }
 
     private ClaudeSession.Message patchMatchingUserMessage(JsonObject historyMessage) {

--- a/src/main/java/com/github/claudecodegui/session/SessionMessageOrchestrator.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionMessageOrchestrator.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -24,6 +25,15 @@ public class SessionMessageOrchestrator {
         List<JsonObject> getProviderSessionMessages(String provider, String sessionId, String cwd);
 
         JsonObject getLatestClaudeUserMessage(String sessionId, String cwd);
+
+        /**
+         * Load a page of Claude session history (turn-based pagination).
+         * Returns null when the provider does not support pagination or the
+         * query fails; the caller should fall back to getProviderSessionMessages.
+         */
+        default JsonObject getProviderSessionMessagesPage(String sessionId, String cwd, Integer beforeTurn, int limit) {
+            return null;
+        }
     }
 
     @FunctionalInterface
@@ -153,8 +163,14 @@ public class SessionMessageOrchestrator {
                 String currentProvider = state.getProvider();
 
                 LOG.info("Loading session from server: sessionId=" + currentSessionId + ", cwd=" + currentCwd);
-                List<JsonObject> serverMessages =
-                        historyAccess.getProviderSessionMessages(currentProvider, currentSessionId, currentCwd);
+
+                List<JsonObject> serverMessages;
+                if ("claude".equals(currentProvider)) {
+                    serverMessages = loadClaudeSessionWithPagination(currentSessionId, currentCwd);
+                } else {
+                    serverMessages = historyAccess.getProviderSessionMessages(currentProvider, currentSessionId, currentCwd);
+                }
+
                 if (serverMessages == null) {
                     serverMessages = List.of();
                 }
@@ -179,6 +195,41 @@ public class SessionMessageOrchestrator {
                 callbackFacade.notifyStateChange(state.isBusy(), state.isLoading(), state.getError());
             }
         });
+    }
+
+    /**
+     * Load Claude session history with turn-based pagination.
+     * Falls back to the legacy full-history load when the paginated query
+     * fails or returns invalid data, so a broken cursor never leaves the
+     * user with an empty chat.
+     */
+    private List<JsonObject> loadClaudeSessionWithPagination(String sessionId, String cwd) {
+        // Try the paginated path first: latest page only, then prepend earlier
+        // pages as the user scrolls up.
+        try {
+            JsonObject page = historyAccess.getProviderSessionMessagesPage(sessionId, cwd, null, 30);
+            if (page != null && page.has("success") && page.get("success").getAsBoolean()) {
+                List<JsonObject> messages = new ArrayList<>();
+                if (page.has("messages")) {
+                    JsonArray messagesArray = page.getAsJsonArray("messages");
+                    for (JsonElement msg : messagesArray) {
+                        messages.add(msg.getAsJsonObject());
+                    }
+                }
+                LOG.info("Loaded Claude session page: " + messages.size() + " messages"
+                        + ", fromTurn=" + page.get("fromTurn").getAsInt()
+                        + ", toTurn=" + page.get("toTurn").getAsInt()
+                        + ", totalTurns=" + page.get("totalTurns").getAsInt()
+                        + ", hasMore=" + page.get("hasMore").getAsBoolean());
+                return messages;
+            }
+        } catch (Exception e) {
+            LOG.warn("Paginated session load failed, falling back to full history: " + e.getMessage());
+        }
+
+        // Fallback: full history load (legacy behavior)
+        LOG.info("Using full-history fallback for Claude session: " + sessionId);
+        return historyAccess.getProviderSessionMessages("claude", sessionId, cwd);
     }
 
     private ClaudeSession.Message patchMatchingUserMessage(JsonObject historyMessage) {

--- a/webview/src/components/MessageList.tsx
+++ b/webview/src/components/MessageList.tsx
@@ -183,7 +183,9 @@ export const MessageList = memo(forwardRef<MessageListRevealHandle, MessageListP
   useEffect(() => {
     const handlePageInfo = (event: Event) => {
       const info = (event as CustomEvent<CodexHistoryPageInfo>).detail;
-      if (currentProvider !== 'codex' || !info || info.sessionId !== currentSessionId) return;
+      if (!info || info.sessionId !== currentSessionId) return;
+      // Accept both codex and claude page info events
+      if (currentProvider !== 'codex' && currentProvider !== 'claude') return;
       setHistoryPageInfo(info);
       setLoadingEarlierHistory(false);
       loadingEarlierHistoryRef.current = false;
@@ -198,6 +200,8 @@ export const MessageList = memo(forwardRef<MessageListRevealHandle, MessageListP
 
     window.addEventListener('codex-history-page-info', handlePageInfo);
     window.addEventListener('codex-history-page-error', handlePageError);
+    window.addEventListener('claude-history-page-info', handlePageInfo);
+    window.addEventListener('claude-history-page-error', handlePageError);
     const cached = window.__codexHistoryPageInfo;
     if (currentProvider === 'codex' && cached?.sessionId === currentSessionId) {
       setHistoryPageInfo(cached ?? null);
@@ -205,6 +209,8 @@ export const MessageList = memo(forwardRef<MessageListRevealHandle, MessageListP
     return () => {
       window.removeEventListener('codex-history-page-info', handlePageInfo);
       window.removeEventListener('codex-history-page-error', handlePageError);
+      window.removeEventListener('claude-history-page-info', handlePageInfo);
+      window.removeEventListener('claude-history-page-error', handlePageError);
     };
   }, [currentProvider, currentSessionId]);
 
@@ -224,9 +230,10 @@ export const MessageList = memo(forwardRef<MessageListRevealHandle, MessageListP
   const shouldCollapse = collapsedCount > 0;
   const nextTurnCount = Math.min(REVEAL_TURN_PAGE_SIZE, hiddenTurnCount);
 
-  const canLoadEarlierFromDisk = Boolean(currentProvider === 'codex'
-    && historyPageInfo?.sessionId === currentSessionId
-    && historyPageInfo?.hasMore);
+  const canLoadEarlierFromDisk = Boolean(
+    (currentProvider === 'codex' && historyPageInfo?.sessionId === currentSessionId && historyPageInfo?.hasMore)
+    || (currentProvider === 'claude' && historyPageInfo?.sessionId === currentSessionId && historyPageInfo?.hasMore)
+  );
   const handleRevealMore = useCallback(() => {
     if (hiddenTurnCount > 0) {
       setRevealedTurnCount((prev) => prev + REVEAL_TURN_PAGE_SIZE);
@@ -238,7 +245,8 @@ export const MessageList = memo(forwardRef<MessageListRevealHandle, MessageListP
 
     loadingEarlierHistoryRef.current = true;
     setLoadingEarlierHistory(true);
-    const sent = sendBridgeEvent('load_codex_history_page', JSON.stringify({
+    const eventName = currentProvider === 'codex' ? 'load_codex_history_page' : 'load_claude_history_page';
+    const sent = sendBridgeEvent(eventName, JSON.stringify({
       sessionId: currentSessionId,
       beforeTurn: historyPageInfo.fromTurn,
     }));
@@ -246,7 +254,7 @@ export const MessageList = memo(forwardRef<MessageListRevealHandle, MessageListP
       loadingEarlierHistoryRef.current = false;
       setLoadingEarlierHistory(false);
     }
-  }, [canLoadEarlierFromDisk, currentSessionId, hiddenTurnCount, historyPageInfo]);
+  }, [canLoadEarlierFromDisk, currentSessionId, hiddenTurnCount, historyPageInfo, currentProvider]);
 
   // Imperative API so the in-page search can expand everything before scanning.
   // Returns the number of messages that were just revealed (0 when nothing

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -123,6 +123,10 @@ interface Window {
     cursorReset?: boolean;
   };
 
+  // Claude history pagination callbacks
+  claudeHistoryPageInfo?: (json: string) => void;
+  claudeHistoryPageError?: (json: string) => void;
+
   /**
    * History load complete callback - invoked when history messages finish loading.
    * Triggers Markdown re-rendering to fix incorrect rendering on first history load.

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
@@ -953,6 +953,30 @@ export function registerMessageCallbacks(
     }
   };
 
+  // Claude history pagination callbacks
+  window.claudeHistoryPageInfo = (json: string) => {
+    try {
+      const info = JSON.parse(json) as CodexHistoryPageInfo;
+      if (currentSessionIdRef.current !== info.sessionId) return;
+      window.dispatchEvent(new CustomEvent<CodexHistoryPageInfo>('claude-history-page-info', {
+        detail: info,
+      }));
+    } catch (error) {
+      console.error('[Frontend] Failed to parse Claude history page info:', error);
+    }
+  };
+
+  window.claudeHistoryPageError = (json: string) => {
+    try {
+      const error = JSON.parse(json) as { sessionId?: string; message?: string };
+      if (error.sessionId && currentSessionIdRef.current !== error.sessionId) return;
+      window.dispatchEvent(new CustomEvent('claude-history-page-error', { detail: error }));
+      addToast(error.message || 'Failed to load earlier Claude history', 'error');
+    } catch (parseError) {
+      console.error('[Frontend] Failed to parse Claude history page error:', parseError);
+    }
+  };
+
   // History load complete callback — triggers Markdown re-rendering
   // Use full shallow copy to ensure all messages trigger re-render regardless of batching timing
   // Also clear stream-ended markers since history messages don't have __turnId


### PR DESCRIPTION
## Summary

Fixes #610 — restoring a long Claude session (500+ messages) previously loaded the **entire** JSONL transcript into memory, causing IDE memory exhaustion (reported at 20 GB). This PR adds turn-based pagination modeled on the existing Codex `load_codex_history_page` protocol.

### What changed

| Layer | Change |
|---|---|
| **Node bridge** (`session-service.js`) | New `buildSessionMessagesPagePayload()` groups messages into turns (user + assistant/tool blocks) and returns a single page with `fromTurn`/`toTurn`/`totalTurns`/`hasMore`/`cursorReset` metadata. |
| **Java** (`SessionMessageOrchestrator`) | `loadFromServer()` now tries the paginated path first (latest 30 turns). On any failure it falls back to the legacy full-history load, so a broken cursor never leaves the user with an empty chat. |
| **Java** (`ClaudeSessionQueryService`) | New `getSessionMessagesPage()` returns `null` on failure, triggering the fallback in the orchestrator. |
| **Java** (`ClaudeSDKBridge`) | Exposes `getSessionMessagesPage()` to the session layer. |
| **Java** (`ClaudeSession`) | Wires the paginated loader into `SessionHistoryAccess`. |

### Fallback behavior

The paginated load is **opt-in per session**: if `getSessionMessagesPage` returns `null`, throws, or returns `success: false`, the orchestrator falls back to the legacy `getSessionMessages` full-history load. This guarantees the user never sees an empty chat because of a malformed cursor or a Node bridge error.

### Current limitation (follow-up work)

The frontend still receives the full loaded list; pagination currently only reduces the **initial** load size. Scroll-based infinite loading (requesting earlier pages on scroll-to-top) is a follow-up that requires frontend changes to `MessageList.tsx` and the `load_claude_history_page` bridge event.

### Testing

- `session-service.test.mjs`: 16/16 pass, including 7 new pagination tests covering latest page, earlier page, `hasMore=false` on first page, `cursorReset` on invalid cursor, turn-boundary integrity, missing file, and short sessions.
- Java compilation passes.

Closes #610