### PR TITLE
fix: render unlabeled code blocks as plain text instead of auto-detection

### DIFF
--- a/webview/src/components/MarkdownBlock.tsx
+++ b/webview/src/components/MarkdownBlock.tsx
@@ -177,10 +177,12 @@ marked.use(
         try {
           return hljs.highlight(code, { language: lang }).value;
         } catch {
-          // Silently fall through to auto-highlight
+          // Silently fall through to plain-text rendering
         }
       }
-      return hljs.highlightAuto(code).value;
+      // highlightAuto misclassifies prose like commit messages (leading "- " lines
+      // score as diff deletions), so unlabeled blocks render as plain text
+      return hljs.highlight(code, { language: 'plaintext' }).value;
     },
   })
 );


### PR DESCRIPTION
## Problem

Code blocks without a language tag (e.g. git commit messages quoted by the assistant) were rendered with **diff** syntax highlighting: every line starting with `- ` was wrapped in `hljs-deletion` and painted red, making plain prose look like a wall of deletions.

## Root cause

`MarkdownBlock.tsx` fell back to `hljs.highlightAuto(code)` for unlabeled blocks. highlight.js's `diff` language defines `deletion` as `begin: /^-/`, so any list-style prose with `- ` leading lines scores high for diff and wins the auto-detection.

Reproduction (same language subset as the webview registers):

- `highlightAuto` verdict: **diff** (relevance 3, tied with markdown but diff wins)
- Output: each `- ` line wrapped in `<span class="hljs-deletion">…</span>`

## Fix

Fall back to `plaintext` instead of auto-detection:

- Plaintext has zero highlighting rules, so unlabeled blocks render neutral — no more red-deletion false positives.
- Labeled blocks (the vast majority) still take the exact `hljs.highlight(code, { language: lang })` path and are unaffected.
- Bonus: plaintext skips the O(languages × length) heuristic sweep of `highlightAuto`, which is friendlier to streaming renders.

Markdown was considered as the fallback but rejected: it would still paint `- ` bullets, `**bold**` and backtick runs with colored styles — a new kind of visual noise for commit-message-style text. Real markdown content is rendered as message body, not inside code fences.

## Verification

- `npx vitest run src/components/MarkdownBlock.test.tsx` — 36/36 passed
- `npx tsc -p tsconfig.test.json --noEmit` — clean