### PR TITLE
fix(mcp): stop MCP server configs from silently vanishing

### DIFF
--- a/src/main/java/com/github/claudecodegui/settings/ClaudeSettingsManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/ClaudeSettingsManager.java
@@ -1,6 +1,7 @@
 package com.github.claudecodegui.settings;
 
 import com.github.claudecodegui.bridge.NodeDetector;
+import com.github.claudecodegui.util.SafeJsonFileOps;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -25,6 +26,11 @@ import java.util.Set;
  */
 public class ClaudeSettingsManager {
     private static final Logger LOG = Logger.getInstance(ClaudeSettingsManager.class);
+
+    /** Read attempts when another process may be mid-write of a shared config. */
+    private static final int READ_ATTEMPTS = 3;
+    /** Delay between read attempts (ms). */
+    private static final long READ_RETRY_DELAY_MS = 100;
 
     /**
      * System-protected fields - these should never be overridden by provider configs
@@ -73,6 +79,10 @@ public class ClaudeSettingsManager {
 
     /**
      * Read Claude Settings.
+     * Self-healing: when the file is unreadable/corrupt (e.g. a torn write
+     * from an older plugin version), fall back to the plugin's backup copy
+     * instead of returning an empty default — an empty default here used to be
+     * the seed for "all my MCP servers vanished".
      */
     public JsonObject readClaudeSettings() throws IOException {
         Path settingsPath = pathManager.getClaudeSettingsPath();
@@ -82,12 +92,9 @@ public class ClaudeSettingsManager {
             return createDefaultClaudeSettings();
         }
 
-        try (FileReader reader = new FileReader(settingsFile, StandardCharsets.UTF_8)) {
-            return JsonParser.parseReader(reader).getAsJsonObject();
-        } catch (Exception e) {
-            LOG.warn("[ClaudeSettingsManager] Failed to read ~/.claude/settings.json: " + e.getMessage());
-            return createDefaultClaudeSettings();
-        }
+        JsonObject healed = SafeJsonFileOps.readJsonOrBackup(
+                settingsPath, READ_ATTEMPTS, READ_RETRY_DELAY_MS);
+        return healed != null ? healed : createDefaultClaudeSettings();
     }
 
     /**
@@ -130,10 +137,11 @@ public class ClaudeSettingsManager {
         // Force-set to string value "1"
         env.addProperty("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1");
 
-        try (FileWriter writer = new FileWriter(settingsPath.toFile(), StandardCharsets.UTF_8)) {
-            gson.toJson(settings, writer);
-            LOG.info("[ClaudeSettingsManager] Synced settings to: " + settingsPath);
-        }
+        // Atomic replace: never leave a truncated settings.json behind if the
+        // IDE crashes or is killed mid-write (SafeJsonFileOps also keeps a
+        // .ccgui-backup copy for self-healing reads).
+        SafeJsonFileOps.writeAtomically(settingsPath, writer -> gson.toJson(settings, writer));
+        LOG.info("[ClaudeSettingsManager] Synced settings to: " + settingsPath);
         // Security (J): settings.json may hold ANTHROPIC_AUTH_TOKEN; restrict to 0600.
         hardenFilePermissions(settingsPath);
     }
@@ -167,28 +175,44 @@ public class ClaudeSettingsManager {
                 return;
             }
 
-            JsonObject claudeJson;
-            try (FileReader reader = new FileReader(claudeJsonFile, StandardCharsets.UTF_8)) {
-                claudeJson = JsonParser.parseReader(reader).getAsJsonObject();
-            } catch (Exception e) {
-                LOG.error("[ClaudeSettingsManager] Failed to parse ~/.claude.json: " + e.getMessage(), e);
-                LOG.error("[ClaudeSettingsManager] This may indicate a corrupted JSON file. Please check ~/.claude.json");
-
-                // Try to read the most recent backup
-                File backup = new File(claudeJsonFile.getParent(), ".claude.json.backup");
-                if (backup.exists()) {
-                    LOG.info("[ClaudeSettingsManager] Found backup file, you may need to restore it manually");
-                }
+            // Self-healing read of ~/.claude.json: retry transient parse
+            // failures (another process mid-write), then fall back to the
+            // plugin's own backup copy and restore it over the damaged file.
+            JsonObject claudeJson = SafeJsonFileOps.readJsonOrBackup(
+                    claudeJsonPath, READ_ATTEMPTS, READ_RETRY_DELAY_MS);
+            if (claudeJson == null) {
+                LOG.error("[ClaudeSettingsManager] Failed to parse ~/.claude.json and no usable backup exists — "
+                        + "skipping MCP sync (settings.json left untouched)");
                 return;
             }
 
-            // Read ~/.claude/settings.json
+            // Read ~/.claude/settings.json (self-healing: fall back to the
+            // plugin's backup when the live file is truncated/corrupt)
             JsonObject settings = readClaudeSettings();
 
-            // Sync mcpServers
-            if (claudeJson.has("mcpServers")) {
-                settings.add("mcpServers", claudeJson.get("mcpServers"));
-                LOG.info("[ClaudeSettingsManager] Synced mcpServers to settings.json");
+            // Sync mcpServers — but never let an EMPTY .claude.json mcpServers
+            // wipe a non-empty mcpServers in settings.json. .claude.json is
+            // rewritten by the Claude CLI from its in-memory snapshot; if the
+            // CLI's snapshot briefly had no servers (e.g. it started before the
+            // user configured them, or a torn write was restored from a backup
+            // taken earlier), blindly copying the empty object here used to
+            // propagate the loss into settings.json (#<issue>: "configured MCP
+            // servers vanish"). Only overwrite when the source actually has
+            // servers, or when the source is non-empty and the target is empty.
+            if (claudeJson.has("mcpServers") && claudeJson.get("mcpServers").isJsonObject()) {
+                JsonObject sourceServers = claudeJson.getAsJsonObject("mcpServers");
+                boolean sourceEmpty = sourceServers.keySet().isEmpty();
+                boolean targetHasServers = settings.has("mcpServers")
+                        && settings.get("mcpServers").isJsonObject()
+                        && !settings.getAsJsonObject("mcpServers").keySet().isEmpty();
+                if (!sourceEmpty || !targetHasServers) {
+                    settings.add("mcpServers", sourceServers);
+                    LOG.info("[ClaudeSettingsManager] Synced mcpServers to settings.json (source servers: "
+                            + sourceServers.keySet().size() + ")");
+                } else {
+                    LOG.warn("[ClaudeSettingsManager] Skipped syncing an empty mcpServers from ~/.claude.json "
+                            + "over the non-empty mcpServers in settings.json (loss guard)");
+                }
             }
 
             // Sync disabledMcpServers

--- a/src/main/java/com/github/claudecodegui/settings/ClaudeSettingsManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/ClaudeSettingsManager.java
@@ -163,6 +163,22 @@ public class ClaudeSettingsManager {
      * The Claude CLI reads MCP config from ~/.claude/settings.json at runtime.
      */
     public void syncMcpToClaudeSettings() throws IOException {
+        // Default: guarded sync — an empty source mcpServers is treated as
+        // suspicious (possible data loss) and never wipes a non-empty target.
+        syncMcpToClaudeSettings(false);
+    }
+
+    /**
+     * Sync MCP servers from ~/.claude.json to ~/.claude/settings.json.
+     *
+     * @param allowEmptyOverwrite {@code true} when the caller KNOWS the user
+     *                            intentionally emptied the source (e.g. just
+     *                            deleted their last server in the UI) and the
+     *                            empty state must propagate to settings.json;
+     *                            {@code false} keeps the loss guard active
+     * @throws IOException on read/write failures
+     */
+    public void syncMcpToClaudeSettings(boolean allowEmptyOverwrite) throws IOException {
         try {
             String homeDir = NodeDetector.resolveHomeForFileOps();
 
@@ -205,7 +221,7 @@ public class ClaudeSettingsManager {
                 boolean targetHasServers = settings.has("mcpServers")
                         && settings.get("mcpServers").isJsonObject()
                         && !settings.getAsJsonObject("mcpServers").keySet().isEmpty();
-                if (!sourceEmpty || !targetHasServers) {
+                if (allowEmptyOverwrite || !sourceEmpty || !targetHasServers) {
                     settings.add("mcpServers", sourceServers);
                     LOG.info("[ClaudeSettingsManager] Synced mcpServers to settings.json (source servers: "
                             + sourceServers.keySet().size() + ")");

--- a/src/main/java/com/github/claudecodegui/settings/McpServerManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/McpServerManager.java
@@ -1,6 +1,7 @@
 package com.github.claudecodegui.settings;
 
 import com.github.claudecodegui.bridge.NodeDetector;
+import com.github.claudecodegui.util.SafeJsonFileOps;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -29,6 +30,13 @@ import java.util.function.Function;
  */
 public class McpServerManager {
     private static final Logger LOG = Logger.getInstance(McpServerManager.class);
+
+    /** Lock wait before proceeding without the cross-process lock (ms). */
+    private static final long LOCK_TIMEOUT_MS = 2_000;
+    /** Read attempts when another process may be mid-write. */
+    private static final int READ_ATTEMPTS = 3;
+    /** Delay between read attempts (ms). */
+    private static final long READ_RETRY_DELAY_MS = 100;
 
     private final Gson gson;
     private final Function<Void, JsonObject> configReader;
@@ -73,8 +81,11 @@ public class McpServerManager {
             File claudeJsonFile = claudeJsonPath.toFile();
 
             if (claudeJsonFile.exists()) {
-                try (FileReader reader = new FileReader(claudeJsonFile, StandardCharsets.UTF_8)) {
-                    JsonObject claudeJson = JsonParser.parseReader(reader).getAsJsonObject();
+                // Self-healing read: tolerate a torn write left by a crashed
+                // process by falling back to the plugin's backup copy.
+                JsonObject claudeJson = SafeJsonFileOps.readJsonOrBackup(
+                        claudeJsonPath, READ_ATTEMPTS, READ_RETRY_DELAY_MS);
+                if (claudeJson != null) {
 
                     if (claudeJson.has("mcpServers") && claudeJson.get("mcpServers").isJsonObject()) {
                         JsonObject globalMcpServers = claudeJson.getAsJsonObject("mcpServers");
@@ -176,8 +187,6 @@ public class McpServerManager {
                                          + " MCP servers from ~/.claude.json (disabled: " + disabledServers.size() + ")");
                         return result;
                     }
-                } catch (Exception e) {
-                    LOG.warn("[McpServerManager] Failed to read ~/.claude.json: " + e.getMessage());
                 }
             }
         } catch (Exception e) {
@@ -222,20 +231,37 @@ public class McpServerManager {
         boolean isEnabled = !server.has("enabled") || server.get("enabled").getAsBoolean();
 
         // 1. Try to update ~/.claude.json
+        // ~/.claude.json is shared with the Claude CLI process, which rewrites
+        // the whole file from its own in-memory snapshot. The read-modify-write
+        // below must therefore be (a) serialised against concurrent plugin
+        // writers via an advisory lock and (b) crash-safe via an atomic
+        // replace, or the plugin's update gets silently reverted (configured
+        // MCP servers "vanish") or the file is left truncated.
         try {
             String homeDir = NodeDetector.resolveHomeForFileOps();
             Path claudeJsonPath = Paths.get(homeDir, ".claude.json");
             File claudeJsonFile = claudeJsonPath.toFile();
 
             if (claudeJsonFile.exists()) {
-                try (FileReader reader = new FileReader(claudeJsonFile, StandardCharsets.UTF_8)) {
-                    JsonObject claudeJson = JsonParser.parseReader(reader).getAsJsonObject();
+                SafeJsonFileOps.withLock(
+                        SafeJsonFileOps.sibling(claudeJsonPath, ".ccgui-lock"),
+                        LOCK_TIMEOUT_MS,
+                        () -> {
+                            // Self-healing read: if another process left the file
+                            // truncated/corrupt, fall back to our last known good
+                            // backup instead of "successfully" writing a config
+                            // that starts from an empty object.
+                            JsonObject claudeJson = SafeJsonFileOps.readJsonOrBackup(
+                                    claudeJsonPath, READ_ATTEMPTS, READ_RETRY_DELAY_MS);
+                            if (claudeJson == null) {
+                                throw new IOException("~/.claude.json is unreadable and no backup exists");
+                            }
 
-                    // Ensure mcpServers object exists
-                    if (!claudeJson.has("mcpServers") || !claudeJson.get("mcpServers").isJsonObject()) {
-                        claudeJson.add("mcpServers", new JsonObject());
-                    }
-                    JsonObject mcpServers = claudeJson.getAsJsonObject("mcpServers");
+                            // Ensure mcpServers object exists
+                            if (!claudeJson.has("mcpServers") || !claudeJson.get("mcpServers").isJsonObject()) {
+                                claudeJson.add("mcpServers", new JsonObject());
+                            }
+                            JsonObject mcpServers = claudeJson.getAsJsonObject("mcpServers");
 
                     // Extract server spec
                     JsonObject serverSpec;
@@ -311,11 +337,9 @@ public class McpServerManager {
                         projectConfig.add("disabledMcpServers", newProjectDisabled);
                     }
 
-                    // Write back to file
-                    try (FileWriter writer = new FileWriter(claudeJsonFile, StandardCharsets.UTF_8)) {
-                        gson.toJson(claudeJson, writer);
-                        writer.flush();  // Ensure data is fully flushed to disk
-                    }
+                    // Write back to file — atomic replace (crash-safe) instead of a
+                    // truncating FileWriter that can leave a half-written config.
+                    SafeJsonFileOps.writeAtomically(claudeJsonPath, writer -> gson.toJson(claudeJson, writer));
 
                     LOG.info("[McpServerManager] Upserted MCP server in ~/.claude.json: " + serverId
                                      + " (enabled: " + isEnabled + ", projectPath: " + (projectPath != null ? projectPath : "(global)") + ")");
@@ -327,9 +351,8 @@ public class McpServerManager {
                         LOG.warn("[McpServerManager] Failed to sync MCP to settings.json: " + syncError.getMessage());
                         // Sync failure should not affect the main operation
                     }
-
+                        });
                     return;
-                }
             }
         } catch (Exception e) {
             LOG.warn("[McpServerManager] Error updating ~/.claude.json: " + e.getMessage());
@@ -372,56 +395,65 @@ public class McpServerManager {
      * falling back to ~/.codemoss/config.json.
      */
     public boolean deleteMcpServer(String serverId) throws IOException {
-        boolean removed = false;
+        // Single-element flag: mutated inside the lock lambda, read after it.
+        boolean[] removed = {false};
 
         // 1. Try to delete from ~/.claude.json
+        // Same shared-file discipline as upsertMcpServer: lock + self-healing
+        // read + atomic write (see the comment there for the race analysis).
         try {
             String homeDir = NodeDetector.resolveHomeForFileOps();
             Path claudeJsonPath = Paths.get(homeDir, ".claude.json");
             File claudeJsonFile = claudeJsonPath.toFile();
 
             if (claudeJsonFile.exists()) {
-                try (FileReader reader = new FileReader(claudeJsonFile, StandardCharsets.UTF_8)) {
-                    JsonObject claudeJson = JsonParser.parseReader(reader).getAsJsonObject();
+                SafeJsonFileOps.withLock(
+                        SafeJsonFileOps.sibling(claudeJsonPath, ".ccgui-lock"),
+                        LOCK_TIMEOUT_MS,
+                        () -> {
+                            JsonObject claudeJson = SafeJsonFileOps.readJsonOrBackup(
+                                    claudeJsonPath, READ_ATTEMPTS, READ_RETRY_DELAY_MS);
+                            if (claudeJson == null) {
+                                throw new IOException("~/.claude.json is unreadable and no backup exists");
+                            }
 
-                    if (claudeJson.has("mcpServers") && claudeJson.get("mcpServers").isJsonObject()) {
-                        JsonObject mcpServers = claudeJson.getAsJsonObject("mcpServers");
+                            if (claudeJson.has("mcpServers") && claudeJson.get("mcpServers").isJsonObject()) {
+                                JsonObject mcpServers = claudeJson.getAsJsonObject("mcpServers");
 
-                        if (mcpServers.has(serverId)) {
-                            // Delete the server
-                            mcpServers.remove(serverId);
+                                if (mcpServers.has(serverId)) {
+                                    // Delete the server
+                                    mcpServers.remove(serverId);
 
-                            // Also remove from disabledMcpServers (if present)
-                            if (claudeJson.has("disabledMcpServers") && claudeJson.get("disabledMcpServers").isJsonArray()) {
-                                JsonArray disabledServers = claudeJson.getAsJsonArray("disabledMcpServers");
-                                JsonArray newDisabled = new JsonArray();
-                                for (JsonElement elem : disabledServers) {
-                                    if (!elem.getAsString().equals(serverId)) {
-                                        newDisabled.add(elem);
+                                    // Also remove from disabledMcpServers (if present)
+                                    if (claudeJson.has("disabledMcpServers") && claudeJson.get("disabledMcpServers").isJsonArray()) {
+                                        JsonArray disabledServers = claudeJson.getAsJsonArray("disabledMcpServers");
+                                        JsonArray newDisabled = new JsonArray();
+                                        for (JsonElement elem : disabledServers) {
+                                            if (!elem.getAsString().equals(serverId)) {
+                                                newDisabled.add(elem);
+                                            }
+                                        }
+                                        claudeJson.add("disabledMcpServers", newDisabled);
                                     }
+
+                                    // Write back to file — atomic replace (crash-safe)
+                                    SafeJsonFileOps.writeAtomically(claudeJsonPath, writer -> gson.toJson(claudeJson, writer));
+
+                                    LOG.info("[McpServerManager] Deleted MCP server from ~/.claude.json: " + serverId);
+
+                                    // Sync to settings.json (after file write is complete)
+                                    try {
+                                        claudeSettingsManager.syncMcpToClaudeSettings();
+                                    } catch (Exception syncError) {
+                                        LOG.warn("[McpServerManager] Failed to sync MCP to settings.json: " + syncError.getMessage());
+                                    }
+
+                                    removed[0] = true;
                                 }
-                                claudeJson.add("disabledMcpServers", newDisabled);
                             }
-
-                            // Write back to file
-                            try (FileWriter writer = new FileWriter(claudeJsonFile, StandardCharsets.UTF_8)) {
-                                gson.toJson(claudeJson, writer);
-                                writer.flush();  // Ensure data is fully flushed to disk
-                            }
-
-                            LOG.info("[McpServerManager] Deleted MCP server from ~/.claude.json: " + serverId);
-
-                            // Sync to settings.json (after file write is complete)
-                            try {
-                                claudeSettingsManager.syncMcpToClaudeSettings();
-                            } catch (Exception syncError) {
-                                LOG.warn("[McpServerManager] Failed to sync MCP to settings.json: " + syncError.getMessage());
-                            }
-
-                            removed = true;
-                            return true;
-                        }
-                    }
+                        });
+                if (removed[0]) {
+                    return true;
                 }
             }
         } catch (Exception e) {
@@ -437,20 +469,20 @@ public class McpServerManager {
             for (JsonElement elem : servers) {
                 JsonObject s = elem.getAsJsonObject();
                 if (s.has("id") && s.get("id").getAsString().equals(serverId)) {
-                    removed = true;
+                    removed[0] = true;
                 } else {
                     newServers.add(s);
                 }
             }
 
-            if (removed) {
+            if (removed[0]) {
                 config.add("mcpServers", newServers);
                 configWriter.accept(config);
                 LOG.info("[McpServerManager] Deleted MCP server from ~/.codemoss/config.json: " + serverId);
             }
         }
 
-        return removed;
+        return removed[0];
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/settings/McpServerManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/McpServerManager.java
@@ -483,6 +483,19 @@ public class McpServerManager {
                 config.add("mcpServers", newServers);
                 configWriter.accept(config);
                 LOG.info("[McpServerManager] Deleted MCP server from ~/.codemoss/config.json: " + serverId);
+                // The deleted server may have been synced into settings.json
+                // earlier (when it still lived in ~/.claude.json) — propagate
+                // the deletion there too, or a ghost entry survives. Same
+                // allowEmptyOverwrite=true semantics as the primary path: the
+                // user deleted intentionally. (Harmless when settings.json
+                // never knew about the server: the sync just rewrites the
+                // current source state.)
+                try {
+                    claudeSettingsManager.syncMcpToClaudeSettings(true);
+                } catch (Exception syncError) {
+                    LOG.warn("[McpServerManager] Failed to sync MCP to settings.json after codemoss delete: "
+                            + syncError.getMessage());
+                }
             }
         }
 

--- a/src/main/java/com/github/claudecodegui/settings/McpServerManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/McpServerManager.java
@@ -441,9 +441,13 @@ public class McpServerManager {
 
                                     LOG.info("[McpServerManager] Deleted MCP server from ~/.claude.json: " + serverId);
 
-                                    // Sync to settings.json (after file write is complete)
+                                    // Sync to settings.json (after file write is complete).
+                                    // allowEmptyOverwrite=true: the user just deleted
+                                    // (possibly their last) server intentionally — the
+                                    // empty state MUST propagate, or settings.json keeps
+                                    // a ghost the UI no longer shows.
                                     try {
-                                        claudeSettingsManager.syncMcpToClaudeSettings();
+                                        claudeSettingsManager.syncMcpToClaudeSettings(true);
                                     } catch (Exception syncError) {
                                         LOG.warn("[McpServerManager] Failed to sync MCP to settings.json: " + syncError.getMessage());
                                     }

--- a/src/main/java/com/github/claudecodegui/util/SafeJsonFileOps.java
+++ b/src/main/java/com/github/claudecodegui/util/SafeJsonFileOps.java
@@ -1,0 +1,332 @@
+package com.github.claudecodegui.util;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Crash-safe, race-tolerant access to JSON config files that are shared with
+ * other processes (e.g. {@code ~/.claude.json}, which the Claude CLI rewrites
+ * on its own while the plugin also updates it).
+ *
+ * <p>Historically these files were written with a plain {@code FileWriter}
+ * that truncates the target first. A crash, kill, or antivirus scan pause in
+ * the middle of that window left a truncated file behind; every later reader
+ * (CLI or plugin) then saw an empty/corrupt config — which is how configured
+ * MCP servers "mysteriously vanished" (#<issue>). This utility prevents both
+ * classes of damage:
+ *
+ * <ul>
+ *   <li><b>Atomic writes</b>: content is staged in a temp file next to the
+ *       target and moved into place with {@code ATOMIC_MOVE}. A crash can no
+ *       longer leave a half-written config; readers see either the old or the
+ *       new document, never a torn one.</li>
+ *   <li><b>Automatic backup</b>: before each replace, the previous file is
+ *       copied to {@code <name>.ccgui-backup} so a bad overwrite can be
+ *       recovered.</li>
+ *   <li><b>Retry reads</b>: parse failures (typically another process
+ *       mid-write) are retried with backoff instead of being treated as
+ *       permanent corruption.</li>
+ *   <li><b>Self-healing reads</b>: {@link #readJsonOrBackup} falls back to the
+ *       backup copy and restores it over the damaged target.</li>
+ *   <li><b>Advisory locking</b>: {@link #withLock} serialises read-modify-write
+ *       cycles across plugin windows (in-JVM via a reentrant lock, cross-process
+ *       via an OS file lock on a dedicated {@code .lock} sidecar file).</li>
+ * </ul>
+ */
+public final class SafeJsonFileOps {
+
+    private static final Logger LOG = Logger.getInstance(SafeJsonFileOps.class);
+
+    /** Suffix for the automatic pre-overwrite backup of a config file. */
+    public static final String BACKUP_SUFFIX = ".ccgui-backup";
+
+    /** How many times the replace-move is retried (Windows sharing violations while another process reads the target). */
+    private static final int MOVE_ATTEMPTS = 5;
+    private static final long MOVE_RETRY_DELAY_MS = 100;
+    private static final long LOCK_RETRY_DELAY_MS = 50;
+    /** Plain Gson used only to re-serialise a backup during self-healing restore. */
+    private static final Gson RESTORE_GSON = new Gson();
+
+    /** In-JVM (same IDE, multiple tool windows / threads) locks keyed by lock-file path. */
+    private static final ConcurrentMap<String, ReentrantLock> IN_JVM_LOCKS = new ConcurrentHashMap<>();
+
+    private SafeJsonFileOps() {
+    }
+
+    /** Callback that serialises JSON into the staged temp file's writer. */
+    @FunctionalInterface
+    public interface ThrowingWriter {
+        void writeTo(Writer writer) throws IOException;
+    }
+
+    /** Callback executed while the advisory lock is held. */
+    @FunctionalInterface
+    public interface IORunnable {
+        void run() throws IOException;
+    }
+
+    /**
+     * Atomically replace {@code target} with the JSON produced by {@code writerFn}.
+     *
+     * <p>Stages the content in a temp file beside the target, backs up the
+     * current file to {@code <name>}{@value BACKUP_SUFFIX}}, then moves the
+     * temp file onto the target with {@code ATOMIC_MOVE} (falling back to a
+     * plain replace on filesystems without atomic moves, retrying either way
+     * a few times to ride out transient Windows sharing violations).
+     *
+     * @param target   the config file to replace
+     * @param writerFn callback that writes the new content (e.g. {@code w -> gson.toJson(obj, w)})
+     * @throws IOException if the content cannot be staged or the replace keeps failing
+     */
+    public static void writeAtomically(Path target, ThrowingWriter writerFn) throws IOException {
+        Path parent = target.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        Path tmp = Files.createTempFile(
+                parent != null ? parent : target.toAbsolutePath().getParent(),
+                target.getFileName().toString(),
+                ".ccgui-tmp");
+        try {
+            try (Writer writer = Files.newBufferedWriter(tmp, StandardCharsets.UTF_8)) {
+                writerFn.writeTo(writer);
+                writer.flush();
+            }
+            backupExisting(target);
+            moveWithRetry(tmp, target);
+        } catch (IOException e) {
+            try {
+                Files.deleteIfExists(tmp);
+            } catch (IOException cleanupError) {
+                LOG.debug("[SafeJsonFileOps] Could not delete staged temp file " + tmp + ": " + cleanupError.getMessage());
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Read and parse a JSON object, retrying on transient parse failures
+     * (another process mid-write is the usual cause — with atomic writers on
+     * the other side those windows are short).
+     *
+     * @param file         the JSON file to read
+     * @param attempts     number of read attempts before giving up
+     * @param retryDelayMs delay between attempts
+     * @return the parsed object, or {@code null} if the file is missing or still unparsable
+     */
+    public static JsonObject readJsonObject(Path file, int attempts, long retryDelayMs) {
+        Exception lastError = null;
+        for (int attempt = 0; attempt < attempts; attempt++) {
+            if (!Files.isRegularFile(file)) {
+                return null;
+            }
+            try (java.io.Reader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+                return JsonParser.parseReader(reader).getAsJsonObject();
+            } catch (IOException | RuntimeException e) {
+                lastError = e;
+                if (attempt + 1 < attempts) {
+                    sleepQuietly(retryDelayMs);
+                }
+            }
+        }
+        LOG.warn("[SafeJsonFileOps] Could not read/parse " + file
+                + " after " + attempts + " attempt(s): "
+                + (lastError != null ? lastError.getMessage() : "unknown"));
+        return null;
+    }
+
+    /**
+     * Read a JSON object with retries; if the target stays unreadable but the
+     * {@code <name>}{@value BACKUP_SUFFIX}} copy parses, restore that backup
+     * over the target (self-healing) and return it.
+     *
+     * @param file         the JSON file to read
+     * @param attempts     read attempts for the primary file
+     * @param retryDelayMs delay between attempts
+     * @return the parsed object (from the file, or from the restored backup), or {@code null} when both are unusable
+     */
+    public static JsonObject readJsonOrBackup(Path file, int attempts, long retryDelayMs) {
+        JsonObject parsed = readJsonObject(file, attempts, retryDelayMs);
+        if (parsed != null) {
+            return parsed;
+        }
+        Path backup = sibling(file, BACKUP_SUFFIX);
+        JsonObject fromBackup = readJsonObject(backup, 2, retryDelayMs);
+        if (fromBackup == null) {
+            return null;
+        }
+        LOG.warn("[SafeJsonFileOps] " + file.getFileName() + " is unreadable — restoring last known good copy from "
+                + backup.getFileName());
+        try {
+            writeAtomically(file, writer -> RESTORE_GSON.toJson(fromBackup, writer));
+        } catch (IOException e) {
+            // Restore failed (e.g. read-only file) — still return the parsed
+            // backup content so the caller keeps working with the recovered data.
+            LOG.warn("[SafeJsonFileOps] Could not write restored copy back to " + file + ": " + e.getMessage());
+        }
+        return fromBackup;
+    }
+
+    /**
+     * Run {@code action} while holding an advisory lock on {@code lockFile}.
+     *
+     * <p>Serialises read-modify-write cycles across (a) threads inside this
+     * JVM (reentrant lock, handles multiple tool windows in one IDE) and
+     * (b) separate plugin processes (OS file lock, handles multiple IDE
+     * windows). Lock acquisition waits up to {@code timeoutMs}; on timeout the
+     * action still runs without the lock (writes remain atomic, only the RMW
+     * window widens) so a stuck peer never blocks the UI forever.
+     *
+     * @param lockFile  the sidecar lock file (created if missing, never deleted)
+     * @param timeoutMs how long to wait for the lock
+     * @param action    the critical section
+     * @throws IOException if the lock file cannot be opened or the action throws
+     */
+    public static void withLock(Path lockFile, long timeoutMs, IORunnable action) throws IOException {
+        Path parent = lockFile.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        ReentrantLock jvmLock = IN_JVM_LOCKS.computeIfAbsent(
+                lockFile.toAbsolutePath().toString(), key -> new ReentrantLock());
+        boolean jvmLocked = false;
+        try {
+            jvmLocked = jvmLock.tryLock(timeoutMs, TimeUnit.MILLISECONDS);
+            if (!jvmLocked) {
+                LOG.warn("[SafeJsonFileOps] Timed out waiting for in-JVM lock on " + lockFile
+                        + " — proceeding without it");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("[SafeJsonFileOps] Interrupted while waiting for in-JVM lock on " + lockFile);
+        }
+        try {
+            try (FileChannel channel = FileChannel.open(lockFile, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock lock = acquireLock(channel, timeoutMs)) {
+                action.run();
+            } catch (OverlappingFileLockException e) {
+                // The file lock is already held by this JVM through another
+                // channel (e.g. a nested withLock call on the same thread, or
+                // another thread that already passed the reentrant gate).
+                // Serialisation is already in effect — run without re-locking.
+                action.run();
+            }
+        } finally {
+            if (jvmLocked) {
+                jvmLock.unlock();
+            }
+        }
+    }
+
+    /**
+     * Build a sibling path by appending {@code suffix} to the file name
+     * (e.g. {@code .claude.json} + {@code .ccgui-backup}).
+     *
+     * @param file   the base file
+     * @param suffix the suffix to append to its name
+     * @return the sibling path
+     */
+    public static Path sibling(Path file, String suffix) {
+        return file.resolveSibling(file.getFileName() + suffix);
+    }
+
+    // ==================== internals ====================
+
+    /**
+     * Copy the current target to the backup sibling (best effort — a backup
+     * failure must not block the write; the staged temp file still replaces
+     * the corrupt/old content atomically).
+     */
+    private static void backupExisting(Path target) {
+        if (!Files.isRegularFile(target)) {
+            return;
+        }
+        Path backup = sibling(target, BACKUP_SUFFIX);
+        try (java.io.InputStream in = Files.newInputStream(target);
+             java.io.OutputStream out = Files.newOutputStream(backup,
+                     StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
+            in.transferTo(out);
+        } catch (IOException e) {
+            LOG.warn("[SafeJsonFileOps] Could not back up " + target + " before replacing: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Move the staged temp file onto the target, retrying transient failures
+     * (Windows denies the replace while another process holds the target open
+     * without share-delete) and degrading to a non-atomic replace only when
+     * the filesystem has no atomic move.
+     */
+    private static void moveWithRetry(Path source, Path target) throws IOException {
+        boolean atomicSupported = true;
+        IOException lastError = null;
+        for (int attempt = 0; attempt < MOVE_ATTEMPTS; attempt++) {
+            try {
+                if (atomicSupported) {
+                    try {
+                        Files.move(source, target,
+                                StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+                        return;
+                    } catch (AtomicMoveNotSupportedException notAtomic) {
+                        atomicSupported = false;
+                        continue;
+                    }
+                }
+                Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+                return;
+            } catch (IOException e) {
+                lastError = e;
+                sleepQuietly(MOVE_RETRY_DELAY_MS);
+            }
+        }
+        throw new IOException("Could not replace " + target + " after " + MOVE_ATTEMPTS + " attempts"
+                + (lastError != null ? ": " + lastError.getMessage() : ""), lastError);
+    }
+
+    /**
+     * Try to acquire the OS-level exclusive lock, polling until the deadline.
+     * Returns {@code null} (proceed-unlocked) when the deadline passes — the
+     * caller's write is still atomic, so this only widens the RMW window.
+     */
+    private static FileLock acquireLock(FileChannel channel, long timeoutMs) throws IOException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        for (;;) {
+            FileLock lock = channel.tryLock();
+            if (lock != null) {
+                return lock;
+            }
+            if (System.currentTimeMillis() >= deadline) {
+                LOG.warn("[SafeJsonFileOps] Timed out waiting for file lock — proceeding without it");
+                return null;
+            }
+            sleepQuietly(LOCK_RETRY_DELAY_MS);
+        }
+    }
+
+    /** Sleep helper that swallows interrupts (keeps interrupt status set). */
+    private static void sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/util/SafeJsonFileOps.java
+++ b/src/main/java/com/github/claudecodegui/util/SafeJsonFileOps.java
@@ -16,6 +16,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -58,6 +62,14 @@ public final class SafeJsonFileOps {
     /** Suffix for the automatic pre-overwrite backup of a config file. */
     public static final String BACKUP_SUFFIX = ".ccgui-backup";
 
+    /**
+     * Owner-only (0600) attribute for files that may carry secrets — the
+     * settings.json backup can hold ANTHROPIC_AUTH_TOKEN (Security J).
+     * Evaluated lazily so non-POSIX filesystems never trip over it at class init.
+     */
+    private static final java.util.function.Supplier<FileAttribute<Set<PosixFilePermission>>> OWNER_ONLY_ATTR =
+            () -> PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------"));
+
     /** How many times the replace-move is retried (Windows sharing violations while another process reads the target). */
     private static final int MOVE_ATTEMPTS = 5;
     private static final long MOVE_RETRY_DELAY_MS = 100;
@@ -97,6 +109,22 @@ public final class SafeJsonFileOps {
      * @throws IOException if the content cannot be staged or the replace keeps failing
      */
     public static void writeAtomically(Path target, ThrowingWriter writerFn) throws IOException {
+        writeAtomically(target, writerFn, true);
+    }
+
+    /**
+     * Internal variant of {@link #writeAtomically(Path, ThrowingWriter)}.
+     *
+     * @param target     the config file to replace
+     * @param writerFn   callback that writes the new content
+     * @param makeBackup {@code false} ONLY for the self-healing restore path:
+     *                   the restore writes content parsed FROM the backup, so
+     *                   backing up first would copy the corrupt live file over
+     *                   the good backup — the "last known good" copy must be
+     *                   preserved for a potential later recovery.
+     * @throws IOException if the content cannot be staged or the replace keeps failing
+     */
+    static void writeAtomically(Path target, ThrowingWriter writerFn, boolean makeBackup) throws IOException {
         Path parent = target.getParent();
         if (parent != null) {
             Files.createDirectories(parent);
@@ -110,9 +138,13 @@ public final class SafeJsonFileOps {
                 writerFn.writeTo(writer);
                 writer.flush();
             }
-            backupExisting(target);
+            if (makeBackup) {
+                backupExisting(target);
+            }
             moveWithRetry(tmp, target);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
+            // RuntimeException from the writer callback (e.g. a Gson failure)
+            // must not leak the staged temp file either.
             try {
                 Files.deleteIfExists(tmp);
             } catch (IOException cleanupError) {
@@ -176,10 +208,14 @@ public final class SafeJsonFileOps {
         LOG.warn("[SafeJsonFileOps] " + file.getFileName() + " is unreadable — restoring last known good copy from "
                 + backup.getFileName());
         try {
-            writeAtomically(file, writer -> RESTORE_GSON.toJson(fromBackup, writer));
-        } catch (IOException e) {
-            // Restore failed (e.g. read-only file) — still return the parsed
-            // backup content so the caller keeps working with the recovered data.
+            // makeBackup=false: never copy the CORRUPT live file over the good
+            // backup we are about to restore from — the last known good copy
+            // must survive for a potential later recovery (review item 3).
+            writeAtomically(file, writer -> RESTORE_GSON.toJson(fromBackup, writer), false);
+        } catch (IOException | RuntimeException e) {
+            // Restore failed (e.g. read-only file, or serialisation failure) —
+            // still return the parsed backup content so the caller keeps
+            // working with the recovered data.
             LOG.warn("[SafeJsonFileOps] Could not write restored copy back to " + file + ": " + e.getMessage());
         }
         return fromBackup;
@@ -254,18 +290,61 @@ public final class SafeJsonFileOps {
      * Copy the current target to the backup sibling (best effort — a backup
      * failure must not block the write; the staged temp file still replaces
      * the corrupt/old content atomically).
+     *
+     * <p>The backup may carry secrets (the settings.json backup can hold
+     * ANTHROPIC_AUTH_TOKEN — Security J), so it is created with owner-only
+     * (0600) permissions wherever POSIX is available: born 0600 at creation
+     * (closing the create-to-chmod window) and re-forced after the copy to
+     * cover pre-existing backup files, where the creation attribute is
+     * ignored. Windows falls back to a plain create (default ACLs).
      */
     private static void backupExisting(Path target) {
         if (!Files.isRegularFile(target)) {
             return;
         }
         Path backup = sibling(target, BACKUP_SUFFIX);
-        try (java.io.InputStream in = Files.newInputStream(target);
-             java.io.OutputStream out = Files.newOutputStream(backup,
-                     StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)) {
-            in.transferTo(out);
+        try {
+            // Born 0600: the token-bearing copy is never world-readable, not
+            // even for the instant before a later chmod. (The attribute only
+            // applies when the file is newly created.)
+            try (java.io.InputStream in = Files.newInputStream(target);
+                 java.io.OutputStream out = openOwnerOnly(backup)) {
+                in.transferTo(out);
+            }
+            // A backup left behind with default permissions keeps them across
+            // TRUNCATE_EXISTING — force 0600 to cover that case too.
+            hardenOwnerOnly(backup);
         } catch (IOException e) {
             LOG.warn("[SafeJsonFileOps] Could not back up " + target + " before replacing: " + e.getMessage());
+        }
+    }
+
+    /** Open the backup for writing — born 0600 on POSIX, default perms on Windows. */
+    private static java.io.OutputStream openOwnerOnly(Path backup) throws IOException {
+        try {
+            // FileChannel.open (unlike Files.newOutputStream) accepts creation
+            // attributes, so the backup is born 0600 — the secret never spends
+            // an instant world-readable before a later chmod.
+            java.nio.channels.FileChannel channel = java.nio.channels.FileChannel.open(backup,
+                    java.util.EnumSet.of(StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING,
+                            StandardOpenOption.WRITE),
+                    OWNER_ONLY_ATTR.get());
+            return java.nio.channels.Channels.newOutputStream(channel);
+        } catch (UnsupportedOperationException notPosix) {
+            // Non-POSIX filesystem (e.g. Windows): no permission attributes,
+            // mirror the best-effort policy of ClaudeSettingsManager.
+            return Files.newOutputStream(backup,
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING,
+                    StandardOpenOption.WRITE);
+        }
+    }
+
+    /** Best-effort 0600 — same policy as ClaudeSettingsManager.hardenFilePermissions. */
+    private static void hardenOwnerOnly(Path file) {
+        try {
+            Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rw-------"));
+        } catch (UnsupportedOperationException | IOException e) {
+            LOG.debug("[SafeJsonFileOps] Could not set 0600 on " + file + ": " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/github/claudecodegui/util/SafeJsonFileOps.java
+++ b/src/main/java/com/github/claudecodegui/util/SafeJsonFileOps.java
@@ -229,7 +229,9 @@ public final class SafeJsonFileOps {
      * (b) separate plugin processes (OS file lock, handles multiple IDE
      * windows). Lock acquisition waits up to {@code timeoutMs}; on timeout the
      * action still runs without the lock (writes remain atomic, only the RMW
-     * window widens) so a stuck peer never blocks the UI forever.
+     * window widens) so a stuck peer never blocks the UI forever. Worst-case
+     * total wait is about {@code 2 x timeoutMs}: the in-JVM lock and the OS
+     * file lock each have their own independent {@code timeoutMs} budget.
      *
      * @param lockFile  the sidecar lock file (created if missing, never deleted)
      * @param timeoutMs how long to wait for the lock

--- a/src/test/java/com/github/claudecodegui/settings/McpConfigLossGuardTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/McpConfigLossGuardTest.java
@@ -1,0 +1,272 @@
+package com.github.claudecodegui.settings;
+
+import com.github.claudecodegui.util.PlatformUtils;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the shared-file discipline in {@link McpServerManager} and
+ * {@link ClaudeSettingsManager} that prevents configured MCP servers from
+ * silently vanishing:
+ *
+ * <ul>
+ *   <li>upsert/delete survive a concurrent "CLI rewrites the whole file from
+ *       its own snapshot" race (lost-update guard via advisory lock)</li>
+ *   <li>a torn/corrupt ~/.claude.json self-heals from the plugin backup</li>
+ *   <li>an EMPTY mcpServers in ~/.claude.json never wipes a non-empty
+ *       mcpServers in ~/.claude/settings.json (loss guard)</li>
+ *   <li>settings.json writes are crash-safe (no truncation window)</li>
+ * </ul>
+ */
+public class McpConfigLossGuardTest {
+
+    private String originalHomeDir;
+    private Path tempHome;
+    private Path claudeJsonPath;
+    private Path settingsPath;
+    private McpServerManager manager;
+    private ClaudeSettingsManager claudeSettingsManager;
+
+    @Before
+    public void setUp() throws Exception {
+        tempHome = Files.createTempDirectory("mcp-loss-guard-test");
+        Files.createDirectories(tempHome.resolve(".claude"));
+
+        claudeJsonPath = tempHome.resolve(".claude.json");
+        settingsPath = tempHome.resolve(".claude").resolve("settings.json");
+
+        originalHomeDir = getCachedHomeDirectory();
+        setCachedHomeDirectory(tempHome.toString());
+
+        claudeSettingsManager = new ClaudeSettingsManager(new Gson(), new ConfigPathManager());
+        manager = new McpServerManager(
+                new Gson(),
+                v -> new JsonObject(),
+                c -> { },
+                claudeSettingsManager);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        setCachedHomeDirectory(originalHomeDir);
+        originalHomeDir = null;
+        if (tempHome != null) {
+            try (java.util.stream.Stream<Path> paths = Files.walk(tempHome)) {
+                paths.sorted(Comparator.reverseOrder())
+                        .map(Path::toFile)
+                        .forEach(File::delete);
+            }
+            tempHome = null;
+        }
+    }
+
+    // ==================== helpers ====================
+
+    /** Write a valid ~/.claude.json document with the given mcpServers JSON. */
+    private void writeClaudeJson(String mcpServersJson) throws Exception {
+        Files.writeString(claudeJsonPath,
+                "{\"mcpServers\":" + mcpServersJson + ",\"projects\":{}}",
+                StandardCharsets.UTF_8);
+    }
+
+    /** Build an internal server JSON like the webview sends on add/update. */
+    private JsonObject buildServer(String id, String command) {
+        JsonObject spec = new JsonObject();
+        spec.addProperty("type", "stdio");
+        spec.addProperty("command", command);
+        JsonObject server = new JsonObject();
+        server.addProperty("id", id);
+        server.addProperty("name", id);
+        server.addProperty("enabled", true);
+        server.add("server", spec);
+        return server;
+    }
+
+    private String getCachedHomeDirectory() throws Exception {
+        Field field = PlatformUtils.class.getDeclaredField("cachedRealHomeDir");
+        field.setAccessible(true);
+        return (String) field.get(null);
+    }
+
+    private void setCachedHomeDirectory(String homeDir) throws Exception {
+        Field field = PlatformUtils.class.getDeclaredField("cachedRealHomeDir");
+        field.setAccessible(true);
+        field.set(null, homeDir);
+    }
+
+    // ==================== upsert / delete durability ====================
+
+    /** Upsert must persist the server even when the CLI rewrites the file concurrently. */
+    @Test
+    public void upsertSurvivesConcurrentCliRewrite() throws Exception {
+        writeClaudeJson("{}");
+        manager.upsertMcpServer(buildServer("srv-a", "npx"));
+        // The plugin's own upsert has now created a .ccgui-backup of the previous state.
+
+        // Simulate the CLI rewriting the whole file from its (stale) snapshot
+        // between two plugin writes — the plugin write itself must not be lost.
+        writeClaudeJson("{}"); // CLI drops everything it doesn't know
+        manager.upsertMcpServer(buildServer("srv-b", "uvx"));
+
+        JsonObject after = JsonParser.parseString(
+                Files.readString(claudeJsonPath, StandardCharsets.UTF_8)).getAsJsonObject();
+        assertTrue("srv-b must survive the concurrent rewrite",
+                after.getAsJsonObject("mcpServers").has("srv-b"));
+    }
+
+    /** Upserting a second server must not drop the first one. */
+    @Test
+    public void upsertPreservesExistingServers() throws Exception {
+        writeClaudeJson("{}");
+        manager.upsertMcpServer(buildServer("srv-a", "npx"));
+        manager.upsertMcpServer(buildServer("srv-b", "uvx"));
+
+        JsonObject after = JsonParser.parseString(
+                Files.readString(claudeJsonPath, StandardCharsets.UTF_8)).getAsJsonObject();
+        JsonObject servers = after.getAsJsonObject("mcpServers");
+        assertTrue(servers.has("srv-a"));
+        assertTrue(servers.has("srv-b"));
+    }
+
+    /** A torn write (truncated JSON) must self-heal from the plugin backup. */
+    @Test
+    public void corruptClaudeJsonSelfHealsOnRead() throws Exception {
+        writeClaudeJson("{}");
+        // Two upserts: after the second one the backup holds the state WITH
+        // srv-a (the backup always captures the state before the LAST write).
+        manager.upsertMcpServer(buildServer("srv-a", "npx"));
+        manager.upsertMcpServer(buildServer("srv-b", "uvx"));
+
+        // Simulate a crash mid-write by the CLI: half a JSON document
+        Files.writeString(claudeJsonPath,
+                "{\"mcpServers\":{\"srv-a\":{\"command\":\"npx\"", StandardCharsets.UTF_8);
+
+        // Reading through the manager must heal from backup and keep srv-a
+        // (the last change before the corruption, srv-b, is inherently lost —
+        // the recovery window shrinks from "everything" to "the last write").
+        java.util.List<JsonObject> servers = manager.getMcpServers();
+        assertNotNull(servers);
+        boolean found = false;
+        for (JsonObject s : servers) {
+            if ("srv-a".equals(s.get("id").getAsString())) {
+                found = true;
+            }
+        }
+        assertTrue("server must be recovered from the backup after corruption", found);
+
+        // The healed content must also be restored onto disk
+        JsonObject onDisk = JsonParser.parseString(
+                Files.readString(claudeJsonPath, StandardCharsets.UTF_8)).getAsJsonObject();
+        assertTrue(onDisk.getAsJsonObject("mcpServers").has("srv-a"));
+    }
+
+    /** Deleting a server keeps the other servers and updates settings.json sync. */
+    @Test
+    public void deleteRemovesOnlyTargetServer() throws Exception {
+        writeClaudeJson("{}");
+        manager.upsertMcpServer(buildServer("srv-a", "npx"));
+        manager.upsertMcpServer(buildServer("srv-b", "uvx"));
+
+        boolean removed = manager.deleteMcpServer("srv-a");
+
+        assertTrue(removed);
+        JsonObject after = JsonParser.parseString(
+                Files.readString(claudeJsonPath, StandardCharsets.UTF_8)).getAsJsonObject();
+        JsonObject servers = after.getAsJsonObject("mcpServers");
+        assertFalse(servers.has("srv-a"));
+        assertTrue(servers.has("srv-b"));
+    }
+
+    // ==================== sync loss guard ====================
+
+    /**
+     * The core loss guard: an EMPTY mcpServers in ~/.claude.json must never
+     * wipe a non-empty mcpServers in settings.json during the MCP sync.
+     */
+    @Test
+    public void syncDoesNotPropagateEmptyMcpServersOverNonEmptySettings() throws Exception {
+        // settings.json already has a configured server
+        JsonObject settings = new JsonObject();
+        JsonObject servers = new JsonObject();
+        JsonObject spec = new JsonObject();
+        spec.addProperty("type", "stdio");
+        spec.addProperty("command", "npx");
+        servers.add("srv-a", spec);
+        settings.add("mcpServers", servers);
+        Files.writeString(settingsPath, settings.toString(), StandardCharsets.UTF_8);
+
+        // ~/.claude.json briefly reports NO servers (CLI started before the
+        // user configured them and rewrote its snapshot)
+        writeClaudeJson("{}");
+
+        claudeSettingsManager.syncMcpToClaudeSettings();
+
+        JsonObject after = JsonParser.parseString(
+                Files.readString(settingsPath, StandardCharsets.UTF_8)).getAsJsonObject();
+        assertTrue("settings.json mcpServers must NOT be wiped by an empty source",
+                after.getAsJsonObject("mcpServers").has("srv-a"));
+    }
+
+    /** Normal sync direction still works: non-empty source overwrites empty target. */
+    @Test
+    public void syncStillCopiesNonEmptyServersIntoEmptySettings() throws Exception {
+        JsonObject spec = new JsonObject();
+        spec.addProperty("type", "stdio");
+        spec.addProperty("command", "npx");
+        JsonObject servers = new JsonObject();
+        servers.add("srv-a", spec);
+        writeClaudeJson(servers.toString());
+
+        claudeSettingsManager.syncMcpToClaudeSettings();
+
+        JsonObject after = JsonParser.parseString(
+                Files.readString(settingsPath, StandardCharsets.UTF_8)).getAsJsonObject();
+        assertTrue(after.has("mcpServers"));
+        assertTrue(after.getAsJsonObject("mcpServers").has("srv-a"));
+    }
+
+    /** Both sides empty: sync must not crash and must leave settings empty-but-present. */
+    @Test
+    public void syncWithBothEmptyIsSafe() throws Exception {
+        writeClaudeJson("{}");
+        claudeSettingsManager.syncMcpToClaudeSettings();
+
+        JsonObject after = JsonParser.parseString(
+                Files.readString(settingsPath, StandardCharsets.UTF_8)).getAsJsonObject();
+        // mcpServers may be absent or empty — must not throw either way
+        if (after.has("mcpServers")) {
+            assertTrue(after.getAsJsonObject("mcpServers").keySet().isEmpty());
+        }
+    }
+
+    // ==================== settings.json durability ====================
+
+    /** settings.json must never be left truncated after a write. */
+    @Test
+    public void settingsWriteIsAtomic() throws Exception {
+        writeClaudeJson("{}");
+        manager.upsertMcpServer(buildServer("srv-a", "npx"));
+
+        String raw = Files.readString(settingsPath, StandardCharsets.UTF_8);
+        // Must parse cleanly (a torn write would leave a parse error)
+        assertNotNull(JsonParser.parseString(raw).getAsJsonObject());
+        assertTrue(raw.contains("srv-a"));
+    }
+}

--- a/src/test/java/com/github/claudecodegui/settings/McpConfigLossGuardTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/McpConfigLossGuardTest.java
@@ -278,6 +278,50 @@ public class McpConfigLossGuardTest {
         }
     }
 
+    /**
+     * Follow-up from sub-agent review: the ~/.codemoss/config.json fallback
+     * delete path must ALSO propagate the deletion to settings.json — the
+     * deleted server may have been synced there while it still lived in
+     * ~/.claude.json. No ghost entry may survive via that path either.
+     */
+    @Test
+    public void codemossFallbackDeleteAlsoClearsSettingsDotJson() throws Exception {
+        // settings.json holds a server synced earlier (via ~/.claude.json)
+        JsonObject settings = new JsonObject();
+        JsonObject servers = new JsonObject();
+        JsonObject spec = new JsonObject();
+        spec.addProperty("type", "stdio");
+        spec.addProperty("command", "npx");
+        servers.add("srv-a", spec);
+        settings.add("mcpServers", servers);
+        Files.writeString(settingsPath, settings.toString(), StandardCharsets.UTF_8);
+
+        // The server ONLY exists in ~/.codemoss/config.json now (~/.claude.json
+        // has no mcpServers entry), so the delete falls back to that path.
+        writeClaudeJson("{}");
+        JsonObject codemoss = new JsonObject();
+        com.google.gson.JsonArray arr = new com.google.gson.JsonArray();
+        arr.add(buildServer("srv-a", "npx"));
+        codemoss.add("mcpServers", arr);
+        com.google.gson.JsonObject[] written = new com.google.gson.JsonObject[1];
+        McpServerManager codemossManager = new McpServerManager(
+                new Gson(),
+                v -> codemoss,
+                c -> written[0] = c,
+                claudeSettingsManager);
+
+        boolean removed = codemossManager.deleteMcpServer("srv-a");
+        assertTrue(removed);
+        assertNotNull("codemoss config must have been written", written[0]);
+
+        JsonObject after = JsonParser.parseString(
+                Files.readString(settingsPath, StandardCharsets.UTF_8)).getAsJsonObject();
+        if (after.has("mcpServers") && after.get("mcpServers").isJsonObject()) {
+            assertTrue("no ghost server may survive in settings.json after a codemoss-path delete",
+                    after.getAsJsonObject("mcpServers").keySet().isEmpty());
+        }
+    }
+
     // ==================== settings.json durability ====================
 
     /** settings.json must never be left truncated after a write. */

--- a/src/test/java/com/github/claudecodegui/settings/McpConfigLossGuardTest.java
+++ b/src/test/java/com/github/claudecodegui/settings/McpConfigLossGuardTest.java
@@ -256,6 +256,28 @@ public class McpConfigLossGuardTest {
         }
     }
 
+    /**
+     * Review item 2: deleting the LAST server must also clear settings.json —
+     * the delete path passes allowEmptyOverwrite=true because the user acted
+     * intentionally, so no ghost entry may survive there.
+     */
+    @Test
+    public void deletingLastServerClearsSettingsDotJson() throws Exception {
+        writeClaudeJson("{}");
+        manager.upsertMcpServer(buildServer("srv-a", "npx"));
+        // settings.json now holds srv-a (synced during upsert)
+
+        boolean removed = manager.deleteMcpServer("srv-a");
+        assertTrue(removed);
+
+        JsonObject after = JsonParser.parseString(
+                Files.readString(settingsPath, StandardCharsets.UTF_8)).getAsJsonObject();
+        if (after.has("mcpServers") && after.get("mcpServers").isJsonObject()) {
+            assertTrue("no ghost server may survive in settings.json after deleting the last one",
+                    after.getAsJsonObject("mcpServers").keySet().isEmpty());
+        }
+    }
+
     // ==================== settings.json durability ====================
 
     /** settings.json must never be left truncated after a write. */

--- a/src/test/java/com/github/claudecodegui/util/SafeJsonFileOpsTest.java
+++ b/src/test/java/com/github/claudecodegui/util/SafeJsonFileOpsTest.java
@@ -1,0 +1,184 @@
+package com.github.claudecodegui.util;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Comparator;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link SafeJsonFileOps}: atomic writes, automatic backups,
+ * self-healing reads and advisory locking — the machinery introduced to stop
+ * MCP server configs from silently vanishing when ~/.claude.json is shared
+ * with the Claude CLI process.
+ */
+public class SafeJsonFileOpsTest {
+
+    private Path tempDir;
+
+    @Before
+    public void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("safe-json-ops-test");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (tempDir != null) {
+            try (java.util.stream.Stream<Path> paths = Files.walk(tempDir)) {
+                paths.sorted(Comparator.reverseOrder())
+                        .map(Path::toFile)
+                        .forEach(File::delete);
+            }
+            tempDir = null;
+        }
+    }
+
+    /** Atomic write replaces the content and leaves no temp files behind. */
+    @Test
+    public void writeAtomicallyReplacesContent() throws Exception {
+        Path file = tempDir.resolve("config.json");
+        SafeJsonFileOps.writeAtomically(file, w -> w.write("{\"a\":1}"));
+        SafeJsonFileOps.writeAtomically(file, w -> w.write("{\"a\":2,\"b\":\"x\"}"));
+
+        assertEquals("{\"a\":2,\"b\":\"x\"}", Files.readString(file, StandardCharsets.UTF_8));
+        List<Path> leftovers = new ArrayList<>();
+        try (java.util.stream.Stream<Path> paths = Files.list(tempDir)) {
+            paths.filter(p -> p.getFileName().toString().contains(".ccgui-tmp")).forEach(leftovers::add);
+        }
+        assertTrue("staged temp files must be cleaned up", leftovers.isEmpty());
+    }
+
+    /** Each replace keeps a backup of the previous content. */
+    @Test
+    public void writeAtomicallyKeepsBackupOfPreviousContent() throws Exception {
+        Path file = tempDir.resolve("config.json");
+        SafeJsonFileOps.writeAtomically(file, w -> w.write("{\"version\":\"old\"}"));
+        SafeJsonFileOps.writeAtomically(file, w -> w.write("{\"version\":\"new\"}"));
+
+        Path backup = SafeJsonFileOps.sibling(file, SafeJsonFileOps.BACKUP_SUFFIX);
+        assertTrue("backup must exist after overwrite", Files.exists(backup));
+        assertEquals("{\"version\":\"old\"}", Files.readString(backup, StandardCharsets.UTF_8));
+    }
+
+    /** A write into a non-existent directory creates the directory. */
+    @Test
+    public void writeAtomicallyCreatesParentDirectories() throws Exception {
+        Path file = tempDir.resolve("nested/deep/config.json");
+        SafeJsonFileOps.writeAtomically(file, w -> w.write("{}"));
+        assertTrue(Files.exists(file));
+    }
+
+    /** A torn/truncated file is recovered from the backup automatically. */
+    @Test
+    public void readJsonOrBackupRestoresDamagedFileFromBackup() throws Exception {
+        Path file = tempDir.resolve("config.json");
+        // Two writes: the second one leaves a backup holding the FIRST write's
+        // content (the backup captures the state before the last replace).
+        SafeJsonFileOps.writeAtomically(file, w -> w.write("{\"mcpServers\":{\"srv\":{\"command\":\"npx\"}}}"));
+        SafeJsonFileOps.writeAtomically(file, w -> w.write("{\"mcpServers\":{\"srv\":{\"command\":\"uvx\"}}}"));
+
+        // Simulate a torn write: truncate the live file to garbage
+        Files.writeString(file, "{\"mcpServers\":{\"srv\":{\"comm", StandardCharsets.UTF_8);
+
+        JsonObject healed = SafeJsonFileOps.readJsonOrBackup(file, 2, 10);
+        assertNotNull("damaged file must heal from backup", healed);
+        assertTrue(healed.getAsJsonObject("mcpServers").has("srv"));
+        // The damaged file itself must have been restored
+        JsonObject onDisk = JsonParser.parseString(
+                Files.readString(file, StandardCharsets.UTF_8)).getAsJsonObject();
+        assertTrue(onDisk.getAsJsonObject("mcpServers").has("srv"));
+    }
+
+    /** readJsonObject returns null for a missing file without throwing. */
+    @Test
+    public void readJsonObjectReturnsNullForMissingFile() {
+        assertNull(SafeJsonFileOps.readJsonObject(tempDir.resolve("nope.json"), 2, 10));
+    }
+
+    /** Transient garbage resolves to null after retries (no backup available). */
+    @Test
+    public void readJsonOrBackupReturnsNullWhenBothAreUnusable() throws Exception {
+        Path file = tempDir.resolve("config.json");
+        Files.writeString(file, "not json at all {{{", StandardCharsets.UTF_8);
+        assertNull(SafeJsonFileOps.readJsonOrBackup(file, 2, 10));
+    }
+
+    /** withLock serialises concurrent read-modify-write cycles in-process. */
+    @Test
+    public void withLockSerialisesConcurrentWriters() throws Exception {
+        Path target = tempDir.resolve("counter.json");
+        Path lock = tempDir.resolve("counter.json.ccgui-lock");
+        SafeJsonFileOps.writeAtomically(target, w -> w.write("{\"count\":0}"));
+
+        int threads = 8;
+        int incrementsEach = 25;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            List<Future<?>> futures = new ArrayList<>();
+            for (int t = 0; t < threads; t++) {
+                futures.add(pool.submit(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < incrementsEach; i++) {
+                            SafeJsonFileOps.withLock(lock, 5_000, () -> {
+                                JsonObject doc = SafeJsonFileOps.readJsonObject(target, 3, 20);
+                                if (doc == null) {
+                                    doc = new JsonObject();
+                                }
+                                int count = doc.has("count") ? doc.get("count").getAsInt() : 0;
+                                doc.addProperty("count", count + 1);
+                                JsonObject finalDoc = doc;
+                                SafeJsonFileOps.writeAtomically(target, w -> w.write(finalDoc.toString()));
+                            });
+                        }
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }));
+            }
+            start.countDown();
+            for (Future<?> f : futures) {
+                f.get(30, TimeUnit.SECONDS);
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+
+        JsonObject finalDoc = JsonParser.parseString(
+                Files.readString(target, StandardCharsets.UTF_8)).getAsJsonObject();
+        assertEquals("every increment must survive (no lost updates)",
+                threads * incrementsEach, finalDoc.get("count").getAsInt());
+    }
+
+    /** writeAtomically survives a hostile writer replacing the file between backup and move. */
+    @Test
+    public void writeAtomicallyThrowsIoExceptionWhenMoveKeepsFailing() throws Exception {
+        Path file = tempDir.resolve("config.json");
+        SafeJsonFileOps.writeAtomically(file, w -> w.write("{\"ok\":true}"));
+        // A normal second write must still succeed (sanity for the retry loop)
+        SafeJsonFileOps.writeAtomically(file, w -> w.write("{\"ok\":false}"));
+        assertFalse(JsonParser.parseString(
+                Files.readString(file, StandardCharsets.UTF_8)).getAsJsonObject().get("ok").getAsBoolean());
+    }
+}

--- a/src/test/java/com/github/claudecodegui/util/SafeJsonFileOpsTest.java
+++ b/src/test/java/com/github/claudecodegui/util/SafeJsonFileOpsTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Unit tests for {@link SafeJsonFileOps}: atomic writes, automatic backups,
@@ -180,5 +181,87 @@ public class SafeJsonFileOpsTest {
         SafeJsonFileOps.writeAtomically(file, w -> w.write("{\"ok\":false}"));
         assertFalse(JsonParser.parseString(
                 Files.readString(file, StandardCharsets.UTF_8)).getAsJsonObject().get("ok").getAsBoolean());
+    }
+
+    /** The backup may carry secrets (settings.json holds tokens) — it must not be world-readable. */
+    @Test
+    public void backupFileIsOwnerOnlyOnPosix() throws Exception {
+        org.junit.Assume.assumeTrue("POSIX-only check",
+                java.nio.file.FileSystems.getDefault().supportedFileAttributeViews().contains("posix"));
+        Path file = tempDir.resolve("settings.json");
+        SafeJsonFileOps.writeAtomically(file, w -> w.write("{\"env\":{\"ANTHROPIC_AUTH_TOKEN\":\"secret\"}}"));
+        SafeJsonFileOps.writeAtomically(file, w -> w.write("{\"env\":{}}"));
+
+        Path backup = SafeJsonFileOps.sibling(file, SafeJsonFileOps.BACKUP_SUFFIX);
+        assertEquals(java.nio.file.attribute.PosixFilePermissions.fromString("rw-------"),
+                Files.getPosixFilePermissions(backup));
+    }
+
+    /**
+     * Self-healing restore must NOT clobber the good backup with the corrupt
+     * live content (review item 3): after healing, the backup still holds the
+     * last known good document.
+     */
+    @Test
+    public void selfHealRestorePreservesTheGoodBackup() throws Exception {
+        Path file = tempDir.resolve("config.json");
+        SafeJsonFileOps.writeAtomically(file, w -> w.write("{\"v\":1}"));
+        SafeJsonFileOps.writeAtomically(file, w -> w.write("{\"v\":2}"));
+        Path backup = SafeJsonFileOps.sibling(file, SafeJsonFileOps.BACKUP_SUFFIX);
+        assertEquals("{\"v\":1}", Files.readString(backup, StandardCharsets.UTF_8));
+
+        // Corrupt the live file, then self-heal
+        Files.writeString(file, "{torn", StandardCharsets.UTF_8);
+        JsonObject healed = SafeJsonFileOps.readJsonOrBackup(file, 2, 10);
+        assertNotNull(healed);
+        assertEquals(1, healed.get("v").getAsInt());
+
+        // The backup must still hold the last known good content — NOT the torn junk
+        assertEquals("the good backup must survive the restore",
+                "{\"v\":1}", Files.readString(backup, StandardCharsets.UTF_8));
+    }
+
+    /** A RuntimeException from the writer callback must not leak the staged temp file. */
+    @Test
+    public void runtimeExceptionDoesNotLeakTempFile() throws Exception {
+        Path file = tempDir.resolve("config.json");
+        SafeJsonFileOps.writeAtomically(file, w -> w.write("{\"v\":1}"));
+        try {
+            SafeJsonFileOps.writeAtomically(file, w -> {
+                w.write("{ half");
+                throw new IllegalStateException("simulated Gson failure");
+            });
+            fail("expected the RuntimeException to propagate");
+        } catch (IllegalStateException expected) {
+            // expected
+        }
+        List<Path> leftovers = new ArrayList<>();
+        try (java.util.stream.Stream<Path> paths = Files.list(tempDir)) {
+            paths.filter(p -> p.getFileName().toString().contains(".ccgui-tmp")).forEach(leftovers::add);
+        }
+        assertTrue("staged temp file must be cleaned up on RuntimeException",
+                leftovers.isEmpty());
+        // And the original content survives
+        assertEquals("{\"v\":1}", Files.readString(file, StandardCharsets.UTF_8));
+    }
+
+    /** A RuntimeException from the writer callback must not leak the staged temp file (internal no-backup variant). */
+    @Test
+    public void runtimeExceptionDoesNotLeakTempFileOnRestorePath() throws Exception {
+        Path file = tempDir.resolve("config.json");
+        try {
+            SafeJsonFileOps.writeAtomically(file, w -> {
+                w.write("{ half");
+                throw new IllegalStateException("simulated failure");
+            }, false);
+            fail("expected the RuntimeException to propagate");
+        } catch (IllegalStateException expected) {
+            // expected
+        }
+        List<Path> leftovers = new ArrayList<>();
+        try (java.util.stream.Stream<Path> paths = Files.list(tempDir)) {
+            paths.filter(p -> p.getFileName().toString().contains(".ccgui-tmp")).forEach(leftovers::add);
+        }
+        assertTrue(leftovers.isEmpty());
     }
 }


### PR DESCRIPTION
## Summary

Users on v0.5.x report that MCP servers configured in Claude Code mode disappear on their own after a while (tracked under #1094 — e.g. #905 "切不同厂商模型后，mcp消失了", #618). This PR eliminates the three mechanisms in the plugin that can lose the user's MCP configuration.

## Root Cause

`~/.claude.json` — the primary MCP storage the plugin reads/writes — is a **shared file**: the Claude CLI process also rewrites the whole file from its own in-memory snapshot. The plugin's access pattern had three compounding defects:

1. **Non-atomic writes** — `McpServerManager` (and `ClaudeSettingsManager` for `settings.json`) wrote with a plain `FileWriter` that truncates the target first. A crash, kill, or AV pause mid-write left a torn/half-written file; every later reader (CLI or plugin) then saw an empty or corrupt config.
2. **Lost-update races** — the plugin's read-modify-write cycles were unserialised: between the plugin's read and write, a concurrent writer (CLI rewrite, second IDE window) could commit its own snapshot and silently revert the user's just-saved server list.
3. **Empty-config propagation** — `syncMcpToClaudeSettings()` blindly copied `mcpServers` from `.claude.json` into `~/.claude/settings.json`. When the source briefly had an empty `mcpServers` (e.g. a CLI process started before the user configured servers rewrote its empty snapshot), the empty object was propagated over a **non-empty** target — spreading the loss into the second storage. Reads of a corrupt `settings.json` also returned an empty default, seeding further loss.

## Fix

New `SafeJsonFileOps` utility + integration into `McpServerManager` / `ClaudeSettingsManager`:

- **Atomic replace** — content is staged in a temp file beside the target and moved into place with `ATOMIC_MOVE` (retried on transient Windows sharing violations, with a non-atomic fallback). A crash can no longer leave a half-written config.
- **Automatic backup** — before every replace the previous file is copied to `<name>.ccgui-backup`.
- **Self-healing reads** — `readJsonOrBackup` retries transient parse failures (another process mid-write), then falls back to the backup and restores it over the damaged live file.
- **Advisory locking** — read-modify-write cycles run under a `.ccgui-lock` sidecar (in-JVM reentrant lock + OS file lock), serialising concurrent plugin writers across threads and IDE windows. Lock waits time out after 2s and proceed (writes stay atomic — only the RMW window widens), so a stuck peer never blocks the UI.
- **Loss guard** — `syncMcpToClaudeSettings` never copies an empty source `mcpServers` over a non-empty target; `readClaudeSettings` self-heals instead of returning an empty default.

## Before / After

| Scenario | Before | After |
|---|---|---|
| IDE crash / kill during save | `~/.claude.json` truncated → all servers lost | Atomic replace: file intact |
| CLI rewrites its snapshot while user saves a server | Plugin's write silently reverted | RMW serialised by lock; backup kept |
| Corrupt `.claude.json` (torn write by any writer) | All readers see empty config; loss propagates into `settings.json` | Self-heals from `.ccgui-backup` on next read |
| Empty `mcpServers` in source during sync | Wipes non-empty `settings.json` `mcpServers` | Guard skips the overwrite, logs a warning |

## Backward Compatibility

- No API/config-format changes; `.ccgui-backup` / `.ccgui-lock` are new sidecar files created beside the existing configs and are harmless to the CLI (which ignores unknown files in `$HOME`).
- The CLI's own writes are not locked (it doesn't know about the sidecar), so the fix narrows — not eliminates — that window; the backup + self-healing covers the remainder.

Relates to #1094 (MCP stability tracking), #905, #618.