### PR TITLE
fix: files and lines not being sent correctly to pi/omp

### DIFF
--- a/ai-bridge/services/omp/message-service.js
+++ b/ai-bridge/services/omp/message-service.js
@@ -38,6 +38,7 @@ import {
   cleanupMaterializedImagePaths,
   materializeImageAttachments,
 } from '../../utils/cli-image-input.js';
+import { reformatFileLineReferences } from '../../utils/file-line-references.js';
 
 const THINKING_LEVELS = new Set(['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
 
@@ -144,6 +145,7 @@ export async function sendMessage(
   } catch (err) {
     console.error('[OMP] failed to materialize image attachments:', err?.message || err);
   }
+  promptText = reformatFileLineReferences(promptText);
 
   const bin = resolveOmpCliPath();
   const args = buildOmpArgs({ message: promptText, sessionId, model, reasoningEffort });

--- a/ai-bridge/services/pi/message-service.js
+++ b/ai-bridge/services/pi/message-service.js
@@ -38,6 +38,7 @@ import {
   cleanupMaterializedImagePaths,
   materializeImageAttachments,
 } from '../../utils/cli-image-input.js';
+import { reformatFileLineReferences } from '../../utils/file-line-references.js';
 
 const THINKING_LEVELS = new Set(['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
 
@@ -142,6 +143,7 @@ export async function sendMessage(
   } catch (err) {
     console.error('[PI] failed to materialize image attachments:', err?.message || err);
   }
+  promptText = reformatFileLineReferences(promptText);
 
   const bin = resolvePiCliPath();
   const args = buildPiArgs({ message: promptText, sessionId, model, reasoningEffort });

--- a/ai-bridge/utils/file-line-references.js
+++ b/ai-bridge/utils/file-line-references.js
@@ -1,0 +1,28 @@
+/**
+ * Reformat Claude-style line references for pi/omp CLIs.
+ *
+ * pi/omp cannot parse `@path#L1` / `@path#L1-5`:
+ * - pi (upstream pi-mono) has no @-mention expansion in prompt text at all;
+ *   the token is plain text for the model.
+ * - omp's mention regex keeps `#L1` glued to the path, the file lookup misses
+ *   and the mention is silently dropped, so the file is never attached.
+ *
+ * Rewriting to `@path` + prose keeps the mention resolvable (omp auto-attaches
+ * the file) and preserves the line information as text both CLIs' models can
+ * act on with their file tools.
+ */
+
+const LINE_REFERENCE_PATTERN = /@([^\s@]+)#L(\d+)(?:-L?(\d+))?/g;
+
+/**
+ * @param {string} text
+ * @returns {string} text with `@path#L1[-L2]` rewritten to `@path (lines 1[-2])`
+ */
+export function reformatFileLineReferences(text) {
+  if (typeof text !== 'string' || text.length === 0) return text;
+  return text.replace(LINE_REFERENCE_PATTERN, (match, filePath, startLine, endLine) =>
+    endLine
+      ? `@${filePath} (lines ${startLine}-${endLine})`
+      : `@${filePath} (lines ${startLine})`
+  );
+}

--- a/ai-bridge/utils/file-line-references.test.js
+++ b/ai-bridge/utils/file-line-references.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { reformatFileLineReferences } from './file-line-references.js';
+
+test('reformats the issue reference with a Windows path', () => {
+  const input = String.raw`@E:\proj\H2Migrator.java#L77 这段代码是什么意思`;
+  const expected = String.raw`@E:\proj\H2Migrator.java (lines 77) 这段代码是什么意思`;
+  assert.equal(reformatFileLineReferences(input), expected);
+});
+
+test('reformats a line range', () => {
+  assert.equal(
+    reformatFileLineReferences('@/home/user/Foo.java#L12-24 explica'),
+    '@/home/user/Foo.java (lines 12-24) explica',
+  );
+});
+
+test('accepts the manually written L-prefixed range form', () => {
+  assert.equal(
+    reformatFileLineReferences('@/home/user/Foo.java#L3-L9 explica'),
+    '@/home/user/Foo.java (lines 3-9) explica',
+  );
+});
+
+test('reformats every reference in a message', () => {
+  assert.equal(
+    reformatFileLineReferences('@a/Foo.java#L1 and @b/Bar.java#L2-4'),
+    '@a/Foo.java (lines 1) and @b/Bar.java (lines 2-4)',
+  );
+});
+
+test('leaves non-line references and unrelated text unchanged', () => {
+  assert.equal(reformatFileLineReferences('@/path/Foo.java'), '@/path/Foo.java');
+  assert.equal(reformatFileLineReferences('Foo.java#L1'), 'Foo.java#L1');
+  assert.equal(reformatFileLineReferences('text without references'), 'text without references');
+});
+
+test('passes through empty and non-string values', () => {
+  assert.equal(reformatFileLineReferences(''), '');
+  assert.equal(reformatFileLineReferences(null), null);
+  assert.equal(reformatFileLineReferences(undefined), undefined);
+});

--- a/ai-bridge/utils/marker-protocol.js
+++ b/ai-bridge/utils/marker-protocol.js
@@ -75,8 +75,13 @@ export function emitToolResultMessage({ toolUseId, content, isError = false }) {
   });
 }
 
+// Leading "@" is guarded the same way as leading "-": pi/omp (parseArgs in
+// cli/args.ts) classify ANY argv token starting with "@" as a file argument
+// (fileArgs -> processFileArguments -> "Error: File not found" + exit 1).
+// A leading space keeps the token in `messages` while the mention still
+// parses (omp's mention regex allows whitespace before "@").
 export function safePromptArg(text) {
-  if (typeof text === 'string' && text.startsWith('-')) {
+  if (typeof text === 'string' && (text.startsWith('-') || text.startsWith('@'))) {
     return ` ${text}`;
   }
   return text ?? '';

--- a/ai-bridge/utils/marker-protocol.test.js
+++ b/ai-bridge/utils/marker-protocol.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { safePromptArg } from './marker-protocol.js';
+
+test('guards a leading @ from pi/omp file argument parsing', () => {
+  assert.equal(safePromptArg('@/abs/Foo.java#L1 pregunta'), ' @/abs/Foo.java#L1 pregunta');
+});
+
+test('preserves the existing leading dash guard', () => {
+  assert.equal(safePromptArg('-algo'), ' -algo');
+});
+
+test('leaves ordinary text unchanged', () => {
+  assert.equal(safePromptArg('texto normal'), 'texto normal');
+});
+
+test('normalizes nullish prompt values to an empty string', () => {
+  assert.equal(safePromptArg(null), '');
+  assert.equal(safePromptArg(undefined), '');
+});


### PR DESCRIPTION
Fixes #1740 
## Summary

Fixes an issue where prompts sent through the `pi` or `omp` CLI providers could fail when they started with a Claude-style file reference such as `@path/to/File.java#L77`.

## Root Cause

`pi` and `omp` interpret any positional CLI argument beginning with `@` as a file argument. When the selected-code reference was the first part of the prompt, the entire prompt was incorrectly classified as a file path, causing:

```text
Error: File not found
 ```                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                      
 Additionally, omp did not resolve line references because its file-mention parser kept the #L... suffix attached to the file path.                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                      
 Changes                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                      
 - Guard leading @ characters in positional prompts so they remain regular messages.                                                                                                                                                                                                                  
 - Reformat line references before invoking pi or omp:                                                                                                                                                                                                                                                
   - @File.java#L77 → @File.java (lines 77)                                                                                                                                                                                                                                                           
   - @File.java#L12-24 → @File.java (lines 12-24)                                                                                                                                                                                                                                                     
   - @File.java#L3-L9 → @File.java (lines 3-9)                                                                                                                                                                                                                                                        
 - Apply the fix to both the pi and omp message services.                                                                                                                                                                                                                                             
 - Add regression tests covering Windows paths, line ranges, multiple references, and leading prompt markers.                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                      
 Validation                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                      
 - Focused tests: 10 passed, 0 failed.                                                                                                                                                                                                                                                                
 - Full AI bridge suite: 497 passed, 0 failed.                                                                                                                                                                                                                                                        
 - Verified with the real omp CLI that file mentions are attached correctly and the referenced content is returned.                                                                                                                                                                                   
 - Verified that the original leading-@ parsing crash no longer occurs.                                                                                                                                                                                                                               
 ```                                                                         