### PR TITLE
fix(codex): respect CODEX_HOME env in CodexSettingsManager

### DIFF
--- a/src/main/java/com/github/claudecodegui/settings/CodexSettingsManager.java
+++ b/src/main/java/com/github/claudecodegui/settings/CodexSettingsManager.java
@@ -53,7 +53,17 @@ public class CodexSettingsManager {
     public CodexSettingsManager(Gson gson) {
         this.gson = gson;
         String userHome = NodeDetector.resolveHomeForFileOps();
-        this.codexDir = Paths.get(userHome, ".codex");
+        // Respect CODEX_HOME so the plugin can operate on an isolated Codex home
+        // (e.g. when the IDE is launched with CODEX_HOME set), keeping the
+        // default ~/.codex untouched for other clients such as the Codex app.
+        // EnvironmentConfigurator already propagates CODEX_HOME to the bridge
+        // daemon and SDK child processes; this keeps file operations consistent.
+        String codexHome = System.getenv("CODEX_HOME");
+        if (codexHome == null || codexHome.isBlank()) {
+            this.codexDir = Paths.get(userHome, ".codex");
+        } else {
+            this.codexDir = Paths.get(codexHome);
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

Switching Codex providers in the plugin rewrites the **global** `~/.codex/config.toml` and `auth.json`. For users who also run the official Codex desktop app (or multiple Codex clients) on the same machine, this flips the desktop app to whatever provider the IDE plugin selected, and vice versa — the clients cannot use different providers at the same time.

## Root cause

The runtime layer already honors `CODEX_HOME`:

- `EnvironmentConfigurator` ensures `CODEX_HOME` is set (defaulting to `~/.codex`) and propagates it to the bridge daemon and the SDK child processes
- `CodexSDKBridge` lists `CODEX_HOME` in `PROTECTED_ENV_KEYS`

…but the file layer does not: `CodexSettingsManager` hardcodes

```java
this.codexDir = Paths.get(userHome, ".codex");
```

so all config/auth/MCP/skill file operations (including `transitionProvider`, which is the provider-switch write path) always target the global Codex home, even when the IDE is launched with `CODEX_HOME` pointing elsewhere.

## Fix

Resolve `codexDir` from the `CODEX_HOME` environment variable when it is set and non-blank; otherwise keep the existing `~/.codex` default. Since all other components resolve paths through `CodexSettingsManager`, this single change makes the file layer consistent with the runtime layer.

## Behavior

- `CODEX_HOME` unset (the default for everyone): no behavior change at all.
- IDE launched with `CODEX_HOME=~/.codex-ccgui` (e.g. `open --env CODEX_HOME=... -a PyCharm`): the plugin operates fully inside that directory — provider switching, config/auth reads and writes, MCP and skill files — leaving `~/.codex` to other Codex clients.

## Notes

- On macOS/Linux this is a plain path read. On native-Windows hosts with a WSL node the env var would need WSL path normalization (`WslPathUtil`); I left that out to keep the change minimal, happy to add it if preferred.
- The rollout-history reader (`CodexHistoryReader` / ai-bridge session loader) still defaults to `~/.codex`; that is read-only display state and can be a follow-up.

Fixes the coexistence issue reported by users running the Codex desktop app alongside the plugin.
