### PR TITLE
feat(claude) Claude 增加国产厂商coding plan用量查询

### DIFF
--- a/docs/plans/2026-09-02-claude-relay-usage-vendors.md
+++ b/docs/plans/2026-09-02-claude-relay-usage-vendors.md
@@ -1,0 +1,88 @@
+# Claude 中转厂商用量查询扩展（多厂商接入）
+
+- 日期：2026-09-02
+- 分支：`feature/v0.5.6`
+- 状态：阶段一已完成（单测全绿；`CliStatusDetectorLoginShellTest` 为预存的环境相关失败，与本特性无关）
+
+## 1. 背景与目标
+
+`ClaudePlanUsageService` 目前只识别 z.ai / bigmodel.cn 一种中转后端，命中后探测
+`{origin}/api/monitor/usage/quota/limit`；其余后端回落到 SDK `rate_limit_event` 缓存。
+
+目标：把"识别后端 → 探测厂商 API → 解析为 capacity payload"抽象为可插拔的
+`RelayUsageVendor` SPI，按 `ANTHROPIC_BASE_URL` host 匹配分发，分阶段接入国内厂商。
+输出契约（`capacity_pct` + `windows[]{id, used_pct, reset_at, period_type}`，见
+`webview/src/utils/planUsagePace.ts` 的 `parseCapacityPayload`）保持不变，webview 零改动。
+
+## 2. 厂商能力矩阵
+
+| 厂商 | 用量 API | 认证 | 数据形态 | 阶段 |
+|---|---|---|---|---|
+| 智谱 GLM（z.ai / bigmodel.cn） | `{origin}/api/monitor/usage/quota/limit` | 现有 `ANTHROPIC_AUTH_TOKEN`/`ANTHROPIC_API_KEY` | 5h/7d/月 百分比 | 已有 → 迁入 SPI |
+| MiniMax Coding Plan（minimaxi.com / minimax.io） | `{origin}/v1/api/openplatform/coding_plan/remains` | 同上（Bearer） | 5h/7d/月 剩余% | **一** |
+| Kimi For Coding（api.kimi.com/coding） | `{origin}/coding/v1/usages` | 同上（Bearer） | 5h/7d limit/remaining | **一** |
+| 火山引擎 Ark（volces.com） | `open.volcengineapi.com` `GetAFPUsage` → `GetCodingPlanUsage` 回落 | AccessKey/Secret（新增 env），HMAC-SHA256 V4 签名 | 5h/7d/月 百分比 | 二 |
+| DeepSeek / 硅基流动 / StepFun / Moonshot / OpenRouter / Novita | 各自余额接口 | Bearer | ¥/USD 余额，无百分比分母 | 三（需 webview 余额渲染） |
+| 阿里 DashScope | 阿里云 BSS `QueryAccountBalance` | AK/SK + HMAC-SHA1 RPC 签名 | ¥ 余额 | 三 |
+| 小米 MiMo | `platform.xiaomimimo.com/api/v1/tokenPlan/usage` | 浏览器 Cookie | 月度百分比 | **不做**（Cookie 为完整会话凭证，敏感且易过期） |
+| 百度千帆 / 腾讯混元 / 讯飞星辰 | 无公开 API | — | — | 不做 |
+
+## 3. 架构
+
+新增 `com.github.claudecodegui.provider.claude.usage` 包：
+
+```
+provider/claude/usage/
+├── RelayUsageVendor.java     # SPI：id() / matches(host, path) / probe(env)
+├── RelayUsageEnv.java        # 从 settings.env 提取 baseUrl/token/model 的值对象
+├── RelayUsageRegistry.java   # 有序厂商表 + host 匹配 + 缓存/stale 编排
+├── RelayUsageCache.java      # 由 ZaiCache 泛化：key=vendor+baseUrl+token，TTL 115s，stale 兜底 30min
+├── RelayUsageHttp.java       # 共享 GET（HttpClient、超时、UA、TLS-only 规则）+ 测试 transport 缝
+├── RelayUsageJson.java       # 共享 JSON 取值/clamp/窗口与 capacity payload 构造
+├── ZaiUsageVendor.java       # 现有 z.ai 逻辑原样迁入（含窗口合并取最差、level、TIME_LIMIT→monthly）
+├── MiniMaxUsageVendor.java   # 剩余%→已用%；模型回退链；weekly_status 门控
+└── KimiCodingUsageVendor.java # window.duration 判别 5h/7d；remaining/used 双兼容
+```
+
+要点：
+
+- `ClaudePlanUsageService` 保持门面不变（`resolvePlanUsagePayload` 签名、
+  `cacheRateLimitInfo`、`ClaudePlanUsageHandler` 全不动），内部改为委托
+  `RelayUsageRegistry.resolve(settings, nowMs)`，未命中/探测失败回落 rate_limit 缓存。
+- 厂商注册顺序语义：`kimi-coding` 必须先于（未来阶段的）`kimi`/`moonshot`，
+  因为 api.kimi.com 同时承载两类入口（path 含 `/coding` 才是 Coding Plan）。
+- host 匹配用 `URI.getHost()` 等于/后缀比较，避免全 URL 子串匹配
+  （`url.includes('glm')` 之类会被 path 误触发）。
+- 安全规则沿用 `monitorUrl` 先例：远端必须 HTTPS，明文 HTTP 仅放行 loopback；
+  缓存 key 含 token，账号切换不会串台。
+
+## 4. 阶段一（本次）范围
+
+1. SPI + 注册表 + 缓存/HTTP/JSON 基建（上述 6 个基础文件）。
+2. z.ai 逻辑迁移（行为等价，现有测试随之迁移）。
+3. 新增 MiniMax、Kimi For Coding 两个 vendor。
+4. 测试：每 vendor 解析 fixture、host 识别、
+   缓存 TTL/stale、凭证回退链；`gradlew test` 全绿。
+
+## 5. 阶段二（下一个 PR）：火山 Ark
+
+- `VolcengineUsageVendor`：JDK 自带 `javax.crypto.Mac`（HmacSHA256）+ `MessageDigest`
+  实现 V4 签名，无新依赖；`GetAFPUsage` 失败回落 `GetCodingPlanUsage`。
+- AK/SK 从 settings env 读，变量名兼容 `VOLCENGINE_ACCESS_KEY`/`VOLCENGINE_SECRET_KEY`
+  与官方 SDK 的 `VOLCENGINE_ACCESSKEY`/`VOLCENGINE_SECRETKEY`；未配置时静默跳过。
+- host 匹配 `volces.com`；返回 5h/7d/月百分比窗口，仍无需 webview 改动。
+
+## 6. 阶段三（独立 PR）：余额型厂商
+
+- webview `PlanUsageSnapshot` 增加可选 `balance{remaining, total?, unit}`，
+  `PlanUsageIndicator` 有余额时显示金额（如 `¥42.50`）替代百分比条，tooltip 放明细。
+- 接入 DeepSeek / SiliconFlow（国内外双端点，CNY/USD）/ StepFun / Moonshot /
+  OpenRouter / Novita（金额 ÷10000）/ 阿里 BSS（AK/SK + HMAC-SHA1）。
+
+## 7. 风险
+
+1. MiniMax / Kimi Coding 的接口无官方公开文档，解析基于其线上实际响应格式实现；
+   字段变更时探测失败 → stale 缓存兜底 → 静默回落 rate_limit，不影响主流程。
+2. 国内/国际双端点按 base URL 域名区分，自建反代域名识别不到（与 z.ai 现状一致）。
+3. MiniMax `model_remains` 多模型条目按"当前模型 → general → 第一条"选取，
+   展示的是所选模型的配额，用户切模型后最多 115s 内刷新。

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudePlanUsageService.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudePlanUsageService.java
@@ -1,20 +1,13 @@
 package com.github.claudecodegui.provider.claude;
 
+import com.github.claudecodegui.provider.claude.usage.RelayUsageJson;
+import com.github.claudecodegui.provider.claude.usage.RelayUsageRegistry;
 import com.github.claudecodegui.settings.CodemossSettingsService;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.intellij.openapi.diagnostic.Logger;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.time.Duration;
 import java.time.Instant;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 /**
  * Claude plan-usage snapshot builder + resolver.
@@ -25,12 +18,10 @@ import java.util.Map;
  *
  * <p>Two data sources, picked by backend:
  * <ul>
- *   <li><b>z.ai / bigmodel.cn proxy</b> (detected via {@code ANTHROPIC_BASE_URL}
- *       host being {@code z.ai}, {@code open.bigmodel.cn} or a subdomain of either;
- *       bigmodel.cn exposes the same usage API): probes
- *       {@code {origin}/api/monitor/usage/quota/limit}
- *       and parses the {@code TOKENS_LIMIT}/{@code CREDIT_LIMIT} windows (5h + 7d) plus the
- *       {@code TIME_LIMIT} monthly MCP budget. Returns {@code percentage} per window.</li>
+ *   <li><b>Relay vendors</b> (z.ai/bigmodel.cn, MiniMax Coding Plan, Kimi For
+ *       Coding): {@link RelayUsageRegistry} matches the {@code ANTHROPIC_BASE_URL}
+ *       host against the registered vendors and probes their usage API — see
+ *       the {@code provider.claude.usage} package.</li>
  *   <li><b>Real Anthropic (OAuth subscription):</b> the SDK emits
  *       {@code rate_limit_event} ({@code rate_limit_info: {status, resetsAt, utilization}})
  *       during turns; {@link com.github.claudecodegui.session.ClaudeMessageHandler}
@@ -40,28 +31,11 @@ import java.util.Map;
  * <p>The webview polls {@code get_claude_plan_usage} (~every 120s, like Gemini).
  */
 public final class ClaudePlanUsageService {
-    /**
-     * Fresh-cache TTL. Set just under the webview's 120s poll cadence so that
-     * back-to-back polls (multiple tool windows, manual refresh) dedupe onto a
-     * single probe; a regular 120s poll always re-probes.
-     */
-    static final long ZAI_CACHE_TTL_MS = 115_000L;
-    /** Max age for serving a stale cached payload after repeated probe failures. */
-    static final long ZAI_STALE_MAX_MS = 30 * 60_000L;
-    private static final long HTTP_TIMEOUT_MS = 15_000L;
+
     private static final Logger LOG = Logger.getInstance(ClaudePlanUsageService.class);
 
     /** Last rate_limit_event snapshot (real Anthropic). Null until the first event arrives. */
     private static volatile JsonObject cachedRateLimit;
-
-    private static volatile ZaiCache cachedZai;
-
-    /** Test-only seam replacing the real HTTP probe. */
-    private static volatile ZaiTransport transportOverride;
-
-    private static final HttpClient HTTP = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(10))
-            .build();
 
     private ClaudePlanUsageService() {
     }
@@ -85,9 +59,11 @@ public final class ClaudePlanUsageService {
     }
 
     /**
-     * Resolve the plan-usage payload for the webview poll. Probes the z.ai monitor
-     * endpoint on a z.ai/bigmodel.cn backend; otherwise returns the cached rate_limit snapshot
-     * (real Anthropic). Falls back to an unavailable marker.
+     * Resolve the plan-usage payload for the webview poll. Delegates to the
+     * relay vendor registry (cache + probe + stale policy inside); when no
+     * vendor matches or every probe path fails, falls back to the cached
+     * rate_limit snapshot (real Anthropic). Final fallback is an unavailable
+     * marker.
      *
      * <p>The settings service is passed in by the caller (which holds a long-lived
      * instance) — constructing a fresh {@code CodemossSettingsService} per poll would
@@ -97,12 +73,10 @@ public final class ClaudePlanUsageService {
     public static JsonObject resolvePlanUsagePayload(CodemossSettingsService settingsService) {
         try {
             if (settingsService != null) {
-                JsonObject settings = settingsService.readClaudeSettings();
-                if (isZaiBackend(settings)) {
-                    JsonObject zai = resolveViaZaiMonitor(settings);
-                    if (zai != null) {
-                        return zai;
-                    }
+                JsonObject relay = RelayUsageRegistry.resolve(
+                        settingsService.readClaudeSettings(), System.currentTimeMillis());
+                if (relay != null) {
+                    return relay;
                 }
             }
         } catch (Exception e) {
@@ -115,257 +89,10 @@ public final class ClaudePlanUsageService {
         return unavailable("Claude usage unavailable");
     }
 
-    // ===== z.ai monitor endpoint =====
-
-    /**
-     * A z.ai backend is identified by its anthropic-compat base URL host being {@code z.ai}
-     * or a subdomain; {@code open.bigmodel.cn} (and subdomains) expose the same
-     * usage-quota API, so they are matched too.
-     */
-    static boolean isZaiBackend(JsonObject settings) {
-        String base = envString(settings, "ANTHROPIC_BASE_URL");
-        if (base == null) {
-            return false;
-        }
-        try {
-            String host = URI.create(base).getHost();
-            if (host == null) {
-                return false;
-            }
-            host = host.toLowerCase(java.util.Locale.ROOT);
-            return host.equals("z.ai") || host.endsWith(".z.ai") || host.equals("open.bigmodel.cn") || host.endsWith(".bigmodel.cn");
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    static JsonObject resolveViaZaiMonitor(JsonObject settings) {
-        return resolveViaZaiMonitor(settings, System.currentTimeMillis());
-    }
-
-    static JsonObject resolveViaZaiMonitor(JsonObject settings, long nowMs) {
-        String base = envString(settings, "ANTHROPIC_BASE_URL");
-        String token = envString(settings, "ANTHROPIC_AUTH_TOKEN");
-        if (token == null) {
-            token = envString(settings, "ANTHROPIC_API_KEY");
-        }
-        String url = (base != null && token != null) ? monitorUrl(base) : null;
-        if (url == null) {
-            return null;
-        }
-        // Key the cache by endpoint + credential so an account/base-URL switch
-        // never serves the previous account's quota.
-        String cacheKey = url + '\n' + token;
-
-        ZaiCache c = cachedZai;
-        if (c != null && c.key.equals(cacheKey) && nowMs - c.atMs < ZAI_CACHE_TTL_MS) {
-            return c.payload.deepCopy();
-        }
-        try {
-            JsonObject body = httpGetJson(url, token);
-            JsonObject payload = parseZaiQuota(body);
-            if (payload != null) {
-                cachedZai = new ZaiCache(nowMs, cacheKey, payload);
-                return payload.deepCopy();
-            }
-        } catch (Exception e) {
-            LOG.warn("z.ai quota probe failed: " + e.getMessage());
-        }
-        // Serve the last good payload while probes keep failing — but only for a
-        // bounded window, so a long outage doesn't masquerade as live data.
-        if (c != null && c.key.equals(cacheKey) && nowMs - c.atMs < ZAI_STALE_MAX_MS) {
-            JsonObject copy = c.payload.deepCopy();
-            copy.addProperty("stale", true);
-            return copy;
-        }
-        return null;
-    }
-
-    /**
-     * Derive {@code <origin>/api/monitor/usage/quota/limit} from the anthropic base URL
-     * (port kept). The Bearer token rides along, so plain HTTP is only allowed for
-     * loopback targets (local proxies); anything else must be TLS.
-     */
-    static String monitorUrl(String baseUrl) {
-        try {
-            URI u = URI.create(baseUrl);
-            String scheme = u.getScheme();
-            String host = u.getHost();
-            if (scheme == null || host == null) {
-                return null;
-            }
-            boolean loopback = host.equalsIgnoreCase("localhost")
-                    || host.equals("127.0.0.1")
-                    || host.equals("::1");
-            if (!"https".equalsIgnoreCase(scheme)
-                    && !("http".equalsIgnoreCase(scheme) && loopback)) {
-                return null;
-            }
-            int port = u.getPort();
-            String origin = port == -1
-                    ? scheme + "://" + host
-                    : scheme + "://" + host + ":" + port;
-            return origin + "/api/monitor/usage/quota/limit";
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    /**
-     * Parse the z.ai {@code /api/monitor/usage/quota/limit} body into the capacity shape.
-     * Coding-token windows ({@code CREDIT_LIMIT}/{@code TOKENS_LIMIT}) map to 5h/7d; the
-     * {@code TIME_LIMIT} monthly MCP budget maps to a {@code monthly} window. Only limits
-     * carrying a {@code percentage} are emitted.
-     */
-    static JsonObject parseZaiQuota(JsonObject body) {
-        if (body == null) {
-            return null;
-        }
-        JsonObject data = body.has("data") && body.get("data").isJsonObject()
-                ? body.getAsJsonObject("data") : null;
-        if (data == null || !data.has("limits") || !data.get("limits").isJsonArray()) {
-            return null;
-        }
-        String level = asString(data, "level");
-
-        // Two limit types can map to the same window (e.g. TOKENS_LIMIT and
-        // CREDIT_LIMIT both with unit=3 → "5h"); merge them, surfacing the worse
-        // usage, so the frontend never sees duplicate window ids.
-        Map<String, JsonObject> byPeriod = new LinkedHashMap<>();
-        for (JsonElement el : data.getAsJsonArray("limits")) {
-            if (!el.isJsonObject()) {
-                continue;
-            }
-            JsonObject lim = el.getAsJsonObject();
-            Double pct = asDouble(lim, "percentage");
-            if (pct == null || !Double.isFinite(pct)) {
-                continue;
-            }
-            pct = clampPct(pct);
-            String type = asString(lim, "type");
-            String period = zaiPeriod(lim, type);
-            Long resetsAtMs = asLong(lim, "nextResetTime", "next_reset_time");
-            String resetAt = resetsAtMs != null ? Instant.ofEpochMilli(resetsAtMs).toString() : null;
-
-            JsonObject existing = byPeriod.get(period);
-            if (existing != null) {
-                if (pct > existing.get("used_pct").getAsDouble()) {
-                    existing.addProperty("used_pct", pct);
-                }
-                if (!existing.has("reset_at") && resetAt != null) {
-                    existing.addProperty("reset_at", resetAt);
-                }
-                continue;
-            }
-
-            JsonObject w = new JsonObject();
-            w.addProperty("id", period);
-            w.addProperty("used_pct", pct);
-            if (resetAt != null) {
-                w.addProperty("reset_at", resetAt);
-            }
-            w.addProperty("period_type", period);
-            byPeriod.put(period, w);
-        }
-        if (byPeriod.isEmpty()) {
-            return null;
-        }
-
-        Double primary5h = null;
-        double maxPct = 0;
-        for (JsonObject w : byPeriod.values()) {
-            double pct = w.get("used_pct").getAsDouble();
-            if ("5h".equals(w.get("id").getAsString())) {
-                primary5h = pct;
-            }
-            if (pct > maxPct) {
-                maxPct = pct;
-            }
-        }
-
-        double capacity = primary5h != null ? primary5h : maxPct;
-        JsonObject out = new JsonObject();
-        out.addProperty("ok", true);
-        out.addProperty("present", true);
-        out.addProperty("provider", "claude");
-        out.addProperty("source", "zai-quota-limit");
-        out.addProperty("capacity_pct", capacity);
-        out.addProperty("period_type", byPeriod.keySet().iterator().next());
-        JsonArray arr = new JsonArray();
-        for (JsonObject w : byPeriod.values()) {
-            arr.add(w);
-        }
-        out.add("windows", arr);
-        if (level != null) {
-            out.addProperty("level", level);
-        }
-        return out;
-    }
-
-    /**
-     * Map a z.ai limit to a window id/period. Observed z.ai payloads use
-     * unit 3=hours (number=5 → 5h), unit 6=weeks (number=1 → 7d) and unit 4=days
-     * (number=7 → 7d). The {@code number} field is assumed to match those shapes —
-     * a hypothetical unit=4/number=1 (1-day) window would still be labelled 7d.
-     */
-    static String zaiPeriod(JsonObject lim, String type) {
-        if (type != null && type.toUpperCase().contains("TIME")) {
-            return "monthly";
-        }
-        Integer unit = asInt(lim, "unit");
-        if (unit == null) {
-            return "5h";
-        }
-        switch (unit) {
-            case 3:
-                return "5h";
-            case 6:
-            case 4:
-                return "7d";
-            default:
-                return "5h";
-        }
-    }
-
-    private static JsonObject httpGetJson(String url, String token) throws Exception {
-        ZaiTransport override = transportOverride;
-        if (override != null) {
-            return override.get(url, token);
-        }
-        HttpRequest req = HttpRequest.newBuilder()
-                .uri(URI.create(url))
-                .timeout(Duration.ofMillis(HTTP_TIMEOUT_MS))
-                .header("Authorization", "Bearer " + token)
-                .header("Accept", "application/json")
-                .header("User-Agent", "jetbrains-cc-gui-claude-plan-usage")
-                .GET()
-                .build();
-        HttpResponse<String> resp = HTTP.send(req, HttpResponse.BodyHandlers.ofString());
-        if (resp.statusCode() != 200) {
-            throw new IllegalStateException("z.ai monitor HTTP " + resp.statusCode());
-        }
-        return JsonParser.parseString(resp.body()).getAsJsonObject();
-    }
-
-    /** Test-only: replace the HTTP transport. Pass null to restore the real one. */
-    static void setZaiTransportForTests(ZaiTransport transport) {
-        transportOverride = transport;
-    }
-
-    /** Test-only: drop the cached z.ai payload. */
-    static void resetZaiCacheForTests() {
-        cachedZai = null;
-    }
-
-    /** Transport seam for the z.ai monitor probe — production hits HTTP, tests substitute. */
-    interface ZaiTransport {
-        JsonObject get(String url, String token) throws Exception;
-    }
-
     // ===== real Anthropic rate_limit_event =====
 
     static JsonObject buildCapacityPayload(JsonObject rateLimitInfo) {
-        Double utilization = asDouble(rateLimitInfo, "utilization");
+        Double utilization = RelayUsageJson.asDouble(rateLimitInfo, "utilization");
         if (utilization == null || !Double.isFinite(utilization)) {
             return null;
         }
@@ -373,11 +100,11 @@ public final class ClaudePlanUsageService {
         // exceeding 1 when over capacity), so scale it to a percent. The <= 10
         // guard only protects against a hypothetical already-percent payload
         // (0-100) from being scaled twice.
-        double pct = clampPct(utilization <= 10.0 ? utilization * 100.0 : utilization);
+        double pct = RelayUsageJson.clampPct(utilization <= 10.0 ? utilization * 100.0 : utilization);
 
         // resetsAt is unix epoch SECONDS in the CLI schema (the CLI computes
         // `resetsAt - Date.now()/1000`), not millis — convert before use.
-        Long resetsAtSec = asLong(rateLimitInfo, "resetsAt", "resets_at", "resetAt");
+        Long resetsAtSec = RelayUsageJson.asLong(rateLimitInfo, "resetsAt", "resets_at", "resetAt");
         Long resetsAtMs = resetsAtSec != null ? resetsAtSec * 1000L : null;
         String resetAt = resetsAtMs != null ? Instant.ofEpochMilli(resetsAtMs).toString() : null;
         String periodType = periodTypeFromRateLimit(rateLimitInfo, resetsAtMs);
@@ -403,7 +130,7 @@ public final class ClaudePlanUsageService {
         }
         out.addProperty("period_type", periodType);
         out.add("windows", windows);
-        String status = asString(rateLimitInfo, "status");
+        String status = RelayUsageJson.asString(rateLimitInfo, "status");
         if (status != null) {
             out.addProperty("rate_limit_status", status);
         }
@@ -416,9 +143,9 @@ public final class ClaudePlanUsageService {
      * the reset-delta heuristic, which only survives as a fallback.
      */
     static String periodTypeFromRateLimit(JsonObject rateLimitInfo, Long resetsAtMs) {
-        String type = asString(rateLimitInfo, "rateLimitType");
+        String type = RelayUsageJson.asString(rateLimitInfo, "rateLimitType");
         if (type == null) {
-            type = asString(rateLimitInfo, "rate_limit_type");
+            type = RelayUsageJson.asString(rateLimitInfo, "rate_limit_type");
         }
         if (type != null) {
             if (type.startsWith("five_hour")) {
@@ -439,13 +166,6 @@ public final class ClaudePlanUsageService {
         return "7d";
     }
 
-    static double clampPct(double v) {
-        if (!Double.isFinite(v)) {
-            return 0;
-        }
-        return Math.max(0, Math.min(100, v));
-    }
-
     static JsonObject unavailable(String message) {
         JsonObject out = new JsonObject();
         out.addProperty("present", false);
@@ -455,70 +175,9 @@ public final class ClaudePlanUsageService {
         return out;
     }
 
-    // ===== accessors =====
-
-    private static String envString(JsonObject settings, String key) {
-        if (settings == null || !settings.has("env") || !settings.get("env").isJsonObject()) {
-            return null;
-        }
-        JsonObject env = settings.getAsJsonObject("env");
-        if (!env.has(key) || env.get(key).isJsonNull()) {
-            return null;
-        }
-        return env.get(key).getAsString();
-    }
-
-    private static Double asDouble(JsonObject o, String... keys) {
-        for (String k : keys) {
-            if (o.has(k) && o.get(k).isJsonPrimitive() && !o.get(k).isJsonNull()) {
-                try {
-                    return o.get(k).getAsDouble();
-                } catch (RuntimeException ignored) {
-                }
-            }
-        }
-        return null;
-    }
-
-    private static Long asLong(JsonObject o, String... keys) {
-        for (String k : keys) {
-            if (o.has(k) && o.get(k).isJsonPrimitive() && !o.get(k).isJsonNull()) {
-                try {
-                    return o.get(k).getAsLong();
-                } catch (RuntimeException ignored) {
-                }
-            }
-        }
-        return null;
-    }
-
-    private static Integer asInt(JsonObject o, String key) {
-        if (o.has(key) && o.get(key).isJsonPrimitive() && !o.get(key).isJsonNull()) {
-            try {
-                return o.get(key).getAsInt();
-            } catch (RuntimeException ignored) {
-            }
-        }
-        return null;
-    }
-
-    private static String asString(JsonObject o, String key) {
-        if (o.has(key) && o.get(key).isJsonPrimitive() && !o.get(key).isJsonNull()) {
-            return o.get(key).getAsString();
-        }
-        return null;
-    }
-
-    private static final class ZaiCache {
-        final long atMs;
-        final String key;
-        final JsonObject payload;
-
-        ZaiCache(long atMs, String key, JsonObject payload) {
-            this.atMs = atMs;
-            this.key = key;
-            this.payload = payload;
-        }
+    /** Test-only: drop the cached rate_limit snapshot. */
+    static void resetRateLimitCacheForTests() {
+        cachedRateLimit = null;
     }
 
 }

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudePlanUsageService.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudePlanUsageService.java
@@ -25,8 +25,10 @@ import java.util.Map;
  *
  * <p>Two data sources, picked by backend:
  * <ul>
- *   <li><b>z.ai proxy</b> (detected via {@code ANTHROPIC_BASE_URL} host being
- *       {@code z.ai} or a subdomain): probes {@code {origin}/api/monitor/usage/quota/limit}
+ *   <li><b>z.ai / bigmodel.cn proxy</b> (detected via {@code ANTHROPIC_BASE_URL}
+ *       host being {@code z.ai}, {@code open.bigmodel.cn} or a subdomain of either;
+ *       bigmodel.cn exposes the same usage API): probes
+ *       {@code {origin}/api/monitor/usage/quota/limit}
  *       and parses the {@code TOKENS_LIMIT}/{@code CREDIT_LIMIT} windows (5h + 7d) plus the
  *       {@code TIME_LIMIT} monthly MCP budget. Returns {@code percentage} per window.</li>
  *   <li><b>Real Anthropic (OAuth subscription):</b> the SDK emits
@@ -84,7 +86,7 @@ public final class ClaudePlanUsageService {
 
     /**
      * Resolve the plan-usage payload for the webview poll. Probes the z.ai monitor
-     * endpoint on a z.ai backend; otherwise returns the cached rate_limit snapshot
+     * endpoint on a z.ai/bigmodel.cn backend; otherwise returns the cached rate_limit snapshot
      * (real Anthropic). Falls back to an unavailable marker.
      *
      * <p>The settings service is passed in by the caller (which holds a long-lived
@@ -115,7 +117,11 @@ public final class ClaudePlanUsageService {
 
     // ===== z.ai monitor endpoint =====
 
-    /** A z.ai backend is identified by its anthropic-compat base URL host being {@code z.ai} or a subdomain. */
+    /**
+     * A z.ai backend is identified by its anthropic-compat base URL host being {@code z.ai}
+     * or a subdomain; {@code open.bigmodel.cn} (and subdomains) expose the same
+     * usage-quota API, so they are matched too.
+     */
     static boolean isZaiBackend(JsonObject settings) {
         String base = envString(settings, "ANTHROPIC_BASE_URL");
         if (base == null) {
@@ -127,7 +133,7 @@ public final class ClaudePlanUsageService {
                 return false;
             }
             host = host.toLowerCase(java.util.Locale.ROOT);
-            return host.equals("z.ai") || host.endsWith(".z.ai");
+            return host.equals("z.ai") || host.endsWith(".z.ai") || host.equals("open.bigmodel.cn") || host.endsWith(".bigmodel.cn");
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudePlanUsageService.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudePlanUsageService.java
@@ -127,7 +127,7 @@ public final class ClaudePlanUsageService {
                 return false;
             }
             host = host.toLowerCase(java.util.Locale.ROOT);
-            return host.equals("z.ai") || host.endsWith(".z.ai");
+            return host.equals("z.ai") || host.endsWith(".z.ai") || host.equals("open.bigmodel.cn") || host.endsWith(".bigmodel.cn");
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/com/github/claudecodegui/provider/claude/usage/KimiCodingUsageVendor.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/usage/KimiCodingUsageVendor.java
@@ -1,0 +1,140 @@
+package com.github.claudecodegui.provider.claude.usage;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Kimi For Coding (Moonshot's Claude-compatible coding plan) via the
+ * {@code api.kimi.com/coding} backend.
+ *
+ * <p>Probes {@code {origin}/coding/v1/usages}, which reports quota as
+ * limit/remaining (or limit/used) pairs: each {@code limits[]} entry is a
+ * rolling window (identified by {@code window.duration}) and the top-level
+ * {@code usage} object is the weekly quota. Percentages are derived as
+ * {@code (limit − remaining) / limit} (or {@code used / limit} when the API
+ * reports {@code used} directly).
+ */
+public final class KimiCodingUsageVendor implements RelayUsageVendor {
+
+    private static final String USAGE_PATH = "/coding/v1/usages";
+
+    @Override
+    public String id() {
+        return "kimi-coding";
+    }
+
+    @Override
+    public boolean matches(String host, String path) {
+        // api.kimi.com also serves the plain Moonshot-style API; only the
+        // /coding path is the Coding Plan whose /v1/usages endpoint exists.
+        // Must be matched before any future plain-kimi vendor.
+        return "api.kimi.com".equals(host) && path != null && path.startsWith("/coding");
+    }
+
+    @Override
+    public JsonObject probe(RelayUsageEnv env) throws Exception {
+        String origin = RelayUsageHttp.secureOrigin(env.baseUrl());
+        if (origin == null) {
+            return null;
+        }
+        JsonObject body = RelayUsageHttp.getJson(origin + USAGE_PATH, env.token());
+        return parseUsages(body);
+    }
+
+    /** Parse the usages body into the capacity shape (5h from limits[], 7d from usage). */
+    static JsonObject parseUsages(JsonObject body) {
+        if (body == null) {
+            return null;
+        }
+        Map<String, JsonObject> byPeriod = new LinkedHashMap<>();
+        JsonArray limits = RelayUsageJson.asArray(body, "limits");
+        if (limits != null) {
+            for (JsonElement el : limits) {
+                if (!RelayUsageJson.isObject(el)) {
+                    continue;
+                }
+                JsonObject item = el.getAsJsonObject();
+                String period = windowPeriod(item);
+                if (period != null) {
+                    mergeWindow(byPeriod, period, RelayUsageJson.asObject(item, "detail"));
+                }
+            }
+        }
+        mergeWindow(byPeriod, "7d", RelayUsageJson.asObject(body, "usage"));
+        if (byPeriod.isEmpty()) {
+            return null;
+        }
+        return RelayUsageJson.capacityPayload("kimi-coding-usages", byPeriod.values(), null);
+    }
+
+    /**
+     * Classify a limits[] entry by its window duration. Observed shapes:
+     * 300 (minutes, or 18000 seconds) → 5h; 604800 (seconds) or 7 (days) → 7d.
+     * Anything else is ignored rather than guessed.
+     */
+    static String windowPeriod(JsonObject item) {
+        JsonObject window = RelayUsageJson.asObject(item, "window");
+        if (window == null) {
+            return null;
+        }
+        Double duration = RelayUsageJson.asDouble(window, "duration");
+        if (duration == null || !Double.isFinite(duration)) {
+            return null;
+        }
+        String unit = RelayUsageJson.asString(window, "timeUnit");
+        if (duration == 300 || duration == 18000) {
+            return "5h";
+        }
+        if (duration == 604800) {
+            return "7d";
+        }
+        if (duration == 7 && "TIME_UNIT_DAY".equalsIgnoreCase(unit)) {
+            return "7d";
+        }
+        return null;
+    }
+
+    /**
+     * Merge one limit/remaining (or limit/used) pair into {@code byPeriod},
+     * keeping the worse usage when both sources report the same window
+     * (e.g. a weekly limits[] entry plus the top-level usage object).
+     */
+    private static void mergeWindow(Map<String, JsonObject> byPeriod, String period, JsonObject detail) {
+        if (detail == null) {
+            return;
+        }
+        Double limit = RelayUsageJson.asDouble(detail, "limit");
+        if (limit == null || !Double.isFinite(limit) || limit <= 0) {
+            return;
+        }
+        Double used = RelayUsageJson.asDouble(detail, "used");
+        Double pct;
+        if (used != null && Double.isFinite(used)) {
+            pct = used / limit * 100.0;
+        } else {
+            Double remaining = RelayUsageJson.asDouble(detail, "remaining");
+            if (remaining == null || !Double.isFinite(remaining)) {
+                return;
+            }
+            pct = Math.max(0, limit - remaining) / limit * 100.0;
+        }
+        pct = RelayUsageJson.clampPct(pct);
+        Long resetAtMs = RelayUsageJson.asLong(detail, "resetTime", "reset_time");
+
+        JsonObject existing = byPeriod.get(period);
+        if (existing != null) {
+            if (pct > existing.get("used_pct").getAsDouble()) {
+                existing.addProperty("used_pct", pct);
+            }
+            if (!existing.has("reset_at") && resetAtMs != null) {
+                existing.addProperty("reset_at", RelayUsageJson.epochMsToIso(resetAtMs));
+            }
+            return;
+        }
+        byPeriod.put(period, RelayUsageJson.window(period, pct, resetAtMs));
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/claude/usage/MiniMaxUsageVendor.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/usage/MiniMaxUsageVendor.java
@@ -1,0 +1,144 @@
+package com.github.claudecodegui.provider.claude.usage;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * MiniMax Coding Plan via the minimaxi.com (国内) / minimax.io (国际)
+ * anthropic-compat backend.
+ *
+ * <p>Probes {@code {origin}/v1/api/openplatform/coding_plan/remains}, which
+ * reports <em>remaining</em> percentages per model per window — translated here
+ * into used percentages. The entry matching the active model is preferred
+ * (falling back to "general", the Coding Plan default, then the first entry);
+ * the weekly window is only reported when
+ * {@code current_weekly_status == 1} (weekly quota enabled for the plan).
+ */
+public final class MiniMaxUsageVendor implements RelayUsageVendor {
+
+    private static final String USAGE_PATH = "/v1/api/openplatform/coding_plan/remains";
+
+    @Override
+    public String id() {
+        return "minimax";
+    }
+
+    @Override
+    public boolean matches(String host, String path) {
+        return host.equals("minimaxi.com") || host.endsWith(".minimaxi.com")
+                || host.equals("minimax.io") || host.endsWith(".minimax.io");
+    }
+
+    @Override
+    public JsonObject probe(RelayUsageEnv env) throws Exception {
+        String origin = RelayUsageHttp.secureOrigin(env.baseUrl());
+        if (origin == null) {
+            return null;
+        }
+        JsonObject body = RelayUsageHttp.getJson(origin + USAGE_PATH, env.token());
+        return parseRemains(body, env.model());
+    }
+
+    /** Parse the coding-plan-remains body for {@code currentModel} into the capacity shape. */
+    static JsonObject parseRemains(JsonObject body, String currentModel) {
+        if (body == null) {
+            return null;
+        }
+        // base_resp carries a non-zero status_code on API errors — treat as
+        // "no data" so the caller can fall back rather than show garbage.
+        JsonObject baseResp = RelayUsageJson.asObject(body, "base_resp");
+        Integer statusCode = baseResp != null ? RelayUsageJson.asInt(baseResp, "status_code") : null;
+        if (statusCode != null && statusCode != 0) {
+            return null;
+        }
+        JsonArray remains = RelayUsageJson.asArray(body, "model_remains");
+        if (remains == null || remains.isEmpty()) {
+            return null;
+        }
+        JsonObject main = pickModel(remains, currentModel);
+        if (main == null) {
+            return null;
+        }
+
+        List<JsonObject> windows = new ArrayList<>();
+        addWindow(windows, "5h",
+                invertRemaining(RelayUsageJson.asDouble(main, "current_interval_remaining_percent")),
+                RelayUsageJson.asLong(main, "end_time"));
+        Integer weeklyStatus = RelayUsageJson.asInt(main, "current_weekly_status");
+        if (weeklyStatus != null && weeklyStatus == 1) {
+            addWindow(windows, "7d",
+                    invertRemaining(RelayUsageJson.asDouble(main, "current_weekly_remaining_percent")),
+                    RelayUsageJson.asLong(main, "weekly_end_time"));
+        }
+        addWindow(windows, "monthly",
+                invertRemaining(RelayUsageJson.asDouble(main, "current_monthly_remaining_percent")),
+                RelayUsageJson.asLong(main, "monthly_end_time"));
+        if (windows.isEmpty()) {
+            return null;
+        }
+        return RelayUsageJson.capacityPayload("minimax-coding-plan", windows, null);
+    }
+
+    /** Remaining percent (0-100) → clamped used percent; null when the field is absent. */
+    private static Double invertRemaining(Double remainingPct) {
+        if (remainingPct == null || !Double.isFinite(remainingPct)) {
+            return null;
+        }
+        return RelayUsageJson.clampPct(100.0 - remainingPct);
+    }
+
+    private static void addWindow(List<JsonObject> windows, String id, Double usedPct, Long resetAtMs) {
+        if (usedPct == null) {
+            return;
+        }
+        windows.add(RelayUsageJson.window(id, usedPct, resetAtMs));
+    }
+
+    /**
+     * Pick the model_remains entry for the user's active model. Matching is
+     * bidirectional substring on normalized names so "MiniMax-M3" matches "M3",
+     * "minimax_m3", Unicode-dash variants etc.; fallback chain is "general"
+     * (Coding Plan default) → first entry.
+     */
+    static JsonObject pickModel(JsonArray remains, String currentModel) {
+        if (currentModel != null && !currentModel.isBlank()) {
+            String cur = normalizeModelKey(currentModel);
+            if (!cur.isEmpty()) {
+                for (JsonElement el : remains) {
+                    if (!RelayUsageJson.isObject(el)) {
+                        continue;
+                    }
+                    String name = normalizeModelKey(RelayUsageJson.asString(el.getAsJsonObject(), "model_name"));
+                    if (!name.isEmpty() && (name.equals(cur) || name.contains(cur) || cur.contains(name))) {
+                        return el.getAsJsonObject();
+                    }
+                }
+            }
+        }
+        for (JsonElement el : remains) {
+            if (RelayUsageJson.isObject(el)
+                    && "general".equals(RelayUsageJson.asString(el.getAsJsonObject(), "model_name"))) {
+                return el.getAsJsonObject();
+            }
+        }
+        for (JsonElement el : remains) {
+            if (RelayUsageJson.isObject(el)) {
+                return el.getAsJsonObject();
+            }
+        }
+        return null;
+    }
+
+    /** Lowercase + strip non-alphanumerics, for tolerant cross-format model matching. */
+    static String normalizeModelKey(String s) {
+        if (s == null) {
+            return "";
+        }
+        return s.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]", "");
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageCache.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageCache.java
@@ -1,0 +1,73 @@
+package com.github.claudecodegui.provider.claude.usage;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Payload cache shared by all relay usage vendors (one active account per
+ * vendor at a time, so a single entry keyed by vendor + endpoint + credential
+ * suffices).
+ *
+ * <p>Serves three roles, mirroring the original z.ai-only cache:
+ * <ul>
+ *   <li><b>fresh</b> — probe result within {@link #TTL_MS}, served verbatim;</li>
+ *   <li><b>stale</b> — last good payload after a failed probe, served for at
+ *       most {@link #STALE_MAX_MS} and flagged {@code stale: true} so the UI can
+ *       mark it, then given up on (a long outage must not masquerade as live
+ *       data);</li>
+ *   <li>cache misses simply fall through to the caller's fallback chain.</li>
+ * </ul>
+ */
+final class RelayUsageCache {
+
+    /** Fresh TTL, set just under the webview's 120s poll cadence. */
+    static final long TTL_MS = 115_000L;
+    /** Max age for serving a stale payload after repeated probe failures. */
+    static final long STALE_MAX_MS = 30 * 60_000L;
+
+    private static volatile Entry entry;
+
+    private RelayUsageCache() {
+    }
+
+    /** Fresh cached payload for {@code key}, or null when absent/expired. */
+    static JsonObject fresh(String key, long nowMs) {
+        Entry c = entry;
+        if (c != null && c.key.equals(key) && nowMs - c.atMs < TTL_MS) {
+            return c.payload.deepCopy();
+        }
+        return null;
+    }
+
+    /** Stale cached payload (flagged) for {@code key} within {@link #STALE_MAX_MS}, or null. */
+    static JsonObject stale(String key, long nowMs) {
+        Entry c = entry;
+        if (c != null && c.key.equals(key) && nowMs - c.atMs < STALE_MAX_MS) {
+            JsonObject copy = c.payload.deepCopy();
+            copy.addProperty("stale", true);
+            return copy;
+        }
+        return null;
+    }
+
+    /** Persist a successful probe result for {@code key}. */
+    static void store(String key, JsonObject payload, long nowMs) {
+        entry = new Entry(nowMs, key, payload);
+    }
+
+    /** Test-only: drop the cached payload. */
+    static void clearForTests() {
+        entry = null;
+    }
+
+    private static final class Entry {
+        final long atMs;
+        final String key;
+        final JsonObject payload;
+
+        Entry(long atMs, String key, JsonObject payload) {
+            this.atMs = atMs;
+            this.key = key;
+            this.payload = payload;
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageEnv.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageEnv.java
@@ -1,0 +1,80 @@
+package com.github.claudecodegui.provider.claude.usage;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Credentials and routing inputs a relay usage vendor needs, extracted from the
+ * Claude {@code settings.json} env block once per resolve so every vendor sees a
+ * consistent snapshot.
+ *
+ * <ul>
+ *   <li>{@code baseUrl} — {@code ANTHROPIC_BASE_URL}, the anthropic-compat
+ *       endpoint whose host identifies the vendor.</li>
+ *   <li>{@code token} — {@code ANTHROPIC_AUTH_TOKEN}, falling back to
+ *       {@code ANTHROPIC_API_KEY} (the same chain the SDK itself uses).</li>
+ *   <li>{@code model} — the active model id (from {@code ANTHROPIC_MODEL} or the
+ *       per-tier defaults), used by vendors whose quota is reported per model
+ *       (MiniMax Coding Plan).</li>
+ * </ul>
+ */
+public final class RelayUsageEnv {
+
+    private static final RelayUsageEnv EMPTY = new RelayUsageEnv(null, null, null);
+
+    private final String baseUrl;
+    private final String token;
+    private final String model;
+
+    private RelayUsageEnv(String baseUrl, String token, String model) {
+        this.baseUrl = baseUrl;
+        this.token = token;
+        this.model = model;
+    }
+
+    /** Extract the env snapshot from a settings object; null-safe. */
+    public static RelayUsageEnv from(JsonObject settings) {
+        if (settings == null) {
+            return EMPTY;
+        }
+        String base = envString(settings, "ANTHROPIC_BASE_URL");
+        String token = envString(settings, "ANTHROPIC_AUTH_TOKEN");
+        if (token == null) {
+            token = envString(settings, "ANTHROPIC_API_KEY");
+        }
+        String model = null;
+        for (String key : new String[]{
+                "ANTHROPIC_MODEL",
+                "ANTHROPIC_DEFAULT_OPUS_MODEL",
+                "ANTHROPIC_DEFAULT_SONNET_MODEL",
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL"}) {
+            model = envString(settings, key);
+            if (model != null) {
+                break;
+            }
+        }
+        return new RelayUsageEnv(base, token, model);
+    }
+
+    /** Anthropic-compat base URL; null when unset. */
+    public String baseUrl() {
+        return baseUrl;
+    }
+
+    /** Bearer token for the vendor API; null when unset. */
+    public String token() {
+        return token;
+    }
+
+    /** Active model id for per-model quota APIs; null when unset. */
+    public String model() {
+        return model;
+    }
+
+    private static String envString(JsonObject settings, String key) {
+        JsonObject env = RelayUsageJson.asObject(settings, "env");
+        if (env == null || !env.has(key) || env.get(key).isJsonNull()) {
+            return null;
+        }
+        return env.get(key).getAsString();
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageHttp.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageHttp.java
@@ -1,0 +1,102 @@
+package com.github.claudecodegui.provider.claude.usage;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Shared HTTP transport for relay usage probes: one pooled {@link HttpClient},
+ * one timeout policy, one User-Agent, and a test seam.
+ *
+ * <p>Also owns the credential-safety rule for URL derivation: probe URLs are
+ * built from the anthropic base URL's origin, and the Bearer token must never
+ * travel over plaintext to a remote host — plain HTTP is only allowed for
+ * loopback targets (local dev proxies), see {@link #secureOrigin(String)}.
+ */
+public final class RelayUsageHttp {
+
+    private static final long HTTP_TIMEOUT_MS = 15_000L;
+    private static final HttpClient HTTP = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+    /** Test-only seam replacing the real HTTP transport. */
+    private static volatile Transport transportOverride;
+
+    private RelayUsageHttp() {
+    }
+
+    /** Transport seam — production hits HTTP, tests substitute. */
+    public interface Transport {
+        JsonObject get(String url, Map<String, String> headers) throws Exception;
+    }
+
+    /** GET {@code url} with a Bearer Authorization header. */
+    public static JsonObject getJson(String url, String bearerToken) throws Exception {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("Authorization", "Bearer " + bearerToken);
+        return getJson(url, headers);
+    }
+
+    /** GET {@code url} with the given headers (Accept/UA added here). */
+    public static JsonObject getJson(String url, Map<String, String> headers) throws Exception {
+        Transport override = transportOverride;
+        if (override != null) {
+            return override.get(url, headers);
+        }
+        HttpRequest.Builder req = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofMillis(HTTP_TIMEOUT_MS))
+                .header("Accept", "application/json")
+                .header("User-Agent", "jetbrains-cc-gui-relay-usage")
+                .GET();
+        for (Map.Entry<String, String> h : headers.entrySet()) {
+            req.header(h.getKey(), h.getValue());
+        }
+        HttpResponse<String> resp = HTTP.send(req.build(), HttpResponse.BodyHandlers.ofString());
+        if (resp.statusCode() != 200) {
+            throw new IllegalStateException("relay usage HTTP " + resp.statusCode());
+        }
+        return JsonParser.parseString(resp.body()).getAsJsonObject();
+    }
+
+    /**
+     * Origin ({@code scheme://host[:port]}) of the anthropic base URL when it is
+     * safe to send credentials there — TLS, or plain HTTP for loopback targets
+     * only; any custom port is kept. Null when the URL is malformed or unsafe.
+     */
+    public static String secureOrigin(String baseUrl) {
+        try {
+            URI u = URI.create(baseUrl);
+            String scheme = u.getScheme();
+            String host = u.getHost();
+            if (scheme == null || host == null) {
+                return null;
+            }
+            boolean loopback = host.equalsIgnoreCase("localhost")
+                    || host.equals("127.0.0.1")
+                    || host.equals("::1");
+            if (!"https".equalsIgnoreCase(scheme)
+                    && !("http".equalsIgnoreCase(scheme) && loopback)) {
+                return null;
+            }
+            int port = u.getPort();
+            return port == -1
+                    ? scheme + "://" + host
+                    : scheme + "://" + host + ":" + port;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** Test-only: replace the HTTP transport. Pass null to restore the real one. */
+    public static void setTransportForTests(Transport transport) {
+        transportOverride = transport;
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageJson.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageJson.java
@@ -1,0 +1,159 @@
+package com.github.claudecodegui.provider.claude.usage;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.time.Instant;
+import java.util.Collection;
+
+/**
+ * Shared JSON accessors and capacity-payload builders for relay usage vendors.
+ *
+ * <p>Every vendor must translate its native usage API response into the capacity
+ * shape consumed by the webview ({@code capacity_pct} + {@code windows[]}); these
+ * helpers keep that translation in one place so all vendors emit an identical,
+ * contract-stable structure (see {@code planUsagePace.ts#parseCapacityPayload}).
+ */
+public final class RelayUsageJson {
+
+    private RelayUsageJson() {
+    }
+
+    // ===== tolerant accessors (accept the first present, numeric-parsable key) =====
+
+    /** First finite double among {@code keys}, or null. String primitives are parsed. */
+    public static Double asDouble(JsonObject o, String... keys) {
+        for (String k : keys) {
+            if (o != null && o.has(k) && o.get(k).isJsonPrimitive() && !o.get(k).isJsonNull()) {
+                try {
+                    return o.get(k).getAsDouble();
+                } catch (RuntimeException ignored) {
+                }
+            }
+        }
+        return null;
+    }
+
+    /** First long among {@code keys}, or null. String primitives are parsed. */
+    public static Long asLong(JsonObject o, String... keys) {
+        for (String k : keys) {
+            if (o != null && o.has(k) && o.get(k).isJsonPrimitive() && !o.get(k).isJsonNull()) {
+                try {
+                    return o.get(k).getAsLong();
+                } catch (RuntimeException ignored) {
+                }
+            }
+        }
+        return null;
+    }
+
+    /** Integer value of {@code key}, or null when absent/not numeric. */
+    public static Integer asInt(JsonObject o, String key) {
+        if (o != null && o.has(key) && o.get(key).isJsonPrimitive() && !o.get(key).isJsonNull()) {
+            try {
+                return o.get(key).getAsInt();
+            } catch (RuntimeException ignored) {
+            }
+        }
+        return null;
+    }
+
+    /** String value of {@code key}, or null. */
+    public static String asString(JsonObject o, String key) {
+        if (o != null && o.has(key) && o.get(key).isJsonPrimitive() && !o.get(key).isJsonNull()) {
+            return o.get(key).getAsString();
+        }
+        return null;
+    }
+
+    /** Object value of {@code key}, or null when absent or not an object. */
+    public static JsonObject asObject(JsonObject o, String key) {
+        if (o != null && o.has(key) && o.get(key).isJsonObject()) {
+            return o.getAsJsonObject(key);
+        }
+        return null;
+    }
+
+    /** Array value of {@code key}, or null when absent or not an array. */
+    public static JsonArray asArray(JsonObject o, String key) {
+        if (o != null && o.has(key) && o.get(key).isJsonArray()) {
+            return o.getAsJsonArray(key);
+        }
+        return null;
+    }
+
+    /** Clamp a percentage into [0, 100]; non-finite values collapse to 0. */
+    public static double clampPct(double v) {
+        if (!Double.isFinite(v)) {
+            return 0;
+        }
+        return Math.max(0, Math.min(100, v));
+    }
+
+    /** Render epoch milliseconds as an ISO-8601 instant (the payload reset_at format). */
+    public static String epochMsToIso(long epochMs) {
+        return Instant.ofEpochMilli(epochMs).toString();
+    }
+
+    // ===== capacity payload construction =====
+
+    /**
+     * One {@code windows[]} entry. {@code id} doubles as {@code period_type}
+     * ("5h" / "7d" / "monthly" / …); {@code resetAtMs} is optional.
+     */
+    public static JsonObject window(String id, double usedPct, Long resetAtMs) {
+        JsonObject w = new JsonObject();
+        w.addProperty("id", id);
+        w.addProperty("used_pct", usedPct);
+        if (resetAtMs != null) {
+            w.addProperty("reset_at", epochMsToIso(resetAtMs));
+        }
+        w.addProperty("period_type", id);
+        return w;
+    }
+
+    /**
+     * Assemble the shared capacity payload from ordered windows. The binding
+     * {@code capacity_pct} prefers the 5h window (the shortest actionable budget)
+     * and otherwise falls back to the worst window, mirroring the original z.ai
+     * behaviour. {@code windows} must be non-empty; {@code level} (plan tier) is
+     * optional and vendor-specific.
+     */
+    public static JsonObject capacityPayload(String source, Collection<JsonObject> windows, String level) {
+        Double primary5h = null;
+        double maxPct = 0;
+        for (JsonObject w : windows) {
+            double pct = w.get("used_pct").getAsDouble();
+            if ("5h".equals(w.get("id").getAsString())) {
+                primary5h = pct;
+            }
+            if (pct > maxPct) {
+                maxPct = pct;
+            }
+        }
+        double capacity = primary5h != null ? primary5h : maxPct;
+
+        JsonObject out = new JsonObject();
+        out.addProperty("ok", true);
+        out.addProperty("present", true);
+        out.addProperty("provider", "claude");
+        out.addProperty("source", source);
+        out.addProperty("capacity_pct", capacity);
+        out.addProperty("period_type", windows.iterator().next().get("id").getAsString());
+        JsonArray arr = new JsonArray();
+        for (JsonObject w : windows) {
+            arr.add(w);
+        }
+        out.add("windows", arr);
+        if (level != null) {
+            out.addProperty("level", level);
+        }
+        return out;
+    }
+
+    /** {@code true} when {@code el} is a JSON object (array element guard). */
+    public static boolean isObject(JsonElement el) {
+        return el != null && el.isJsonObject();
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageRegistry.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageRegistry.java
@@ -1,0 +1,96 @@
+package com.github.claudecodegui.provider.claude.usage;
+
+import com.github.claudecodegui.settings.CodemossSettingsService;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Resolves the plan-usage payload for the active relay backend: matches
+ * {@code ANTHROPIC_BASE_URL} against the registered {@link RelayUsageVendor}s,
+ * then probes with the shared cache/stale policy.
+ *
+ * <p>Registration order matters where vendors share a host:
+ * {@code api.kimi.com} serves both the plain Moonshot API and the Coding Plan,
+ * so {@code kimi-coding} (path-gated on {@code /coding}) must sit before any
+ * future plain-kimi/moonshot vendor.
+ */
+public final class RelayUsageRegistry {
+
+    private static final Logger LOG = Logger.getInstance(RelayUsageRegistry.class);
+
+    private static final List<RelayUsageVendor> VENDORS = List.of(
+            new KimiCodingUsageVendor(),
+            new MiniMaxUsageVendor(),
+            new ZaiUsageVendor());
+
+    private RelayUsageRegistry() {
+    }
+
+    /**
+     * Resolve the capacity payload for the relay backend described by
+     * {@code settings} (the Claude settings object; see
+     * {@link CodemossSettingsService#readClaudeSettings()}). Null when no
+     * vendor matches, the credential is missing, the probe yields no usable
+     * data and no fresh/stale cache entry can be served — callers fall back to
+     * the SDK rate_limit snapshot.
+     */
+    public static JsonObject resolve(JsonObject settings, long nowMs) {
+        RelayUsageEnv env = RelayUsageEnv.from(settings);
+        RelayUsageVendor vendor = match(env.baseUrl());
+        if (vendor == null || env.token() == null) {
+            return null;
+        }
+        // Key the cache by vendor + endpoint + credential so an account/base-URL
+        // switch never serves the previous account's quota.
+        String cacheKey = vendor.id() + '\n' + env.baseUrl() + '\n' + env.token();
+
+        JsonObject fresh = RelayUsageCache.fresh(cacheKey, nowMs);
+        if (fresh != null) {
+            return fresh;
+        }
+        try {
+            JsonObject payload = vendor.probe(env);
+            if (payload != null) {
+                RelayUsageCache.store(cacheKey, payload, nowMs);
+                return payload.deepCopy();
+            }
+        } catch (Exception e) {
+            LOG.warn("relay usage probe failed (" + vendor.id() + "): " + e.getMessage());
+        }
+        return RelayUsageCache.stale(cacheKey, nowMs);
+    }
+
+    /** Vendor owning {@code baseUrl}, or null when unassigned/malformed. */
+    static RelayUsageVendor match(String baseUrl) {
+        if (baseUrl == null) {
+            return null;
+        }
+        String host;
+        String path;
+        try {
+            URI u = URI.create(baseUrl);
+            if (u.getHost() == null) {
+                return null;
+            }
+            host = u.getHost().toLowerCase(Locale.ROOT);
+            path = u.getPath() == null ? "" : u.getPath().toLowerCase(Locale.ROOT);
+        } catch (Exception e) {
+            return null;
+        }
+        for (RelayUsageVendor vendor : VENDORS) {
+            if (vendor.matches(host, path)) {
+                return vendor;
+            }
+        }
+        return null;
+    }
+
+    /** Registered vendors, in match order (tests). */
+    static List<RelayUsageVendor> vendors() {
+        return VENDORS;
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageVendor.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageVendor.java
@@ -1,0 +1,37 @@
+package com.github.claudecodegui.provider.claude.usage;
+
+import com.google.gson.JsonObject;
+
+/**
+ * One relay vendor that can report Claude plan usage for its own backend.
+ *
+ * <p>Implementations are stateless; caching, HTTP and error policy live in
+ * {@link RelayUsageRegistry} / {@link RelayUsageHttp} / {@link RelayUsageCache}.
+ * Vendors only decide <em>whether</em> they own a base URL and <em>how</em> to
+ * translate their usage API into the shared capacity payload
+ * ({@code capacity_pct} + {@code windows[]}).
+ */
+public interface RelayUsageVendor {
+
+    /**
+     * Stable vendor id ("zai", "minimax", "kimi-coding", …). Namespaces the
+     * probe cache; also used in log messages.
+     */
+    String id();
+
+    /**
+     * Whether this vendor serves the given anthropic base URL. {@code host} is
+     * the lowercased {@code ANTHROPIC_BASE_URL} host; {@code path} is its
+     * (possibly empty) lowercased path — needed because some vendors share a
+     * host and are distinguished by path only (api.kimi.com/coding).
+     */
+    boolean matches(String host, String path);
+
+    /**
+     * Probe the vendor usage API and translate the response into a capacity
+     * payload (or null when the response carries no usable data — e.g. an
+     * expired plan). Throwing signals a transport/API failure and triggers the
+     * caller's stale-cache fallback.
+     */
+    JsonObject probe(RelayUsageEnv env) throws Exception;
+}

--- a/src/main/java/com/github/claudecodegui/provider/claude/usage/ZaiUsageVendor.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/usage/ZaiUsageVendor.java
@@ -1,0 +1,119 @@
+package com.github.claudecodegui.provider.claude.usage;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * 智谱 GLM Coding Plan via the z.ai / bigmodel.cn anthropic-compat backend.
+ *
+ * <p>Probes {@code {origin}/api/monitor/usage/quota/limit} (both hosts expose
+ * the same usage API) and parses the {@code TOKENS_LIMIT}/{@code CREDIT_LIMIT}
+ * windows (5h + 7d) plus the {@code TIME_LIMIT} monthly MCP budget, returning
+ * the per-window {@code percentage}. Migrated verbatim from the original
+ * z.ai-only logic in {@code ClaudePlanUsageService}.
+ */
+public final class ZaiUsageVendor implements RelayUsageVendor {
+
+    private static final String USAGE_PATH = "/api/monitor/usage/quota/limit";
+
+    @Override
+    public String id() {
+        return "zai";
+    }
+
+    @Override
+    public boolean matches(String host, String path) {
+        return host.equals("z.ai") || host.endsWith(".z.ai")
+                || host.equals("open.bigmodel.cn") || host.endsWith(".bigmodel.cn");
+    }
+
+    @Override
+    public JsonObject probe(RelayUsageEnv env) throws Exception {
+        String origin = RelayUsageHttp.secureOrigin(env.baseUrl());
+        if (origin == null) {
+            return null;
+        }
+        JsonObject body = RelayUsageHttp.getJson(origin + USAGE_PATH, env.token());
+        return parseQuota(body);
+    }
+
+    /**
+     * Parse the quota-limit body into the capacity shape. Coding-token windows
+     * ({@code CREDIT_LIMIT}/{@code TOKENS_LIMIT}) map to 5h/7d; the
+     * {@code TIME_LIMIT} monthly MCP budget maps to a {@code monthly} window.
+     * Only limits carrying a {@code percentage} are emitted.
+     */
+    static JsonObject parseQuota(JsonObject body) {
+        if (body == null) {
+            return null;
+        }
+        JsonObject data = RelayUsageJson.asObject(body, "data");
+        if (data == null || RelayUsageJson.asArray(data, "limits") == null) {
+            return null;
+        }
+        String level = RelayUsageJson.asString(data, "level");
+
+        // Two limit types can map to the same window (e.g. TOKENS_LIMIT and
+        // CREDIT_LIMIT both with unit=3 → "5h"); merge them, surfacing the worse
+        // usage, so the frontend never sees duplicate window ids.
+        Map<String, JsonObject> byPeriod = new LinkedHashMap<>();
+        for (JsonElement el : data.getAsJsonArray("limits")) {
+            if (!RelayUsageJson.isObject(el)) {
+                continue;
+            }
+            JsonObject lim = el.getAsJsonObject();
+            Double pct = RelayUsageJson.asDouble(lim, "percentage");
+            if (pct == null || !Double.isFinite(pct)) {
+                continue;
+            }
+            pct = RelayUsageJson.clampPct(pct);
+            String type = RelayUsageJson.asString(lim, "type");
+            String period = period(lim, type);
+            Long resetsAtMs = RelayUsageJson.asLong(lim, "nextResetTime", "next_reset_time");
+
+            JsonObject existing = byPeriod.get(period);
+            if (existing != null) {
+                if (pct > existing.get("used_pct").getAsDouble()) {
+                    existing.addProperty("used_pct", pct);
+                }
+                if (!existing.has("reset_at") && resetsAtMs != null) {
+                    existing.addProperty("reset_at", RelayUsageJson.epochMsToIso(resetsAtMs));
+                }
+                continue;
+            }
+            byPeriod.put(period, RelayUsageJson.window(period, pct, resetsAtMs));
+        }
+        if (byPeriod.isEmpty()) {
+            return null;
+        }
+        return RelayUsageJson.capacityPayload("zai-quota-limit", byPeriod.values(), level);
+    }
+
+    /**
+     * Map a limit to a window id/period. Observed payloads use unit 3=hours
+     * (number=5 → 5h), unit 6=weeks (number=1 → 7d) and unit 4=days (number=7
+     * → 7d). The {@code number} field is assumed to match those shapes — a
+     * hypothetical unit=4/number=1 (1-day) window would still be labelled 7d.
+     */
+    static String period(JsonObject lim, String type) {
+        if (type != null && type.toUpperCase().contains("TIME")) {
+            return "monthly";
+        }
+        Integer unit = RelayUsageJson.asInt(lim, "unit");
+        if (unit == null) {
+            return "5h";
+        }
+        switch (unit) {
+            case 3:
+                return "5h";
+            case 6:
+            case 4:
+                return "7d";
+            default:
+                return "5h";
+        }
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/claude/ClaudePlanUsageServiceTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/ClaudePlanUsageServiceTest.java
@@ -1,7 +1,7 @@
 package com.github.claudecodegui.provider.claude;
 
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import org.junit.After;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -24,6 +24,11 @@ public class ClaudePlanUsageServiceTest {
 
     private static long nowSec() {
         return System.currentTimeMillis() / 1000L;
+    }
+
+    @After
+    public void tearDown() {
+        ClaudePlanUsageService.resetRateLimitCacheForTests();
     }
 
     @Test
@@ -100,13 +105,6 @@ public class ClaudePlanUsageServiceTest {
     }
 
     @Test
-    public void clampPct_boundsZeroToHundred() {
-        assertEquals(0.0, ClaudePlanUsageService.clampPct(-5), 0.001);
-        assertEquals(100.0, ClaudePlanUsageService.clampPct(144), 0.001);
-        assertEquals(50.0, ClaudePlanUsageService.clampPct(50), 0.001);
-    }
-
-    @Test
     public void periodTypeFromResetMs_classifies5hAnd7d() {
         long now = System.currentTimeMillis();
         assertEquals("5h", ClaudePlanUsageService.periodTypeFromResetMs(now + 2L * 60 * 60 * 1000));
@@ -114,243 +112,28 @@ public class ClaudePlanUsageServiceTest {
         assertEquals("7d", ClaudePlanUsageService.periodTypeFromResetMs(now + 2L * 24 * 60 * 60 * 1000));
     }
 
-    @Test
-    public void parseZaiQuota_maps5h7dWindowsAndLevel() {
-        JsonObject body = JsonParser.parseString("""
-                {"code":200,"success":true,"data":{
-                  "level":"max",
-                  "limits":[
-                    {"type":"CREDIT_LIMIT","unit":3,"number":5,"percentage":13,"nextResetTime":1786624965401},
-                    {"type":"CREDIT_LIMIT","unit":6,"number":1,"percentage":2,"nextResetTime":1787155353998}
-                  ]
-                }}
-                """).getAsJsonObject();
-        JsonObject payload = ClaudePlanUsageService.parseZaiQuota(body);
+    // ===== facade: registry miss falls back to the cached rate_limit snapshot =====
 
-        assertEquals("claude", payload.get("provider").getAsString());
-        assertEquals("zai-quota-limit", payload.get("source").getAsString());
+    @Test
+    public void resolvePlanUsagePayload_noSettings_fallsBackToRateLimitCache() {
+        // With no settings service there is no registry match and no cached
+        // snapshot yet → the unavailable marker.
+        assertFalse(ClaudePlanUsageService.resolvePlanUsagePayload(null).get("present").getAsBoolean());
+
+        JsonObject rateLimit = info(0.42, nowSec() + 3L * 60 * 60, "allowed_warning");
+        ClaudePlanUsageService.cacheRateLimitInfo(rateLimit);
+
+        JsonObject payload = ClaudePlanUsageService.resolvePlanUsagePayload(null);
         assertTrue(payload.get("present").getAsBoolean());
-        assertEquals(13.0, payload.get("capacity_pct").getAsDouble(), 0.01);
-        assertEquals("5h", payload.get("period_type").getAsString());
-        assertEquals("max", payload.get("level").getAsString());
-
-        com.google.gson.JsonArray windows = payload.getAsJsonArray("windows");
-        assertEquals(2, windows.size());
-        JsonObject w0 = windows.get(0).getAsJsonObject();
-        assertEquals("5h", w0.get("id").getAsString());
-        assertEquals(13.0, w0.get("used_pct").getAsDouble(), 0.01);
-        assertEquals("7d", windows.get(1).getAsJsonObject().get("id").getAsString());
-        assertEquals(2.0, windows.get(1).getAsJsonObject().get("used_pct").getAsDouble(), 0.01);
-    }
-
-    @Test
-    public void parseZaiQuota_timeLimitMapsToMonthly() {
-        JsonObject body = JsonParser.parseString("""
-                {"data":{"level":"pro","limits":[
-                  {"type":"TIME_LIMIT","unit":4,"number":1,"percentage":55}
-                ]}}
-                """).getAsJsonObject();
-        JsonObject payload = ClaudePlanUsageService.parseZaiQuota(body);
-        assertEquals("monthly", payload.getAsJsonArray("windows").get(0).getAsJsonObject().get("id").getAsString());
-        assertEquals("pro", payload.get("level").getAsString());
-    }
-
-    @Test
-    public void parseZaiQuota_emptyLimitsReturnsNull() {
-        JsonObject body = JsonParser.parseString("{\"data\":{\"limits\":[]}}").getAsJsonObject();
-        assertNull(ClaudePlanUsageService.parseZaiQuota(body));
-    }
-
-    @Test
-    public void parseZaiQuota_creditLimitUnitDays_mapsTo7d() {
-        JsonObject body = JsonParser.parseString("""
-                {"data":{"limits":[
-                  {"type":"CREDIT_LIMIT","unit":4,"number":7,"percentage":41}
-                ]}}
-                """).getAsJsonObject();
-        JsonObject payload = ClaudePlanUsageService.parseZaiQuota(body);
-        assertEquals("7d", payload.getAsJsonArray("windows").get(0).getAsJsonObject().get("id").getAsString());
-        assertEquals(41.0, payload.get("capacity_pct").getAsDouble(), 0.01);
-    }
-
-    @Test
-    public void isZaiBackend_matchesHostOnly() {
-        assertTrue(ClaudePlanUsageService.isZaiBackend(settingsWithBase("https://api.z.ai/api/anthropic")));
-        assertTrue(ClaudePlanUsageService.isZaiBackend(settingsWithBase("https://z.ai/api/anthropic")));
-        assertFalse(ClaudePlanUsageService.isZaiBackend(settingsWithBase("https://api.anthropic.com")));
-        // Look-alike hosts must not trigger the z.ai probe
-        assertFalse(ClaudePlanUsageService.isZaiBackend(settingsWithBase("https://quiz.ai/api/anthropic")));
-        assertFalse(ClaudePlanUsageService.isZaiBackend(settingsWithBase("https://buzz.ai/api")));
-        // z.ai appearing only in the path is not a z.ai host
-        assertFalse(ClaudePlanUsageService.isZaiBackend(settingsWithBase("https://gateway.example.com/z.ai/proxy")));
-        // Malformed base URL → not z.ai, never throws
-        assertFalse(ClaudePlanUsageService.isZaiBackend(settingsWithBase("not a url")));
-    }
-
-    @Test
-    public void monitorUrl_derivesOriginAndPath() {
-        assertEquals("https://api.z.ai/api/monitor/usage/quota/limit",
-                ClaudePlanUsageService.monitorUrl("https://api.z.ai/api/anthropic"));
-    }
-
-    @Test
-    public void monitorUrl_keepsCustomPort() {
-        assertEquals("http://localhost:8080/api/monitor/usage/quota/limit",
-                ClaudePlanUsageService.monitorUrl("http://localhost:8080/api/anthropic"));
-    }
-
-    @Test
-    public void monitorUrl_rejectsPlainHttpExceptLoopback() {
-        // Bearer tokens must not travel over plaintext to a remote host
-        assertNull(ClaudePlanUsageService.monitorUrl("http://api.z.ai/api/anthropic"));
-        assertNull(ClaudePlanUsageService.monitorUrl("http://z.ai/api/anthropic"));
-        // Loopback proxies (local dev / tests) may use plain HTTP
-        assertEquals("http://127.0.0.1:9000/api/monitor/usage/quota/limit",
-                ClaudePlanUsageService.monitorUrl("http://127.0.0.1:9000/api/anthropic"));
-        assertEquals("http://localhost:8080/api/monitor/usage/quota/limit",
-                ClaudePlanUsageService.monitorUrl("http://localhost:8080/api/anthropic"));
-    }
-
-    @Test
-    public void parseZaiQuota_duplicatePeriodsMergeKeepingWorst() {
-        JsonObject body = JsonParser.parseString("""
-                {"data":{"limits":[
-                  {"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":10,"nextResetTime":1786624965401},
-                  {"type":"CREDIT_LIMIT","unit":3,"number":5,"percentage":20,"nextResetTime":1786624965401}
-                ]}}
-                """).getAsJsonObject();
-        JsonObject payload = ClaudePlanUsageService.parseZaiQuota(body);
-
-        com.google.gson.JsonArray windows = payload.getAsJsonArray("windows");
-        assertEquals(1, windows.size());
-        JsonObject w = windows.get(0).getAsJsonObject();
-        assertEquals("5h", w.get("id").getAsString());
-        assertEquals(20.0, w.get("used_pct").getAsDouble(), 0.01);
-        assertEquals(20.0, payload.get("capacity_pct").getAsDouble(), 0.01);
-    }
-
-    // ===== probe pipeline (transport injected) =====
-
-    @org.junit.After
-    public void tearDown() {
-        ClaudePlanUsageService.setZaiTransportForTests(null);
-        ClaudePlanUsageService.resetZaiCacheForTests();
-    }
-
-    @Test
-    public void resolveViaZaiMonitor_sendsBearerTokenToMonitorUrl() {
-        String[] seen = new String[2];
-        ClaudePlanUsageService.setZaiTransportForTests((url, token) -> {
-            seen[0] = url;
-            seen[1] = token;
-            return zaiBody(42);
-        });
-
-        JsonObject payload = ClaudePlanUsageService.resolveViaZaiMonitor(
-                settingsWithBaseAndToken("https://api.z.ai/api/anthropic", "glm-secret"), 1000L);
-
-        assertEquals("https://api.z.ai/api/monitor/usage/quota/limit", seen[0]);
-        assertEquals("glm-secret", seen[1]);
+        assertEquals("sdk-rate-limit", payload.get("source").getAsString());
         assertEquals(42.0, payload.get("capacity_pct").getAsDouble(), 0.01);
     }
 
     @Test
-    public void resolveViaZaiMonitor_fallsBackToApiKeyWhenAuthTokenMissing() {
-        String[] seen = new String[1];
-        ClaudePlanUsageService.setZaiTransportForTests((url, token) -> {
-            seen[0] = token;
-            return zaiBody(1);
-        });
-
-        JsonObject settings = settingsWithBase("https://api.z.ai/api/anthropic");
-        settings.getAsJsonObject("env").addProperty("ANTHROPIC_API_KEY", "sk-fallback");
-        ClaudePlanUsageService.resolveViaZaiMonitor(settings, 1000L);
-
-        assertEquals("sk-fallback", seen[0]);
-    }
-
-    @Test
-    public void resolveViaZaiMonitor_cacheTtlEnforced() {
-        int[] calls = {0};
-        ClaudePlanUsageService.setZaiTransportForTests((url, token) -> {
-            calls[0]++;
-            return zaiBody(10);
-        });
-        JsonObject settings = settingsWithBaseAndToken("https://api.z.ai/api/anthropic", "t");
-        long t0 = 1_000_000L;
-
-        ClaudePlanUsageService.resolveViaZaiMonitor(settings, t0);
-        assertEquals(1, calls[0]);
-        // Within TTL → served from cache, no second probe
-        ClaudePlanUsageService.resolveViaZaiMonitor(settings, t0 + ClaudePlanUsageService.ZAI_CACHE_TTL_MS - 1);
-        assertEquals(1, calls[0]);
-        // TTL expired → probes again
-        ClaudePlanUsageService.resolveViaZaiMonitor(settings, t0 + ClaudePlanUsageService.ZAI_CACHE_TTL_MS + 1);
-        assertEquals(2, calls[0]);
-    }
-
-    @Test
-    public void resolveViaZaiMonitor_cacheKeyedByUrlAndToken() {
-        int[] calls = {0};
-        ClaudePlanUsageService.setZaiTransportForTests((url, token) -> {
-            calls[0]++;
-            return zaiBody(10);
-        });
-        long t0 = 1_000_000L;
-
-        ClaudePlanUsageService.resolveViaZaiMonitor(
-                settingsWithBaseAndToken("https://api.z.ai/api/anthropic", "account-a"), t0);
-        assertEquals(1, calls[0]);
-        // Same URL but a different token (account switch) must not reuse the cache
-        ClaudePlanUsageService.resolveViaZaiMonitor(
-                settingsWithBaseAndToken("https://api.z.ai/api/anthropic", "account-b"), t0 + 1);
-        assertEquals(2, calls[0]);
-    }
-
-    @Test
-    public void resolveViaZaiMonitor_staleFallbackOnProbeFailure() {
-        boolean[] fail = {false};
-        ClaudePlanUsageService.setZaiTransportForTests((url, token) -> {
-            if (fail[0]) {
-                throw new IllegalStateException("boom");
-            }
-            return zaiBody(33);
-        });
-        JsonObject settings = settingsWithBaseAndToken("https://api.z.ai/api/anthropic", "t");
-        long t0 = 1_000_000L;
-
-        ClaudePlanUsageService.resolveViaZaiMonitor(settings, t0);
-
-        fail[0] = true;
-        // Probe fails with an expired-but-recent cache → stale payload
-        JsonObject stale = ClaudePlanUsageService.resolveViaZaiMonitor(
-                settings, t0 + ClaudePlanUsageService.ZAI_CACHE_TTL_MS + 1);
-        assertEquals(33.0, stale.get("capacity_pct").getAsDouble(), 0.01);
-        assertTrue(stale.get("stale").getAsBoolean());
-
-        // Cache older than the stale cap → give up (null → caller falls back)
-        assertNull(ClaudePlanUsageService.resolveViaZaiMonitor(
-                settings, t0 + ClaudePlanUsageService.ZAI_STALE_MAX_MS + 1));
-    }
-
-    private static JsonObject zaiBody(double pct) {
-        return JsonParser.parseString(
-                "{\"data\":{\"level\":\"max\",\"limits\":["
-                        + "{\"type\":\"CREDIT_LIMIT\",\"unit\":3,\"number\":5,\"percentage\":" + pct
-                        + ",\"nextResetTime\":1786624965401}]}}").getAsJsonObject();
-    }
-
-    private static JsonObject settingsWithBaseAndToken(String base, String token) {
-        JsonObject settings = settingsWithBase(base);
-        settings.getAsJsonObject("env").addProperty("ANTHROPIC_AUTH_TOKEN", token);
-        return settings;
-    }
-
-    private static JsonObject settingsWithBase(String base) {
-        JsonObject settings = new JsonObject();
-        JsonObject env = new JsonObject();
-        env.addProperty("ANTHROPIC_BASE_URL", base);
-        settings.add("env", env);
-        return settings;
+    public void resolvePlanUsagePayload_noSnapshotAtAll_returnsUnavailableMarker() {
+        JsonObject payload = ClaudePlanUsageService.resolvePlanUsagePayload(null);
+        assertFalse(payload.get("present").getAsBoolean());
+        assertTrue(payload.get("unavailable").getAsBoolean());
+        assertEquals("claude", payload.get("provider").getAsString());
     }
 }

--- a/src/test/java/com/github/claudecodegui/provider/claude/usage/KimiCodingUsageVendorTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/usage/KimiCodingUsageVendorTest.java
@@ -1,0 +1,136 @@
+package com.github.claudecodegui.provider.claude.usage;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class KimiCodingUsageVendorTest {
+
+    private final KimiCodingUsageVendor vendor = new KimiCodingUsageVendor();
+
+    @After
+    public void tearDown() {
+        RelayUsageHttp.setTransportForTests(null);
+    }
+
+    // ===== host/path matching: the /coding path is what makes it a Coding Plan =====
+
+    @Test
+    public void matches_apiKimiHostWithCodingPathOnly() {
+        assertTrue(vendor.matches("api.kimi.com", "/coding"));
+        assertTrue(vendor.matches("api.kimi.com", "/coding/"));
+        assertFalse(vendor.matches("api.kimi.com", ""));
+        assertFalse(vendor.matches("api.kimi.com", "/v1"));
+        assertFalse(vendor.matches("moonshot.cn", "/coding"));
+        assertFalse(vendor.matches("api.moonshot.cn", "/coding"));
+    }
+
+    // ===== response parsing =====
+
+    @Test
+    public void parseUsages_limitAndRemainingProduce5hAndWeeklyWindows() {
+        JsonObject body = JsonParser.parseString("""
+                {"limits":[
+                  {"window":{"duration":300,"timeUnit":"TIME_UNIT_MINUTE"},
+                   "detail":{"limit":"120","remaining":"30","resetTime":"1759180800000"}}
+                ],
+                "usage":{"limit":"500","used":"150","resetTime":"1759699200000"}}
+                """).getAsJsonObject();
+
+        JsonObject payload = KimiCodingUsageVendor.parseUsages(body);
+
+        assertEquals("kimi-coding-usages", payload.get("source").getAsString());
+        // (120−30)/120 = 75% binds capacity
+        assertEquals(75.0, payload.get("capacity_pct").getAsDouble(), 0.01);
+        assertEquals("5h", payload.get("period_type").getAsString());
+
+        com.google.gson.JsonArray windows = payload.getAsJsonArray("windows");
+        assertEquals(2, windows.size());
+        JsonObject w5h = windows.get(0).getAsJsonObject();
+        assertEquals("5h", w5h.get("id").getAsString());
+        assertEquals(75.0, w5h.get("used_pct").getAsDouble(), 0.01);
+        assertEquals(java.time.Instant.ofEpochMilli(1759180800000L).toString(), w5h.get("reset_at").getAsString());
+        JsonObject w7d = windows.get(1).getAsJsonObject();
+        assertEquals("7d", w7d.get("id").getAsString());
+        assertEquals(30.0, w7d.get("used_pct").getAsDouble(), 0.01);
+    }
+
+    @Test
+    public void parseUsages_durationVariantsRecognized() {
+        // 18000 seconds == 300 minutes == 5h; 604800 seconds == 7d; 7 days == 7d
+        JsonObject body = JsonParser.parseString("""
+                {"limits":[
+                  {"window":{"duration":18000,"timeUnit":"TIME_UNIT_SECOND"},
+                   "detail":{"limit":"100","used":"20"}},
+                  {"window":{"duration":604800},
+                   "detail":{"limit":"400","used":"100"}},
+                  {"window":{"duration":7,"timeUnit":"TIME_UNIT_DAY"},
+                   "detail":{"limit":"400","used":"300"}},
+                  {"window":{"duration":999},
+                   "detail":{"limit":"1","used":"1"}}
+                ]}
+                """).getAsJsonObject();
+
+        com.google.gson.JsonArray windows = KimiCodingUsageVendor.parseUsages(body).getAsJsonArray("windows");
+        // 5h once, then the two weekly variants merged keeping the worst (300/400)
+        assertEquals(2, windows.size());
+        assertEquals("5h", windows.get(0).getAsJsonObject().get("id").getAsString());
+        assertEquals(20.0, windows.get(0).getAsJsonObject().get("used_pct").getAsDouble(), 0.01);
+        assertEquals("7d", windows.get(1).getAsJsonObject().get("id").getAsString());
+        assertEquals(75.0, windows.get(1).getAsJsonObject().get("used_pct").getAsDouble(), 0.01);
+    }
+
+    @Test
+    public void parseUsages_weeklyUsageOnly() {
+        JsonObject body = JsonParser.parseString("""
+                {"usage":{"limit":"400","remaining":"100","resetTime":1759699200000}}
+                """).getAsJsonObject();
+
+        JsonObject payload = KimiCodingUsageVendor.parseUsages(body);
+        assertEquals("7d", payload.get("period_type").getAsString());
+        assertEquals(75.0, payload.get("capacity_pct").getAsDouble(), 0.01);
+    }
+
+    @Test
+    public void parseUsages_overRemainingClampsToHundred() {
+        JsonObject body = JsonParser.parseString("""
+                {"usage":{"limit":"100","remaining":"-50"}}
+                """).getAsJsonObject();
+        assertEquals(100.0, KimiCodingUsageVendor.parseUsages(body).get("capacity_pct").getAsDouble(), 0.01);
+    }
+
+    @Test
+    public void parseUsages_zeroLimitOrNoQuotaFieldsReturnsNull() {
+        assertNull(KimiCodingUsageVendor.parseUsages(JsonParser.parseString(
+                "{\"limits\":[{\"window\":{\"duration\":300},\"detail\":{\"limit\":\"0\"}}]}").getAsJsonObject()));
+        assertNull(KimiCodingUsageVendor.parseUsages(JsonParser.parseString(
+                "{\"limits\":[{\"window\":{\"duration\":300},\"detail\":{}},\"no-window\"]}").getAsJsonObject()));
+        assertNull(KimiCodingUsageVendor.parseUsages(new JsonObject()));
+        assertNull(KimiCodingUsageVendor.parseUsages(null));
+    }
+
+    // ===== probe pipeline (transport injected) =====
+
+    @Test
+    public void probe_appendsUsagesPathToOrigin() throws Exception {
+        String[] seen = new String[2];
+        RelayUsageHttp.setTransportForTests((url, headers) -> {
+            seen[0] = url;
+            seen[1] = headers.get("Authorization");
+            return JsonParser.parseString(
+                    "{\"usage\":{\"limit\":\"100\",\"used\":\"10\"}}").getAsJsonObject();
+        });
+
+        JsonObject payload = vendor.probe(ZaiUsageVendorTest.env("https://api.kimi.com/coding", "kimi-t"));
+
+        assertEquals("https://api.kimi.com/coding/v1/usages", seen[0]);
+        assertEquals("Bearer kimi-t", seen[1]);
+        assertEquals(10.0, payload.get("capacity_pct").getAsDouble(), 0.01);
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/claude/usage/MiniMaxUsageVendorTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/usage/MiniMaxUsageVendorTest.java
@@ -1,0 +1,147 @@
+package com.github.claudecodegui.provider.claude.usage;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class MiniMaxUsageVendorTest {
+
+    private final MiniMaxUsageVendor vendor = new MiniMaxUsageVendor();
+
+    @After
+    public void tearDown() {
+        RelayUsageHttp.setTransportForTests(null);
+    }
+
+    // ===== host matching =====
+
+    @Test
+    public void matches_cnAndIntlHostsOnly() {
+        assertTrue(vendor.matches("api.minimaxi.com", "/v1"));
+        assertTrue(vendor.matches("minimaxi.com", ""));
+        assertTrue(vendor.matches("api.minimax.io", "/v1"));
+        // Look-alikes: suffix must be a domain boundary, not a substring
+        assertFalse(vendor.matches("notminimaxi.com", ""));
+        assertFalse(vendor.matches("api.minimaxi.com.evil.net", ""));
+        assertFalse(vendor.matches("minimaxis.com", ""));
+    }
+
+    // ===== response parsing =====
+
+    @Test
+    public void parseRemains_generalEntryMapsRemainingToUsed() {
+        JsonObject body = JsonParser.parseString("""
+                {"base_resp":{"status_code":0},"model_remains":[{
+                  "model_name":"general",
+                  "current_interval_remaining_percent":65.5,
+                  "end_time":1786624965401,
+                  "current_weekly_status":1,
+                  "current_weekly_remaining_percent":80,
+                  "weekly_end_time":1787155353998,
+                  "current_monthly_remaining_percent":90,
+                  "monthly_end_time":1789747353998
+                }]}
+                """).getAsJsonObject();
+
+        JsonObject payload = MiniMaxUsageVendor.parseRemains(body, null);
+
+        assertEquals("minimax-coding-plan", payload.get("source").getAsString());
+        // 5h window binds capacity: 100 − 65.5 remaining = 34.5 used
+        assertEquals(34.5, payload.get("capacity_pct").getAsDouble(), 0.01);
+
+        com.google.gson.JsonArray windows = payload.getAsJsonArray("windows");
+        assertEquals(3, windows.size());
+        JsonObject w5h = windows.get(0).getAsJsonObject();
+        assertEquals("5h", w5h.get("id").getAsString());
+        assertEquals(34.5, w5h.get("used_pct").getAsDouble(), 0.01);
+        assertEquals(java.time.Instant.ofEpochMilli(1786624965401L).toString(), w5h.get("reset_at").getAsString());
+        JsonObject w7d = windows.get(1).getAsJsonObject();
+        assertEquals("7d", w7d.get("id").getAsString());
+        assertEquals(20.0, w7d.get("used_pct").getAsDouble(), 0.01);
+        JsonObject wMo = windows.get(2).getAsJsonObject();
+        assertEquals("monthly", wMo.get("id").getAsString());
+        assertEquals(10.0, wMo.get("used_pct").getAsDouble(), 0.01);
+    }
+
+    @Test
+    public void parseRemains_weeklyWindowOnlyWhenStatusEnabled() {
+        JsonObject body = JsonParser.parseString("""
+                {"model_remains":[{
+                  "model_name":"general",
+                  "current_interval_remaining_percent":50,
+                  "current_weekly_status":0,
+                  "current_weekly_remaining_percent":80
+                }]}
+                """).getAsJsonObject();
+
+        com.google.gson.JsonArray windows = MiniMaxUsageVendor.parseRemains(body, null).getAsJsonArray("windows");
+        assertEquals(1, windows.size());
+        assertEquals("5h", windows.get(0).getAsJsonObject().get("id").getAsString());
+    }
+
+    @Test
+    public void parseRemains_prefersCurrentModelOverGeneral() {
+        JsonObject body = JsonParser.parseString("""
+                {"model_remains":[
+                  {"model_name":"MiniMax-M3","current_interval_remaining_percent":10},
+                  {"model_name":"general","current_interval_remaining_percent":90}
+                ]}
+                """).getAsJsonObject();
+
+        // Exact id, cased/underscore variants and unicode dashes all normalize alike
+        assertEquals(90.0, usedPct(MiniMaxUsageVendor.parseRemains(body, "minimax_m3")), 0.01);
+        assertEquals(90.0, usedPct(MiniMaxUsageVendor.parseRemains(body, "MiniMax–M3")), 0.01);
+        // No model context → the "general" Coding Plan default
+        assertEquals(10.0, usedPct(MiniMaxUsageVendor.parseRemains(body, null)), 0.01);
+        // Unknown model still falls back to general
+        assertEquals(10.0, usedPct(MiniMaxUsageVendor.parseRemains(body, "gpt-9")), 0.01);
+    }
+
+    @Test
+    public void parseRemains_apiErrorReturnsNull() {
+        JsonObject body = JsonParser.parseString(
+                "{\"base_resp\":{\"status_code\":1004,\"status_msg\":\"invalid api key\"}}").getAsJsonObject();
+        assertNull(MiniMaxUsageVendor.parseRemains(body, null));
+    }
+
+    @Test
+    public void parseRemains_emptyRemainsReturnsNull() {
+        assertNull(MiniMaxUsageVendor.parseRemains(JsonParser.parseString(
+                "{\"model_remains\":[]}").getAsJsonObject(), null));
+        assertNull(MiniMaxUsageVendor.parseRemains(new JsonObject(), null));
+        assertNull(MiniMaxUsageVendor.parseRemains(null, null));
+    }
+
+    // ===== probe pipeline (transport injected) =====
+
+    @Test
+    public void probe_cnAndIntlEndpointsDerivedFromBase() throws Exception {
+        String[] seen = new String[2];
+        RelayUsageHttp.setTransportForTests((url, headers) -> {
+            seen[0] = url;
+            return minimaxBody();
+        });
+
+        vendor.probe(ZaiUsageVendorTest.env("https://api.minimaxi.com/v1", "mm-cn"));
+        assertEquals("https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains", seen[0]);
+
+        vendor.probe(ZaiUsageVendorTest.env("https://api.minimax.io/v1", "mm-intl"));
+        assertEquals("https://api.minimax.io/v1/api/openplatform/coding_plan/remains", seen[0]);
+    }
+
+    private static double usedPct(JsonObject payload) {
+        return payload.get("capacity_pct").getAsDouble();
+    }
+
+    private static JsonObject minimaxBody() {
+        return JsonParser.parseString("""
+                {"model_remains":[{"model_name":"general","current_interval_remaining_percent":50}]}
+                """).getAsJsonObject();
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageEnvTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageEnvTest.java
@@ -1,0 +1,41 @@
+package com.github.claudecodegui.provider.claude.usage;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class RelayUsageEnvTest {
+
+    private static JsonObject env(String json) {
+        JsonObject settings = new JsonObject();
+        settings.add("env", JsonParser.parseString(json).getAsJsonObject());
+        return settings;
+    }
+
+    @Test
+    public void token_prefersAuthTokenFallsBackToApiKey() {
+        assertEquals("auth-tok", RelayUsageEnv.from(env(
+                "{\"ANTHROPIC_BASE_URL\":\"https://api.z.ai\",\"ANTHROPIC_AUTH_TOKEN\":\"auth-tok\",\"ANTHROPIC_API_KEY\":\"sk-key\"}")).token());
+        assertEquals("sk-key", RelayUsageEnv.from(env(
+                "{\"ANTHROPIC_BASE_URL\":\"https://api.z.ai\",\"ANTHROPIC_API_KEY\":\"sk-key\"}")).token());
+        assertNull(RelayUsageEnv.from(env("{\"ANTHROPIC_BASE_URL\":\"https://api.z.ai\"}")).token());
+    }
+
+    @Test
+    public void model_followsEnvTierChain() {
+        assertEquals("glm-4.7", RelayUsageEnv.from(env(
+                "{\"ANTHROPIC_MODEL\":\"glm-4.7\",\"ANTHROPIC_DEFAULT_SONNET_MODEL\":\"other\"}")).model());
+        assertEquals("sonnet-model", RelayUsageEnv.from(env(
+                "{\"ANTHROPIC_DEFAULT_SONNET_MODEL\":\"sonnet-model\",\"ANTHROPIC_DEFAULT_HAIKU_MODEL\":\"haiku\"}")).model());
+        assertNull(RelayUsageEnv.from(env("{}")).model());
+    }
+
+    @Test
+    public void from_nullOrMissingEnvBlockYieldsEmptySnapshot() {
+        assertNull(RelayUsageEnv.from(null).baseUrl());
+        assertNull(RelayUsageEnv.from(new JsonObject()).token());
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageHttpTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageHttpTest.java
@@ -1,0 +1,31 @@
+package com.github.claudecodegui.provider.claude.usage;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class RelayUsageHttpTest {
+
+    @Test
+    public void secureOrigin_httpsOriginKeptPortAndPathDropped() {
+        assertEquals("https://api.z.ai", RelayUsageHttp.secureOrigin("https://api.z.ai/api/anthropic"));
+        assertEquals("https://proxy.corp:8443", RelayUsageHttp.secureOrigin("https://proxy.corp:8443/anthropic"));
+    }
+
+    @Test
+    public void secureOrigin_plainHttpOnlyForLoopback() {
+        assertEquals("http://localhost:8080", RelayUsageHttp.secureOrigin("http://localhost:8080/api"));
+        assertEquals("http://127.0.0.1:9000", RelayUsageHttp.secureOrigin("http://127.0.0.1:9000/api"));
+        // Credentials must not travel over plaintext to a remote host
+        assertNull(RelayUsageHttp.secureOrigin("http://api.z.ai/api/anthropic"));
+        assertNull(RelayUsageHttp.secureOrigin("http://evil.com"));
+    }
+
+    @Test
+    public void secureOrigin_malformedYieldsNull() {
+        assertNull(RelayUsageHttp.secureOrigin(null));
+        assertNull(RelayUsageHttp.secureOrigin("not a url"));
+        assertNull(RelayUsageHttp.secureOrigin("api.z.ai")); // no scheme
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageJsonTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageJsonTest.java
@@ -1,0 +1,64 @@
+package com.github.claudecodegui.provider.claude.usage;
+
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class RelayUsageJsonTest {
+
+    @Test
+    public void clampPct_boundsZeroToHundred() {
+        assertEquals(0.0, RelayUsageJson.clampPct(-5), 0.001);
+        assertEquals(100.0, RelayUsageJson.clampPct(144), 0.001);
+        assertEquals(50.0, RelayUsageJson.clampPct(50), 0.001);
+        assertEquals(0.0, RelayUsageJson.clampPct(Double.NaN), 0.001);
+    }
+
+    @Test
+    public void accessors_acceptFirstPresentKeyAndParseStrings() {
+        JsonObject o = com.google.gson.JsonParser.parseString(
+                "{\"n\":\"12.5\",\"m\":7,\"s\":\"x\",\"absent\":null}").getAsJsonObject();
+        assertEquals(12.5, RelayUsageJson.asDouble(o, "n"), 0.001);
+        // "12.5" is not a long → skipped, the next parsable key wins
+        assertEquals(Long.valueOf(7), RelayUsageJson.asLong(o, "n", "m"));
+        assertEquals(Integer.valueOf(7), RelayUsageJson.asInt(o, "m"));
+        assertEquals("x", RelayUsageJson.asString(o, "s"));
+        // absent/null keys yield null instead of throwing
+        assertNull(RelayUsageJson.asDouble(o, "absent", "missing"));
+        assertNull(RelayUsageJson.asString(o, "missing"));
+        assertNull(RelayUsageJson.asObject(o, "missing"));
+        assertNull(RelayUsageJson.asArray(o, "missing"));
+        assertNull(RelayUsageJson.asDouble(null, "n"));
+    }
+
+    @Test
+    public void capacityPayload_prefers5hWindowOverWorst() {
+        JsonObject payload = RelayUsageJson.capacityPayload("test",
+                List.of(RelayUsageJson.window("5h", 13, null),
+                        RelayUsageJson.window("7d", 99, null)), null);
+        assertEquals(13.0, payload.get("capacity_pct").getAsDouble(), 0.001);
+        assertEquals("5h", payload.get("period_type").getAsString());
+        assertEquals("test", payload.get("source").getAsString());
+        assertTrue(payload.get("present").getAsBoolean());
+        assertFalse(payload.has("level"));
+        assertEquals(2, payload.getAsJsonArray("windows").size());
+    }
+
+    @Test
+    public void capacityPayload_without5hFallsBackToWorstWindow() {
+        JsonObject payload = RelayUsageJson.capacityPayload("test",
+                List.of(RelayUsageJson.window("monthly", 55, 1786624965401L)), "pro");
+        assertEquals(55.0, payload.get("capacity_pct").getAsDouble(), 0.001);
+        assertEquals("monthly", payload.get("period_type").getAsString());
+        assertEquals("pro", payload.get("level").getAsString());
+        JsonObject w = payload.getAsJsonArray("windows").get(0).getAsJsonObject();
+        assertTrue(w.has("reset_at"));
+        assertEquals("monthly", w.get("period_type").getAsString());
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageRegistryTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageRegistryTest.java
@@ -1,0 +1,131 @@
+package com.github.claudecodegui.provider.claude.usage;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class RelayUsageRegistryTest {
+
+    @After
+    public void tearDown() {
+        RelayUsageHttp.setTransportForTests(null);
+        RelayUsageCache.clearForTests();
+    }
+
+    // ===== vendor dispatch by base URL =====
+
+    @Test
+    public void match_dispatchesByHostAndPath() {
+        assertEquals("kimi-coding", RelayUsageRegistry.match("https://api.kimi.com/coding").id());
+        assertEquals("minimax", RelayUsageRegistry.match("https://api.minimaxi.com/v1").id());
+        assertEquals("minimax", RelayUsageRegistry.match("https://api.minimax.io/v1").id());
+        assertEquals("zai", RelayUsageRegistry.match("https://api.z.ai/api/anthropic").id());
+        assertEquals("zai", RelayUsageRegistry.match("https://open.bigmodel.cn/api/anthropic").id());
+        assertNull(RelayUsageRegistry.match("https://api.anthropic.com"));
+        assertNull(RelayUsageRegistry.match("https://gateway.example.com"));
+        assertNull(RelayUsageRegistry.match("https://gateway.example.com/z.ai/proxy"));
+        assertNull(RelayUsageRegistry.match(null));
+        assertNull(RelayUsageRegistry.match("not a url"));
+    }
+
+    @Test
+    public void resolve_unknownHostOrNullToken_neverProbes() {
+        int[] calls = {0};
+        RelayUsageHttp.setTransportForTests((url, headers) -> {
+            calls[0]++;
+            return new JsonObject();
+        });
+
+        assertNull(RelayUsageRegistry.resolve(ZaiUsageVendorTest.settings("https://api.deepseek.com", "sk-x"), 1000L));
+        // Vendor host but no credential → nothing to authenticate with
+        assertNull(RelayUsageRegistry.resolve(ZaiUsageVendorTest.settings("https://api.z.ai/api/anthropic", null), 1000L));
+        assertNull(RelayUsageRegistry.resolve(null, 1000L));
+        assertEquals(0, calls[0]);
+    }
+
+    @Test
+    public void resolve_probesMatchingVendorAndCachesWithinTtl() {
+        int[] calls = {0};
+        String[] seenUrl = {null};
+        RelayUsageHttp.setTransportForTests((url, headers) -> {
+            calls[0]++;
+            seenUrl[0] = url;
+            return zaiBody(42);
+        });
+        JsonObject settings = ZaiUsageVendorTest.settings("https://api.z.ai/api/anthropic", "t");
+        long t0 = 1_000_000L;
+
+        JsonObject payload = RelayUsageRegistry.resolve(settings, t0);
+        assertEquals("https://api.z.ai/api/monitor/usage/quota/limit", seenUrl[0]);
+        assertEquals(42.0, payload.get("capacity_pct").getAsDouble(), 0.01);
+
+        // Within TTL → served from cache, no second probe
+        RelayUsageRegistry.resolve(settings, t0 + RelayUsageCache.TTL_MS - 1);
+        assertEquals(1, calls[0]);
+        // TTL expired → probes again
+        RelayUsageRegistry.resolve(settings, t0 + RelayUsageCache.TTL_MS + 1);
+        assertEquals(2, calls[0]);
+    }
+
+    @Test
+    public void resolve_cacheKeyedByVendorEndpointAndToken() {
+        int[] calls = {0};
+        RelayUsageHttp.setTransportForTests((url, headers) -> {
+            calls[0]++;
+            return zaiBody(10);
+        });
+        long t0 = 1_000_000L;
+
+        RelayUsageRegistry.resolve(ZaiUsageVendorTest.settings("https://api.z.ai/api/anthropic", "account-a"), t0);
+        assertEquals(1, calls[0]);
+        // Same endpoint but a different token (account switch) must not reuse the cache
+        RelayUsageRegistry.resolve(ZaiUsageVendorTest.settings("https://api.z.ai/api/anthropic", "account-b"), t0 + 1);
+        assertEquals(2, calls[0]);
+        // Same token on a different vendor never collides (different endpoint anyway)
+        RelayUsageRegistry.resolve(ZaiUsageVendorTest.settings("https://api.minimaxi.com/v1", "account-a"), t0 + 2);
+        assertEquals(3, calls[0]);
+    }
+
+    @Test
+    public void resolve_staleFallbackOnProbeFailure() {
+        boolean[] fail = {false};
+        RelayUsageHttp.setTransportForTests((url, headers) -> {
+            if (fail[0]) {
+                throw new IllegalStateException("boom");
+            }
+            return zaiBody(33);
+        });
+        JsonObject settings = ZaiUsageVendorTest.settings("https://api.z.ai/api/anthropic", "t");
+        long t0 = 1_000_000L;
+
+        RelayUsageRegistry.resolve(settings, t0);
+
+        fail[0] = true;
+        // Probe fails with an expired-but-recent cache → stale payload
+        JsonObject stale = RelayUsageRegistry.resolve(settings, t0 + RelayUsageCache.TTL_MS + 1);
+        assertEquals(33.0, stale.get("capacity_pct").getAsDouble(), 0.01);
+        assertTrue(stale.get("stale").getAsBoolean());
+
+        // Cache older than the stale cap → give up (null → caller falls back)
+        assertNull(RelayUsageRegistry.resolve(settings, t0 + RelayUsageCache.STALE_MAX_MS + 1));
+    }
+
+    @Test
+    public void resolve_parseFailureWithoutCacheReturnsNull() {
+        RelayUsageHttp.setTransportForTests((url, headers) -> new JsonObject());
+        assertNull(RelayUsageRegistry.resolve(
+                ZaiUsageVendorTest.settings("https://api.z.ai/api/anthropic", "t"), 1000L));
+    }
+
+    private static JsonObject zaiBody(double pct) {
+        return JsonParser.parseString(
+                "{\"data\":{\"level\":\"max\",\"limits\":["
+                        + "{\"type\":\"CREDIT_LIMIT\",\"unit\":3,\"number\":5,\"percentage\":" + pct
+                        + ",\"nextResetTime\":1786624965401}]}}").getAsJsonObject();
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/claude/usage/ZaiUsageVendorTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/usage/ZaiUsageVendorTest.java
@@ -1,0 +1,178 @@
+package com.github.claudecodegui.provider.claude.usage;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/** ZaiUsageVendor — migrated from the z.ai half of ClaudePlanUsageServiceTest. */
+public class ZaiUsageVendorTest {
+
+    private final ZaiUsageVendor vendor = new ZaiUsageVendor();
+
+    @After
+    public void tearDown() {
+        RelayUsageHttp.setTransportForTests(null);
+    }
+
+    // ===== host matching =====
+
+    @Test
+    public void matches_hostsOnlyNotLookalikes() {
+        assertTrue(vendor.matches("api.z.ai", "/api/anthropic"));
+        assertTrue(vendor.matches("z.ai", "/api/anthropic"));
+        assertTrue(vendor.matches("open.bigmodel.cn", "/api/anthropic"));
+        assertTrue(vendor.matches("sub.open.bigmodel.cn", "/api/anthropic"));
+        // Look-alike hosts must not trigger the z.ai probe
+        assertFalse(vendor.matches("quiz.ai", "/api/anthropic"));
+        assertFalse(vendor.matches("buzz.ai", "/api"));
+        assertFalse(vendor.matches("api.anthropic.com", ""));
+    }
+
+    // ===== response parsing =====
+
+    @Test
+    public void parseQuota_maps5h7dWindowsAndLevel() {
+        JsonObject body = JsonParser.parseString("""
+                {"code":200,"success":true,"data":{
+                  "level":"max",
+                  "limits":[
+                    {"type":"CREDIT_LIMIT","unit":3,"number":5,"percentage":13,"nextResetTime":1786624965401},
+                    {"type":"CREDIT_LIMIT","unit":6,"number":1,"percentage":2,"nextResetTime":1787155353998}
+                  ]
+                }}
+                """).getAsJsonObject();
+        JsonObject payload = ZaiUsageVendor.parseQuota(body);
+
+        assertEquals("claude", payload.get("provider").getAsString());
+        assertEquals("zai-quota-limit", payload.get("source").getAsString());
+        assertTrue(payload.get("present").getAsBoolean());
+        assertEquals(13.0, payload.get("capacity_pct").getAsDouble(), 0.01);
+        assertEquals("5h", payload.get("period_type").getAsString());
+        assertEquals("max", payload.get("level").getAsString());
+
+        com.google.gson.JsonArray windows = payload.getAsJsonArray("windows");
+        assertEquals(2, windows.size());
+        JsonObject w0 = windows.get(0).getAsJsonObject();
+        assertEquals("5h", w0.get("id").getAsString());
+        assertEquals(13.0, w0.get("used_pct").getAsDouble(), 0.01);
+        assertEquals("7d", windows.get(1).getAsJsonObject().get("id").getAsString());
+        assertEquals(2.0, windows.get(1).getAsJsonObject().get("used_pct").getAsDouble(), 0.01);
+    }
+
+    @Test
+    public void parseQuota_timeLimitMapsToMonthly() {
+        JsonObject body = JsonParser.parseString("""
+                {"data":{"level":"pro","limits":[
+                  {"type":"TIME_LIMIT","unit":4,"number":1,"percentage":55}
+                ]}}
+                """).getAsJsonObject();
+        JsonObject payload = ZaiUsageVendor.parseQuota(body);
+        assertEquals("monthly", payload.getAsJsonArray("windows").get(0).getAsJsonObject().get("id").getAsString());
+        assertEquals("pro", payload.get("level").getAsString());
+    }
+
+    @Test
+    public void parseQuota_emptyLimitsReturnsNull() {
+        JsonObject body = JsonParser.parseString("{\"data\":{\"limits\":[]}}").getAsJsonObject();
+        assertNull(ZaiUsageVendor.parseQuota(body));
+    }
+
+    @Test
+    public void parseQuota_creditLimitUnitDays_mapsTo7d() {
+        JsonObject body = JsonParser.parseString("""
+                {"data":{"limits":[
+                  {"type":"CREDIT_LIMIT","unit":4,"number":7,"percentage":41}
+                ]}}
+                """).getAsJsonObject();
+        JsonObject payload = ZaiUsageVendor.parseQuota(body);
+        assertEquals("7d", payload.getAsJsonArray("windows").get(0).getAsJsonObject().get("id").getAsString());
+        assertEquals(41.0, payload.get("capacity_pct").getAsDouble(), 0.01);
+    }
+
+    @Test
+    public void parseQuota_duplicatePeriodsMergeKeepingWorst() {
+        JsonObject body = JsonParser.parseString("""
+                {"data":{"limits":[
+                  {"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":10,"nextResetTime":1786624965401},
+                  {"type":"CREDIT_LIMIT","unit":3,"number":5,"percentage":20,"nextResetTime":1786624965401}
+                ]}}
+                """).getAsJsonObject();
+        JsonObject payload = ZaiUsageVendor.parseQuota(body);
+
+        com.google.gson.JsonArray windows = payload.getAsJsonArray("windows");
+        assertEquals(1, windows.size());
+        JsonObject w = windows.get(0).getAsJsonObject();
+        assertEquals("5h", w.get("id").getAsString());
+        assertEquals(20.0, w.get("used_pct").getAsDouble(), 0.01);
+        assertEquals(20.0, payload.get("capacity_pct").getAsDouble(), 0.01);
+    }
+
+    // ===== probe pipeline (transport injected) =====
+
+    @Test
+    public void probe_sendsBearerTokenToMonitorUrl() throws Exception {
+        String[] seen = new String[2];
+        RelayUsageHttp.setTransportForTests((url, headers) -> {
+            seen[0] = url;
+            seen[1] = headers.get("Authorization");
+            return zaiBody(42);
+        });
+
+        JsonObject payload = vendor.probe(env("https://api.z.ai/api/anthropic", "glm-secret"));
+
+        assertEquals("https://api.z.ai/api/monitor/usage/quota/limit", seen[0]);
+        assertEquals("Bearer glm-secret", seen[1]);
+        assertEquals(42.0, payload.get("capacity_pct").getAsDouble(), 0.01);
+    }
+
+    @Test
+    public void probe_customLoopbackPortKept_plainHttpAllowed() throws Exception {
+        String[] seen = new String[1];
+        RelayUsageHttp.setTransportForTests((url, headers) -> {
+            seen[0] = url;
+            return zaiBody(1);
+        });
+
+        vendor.probe(env("http://127.0.0.1:9000/api/anthropic", "t"));
+        assertEquals("http://127.0.0.1:9000/api/monitor/usage/quota/limit", seen[0]);
+    }
+
+    @Test
+    public void probe_plainHttpToRemoteHostRefused() throws Exception {
+        // Bearer tokens must not travel over plaintext to a remote host
+        RelayUsageHttp.setTransportForTests((url, headers) -> {
+            throw new IllegalStateException("transport must not be reached");
+        });
+        assertNull(vendor.probe(env("http://api.z.ai/api/anthropic", "t")));
+    }
+
+    private static JsonObject zaiBody(double pct) {
+        return JsonParser.parseString(
+                "{\"data\":{\"level\":\"max\",\"limits\":["
+                        + "{\"type\":\"CREDIT_LIMIT\",\"unit\":3,\"number\":5,\"percentage\":" + pct
+                        + ",\"nextResetTime\":1786624965401}]}}").getAsJsonObject();
+    }
+
+    static RelayUsageEnv env(String base, String token) {
+        return RelayUsageEnv.from(settings(base, token));
+    }
+
+    static JsonObject settings(String base, String token) {
+        JsonObject settings = new JsonObject();
+        JsonObject envObj = new JsonObject();
+        if (base != null) {
+            envObj.addProperty("ANTHROPIC_BASE_URL", base);
+        }
+        if (token != null) {
+            envObj.addProperty("ANTHROPIC_AUTH_TOKEN", token);
+        }
+        settings.add("env", envObj);
+        return settings;
+    }
+}


### PR DESCRIPTION
### 一、z.ai 和 bigmodel.cn 的用量查询api是一样的，可以直接兼容
### 二、重构、同时增加其他国产厂商用量查询
现已支持：
1. 智谱 GLM（z.ai / bigmodel.cn）
2. MiniMax Coding Plan（minimaxi.com / minimax.io）
3. Kimi For Coding（api.kimi.com/coding）

