### PR TITLE
fix: correct provider runtime, usage and cross-platform regressions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,8 +18,12 @@ jobs:
   # invoked from the repository root because api-config.test.js resolves modules
   # via path.resolve('ai-bridge/...') relative to the working directory.
   ai-bridge:
-    name: ai-bridge unit tests
-    runs-on: ubuntu-latest
+    name: ai-bridge unit tests (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -30,7 +34,7 @@ jobs:
           node-version: '22.12.0'
 
       - name: Run ai-bridge tests
-        run: node --test "ai-bridge/**/*.test.js"
+        run: node --test "ai-bridge/**/*.test.js" "ai-bridge/**/*.test.mjs"
 
   # webview unit tests: vitest run plus a typecheck of the test sources.
   # No build step is needed — the vitest suite operates against source, not dist.

--- a/ai-bridge/services/claude/permission-mode.js
+++ b/ai-bridge/services/claude/permission-mode.js
@@ -34,23 +34,22 @@ const PLAN_MODE_ALLOWED_TOOLS = new Set([
 /**
  * Read-only MCP tool detection — a positive allowlist (default-deny).
  *
- * MCP tool names are `mcp__<server>__<action>`. A tool counts as read-only only when its
- * ACTION begins with a known read-only verb. This replaces an earlier blocklist
- * (`name.startsWith('mcp__') && !name.includes('Write') && !name.includes('Edit')`) that was
- * default-ALLOW: destructive actions whose names happen to lack "Write"/"Edit"
- * (mcp__fs__delete_file, mcp__shell__run_command, mcp__db__execute) slipped through — auto-yielded
- * during read-only plan mode, and (in default mode) auto-approvable by an attacker-controlled
- * project/local settings.json allow-rule. Anything not matched here falls through to 'ask'
- * (default mode) or 'deny' (plan mode), so unknown/ambiguous MCP tools are safe by default.
+ * MCP tool names are allowlisted by their complete name. An MCP server can choose any action
+ * name, so action prefixes are not enough to prove that a tool is side-effect free. Unknown or
+ * ambiguous MCP tools fall through to 'ask' (default mode) or 'deny' (plan mode), safe by default.
  */
-const READ_ONLY_MCP_ACTION = /^(read|list|get|search|query|fetch|find|view|describe|show|resolve|lookup|status|info|inspect|count|exists|preview|ls|cat|head|tail)([_-]|$)/i;
+const READ_ONLY_MCP_TOOLS = new Set([
+  'mcp__ace-tool__search_context',
+  'mcp__context7__resolve-library-id',
+  'mcp__context7__query-docs',
+  'mcp__conductor__GetWorkspaceDiff',
+  'mcp__conductor__GetTerminalOutput',
+  'mcp__time__get_current_time',
+  'mcp__time__convert_time',
+]);
 
 function isReadOnlyMcpTool(toolName) {
-  if (typeof toolName !== 'string' || !toolName.startsWith('mcp__')) {
-    return false;
-  }
-  const action = toolName.split('__').slice(2).join('__');
-  return action.length > 0 && READ_ONLY_MCP_ACTION.test(action);
+  return typeof toolName === 'string' && READ_ONLY_MCP_TOOLS.has(toolName);
 }
 
 const PLAN_FILE_NAME = 'PLAN.md';
@@ -121,18 +120,14 @@ export function createPreToolUseHook(permissionModeState, cwd = null, onModeChan
   };
   const updatePermissionMode = async (mode) => {
     const normalized = normalizePermissionMode(mode);
-    const previousMode = readPermissionMode();
+    if (typeof onModeChange === 'function') {
+      // The runtime owns SDK acknowledgements and concurrent transitions. A
+      // superseded hook must not roll back the mode that the SDK already accepted.
+      await onModeChange(normalized);
+      return readPermissionMode();
+    }
     if (permissionModeState && typeof permissionModeState === 'object') {
       permissionModeState.value = normalized;
-    }
-    if (typeof onModeChange === 'function') {
-      const applied = await onModeChange(normalized);
-      if (applied === false) {
-        if (permissionModeState && typeof permissionModeState === 'object') {
-          permissionModeState.value = previousMode;
-        }
-        return previousMode;
-      }
     }
     return normalized;
   };
@@ -291,7 +286,7 @@ export function createPreToolUseHook(permissionModeState, cwd = null, onModeChan
         return YIELD_TO_SDK;
       }
 
-      // Step 6: Auto-approve read-only MCP tools (positive verb allowlist; see isReadOnlyMcpTool).
+      // Step 6: Yield known read-only MCP tools to the SDK (see isReadOnlyMcpTool).
       // Destructive/ambiguous MCP tools fall through to the plan-mode deny below — plan mode is read-only.
       if (isReadOnlyMcpTool(toolName)) {
         return YIELD_TO_SDK;

--- a/ai-bridge/services/claude/permission-mode.test.js
+++ b/ai-bridge/services/claude/permission-mode.test.js
@@ -118,20 +118,26 @@ test('acceptEdits mode: Bash returns "ask" (acceptEdits auto-accepts edits only,
   assert.equal(result?.hookSpecificOutput?.permissionDecision, 'ask');
 });
 
-test('default mode: read-only MCP tool (verb allowlist) yields "continue"', async () => {
+test('default mode: known read-only MCP tools yield "continue"', async () => {
   const hook = makeHook('default');
-  for (const toolName of ['mcp__some-server__search_docs', 'mcp__context7__get_library', 'mcp__db__list_tables']) {
+  for (const toolName of [
+    'mcp__ace-tool__search_context',
+    'mcp__context7__query-docs',
+    'mcp__time__get_current_time',
+  ]) {
     const result = await hook({ tool_name: toolName, tool_input: { query: 'x' } });
     assert.equal(result?.continue, true, `expected ${toolName} to yield to the SDK`);
   }
 });
 
-test('default mode: non-read-only MCP tool returns "ask" so a settings.json allow-rule cannot silently auto-approve it', async () => {
+test('default mode: unknown or compound MCP tools return "ask"', async () => {
   const hook = makeHook('default');
-  // Names lacking "Write"/"Edit" (delete_file, run_command, exec) must NOT be treated as
-  // read-only: the old blocklist heuristic let them yield to the SDK, where a project/local
-  // .claude/settings.json allow-rule (attacker-controllable) could auto-approve them silently.
-  for (const toolName of ['mcp__fs__delete_file', 'mcp__shell__run_command', 'mcp__db__execute', 'mcp__some-server__some-tool']) {
+  for (const toolName of [
+    'mcp__some-server__search_docs',
+    'mcp__evil__read_and_delete',
+    'mcp__evil__get_or_create',
+    'mcp__evil__search_and_replace',
+  ]) {
     const result = await hook({ tool_name: toolName, tool_input: {} });
     assert.equal(result?.hookSpecificOutput?.permissionDecision, 'ask', `expected ${toolName} to ask`);
   }
@@ -167,7 +173,7 @@ test('plan mode: PLAN_MODE_ALLOWED_TOOLS (WebFetch) yields "continue"', async ()
 test('plan mode: read-only MCP tool yields "continue"', async () => {
   const hook = makeHook('plan');
   const result = await hook({
-    tool_name: 'mcp__some-server__lookup',
+    tool_name: 'mcp__context7__query-docs',
     tool_input: { query: 'x' },
   });
   assert.equal(result?.continue, true);
@@ -177,7 +183,7 @@ test('plan mode: non-read-only MCP tool is denied (plan mode is read-only; must 
   const hook = makeHook('plan');
   // The old blocklist yielded these to the SDK during plan mode; a destructive MCP tool must
   // instead fall through to the plan-mode deny.
-  for (const toolName of ['mcp__fs__delete_file', 'mcp__shell__run_command']) {
+  for (const toolName of ['mcp__fs__delete_file', 'mcp__shell__run_command', 'mcp__some-server__lookup']) {
     const result = await hook({ tool_name: toolName, tool_input: {} });
     assert.equal(result?.hookSpecificOutput?.permissionDecision, 'deny', `expected ${toolName} to be denied`);
   }

--- a/ai-bridge/services/claude/persistent-query-service.context.test.mjs
+++ b/ai-bridge/services/claude/persistent-query-service.context.test.mjs
@@ -1,3 +1,5 @@
+// Isolate credentials before the runtime caches the user's home directory.
+import './testing/cli-login-home.js';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -103,6 +105,13 @@ test('buildRequestContext preserves resolved model mapping for context usage run
       env: {
         CLAUDE_CODE_EFFORT_LEVEL: '',
         MAX_THINKING_TOKENS: '',
+        ANTHROPIC_MODEL: '',
+        ANTHROPIC_DEFAULT_FABLE_MODEL: '',
+        ANTHROPIC_DEFAULT_OPUS_MODEL: '',
+        ANTHROPIC_DEFAULT_SONNET_MODEL: '',
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: '',
+        ANTHROPIC_SMALL_FAST_MODEL: '',
+        CLAUDE_CODE_SUBAGENT_MODEL: '',
         CLAUDE_CODE_DISABLE_1M_CONTEXT: '1',
       },
     });

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -68,20 +68,6 @@ import { getClaudeCliPathOverride } from '../../utils/claude-cli-path.js';
 
 const SUPPORTED_EFFORT_LEVELS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
 
-// Backstop for the foreign-result skip in executeTurn: that skip assumes a
-// real run always emits output before its result. If a turn legitimately
-// produces zero messages before its result, its own result is misclassified
-// as foreign and skipped — without this idle backstop the take() loop would
-// hang forever. When armed, any message arriving for the turn disarms it; on
-// expiry the turn is settled empty (see the skip branch below).
-const FOREIGN_RESULT_IDLE_BACKSTOP_MS = 60_000;
-// Marker set on the synthetic result the backstop pushes so the foreign-result
-// check lets it through and ends the turn.
-const IDLE_BACKSTOP_RESULT = Symbol('idleBackstopResult');
-// Test hook (see __testing): tests shrink the backstop instead of mocking
-// timers globally, which would also intercept the reader/settle helpers.
-let foreignResultIdleBackstopMs = FOREIGN_RESULT_IDLE_BACKSTOP_MS;
-
 function resolveReasoningEffort(params) {
   const effort = typeof params.reasoningEffort === 'string'
     ? params.reasoningEffort.trim()
@@ -284,17 +270,6 @@ _sessionCleanupTimer.unref();
     turnMeta.state = turnState;
   }
 
-  // Idle backstop timer armed when a foreign bare-success result is skipped
-  // (see the result branch below). Must be cleared on any turn activity and
-  // when the turn ends, or it would settle a later turn by mistake.
-  let foreignResultIdleTimer = null;
-  const disarmForeignResultIdleBackstop = () => {
-    if (foreignResultIdleTimer !== null) {
-      clearTimeout(foreignResultIdleTimer);
-      foreignResultIdleTimer = null;
-    }
-  };
-
   try {
     beginRuntimeTurn(runtime);
     // Scope the abort flag to the turn that aborted: it is set by
@@ -345,11 +320,6 @@ _sessionCleanupTimer.unref();
       touchRuntime(runtime);
       const msg = next.value;
 
-      // Any arriving message proves the pipe is alive, so disarm the idle
-      // backstop armed by the foreign-result skip below. The skip re-arms it
-      // when this message turns out to be another foreign bare result.
-      disarmForeignResultIdleBackstop();
-
       if (turnState.streamingEnabled && !turnState.streamStarted) {
         process.stdout.write('[STREAM_START]\n');
         turnState.streamStarted = true;
@@ -362,6 +332,14 @@ _sessionCleanupTimer.unref();
       // session stream, otherwise the subagent's internals pollute the main chat.
       // task_notification (type:'system') has no parent_tool_use_id and is preserved.
       if (msg?.parent_tool_use_id) {
+        continue;
+      }
+
+      // A result with task-notification origin belongs to a background follow-up
+      // rather than the user message currently being consumed. The SDK forwards
+      // this provenance specifically so hosts can keep it out of the main turn.
+      if (msg?.type === 'result' && msg.origin?.kind === 'task-notification') {
+        console.log('[LIFECYCLE] Skipping task-notification result for active user turn');
         continue;
       }
 
@@ -386,17 +364,6 @@ _sessionCleanupTimer.unref();
           console.log('[LIFECYCLE] In-turn task-notification message for anonymous runtime, consuming silently');
         }
         continue;
-      }
-
-      // Substantive output (assistant / user / stream_event) belongs to THIS
-      // turn, so a later result is ours. A bare SUCCESS result arriving with
-      // sawTurnMessage still false is provably foreign (a real run emits output
-      // before its result) and is skipped below rather than ending the turn
-      // empty and seeding the one-behind shift. system/control messages are NOT
-      // counted: a turn almost always opens with a system session_id message,
-      // so counting it would defang the foreign-result skip in production.
-      if (msg?.type === 'assistant' || msg?.type === 'user' || msg?.type === 'stream_event') {
-        turnState.sawTurnMessage = true;
       }
 
       if (msg?.type === 'stream_event' && turnState.streamingEnabled) {
@@ -435,47 +402,8 @@ _sessionCleanupTimer.unref();
           // failure reaches the UI instead of a generic fallback.
           throw new Error(extractResultError(msg));
         }
-        // Defense in depth for the boundary the quiescence gate cannot close: a
-        // foreign run whose closing SUCCESS result is read only AFTER this sink
-        // opened. With no prior turn output (sawTurnMessage still false) it is
-        // provably not ours — a real run always emits output before its result —
-        // so skip it instead of ending the turn empty and seeding the one-behind
-        // shift. The background run still renders via the inter-turn
-        // session_updated path (#1305).
-        if (!turnState.sawTurnMessage && msg[IDLE_BACKSTOP_RESULT] !== true) {
-          console.log('[LIFECYCLE] Skipping foreign bare-success result (no prior turn output this turn)');
-          // The "real run emits output first" assumption fails for a turn that
-          // legitimately produces zero messages: its own result would be
-          // misclassified as foreign and skipped, leaving take() parked
-          // forever. Arm an idle backstop that settles the turn empty if no
-          // message belonging to this turn arrives in time.
-          foreignResultIdleTimer = setTimeout(() => {
-            foreignResultIdleTimer = null;
-            console.warn('[LIFECYCLE] Foreign-result idle backstop fired: no turn output within '
-              + foreignResultIdleBackstopMs + 'ms of skipping a foreign result; settling the turn empty'
-              + ' sessionId=' + (turnState.finalSessionId || runtime.sessionId || requestContext.requestedSessionId || '(none)')
-              + ' epoch=' + (requestContext.runtimeSessionEpoch || runtime.runtimeSessionEpoch || '(none)'));
-            // Unblock the parked take() with a sentinel result that bypasses
-            // the foreign check above and ends this turn with empty output.
-            runtime.turnSink?.push({ type: 'result', is_error: false, [IDLE_BACKSTOP_RESULT]: true });
-          }, foreignResultIdleBackstopMs);
-          // Do not unref: this timer is the only handle keeping a silent turn
-          // (and node:test) alive until the backstop settles it. Unref'ing it
-          // lets the event loop drain while executeTurn is still parked on
-          // take(), which cancels remaining tests with
-          // "Promise resolution is still pending but the event loop has already resolved".
-          continue;
-        }
-        // A task_notification for a background (run_in_background) Agent that
-        // settles AFTER this result cannot ride the in-turn [MESSAGE] stream:
-        // executeTurn breaks here and clears turnSink in the finally below
-        // (synchronously, before the perpetual reader's next query.next()
-        // resolves), so the perpetual reader routes that late event to the
-        // inter-turn daemon path (emitTaskEvent -> DaemonBridge "task_event"
-        // -> window.onTaskEvent). task_notification that settles BEFORE the
-        // result is still processed above in the in-turn [MESSAGE] stream.
-        // Both paths converge on window.onTaskEvent, which dedups by
-        // tool_use_id + observable fields - see DaemonBridge.handleDaemonEvent.
+        // A result belongs to the active user turn unless the SDK explicitly marks
+        // it as a background task follow-up above. Result-only turns are valid.
         break;
       }
     }
@@ -521,7 +449,6 @@ _sessionCleanupTimer.unref();
       }
     }
   } finally {
-    disarmForeignResultIdleBackstop();
     endRuntimeTurn(runtime);
     // Clear turnSink after endRuntimeTurn (reverse of creation order)
     runtime.turnSink = null;
@@ -778,12 +705,6 @@ export async function setPermissionModePersistent(params = {}) {
     return;
   }
 
-  if (runtime.currentPermissionMode === targetPermissionMode) {
-    log(`setPermissionModePersistent no-op: already ${targetPermissionMode}`
-      + ` sessionId=${sessionId || '(none)'} epoch=${epoch || '(none)'}`);
-    return;
-  }
-
   // Transition mechanics are centralized in applyPermissionModeToRuntime so the
   // hook path, applyDynamicControls, and this daemon entry point follow one rule
   // set: a Full Auto (bypassPermissions) transition marks the runtime for rebuild
@@ -795,6 +716,13 @@ export async function setPermissionModePersistent(params = {}) {
     (targetPermissionMode === 'bypassPermissions')
       !== (runtime.currentPermissionMode === 'bypassPermissions');
   const applied = await applyPermissionModeToRuntime(runtime, targetPermissionMode);
+  if (runtime.closed
+      || (sessionId && getRuntimeForSession(sessionId) !== runtime)
+      || (!sessionId && getActiveTurnRuntime() !== runtime)) {
+    log(`setPermissionModePersistent ignored stale runtime result sessionId=${sessionId || '(none)'}`
+      + ` epoch=${epoch || '(none)'} mode=${targetPermissionMode}`);
+    return;
+  }
   if (!applied) {
     log(`setPermissionMode failed, local state left unchanged (will resync next turn):`
       + ` sessionId=${sessionId || '(none)'} epoch=${epoch || '(none)'}`
@@ -936,11 +864,6 @@ export const __testing = {
   },
   setQueryFn(queryFn) {
     setCachedQueryFn(queryFn);
-  },
-  setForeignResultIdleBackstopMs(ms) {
-    foreignResultIdleBackstopMs = typeof ms === 'number' && ms > 0
-      ? ms
-      : FOREIGN_RESULT_IDLE_BACKSTOP_MS;
   },
   async buildRequestContext(params = {}, withAttachments = false, overrides = {}) {
     return buildRequestContext(params, withAttachments, overrides);

--- a/ai-bridge/services/claude/persistent-query-service.test.mjs
+++ b/ai-bridge/services/claude/persistent-query-service.test.mjs
@@ -1,3 +1,5 @@
+// Isolate credentials before the runtime caches the user's home directory.
+import './testing/cli-login-home.js';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -15,6 +17,14 @@ function createDeferred() {
     reject = rej;
   });
   return { promise, resolve, reject };
+}
+
+async function waitForTurnSink(runtime) {
+  const deadline = Date.now() + 2000;
+  while (!runtime.turnSink) {
+    assert.ok(Date.now() < deadline, 'the turn must attach its sink before cleanup is tested');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
 }
 
 function createQueryFactory() {
@@ -62,6 +72,15 @@ function createSequencedQueryFactory(steps) {
     runtimes,
     queryFn({ prompt, options }) {
       let index = 0;
+      let closeResolve;
+      const closed = new Promise((resolve) => { closeResolve = resolve; });
+      let inputResolve;
+      const inputReady = new Promise((resolve) => { inputResolve = resolve; });
+      const enqueue = prompt.enqueue.bind(prompt);
+      prompt.enqueue = (value) => {
+        enqueue(value);
+        inputResolve();
+      };
       const runtime = {
         prompt,
         options,
@@ -71,11 +90,21 @@ function createSequencedQueryFactory(steps) {
         setMaxThinkingTokens: async () => {},
         close() {
           this.closed = true;
+          closeResolve();
         },
         async next() {
           const step = steps[index++];
           if (!step) {
-            return { done: false, value: { type: 'result', is_error: false } };
+            // Keep the fake reader parked like the real SDK until disposal.
+            await closed;
+            return { done: true };
+          }
+          if (typeof step !== 'function') {
+            const inputArrived = await Promise.race([
+              inputReady.then(() => true),
+              closed.then(() => false)
+            ]);
+            if (!inputArrived) return { done: true };
           }
           return typeof step === 'function' ? await step() : step;
         }
@@ -148,6 +177,48 @@ test('anonymous runtime is isolated by runtimeSessionEpoch', async () => {
   const runtime2 = await __testing.acquireRuntime(secondContext);
   assert.notEqual(runtime1, runtime2);
   assert.equal(factory.runtimes.length, 2);
+});
+
+test('concurrent acquisitions share one runtime for anonymous and named sessions', async () => {
+  for (const requestedSessionId of [null, 'session-concurrent']) {
+    const factory = createQueryFactory();
+    __testing.setQueryFn(factory.queryFn);
+    const context = {
+      requestedSessionId,
+      runtimeSessionEpoch: 'epoch-concurrent',
+      runtimeSignature: 'sig-concurrent',
+      permissionMode: 'default',
+      options: { cwd: process.cwd() },
+    };
+    const [first, second] = await Promise.all([
+      __testing.acquireRuntime(context),
+      __testing.acquireRuntime(context),
+    ]);
+    assert.equal(first, second);
+    assert.equal(first.closed, false);
+    assert.equal(factory.runtimes.length, 1);
+  }
+});
+
+test('a failed acquisition does not block the next request for that session', async () => {
+  const factory = createQueryFactory();
+  let attempts = 0;
+  __testing.setQueryFn((args) => {
+    if (attempts++ === 0) throw new Error('startup failed');
+    return factory.queryFn(args);
+  });
+  const context = {
+    requestedSessionId: 'session-retry',
+    runtimeSessionEpoch: 'epoch-retry',
+    runtimeSignature: 'sig-retry',
+    permissionMode: 'default',
+    options: { cwd: process.cwd() },
+  };
+  const first = __testing.acquireRuntime(context);
+  const second = __testing.acquireRuntime(context);
+  await assert.rejects(first, /startup failed/);
+  assert.equal((await second).closed, false);
+  assert.equal(factory.runtimes.length, 1);
 });
 
 test('same-tab new-session isolation matches fresh runtime isolation expectations', async () => {
@@ -254,6 +325,7 @@ test('active session runtime is not disposed by idle cleanup while a turn is exe
 
   const turnPromise = __testing.executeTurn(runtime, context);
   await enteredDeferred.promise;
+  await waitForTurnSink(runtime);
 
   await __testing.cleanupSessionRuntimes();
 
@@ -306,6 +378,7 @@ test('active anonymous runtime is not disposed by idle cleanup while a turn is e
 
   const turnPromise = __testing.executeTurn(runtime, context);
   await enteredDeferred.promise;
+  await waitForTurnSink(runtime);
 
   await __testing.cleanupAnonymousRuntimes();
 

--- a/ai-bridge/services/claude/runtime-lifecycle.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.js
@@ -169,37 +169,54 @@ export async function applyPermissionModeToRuntime(runtime, targetPermissionMode
   if (!runtime || runtime.closed) {
     return false;
   }
-  if (runtime.currentPermissionMode === normalizedTargetPermissionMode) {
-    runtime.permissionModeState.value = normalizedTargetPermissionMode;
-    return true;
-  }
 
-  const previousMode = runtime.currentPermissionMode;
-  const bypassBitChanged =
-    (normalizedTargetPermissionMode === 'bypassPermissions') !== (previousMode === 'bypassPermissions');
-  if (bypassBitChanged) {
-    // The bypass flag is frozen at process spawn, so a mode transition
-    // involving Full Auto must wait for acquireRuntime to rebuild it.
-    runtime.runtimeSignature = '__rebuild-pending-bypass-change__';
-    runtime.currentPermissionMode = normalizedTargetPermissionMode;
-    runtime.permissionModeState.value = normalizedTargetPermissionMode;
-    return true;
-  }
+  const sequence = (runtime.permissionModeTransitionSequence || 0) + 1;
+  runtime.permissionModeTransitionSequence = sequence;
+  const previous = runtime.permissionModeTransitionPromise || Promise.resolve();
+  const transition = previous.then(async () => {
+    if (runtime.closed) return false;
+    if (runtime.currentPermissionMode === normalizedTargetPermissionMode) {
+      runtime.permissionModeState.value = normalizedTargetPermissionMode;
+      return runtime.permissionModeTransitionSequence === sequence;
+    }
 
-  if (typeof runtime.query?.setPermissionMode === 'function') {
-    try {
-      await runtime.query.setPermissionMode(normalizedTargetPermissionMode);
-    } catch {
-      if (runtime.currentPermissionMode === previousMode) {
-        runtime.permissionModeState.value = previousMode;
+    const previousMode = runtime.currentPermissionMode;
+    const bypassBitChanged =
+      (normalizedTargetPermissionMode === 'bypassPermissions') !== (previousMode === 'bypassPermissions');
+    if (bypassBitChanged) {
+      // The bypass flag is frozen at process spawn, so a mode transition
+      // involving Full Auto must wait for acquireRuntime to rebuild it.
+      runtime.runtimeSignature = '__rebuild-pending-bypass-change__';
+      runtime.currentPermissionMode = normalizedTargetPermissionMode;
+      runtime.permissionModeState.value = normalizedTargetPermissionMode;
+      return runtime.permissionModeTransitionSequence === sequence;
+    }
+
+    if (typeof runtime.query?.setPermissionMode === 'function') {
+      try {
+        await runtime.query.setPermissionMode(normalizedTargetPermissionMode);
+      } catch {
+        if (!runtime.closed && runtime.permissionModeTransitionSequence === sequence
+            && runtime.currentPermissionMode === previousMode) {
+          runtime.permissionModeState.value = previousMode;
+        }
+        return false;
       }
+    }
+
+    // A successful SDK call changes the live runtime even when a later request
+    // has already superseded this caller. Record that fact before checking the
+    // sequence, so the next queued transition compares against the SDK's real
+    // mode instead of a stale local value.
+    if (runtime.closed) {
       return false;
     }
-  }
-
-  runtime.currentPermissionMode = normalizedTargetPermissionMode;
-  runtime.permissionModeState.value = normalizedTargetPermissionMode;
-  return true;
+    runtime.currentPermissionMode = normalizedTargetPermissionMode;
+    runtime.permissionModeState.value = normalizedTargetPermissionMode;
+    return runtime.permissionModeTransitionSequence === sequence;
+  });
+  runtime.permissionModeTransitionPromise = transition.catch(() => false);
+  return transition;
 }
 
 async function ensureQueryFn() {
@@ -346,14 +363,18 @@ async function createRuntime(requestContext, callbacks) {
  */
 export async function waitForReaderQuiescent(runtime) {
   if (!runtime || runtime.closed) {
-    throw new Error('Runtime closed while waiting for the CLI to become quiet');
+    throw new Error(runtime?.abortRequested
+      ? 'Turn aborted'
+      : 'Runtime closed while waiting for the CLI to become quiet');
   }
   const deadline = Date.now() + 120_000;
   let lastProgress = runtime.readerProgress || 0;
   for (;;) {
     await new Promise((resolve) => setTimeout(resolve, 0));
     if (runtime.closed) {
-      throw new Error('Runtime closed while waiting for the CLI to become quiet');
+      throw new Error(runtime.abortRequested
+        ? 'Turn aborted'
+        : 'Runtime closed while waiting for the CLI to become quiet');
     }
     // Normalize: readerProgress is undefined until the reader processes its
     // first message, and undefined !== 0 would otherwise read as perpetual
@@ -551,11 +572,9 @@ async function applyDynamicControls(runtime, requestContext) {
   if (!runtime || runtime.closed) return;
 
   const targetPermissionMode = normalizePermissionMode(requestContext.permissionMode);
-  if (runtime.currentPermissionMode !== targetPermissionMode) {
-    const applied = await applyPermissionModeToRuntime(runtime, targetPermissionMode);
-    if (!applied) {
-      console.error('[DAEMON] setPermissionMode failed; keeping local state unchanged:', targetPermissionMode);
-    }
+  const applied = await applyPermissionModeToRuntime(runtime, targetPermissionMode);
+  if (!applied) {
+    console.error('[DAEMON] setPermissionMode failed; keeping local state unchanged:', targetPermissionMode);
   }
 
   const targetModel = requestContext.sdkModelName || null;
@@ -614,7 +633,9 @@ function assertRuntimeOwnership(runtime, requestContext) {
   }
 }
 
-export async function acquireRuntime(requestContext, callbacks) {
+const acquireLocks = new Map();
+
+async function acquireRuntimeUnlocked(requestContext, callbacks) {
   await cleanupAnonymousFromRegistry((runtime) => disposeRuntime(runtime, callbacks));
 
   let runtime = findRuntimeForRequest(requestContext);
@@ -658,6 +679,24 @@ export async function acquireRuntime(requestContext, callbacks) {
   await applyDynamicControls(runtime, requestContext);
   touchRuntime(runtime);
   return runtime;
+}
+
+export async function acquireRuntime(requestContext, callbacks) {
+  const key = requestContext.requestedSessionId
+    ? `session:${requestContext.requestedSessionId}`
+    : `anonymous:${requestContext.runtimeSignature || '(none)'}`;
+  const previous = acquireLocks.get(key) || Promise.resolve();
+  const operation = previous
+    .then(() => acquireRuntimeUnlocked(requestContext, callbacks));
+  const queued = operation.catch(() => undefined);
+  acquireLocks.set(key, queued);
+  try {
+    return await operation;
+  } finally {
+    if (acquireLocks.get(key) === queued) {
+      acquireLocks.delete(key);
+    }
+  }
 }
 
 export async function cleanupStaleAnonymousRuntimes(callbacks) {

--- a/ai-bridge/services/claude/runtime-lifecycle.test.js
+++ b/ai-bridge/services/claude/runtime-lifecycle.test.js
@@ -6,6 +6,8 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { buildRuntimeSignature, applyDynamicControls, applyPermissionModeToRuntime, createTurnSink } from './runtime-lifecycle.js';
+import { findRuntimeForRequest, rememberRuntime, resetRegistryState } from './runtime-registry.js';
+import { createPreToolUseHook } from './permission-mode.js';
 
 // ============================================================================
 // TurnSink Tests - Core Message Queue Functionality
@@ -527,6 +529,29 @@ test('applyPermissionModeToRuntime marks Full Auto transitions for rebuild', asy
   assert.equal(runtime.runtimeSignature, '__rebuild-pending-bypass-change__');
 });
 
+test('pending anonymous bypass runtime stays isolated by session epoch', () => {
+  resetRegistryState();
+  const pending = {
+    runtimeSignature: '__rebuild-pending-bypass-change__',
+    runtimeSessionEpoch: 'epoch-a',
+  };
+  rememberRuntime(pending, {
+    requestedSessionId: null,
+    runtimeSignature: 'sig-a',
+  });
+
+  assert.equal(findRuntimeForRequest({
+    requestedSessionId: null,
+    runtimeSignature: 'sig-b',
+    runtimeSessionEpoch: 'epoch-b',
+  }), null);
+  assert.equal(findRuntimeForRequest({
+    requestedSessionId: null,
+    runtimeSignature: 'sig-a-new',
+    runtimeSessionEpoch: 'epoch-a',
+  }), pending);
+  resetRegistryState();
+});
 test('applyDynamicControls passes the resolved model id to setModel, not the short name', async () => {
   // The CLI subprocess resolves short names ("sonnet") against its own env,
   // which was frozen at spawn — a daemon-side env update never reaches it.
@@ -535,6 +560,7 @@ test('applyDynamicControls passes the resolved model id to setModel, not the sho
   const runtime = {
     closed: false,
     currentPermissionMode: 'default',
+    permissionModeState: { value: 'default' },
     currentModel: 'sonnet',
     currentResolvedModel: 'claude-sonnet-4-6',
     currentMaxThinkingTokens: null,
@@ -560,6 +586,7 @@ test('applyDynamicControls skips setModel when short name and resolved id are un
   const runtime = {
     closed: false,
     currentPermissionMode: 'default',
+    permissionModeState: { value: 'default' },
     currentModel: 'sonnet',
     currentResolvedModel: 'claude-sonnet-4-6',
     currentMaxThinkingTokens: null,
@@ -576,6 +603,45 @@ test('applyDynamicControls skips setModel when short name and resolved id are un
   });
 
   assert.deepEqual(setModelCalls, []);
+});
+
+test('applyDynamicControls reapplies a mode skipped while another transition is pending', async () => {
+  const pending = [];
+  const runtime = {
+    closed: false,
+    currentPermissionMode: 'default',
+    permissionModeState: { value: 'default' },
+    currentModel: null,
+    currentResolvedModel: null,
+    currentMaxThinkingTokens: null,
+    query: {
+      setPermissionMode: (mode) => new Promise((resolve) => pending.push({ mode, resolve })),
+    },
+  };
+
+  const first = applyDynamicControls(runtime, {
+    permissionMode: 'acceptEdits',
+    sdkModelName: null,
+    resolvedModelId: null,
+    maxThinkingTokens: null,
+  });
+  const second = applyDynamicControls(runtime, {
+    permissionMode: 'default',
+    sdkModelName: null,
+    resolvedModelId: null,
+    maxThinkingTokens: null,
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(pending.map((item) => item.mode), ['acceptEdits']);
+  pending[0].resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(pending.map((item) => item.mode), ['acceptEdits', 'default']);
+
+  pending[1].resolve();
+  await Promise.all([first, second]);
+  assert.equal(runtime.currentPermissionMode, 'default');
+  assert.equal(runtime.permissionModeState.value, 'default');
 });
 
 test('acquireRuntime rebuilds the runtime when the [1m] context toggle changes', () => {
@@ -645,6 +711,123 @@ test('buildRuntimeSignature is stable across native modes (default/plan/acceptEd
 test('buildRuntimeSignature treats a missing permissionMode as non-bypass', () => {
   const sig = buildRuntimeSignature({ cwd: '/w', model: 'sonnet' }, '', true, 'ep');
   assert.match(sig, /"bypassPermissions":false/);
+});
+
+test('applyPermissionModeToRuntime serializes transitions and preserves request order', async () => {
+  const pending = [];
+  const runtime = {
+    closed: false,
+    currentPermissionMode: 'default',
+    permissionModeState: { value: 'default' },
+    query: {
+      setPermissionMode: (mode) => new Promise((resolve) => pending.push({ mode, resolve }))
+    }
+  };
+
+  const first = applyPermissionModeToRuntime(runtime, 'acceptEdits');
+  const second = applyPermissionModeToRuntime(runtime, 'plan');
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(pending.map((item) => item.mode), ['acceptEdits']);
+
+  pending[0].resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(pending.map((item) => item.mode), ['acceptEdits', 'plan']);
+  pending[1].resolve();
+  assert.equal(await first, false);
+  assert.equal(await second, true);
+  assert.equal(runtime.currentPermissionMode, 'plan');
+  assert.equal(runtime.permissionModeState.value, 'plan');
+});
+
+test('applyPermissionModeToRuntime reapplies the original mode after a superseded transition', async () => {
+  const pending = [];
+  const runtime = {
+    closed: false,
+    currentPermissionMode: 'default',
+    permissionModeState: { value: 'default' },
+    query: {
+      setPermissionMode: (mode) => new Promise((resolve) => pending.push({ mode, resolve }))
+    }
+  };
+
+  const first = applyPermissionModeToRuntime(runtime, 'acceptEdits');
+  const second = applyPermissionModeToRuntime(runtime, 'default');
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(pending.map((item) => item.mode), ['acceptEdits']);
+
+  pending[0].resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(pending.map((item) => item.mode), ['acceptEdits', 'default']);
+
+  pending[1].resolve();
+  assert.equal(await first, false);
+  assert.equal(await second, true);
+  assert.equal(runtime.currentPermissionMode, 'default');
+  assert.equal(runtime.permissionModeState.value, 'default');
+});
+
+test('applyPermissionModeToRuntime ignores absent or closed runtimes', async () => {
+  assert.equal(await applyPermissionModeToRuntime(null, 'plan'), false);
+  assert.equal(await applyPermissionModeToRuntime({ closed: true, permissionModeState: {} }, 'plan'), false);
+});
+
+test('a superseded plan hook preserves the acknowledged SDK mode while the next change waits', async () => {
+  const pending = [];
+  const runtime = {
+    currentPermissionMode: 'default',
+    permissionModeState: { value: 'default' },
+    query: {
+      setPermissionMode: (mode) => new Promise((resolve) => pending.push({ mode, resolve })),
+    },
+  };
+  const hook = createPreToolUseHook(runtime.permissionModeState, process.cwd(),
+    (mode) => applyPermissionModeToRuntime(runtime, mode));
+  const enterPlan = hook({ tool_name: 'EnterPlanMode' });
+  await new Promise((resolve) => setImmediate(resolve));
+  const acceptEdits = applyPermissionModeToRuntime(runtime, 'acceptEdits');
+  pending[0].resolve();
+  await enterPlan;
+  await new Promise((resolve) => setImmediate(resolve));
+
+  try {
+    assert.equal(runtime.currentPermissionMode, 'plan');
+    assert.equal(runtime.permissionModeState.value, 'plan');
+  } finally {
+    pending[1].resolve();
+    await acceptEdits;
+  }
+});
+
+test('superseded no-op and bypass transitions do not report themselves as the latest mode', async () => {
+  for (const target of ['default', 'bypassPermissions']) {
+    const runtime = {
+      currentPermissionMode: 'default',
+      permissionModeState: { value: 'default' },
+      query: { setPermissionMode: async () => {} },
+    };
+    const first = applyPermissionModeToRuntime(runtime, target);
+    const second = applyPermissionModeToRuntime(runtime, 'plan');
+    assert.deepEqual(await Promise.all([first, second]), [false, true]);
+    assert.equal(runtime.permissionModeState.value, 'plan');
+  }
+});
+
+test('applyPermissionModeToRuntime ignores a transition completed after disposal', async () => {
+  let resolveSdk;
+  const runtime = {
+    closed: false,
+    currentPermissionMode: 'default',
+    permissionModeState: { value: 'default' },
+    query: { setPermissionMode: () => new Promise((resolve) => { resolveSdk = resolve; }) }
+  };
+
+  const result = applyPermissionModeToRuntime(runtime, 'plan');
+  await new Promise((resolve) => setImmediate(resolve));
+  runtime.closed = true;
+  resolveSdk();
+  assert.equal(await result, false);
+  assert.equal(runtime.currentPermissionMode, 'default');
+  assert.equal(runtime.permissionModeState.value, 'default');
 });
 
 console.log('\n✅ All TurnSink tests defined. Run with: node runtime-lifecycle.test.js');

--- a/ai-bridge/services/claude/runtime-registry.js
+++ b/ai-bridge/services/claude/runtime-registry.js
@@ -74,7 +74,19 @@ export function findRuntimeForRequest(requestContext) {
   if (requestContext.requestedSessionId) {
     return runtimesBySessionId.get(requestContext.requestedSessionId) || null;
   }
-  return anonymousRuntimesBySignature.get(requestContext.runtimeSignature) || null;
+  const exact = anonymousRuntimesBySignature.get(requestContext.runtimeSignature);
+  if (exact) return exact;
+  // A bypass transition changes the spawn-time signature before the next
+  // request arrives. Only consider a pending runtime from the same anonymous
+  // session epoch; otherwise a request could dispose another session's runtime.
+  if (!requestContext.runtimeSessionEpoch) return null;
+  for (const runtime of anonymousRuntimes) {
+    if (runtime.runtimeSignature === '__rebuild-pending-bypass-change__'
+        && runtime.runtimeSessionEpoch === requestContext.runtimeSessionEpoch) {
+      return runtime;
+    }
+  }
+  return null;
 }
 
 export function beginRuntimeTurn(runtime) {

--- a/ai-bridge/services/claude/setPermissionModePersistent.test.mjs
+++ b/ai-bridge/services/claude/setPermissionModePersistent.test.mjs
@@ -1,3 +1,5 @@
+// Isolate credentials before the runtime caches the user's home directory.
+import './testing/cli-login-home.js';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -129,6 +131,37 @@ test('setPermissionModePersistent is a no-op when the mode is unchanged', async 
   assert.equal(calls, 0);
   assert.equal(runtime.currentPermissionMode, 'plan');
   assert.equal(runtime.permissionModeState.value, 'plan');
+});
+
+test('setPermissionModePersistent reapplies an original mode after a superseded transition', async () => {
+  const pending = [];
+  const runtime = createFakeRuntime({
+    currentPermissionMode: 'default',
+    setPermissionMode: (mode) => new Promise((resolve) => pending.push({ mode, resolve }))
+  });
+  __testing.setActiveTurnRuntime(runtime);
+
+  const first = setPermissionModePersistent({
+    sessionId: 'sess-1',
+    runtimeSessionEpoch: 'epoch-1',
+    permissionMode: 'acceptEdits'
+  });
+  const second = setPermissionModePersistent({
+    sessionId: 'sess-1',
+    runtimeSessionEpoch: 'epoch-1',
+    permissionMode: 'default'
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(pending.map((item) => item.mode), ['acceptEdits']);
+  pending[0].resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(pending.map((item) => item.mode), ['acceptEdits', 'default']);
+
+  pending[1].resolve();
+  await Promise.all([first, second]);
+  assert.equal(runtime.currentPermissionMode, 'default');
+  assert.equal(runtime.permissionModeState.value, 'default');
 });
 
 test('setPermissionModePersistent leaves local state unchanged when the SDK call fails', async () => {

--- a/ai-bridge/services/claude/stale-turn-isolation.test.js
+++ b/ai-bridge/services/claude/stale-turn-isolation.test.js
@@ -238,7 +238,7 @@ test('a new turn waits for an in-flight CLI-initiated turn and never absorbs its
   assert.ok(!meta2.state.lastAssistantContent.includes('background notification'));
 });
 
-test('a foreign success result arriving first in a new turn is skipped, not treated as the turn end', async () => {
+test('a background success result arriving first in a new turn is skipped, not treated as the turn end', async () => {
   // The boundary straddle the gate cannot see: the background run's closing
   // result is read only AFTER the new turn's sink opened. Consuming it as the
   // new turn's own result would end the turn with empty output and seed the
@@ -265,7 +265,7 @@ test('a foreign success result arriving first in a new turn is skipped, not trea
   assert.equal(query.inputs.length, 2, 'gate must not trigger: the CLI was quiet at turn start');
 
   // Foreign result lands in the fresh sink before any of this turn's output.
-  query.channel.enqueue({ type: 'result', is_error: false });
+  query.channel.enqueue({ type: 'result', is_error: false, origin: { kind: 'task-notification' } });
   await settleReader();
 
   // The real answer follows — the turn must still be alive to receive it.
@@ -276,7 +276,7 @@ test('a foreign success result arriving first in a new turn is skipped, not trea
 
   await turn2Promise;
   assert.equal(meta2.state.lastAssistantContent, 'real answer two',
-    'a bare foreign success result must not terminate the turn');
+    'a background success result must not terminate the turn');
 });
 
 test('an error result as the first message of a turn still fails the turn (not treated as foreign)', async () => {
@@ -297,23 +297,48 @@ test('an error result as the first message of a turn still fails the turn (not t
   );
 });
 
-test('a skipped foreign result arms an idle backstop that settles a silent turn instead of hanging', async () => {
-  // The foreign-result skip assumes a real run always emits output before its
-  // result. A turn that legitimately produces zero messages breaks that
-  // assumption: its own result is skipped as foreign and, without a backstop,
-  // the take() loop parks forever. The idle backstop must settle the turn
-  // empty (with a warn) once no turn output arrives within the window.
-  const turn1 = [messageStart(), streamTextDelta('answer one'), assistantText('answer one'), RESULT_OK];
+test('a result-only turn completes without waiting for substantive output', async () => {
+  const turn1 = [messageStart(), assistantText('answer one'), RESULT_OK];
+  const turn2 = [RESULT_OK];
 
   let query;
   __testing.setQueryFn((args) => {
-    query = createScriptedQuery(args, [turn1]);
+    query = createScriptedQuery(args, [turn1, turn2]);
     return query;
   });
 
-  __testing.setForeignResultIdleBackstopMs(50);
-  try {
-    const params = baseParams('idle-backstop');
+  const params = baseParams('result-only');
+  const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
+  const runtime = await __testing.acquireRuntime(ctx1);
+  await __testing.executeTurn(runtime, ctx1, { state: null });
+  await settleReader();
+
+  const ctx2 = await __testing.buildRequestContext({ ...params, message: 'q2' }, false, OVERRIDES);
+  const meta2 = { state: null };
+  await __testing.executeTurn(runtime, ctx2, meta2);
+
+  assert.equal(meta2.state.lastAssistantContent, '');
+  assert.equal(query.inputs.length, 2);
+});
+
+for (const isError of [false, true]) {
+  test(`a task-notification ${isError ? 'error' : 'success'} result does not end the active user turn`, { timeout: 5000 }, async () => {
+    const turn1 = [messageStart(), assistantText('answer one'), RESULT_OK];
+    const turn2 = [
+      { type: 'result', is_error: isError, origin: { kind: 'task-notification' } },
+      messageStart(),
+      assistantText('answer two'),
+      { type: 'result', is_error: isError, origin: { kind: 'task-notification' } },
+      RESULT_OK,
+    ];
+
+    let query;
+    __testing.setQueryFn((args) => {
+      query = createScriptedQuery(args, [turn1, turn2]);
+      return query;
+    });
+
+    const params = baseParams('task-result');
     const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
     const runtime = await __testing.acquireRuntime(ctx1);
     await __testing.executeTurn(runtime, ctx1, { state: null });
@@ -321,99 +346,11 @@ test('a skipped foreign result arms an idle backstop that settles a silent turn 
 
     const ctx2 = await __testing.buildRequestContext({ ...params, message: 'q2' }, false, OVERRIDES);
     const meta2 = { state: null };
-    const turn2Promise = __testing.executeTurn(runtime, ctx2, meta2);
-    await settleReader();
-    assert.equal(query.inputs.length, 2, 'gate must not trigger: the CLI was quiet at turn start');
-
-    const warnings = [];
-    const originalWarn = console.warn;
-    console.warn = (...args) => { warnings.push(args.map(String).join(' ')); };
-    try {
-      // A foreign bare-success result lands first and is skipped; nothing
-      // belonging to this turn ever follows. Without the backstop this
-      // executeTurn would never resolve.
-      query.channel.enqueue({ type: 'result', is_error: false });
-      await turn2Promise;
-    } finally {
-      console.warn = originalWarn;
-    }
-
-    assert.equal(meta2.state.lastAssistantContent, '',
-      'the backstop-settled turn must end with empty output');
-    assert.ok(
-      warnings.some((line) => line.includes('idle backstop') && line.includes('epoch-idle-backstop')),
-      'the backstop must log a warn with session/epoch context'
-    );
-
-    // The runtime must stay usable: a follow-up turn runs normally.
-    const turn3 = [messageStart(), streamTextDelta('answer three'), assistantText('answer three'), RESULT_OK];
-    const ctx3 = await __testing.buildRequestContext({ ...params, message: 'q3' }, false, OVERRIDES);
-    const meta3 = { state: null };
-    const turn3Promise = __testing.executeTurn(runtime, ctx3, meta3);
-    await query.waitForInput(); // consume turn 1's tracked input (FIFO)
-    await query.waitForInput(); // consume turn 2's tracked input
-    await query.waitForInput(); // resolves once turn 3's user message lands
-    // NOTE: enqueue takes a single event per call — a spread would silently
-    // drop all but the first event.
-    for (const event of turn3) {
-      query.channel.enqueue(event);
-    }
-    await turn3Promise;
-    assert.equal(meta3.state.lastAssistantContent, 'answer three');
-  } finally {
-    __testing.setForeignResultIdleBackstopMs();
-  }
-});
-
-test('turn output arriving after a skipped foreign result disarms the idle backstop', async () => {
-  // The normal path must be unaffected: output that arrives within the
-  // backstop window disarms it, and no synthetic empty settlement occurs.
-  const turn1 = [messageStart(), streamTextDelta('answer one'), assistantText('answer one'), RESULT_OK];
-
-  let query;
-  __testing.setQueryFn((args) => {
-    query = createScriptedQuery(args, [turn1]);
-    return query;
+    await __testing.executeTurn(runtime, ctx2, meta2);
+    assert.equal(query.inputs.length, 2);
+    assert.equal(meta2.state.lastAssistantContent, 'answer two');
   });
-
-  __testing.setForeignResultIdleBackstopMs(80);
-  try {
-    const params = baseParams('backstop-disarm');
-    const ctx1 = await __testing.buildRequestContext({ ...params, message: 'q1' }, false, OVERRIDES);
-    const runtime = await __testing.acquireRuntime(ctx1);
-    await __testing.executeTurn(runtime, ctx1, { state: null });
-    await settleReader();
-
-    const ctx2 = await __testing.buildRequestContext({ ...params, message: 'q2' }, false, OVERRIDES);
-    const meta2 = { state: null };
-    const turn2Promise = __testing.executeTurn(runtime, ctx2, meta2);
-    await settleReader();
-
-    const warnings = [];
-    const originalWarn = console.warn;
-    console.warn = (...args) => { warnings.push(args.map(String).join(' ')); };
-    try {
-      query.channel.enqueue({ type: 'result', is_error: false }); // foreign, skipped
-      await settleReader();
-      // Real turn output arrives within the window and disarms the backstop.
-      query.channel.enqueue(messageStart());
-      query.channel.enqueue(streamTextDelta('real answer'));
-      query.channel.enqueue(assistantText('real answer'));
-      query.channel.enqueue(RESULT_OK);
-      await turn2Promise;
-      // Outlive the backstop window: no late synthetic settlement may fire.
-      await new Promise((resolve) => setTimeout(resolve, 150));
-    } finally {
-      console.warn = originalWarn;
-    }
-
-    assert.equal(meta2.state.lastAssistantContent, 'real answer');
-    assert.ok(!warnings.some((line) => line.includes('idle backstop')),
-      'the backstop must not fire once real turn output arrived');
-  } finally {
-    __testing.setForeignResultIdleBackstopMs();
-  }
-});
+}
 
 test('abort while gated on an in-flight CLI turn fails the turn instead of hanging', async () => {
   const turn1 = [messageStart(), assistantText('answer one'), RESULT_OK];
@@ -441,8 +378,9 @@ test('abort while gated on an in-flight CLI turn fails the turn instead of hangi
 
   // User hits stop: dispose resolves the gate, the turn fails fast.
   await __testing.abortCurrentTurn();
-  await assert.rejects(turn2Promise, /Runtime closed while waiting/);
+  await assert.rejects(turn2Promise, /Turn aborted/);
   assert.equal(runtime.closed, true);
+  assert.equal(query.inputs.length, 1, 'the aborted message must never reach the CLI');
 });
 
 test('a background-turn tail already in the pipe does not contaminate the next user turn', async () => {
@@ -453,7 +391,7 @@ test('a background-turn tail already in the pipe does not contaminate the next u
   // starts in that window.
   //
   // Without deferring the sink until the pipe is quiet, turn 2 would open its
-  // sink, receive the background assistant (arming sawTurnMessage), then take
+  // sink, receive the background assistant, then take
   // the background *result* as its own — ending turn 2 before its real answer,
   // which then completes unobserved between turns. Every later answer shifts
   // back by one ("answer to the previous / pre-previous phrase").

--- a/ai-bridge/services/claude/stream-event-processor.js
+++ b/ai-bridge/services/claude/stream-event-processor.js
@@ -30,11 +30,6 @@ export function createTurnState(requestContext, runtime) {
     streamStarted: false,
     streamEnded: false,
     hasStreamEvents: false,
-    // True once any non-result message has been processed this turn. A closing
-    // SUCCESS result arriving with this still false is provably foreign (a real
-    // run emits output before its result) and is skipped rather than ending the
-    // turn empty — see the foreign-result skip in executeTurn (#1410).
-    sawTurnMessage: false,
     lastAssistantContent: '',
     lastThinkingContent: '',
     textBlockContentByIndex: new Map(),

--- a/ai-bridge/services/codex/codex-utils.js
+++ b/ai-bridge/services/codex/codex-utils.js
@@ -111,11 +111,11 @@ export function buildCodexCliEnvironment(baseEnv) {
     if (typeof rawValue !== 'string' || rawValue.length === 0) {
       continue;
     }
-    if (CODEX_CLI_ENV_BLOCKLIST.has(key)) {
+    const normalizedKey = key.toUpperCase();
+    if (CODEX_CLI_ENV_BLOCKLIST.has(normalizedKey)) {
       removedKeys.push(key);
       continue;
     }
-    const normalizedKey = key.toUpperCase();
     if (normalizedKey === CODEX_PROXY_ENV_OPT_IN ||
         (!inheritProxyEnvironment && PROXY_ENV_KEYS.has(normalizedKey))) {
       removedKeys.push(key);
@@ -176,10 +176,11 @@ export function normalizeCodexPermissionMode(mode) {
   if (!trimmed) {
     return 'default';
   }
-  if (trimmed.toLowerCase() === 'auto') {
+  const normalized = trimmed.toLowerCase();
+  if (normalized === 'auto') {
     return 'auto';
   }
-  if (trimmed === 'autoEdit') {
+  if (normalized === 'autoedit') {
     return 'acceptEdits';
   }
   return trimmed;

--- a/ai-bridge/services/codex/codex-utils.test.js
+++ b/ai-bridge/services/codex/codex-utils.test.js
@@ -54,9 +54,22 @@ test('does not enable proxy inheritance for false-like values', () => {
   ]);
 });
 
-test('normalizes native auto mode casing before dispatch', () => {
+test('removes Codex policy variables regardless of key casing', () => {
+  const result = buildCodexCliEnvironment({
+    codex_approval_policy: 'never',
+    CoDeX_SaNdBoX: 'danger-full-access',
+    SAFE_VALUE: 'kept'
+  });
+
+  assert.deepEqual(result.cliEnv, { SAFE_VALUE: 'kept' });
+  assert.deepEqual(result.removedKeys, ['codex_approval_policy', 'CoDeX_SaNdBoX']);
+});
+
+test('normalizes native auto mode casing and aliases before dispatch', () => {
   assert.equal(normalizeCodexPermissionMode('AUTO'), 'auto');
   assert.equal(normalizeCodexPermissionMode(' auto '), 'auto');
+  assert.equal(normalizeCodexPermissionMode('AUTOEDIT'), 'acceptEdits');
+  assert.equal(normalizeCodexPermissionMode(' AutoEdit '), 'acceptEdits');
 });
 
 test('requires Codex 0.146.0 or later for native auto review config', () => {

--- a/ai-bridge/services/dsh/preset-overlay.test.js
+++ b/ai-bridge/services/dsh/preset-overlay.test.js
@@ -1,5 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import {
   DSH_PRESET_IDS,
@@ -153,6 +155,7 @@ test('buildPresetOverlay drops the tool-cordis row for the cordis preset', () =>
 });
 
 test('buildPresetOverlay rewrites relative plugin rows and baseUrl against the preset dir', () => {
+  const presetDir = resolve('test-presets', 'router');
   const presetText = [
     '- id: router',
     '  name: ./router-bootstrap.mjs',
@@ -164,12 +167,12 @@ test('buildPresetOverlay rewrites relative plugin rows and baseUrl against the p
     presetId: 'router-standard',
     presetText,
     baseIds: new Set(),
-    presetDir: '/tmp/preset',
+    presetDir,
   });
-  assert.ok(overlay.includes('name: file:///tmp/preset/router-bootstrap.mjs'));
-  assert.ok(overlay.includes('root: "file:///tmp/preset/"'));
+  assert.ok(overlay.includes(`name: ${pathToFileURL(join(presetDir, 'router-bootstrap.mjs')).href}`));
+  assert.ok(overlay.includes(`root: "${pathToFileURL(presetDir + '/').href}"`));
   // The skills/ + baseUrl expression is emitted as a resolved path.
-  assert.ok(overlay.includes('- /tmp/preset/skills'));
+  assert.ok(overlay.includes(`- ${join(presetDir, 'skills').replace(/\\/g, '/')}`));
   assert.ok(!overlay.includes('baseUrl'));
 });
 

--- a/ai-bridge/services/grok/acp-terminal-host.js
+++ b/ai-bridge/services/grok/acp-terminal-host.js
@@ -11,6 +11,7 @@ import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { resolveCliSpawn } from '../../utils/cli-path.js';
 
 const DEFAULT_OUTPUT_BYTE_LIMIT = 1024 * 1024; // 1 MiB soft default if agent omits limit
 const MAX_TERMINALS = 32;
@@ -266,10 +267,9 @@ export class AcpTerminalHost {
     const terminalId = randomUUID();
     const rawEnv = buildEnv(this.env, params.env);
 
-    // Clean env: explicitly build minimal user env without any IDEA_* pollution
-    // so that when Grok's wrapper does /bin/bash -lc 'cmd' (or direct), the bash/mvn
-    // see normal user env (not "launched from inside IDEA").
-    const cleanEnv = {
+    // Unix login shells rebuild the user environment without IDEA_* pollution.
+    // Native Windows tools also need SystemRoot, ComSpec and the profile paths.
+    const cleanEnv = process.platform === 'win32' ? rawEnv : {
       PATH: rawEnv.PATH || process.env.PATH,
       HOME: rawEnv.HOME || process.env.HOME,
       USER: rawEnv.USER || process.env.USER,
@@ -282,12 +282,8 @@ export class AcpTerminalHost {
     };
     if (rawEnv.NODE_PATH) cleanEnv.NODE_PATH = rawEnv.NODE_PATH;
 
-    // Always run through the user's login shell (profiles / normal env).
-    // Array form only — never pass a full "/bin/bash -lc '…'" string as argv[0]/path.
-    // Flag shape matches daemon.js: bash uses -lc, fish -c, others -l -c.
-    // Always respect the user's login shell ($SHELL).
-    // If not set, prefer zsh on macOS only if the binary exists,
-    // otherwise fall back to bash or POSIX sh.
+    // Windows command strings need cmd syntax even when Git Bash sets SHELL.
+    // Unix commands retain the user's login shell and its profiles.
     function resolveDefaultShell() {
       if (process.platform === 'win32') return 'cmd.exe';
       if (process.platform === 'darwin') {
@@ -300,7 +296,9 @@ export class AcpTerminalHost {
       return '/bin/sh';
     }
 
-    const loginShell = rawEnv.SHELL || process.env.SHELL || resolveDefaultShell();
+    const loginShell = process.platform === 'win32'
+      ? rawEnv.ComSpec || rawEnv.COMSPEC || resolveDefaultShell()
+      : rawEnv.SHELL || process.env.SHELL || resolveDefaultShell();
     let commandLine = unwrapShellWrapperCommand(command, args);
     if (!commandLine.trim()) {
       throw Object.assign(new Error('command is empty after unwrapping shell wrapper'), {
@@ -309,20 +307,28 @@ export class AcpTerminalHost {
     }
 
     let scriptPath = null;
-    if (needsFileExecution(commandLine)) {
+    if (process.platform !== 'win32' && needsFileExecution(commandLine)) {
       // Complex payload (shebang / heredoc / ! / heavy quoting) — write to temp script.
       // This bypasses the outer wrapper mangling that corrupts heredoc, bang, nested quotes.
       scriptPath = writeTempScript(commandLine);
       commandLine = scriptPath; // pass the path; loginShell will exec it
     }
 
-    // Execution strategy (robust against noexec):
-    // - Normal commands: loginShell -lc/-l -c "commandLine"
-    // - Complex payloads (heredoc/!/shebang): write to temp script, then
-    //   ALWAYS invoke via the user's login shell: loginShell -c "/tmp/.../cmd.sh"
-    //   This works even when /tmp has noexec.
+    // Unix shells read complex scripts as files, which also works on noexec mounts.
     let child;
-    if (scriptPath) {
+    if (process.platform === 'win32') {
+      const options = { cwd, env: cleanEnv, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true };
+      if (args.length > 0 && !isShellExecutable(command)) {
+        // Keep argv intact; shell escaping would turn literal metacharacters into code.
+        const invocation = resolveCliSpawn(String(command), args, options);
+        child = spawn(invocation.file, invocation.args, invocation.options);
+      } else {
+        child = spawn(loginShell, ['/d', '/s', '/c', `"${commandLine}"`], {
+          ...options,
+          windowsVerbatimArguments: true,
+        });
+      }
+    } else if (scriptPath) {
       // Execute the temp script directly via the login shell as a file, not via -c.
       // This bypasses the outer ACP wrapper entirely and avoids treating the path as code.
       // Strategy: loginShell -l scriptPath  (or equivalent per shell)

--- a/ai-bridge/services/grok/acp-terminal-host.test.js
+++ b/ai-bridge/services/grok/acp-terminal-host.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
+import os from 'node:os';
 import {
   AcpTerminalHost,
   truncateOutputFromStart,
@@ -26,11 +27,12 @@ test('truncateOutputFromStart keeps suffix within byte limit', () => {
   assert.ok(text.endsWith('z'));
 });
 
-test('create → output → wait_for_exit for simple command', async () => {
+test('create → output → wait_for_exit for simple command', async (t) => {
   const host = new AcpTerminalHost({
     defaultCwd: process.cwd(),
     authorizeCreate: async () => true,
   });
+  t.after(() => host.disposeAll());
   const { terminalId } = await host.create({
     sessionId: 's1',
     command: process.execPath,
@@ -49,6 +51,43 @@ test('create → output → wait_for_exit for simple command', async () => {
 
   await host.release({ terminalId });
   assert.equal(host.size(), 0);
+});
+
+test('argv preserves spaces, quotes and shell metacharacters', async (t) => {
+  const host = new AcpTerminalHost({ authorizeCreate: async () => true });
+  t.after(() => host.disposeAll());
+  const values = ['two words', 'a"b', '%PATH%', 'x&echo wrong', 'tail\\', '', "it's"];
+  const { terminalId } = await host.create({
+    command: process.execPath,
+    args: ['-e', 'process.stdout.write(JSON.stringify(process.argv.slice(1)))', ...values],
+  });
+  assert.equal((await host.waitForExit({ terminalId })).exitCode, 0);
+  assert.deepEqual(JSON.parse((await host.output({ terminalId })).output), values);
+});
+
+test('failed commands report their actual exit code', async (t) => {
+  const host = new AcpTerminalHost({ authorizeCreate: async () => true });
+  t.after(() => host.disposeAll());
+  const { terminalId } = await host.create({ command: process.execPath, args: ['-e', 'process.exit(17)'] });
+  assert.equal((await host.waitForExit({ terminalId })).exitCode, 17);
+});
+
+test('launches a CLI shim from a directory containing spaces', async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'grok cli '));
+  const shim = path.join(dir, process.platform === 'win32' ? 'tool.cmd' : 'tool');
+  const script = process.platform === 'win32'
+    ? `@echo off\r\n"${process.execPath}" -e "process.stdout.write(JSON.stringify(process.argv.slice(1)))" %*\r\n`
+    : `#!/bin/sh\nexec '${process.execPath}' -e 'process.stdout.write(JSON.stringify(process.argv.slice(1)))' "$@"\n`;
+  fs.writeFileSync(shim, script, { mode: 0o700 });
+  const host = new AcpTerminalHost({ authorizeCreate: async () => true });
+  t.after(async () => {
+    await host.disposeAll();
+    fs.unlinkSync(shim);
+    fs.rmdirSync(dir);
+  });
+  const { terminalId } = await host.create({ command: shim, args: ['two words', 'x&y'] });
+  assert.equal((await host.waitForExit({ terminalId })).exitCode, 0);
+  assert.deepEqual(JSON.parse((await host.output({ terminalId })).output), ['two words', 'x&y']);
 });
 
 test('kill terminates long-running process', async () => {
@@ -104,11 +143,12 @@ test('loginShellSpawnArgs matches daemon.js flag shapes', () => {
   assert.deepEqual(loginShellSpawnArgs('/usr/bin/fish', 'echo hi'), ['-c', 'echo hi']);
 });
 
-test('create with Grok-style /bin/bash -lc args', async () => {
+test('create with Grok-style /bin/bash -lc args', async (t) => {
   const host = new AcpTerminalHost({
     authorizeCreate: async () => true,
     env: { ...process.env, SHELL: '/bin/bash' },
   });
+  t.after(() => host.disposeAll());
   const { terminalId } = await host.create({
     sessionId: 's',
     command: '/bin/bash',
@@ -120,11 +160,12 @@ test('create with Grok-style /bin/bash -lc args', async () => {
   await host.release({ terminalId });
 });
 
-test('shell string command with empty args', async () => {
+test('shell string command with empty args', async (t) => {
   const host = new AcpTerminalHost({
     authorizeCreate: async () => true,
     env: { ...process.env, SHELL: '/bin/bash' },
   });
+  t.after(() => host.disposeAll());
   const { terminalId } = await host.create({
     sessionId: 's',
     command: 'echo shell-ok',
@@ -138,11 +179,12 @@ test('shell string command with empty args', async () => {
   await host.release({ terminalId });
 });
 
-test('shell string with metacharacters runs as script not as binary name', async () => {
+test('shell string with metacharacters runs as script not as binary name', async (t) => {
   const host = new AcpTerminalHost({
     authorizeCreate: async () => true,
     env: { ...process.env, SHELL: '/bin/bash' },
   });
+  t.after(() => host.disposeAll());
   const { terminalId } = await host.create({
     sessionId: 's',
     command: 'echo hello && echo world',

--- a/ai-bridge/utils/cli-path.test.js
+++ b/ai-bridge/utils/cli-path.test.js
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join, normalize } from 'node:path';
 import {
   decodeCliOutput,
   isWindowsCmdShim,
@@ -161,7 +161,7 @@ test('resolveCliPath expands {localAppData} candidates (OMP Windows installer la
       envKeys: [],
       homeCandidates: ['{localAppData}/omp/{bin}'],
     });
-    assert.ok(resolved.startsWith(binDir), `expected hit under ${binDir}, got ${resolved}`);
+    assert.equal(dirname(normalize(resolved)), binDir);
   } finally {
     if (saved === undefined) {
       delete process.env.LOCALAPPDATA;
@@ -218,8 +218,8 @@ test('resolveCliPath finds a CLI shim installed under an nvm version dir', () =>
 
 test('commonCliBinDirs includes the OMP bin dir after the PI entry', () => {
   const dirs = commonCliBinDirs('/home/tester');
-  const piIndex = dirs.indexOf('/home/tester/.pi/bin');
-  const ompIndex = dirs.indexOf('/home/tester/.omp/bin');
+  const piIndex = dirs.indexOf(join('/home/tester', '.pi', 'bin'));
+  const ompIndex = dirs.indexOf(join('/home/tester', '.omp', 'bin'));
   assert.ok(piIndex !== -1, 'expected .pi/bin entry');
   assert.ok(ompIndex !== -1, 'expected .omp/bin entry');
   assert.equal(ompIndex, piIndex + 1);

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudePlanUsageService.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudePlanUsageService.java
@@ -7,8 +7,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 
-import java.time.Instant;
-
 /**
  * Claude plan-usage snapshot builder + resolver.
  *
@@ -104,9 +102,8 @@ public final class ClaudePlanUsageService {
 
         // resetsAt is unix epoch SECONDS in the CLI schema (the CLI computes
         // `resetsAt - Date.now()/1000`), not millis — convert before use.
-        Long resetsAtSec = RelayUsageJson.asLong(rateLimitInfo, "resetsAt", "resets_at", "resetAt");
-        Long resetsAtMs = resetsAtSec != null ? resetsAtSec * 1000L : null;
-        String resetAt = resetsAtMs != null ? Instant.ofEpochMilli(resetsAtMs).toString() : null;
+        Long resetsAtMs = RelayUsageJson.asEpochMs(rateLimitInfo, "resetsAt", "resets_at", "resetAt");
+        String resetAt = resetsAtMs != null ? RelayUsageJson.epochMsToIso(resetsAtMs) : null;
         String periodType = periodTypeFromRateLimit(rateLimitInfo, resetsAtMs);
 
         JsonObject window = new JsonObject();

--- a/src/main/java/com/github/claudecodegui/provider/claude/usage/KimiCodingUsageVendor.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/usage/KimiCodingUsageVendor.java
@@ -34,8 +34,8 @@ public final class KimiCodingUsageVendor implements RelayUsageVendor {
         // /coding path is the Coding Plan whose /v1/usages endpoint exists.
         // Must be matched before any future plain-kimi vendor. The segment
         // boundary matters: a hypothetical "/codingfoo" path is not the plan.
-        return "api.kimi.com".equals(host) && path != null
-                && (path.equals("/coding") || path.startsWith("/coding/"));
+        return "api.kimi.com".equalsIgnoreCase(host) && path != null
+                && (path.equalsIgnoreCase("/coding") || path.toLowerCase(java.util.Locale.ROOT).startsWith("/coding/"));
     }
 
     @Override

--- a/src/main/java/com/github/claudecodegui/provider/claude/usage/MiniMaxUsageVendor.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/usage/MiniMaxUsageVendor.java
@@ -30,8 +30,12 @@ public final class MiniMaxUsageVendor implements RelayUsageVendor {
 
     @Override
     public boolean matches(String host, String path) {
-        return host.equals("minimaxi.com") || host.endsWith(".minimaxi.com")
-                || host.equals("minimax.io") || host.endsWith(".minimax.io");
+        if (host == null) {
+            return false;
+        }
+        String normalizedHost = host.toLowerCase(java.util.Locale.ROOT);
+        return normalizedHost.equals("minimaxi.com") || normalizedHost.endsWith(".minimaxi.com")
+                || normalizedHost.equals("minimax.io") || normalizedHost.endsWith(".minimax.io");
     }
 
     @Override

--- a/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageCache.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageCache.java
@@ -2,20 +2,16 @@ package com.github.claudecodegui.provider.claude.usage;
 
 import com.google.gson.JsonObject;
 
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
- * Payload cache shared by all relay usage vendors (one active account per
- * vendor at a time, so a single entry keyed by vendor + endpoint + credential
- * suffices).
+ * Payload cache shared by all relay usage vendors.
  *
- * <p>Serves three roles, mirroring the original z.ai-only cache:
- * <ul>
- *   <li><b>fresh</b> — probe result within {@link #TTL_MS}, served verbatim;</li>
- *   <li><b>stale</b> — last good payload after a failed probe, served for at
- *       most {@link #STALE_MAX_MS} and flagged {@code stale: true} so the UI can
- *       mark it, then given up on (a long outage must not masquerade as live
- *       data);</li>
- *   <li>cache misses simply fall through to the caller's fallback chain.</li>
- * </ul>
+ * <p>The cache is bounded because settings can contain multiple relay
+ * credentials over the lifetime of one IDE process. Payloads are copied at the
+ * boundary so callers cannot mutate cached data.
  */
 final class RelayUsageCache {
 
@@ -23,25 +19,34 @@ final class RelayUsageCache {
     static final long TTL_MS = 115_000L;
     /** Max age for serving a stale payload after repeated probe failures. */
     static final long STALE_MAX_MS = 30 * 60_000L;
+    private static final int MAX_ENTRIES = 16;
 
-    private static volatile Entry entry;
+    private static final Map<String, Entry> entries = new LinkedHashMap<>();
 
     private RelayUsageCache() {
     }
 
     /** Fresh cached payload for {@code key}, or null when absent/expired. */
-    static JsonObject fresh(String key, long nowMs) {
-        Entry c = entry;
-        if (c != null && c.key.equals(key) && nowMs - c.atMs < TTL_MS) {
+    static synchronized JsonObject fresh(String key, long nowMs) {
+        if (key == null) {
+            return null;
+        }
+        Entry c = entries.get(key);
+        long age = age(nowMs, c);
+        if (age >= 0 && age < TTL_MS) {
             return c.payload.deepCopy();
         }
         return null;
     }
 
     /** Stale cached payload (flagged) for {@code key} within {@link #STALE_MAX_MS}, or null. */
-    static JsonObject stale(String key, long nowMs) {
-        Entry c = entry;
-        if (c != null && c.key.equals(key) && nowMs - c.atMs < STALE_MAX_MS) {
+    static synchronized JsonObject stale(String key, long nowMs) {
+        if (key == null) {
+            return null;
+        }
+        Entry c = entries.get(key);
+        long age = age(nowMs, c);
+        if (age >= 0 && age < STALE_MAX_MS) {
             JsonObject copy = c.payload.deepCopy();
             copy.addProperty("stale", true);
             return copy;
@@ -50,23 +55,38 @@ final class RelayUsageCache {
     }
 
     /** Persist a successful probe result for {@code key}. */
-    static void store(String key, JsonObject payload, long nowMs) {
-        entry = new Entry(nowMs, key, payload);
+    static synchronized void store(String key, JsonObject payload, long nowMs) {
+        if (key == null || payload == null) {
+            return;
+        }
+        // Refresh insertion order so eviction keeps the most recently fetched quotas.
+        entries.remove(key);
+        entries.put(key, new Entry(nowMs, payload.deepCopy()));
+        while (entries.size() > MAX_ENTRIES) {
+            Iterator<String> iterator = entries.keySet().iterator();
+            entries.remove(iterator.next());
+        }
     }
 
     /** Test-only: drop the cached payload. */
-    static void clearForTests() {
-        entry = null;
+    static synchronized void clearForTests() {
+        entries.clear();
+    }
+
+    private static long age(long nowMs, Entry entry) {
+        if (entry == null || nowMs < entry.atMs) {
+            return -1L;
+        }
+        long age = nowMs - entry.atMs;
+        return age < 0 ? Long.MAX_VALUE : age;
     }
 
     private static final class Entry {
         final long atMs;
-        final String key;
         final JsonObject payload;
 
-        Entry(long atMs, String key, JsonObject payload) {
+        Entry(long atMs, JsonObject payload) {
             this.atMs = atMs;
-            this.key = key;
             this.payload = payload;
         }
     }

--- a/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageEnv.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageEnv.java
@@ -44,6 +44,7 @@ public final class RelayUsageEnv {
         String model = null;
         for (String key : new String[]{
                 "ANTHROPIC_MODEL",
+                "ANTHROPIC_DEFAULT_FABLE_MODEL",
                 "ANTHROPIC_DEFAULT_OPUS_MODEL",
                 "ANTHROPIC_DEFAULT_SONNET_MODEL",
                 "ANTHROPIC_DEFAULT_HAIKU_MODEL"}) {

--- a/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageHttp.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageHttp.java
@@ -81,15 +81,19 @@ public final class RelayUsageHttp {
             }
             boolean loopback = host.equalsIgnoreCase("localhost")
                     || host.equals("127.0.0.1")
-                    || host.equals("::1");
+                    || host.equals("::1")
+                    || host.equals("[::1]");
             if (!"https".equalsIgnoreCase(scheme)
                     && !("http".equalsIgnoreCase(scheme) && loopback)) {
                 return null;
             }
             int port = u.getPort();
+            String originHost = host.contains(":") && !host.startsWith("[")
+                    ? "[" + host + "]"
+                    : host;
             return port == -1
-                    ? scheme + "://" + host
-                    : scheme + "://" + host + ":" + port;
+                    ? scheme + "://" + originHost
+                    : scheme + "://" + originHost + ":" + port;
         } catch (Exception e) {
             return null;
         }

--- a/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageJson.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageJson.java
@@ -103,7 +103,7 @@ public final class RelayUsageJson {
     /** Epoch timestamp among {@code keys}, normalized to milliseconds, or null. */
     public static Long asEpochMs(JsonObject o, String... keys) {
         Long v = asLong(o, keys);
-        if (v == null) {
+        if (v == null || v < 0) {
             return null;
         }
         return v < EPOCH_SECONDS_CEILING ? v * 1000L : v;
@@ -111,6 +111,9 @@ public final class RelayUsageJson {
 
     /** Render epoch milliseconds as an ISO-8601 instant (the payload reset_at format). */
     public static String epochMsToIso(long epochMs) {
+        if (epochMs < 0) {
+            return null;
+        }
         return Instant.ofEpochMilli(epochMs).toString();
     }
 
@@ -125,7 +128,10 @@ public final class RelayUsageJson {
         w.addProperty("id", id);
         w.addProperty("used_pct", usedPct);
         if (resetAtMs != null) {
-            w.addProperty("reset_at", epochMsToIso(resetAtMs));
+            String resetAt = epochMsToIso(resetAtMs);
+            if (resetAt != null) {
+                w.addProperty("reset_at", resetAt);
+            }
         }
         w.addProperty("period_type", id);
         return w;
@@ -139,6 +145,9 @@ public final class RelayUsageJson {
      * optional and vendor-specific.
      */
     public static JsonObject capacityPayload(String source, Collection<JsonObject> windows, String level) {
+        if (windows == null || windows.isEmpty()) {
+            return null;
+        }
         Double primary5h = null;
         double maxPct = 0;
         for (JsonObject w : windows) {

--- a/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageRegistry.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/usage/RelayUsageRegistry.java
@@ -5,6 +5,9 @@ import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Locale;
 
@@ -44,9 +47,12 @@ public final class RelayUsageRegistry {
         if (vendor == null || env.token() == null) {
             return null;
         }
-        // Key the cache by vendor + endpoint + credential so an account/base-URL
-        // switch never serves the previous account's quota.
-        String cacheKey = vendor.id() + '\n' + env.baseUrl() + '\n' + env.token();
+        // Keep credentials out of long-lived cache objects while retaining account isolation.
+        String cacheKey = vendor.id() + '\n' + canonicalBaseUrl(env.baseUrl()) + '\n' + sha256(env.token());
+        // MiniMax selects a model-specific quota before the payload reaches the cache.
+        if ("minimax".equals(vendor.id())) {
+            cacheKey += '\n' + (env.model() == null ? "" : env.model());
+        }
 
         JsonObject fresh = RelayUsageCache.fresh(cacheKey, nowMs);
         if (fresh != null) {
@@ -87,6 +93,44 @@ public final class RelayUsageRegistry {
             }
         }
         return null;
+    }
+
+    private static String canonicalBaseUrl(String baseUrl) {
+        try {
+            URI u = URI.create(baseUrl.trim());
+            String scheme = u.getScheme().toLowerCase(Locale.ROOT);
+            String host = u.getHost();
+            if (host == null) {
+                return baseUrl.trim();
+            }
+            host = host.toLowerCase(Locale.ROOT);
+            int port = u.getPort();
+            boolean defaultPort = ("http".equals(scheme) && port == 80)
+                    || ("https".equals(scheme) && port == 443);
+            String authorityHost = host.contains(":") && !host.startsWith("[")
+                    ? "[" + host + "]" : host;
+            StringBuilder out = new StringBuilder(scheme).append("://").append(authorityHost);
+            if (port != -1 && !defaultPort) {
+                out.append(':').append(port);
+            }
+            return out.toString();
+        } catch (RuntimeException ignored) {
+            return baseUrl == null ? "" : baseUrl.trim();
+        }
+    }
+
+    private static String sha256(String value) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                hex.append(String.format(Locale.ROOT, "%02x", b & 0xff));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
     }
 
     /** Registered vendors, in match order (tests). */

--- a/src/main/java/com/github/claudecodegui/provider/claude/usage/ZaiUsageVendor.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/usage/ZaiUsageVendor.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -26,8 +27,12 @@ public final class ZaiUsageVendor implements RelayUsageVendor {
 
     @Override
     public boolean matches(String host, String path) {
-        return host.equals("z.ai") || host.endsWith(".z.ai")
-                || host.equals("open.bigmodel.cn") || host.endsWith(".bigmodel.cn");
+        if (host == null) {
+            return false;
+        }
+        String normalizedHost = host.toLowerCase(java.util.Locale.ROOT);
+        return normalizedHost.equals("z.ai") || normalizedHost.endsWith(".z.ai")
+                || normalizedHost.equals("open.bigmodel.cn") || normalizedHost.endsWith(".bigmodel.cn");
     }
 
     @Override
@@ -72,6 +77,9 @@ public final class ZaiUsageVendor implements RelayUsageVendor {
             pct = RelayUsageJson.clampPct(pct);
             String type = RelayUsageJson.asString(lim, "type");
             String period = period(lim, type);
+            if (period == null) {
+                continue;
+            }
             Long resetsAtMs = RelayUsageJson.asEpochMs(lim, "nextResetTime", "next_reset_time");
 
             JsonObject existing = byPeriod.get(period);
@@ -94,26 +102,28 @@ public final class ZaiUsageVendor implements RelayUsageVendor {
 
     /**
      * Map a limit to a window id/period. Observed payloads use unit 3=hours
-     * (number=5 → 5h), unit 6=weeks (number=1 → 7d) and unit 4=days (number=7
-     * → 7d). The {@code number} field is assumed to match those shapes — a
-     * hypothetical unit=4/number=1 (1-day) window would still be labelled 7d.
+     * (number=5 → 5h), unit 6=weeks (number=1 → 7d) and unit 4=weeks expressed
+     * as seven days (number=7 → 7d). Unknown or inconsistent shapes are ignored
+     * rather than guessed.
      */
     static String period(JsonObject lim, String type) {
-        if (type != null && type.toUpperCase().contains("TIME")) {
+        if (type != null && type.toUpperCase(Locale.ROOT).contains("TIME")) {
             return "monthly";
         }
         Integer unit = RelayUsageJson.asInt(lim, "unit");
-        if (unit == null) {
-            return "5h";
+        Integer number = RelayUsageJson.asInt(lim, "number");
+        if (unit == null || number == null) {
+            return null;
         }
         switch (unit) {
             case 3:
-                return "5h";
+                return number == 5 ? "5h" : null;
             case 6:
+                return number == 1 ? "7d" : null;
             case 4:
-                return "7d";
+                return number == 7 ? "7d" : null;
             default:
-                return "5h";
+                return null;
         }
     }
 }

--- a/src/test/java/com/github/claudecodegui/cli/CliStatusDetectorLoginShellTest.java
+++ b/src/test/java/com/github/claudecodegui/cli/CliStatusDetectorLoginShellTest.java
@@ -1,8 +1,9 @@
 package com.github.claudecodegui.cli;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -15,6 +16,10 @@ import static org.junit.Assert.assertTrue;
  * the parser contract: only {@code name=absolute-existing-path} lines survive.
  */
 public class CliStatusDetectorLoginShellTest {
+
+    /** Keep lookup fixtures independent of the host's installed shells. */
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Test
     public void buildLookupScriptEmitsOneLinePerTool() {
@@ -38,9 +43,10 @@ public class CliStatusDetectorLoginShellTest {
         assertFalse(script.contains("$("));
     }
 
+    /** Recognize an existing absolute path on every supported host. */
     @Test
-    public void parseLoginShellLookupKeepsAbsoluteExistingPaths() {
-        String existing = new File("/bin/sh").getAbsolutePath();
+    public void parseLoginShellLookupKeepsAbsoluteExistingPaths() throws Exception {
+        String existing = this.temporaryFolder.newFile("shell").getAbsolutePath();
         Map<String, String> parsed = CliStatusDetector.parseLoginShellLookup(
                 "omp=" + existing + "\n"
                         + "pi=\n"                       // not found: empty value dropped
@@ -57,13 +63,13 @@ public class CliStatusDetectorLoginShellTest {
         assertTrue(CliStatusDetector.parseLoginShellLookup("   \n  ").isEmpty());
     }
 
+    /** Preserve equals signs in existing paths and reject missing files. */
     @Test
-    public void parseLoginShellLookupSplitsOnFirstEqualsOnly() {
-        String existing = new File("/bin/sh").getAbsolutePath();
+    public void parseLoginShellLookupSplitsOnFirstEqualsOnly() throws Exception {
+        String existing = this.temporaryFolder.newFile("shell=extra").getAbsolutePath();
         // Values containing '=' (unusual but legal in paths) must not break parsing.
         Map<String, String> parsed = CliStatusDetector.parseLoginShellLookup(
-                "omp=" + existing + "=extra\n");
-        // "/bin/sh=extra" does not exist → dropped; key itself stays intact.
-        assertTrue(parsed.isEmpty());
+                "omp=" + existing + "\npi=" + existing + "=missing\n");
+        assertEquals(Map.of("omp", existing), parsed);
     }
 }

--- a/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageCacheTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageCacheTest.java
@@ -1,0 +1,93 @@
+package com.github.claudecodegui.provider.claude.usage;
+
+import com.google.gson.JsonObject;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/** Verify isolation, expiry and bounded retention of relay quota snapshots. */
+public class RelayUsageCacheTest {
+
+    /** Release shared entries so every test starts with an empty cache. */
+    @After
+    public void tearDown() {
+        RelayUsageCache.clearForTests();
+    }
+
+    /** Retain newly fetched quotas when older accounts fill the cache. */
+    @Test
+    public void store_retiresOldQuotasBeforeTheNewestSnapshot() {
+        for (int i = 0; i < 32; i++) {
+            RelayUsageCache.store("account-" + i, payload(i), 1000L + i);
+            assertNotNull("The latest probe must remain available", RelayUsageCache.fresh("account-" + i, 1032L));
+        }
+        for (int i = 0; i < 32; i++) {
+            if (i < 16) {
+                assertNull(RelayUsageCache.fresh("account-" + i, 1032L));
+            } else {
+                assertNotNull(RelayUsageCache.fresh("account-" + i, 1032L));
+            }
+        }
+    }
+
+    /** Protect refreshed accounts even when all timestamps are identical. */
+    @Test
+    public void store_keepsRefreshedAccountsWhenRetiringOlderEntries() {
+        for (int i = 0; i < 16; i++) {
+            RelayUsageCache.store("account-" + i, payload(i), 1000L);
+        }
+        RelayUsageCache.store("account-0", payload(42), 1000L);
+        RelayUsageCache.store("account-16", payload(16), 1000L);
+        assertEquals(42, RelayUsageCache.fresh("account-0", 1000L).getAsJsonObject("window").get("used_pct").getAsInt());
+        assertNull(RelayUsageCache.fresh("account-1", 1000L));
+        assertNotNull(RelayUsageCache.fresh("account-16", 1000L));
+    }
+
+    /** Prevent callers and stale flags from changing stored payloads. */
+    @Test
+    public void cache_keepsAccountSnapshotsAndReturnedCopiesIndependent() {
+        JsonObject original = payload(10);
+        RelayUsageCache.store("a", original, 1000L);
+        RelayUsageCache.store("b", payload(20), 1000L);
+        original.getAsJsonObject("window").addProperty("used_pct", 99);
+        JsonObject fresh = RelayUsageCache.fresh("a", 1000L);
+        fresh.getAsJsonObject("window").addProperty("used_pct", 88);
+        JsonObject stale = RelayUsageCache.stale("a", 1000L + RelayUsageCache.TTL_MS);
+        assertTrue(stale.get("stale").getAsBoolean());
+        assertEquals(10, stale.getAsJsonObject("window").get("used_pct").getAsInt());
+        stale.getAsJsonObject("window").addProperty("used_pct", 77);
+        assertFalse(RelayUsageCache.fresh("a", 1001L).has("stale"));
+        assertEquals(10, RelayUsageCache.fresh("a", 1001L).getAsJsonObject("window").get("used_pct").getAsInt());
+        assertEquals(20, RelayUsageCache.fresh("b", 1001L).getAsJsonObject("window").get("used_pct").getAsInt());
+    }
+
+    /** Expire on the exact boundary and reject clock rollback or overflow. */
+    @Test
+    public void cache_honorsExpiryAndClockBoundaries() {
+        RelayUsageCache.store("a", payload(10), 1000L);
+        assertNotNull(RelayUsageCache.fresh("a", 1000L + RelayUsageCache.TTL_MS - 1));
+        assertNull(RelayUsageCache.fresh("a", 1000L + RelayUsageCache.TTL_MS));
+        assertNotNull(RelayUsageCache.stale("a", 1000L + RelayUsageCache.STALE_MAX_MS - 1));
+        assertNull(RelayUsageCache.stale("a", 1000L + RelayUsageCache.STALE_MAX_MS));
+        assertNull(RelayUsageCache.fresh("a", 999L));
+        assertNull(RelayUsageCache.stale("a", 999L));
+        RelayUsageCache.store("overflow", payload(10), Long.MIN_VALUE);
+        assertNull(RelayUsageCache.fresh("overflow", Long.MAX_VALUE));
+        assertNull(RelayUsageCache.stale("overflow", Long.MAX_VALUE));
+        RelayUsageCache.store("null", null, 1000L);
+        assertNull(RelayUsageCache.fresh("null", 1000L));
+    }
+
+    private static JsonObject payload(int usedPct) {
+        JsonObject window = new JsonObject();
+        window.addProperty("used_pct", usedPct);
+        JsonObject payload = new JsonObject();
+        payload.add("window", window);
+        return payload;
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageEnvTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageEnvTest.java
@@ -30,6 +30,8 @@ public class RelayUsageEnvTest {
                 "{\"ANTHROPIC_MODEL\":\"glm-4.7\",\"ANTHROPIC_DEFAULT_SONNET_MODEL\":\"other\"}")).model());
         assertEquals("sonnet-model", RelayUsageEnv.from(env(
                 "{\"ANTHROPIC_DEFAULT_SONNET_MODEL\":\"sonnet-model\",\"ANTHROPIC_DEFAULT_HAIKU_MODEL\":\"haiku\"}")).model());
+        assertEquals("fable-model", RelayUsageEnv.from(env(
+                "{\"ANTHROPIC_DEFAULT_FABLE_MODEL\":\"fable-model\"}")).model());
         assertNull(RelayUsageEnv.from(env("{}")).model());
     }
 

--- a/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageHttpTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageHttpTest.java
@@ -1,11 +1,19 @@
 package com.github.claudecodegui.provider.claude.usage;
 
+import com.google.gson.JsonObject;
+import org.junit.After;
 import org.junit.Test;
 
+import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class RelayUsageHttpTest {
+
+    @After
+    public void tearDown() {
+        RelayUsageHttp.setTransportForTests(null);
+    }
 
     @Test
     public void secureOrigin_httpsOriginKeptPortAndPathDropped() {
@@ -17,9 +25,25 @@ public class RelayUsageHttpTest {
     public void secureOrigin_plainHttpOnlyForLoopback() {
         assertEquals("http://localhost:8080", RelayUsageHttp.secureOrigin("http://localhost:8080/api"));
         assertEquals("http://127.0.0.1:9000", RelayUsageHttp.secureOrigin("http://127.0.0.1:9000/api"));
-        // Credentials must not travel over plaintext to a remote host
-        assertNull(RelayUsageHttp.secureOrigin("http://api.z.ai/api/anthropic"));
+        assertEquals("http://[::1]:8080", RelayUsageHttp.secureOrigin("http://[::1]:8080/api"));
+        assertEquals("https://[::1]:8443", RelayUsageHttp.secureOrigin("https://[::1]:8443/api"));
+        assertNull(RelayUsageHttp.secureOrigin("http://[2001:db8::1]:8080/api"));
         assertNull(RelayUsageHttp.secureOrigin("http://evil.com"));
+    }
+
+    @Test
+    public void getJson_addsBearerAndPreservesHeaders() throws Exception {
+        String[] seenUrl = {null};
+        Map<String, String>[] seenHeaders = new Map[]{null};
+        RelayUsageHttp.setTransportForTests((url, headers) -> {
+            seenUrl[0] = url;
+            seenHeaders[0] = headers;
+            return new JsonObject();
+        });
+
+        RelayUsageHttp.getJson("https://api.example.test/usage", "secret");
+        assertEquals("https://api.example.test/usage", seenUrl[0]);
+        assertEquals("Bearer secret", seenHeaders[0].get("Authorization"));
     }
 
     @Test

--- a/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageJsonTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageJsonTest.java
@@ -47,6 +47,12 @@ public class RelayUsageJsonTest {
         assertEquals(Long.valueOf(1759180800000L), RelayUsageJson.asEpochMs(o, "strSec"));
         assertNull(RelayUsageJson.asEpochMs(o, "missing"));
         assertNull(RelayUsageJson.asEpochMs(null, "sec"));
+        assertNull(RelayUsageJson.asEpochMs(com.google.gson.JsonParser.parseString("{\"v\":-1}").getAsJsonObject(), "v"));
+    }
+
+    @Test
+    public void capacityPayload_emptyWindowsReturnsNull() {
+        assertNull(RelayUsageJson.capacityPayload("test", List.of(), null));
     }
 
     @Test

--- a/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageRegistryTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/usage/RelayUsageRegistryTest.java
@@ -92,6 +92,23 @@ public class RelayUsageRegistryTest {
     }
 
     @Test
+    public void resolve_cacheKeyUsesProbeOriginNotIgnoredPathOrQuery() {
+        int[] calls = {0};
+        RelayUsageHttp.setTransportForTests((url, headers) -> {
+            calls[0]++;
+            return zaiBody(10);
+        });
+        long t0 = 1_000_000L;
+
+        RelayUsageRegistry.resolve(ZaiUsageVendorTest.settings(
+                "https://api.z.ai/api/anthropic?token=secret", "account-a"), t0);
+        RelayUsageRegistry.resolve(ZaiUsageVendorTest.settings(
+                "https://api.z.ai/another-path?token=secret", "account-a"), t0 + 1);
+
+        assertEquals(1, calls[0]);
+    }
+
+    @Test
     public void resolve_staleFallbackOnProbeFailure() {
         boolean[] fail = {false};
         RelayUsageHttp.setTransportForTests((url, headers) -> {
@@ -120,6 +137,35 @@ public class RelayUsageRegistryTest {
         RelayUsageHttp.setTransportForTests((url, headers) -> new JsonObject());
         assertNull(RelayUsageRegistry.resolve(
                 ZaiUsageVendorTest.settings("https://api.z.ai/api/anthropic", "t"), 1000L));
+    }
+
+    @Test
+    public void cache_nullKeyIsHandledAsMiss() {
+        assertNull(RelayUsageCache.fresh(null, 1000L));
+        assertNull(RelayUsageCache.stale(null, 1000L));
+        RelayUsageCache.store(null, new JsonObject(), 1000L);
+    }
+
+    /** Keep per-model quotas separate even when the account and endpoint match. */
+    @Test
+    public void resolve_remembersEachMiniMaxModelQuota() {
+        int[] calls = {0};
+        RelayUsageHttp.setTransportForTests((url, headers) -> {
+            calls[0]++;
+            return JsonParser.parseString("""
+                    {"model_remains":[
+                      {"model_name":"MiniMax-M3","current_interval_remaining_percent":10},
+                      {"model_name":"general","current_interval_remaining_percent":90}
+                    ]}
+                    """).getAsJsonObject();
+        });
+        JsonObject settings = ZaiUsageVendorTest.settings("https://api.minimax.io/v1", "account-a");
+        assertEquals(10, RelayUsageRegistry.resolve(settings, 1000L).get("capacity_pct").getAsDouble(), 0.01);
+        settings.getAsJsonObject("env").addProperty("ANTHROPIC_MODEL", "MiniMax-M3");
+        assertEquals(90, RelayUsageRegistry.resolve(settings, 1001L).get("capacity_pct").getAsDouble(), 0.01);
+        settings.getAsJsonObject("env").remove("ANTHROPIC_MODEL");
+        assertEquals(10, RelayUsageRegistry.resolve(settings, 1002L).get("capacity_pct").getAsDouble(), 0.01);
+        assertEquals(2, calls[0]);
     }
 
     private static JsonObject zaiBody(double pct) {

--- a/src/test/java/com/github/claudecodegui/provider/claude/usage/ZaiUsageVendorTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/usage/ZaiUsageVendorTest.java
@@ -5,6 +5,8 @@ import com.google.gson.JsonParser;
 import org.junit.After;
 import org.junit.Test;
 
+import java.util.Locale;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -34,7 +36,19 @@ public class ZaiUsageVendorTest {
         assertFalse(vendor.matches("api.anthropic.com", ""));
     }
 
-    // ===== response parsing =====
+    @Test
+    public void matches_isNullSafeAndCaseInsensitive() {
+        assertFalse(vendor.matches(null, "/api/anthropic"));
+        assertTrue(vendor.matches("API.Z.AI", "/api/anthropic"));
+    }
+
+    @Test
+    public void parseQuota_ignoresUnknownWindowShape() {
+        JsonObject body = JsonParser.parseString("{\"data\":{\"limits\":["
+                + "{\"type\":\"CREDIT_LIMIT\",\"unit\":4,\"number\":1,\"percentage\":41}]}}")
+                .getAsJsonObject();
+        assertNull(ZaiUsageVendor.parseQuota(body));
+    }
 
     @Test
     public void parseQuota_maps5h7dWindowsAndLevel() {
@@ -75,6 +89,23 @@ public class ZaiUsageVendorTest {
         JsonObject payload = ZaiUsageVendor.parseQuota(body);
         assertEquals("monthly", payload.getAsJsonArray("windows").get(0).getAsJsonObject().get("id").getAsString());
         assertEquals("pro", payload.get("level").getAsString());
+    }
+
+    @Test
+    public void parseQuota_timeLimitIsLocaleIndependent() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            JsonObject body = JsonParser.parseString("""
+                    {"data":{"limits":[
+                      {"type":"time_limit","unit":4,"number":1,"percentage":55}
+                    ]}}
+                    """).getAsJsonObject();
+            assertEquals("monthly", ZaiUsageVendor.parseQuota(body)
+                    .getAsJsonArray("windows").get(0).getAsJsonObject().get("id").getAsString());
+        } finally {
+            Locale.setDefault(previous);
+        }
     }
 
     @Test

--- a/webview/e2e/menu-viewports.spec.ts
+++ b/webview/e2e/menu-viewports.spec.ts
@@ -236,6 +236,39 @@ test('footer selector menus render inside the viewport', async ({ page }) => {
   expect(significantErrors(errors)).toEqual([]);
 });
 
+test('Codex auto review appears only after the SDK confirms support', async ({ page }) => {
+  await page.addInitScript(() => {
+    // JCEF sets this before user changes can be persisted across tabs.
+    window.__CCGUI_PAGE_CONTEXT_READY__ = true;
+    const saved = JSON.parse(localStorage.getItem('model-selection-state') || '{}');
+    localStorage.setItem('model-selection-state', JSON.stringify({ ...saved, provider: 'codex' }));
+  });
+  await page.goto('/');
+  await expect(page.locator('.button-area').first()).toHaveAttribute('data-provider', 'codex');
+  await page.locator('.button-area-left .selector-button').nth(2).click();
+  await expect(page.getByTestId('mode-option-default')).toBeVisible();
+  await expect(page.getByTestId('mode-option-auto')).toHaveCount(0);
+
+  await page.evaluate(() => window.updateDependencyStatus?.(JSON.stringify({
+    'codex-sdk': { installed: true, meetsMinimumVersion: true },
+  })));
+  await expect(page.getByTestId('mode-option-auto')).toBeVisible();
+  await page.getByTestId('mode-option-auto').click();
+  await expect.poll(() => page.evaluate(() => JSON.parse(
+    localStorage.getItem('model-selection-state') || '{}',
+  ).codexPermissionMode)).toBe('auto');
+
+  await page.evaluate(() => window.updateDependencyStatus?.(JSON.stringify({
+    'codex-sdk': { installed: true, meetsMinimumVersion: false },
+  })));
+  await expect.poll(() => page.evaluate(() => JSON.parse(
+    localStorage.getItem('model-selection-state') || '{}',
+  ).codexPermissionMode)).toBe('default');
+  await page.locator('.button-area-left .selector-button').nth(2).click();
+  await expect(page.getByTestId('mode-option-default')).toBeVisible();
+  await expect(page.getByTestId('mode-option-auto')).toHaveCount(0);
+});
+
 test('config submenus stay visible across constrained viewports', async ({ page }) => {
   const errors = collectPageErrors(page);
   await page.goto('/');
@@ -294,9 +327,7 @@ test('long model and mode text stays contained in selector menus', async ({ page
   const modelConfigDropdown = page.locator('.model-config-dropdown');
   await expect(modelConfigDropdown).toBeVisible();
   await expectInsideViewport(page, modelConfigDropdown, 'model config dropdown');
-  const modelRow = modelConfigDropdown.getByTestId('model-config-option-model');
-  await modelRow.hover();
-  const modelDropdown = page.locator('.model-selector-dropdown');
+  const modelDropdown = modelConfigDropdown.getByTestId('model-selector-dropdown');
   await expect(modelDropdown).toBeVisible();
   await expectInsideViewport(page, modelDropdown, 'model dropdown with long custom model');
   const longModelOption = modelDropdown.locator('.selector-option').filter({ hasText: LONG_MODEL.label }).first();
@@ -319,10 +350,9 @@ test('large model selector remains searchable and capped', async ({ page }) => {
   await modelButton.click();
   const modelConfigDropdown = page.locator('.model-config-dropdown');
   await expect(modelConfigDropdown).toBeVisible();
-  await modelConfigDropdown.getByTestId('model-config-option-model').hover();
-  const modelDropdown = page.locator('.model-selector-dropdown');
+  const modelDropdown = modelConfigDropdown.getByTestId('model-selector-dropdown');
   await expect(modelDropdown).toBeVisible();
-  await expectInsideViewport(page, modelDropdown, 'large model dropdown');
+  await expectInsideViewport(page, modelConfigDropdown, 'large model dropdown');
 
   const renderedLargeModels = modelDropdown.getByText(/^Large Model \d{3}$/);
   await expect(renderedLargeModels).toHaveCount(100);
@@ -336,7 +366,7 @@ test('large model selector remains searchable and capped', async ({ page }) => {
   const targetOption = modelDropdown.locator('.selector-option').filter({ hasText: SEARCH_TARGET_MODEL.label }).first();
   await expect(targetOption).toBeVisible();
   await targetOption.click();
-  await expect(modelButton).toHaveAttribute('title', new RegExp(SEARCH_TARGET_MODEL.label));
+  await expect(targetOption).toHaveClass(/selected/);
 
   expect(significantErrors(errors)).toEqual([]);
 });

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -433,7 +433,8 @@ const App = () => {
     interruptSession,
   } = useMessageSender({
     t, addToast,
-    currentProvider, selectedModel, permissionMode, reasoningEffort, selectedAgent, codexFastMode, dshPreset,
+    currentProvider, selectedModel, permissionMode, reasoningEffort, selectedAgent, codexFastMode,
+    codexNativeAutoReviewAvailable, dshPreset,
     sdkStatusLoading, currentSdkInstalled,
     sentAttachmentsRef, chatInputRef, messagesContainerRef,
     isUserAtBottomRef, userPausedRef, isStreamingRef,

--- a/webview/src/components/ChatInputBox/selectors/ModelConfigSelect.tsx
+++ b/webview/src/components/ChatInputBox/selectors/ModelConfigSelect.tsx
@@ -181,7 +181,7 @@ export const ModelConfigSelect = ({
     }
   }, [clearHoverTimer]);
 
-  const { positionedStyle: mainPositionedStyle, recalculate: mainRecalculate } = useDropdownPosition({
+  const { positionedStyle: mainPositionedStyle, maxHeight: mainMaxHeight, recalculate: mainRecalculate } = useDropdownPosition({
     buttonRef,
     dropdownRef,
     preferredAlignment: 'right',
@@ -327,14 +327,14 @@ export const ModelConfigSelect = ({
           ref={dropdownRef}
           className="selector-dropdown model-config-dropdown"
           data-testid="model-config-dropdown"
-          style={{ ...DROPDOWN_STYLE, ...mainPositionedStyle }}
+          style={{ ...DROPDOWN_STYLE, ...mainPositionedStyle, maxHeight: mainMaxHeight, boxSizing: 'border-box' }}
           onMouseOverCapture={retainActiveSubmenu}
         >
           {/* The flat list has no hover row of its own; entering it must
               dismiss any open fly-out (effort / speed / preset). It sits at
               the top so model switching — the most frequent action — never
               crosses the submenu rows. */}
-          <div onMouseEnter={() => scheduleSubmenu('none')}>
+          <div className="model-config-models" onMouseEnter={() => scheduleSubmenu('none')}>
             <ModelSelect
               value={selectedModel}
               onChange={onModelSelect}

--- a/webview/src/components/ChatInputBox/styles/selectors.css
+++ b/webview/src/components/ChatInputBox/styles/selectors.css
@@ -49,6 +49,15 @@
 
 .model-config-dropdown {
   min-width: 280px;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Keep the function rows visible while the model list yields to short viewports. */
+.model-config-models {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 /* Flat inline model list inside the model-config popover (no own chrome) */
 .model-selector-inline {

--- a/webview/src/components/settings/AiFeatureProviderModelPanel/index.test.tsx
+++ b/webview/src/components/settings/AiFeatureProviderModelPanel/index.test.tsx
@@ -70,6 +70,7 @@ describe('AiFeatureProviderModelPanel', () => {
       opencode: false,
       pi: false,
       omp: false,
+      minimax: false,
     },
   };
 

--- a/webview/src/components/settings/CommitSection/index.test.tsx
+++ b/webview/src/components/settings/CommitSection/index.test.tsx
@@ -38,6 +38,7 @@ describe('CommitSection', () => {
         opencode: false,
         pi: false,
         omp: false,
+        minimax: false,
       },
     };
 

--- a/webview/src/components/settings/PromptEnhancerSection/index.test.tsx
+++ b/webview/src/components/settings/PromptEnhancerSection/index.test.tsx
@@ -38,6 +38,7 @@ describe('PromptEnhancerSection', () => {
         opencode: false,
         pi: false,
         omp: false,
+        minimax: false,
       },
     };
 
@@ -82,6 +83,7 @@ describe('PromptEnhancerSection', () => {
             opencode: false,
             pi: false,
             omp: false,
+            minimax: false,
           },
         }}
         onPromptEnhancerProviderChange={vi.fn()}

--- a/webview/src/components/settings/hooks/useSettingsBasicActions.test.ts
+++ b/webview/src/components/settings/hooks/useSettingsBasicActions.test.ts
@@ -19,6 +19,7 @@ describe('useSettingsBasicActions', () => {
       opencode: false,
       pi: false,
       omp: false,
+      minimax: false,
     },
   };
 
@@ -118,6 +119,7 @@ describe('useSettingsBasicActions', () => {
           opencode: false,
           pi: false,
           omp: false,
+          minimax: false,
         },
       });
     });
@@ -148,6 +150,7 @@ describe('useSettingsBasicActions', () => {
           opencode: false,
           pi: false,
           omp: false,
+          minimax: false,
         },
       });
     });
@@ -181,6 +184,7 @@ describe('useSettingsBasicActions', () => {
           opencode: false,
           pi: false,
           omp: false,
+          minimax: false,
         },
       });
     });
@@ -212,6 +216,7 @@ describe('useSettingsBasicActions', () => {
           opencode: false,
           pi: false,
           omp: false,
+          minimax: false,
         },
       });
     });

--- a/webview/src/hooks/useMessageSender.context.test.ts
+++ b/webview/src/hooks/useMessageSender.context.test.ts
@@ -13,6 +13,7 @@ describe('useMessageSender - /context command', () => {
     permissionMode: 'default',
     reasoningEffort: 'high',
     codexFastMode: 'normal',
+    codexNativeAutoReviewAvailable: true,
     selectedAgent: null,
     sdkStatusLoading: false,
     currentSdkInstalled: true,
@@ -148,6 +149,30 @@ describe('useMessageSender - /context command', () => {
       expect.any(String),
       'error',
     );
+  });
+
+  it.each([
+    { supported: false, withAttachment: false },
+    { supported: false, withAttachment: true },
+    { supported: true, withAttachment: false },
+    { supported: true, withAttachment: true },
+  ])('sends Codex auto mode only with confirmed support ($supported, attachment: $withAttachment)', ({ supported, withAttachment }) => {
+    const opts = createOptions({
+      currentProvider: 'codex',
+      permissionMode: 'auto',
+      codexNativeAutoReviewAvailable: supported,
+    });
+
+    const { result } = renderHook(() => useMessageSender(opts));
+
+    act(() => {
+      result.current.handleSubmit('hello', withAttachment ? [{
+        id: 'att-1', fileName: 'note.txt', mediaType: 'text/plain', data: 'aGVsbG8=',
+      }] : undefined);
+    });
+
+    const event = withAttachment ? 'send_message_with_attachments' : 'send_message';
+    expect(getBridgePayload(event).permissionMode).toBe(supported ? 'auto' : 'default');
   });
 
   it('includes explicit Claude high reasoning effort in plain message payload', () => {

--- a/webview/src/hooks/useMessageSender.ts
+++ b/webview/src/hooks/useMessageSender.ts
@@ -43,6 +43,7 @@ export interface UseMessageSenderOptions {
   permissionMode: PermissionMode;
   reasoningEffort: ReasoningEffort;
   codexFastMode: CodexFastMode;
+  codexNativeAutoReviewAvailable: boolean;
   dshPreset?: string;
   selectedAgent: SelectedAgent | null;
   sdkStatusLoading: boolean;
@@ -77,6 +78,7 @@ export function useMessageSender({
   permissionMode,
   reasoningEffort,
   codexFastMode,
+  codexNativeAutoReviewAvailable,
   dshPreset,
   selectedAgent,
   sdkStatusLoading,
@@ -257,7 +259,9 @@ export function useMessageSender({
     requestedPermissionMode: PermissionMode
   ) => {
     const hasAttachments = Array.isArray(attachments) && attachments.length > 0;
-    const effectivePermissionMode: PermissionMode = currentProvider === 'codex' && requestedPermissionMode === 'plan'
+    const effectivePermissionMode: PermissionMode = currentProvider === 'codex'
+      && (requestedPermissionMode === 'plan'
+        || (requestedPermissionMode === 'auto' && !codexNativeAutoReviewAvailable))
       ? 'default'
       : requestedPermissionMode;
     console.debug('[ModeSync][Frontend] send request mode', {
@@ -312,7 +316,7 @@ export function useMessageSender({
       });
       sendBridgeEvent('send_message', payload);
     }
-  }, [codexFastMode, currentProvider, dshPreset, selectedModel, reasoningEffort]);
+  }, [codexFastMode, codexNativeAutoReviewAvailable, currentProvider, dshPreset, selectedModel, reasoningEffort]);
 
   /**
    * Execute message sending (from queue or directly)

--- a/webview/src/hooks/useModelProviderState.test.ts
+++ b/webview/src/hooks/useModelProviderState.test.ts
@@ -1,0 +1,51 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import type { TFunction } from 'i18next';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useModelProviderState } from './useModelProviderState';
+import { sendBridgeEvent } from '../utils/bridge';
+
+vi.mock('../utils/bridge', () => ({ sendBridgeEvent: vi.fn() }));
+
+const options = { addToast: vi.fn(), t: ((key: string) => key) as TFunction };
+
+describe('Codex native auto review availability', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it('waits for explicit SDK support and follows later dependency changes', () => {
+    const { result } = renderHook(() => useModelProviderState(options));
+    expect(result.current.codexNativeAutoReviewAvailable).toBe(false);
+    act(() => result.current.setSdkStatus({ 'codex-sdk': { installed: true } }));
+    expect(result.current.codexNativeAutoReviewAvailable).toBe(false);
+    act(() => result.current.setSdkStatus({ 'codex-sdk': { installed: true, meetsMinimumVersion: true } }));
+    expect(result.current.codexNativeAutoReviewAvailable).toBe(true);
+    act(() => result.current.handleProviderSelect('codex'));
+    act(() => result.current.handleModeSelect('auto'));
+    expect(result.current.permissionMode).toBe('auto');
+    expect(sendBridgeEvent).toHaveBeenLastCalledWith('set_mode', 'auto');
+    act(() => result.current.setSdkStatus({ 'codex-sdk': { installed: true, meetsMinimumVersion: false } }));
+    expect(result.current.codexNativeAutoReviewAvailable).toBe(false);
+    expect(result.current.permissionMode).toBe('default');
+    expect(result.current.codexPermissionMode).toBe('default');
+    expect(sendBridgeEvent).toHaveBeenLastCalledWith('set_mode', 'default');
+  });
+
+  it('preserves a saved auto mode while SDK support is unknown', () => {
+    localStorage.setItem('model-selection-state', JSON.stringify({
+      provider: 'codex', codexPermissionMode: 'auto',
+    }));
+    const { result } = renderHook(() => useModelProviderState(options));
+    expect(result.current.codexNativeAutoReviewAvailable).toBe(false);
+    expect(result.current.codexPermissionMode).toBe('auto');
+    act(() => result.current.setSdkStatus({ 'codex-sdk': { meetsMinimumVersion: true } }));
+    expect(result.current.codexNativeAutoReviewAvailable).toBe(true);
+    expect(result.current.codexPermissionMode).toBe('auto');
+  });
+});

--- a/webview/src/hooks/useModelProviderState.ts
+++ b/webview/src/hooks/useModelProviderState.ts
@@ -200,7 +200,7 @@ export function useModelProviderState({ addToast, t }: UseModelProviderStateOpti
   const claudeSdkMeetsMinimum = sdkStatus?.['claude-sdk']?.meetsMinimumVersion;
   // Codex native auto review config is available in the verified @openai/codex-sdk 0.146.0 floor.
   const codexSdkMeetsMinimum = sdkStatus?.['codex-sdk']?.meetsMinimumVersion;
-  const codexNativeAutoReviewAvailable = codexSdkMeetsMinimum !== false;
+  const codexNativeAutoReviewAvailable = codexSdkMeetsMinimum === true;
 
   // A saved auto mode can outlive the SDK that supports it. Reset it before a
   // send can race the dependency-status response; otherwise the selected mode

--- a/webview/src/types/aiFeatureConfig.test.ts
+++ b/webview/src/types/aiFeatureConfig.test.ts
@@ -60,6 +60,7 @@ describe('pickAutoAiFeatureProvider', () => {
       opencode: true,
       pi: true,
       omp: true,
+      minimax: true,
     })).toBe('codex');
     expect(pickAutoAiFeatureProvider({
       claude: true,
@@ -69,6 +70,7 @@ describe('pickAutoAiFeatureProvider', () => {
       opencode: false,
       pi: false,
       omp: false,
+      minimax: false,
     })).toBe('claude');
     expect(pickAutoAiFeatureProvider({
       claude: false,
@@ -78,6 +80,7 @@ describe('pickAutoAiFeatureProvider', () => {
       opencode: false,
       pi: false,
       omp: false,
+      minimax: false,
     })).toBe('grok');
   });
 
@@ -90,6 +93,7 @@ describe('pickAutoAiFeatureProvider', () => {
       opencode: false,
       pi: false,
       omp: false,
+      minimax: false,
     }, 'grok')).toBe('grok');
     expect(pickAutoAiFeatureProvider({
       claude: true,
@@ -99,6 +103,7 @@ describe('pickAutoAiFeatureProvider', () => {
       opencode: false,
       pi: false,
       omp: false,
+      minimax: false,
     }, 'grok')).toBe('codex');
     expect(pickAutoAiFeatureProvider({
       claude: true,
@@ -108,6 +113,7 @@ describe('pickAutoAiFeatureProvider', () => {
       opencode: false,
       pi: false,
       omp: false,
+      minimax: false,
     }, 'unknown-cli')).toBe('codex');
   });
 });


### PR DESCRIPTION
## Problem and resulting behavior

Persistent Claude sessions could create duplicate runtimes during concurrent acquisition, let delayed permission updates overwrite newer state, or stall valid result-only turns because completion was inferred from prior output. Relay quota caching could lose account-specific snapshots or reuse the wrong MiniMax model quota. Codex auto review could be sent before SDK support was confirmed, and Grok terminal commands on Windows could return success without executing because cmd.exe received POSIX shell flags or scripts.

This change makes runtime transitions follow SDK acknowledgements, uses explicit SDK result provenance, isolates quota snapshots correctly, and executes Windows commands with native argument handling. It also keeps model-menu actions accessible in short viewports and makes bridge tests independent of developer credentials and platform-specific paths.

## Changes

### Claude runtime and permissions

- Serialize acquisition for the same session or anonymous signature so simultaneous requests share one runtime.
- Queue permission transitions and preserve the mode actually acknowledged by the SDK; ignore results from superseded callers or disposed runtimes.
- Rebuild anonymous runtimes after bypass-mode changes within the same session epoch.
- Ignore results explicitly marked with task-notification origin while completing legitimate result-only user turns immediately. Remove the obsolete output-presence heuristic, idle backstop and associated test hooks.
- Preserve abort errors during reader quiescence and identify known read-only MCP tools by complete names rather than action-name prefixes.

### Relay usage and Codex compatibility

- Use a bounded, synchronized relay cache with copied payloads, expiry checks and account isolation. Cache keys include vendor, canonical endpoint and a credential digest; MiniMax keys also include the model.
- Correct IPv6 loopback origins, vendor host matching, reset timestamps and empty capacity handling.
- Enable Codex native auto review only after an affirmative SDK capability result and enforce that check when sending text or attachments.
- Match blocked Codex environment keys and legacy permission aliases without case-sensitive gaps.

### UI, Windows execution and portable tests

- Limit the model menu to available viewport height while allowing the model list to shrink and preserving its action rows.
- Launch Windows executables with intact argv, reuse the existing .cmd/.bat launcher, and run command strings through cmd.exe with native flags and the required Windows environment.
- Cover literal arguments, failure exit codes and CLI paths containing spaces.
- Replace hard-coded path expectations and the Java /bin/sh fixture with portable assertions and temporary files.
- Reuse isolated Claude login fixtures so the affected tests pass on clean machines without personal credentials.
- Add Linux and Windows ai-bridge CI jobs and include both .test.js and .test.mjs files.

## Validation

| Area | Result |
| --- | --- |
| ai-bridge, Linux via WSL Ubuntu / Node 22.12.0 | 661 passed; 0 failed; 0 skipped |
| ai-bridge, Windows | 659 passed; 0 failed; 2 existing platform-only skips |
| Webview unit tests | 172 files; 1,495 tests passed |
| Webview TypeScript | Application and test typechecks passed |
| Model-menu browser regressions | 20 tests passed across four viewports |
| Java unit tests | 1,288 passed; 0 failed; 5 skipped, out of 1,293 tests |
| Java style | checkstyleMain passed |
| Repository checks | CI YAML parsed successfully; git diff --check passed |

The Java run used a temporary Gradle init script to select freshly compiled test classes and bypass instrumentTestCode because downloading its asm-all dependency failed over TLS. The regular instrumented Gradle test path was therefore not validated locally. No init scripts, test reports, downloaded runtimes or local configuration files are included in the commit.

The branch starts at the upstream feature/v0.5.6 tip verified before committing and contains one commit with the reviewed source, tests and CI changes.
