### PR TITLE
fix(commit-message): disable thinking on Claude ask path for reasoning models

### DIFF
--- a/ai-bridge/services/commit-message.js
+++ b/ai-bridge/services/commit-message.js
@@ -154,6 +154,9 @@ async function generateWithClaudeAsk(prompt, model, config) {
   const stream = client.messages.stream({
     model: modelId,
     max_tokens: 1024,
+    // Reasoning models (e.g. DeepSeek) otherwise emit only `thinking` blocks and
+    // never a `text` answer, leaving the commit message empty.
+    thinking: { type: 'disabled' },
     messages: [{ role: 'user', content: prompt }],
   });
 


### PR DESCRIPTION
Fixes #1693

## Problem

When the model is mapped to a reasoning model (e.g. DeepSeek via an
Anthropic-compatible endpoint / third-party relay API), the commit-message
"ask" path calls the bare Anthropic SDK `messages.stream()` with no thinking
control. The model emits only `thinking` content blocks and never a `text`
block, so `stream.on('text')` never fires and the `finalMessage` fallback finds
no `type === 'text'` block — generation fails with `Claude commit response is
empty`.

## Root cause

Reasoning models default to thinking. The chat path avoids this because it goes
through the Agent SDK with `disableThinking` / `reasoningEffort` control, but the
commit "ask" path has no such control.

## Fix

Add `thinking: { type: 'disabled' }` to the `messages.stream()` call so the model
always returns a plain-text commit message. `max_tokens` stays at 1024.

## Verification

- `node --test ai-bridge/services/commit-message.test.js` → 3/3 pass
