### PR TITLE
fix(streaming): serialize webview events and protect live snapshots

### DIFF
--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -301,8 +301,11 @@ function processStreamMessage(msg, state, logPrefix) {
   // Capture session_id
   if (msg.type === 'system' && msg.session_id) {
     state.currentSessionId = msg.session_id;
-    console.log('[SESSION_ID]', msg.session_id);
-    setActiveQueryResult(msg.session_id, state.queryResult);
+    if (state.lastEmittedSessionId !== msg.session_id) {
+      state.lastEmittedSessionId = msg.session_id;
+      console.log('[SESSION_ID]', msg.session_id);
+      setActiveQueryResult(msg.session_id, state.queryResult);
+    }
   }
 
   // Error result detection
@@ -355,7 +358,7 @@ async function executeWithRetry({ createQueryResult, streamingEnabled, resumeSes
 
   while (retryAttempt <= AUTO_RETRY_CONFIG.maxRetries) {
     const state = {
-      currentSessionId: resumeSessionId, messageCount: 0, hasStreamEvents: false,
+      currentSessionId: resumeSessionId, lastEmittedSessionId: null, messageCount: 0, hasStreamEvents: false,
       lastAssistantContent: '', lastThinkingContent: '', accumulatedUsage: null,
       streamingEnabled, streamStarted: outerStreamState.streamStarted,
       streamEnded: outerStreamState.streamEnded, queryResult: null

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -420,8 +420,11 @@ _sessionCleanupTimer.unref();
 
       if (msg?.type === 'system' && msg.session_id) {
         turnState.finalSessionId = msg.session_id;
-        console.log('[SESSION_ID]', msg.session_id);
-        registerRuntimeSession(runtime, msg.session_id, { registerActiveQueryResult, removeSession });
+        if (runtime.lastEmittedSessionId !== msg.session_id) {
+          runtime.lastEmittedSessionId = msg.session_id;
+          console.log('[SESSION_ID]', msg.session_id);
+          registerRuntimeSession(runtime, msg.session_id, { registerActiveQueryResult, removeSession });
+        }
       }
 
       if (msg?.type === 'result') {

--- a/ai-bridge/services/claude/runtime-lifecycle.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.js
@@ -231,6 +231,7 @@ async function createRuntime(requestContext, callbacks) {
     stderrLines: [],
     query: null,
     inputStream: new AsyncStream(),
+    lastEmittedSessionId: null,
     titleGenerationAttempted: false
   };
 

--- a/src/main/java/com/github/claudecodegui/handler/core/HandlerContext.java
+++ b/src/main/java/com/github/claudecodegui/handler/core/HandlerContext.java
@@ -5,7 +5,6 @@ import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
 import com.github.claudecodegui.provider.codex.CodexSDKBridge;
 import com.github.claudecodegui.provider.grok.GrokSDKBridge;
 import com.github.claudecodegui.settings.CodemossSettingsService;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.jcef.JBCefBrowser;
 
@@ -44,6 +43,9 @@ public class HandlerContext {
     public interface JsCallback {
         void callJavaScript(String functionName, String... args);
         String escapeJs(String str);
+
+        default void executeJavaScript(String jsCode) {
+        }
     }
 
     public HandlerContext(
@@ -206,20 +208,9 @@ public class HandlerContext {
      * Execute JavaScript on the EDT (Event Dispatch Thread).
      */
     public void executeJavaScriptOnEDT(String jsCode) {
-        JBCefBrowser targetBrowser = this.browser;
-        if (targetBrowser == null || this.disposed) {
+        if (this.disposed || this.jsCallback == null) {
             return;
         }
-        ApplicationManager.getApplication().invokeLater(() -> {
-            if (this.disposed || this.browser != targetBrowser) {
-                return;
-            }
-            try {
-                org.cef.browser.CefBrowser cefBrowser = targetBrowser.getCefBrowser();
-                cefBrowser.executeJavaScript(jsCode, cefBrowser.getURL(), 0);
-            } catch (Exception | LinkageError ignored) {
-                // The webview may be disposed between the generation check and execution.
-            }
-        });
+        this.jsCallback.executeJavaScript(jsCode);
     }
 }

--- a/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
+++ b/src/main/java/com/github/claudecodegui/session/ClaudeSession.java
@@ -73,17 +73,9 @@ public class ClaudeSession {
         }
 
         public Type type;
-        // The streaming handler thread reassigns these on every assistant update
-        // (e.g. `raw = mergedRaw`, `content = builder.toString()`) while
-        // StreamMessageCoalescer serializes the same Message off-EDT — enqueue only
-        // shallow-copies the list, so elements are shared across threads. Without
-        // volatile the serializer could read a stale reference and publish a snapshot
-        // predating a just-reassigned tool_use block, which the frontend's structural
-        // merge (it takes blocks from the new snapshot only) would then freeze as
-        // missing.
-        // This covers the reassignment race, the dominant mutation pattern. Note:
-        // a few call sites still mutate the JsonObject in place (turnUsage / uuid /
-        // usage stamps in ClaudeMessageHandler); those are a separate concern.
+        // Message state is read by callback and UI threads. The coalescer takes a
+        // deep transport snapshot before asynchronous serialization, while volatile
+        // keeps direct readers from observing stale field references.
         public volatile String content;
         public long timestamp;
         public volatile JsonObject raw; // Raw message data from SDK

--- a/src/main/java/com/github/claudecodegui/session/GrokMessageHandler.java
+++ b/src/main/java/com/github/claudecodegui/session/GrokMessageHandler.java
@@ -188,7 +188,7 @@ public class GrokMessageHandler implements MessageCallback {
                 target.raw = parsed.raw;
             }
             // Prefer usage from the incoming message (finishSuccess now attaches it);
-            // otherwise restore prior snapshot so pushUsageUpdateFromMessages still works.
+            // otherwise restore prior snapshot so the next usage refresh still works.
             JsonObject incomingUsage = extractUsageFromAssistantRaw(target.raw);
             if (incomingUsage == null && priorUsage != null) {
                 restoreUsageOnAssistantRaw(target.raw, priorUsage);

--- a/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
+++ b/src/main/java/com/github/claudecodegui/session/SessionCallbackAdapter.java
@@ -9,6 +9,8 @@ import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.util.Alarm;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BooleanSupplier;
 
 /**
@@ -21,6 +23,7 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
     private static final Logger LOG = Logger.getInstance(SessionCallbackAdapter.class);
     /** Throttle interval targeting ~30fps to balance responsiveness with UI thread load. */
     private static final int DELTA_THROTTLE_MS = 33;
+    private static final int STREAM_END_FALLBACK_DELAY_MS = 5_000;
 
     /**
      * Callback interface for JavaScript calls from session events.
@@ -40,8 +43,10 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
     private volatile boolean active = true;
     /** Lock making deactivate() atomic with onMessageUpdate()'s active-check-then-enqueue. */
     private final Object lifecycleLock = new Object();
-    /** Guards against duplicate onStreamEnd delivery from dual-path dispatch. */
-    private volatile boolean streamEndSignalSent = false;
+    private final AtomicBoolean streamEndStarted = new AtomicBoolean();
+    private final AtomicBoolean streamEndSignalSent = new AtomicBoolean();
+    private final AtomicLong streamGeneration = new AtomicLong();
+    private volatile String lastSessionId;
 
     public SessionCallbackAdapter(
             StreamMessageCoalescer streamCoalescer,
@@ -104,27 +109,23 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         if (isInactive()) {
             return;
         }
-        ApplicationManager.getApplication().invokeLater(() -> {
-            if (isInactive()) {
-                return;
-            }
-            // Do not send loading=false during streaming to avoid unexpected loading state resets.
-            // State cleanup is handled uniformly by onStreamEnd.
-            if (!loading && streamCoalescer.isStreamActive()) {
-                LOG.debug("Suppressing showLoading(false) during active streaming");
-                return;
-            }
-
-            jsTarget.callJavaScript("showLoading", String.valueOf(loading));
-            // Show error in status bar only (not as toast) to avoid duplicate notifications.
-            // The primary error display is the ERROR message in chat list (from onError path).
-            if (error != null && !error.isEmpty()) {
-                jsTarget.callJavaScript("updateStatus", JsUtils.escapeJs("Error: " + error));
-            }
-            if (!busy && !loading) {
-                VirtualFileManager.getInstance().asyncRefresh(null);
-            }
-        });
+        // The webview queue owns JS-thread marshalling; only the VFS refresh needs the EDT.
+        if (!loading && streamCoalescer.isStreamActive()) {
+            LOG.debug("Suppressing showLoading(false) during active streaming");
+            return;
+        }
+        jsTarget.callJavaScript("showLoading", String.valueOf(loading));
+        // Show error in status bar only (not as toast) to avoid duplicate notifications.
+        if (error != null && !error.isEmpty()) {
+            jsTarget.callJavaScript("updateStatus", JsUtils.escapeJs("Error: " + error));
+        }
+        if (!busy && !loading) {
+            ApplicationManager.getApplication().invokeLater(() -> {
+                if (!isInactive()) {
+                    VirtualFileManager.getInstance().asyncRefresh(null);
+                }
+            });
+        }
     }
 
     @Override
@@ -132,26 +133,18 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         if (isInactive() || message == null || message.trim().isEmpty()) {
             return;
         }
-        ApplicationManager.getApplication().invokeLater(() -> {
-            if (isInactive()) {
-                return;
-            }
-            jsTarget.callJavaScript("updateStatus", JsUtils.escapeJs(message));
-        });
+        jsTarget.callJavaScript("updateStatus", JsUtils.escapeJs(message));
     }
 
     @Override
     public void onSessionIdReceived(String sessionId) {
-        if (isInactive()) {
+        if (isInactive() || sessionId == null || sessionId.trim().isEmpty()
+                || sessionId.equals(lastSessionId)) {
             return;
         }
+        lastSessionId = sessionId;
         LOG.info("Session ID: " + sessionId);
-        ApplicationManager.getApplication().invokeLater(() -> {
-            if (isInactive()) {
-                return;
-            }
-            jsTarget.callJavaScript("setSessionId", JsUtils.escapeJs(sessionId));
-        });
+        jsTarget.callJavaScript("setSessionId", JsUtils.escapeJs(sessionId));
     }
 
     @Override
@@ -172,13 +165,8 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         if (isInactive()) {
             return;
         }
-        ApplicationManager.getApplication().invokeLater(() -> {
-            if (isInactive()) {
-                return;
-            }
-            jsTarget.callJavaScript("showThinkingStatus", String.valueOf(isThinking));
-            LOG.debug("Thinking status changed: " + isThinking);
-        });
+        jsTarget.callJavaScript("showThinkingStatus", String.valueOf(isThinking));
+        LOG.debug("Thinking status changed: " + isThinking);
     }
 
     @Override
@@ -202,12 +190,7 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         if (isInactive() || summary == null || summary.trim().isEmpty()) {
             return;
         }
-        ApplicationManager.getApplication().invokeLater(() -> {
-            if (isInactive()) {
-                return;
-            }
-            jsTarget.callJavaScript("showSummary", JsUtils.escapeJs(summary));
-        });
+        jsTarget.callJavaScript("showSummary", JsUtils.escapeJs(summary));
     }
 
     @Override
@@ -222,86 +205,71 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         if (isInactive()) {
             return;
         }
-        // Cancel any stale fallback alarm from the previous turn to prevent
-        // it from firing during the new turn's streaming phase.
         streamEndFallbackAlarm.cancelAllRequests();
+        streamEndStarted.set(false);
+        streamEndSignalSent.set(false);
+        streamGeneration.incrementAndGet();
         contentDeltaThrottler.reset();
         thinkingDeltaThrottler.reset();
+        // The queue preserves this lifecycle edge ahead of all following deltas.
+        jsTarget.callJavaScript("showLoading", "true");
+        jsTarget.callJavaScript("onStreamStart");
         streamCoalescer.onStreamStart();
-        ApplicationManager.getApplication().invokeLater(() -> {
-            if (isInactive()) {
-                return;
-            }
-            jsTarget.callJavaScript("showLoading", "true");
-            jsTarget.callJavaScript("onStreamStart");
-            LOG.debug("Stream started - notified frontend with loading=true");
-        });
+        LOG.debug("Stream started - notified frontend with loading=true");
     }
 
     @Override
     public void onStreamEnd() {
-        if (isInactive()) {
+        if (isInactive() || !streamEndStarted.compareAndSet(false, true)) {
             return;
         }
-        // Reset the signal guard so this turn's dual-path dispatch can proceed.
-        // Thread-safety: this runs on the process reader thread; the callbacks that
-        // read/write streamEndSignalSent all run on EDT (via invokeLater or Alarm).
-        // The reset happens-before flush() schedules any callbacks, so no race exists.
-        streamEndSignalSent = false;
+        final long generation = streamGeneration.get();
 
-        // Each step is wrapped in safeRun so that a failure in one step
-        // (e.g., flushNow throwing due to a disposed throttler, or JCEF
-        // rejecting a large payload) does not prevent the critical
-        // onStreamEnd signal from reaching the frontend.
         safeRun("contentDeltaThrottler.flushNow", contentDeltaThrottler::flushNow);
         safeRun("thinkingDeltaThrottler.flushNow", thinkingDeltaThrottler::flushNow);
+
+        streamCoalescer.flush(sequence -> {
+            if (generation != streamGeneration.get()
+                    || !streamEndSignalSent.compareAndSet(false, true)) {
+                return;
+            }
+            streamEndFallbackAlarm.cancelAllRequests();
+            sendStreamEndToFrontend(sequence, generation);
+        });
         safeRun("streamCoalescer.onStreamEnd", streamCoalescer::onStreamEnd);
 
-        // ── Dual-path onStreamEnd delivery ──
-        //
-        // Primary path: chain onStreamEnd inside the flush callback. The callback
-        // runs on the EDT *after* the updateMessages JS call has been dispatched,
-        // guaranteeing the frontend receives the final message snapshot before the
-        // stream-end signal.
-        //
-        // Fallback path: an independent Alarm fires after 300ms. This covers the
-        // scenario where the flush's 3-layer async pipeline fails silently (JCEF
-        // large payload rejection, disposed browser, JSON serialization OOM).
-        //
-        // The frontend's onStreamEnd is idempotent (per-turn guard), so receiving
-        // both signals is harmless — only the first takes effect.
-
-        // Primary: ordered delivery via flush callback
-        streamCoalescer.flush(sequence -> {
-            if (streamEndSignalSent) {
-                return;
-            }
-            streamEndSignalSent = true;
-            streamEndFallbackAlarm.cancelAllRequests();
-            sendStreamEndToFrontend(sequence);
-        });
-
-        // Fallback: independent delivery after timeout
         streamEndFallbackAlarm.cancelAllRequests();
+        scheduleStreamEndFallback(generation);
+    }
+
+    private void scheduleStreamEndFallback(long generation) {
         streamEndFallbackAlarm.addRequest(() -> {
-            if (streamEndSignalSent || isInactive()) {
+            if (generation != streamGeneration.get()
+                    || streamEndSignalSent.get()
+                    || isInactive()) {
                 return;
             }
-            streamEndSignalSent = true;
-            LOG.warn("Stream end signal delivered via fallback (primary flush callback did not fire within 300ms)");
-            sendStreamEndToFrontend(-1);
-        }, 300);
+            if (streamCoalescer.isSnapshotBuildPending()) {
+                scheduleStreamEndFallback(generation);
+                return;
+            }
+            if (!streamEndSignalSent.compareAndSet(false, true)) {
+                return;
+            }
+            LOG.warn("Stream end signal delivered via fallback after snapshot serialization stalled");
+            sendStreamEndToFrontend(-1L, generation);
+        }, STREAM_END_FALLBACK_DELAY_MS);
     }
 
     /**
-     * Send the onStreamEnd signal and associated cleanup to the frontend.
-     * Called from either the primary (flush callback) or fallback (Alarm) path.
+     * Send the stream-end signal after the final snapshot has entered the webview queue.
      *
-     * @param sequence the flush sequence number, or -1 if fired from fallback
+     * @param sequence final snapshot sequence, or -1 when the fallback is used
+     * @param generation stream generation that owns the signal
      */
-    private void sendStreamEndToFrontend(long sequence) {
-        if (isInactive()) {
-            LOG.debug("Skipping sendStreamEndToFrontend — adapter deactivated (sequence=" + sequence + ")");
+    private void sendStreamEndToFrontend(long sequence, long generation) {
+        if (isInactive() || generation != streamGeneration.get()) {
+            LOG.debug("Skipping stale stream-end signal (sequence=" + sequence + ")");
             return;
         }
         safeRun("callJavaScript(onStreamEnd)", () ->
@@ -309,7 +277,11 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         safeRun("callJavaScript(showLoading, false)", () ->
                 jsTarget.callJavaScript("showLoading", "false"));
         if (streamEndCallback != null) {
-            safeRun("streamEndCallback", streamEndCallback);
+            ApplicationManager.getApplication().invokeLater(() -> {
+                if (generation == streamGeneration.get() && !isInactive()) {
+                    safeRun("streamEndCallback", streamEndCallback);
+                }
+            });
         }
         LOG.debug("Stream ended - notified frontend (sequence=" + sequence + ")");
     }
@@ -351,13 +323,8 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         thinkingDeltaThrottler.flushNow();
         contentDeltaThrottler.reset();
         thinkingDeltaThrottler.reset();
-        ApplicationManager.getApplication().invokeLater(() -> {
-            if (isInactive()) {
-                return;
-            }
-            jsTarget.callJavaScript("onBlockReset");
-            LOG.debug("Block reset sent to frontend - streaming refs cleared");
-        });
+        jsTarget.callJavaScript("onBlockReset");
+        LOG.debug("Block reset sent to frontend - streaming refs cleared");
     }
 
     @Override
@@ -365,18 +332,13 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         if (isInactive()) {
             return;
         }
-        ApplicationManager.getApplication().invokeLater(() -> {
-            if (isInactive()) {
-                return;
-            }
-            int safeUsedTokens = normalizeUsageValue(usedTokens);
-            int safeMaxTokens = normalizeUsageValue(maxTokens);
-            double percentage = calculateUsagePercentage(safeUsedTokens, safeMaxTokens);
-            String json = String.format("{\"percentage\":%.2f,\"usedTokens\":%d,\"maxTokens\":%d}",
-                    percentage, safeUsedTokens, safeMaxTokens);
-            jsTarget.callJavaScript("onUsageUpdate", JsUtils.escapeJs(json));
-            LOG.debug("Usage update sent to frontend: " + safeUsedTokens + "/" + safeMaxTokens);
-        });
+        int safeUsedTokens = normalizeUsageValue(usedTokens);
+        int safeMaxTokens = normalizeUsageValue(maxTokens);
+        double percentage = calculateUsagePercentage(safeUsedTokens, safeMaxTokens);
+        String json = String.format("{\"percentage\":%.2f,\"usedTokens\":%d,\"maxTokens\":%d}",
+                percentage, safeUsedTokens, safeMaxTokens);
+        jsTarget.callJavaScript("onUsageUpdate", JsUtils.escapeJs(json));
+        LOG.debug("Usage update sent to frontend: " + safeUsedTokens + "/" + safeMaxTokens);
     }
 
     /**
@@ -412,12 +374,7 @@ public class SessionCallbackAdapter implements ClaudeSession.SessionCallback {
         if (isInactive() || eventJson == null || eventJson.trim().isEmpty()) {
             return;
         }
-        ApplicationManager.getApplication().invokeLater(() -> {
-            if (isInactive()) {
-                return;
-            }
-            jsTarget.callJavaScript("onTaskEvent", JsUtils.escapeJs(eventJson));
-        });
+        jsTarget.callJavaScript("onTaskEvent", JsUtils.escapeJs(eventJson));
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/session/StreamMessageCoalescer.java
+++ b/src/main/java/com/github/claudecodegui/session/StreamMessageCoalescer.java
@@ -3,18 +3,22 @@ package com.github.claudecodegui.session;
 import com.github.claudecodegui.handler.core.HandlerContext;
 import com.github.claudecodegui.util.JsUtils;
 import com.github.claudecodegui.util.MessageJsonConverter;
-import com.intellij.openapi.application.ApplicationManager;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.ui.jcef.JBCefBrowser;
 import com.intellij.util.Alarm;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.function.LongConsumer;
 
 /**
- * Coalesces streaming message updates to throttle webview pushes.
- * Batches rapid onMessageUpdate callbacks into periodic UI refreshes
- * to avoid overwhelming the JCEF browser.
+ * Coalesces streaming message updates before pushing them to the webview.
  */
 public class StreamMessageCoalescer {
 
@@ -22,109 +26,94 @@ public class StreamMessageCoalescer {
     private static final int UPDATE_INTERVAL_MS = 50;
     private static final int LARGE_UPDATE_PAYLOAD_CHARS = 150_000;
     private static final long SLOW_PAYLOAD_BUILD_MS = 25L;
-
-    // FIX: Adaptive throttling to prevent JCEF IPC saturation during long streams.
-    // When the full message JSON is large, V8 must parse the entire string literal
-    // on every executeJavaScript call.  At 50ms intervals with 200KB+ payloads,
-    // the renderer thread falls behind and enters a death spiral where IPC messages
-    // pile up and ALL JavaScript calls (including onContentDelta) are blocked.
-    //
-    // Strategy: during active streaming, scale the coalescing interval based on the
-    // last observed payload size.  Content updates still arrive via onContentDelta
-    // (tiny payloads, <1KB), so the user sees streaming text.  Only the full message
-    // list refresh (updateMessages) is throttled.
-    private static final int LARGE_PAYLOAD_THRESHOLD = 100_000;   // 100KB
-    private static final int MEDIUM_INTERVAL_MS = 500;             // 100-200KB
-    private static final int LARGE_INTERVAL_MS = 2_000;            // 200-500KB
-    private static final int XLARGE_INTERVAL_MS = 5_000;           // >500KB
+    private static final int LARGE_PAYLOAD_THRESHOLD = 100_000;
+    private static final int MEDIUM_INTERVAL_MS = 500;
+    private static final int LARGE_INTERVAL_MS = 2_000;
+    private static final int XLARGE_INTERVAL_MS = 5_000;
     private static final int LONG_CONVERSATION_THRESHOLD = 300;
-    private static final int LONG_CONVERSATION_TAIL_SIZE = 180;
-
-    // During streaming, delta channel (onContentDelta/onThinkingDelta) provides
-    // real-time character-by-character updates.  updateMessages carries authoritative
-    // raw blocks (tool_use, tool_result, etc.) and is the ONLY channel that can
-    // surface structural changes to the frontend.  Keep this minimum tight so that
-    // newly-arrived tool_use / tool_result blocks show up promptly instead of
-    // appearing to "stick" at the bottom while the user waits for an answer.
-    // The adaptive thresholds above will still scale up for large payloads.
+    private static final int LONG_CONVERSATION_TAIL_SIZE = 64;
     private static final int STREAMING_MIN_INTERVAL_MS = 150;
-
-    // FIX: Heartbeat interval during streaming.  During tool execution phases
-    // (command execution, file operations, etc.), no content deltas or message
-    // updates arrive from the SDK.  Without a heartbeat, the frontend stall
-    // watchdog may falsely trigger and prematurely end the streaming state.
-    // This lightweight signal keeps the frontend watchdog alive.
-    private static final int HEARTBEAT_INTERVAL_MS = 10_000;       // 10s
+    private static final int HEARTBEAT_INTERVAL_MS = 10_000;
 
     private final Object lock = new Object();
     private final Alarm updateAlarm = new Alarm(Alarm.ThreadToUse.SWING_THREAD);
     private final Alarm heartbeatAlarm = new Alarm(Alarm.ThreadToUse.SWING_THREAD);
-    private volatile boolean streamActive = false;
-    private volatile boolean updateScheduled = false;
-    private volatile long lastUpdateAtMs = 0L;
-    private volatile long updateSequence = 0L;
-    // Written from the pooled thread in sendToWebView, read from EDT/schedulePush via
-    // effectiveIntervalMs().  Volatile guarantees visibility but not atomicity with the
-    // lock-protected fields.  This is intentional: a one-cycle stale read only means the
-    // interval adapts one push later — acceptable for a best-effort throttling heuristic.
-    private volatile int lastPayloadChars = 0;
-    // Highest sequence actually handed to the webview. Ordering is enforced against THIS,
-    // not against updateSequence: updateSequence only means "newer data is queued", which
-    // is not a reason to drop the in-flight frame. See sendToWebView for why that matters.
-    private volatile long lastPushedSequence = 0L;
-    private volatile List<ClaudeSession.Message> pendingMessages = null;
-    private volatile List<ClaudeSession.Message> lastSnapshot = null;
-    private volatile List<ClaudeSession.Message> lastDeliveredSnapshot = null;
-
+    private final ExecutorService snapshotExecutor;
     private final JsCallbackTarget callbackTarget;
+    private volatile boolean streamActive;
+    private volatile boolean disposed;
+    private volatile boolean updateScheduled;
+    private volatile long lastUpdateAtMs;
+    private volatile long updateSequence;
+    private volatile int lastPayloadChars;
+    private volatile long lastPushedSequence;
+    private boolean snapshotPending;
+    private List<ClaudeSession.Message> latestSourceMessages;
+    private List<ClaudeSession.Message> lastSnapshot;
+    private List<ClaudeSession.Message> lastDeliveredSnapshot;
+    private String latestStructuralSignature;
+    private boolean snapshotBuildRunning;
+    private List<ClaudeSession.Message> requestedSnapshot;
+    private long requestedSequence;
+    private long requestedDeliveryEpoch;
+    private long deliveryEpoch;
+    private LongConsumer requestedAfterFlush;
 
     /**
      * Callback interface to push data to the webview.
      */
     public interface JsCallbackTarget {
         void callJavaScript(String functionName, String... args);
-        JBCefBrowser getBrowser();
         boolean isDisposed();
         HandlerContext getHandlerContext();
-
-        /**
-         * Fired when the stream transitions to inactive (end of a turn's
-         * streaming segment). Lets the host run work that was deferred while the
-         * stream was active — e.g. a session_updated reload held back so it does
-         * not disturb the streaming bubble or race SessionState mutations.
-         * Default no-op so existing targets need not implement it.
-         */
-        default void onStreamEnded() {}
     }
 
     record MessageTransport(
             List<ClaudeSession.Message> messages,
             int baseIndex,
             boolean tailUpdate
-    ) {}
-
-    public StreamMessageCoalescer(JsCallbackTarget callbackTarget) {
-        this.callbackTarget = callbackTarget;
+    ) {
     }
 
     /**
-     * Enqueue a message update for coalesced delivery.
+     * Create a message coalescer for one chat window.
+     *
+     * @param callbackTarget destination for ordered webview events
+     */
+    public StreamMessageCoalescer(JsCallbackTarget callbackTarget) {
+        this.callbackTarget = callbackTarget;
+        this.snapshotExecutor = Executors.newSingleThreadExecutor(new SnapshotThreadFactory());
+    }
+
+    /**
+     * Enqueue the newest message state for coalesced delivery.
      */
     public void enqueue(List<ClaudeSession.Message> messages) {
-        if (callbackTarget.isDisposed()) {
+        if (disposed || callbackTarget.isDisposed() || messages == null) {
             return;
         }
-        // Defensive copy: the caller's list may be mutated on another thread,
-        // so we snapshot it here to guarantee a consistent read in sendToWebView.
-        final List<ClaudeSession.Message> snapshot = List.copyOf(messages);
+        // Delta-capable providers keep text flowing through the lightweight channel;
+        // snapshots remain for structure and final reconciliation.
+        String structuralSignature = getStructuralSignature(messages);
+        boolean shouldSchedule;
+        boolean active;
         synchronized (lock) {
-            pendingMessages = snapshot;
+            if (disposed) {
+                return;
+            }
+            latestSourceMessages = List.copyOf(messages);
+            boolean structuralChanged = !Objects.equals(latestStructuralSignature, structuralSignature);
+            latestStructuralSignature = structuralSignature;
+            active = streamActive;
+            boolean deltaChannelAvailable = hasDeltaChannel();
+            snapshotPending = snapshotPending || !active || !deltaChannelAvailable || structuralChanged;
+            shouldSchedule = !active || !deltaChannelAvailable || structuralChanged;
         }
-        schedulePush();
-        // Restart heartbeat timer: real data just arrived, so the next heartbeat
-        // should fire HEARTBEAT_INTERVAL_MS from now, not from the last heartbeat.
-        if (streamActive) {
+        if (active) {
             startHeartbeat();
+        }
+        if (shouldSchedule) {
+            schedulePush();
         }
     }
 
@@ -134,36 +123,51 @@ public class StreamMessageCoalescer {
     public void onStreamStart() {
         synchronized (lock) {
             streamActive = true;
+            latestStructuralSignature = null;
         }
         startHeartbeat();
     }
 
     /**
-     * Notify that a stream has ended.
+     * Notify that a stream has ended. Only clears the streaming state here; the
+     * deferred-reload drain must wait until the final snapshot has entered the
+     * webview queue, which the adapter guarantees via its stream-end callback.
      */
     public void onStreamEnd() {
         heartbeatAlarm.cancelAllRequests();
         synchronized (lock) {
             streamActive = false;
-            lastPayloadChars = 0;  // Reset so post-stream flush uses normal interval
+            lastPayloadChars = 0;
         }
-        // Notify the host that the stream went inactive, so it can drain work
-        // deferred during streaming (e.g. a background session_updated reload).
-        // Done outside the lock: the host may synchronously schedule EDT work,
-        // and holding `lock` across a foreign callback risks lock-ordering issues.
-        callbackTarget.onStreamEnded();
     }
 
     /**
-     * Reset stream state (e.g., on new session creation).
+     * Forget the previous webview delivery baseline without discarding session state.
+     */
+    public void resetDeliveryBaseline() {
+        synchronized (lock) {
+            deliveryEpoch++;
+            lastSnapshot = null;
+            lastDeliveredSnapshot = null;
+            lastPayloadChars = 0;
+        }
+    }
+
+    /**
+     * Return whether a snapshot is queued or currently being serialized.
      *
-     * @return the post-reset update sequence, to be forwarded to the frontend as
-     *     a "sequence barrier". Any stale updateMessages from the previous
-     *     session that were already dispatched to JS (and are queued in the JCEF
-     *     IPC channel) carry a strictly smaller sequence, so the frontend's
-     *     {@code __minAcceptedUpdateSequence} guard rejects them. This closes the
-     *     race where a delayed old snapshot repopulates a list that "new session"
-     *     just cleared.
+     * @return true when serialization work remains
+     */
+    public boolean isSnapshotBuildPending() {
+        synchronized (lock) {
+            return snapshotBuildRunning || requestedSnapshot != null;
+        }
+    }
+
+    /**
+     * Reset stream state when the active session changes.
+     *
+     * @return the sequence barrier for the frontend
      */
     public long resetStreamState() {
         updateAlarm.cancelAllRequests();
@@ -171,55 +175,68 @@ public class StreamMessageCoalescer {
         synchronized (lock) {
             streamActive = false;
             updateScheduled = false;
-            pendingMessages = null;
+            snapshotPending = false;
+            latestSourceMessages = null;
             lastSnapshot = null;
             lastDeliveredSnapshot = null;
+            latestStructuralSignature = null;
+            requestedSnapshot = null;
+            requestedAfterFlush = null;
             lastUpdateAtMs = 0L;
             lastPayloadChars = 0;
-            // Raise the ordering floor as well: frames still in flight from the previous
-            // session carry a smaller sequence and must not repopulate the list we cleared.
             lastPushedSequence = ++updateSequence;
+            deliveryEpoch++;
             return lastPushedSequence;
         }
     }
 
+    /**
+     * Return whether the current stream is active.
+     *
+     * @return true while a stream is active
+     */
     public boolean isStreamActive() {
         return streamActive;
     }
 
     /**
-     * Flush any pending messages immediately and optionally run a callback afterwards.
+     * Flush the latest messages immediately and optionally run a callback afterwards.
+     *
+     * @param afterFlush callback invoked after the snapshot has entered the webview queue
      */
-    public void flush(LongConsumer afterFlushOnEdt) {
-        if (callbackTarget.isDisposed()) {
+    public void flush(LongConsumer afterFlush) {
+        if (disposed || callbackTarget.isDisposed()) {
             return;
         }
 
+        final List<ClaudeSession.Message> sourceMessages;
         final List<ClaudeSession.Message> snapshot;
         final long sequence;
         synchronized (lock) {
             updateAlarm.cancelAllRequests();
             updateScheduled = false;
-            snapshot = pendingMessages != null ? pendingMessages : lastSnapshot;
-            pendingMessages = null;
+            snapshotPending = false;
+            sourceMessages = latestSourceMessages;
             sequence = ++updateSequence;
         }
+        snapshot = sourceMessages != null
+                ? copyMessagesForTransport(sourceMessages) : lastSnapshot;
 
         if (snapshot == null) {
-            if (afterFlushOnEdt != null) {
-                final long finalSequence = sequence;
-                ApplicationManager.getApplication().invokeLater(() -> afterFlushOnEdt.accept(finalSequence));
+            if (afterFlush != null) {
+                afterFlush.accept(sequence);
             }
             return;
         }
 
-        sendToWebView(snapshot, sequence, afterFlushOnEdt);
+        requestSnapshotBuild(snapshot, sequence, afterFlush);
     }
 
     /**
      * Dispose internal resources.
      */
     public void dispose() {
+        disposed = true;
         try {
             updateAlarm.cancelAllRequests();
             updateAlarm.dispose();
@@ -232,12 +249,9 @@ public class StreamMessageCoalescer {
         } catch (Exception e) {
             LOG.warn("Failed to dispose heartbeat alarm: " + e.getMessage());
         }
+        snapshotExecutor.shutdownNow();
     }
 
-    /**
-     * Compute the effective coalescing interval.  During streaming, scale the
-     * interval based on the last observed payload size to prevent JCEF overload.
-     */
     private int effectiveIntervalMs() {
         if (!streamActive) {
             return UPDATE_INTERVAL_MS;
@@ -254,13 +268,13 @@ public class StreamMessageCoalescer {
             return STREAMING_MIN_INTERVAL_MS;
         }
         if (LOG.isDebugEnabled()) {
-            LOG.debug("[AdaptiveThrottle] payload=" + chars + " chars → interval=" + interval + "ms");
+            LOG.debug("[AdaptiveThrottle] payload=" + chars + " chars, interval=" + interval + "ms");
         }
         return interval;
     }
 
     private void schedulePush() {
-        if (callbackTarget.isDisposed()) {
+        if (disposed || callbackTarget.isDisposed()) {
             return;
         }
 
@@ -277,174 +291,202 @@ public class StreamMessageCoalescer {
         }
 
         updateAlarm.addRequest(() -> {
+            final List<ClaudeSession.Message> sourceMessages;
             final List<ClaudeSession.Message> snapshot;
             final long sequence;
             synchronized (lock) {
                 updateScheduled = false;
+                snapshotPending = false;
                 lastUpdateAtMs = System.currentTimeMillis();
-                snapshot = pendingMessages;
-                pendingMessages = null;
+                sourceMessages = latestSourceMessages;
                 sequence = updateSequence;
             }
+            snapshot = sourceMessages == null ? null : copyMessagesForTransport(sourceMessages);
 
-            if (callbackTarget.isDisposed()) {
+            if (disposed || callbackTarget.isDisposed()) {
                 return;
             }
-
             if (snapshot != null) {
-                sendToWebView(snapshot, sequence, null);
+                requestSnapshotBuild(snapshot, sequence, null);
             }
 
             boolean hasPending;
             synchronized (lock) {
-                hasPending = pendingMessages != null;
+                hasPending = snapshotPending;
             }
-            if (hasPending && !callbackTarget.isDisposed()) {
+            if (hasPending && !disposed && !callbackTarget.isDisposed()) {
                 schedulePush();
             }
         }, delayMs);
     }
 
-    private void sendToWebView(
+    private void requestSnapshotBuild(
             List<ClaudeSession.Message> messages,
             long sequence,
-            LongConsumer afterSendOnEdt
+            LongConsumer afterFlush
     ) {
-        // Keep the snapshot for potential re-flush after webview reload/recreate.
-        // Only a snapshot actually dispatched to the WebView can prove whether
-        // the omitted prefix is stable enough for an indexed tail update.
-        final List<ClaudeSession.Message> deliveredSnapshot;
+        boolean startWorker = false;
         synchronized (lock) {
+            if (disposed) {
+                return;
+            }
+            requestedSnapshot = messages;
+            requestedSequence = sequence;
+            requestedDeliveryEpoch = deliveryEpoch;
+            if (afterFlush != null) {
+                if (requestedAfterFlush == null) {
+                    requestedAfterFlush = afterFlush;
+                } else {
+                    LongConsumer previous = requestedAfterFlush;
+                    requestedAfterFlush = completedSequence -> {
+                        previous.accept(completedSequence);
+                        afterFlush.accept(completedSequence);
+                    };
+                }
+            }
+            if (!snapshotBuildRunning) {
+                snapshotBuildRunning = true;
+                startWorker = true;
+            }
+        }
+        if (startWorker) {
+            try {
+                snapshotExecutor.execute(this::buildNextSnapshot);
+            } catch (RuntimeException e) {
+                synchronized (lock) {
+                    snapshotBuildRunning = false;
+                    requestedSnapshot = null;
+                    requestedAfterFlush = null;
+                }
+                LOG.warn("Failed to schedule message snapshot serialization: " + e.getMessage(), e);
+                runAfterFlush(afterFlush, sequence);
+            }
+        }
+    }
+
+    private void buildNextSnapshot() {
+        final List<ClaudeSession.Message> messages;
+        final long sequence;
+        final LongConsumer afterFlush;
+        final List<ClaudeSession.Message> deliveredSnapshot;
+        final long snapshotDeliveryEpoch;
+        synchronized (lock) {
+            if (disposed || requestedSnapshot == null) {
+                snapshotBuildRunning = false;
+                return;
+            }
+            messages = requestedSnapshot;
+            sequence = requestedSequence;
+            afterFlush = requestedAfterFlush;
             deliveredSnapshot = lastDeliveredSnapshot;
+            snapshotDeliveryEpoch = requestedDeliveryEpoch;
+            requestedSnapshot = null;
+            requestedAfterFlush = null;
             lastSnapshot = messages;
         }
 
-        MessageTransport transport = selectMessageTransport(messages, deliveredSnapshot);
-        final boolean tailUpdate = transport.tailUpdate();
-        final int tailBaseIndex = transport.baseIndex();
-        final List<ClaudeSession.Message> transportMessages = transport.messages();
-
-        ApplicationManager.getApplication().executeOnPooledThread(() -> {
-            final int payloadChars;
-            final long payloadBuildMs;
-            final String escapedMessagesJson;
-            try {
-                long buildStartedAt = System.nanoTime();
-                String messagesJson = MessageJsonConverter.convertMessagesToJson(transportMessages);
-                payloadChars = messagesJson.length();
-                escapedMessagesJson = JsUtils.escapeJs(messagesJson);
-                payloadBuildMs = java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - buildStartedAt);
-
-                // FIX: Record payload size for adaptive throttling
+        boolean sent = false;
+        try {
+            MessageTransport transport = selectMessageTransport(messages, deliveredSnapshot);
+            long buildStartedAt = System.nanoTime();
+            String messagesJson = MessageJsonConverter.convertMessagesToJson(transport.messages());
+            int payloadChars = messagesJson.length();
+            String escapedMessagesJson = JsUtils.escapeJs(messagesJson);
+            long payloadBuildMs = java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(
+                    System.nanoTime() - buildStartedAt);
+            if (isCurrentDeliveryEpoch(snapshotDeliveryEpoch)) {
                 lastPayloadChars = payloadChars;
-
-                if (payloadChars >= LARGE_UPDATE_PAYLOAD_CHARS || payloadBuildMs >= SLOW_PAYLOAD_BUILD_MS) {
-                    LOG.info("[WebviewTransport] updateMessages payload chars=" + payloadChars
-                            + ", messages=" + messages.size()
-                            + ", transportedMessages=" + transportMessages.size()
-                            + ", tailBaseIndex=" + tailBaseIndex
-                            + ", buildMs=" + payloadBuildMs
-                            + ", sequence=" + sequence);
-                } else if (LOG.isDebugEnabled()) {
-                    LOG.debug("[WebviewTransport] updateMessages payload chars=" + payloadChars
-                            + ", messages=" + messages.size()
-                            + ", transportedMessages=" + transportMessages.size()
-                            + ", buildMs=" + payloadBuildMs
-                            + ", sequence=" + sequence);
-                }
-            } catch (Exception e) {
-                LOG.warn("Failed to serialize messages for streaming update: " + e.getMessage(), e);
-                if (afterSendOnEdt != null) {
-                    final long finalSequence = sequence;
-                    ApplicationManager.getApplication().invokeLater(() -> afterSendOnEdt.accept(finalSequence));
-                }
-                return;
             }
 
-            ApplicationManager.getApplication().invokeLater(() -> {
-                if (callbackTarget.isDisposed()) {
-                    // FIX: Still run afterSendOnEdt even when disposed, so that
-                    // onStreamEnd/showLoading(false) callbacks execute and clear
-                    // streaming state. Without this, a dispose race leaves the
-                    // frontend permanently stuck in "responding" state.
-                    if (afterSendOnEdt != null) {
-                        afterSendOnEdt.accept(sequence);
-                    }
-                    return;
-                }
+            if (payloadChars >= LARGE_UPDATE_PAYLOAD_CHARS || payloadBuildMs >= SLOW_PAYLOAD_BUILD_MS) {
+                LOG.info("[WebviewTransport] updateMessages payload chars=" + payloadChars
+                        + ", messages=" + messages.size()
+                        + ", transportedMessages=" + transport.messages().size()
+                        + ", tailBaseIndex=" + transport.baseIndex()
+                        + ", buildMs=" + payloadBuildMs
+                        + ", sequence=" + sequence);
+            } else if (LOG.isDebugEnabled()) {
+                LOG.debug("[WebviewTransport] updateMessages payload chars=" + payloadChars
+                        + ", messages=" + messages.size()
+                        + ", buildMs=" + payloadBuildMs
+                        + ", sequence=" + sequence);
+            }
 
-                final long pushSequence;
-                synchronized (lock) {
-                    // Drop ONLY genuinely out-of-order frames: a snapshot whose
-                    // (large-payload-delayed) invokeLater lands after a newer one already
-                    // reached the webview would roll the list backwards.
-                    //
-                    // A frame that is merely older than `updateSequence` is NOT stale.
-                    // Snapshots grow monotonically within a turn, so a frame whose
-                    // sequence is >= the last pushed one carries content that is a
-                    // superset of whatever the webview already shows — pushing it is
-                    // forward progress, never a regression, even if a newer one is still
-                    // queued. The previous `sequence != updateSequence` check treated
-                    // "newer data is queued" as "this frame is obsolete" and dropped it.
-                    // Because the payload serializes off-EDT, any enqueue arriving in
-                    // that window advanced updateSequence, so frame after frame was
-                    // discarded during dense streaming and structural blocks
-                    // (tool_use / tool_result) never reached the frontend until the
-                    // stream-end flush. Meanwhile onContentDelta kept flowing, so text
-                    // was appended to whichever assistant message the frontend last knew
-                    // about.
-                    //
-                    // The frontend's __minAcceptedUpdateSequence guard applies the same
-                    // ordering rule on its side, so this is not the only line of defence.
-                    if (sequence < lastPushedSequence) {
-                        if (afterSendOnEdt != null) {
-                            afterSendOnEdt.accept(sequence);
-                        }
-                        return;
-                    }
+            final long pushSequence;
+            synchronized (lock) {
+                if (snapshotDeliveryEpoch != deliveryEpoch || sequence < lastPushedSequence) {
+                    pushSequence = -1L;
+                } else {
                     pushSequence = sequence;
                     lastPushedSequence = sequence;
                 }
-
-                // FIX: Wrap callJavaScript in try-catch so that a JCEF failure
-                // (e.g., large payload rejection, disposed browser race) does not
-                // prevent afterSendOnEdt from running.  When afterSendOnEdt carries
-                // the onStreamEnd signal, failing to run it permanently freezes the UI.
-                try {
-                    if (tailUpdate) {
-                        callbackTarget.callJavaScript(
-                                "updateMessageTail",
-                                escapedMessagesJson,
-                                String.valueOf(tailBaseIndex),
-                                String.valueOf(pushSequence));
-                    } else {
-                        callbackTarget.callJavaScript("updateMessages", escapedMessagesJson, String.valueOf(pushSequence));
-                    }
-                    synchronized (lock) {
-                        // Unconditional: this frame reached the webview, so it becomes the
-                        // prefix baseline for tail transport. Gating this on
-                        // `pushSequence == updateSequence` froze the baseline for as long as
-                        // newer data stayed queued, so hasSamePrefix never matched, tail
-                        // updates never engaged on long conversations, and every push kept
-                        // paying full-payload serialization cost.
-                        lastDeliveredSnapshot = messages;
-                    }
-                    MessageJsonConverter.pushUsageUpdateFromMessages(
-                            messages,
-                            callbackTarget.getHandlerContext(),
-                            callbackTarget.getBrowser(),
-                            callbackTarget.isDisposed()
-                    );
-                } catch (Exception e) {
-                    LOG.warn("Failed to push updateMessages to webview (payload chars="
-                            + escapedMessagesJson.length() + "): " + e.getMessage(), e);
+            }
+            if (pushSequence >= 0L && !disposed && !callbackTarget.isDisposed()) {
+                if (transport.tailUpdate()) {
+                    callbackTarget.callJavaScript(
+                            "updateMessageTail",
+                            escapedMessagesJson,
+                            String.valueOf(transport.baseIndex()),
+                            String.valueOf(pushSequence));
+                } else {
+                    callbackTarget.callJavaScript(
+                            "updateMessages", escapedMessagesJson, String.valueOf(pushSequence));
                 }
-
-                if (afterSendOnEdt != null) {
-                    afterSendOnEdt.accept(pushSequence);
+                synchronized (lock) {
+                    lastDeliveredSnapshot = messages;
                 }
-            });
-        });
+                String usageJson = MessageJsonConverter.buildUsageUpdateJson(
+                        messages, callbackTarget.getHandlerContext());
+                if (usageJson != null) {
+                    callbackTarget.callJavaScript("onUsageUpdate", JsUtils.escapeJs(usageJson));
+                }
+                sent = true;
+            }
+        } catch (Exception | LinkageError e) {
+            LOG.warn("Failed to serialize or push message snapshot: " + e.getMessage(), e);
+        }
+
+        runAfterFlush(afterFlush, sequence);
+
+        boolean continueWorker;
+        synchronized (lock) {
+            continueWorker = !disposed && requestedSnapshot != null;
+            if (!continueWorker) {
+                snapshotBuildRunning = false;
+            }
+        }
+        if (continueWorker) {
+            try {
+                snapshotExecutor.execute(this::buildNextSnapshot);
+            } catch (RuntimeException e) {
+                synchronized (lock) {
+                    snapshotBuildRunning = false;
+                    requestedSnapshot = null;
+                    requestedAfterFlush = null;
+                }
+                LOG.warn("Failed to continue message snapshot serialization: " + e.getMessage(), e);
+            }
+        }
+        if (!sent && afterFlush == null && LOG.isDebugEnabled()) {
+            LOG.debug("Message snapshot was not dispatched, sequence=" + sequence);
+        }
+    }
+
+    private boolean isCurrentDeliveryEpoch(long epoch) {
+        synchronized (lock) {
+            return !disposed && epoch == deliveryEpoch;
+        }
+    }
+
+    private void runAfterFlush(LongConsumer afterFlush, long sequence) {
+        if (afterFlush == null) {
+            return;
+        }
+        try {
+            afterFlush.accept(sequence);
+        } catch (RuntimeException e) {
+            LOG.warn("Snapshot completion callback failed: " + e.getMessage(), e);
+        }
     }
 
     static MessageTransport selectMessageTransport(List<ClaudeSession.Message> messages,
@@ -453,8 +495,8 @@ public class StreamMessageCoalescer {
         int candidateBaseIndex = longConversation
                 ? Math.max(0, messages.size() - LONG_CONVERSATION_TAIL_SIZE) : 0;
         boolean stablePrefix = previousMessages != null
-                && (messages.size() >= previousMessages.size()
-                && hasSamePrefix(previousMessages, messages, candidateBaseIndex));
+                && messages.size() >= previousMessages.size()
+                && hasSamePrefix(previousMessages, messages, candidateBaseIndex);
         boolean tailUpdate = longConversation && stablePrefix;
         int baseIndex = tailUpdate ? candidateBaseIndex : 0;
         List<ClaudeSession.Message> transportMessages = tailUpdate
@@ -469,32 +511,148 @@ public class StreamMessageCoalescer {
             return false;
         }
         for (int i = 0; i < prefixLength; i++) {
-            if (previousMessages.get(i) != messages.get(i)) {
+            if (!sameStableMessage(previousMessages.get(i), messages.get(i))) {
                 return false;
             }
         }
         return true;
     }
 
-    // ===== Streaming heartbeat =====
+    private static boolean sameStableMessage(ClaudeSession.Message previous,
+                                             ClaudeSession.Message current) {
+        return previous == current
+                || previous.type == current.type
+                && previous.timestamp == current.timestamp
+                && Objects.equals(previous.content, current.content)
+                && Objects.equals(getMessageStructuralSignature(previous), getMessageStructuralSignature(current));
+    }
 
-    /**
-     * Start (or restart) the periodic heartbeat during streaming.
-     * Sends a lightweight JS signal to the frontend to prevent the stall
-     * watchdog from falsely triggering during tool execution phases where
-     * no content deltas or message updates arrive from the SDK.
-     */
+    static List<ClaudeSession.Message> copyMessagesForTransport(List<ClaudeSession.Message> messages) {
+        List<ClaudeSession.Message> copies = new ArrayList<>(messages.size());
+        for (ClaudeSession.Message message : messages) {
+            ClaudeSession.Message copy = new ClaudeSession.Message(message.type, message.content);
+            copy.timestamp = message.timestamp;
+            copy.raw = message.raw == null ? null : message.raw.deepCopy();
+            copies.add(copy);
+        }
+        return List.copyOf(copies);
+    }
+
+    private static String getStructuralSignature(List<ClaudeSession.Message> messages) {
+        StringBuilder signature = new StringBuilder();
+        for (int i = 0; i < messages.size(); i++) {
+            ClaudeSession.Message message = messages.get(i);
+            signature.append(i)
+                    .append(':')
+                    .append(message.type)
+                    .append(':')
+                    .append(message.timestamp)
+                    .append(':')
+                    .append(getMessageStructuralSignature(message))
+                    .append(';');
+        }
+        return signature.toString();
+    }
+
+    private static String getMessageStructuralSignature(ClaudeSession.Message message) {
+        JsonArray blocks = findContentArray(message.raw);
+        if (blocks == null) {
+            return "";
+        }
+        StringBuilder signature = new StringBuilder();
+        for (JsonElement element : blocks) {
+            if (!element.isJsonObject()) {
+                continue;
+            }
+            JsonObject block = element.getAsJsonObject();
+            String type = block.has("type") && !block.get("type").isJsonNull()
+                    ? block.get("type").getAsString() : "";
+            if ("text".equals(type) || "thinking".equals(type)) {
+                signature.append(type).append('|');
+                continue;
+            }
+            signature.append(type).append(':');
+            if ("tool_use".equals(type)) {
+                appendFieldSignature(signature, block, "id");
+                appendFieldSignature(signature, block, "name");
+                appendElementSignature(signature, block, "input");
+            } else if ("tool_result".equals(type)) {
+                appendFieldSignature(signature, block, "tool_use_id");
+                appendFieldSignature(signature, block, "is_error");
+                appendElementSignature(signature, block, "content");
+            } else if ("attachment".equals(type)) {
+                appendFieldSignature(signature, block, "fileName");
+                appendFieldSignature(signature, block, "mediaType");
+            } else if ("image".equals(type)) {
+                appendElementSignature(signature, block, "src");
+                appendFieldSignature(signature, block, "mediaType");
+            } else {
+                signature.append(element.toString().length())
+                        .append(':')
+                        .append(element.toString().hashCode());
+            }
+            signature.append('|');
+        }
+        return signature.toString();
+    }
+
+    private static JsonArray findContentArray(JsonObject raw) {
+        if (raw == null) {
+            return null;
+        }
+        if (raw.has("content") && raw.get("content").isJsonArray()) {
+            return raw.getAsJsonArray("content");
+        }
+        if (raw.has("message") && raw.get("message").isJsonObject()) {
+            JsonObject message = raw.getAsJsonObject("message");
+            if (message.has("content") && message.get("content").isJsonArray()) {
+                return message.getAsJsonArray("content");
+            }
+        }
+        return null;
+    }
+
+    private static void appendFieldSignature(StringBuilder signature, JsonObject block, String fieldName) {
+        if (!block.has(fieldName) || block.get(fieldName).isJsonNull()) {
+            signature.append(fieldName).append("=;");
+            return;
+        }
+        signature.append(fieldName).append('=').append(block.get(fieldName)).append(';');
+    }
+
+    private static void appendElementSignature(StringBuilder signature, JsonObject block, String fieldName) {
+        if (!block.has(fieldName) || block.get(fieldName).isJsonNull()) {
+            signature.append(fieldName).append("=;");
+            return;
+        }
+        String value = block.get(fieldName).toString();
+        signature.append(fieldName)
+                .append('=').append(value.length()).append(':').append(value.hashCode()).append(';');
+    }
+
+    private boolean hasDeltaChannel() {
+        if (!streamActive) {
+            return false;
+        }
+        HandlerContext context = callbackTarget.getHandlerContext();
+        if (context == null) {
+            return false;
+        }
+        String provider = context.getCurrentProvider();
+        return "claude".equals(provider) || "codex".equals(provider) || "grok".equals(provider);
+    }
+
     private void startHeartbeat() {
         heartbeatAlarm.cancelAllRequests();
         scheduleHeartbeat();
     }
 
     private void scheduleHeartbeat() {
-        if (!streamActive || callbackTarget.isDisposed()) {
+        if (!streamActive || disposed || callbackTarget.isDisposed()) {
             return;
         }
         heartbeatAlarm.addRequest(() -> {
-            if (!streamActive || callbackTarget.isDisposed()) {
+            if (!streamActive || disposed || callbackTarget.isDisposed()) {
                 return;
             }
             try {
@@ -505,8 +663,16 @@ public class StreamMessageCoalescer {
             } catch (Exception e) {
                 LOG.warn("[Heartbeat] Failed to send heartbeat: " + e.getMessage());
             }
-            // Schedule next heartbeat
             scheduleHeartbeat();
         }, HEARTBEAT_INTERVAL_MS);
+    }
+
+    private static final class SnapshotThreadFactory implements ThreadFactory {
+        @Override
+        public Thread newThread(Runnable runnable) {
+            Thread thread = new Thread(runnable, "StreamMessageCoalescer");
+            thread.setDaemon(true);
+            return thread;
+        }
     }
 }

--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -94,6 +94,7 @@ public class ChatWindowDelegate {
         JBCefBrowser getBrowser();
         boolean isDisposed();
         void callJavaScript(String fn, String... args);
+        void executeJavaScriptCode(String jsCode);
         Content getParentContent();
         String getOriginalTabName();
         void setOriginalTabName(String name);
@@ -334,6 +335,10 @@ public class ChatWindowDelegate {
             @Override
             public void callJavaScript(String functionName, String... args) {
                 host.callJavaScript(functionName, args);
+            }
+            @Override
+            public void executeJavaScript(String jsCode) {
+                host.executeJavaScriptCode(jsCode);
             }
             @Override
             public String escapeJs(String str) {
@@ -741,6 +746,7 @@ public class ChatWindowDelegate {
             return;
         }
 
+        host.getStreamCoalescer().resetDeliveryBaseline();
         try {
             String sessionId = session.getSessionId();
             if (sessionId != null && !sessionId.trim().isEmpty()) {

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/ClaudeChatWindow.java
@@ -101,6 +101,7 @@ public class ClaudeChatWindow {
     private volatile ClaudeSession session;
     private final WebviewWatchdog webviewWatchdog;
     private final StreamMessageCoalescer streamCoalescer;
+    private final WebviewEventQueue<JBCefBrowser> webviewEventQueue;
 
     private volatile boolean disposed = false;
     private volatile boolean initialized = false;
@@ -252,15 +253,15 @@ public class ClaudeChatWindow {
         this.mainPanel.setBackground(com.github.claudecodegui.util.ThemeConfigService.getBackgroundColor());
         this.mainPanel.addHierarchyListener(surfaceRefreshHierarchyListener);
 
+        this.webviewEventQueue = new WebviewEventQueue<JBCefBrowser>(
+                () -> this.browser,
+                () -> this.disposed,
+                this::executeQueuedWebviewScript
+        );
         this.streamCoalescer = new StreamMessageCoalescer(new StreamMessageCoalescer.JsCallbackTarget() {
             @Override
             public void callJavaScript(String functionName, String... args) {
                 ClaudeChatWindow.this.callJavaScript(functionName, args);
-            }
-
-            @Override
-            public JBCefBrowser getBrowser() {
-                return browser;
             }
 
             @Override
@@ -271,19 +272,6 @@ public class ClaudeChatWindow {
             @Override
             public HandlerContext getHandlerContext() {
                 return handlerContext;
-            }
-
-            @Override
-            public void onStreamEnded() {
-                ClaudeSession current = ClaudeChatWindow.this.session;
-                if (current != null && shouldReconcileTranscriptAtStreamEnd(
-                        current.getProvider(), current.getSessionId())) {
-                    // Grok's live ACP stream can omit file-tool blocks that are present
-                    // in chat_history.jsonl. Reuse the proven same-session reload path
-                    // once the turn is idle so derived edit statistics use final data.
-                    ClaudeChatWindow.this.deferredReload.defer(current.getSessionId());
-                }
-                ClaudeChatWindow.this.drainDeferredReload();
             }
         });
 
@@ -1230,6 +1218,8 @@ public class ClaudeChatWindow {
         cancelScheduledOsrSurfaceRefresh();
         surfaceRefreshCoordinator.invalidate();
         browser = nextBrowser;
+        webviewEventQueue.browserChanged();
+        streamCoalescer.resetDeliveryBaseline();
         if (nextBrowser != null) {
             observedBrowserComponent = nextBrowser.getComponent();
             observedBrowserComponent.addComponentListener(surfaceRefreshComponentListener);
@@ -2129,22 +2119,21 @@ public class ClaudeChatWindow {
         chatWindowDelegate.sendQuickFixMessage(prompt, isQuickFix, callback);
     }
 
+    /** Execute raw JavaScript through the same ordered webview queue as callback events. */
     public void executeJavaScriptCode(String jsCode) {
-        JBCefBrowser targetBrowser = this.browser;
-        if (this.disposed || targetBrowser == null) {
+        webviewEventQueue.enqueueRaw(jsCode);
+    }
+
+    private void executeQueuedWebviewScript(JBCefBrowser targetBrowser, String jsCode) {
+        if (this.disposed || this.browser != targetBrowser) {
             return;
         }
-        ApplicationManager.getApplication().invokeLater(() -> {
-            if (this.disposed || this.browser != targetBrowser) {
-                return;
-            }
-            try {
-                org.cef.browser.CefBrowser cefBrowser = targetBrowser.getCefBrowser();
-                cefBrowser.executeJavaScript(jsCode, cefBrowser.getURL(), 0);
-            } catch (Exception | LinkageError e) {
-                LOG.warn("Failed to execute raw JS code: " + e.getMessage(), e);
-            }
-        });
+        try {
+            org.cef.browser.CefBrowser cefBrowser = targetBrowser.getCefBrowser();
+            cefBrowser.executeJavaScript(jsCode, cefBrowser.getURL(), 0);
+        } catch (Exception | LinkageError e) {
+            LOG.warn("Failed to execute queued webview JavaScript: " + e.getMessage(), e);
+        }
     }
 
     // ==================== JavaScript Bridge ====================
@@ -2153,54 +2142,11 @@ public class ClaudeChatWindow {
             java.util.regex.Pattern.compile("^[a-zA-Z_$][a-zA-Z0-9_$.]*$");
 
     void callJavaScript(String functionName, String... args) {
-        JBCefBrowser targetBrowser = this.browser;
-        if (this.disposed || targetBrowser == null) {
-            LOG.warn("Cannot call JS function " + functionName + ": disposed=" + this.disposed
-                    + ", browser=" + (targetBrowser == null ? "null" : "exists"));
-            return;
-        }
-
         if (functionName == null || !SAFE_JS_FUNCTION_NAME.matcher(functionName).matches()) {
             LOG.error("Invalid JavaScript function name rejected: " + functionName);
             return;
         }
-
-        ApplicationManager.getApplication().invokeLater(() -> {
-            if (this.disposed || this.browser != targetBrowser) {
-                return;
-            }
-            try {
-                org.cef.browser.CefBrowser cefBrowser = targetBrowser.getCefBrowser();
-                String callee = functionName;
-                if (!functionName.contains(".")) {
-                    callee = "window." + functionName;
-                }
-
-                StringBuilder argsJs = new StringBuilder();
-                if (args != null) {
-                    for (int i = 0; i < args.length; i++) {
-                        if (i > 0) { argsJs.append(", "); }
-                        String arg = args[i] == null ? "" : args[i];
-                        argsJs.append("'").append(arg).append("'");
-                    }
-                }
-
-                String checkAndCall =
-                        "(function() {" +
-                                "  try {" +
-                                "    if (typeof " + callee + " === 'function') {" +
-                                "      " + callee + "(" + argsJs + ");" +
-                                "    }" +
-                                "  } catch (e) {" +
-                                "    console.error('[Backend->Frontend] Failed to call " + functionName + ":', e);" +
-                                "  }" +
-                                "})();";
-
-                cefBrowser.executeJavaScript(checkAndCall, cefBrowser.getURL(), 0);
-            } catch (Exception | LinkageError e) {
-                LOG.warn("Failed to call JS function: " + functionName + ", error: " + e.getMessage(), e);
-            }
-        });
+        webviewEventQueue.enqueue(functionName, args);
     }
 
     void handleJavaScriptMessage(int pageGeneration, String message) {
@@ -2296,6 +2242,10 @@ public class ClaudeChatWindow {
             @Override
             public void onSessionIdReceived(String newSessionId) {
                 super.onSessionIdReceived(newSessionId);
+                if (newSessionId == null || newSessionId.trim().isEmpty()
+                        || newSessionId.equals(sessionId)) {
+                    return;
+                }
                 sessionId = newSessionId;
                 persistTabSessionState();
             }
@@ -2517,7 +2467,8 @@ public class ClaudeChatWindow {
      * only after the user reopens the session.
      *
      * <p>Thread-safety: {@code defer} is called from the daemon event thread,
-     * {@code takeIfRunnable} from the coalescer's onStreamEnded hook; both are
+     * {@code takeIfRunnable} from the adapter's stream-end callback (ordered
+     * after the final snapshot enters the webview queue); both are
      * fully synchronized so a defer/drain interleave never loses or duplicates a
      * pending reload. {@code take} atomically reads-clears-and-gates in one
      * critical section (no read/clear window). Coalescing is last-writer-wins:
@@ -2648,6 +2599,19 @@ public class ClaudeChatWindow {
     }
 
     private void onStreamEnded() {
+        // Runs as the adapter's stream-end callback, already ordered after the
+        // final snapshot and the onStreamEnd signal have entered the webview
+        // queue — the safe point to reconcile and drain a deferred reload.
+        ClaudeSession current = this.session;
+        if (current != null && shouldReconcileTranscriptAtStreamEnd(
+                current.getProvider(), current.getSessionId())) {
+            // Grok's live ACP stream can omit file-tool blocks that are present
+            // in chat_history.jsonl. Reuse the proven same-session reload path
+            // once the turn is idle so derived edit statistics use final data.
+            this.deferredReload.defer(current.getSessionId());
+        }
+        this.drainDeferredReload();
+
         if (session == null) {
             return;
         }
@@ -2798,6 +2762,7 @@ public class ClaudeChatWindow {
             return;
         }
         this.disposed = true;
+        this.webviewEventQueue.dispose();
         JBCefBrowser targetBrowser = this.browser;
         cancelScheduledOsrSurfaceRefresh();
         surfaceRefreshCoordinator.invalidate();
@@ -3227,6 +3192,11 @@ public class ClaudeChatWindow {
             @Override
             public void callJavaScript(String fn, String... args) {
                 ClaudeChatWindow.this.callJavaScript(fn, args);
+            }
+
+            @Override
+            public void executeJavaScriptCode(String jsCode) {
+                ClaudeChatWindow.this.executeJavaScriptCode(jsCode);
             }
 
             @Override

--- a/src/main/java/com/github/claudecodegui/ui/toolwindow/WebviewEventQueue.java
+++ b/src/main/java/com/github/claudecodegui/ui/toolwindow/WebviewEventQueue.java
@@ -1,0 +1,356 @@
+package com.github.claudecodegui.ui.toolwindow;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Serializes Java-to-webview calls and keeps the pending work bounded.
+ */
+final class WebviewEventQueue<T> {
+
+    private static final Logger LOG = Logger.getInstance(WebviewEventQueue.class);
+    private static final int MAX_PENDING_EVENTS = 256;
+    private static final int MAX_BATCH_ARGUMENT_CHARS = 256_000;
+
+    private final Supplier<T> browserSupplier;
+    private final BooleanSupplier disposedSupplier;
+    private final Consumer<Runnable> scheduler;
+    private final BiConsumer<T, String> scriptExecutor;
+    private final Object lock = new Object();
+    private final Deque<JsCall<T>> pending = new ArrayDeque<>();
+    private T queuedBrowser;
+    private boolean drainScheduled;
+    private boolean draining;
+    private boolean disposed;
+
+    WebviewEventQueue(
+            Supplier<T> browserSupplier,
+            BooleanSupplier disposedSupplier,
+            BiConsumer<T, String> scriptExecutor
+    ) {
+        this(
+                browserSupplier,
+                disposedSupplier,
+                runnable -> ApplicationManager.getApplication().invokeLater(runnable),
+                scriptExecutor
+        );
+    }
+
+    WebviewEventQueue(
+            Supplier<T> browserSupplier,
+            BooleanSupplier disposedSupplier,
+            Consumer<Runnable> scheduler,
+            BiConsumer<T, String> scriptExecutor
+    ) {
+        this.browserSupplier = browserSupplier;
+        this.disposedSupplier = disposedSupplier;
+        this.scheduler = scheduler;
+        this.scriptExecutor = scriptExecutor;
+    }
+
+    void enqueue(String functionName, String... args) {
+        T browser = currentBrowser();
+        if (browser == null) {
+            return;
+        }
+        enqueue(new JsCall<T>(browser, functionName, copyArgs(args), null));
+    }
+
+    void enqueueRaw(String script) {
+        if (script == null || script.isEmpty()) {
+            return;
+        }
+        T browser = currentBrowser();
+        if (browser == null) {
+            return;
+        }
+        enqueue(new JsCall<T>(browser, null, new String[0], script));
+    }
+
+    void browserChanged() {
+        synchronized (lock) {
+            pending.clear();
+            queuedBrowser = browserSupplier.get();
+        }
+    }
+
+    void dispose() {
+        synchronized (lock) {
+            disposed = true;
+            pending.clear();
+            queuedBrowser = null;
+        }
+    }
+
+    static String buildBatchScript(List<? extends JsCall<?>> calls) {
+        StringBuilder script = new StringBuilder("(function() {\n");
+        for (JsCall<?> call : calls) {
+            if (call.rawScript != null) {
+                script.append("try { (function() {\n")
+                        .append(call.rawScript)
+                        .append("\n})(); } catch (e) { console.error('[Backend->Frontend] Raw JS failed:', e); }\n");
+                continue;
+            }
+
+            String callee = call.functionName.contains(".")
+                    ? call.functionName : "window." + call.functionName;
+            script.append("try { if (typeof ")
+                    .append(callee)
+                    .append(" === 'function') { ")
+                    .append(callee)
+                    .append('(');
+            for (int i = 0; i < call.args.length; i++) {
+                if (i > 0) {
+                    script.append(", ");
+                }
+                script.append('\'')
+                        .append(call.args[i] == null ? "" : call.args[i])
+                        .append('\'');
+            }
+            script.append("); } } catch (e) { console.error('[Backend->Frontend] Failed to call " )
+                    .append(call.functionName)
+                    .append("', e); }\n");
+        }
+        return script.append("})();").toString();
+    }
+
+    private T currentBrowser() {
+        if (disposed || disposedSupplier.getAsBoolean()) {
+            return null;
+        }
+        return browserSupplier.get();
+    }
+
+    private void enqueue(JsCall<T> call) {
+        boolean scheduleDrain = false;
+        synchronized (lock) {
+            if (disposed || disposedSupplier.getAsBoolean()) {
+                return;
+            }
+            if (queuedBrowser != call.browser) {
+                pending.clear();
+                queuedBrowser = call.browser;
+            }
+
+            if (isDelta(call) && mergeWithTailDelta(call)) {
+                return;
+            }
+            if (isLatestOnly(call) && mergeWithTailLatest(call)) {
+                return;
+            }
+            if (pending.size() >= MAX_PENDING_EVENTS
+                    && !dropOneDisposableEvent()
+                    && !dropOneDelta()) {
+                LOG.warn("Dropping webview event because the bounded queue is full: "
+                        + (call.functionName != null ? call.functionName : "raw"));
+                return;
+            }
+            pending.addLast(call);
+            if (!drainScheduled && !draining) {
+                drainScheduled = true;
+                scheduleDrain = true;
+            }
+        }
+        if (scheduleDrain) {
+            scheduleDrain();
+        }
+    }
+
+    private void scheduleDrain() {
+        try {
+            scheduler.accept(this::drain);
+        } catch (RuntimeException e) {
+            synchronized (lock) {
+                drainScheduled = false;
+            }
+            LOG.warn("Failed to schedule webview event drain: " + e.getMessage(), e);
+        }
+    }
+
+    private void drain() {
+        List<JsCall<T>> batch;
+        T targetBrowser;
+        synchronized (lock) {
+            drainScheduled = false;
+            if (disposed || pending.isEmpty()) {
+                return;
+            }
+            targetBrowser = browserSupplier.get();
+            if (targetBrowser == null || targetBrowser != queuedBrowser || disposedSupplier.getAsBoolean()) {
+                pending.clear();
+                queuedBrowser = targetBrowser;
+                return;
+            }
+            draining = true;
+            batch = takeBatch(targetBrowser);
+        }
+
+        try {
+            scriptExecutor.accept(targetBrowser, buildBatchScript(batch));
+        } catch (Exception | LinkageError e) {
+            LOG.warn("Failed to execute queued webview events: " + e.getMessage(), e);
+        } finally {
+            boolean scheduleDrain = false;
+            synchronized (lock) {
+                draining = false;
+                if (!disposed && !pending.isEmpty() && !drainScheduled) {
+                    drainScheduled = true;
+                    scheduleDrain = true;
+                }
+            }
+            if (scheduleDrain) {
+                scheduleDrain();
+            }
+        }
+    }
+
+    private List<JsCall<T>> takeBatch(T targetBrowser) {
+        List<JsCall<T>> batch = new ArrayList<>();
+        int estimatedChars = 0;
+        Iterator<JsCall<T>> iterator = pending.iterator();
+        while (iterator.hasNext()) {
+            JsCall<T> call = iterator.next();
+            if (call.browser != targetBrowser) {
+                iterator.remove();
+                continue;
+            }
+            int callChars = call.estimatedChars();
+            if (!batch.isEmpty()
+                    && containsMessageSnapshot(batch)
+                    && isSnapshotResetBoundary(call)) {
+                break;
+            }
+            if (!batch.isEmpty() && estimatedChars + callChars > MAX_BATCH_ARGUMENT_CHARS) {
+                break;
+            }
+            iterator.remove();
+            batch.add(call);
+            estimatedChars += callChars;
+        }
+        return batch;
+    }
+
+    private static boolean containsMessageSnapshot(List<? extends JsCall<?>> calls) {
+        return calls.stream().anyMatch(WebviewEventQueue::isMessageSnapshot);
+    }
+
+    private static boolean isMessageSnapshot(JsCall<?> call) {
+        return call.rawScript == null
+                && ("updateMessages".equals(call.functionName)
+                || "updateMessageTail".equals(call.functionName));
+    }
+
+    private static boolean isSnapshotResetBoundary(JsCall<?> call) {
+        return call.rawScript != null
+                || "onStreamStart".equals(call.functionName)
+                || "clearMessages".equals(call.functionName);
+    }
+
+    private boolean mergeWithTailDelta(JsCall<T> call) {
+        JsCall<T> tail = pending.peekLast();
+        if (tail == null || !isDelta(tail) || tail.browser != call.browser
+                || !tail.functionName.equals(call.functionName)) {
+            return false;
+        }
+        String existing = tail.args.length == 0 || tail.args[0] == null ? "" : tail.args[0];
+        String incoming = call.args.length == 0 || call.args[0] == null ? "" : call.args[0];
+        tail.args[0] = existing + incoming;
+        return true;
+    }
+
+    private boolean mergeWithTailLatest(JsCall<T> call) {
+        JsCall<T> tail = pending.peekLast();
+        if (tail == null || !isLatestOnly(tail) || tail.browser != call.browser
+                || !tail.functionName.equals(call.functionName)) {
+            return false;
+        }
+        tail.args = call.args;
+        return true;
+    }
+
+    private boolean dropOneDisposableEvent() {
+        Iterator<JsCall<T>> iterator = pending.iterator();
+        while (iterator.hasNext()) {
+            if (isDisposable(iterator.next())) {
+                iterator.remove();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean dropOneDelta() {
+        Iterator<JsCall<T>> iterator = pending.iterator();
+        while (iterator.hasNext()) {
+            if (isDelta(iterator.next())) {
+                iterator.remove();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isLatestOnly(JsCall<?> call) {
+        if (call.rawScript != null) {
+            return false;
+        }
+        return "updateStatus".equals(call.functionName)
+                || "showLoading".equals(call.functionName)
+                || "showThinkingStatus".equals(call.functionName)
+                || "setSessionId".equals(call.functionName)
+                || "onUsageUpdate".equals(call.functionName)
+                || "onStreamingHeartbeat".equals(call.functionName);
+    }
+
+    private static boolean isDelta(JsCall<?> call) {
+        return call.rawScript == null
+                && ("onContentDelta".equals(call.functionName)
+                || "onThinkingDelta".equals(call.functionName));
+    }
+
+    private static boolean isDisposable(JsCall<?> call) {
+        return call.rawScript == null
+                && ("updateStatus".equals(call.functionName)
+                || "onUsageUpdate".equals(call.functionName)
+                || "onStreamingHeartbeat".equals(call.functionName));
+    }
+
+    private static String[] copyArgs(String[] args) {
+        return args == null ? new String[0] : args.clone();
+    }
+
+    static final class JsCall<T> {
+        private final T browser;
+        private final String functionName;
+        private String[] args;
+        private final String rawScript;
+
+        JsCall(T browser, String functionName, String[] args, String rawScript) {
+            this.browser = browser;
+            this.functionName = functionName;
+            this.args = args;
+            this.rawScript = rawScript;
+        }
+
+        private int estimatedChars() {
+            if (rawScript != null) {
+                return rawScript.length();
+            }
+            int length = functionName.length() + 32;
+            for (String arg : args) {
+                length += arg == null ? 0 : arg.length();
+            }
+            return length;
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/util/MessageJsonConverter.java
+++ b/src/main/java/com/github/claudecodegui/util/MessageJsonConverter.java
@@ -8,9 +8,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.ui.jcef.JBCefBrowser;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -321,22 +319,26 @@ public class MessageJsonConverter {
     }
 
     /**
-     * Extract usage info from messages and push update to the webview.
+     * Build the current usage payload from session messages.
+     *
+     * @param messages session messages
+     * @param handlerContext current provider and model context
+     * @return JSON payload, or null when no usage is available
      */
-    public static void pushUsageUpdateFromMessages(
+    public static String buildUsageUpdateJson(
             List<ClaudeSession.Message> messages,
-            HandlerContext handlerContext,
-            JBCefBrowser browser,
-            boolean disposed
+            HandlerContext handlerContext
     ) {
+        if (messages == null || handlerContext == null) {
+            return null;
+        }
         try {
-            LOG.debug("pushUsageUpdateFromMessages called with " + messages.size() + " messages");
-
+            LOG.debug("buildUsageUpdateJson called with " + messages.size() + " messages");
             String currentProvider = handlerContext.getCurrentProvider();
             JsonObject lastUsage = TokenUsageUtils.findLastUsageFromSessionMessages(messages, currentProvider);
             if (lastUsage == null) {
                 LOG.debug("No usage info found in messages");
-                return;
+                return null;
             }
 
             int usedTokens = TokenUsageUtils.extractContextTokens(lastUsage, currentProvider);
@@ -345,32 +347,16 @@ public class MessageJsonConverter {
             int maxTokens = TokenUsageUtils.extractMaxTokens(lastUsage, fallbackMaxTokens);
             int percentage = Math.min(100, maxTokens > 0 ? (int) ((usedTokens * 100.0) / maxTokens) : 0);
 
-            LOG.debug("Pushing usage update: provider=" + currentProvider + ", usedTokens=" + usedTokens + ", max=" + maxTokens + ", percentage=" + percentage + "%");
-
             JsonObject usageUpdate = new JsonObject();
             usageUpdate.addProperty("percentage", percentage);
             usageUpdate.addProperty("totalTokens", usedTokens);
             usageUpdate.addProperty("limit", maxTokens);
             usageUpdate.addProperty("usedTokens", usedTokens);
             usageUpdate.addProperty("maxTokens", maxTokens);
-
-            String usageJson = new Gson().toJson(usageUpdate);
-            ApplicationManager.getApplication().invokeLater(() -> {
-                if (browser != null && !disposed) {
-                    // Use safe call pattern, check if function exists
-                    String js = "(function() {" +
-                            "  if (typeof window.onUsageUpdate === 'function') {" +
-                            "    window.onUsageUpdate('" + JsUtils.escapeJs(usageJson) + "');" +
-                            "    console.log('[Backend->Frontend] Usage update sent successfully');" +
-                            "  } else {" +
-                            "    console.warn('[Backend->Frontend] window.onUsageUpdate not found');" +
-                            "  }" +
-                            "})();";
-                    browser.getCefBrowser().executeJavaScript(js, browser.getCefBrowser().getURL(), 0);
-                }
-            });
+            return new Gson().toJson(usageUpdate);
         } catch (Exception e) {
-            LOG.warn("Failed to push usage update: " + e.getMessage(), e);
+            LOG.warn("Failed to build usage update: " + e.getMessage(), e);
+            return null;
         }
     }
 }

--- a/src/test/java/com/github/claudecodegui/session/SessionCallbackAdapterStreamEndTest.java
+++ b/src/test/java/com/github/claudecodegui/session/SessionCallbackAdapterStreamEndTest.java
@@ -1,11 +1,7 @@
 package com.github.claudecodegui.session;
 
-import com.intellij.openapi.application.Application;
-import com.intellij.openapi.application.ApplicationManager;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
-import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -157,6 +153,22 @@ public class SessionCallbackAdapterStreamEndTest {
         assertEquals("onStreamEnd:20", jsTarget.calls.get(2));
     }
 
+    @Test
+    public void duplicateSessionIdsAreForwardedOnlyOnce() {
+        RecordingJsTarget jsTarget = new RecordingJsTarget();
+        SessionCallbackAdapter adapter = new SessionCallbackAdapter(
+                null, jsTarget, null, () -> true, null);
+
+        adapter.onSessionIdReceived("session-1");
+        adapter.onSessionIdReceived("session-1");
+        adapter.onSessionIdReceived("session-2");
+
+        assertEquals(2, jsTarget.calls.size());
+        assertEquals("setSessionId:session-1", jsTarget.calls.get(0));
+        assertEquals("setSessionId:session-2", jsTarget.calls.get(1));
+        adapter.deactivate();
+    }
+
     /**
      * Verify the flush LongConsumer callback contract:
      * when StreamMessageCoalescer.flush() invokes the callback with a
@@ -191,8 +203,7 @@ public class SessionCallbackAdapterStreamEndTest {
      *
      * <p>Exercised through the real SessionCallbackAdapter with test-friendly
      * collaborators; the throttlers' default constructor flushes synchronously
-     * via flushNow(), so no IntelliJ Application is needed — the headless
-     * invokeLater in onBlockReset happens after the ordering under test.
+     * via flushNow(), and the ordered webview target records the callbacks directly.
      */
     @Test
     public void blockResetFlushesBufferedDeltasBeforeClearing() throws Exception {
@@ -209,44 +220,10 @@ public class SessionCallbackAdapterStreamEndTest {
         adapter.onContentDelta("text-tail");
         adapter.onThinkingDelta("thinking-tail");
 
-        // onBlockReset dispatches its JS notification via invokeLater, which has
-        // no Application in headless tests. The flush-before-reset ordering under
-        // test completes before that call, so a benign proxy stub suffices.
-        // Not restored afterwards: setApplication(null, ...) is rejected by the
-        // platform's @NotNull contract, and each Gradle test fork owns its JVM.
-        ApplicationManager.setApplication(invokeLaterInlineApplication());
         adapter.onBlockReset();
 
         assertTrue(jsTarget.calls.contains("onContentDelta:text-tail"));
         assertTrue(jsTarget.calls.contains("onThinkingDelta:thinking-tail"));
         adapter.deactivate();
     }
-
-    /**
-     * Headless Application stub whose invokeLater runs the runnable inline — the
-     * adapter only needs a non-null application for its EDT dispatch.
-     */
-    private static @NotNull Application invokeLaterInlineApplication() {
-        return (Application) Proxy.newProxyInstance(
-                Application.class.getClassLoader(),
-                new Class<?>[] { Application.class },
-                (proxy, method, args) -> {
-                    if ("invokeLater".equals(method.getName()) && args != null && args.length >= 1) {
-                        ((Runnable) args[0]).run();
-                        return null;
-                    }
-                    if (method.getName().equals("isDispatchThread")) {
-                        return Boolean.TRUE;
-                    }
-                    // Unimplemented platform calls are irrelevant to this test;
-                    // returning defaults keeps the stub minimal.
-                    Class<?> type = method.getReturnType();
-                    if (type == boolean.class) {
-                        return Boolean.FALSE;
-                    }
-                    return null;
-                }
-        );
-    }
 }
-

--- a/src/test/java/com/github/claudecodegui/session/StreamMessageCoalescerStreamEndHookTest.java
+++ b/src/test/java/com/github/claudecodegui/session/StreamMessageCoalescerStreamEndHookTest.java
@@ -1,78 +1,75 @@
 package com.github.claudecodegui.session;
 
 import com.github.claudecodegui.handler.core.HandlerContext;
-import com.intellij.ui.jcef.JBCefBrowser;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Integration tests for the {@code onStreamEnded()} host hook on the REAL
- * {@link StreamMessageCoalescer} — the signal ClaudeChatWindow uses to drain a
- * deferred background-turn reload at the safe point (stream inactive).
+ * Integration tests for the stream lifecycle on the REAL
+ * {@link StreamMessageCoalescer}.
  *
  * <p>These drive the production coalescer (not a re-implementation), so they
- * catch regressions in the actual onStreamStart/onStreamEnd lifecycle: the hook
- * firing, the {@code streamActive} transition, and per-turn repetition.
+ * catch regressions in the actual onStreamStart/onStreamEnd lifecycle: the
+ * {@code streamActive} transition and per-turn repetition. The deferred-reload
+ * drain no longer hangs off this lifecycle — it is owned by the adapter's
+ * stream-end callback, which fires only after the final snapshot has entered
+ * the ordered webview queue.
  */
 public class StreamMessageCoalescerStreamEndHookTest {
 
-    /** Minimal JsCallbackTarget that counts onStreamEnded() firings. */
+    /** Minimal JsCallbackTarget that records nothing; lifecycle only. */
     private static final class CountingTarget implements StreamMessageCoalescer.JsCallbackTarget {
-        final AtomicInteger streamEndedCount = new AtomicInteger();
-
         @Override public void callJavaScript(String functionName, String... args) {}
-        @Override public JBCefBrowser getBrowser() { return null; }
         @Override public boolean isDisposed() { return false; }
         @Override public HandlerContext getHandlerContext() { return null; }
-        @Override public void onStreamEnded() { streamEndedCount.incrementAndGet(); }
     }
 
     @Test
-    public void onStreamEndFiresHookAndClearsActive() {
+    public void onStreamEndClearsActive() {
         CountingTarget target = new CountingTarget();
         StreamMessageCoalescer coalescer = new StreamMessageCoalescer(target);
         try {
             coalescer.onStreamStart();
             assertTrue("stream active after start", coalescer.isStreamActive());
-            assertEquals("hook not fired yet", 0, target.streamEndedCount.get());
 
             coalescer.onStreamEnd();
             assertFalse("stream inactive after end", coalescer.isStreamActive());
-            assertEquals("onStreamEnd fires the host hook exactly once", 1, target.streamEndedCount.get());
         } finally {
             coalescer.dispose();
         }
     }
 
     @Test
-    public void hookFiresOncePerTurnAcrossMultipleTurns() {
-        // A long session fans out many turns; the deferred-reload drain must get
-        // a signal at EACH turn boundary, not just the first.
+    public void streamActiveFollowsEachTurnAcrossMultipleTurns() {
+        // A long session fans out many turns; each boundary must toggle the
+        // streaming flag so deferred work observes a clean idle edge.
         CountingTarget target = new CountingTarget();
         StreamMessageCoalescer coalescer = new StreamMessageCoalescer(target);
         try {
             for (int i = 0; i < 5; i++) {
                 coalescer.onStreamStart();
+                assertTrue(coalescer.isStreamActive());
                 coalescer.onStreamEnd();
+                assertFalse(coalescer.isStreamActive());
             }
-            assertEquals("hook fires once per turn", 5, target.streamEndedCount.get());
-            assertFalse(coalescer.isStreamActive());
         } finally {
             coalescer.dispose();
         }
     }
 
     @Test
-    public void resetStreamStateClearsActiveWithoutFiringHook() {
+    public void resetStreamStateClearsActive() {
         // resetStreamState() (new-session / restart) also drops streamActive, but
-        // it is NOT a turn boundary — it must not fire the drain hook, or a reload
+        // it is NOT a turn boundary — no drain may be triggered for it, or a reload
         // could run against a session the user just navigated away from.
         CountingTarget target = new CountingTarget();
         StreamMessageCoalescer coalescer = new StreamMessageCoalescer(target);
@@ -82,7 +79,6 @@ public class StreamMessageCoalescerStreamEndHookTest {
 
             coalescer.resetStreamState();
             assertFalse("reset clears active", coalescer.isStreamActive());
-            assertEquals("reset must NOT fire the drain hook", 0, target.streamEndedCount.get());
         } finally {
             coalescer.dispose();
         }
@@ -114,9 +110,14 @@ public class StreamMessageCoalescerStreamEndHookTest {
 
     @Test
     public void growingConversationWithStablePrefixUsesTail() {
-        List<ClaudeSession.Message> previous = messages(300);
-        List<ClaudeSession.Message> growing = new ArrayList<>(previous);
-        for (int i = 300; i < 400; i++) {
+        List<ClaudeSession.Message> previous = messages(400);
+        List<ClaudeSession.Message> growing = new ArrayList<>();
+        for (ClaudeSession.Message message : previous) {
+            ClaudeSession.Message copy = new ClaudeSession.Message(message.type, message.content);
+            copy.timestamp = message.timestamp;
+            growing.add(copy);
+        }
+        for (int i = 400; i < 450; i++) {
             growing.add(new ClaudeSession.Message(ClaudeSession.Message.Type.USER, "message-" + i));
         }
 
@@ -124,8 +125,8 @@ public class StreamMessageCoalescerStreamEndHookTest {
                 StreamMessageCoalescer.selectMessageTransport(growing, previous);
 
         assertTrue(transport.tailUpdate());
-        assertEquals(220, transport.baseIndex());
-        assertEquals(180, transport.messages().size());
+        assertEquals(386, transport.baseIndex());
+        assertEquals(64, transport.messages().size());
     }
 
     @Test
@@ -153,6 +154,36 @@ public class StreamMessageCoalescerStreamEndHookTest {
         assertFalse(transport.tailUpdate());
         assertEquals(0, transport.baseIndex());
         assertEquals(rebuilt, transport.messages());
+    }
+
+    @Test
+    public void transportSnapshotDeepCopiesMutableRaw() {
+        JsonObject block = new JsonObject();
+        block.addProperty("type", "tool_use");
+        block.addProperty("id", "tool-1");
+        block.addProperty("name", "Bash");
+        block.addProperty("input", "before");
+        JsonArray content = new JsonArray();
+        content.add(block);
+        JsonObject message = new JsonObject();
+        message.add("content", content);
+        JsonObject raw = new JsonObject();
+        raw.add("message", message);
+        ClaudeSession.Message original = new ClaudeSession.Message(
+                ClaudeSession.Message.Type.ASSISTANT, "before", raw);
+
+        List<ClaudeSession.Message> snapshot =
+                StreamMessageCoalescer.copyMessagesForTransport(List.of(original));
+        original.content = "after";
+        block.addProperty("input", "after");
+
+        assertNotSame(original, snapshot.get(0));
+        assertEquals("before", snapshot.get(0).content);
+        assertEquals("before", snapshot.get(0).raw
+                .getAsJsonObject("message")
+                .getAsJsonArray("content")
+                .get(0).getAsJsonObject()
+                .get("input").getAsString());
     }
 
     private static List<ClaudeSession.Message> messages(int count) {

--- a/src/test/java/com/github/claudecodegui/ui/toolwindow/WebviewEventQueueTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/toolwindow/WebviewEventQueueTest.java
@@ -1,0 +1,87 @@
+package com.github.claudecodegui.ui.toolwindow;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class WebviewEventQueueTest {
+
+    @Test
+    public void mergesAdjacentContentDeltasIntoOneOrderedCall() {
+        AtomicReference<Object> browser = new AtomicReference<>(new Object());
+        AtomicBoolean disposed = new AtomicBoolean();
+        List<Runnable> scheduled = new ArrayList<>();
+        List<String> scripts = new ArrayList<>();
+        WebviewEventQueue<Object> queue = newQueue(browser, disposed, scheduled, scripts);
+
+        queue.enqueue("onContentDelta", "a");
+        queue.enqueue("onContentDelta", "b");
+
+        assertEquals(1, scheduled.size());
+        scheduled.remove(0).run();
+
+        assertEquals(1, scripts.size());
+        assertTrue(scripts.get(0).contains("window.onContentDelta('ab')"));
+        queue.dispose();
+    }
+
+    @Test
+    public void preservesLifecycleOrderInsteadOfCollapsingStateAcrossBoundaries() {
+        AtomicReference<Object> browser = new AtomicReference<>(new Object());
+        AtomicBoolean disposed = new AtomicBoolean();
+        List<Runnable> scheduled = new ArrayList<>();
+        List<String> scripts = new ArrayList<>();
+        WebviewEventQueue<Object> queue = newQueue(browser, disposed, scheduled, scripts);
+
+        queue.enqueue("showLoading", "true");
+        queue.enqueue("onStreamStart");
+        queue.enqueue("showLoading", "false");
+        scheduled.remove(0).run();
+
+        String script = scripts.get(0);
+        assertTrue(script.indexOf("window.showLoading('true')")
+                < script.indexOf("window.onStreamStart()"));
+        assertTrue(script.indexOf("window.onStreamStart()")
+                < script.indexOf("window.showLoading('false')"));
+        queue.dispose();
+    }
+
+    @Test
+    public void separatesSnapshotFromStreamStartSoStartCannotCancelIt() {
+        AtomicReference<Object> browser = new AtomicReference<>(new Object());
+        AtomicBoolean disposed = new AtomicBoolean();
+        List<Runnable> scheduled = new ArrayList<>();
+        List<String> scripts = new ArrayList<>();
+        WebviewEventQueue<Object> queue = newQueue(browser, disposed, scheduled, scripts);
+
+        queue.enqueue("updateMessages", "snapshot", "1");
+        queue.enqueue("onStreamStart");
+        scheduled.remove(0).run();
+        scheduled.remove(0).run();
+
+        assertEquals(2, scripts.size());
+        assertTrue(scripts.get(0).contains("window.updateMessages('snapshot', '1')"));
+        assertTrue(scripts.get(1).contains("window.onStreamStart()"));
+        queue.dispose();
+    }
+
+    private static WebviewEventQueue<Object> newQueue(
+            AtomicReference<Object> browser,
+            AtomicBoolean disposed,
+            List<Runnable> scheduled,
+            List<String> scripts
+    ) {
+        return new WebviewEventQueue<>(
+                browser::get,
+                disposed::get,
+                scheduled::add,
+                (ignoredBrowser, script) -> scripts.add(script)
+        );
+    }
+}

--- a/webview/src/global.d.ts
+++ b/webview/src/global.d.ts
@@ -786,9 +786,10 @@ interface Window {
   onThinkingDelta?: (delta: string) => void;
 
   /**
-   * Block reset callback - called when a new assistant message starts within
-   * an ongoing stream (e.g., after a tool_use loop iteration). Frontend should
-   * clear streaming content refs to prevent cross-turn content merging.
+   * Block reset callback - fired when a new assistant content block starts
+   * within an ongoing stream (e.g., after a tool_use loop iteration). Only
+   * render bookkeeping resets here; content buffers stay cumulative so the
+   * backend snapshot's per-block routing remains consistent.
    */
   onBlockReset?: () => void;
 
@@ -894,18 +895,23 @@ interface Window {
   __stallWatchdogInterval?: ReturnType<typeof setInterval> | null;
 
   /**
-   * Pending rAF handle and JSON for deferred updateMessages processing.
-   * Stored on window so re-registration of message callbacks cancels stale rAFs.
+   * Pending timer handle and JSON for deferred updateMessages processing during
+   * streaming (historical "rAF" naming). Stored on window so re-registration of
+   * message callbacks cancels stale timers.
    */
   __pendingUpdateRaf?: number | null;
   __pendingUpdateJson?: string | null;
   __pendingUpdateSequence?: number | null;
+  /** Deltas arrived while a structural snapshot was pending; rendering resumes after it applies. */
+  __streamingDeltaRenderDeferred?: boolean;
+  /** Re-schedule deferred delta rendering once the pending snapshot has been applied. */
+  __flushDeferredStreamingRenders?: () => void;
   __minAcceptedUpdateSequence?: number;
   /** Number of paged history messages prepended ahead of the backend session snapshot. */
   __prependedHistoryMessageCount?: number;
   /** Backend index represented by the first non-prepended message; zero means its full prefix is present. */
   __messageBaseIndex?: number;
-  /** Cancel pending rAF-deferred updateMessages (set by messageCallbacks, called by onStreamEnd). */
+  /** Cancel the pending deferred updateMessages (set by messageCallbacks, called by stream lifecycle guards). */
   __cancelPendingUpdateMessages?: () => void;
 
   /**

--- a/webview/src/hooks/useWindowCallbacks.test.ts
+++ b/webview/src/hooks/useWindowCallbacks.test.ts
@@ -1973,6 +1973,46 @@ describe('useWindowCallbacks integration', () => {
       });
     });
 
+    it('defers delta rendering until a pending structural snapshot is processed', () => {
+      vi.useFakeTimers();
+      const rafCallbacks: FrameRequestCallback[] = [];
+      let nextRafId = 0;
+      vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+        rafCallbacks.push(callback);
+        nextRafId += 1;
+        return nextRafId;
+      });
+      vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
+      const opts = createOptions();
+      renderHook(() => useWindowCallbacks(opts));
+
+      act(() => {
+        window.onStreamStart!();
+        window.updateMessages!(JSON.stringify([
+          {
+            type: 'assistant',
+            content: 'snapshot',
+            raw: {
+              message: {
+                content: [{ type: 'tool_use', id: 'tool-1', name: 'Bash', input: { command: 'ls' } }],
+              },
+            },
+          },
+        ]), 1);
+        window.onContentDelta!('delta-after-snapshot');
+      });
+
+      expect(opts.streamingContentRef.current).toBe('delta-after-snapshot');
+      expect(rafCallbacks).toHaveLength(0);
+
+      act(() => {
+        vi.advanceTimersByTime(16);
+      });
+
+      expect(rafCallbacks).toHaveLength(2);
+    });
+
     it('onBlockReset keeps streaming refs cumulative across turns (single assistant message)', () => {
       stubSynchronousTimers();
 

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/messageCallbacks.ts
@@ -28,10 +28,24 @@ import { collectUnresolvedToolUseIds } from './streamingCallbacks';
 
 const isTruthy = (v: unknown) => v === true || v === 'true';
 
+/** Build a bounded signature for a structural JSON value. */
+function getStructuralValueSignature(value: unknown): string {
+  let serialized: string;
+  try {
+    serialized = typeof value === 'string' ? value : JSON.stringify(value) ?? '';
+  } catch {
+    return '';
+  }
+  let hash = 0;
+  for (let i = 0; i < serialized.length; i += 1) {
+    hash = ((hash << 5) - hash + serialized.charCodeAt(i)) | 0;
+  }
+  return `${serialized.length}:${hash}`;
+}
+
 /**
- * Build a lightweight string signature from non-text raw blocks so we can
- * cheaply detect structural changes (new tool_use/tool_result blocks) without
- * a full JSON.stringify of arbitrary objects.
+ * Build a lightweight signature from non-text raw blocks so structural changes
+ * can be detected without retaining another full JSON snapshot.
  */
 function getStructuralRawBlockSignature(
   message: ClaudeMessage,
@@ -50,15 +64,15 @@ function getStructuralRawBlockSignature(
     if (type === 'text' || type === 'thinking') continue;
 
     if (type === 'tool_use') {
-      parts.push(`tu:${block.id ?? ''}:${block.name ?? ''}`);
+      parts.push(`tu:${block.id ?? ''}:${block.name ?? ''}:${getStructuralValueSignature(block.input)}`);
     } else if (type === 'tool_result') {
-      parts.push(`tr:${block.tool_use_id ?? ''}:${block.is_error === true ? '1' : '0'}`);
+      parts.push(`tr:${block.tool_use_id ?? ''}:${block.is_error === true ? '1' : '0'}:${getStructuralValueSignature(block.content)}`);
     } else if (type === 'attachment') {
       parts.push(`at:${block.fileName ?? ''}:${block.mediaType ?? ''}`);
     } else if (type === 'image') {
-      parts.push(`im:${block.src ?? ''}:${block.mediaType ?? ''}`);
+      parts.push(`im:${getStructuralValueSignature(block.src)}:${block.mediaType ?? ''}`);
     } else {
-      parts.push(type);
+      parts.push(`${type}:${getStructuralValueSignature(block)}`);
     }
   }
 
@@ -117,12 +131,11 @@ export function registerMessageCallbacks(
   };
 
   // During streaming, buffer updateMessages calls and process only the latest
-  // one per animation frame. This prevents JSON.parse of large payloads from
-  // blocking the main thread on every coalescer push (which can arrive every
-  // 50ms), eliminating the "fake freeze" symptom.
+  // one per short (~16ms) timer. Structural snapshots are sparse, but a single
+  // snapshot can still be large enough to block the browser while parsing.
   //
   // Stored on `window` so that if registerMessageCallbacks is called again
-  // (e.g., HMR, parent re-render), the previous pending rAF is cancelled
+  // (e.g., HMR, parent re-render), the previous pending timer is cancelled
   // first — preventing stale closures from executing.
   if (window.__pendingUpdateRaf != null) {
     clearTimeout(window.__pendingUpdateRaf);
@@ -171,6 +184,7 @@ export function registerMessageCallbacks(
     window.__pendingUpdateRaf = null;
     window.__pendingUpdateJson = null;
     window.__pendingUpdateSequence = null;
+    window.__streamingDeltaRenderDeferred = false;
   };
   window.__cancelPendingUpdateMessages = cancelPendingUpdateMessages;
 
@@ -589,6 +603,7 @@ export function registerMessageCallbacks(
           if (latestJson) {
             processUpdateMessages(latestJson, latestSequence);
           }
+          window.__flushDeferredStreamingRenders?.();
         }, 16);
         pendingUpdateRaf = timerId as unknown as number;
         window.__pendingUpdateRaf = timerId as unknown as number;

--- a/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks/streamingCallbacks.ts
@@ -2,7 +2,9 @@
  * streamingCallbacks.ts
  *
  * Registers window bridge callbacks for streaming:
- * onStreamStart, onContentDelta, onThinkingDelta, onStreamEnd, onPermissionDenied.
+ * onStreamStart, onContentDelta, onThinkingDelta, onStreamEnd, onBlockReset,
+ * onStreamingHeartbeat, onPermissionDenied, plus __flushDeferredStreamingRenders
+ * (called after a pending structural snapshot is applied to resume delta rendering).
  */
 
 import { startTransition } from 'react';
@@ -137,9 +139,8 @@ export function collectUnresolvedToolUseIds(
  *
  * Set to 60s to avoid false positives during long tool execution phases
  * (e.g., command execution, file operations) where no content deltas arrive
- * but the backend is still actively processing.  The backend heartbeat
- * mechanism in StreamMessageCoalescer keeps __lastStreamActivityAt bumped
- * via periodic updateMessages re-pushes.
+ * but the backend is still actively processing. The backend heartbeat keeps
+ * __lastStreamActivityAt bumped without requiring another message snapshot.
  */
 const STREAM_STALL_TIMEOUT_MS = 60_000;
 const STREAM_STALL_CHECK_INTERVAL_MS = 5_000;
@@ -274,6 +275,7 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     window.__streamEndProcessedTurnId = undefined;
     // Record turn start time for duration calculation in onStreamEnd
     window.__turnStartedAt = Date.now();
+    window.__streamingDeltaRenderDeferred = false;
     streamingContentRef.current = '';
     streamingThinkingRef.current = '';
     isStreamingRef.current = true;
@@ -403,11 +405,25 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
   const scheduleContentRaf = createStreamingRafScheduler(contentUpdateTimeoutRef, lastContentUpdateRef);
   const scheduleThinkingRaf = createStreamingRafScheduler(thinkingUpdateTimeoutRef, lastThinkingUpdateRef);
 
+  window.__flushDeferredStreamingRenders = () => {
+    if (!window.__streamingDeltaRenderDeferred || !isStreamingRef.current) return;
+    window.__streamingDeltaRenderDeferred = false;
+    scheduleContentRaf();
+    scheduleThinkingRaf();
+  };
+
   window.onContentDelta = (delta: string) => {
     if (window.__sessionTransitioning) return;
     if (!isStreamingRef.current) return;
     window.__lastStreamActivityAt = Date.now();
     streamingContentRef.current += delta;
+    if (window.__pendingUpdateRaf != null || window.__pendingUpdateJson != null) {
+      // Let the pending structural snapshot establish the message identity first.
+      // The snapshot merge already consumes this buffer, so a second React update
+      // here would only race the authoritative structural update.
+      window.__streamingDeltaRenderDeferred = true;
+      return;
+    }
     scheduleContentRaf();
   };
 
@@ -416,6 +432,10 @@ export function registerStreamingCallbacks(options: UseWindowCallbacksOptions): 
     if (!isStreamingRef.current) return;
     window.__lastStreamActivityAt = Date.now();
     streamingThinkingRef.current += delta;
+    if (window.__pendingUpdateRaf != null || window.__pendingUpdateJson != null) {
+      window.__streamingDeltaRenderDeferred = true;
+      return;
+    }
     scheduleThinkingRaf();
   };
 


### PR DESCRIPTION
Large message snapshots, text/thinking deltas, lifecycle signals, usage updates, and raw JavaScript were dispatched through independent asynchronous paths. Under long Claude turns, JCEF and the React main thread could accumulate expensive snapshots and then process stale structural data after newer deltas. Because tool blocks depended on the structural snapshot channel while text depended on a separate delta channel, the frontend could append text to the wrong assistant, hide tool calls, and recover only when the final stream snapshot arrived. The same race was amplified by mutable Gson trees being serialized asynchronously. Repeated session-id markers also generated unnecessary frontend work. In addition, deferred session reloads could begin from the stream-end hook before the asynchronous final snapshot had entered the webview queue.

Route Java-to-webview calls through a bounded per-window FIFO queue with browser identity invalidation, delta coalescing, latest-only state replacement, snapshot boundaries, and backpressure. Deep-copy message and raw-content snapshots before serialization, send structural snapshots only when structure changes, include tool inputs and results in structural signatures, and defer delta rendering until a pending structural snapshot establishes message identity. Move usage updates and raw JavaScript onto the same ordered path, deduplicate session-id emission, and invalidate stale delivery epochs during webview replacement. Finally, move deferred reload draining to the adapter callback that runs after the final snapshot and stream-end signal have entered the queue, preventing reload from racing the final stream state. Add regression coverage for queue ordering, reload isolation, snapshot immutability, stream-end lifecycle, and duplicate session events.

Validation:
- ./gradlew checkstyleMain compileTestJava -q
- Stream-related Java tests passed
- webview callback tests: 91 passed
- webview TypeScript check passed