### PR TITLE
perf(codex): route chat sends through the shared node daemon

### DIFF
--- a/ai-bridge/daemon.js
+++ b/ai-bridge/daemon.js
@@ -52,6 +52,7 @@ import {
 } from './services/grok/persistent-acp-service.js';
 import { injectStartupEnvVars, isWebviewControlledEnvVar, isDangerousEnvVar } from './config/api-config.js';
 import { cleanupStaleTempImages } from './services/claude/attachment-service.js';
+import { abortCurrentTurn as codexAbortCurrentTurn } from './services/codex/message-service.js';
 
 // =============================================================================
 // Startup Environment Setup (must run before any HTTPS connection)
@@ -642,10 +643,11 @@ async function runDaemonMain() {
         'utf8'
       );
       if (targetId) {
-        // Fire-and-forget for both providers
+        // Fire-and-forget for all providers
         Promise.all([
           abortCurrentTurn().catch((e) => _originalStderrWrite(`[daemon] Claude abort error: ${e.message}\n`, 'utf8')),
           grokAbortCurrentTurn().catch((e) => _originalStderrWrite(`[daemon] Grok abort error: ${e.message}\n`, 'utf8')),
+          codexAbortCurrentTurn().catch((e) => _originalStderrWrite(`[daemon] Codex abort error: ${e.message}\n`, 'utf8')),
         ]);
       }
       writeRawLine({ id: request.id || '0', done: true, success: true });

--- a/ai-bridge/services/codex/message-service.js
+++ b/ai-bridge/services/codex/message-service.js
@@ -40,6 +40,29 @@ import {
 } from './codex-event-handler.js';
 
 // ---------------------------------------------------------------------------
+// Turn abort (daemon mode)
+// ---------------------------------------------------------------------------
+
+// The AbortController of the in-flight turn. In one-shot mode Java kills the
+// whole process, so nothing needs this — but in daemon mode the process is
+// shared across providers and turns, so the daemon 'abort' command must reach
+// the live turn's signal instead.
+let activeTurnAbortController = null;
+
+/**
+ * Aborts the currently streaming Codex turn, if any.
+ * @returns {boolean} true when an active turn was aborted
+ */
+export function abortCurrentTurn() {
+  const controller = activeTurnAbortController;
+  if (controller && !controller.signal.aborted) {
+    controller.abort();
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
 // sendMessage
 // ---------------------------------------------------------------------------
 
@@ -285,6 +308,7 @@ export async function sendMessage(
     await prepareSessionReplayBoundary(state, threadId);
 
     const turnAbortController = new AbortController();
+    activeTurnAbortController = turnAbortController;
     const { events } = await thread.runStreamed(runInput, {
       signal: turnAbortController.signal
     });
@@ -339,6 +363,7 @@ export async function sendMessage(
       state.finalResponse = noResponseMsg;
     }
 
+    activeTurnAbortController = null;
     console.log('[MESSAGE_END]');
     console.log(JSON.stringify({
       success: true,
@@ -347,6 +372,7 @@ export async function sendMessage(
     }));
 
   } catch (error) {
+    activeTurnAbortController = null;
     emitStreamEndOnce();
     console.error('[DEBUG] Error:', error.message);
     console.error('[DEBUG] Error stack:', error.stack);

--- a/src/main/java/com/github/claudecodegui/provider/codex/CodexDaemonCoordinator.java
+++ b/src/main/java/com/github/claudecodegui/provider/codex/CodexDaemonCoordinator.java
@@ -1,0 +1,103 @@
+package com.github.claudecodegui.provider.codex;
+
+import com.github.claudecodegui.bridge.BridgeDirectoryResolver;
+import com.github.claudecodegui.bridge.EnvironmentConfigurator;
+import com.github.claudecodegui.bridge.NodeDetector;
+import com.github.claudecodegui.provider.common.DaemonBridge;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.Map;
+
+/**
+ * Codex-specific daemon lifecycle owner (mirrors GrokDaemonCoordinator).
+ *
+ * <p>Dedicated daemon instance: the daemon preloads the JS runtime once, so
+ * {@code codex.send} no longer pays a full node + SDK cold start (~2-5s) per
+ * chat message. Codex has no persistent runtime of its own — each turn still
+ * streams a fresh SDK query via {@code handleCodexCommand} — but the process
+ * and module graph stay warm across turns.
+ */
+class CodexDaemonCoordinator {
+
+    private static final long DAEMON_RETRY_DELAY_MS = 60_000;
+
+    private final Logger log;
+    private final NodeDetector nodeDetector;
+    private final Supplier<BridgeDirectoryResolver> directoryResolverSupplier;
+    private final EnvironmentConfigurator envConfigurator;
+    private final Consumer<Map<String, String>> customEnvConfigurator;
+
+    private volatile DaemonBridge daemonBridge;
+    private final Object daemonLock = new Object();
+    private volatile long daemonRetryAfter = 0;
+
+    CodexDaemonCoordinator(
+            Logger log,
+            NodeDetector nodeDetector,
+            Supplier<BridgeDirectoryResolver> directoryResolverSupplier,
+            EnvironmentConfigurator envConfigurator,
+            Consumer<Map<String, String>> customEnvConfigurator
+    ) {
+        this.log = log;
+        this.nodeDetector = nodeDetector;
+        this.directoryResolverSupplier = directoryResolverSupplier;
+        this.envConfigurator = envConfigurator;
+        this.customEnvConfigurator = customEnvConfigurator;
+    }
+
+    DaemonBridge getDaemonBridge() {
+        DaemonBridge current = daemonBridge;
+        if (current != null && current.isAlive()) {
+            return current;
+        }
+        if (System.currentTimeMillis() < daemonRetryAfter) {
+            return null;
+        }
+
+        synchronized (daemonLock) {
+            current = daemonBridge;
+            if (current != null && current.isAlive()) {
+                return current;
+            }
+
+            daemonRetryAfter = System.currentTimeMillis() + DAEMON_RETRY_DELAY_MS;
+            try {
+                if (current != null) {
+                    current.stop();
+                }
+
+                DaemonBridge newBridge = new DaemonBridge(
+                        nodeDetector,
+                        directoryResolverSupplier.get(),
+                        envConfigurator,
+                        customEnvConfigurator
+                );
+                if (newBridge.start()) {
+                    daemonBridge = newBridge;
+                    daemonRetryAfter = 0;
+                    log.info("[CodexDaemonCoordinator] Daemon bridge started successfully");
+                    return newBridge;
+                }
+                log.warn("[CodexDaemonCoordinator] Failed to start daemon, falling back to one-shot");
+            } catch (Exception e) {
+                log.debug("[CodexDaemonCoordinator] Daemon init failed: " + e.getMessage());
+            }
+            return null;
+        }
+    }
+
+    DaemonBridge getCurrentDaemonBridge() {
+        return daemonBridge;
+    }
+
+    void shutdownDaemon() {
+        DaemonBridge current = daemonBridge;
+        if (current != null) {
+            current.stop();
+            daemonBridge = null;
+            daemonRetryAfter = 0;
+        }
+    }
+}

--- a/src/main/java/com/github/claudecodegui/provider/codex/CodexDaemonRequestExecutor.java
+++ b/src/main/java/com/github/claudecodegui/provider/codex/CodexDaemonRequestExecutor.java
@@ -1,0 +1,202 @@
+package com.github.claudecodegui.provider.codex;
+
+import com.github.claudecodegui.provider.common.DaemonBridge;
+import com.github.claudecodegui.provider.common.MessageCallback;
+import com.github.claudecodegui.provider.common.SDKResult;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Sends Codex requests through the long-running daemon ({@code codex.send}).
+ *
+ * <p>The daemon dispatches to {@code handleCodexCommand('send')} inside the
+ * warm process, so the node + SDK cold start is paid once instead of per
+ * chat message. Output lines carry the same [MESSAGE]/[STREAM_*] tags as the
+ * one-shot channel, so {@link CodexSDKBridge#processOutputLine} is reused
+ * verbatim.
+ */
+class CodexDaemonRequestExecutor {
+
+    private final Logger log;
+    private final CodexSDKBridge bridge; // for processOutputLine
+
+    CodexDaemonRequestExecutor(Logger log, CodexSDKBridge bridge) {
+        this.log = log;
+        this.bridge = bridge;
+    }
+
+    /**
+     * @param params the fully built request payload (message/threadId/env/...)
+     *               — the daemon applies {@code params.env} to its process
+     *               environment for the duration of the request.
+     * @param cleanup invoked exactly once after the turn settles (success,
+     *                error or abort) — e.g. temp image deletion.
+     */
+    CompletableFuture<SDKResult> sendMessageViaDaemon(
+            DaemonBridge daemon,
+            String channelId,
+            JsonObject params,
+            MessageCallback callback,
+            Runnable cleanup
+    ) {
+        return CompletableFuture.supplyAsync(() -> {
+            SDKResult result = new SDKResult();
+            StringBuilder assistantContent = new StringBuilder();
+            AtomicBoolean hadSendError = new AtomicBoolean(false);
+            AtomicReference<String> lastNodeError = new AtomicReference<>(null);
+            AtomicBoolean wasAborted = new AtomicBoolean(false);
+            long startTime = System.currentTimeMillis();
+
+            try {
+                try {
+                    return runTurn(daemon, channelId, params, callback, result,
+                            assistantContent, hadSendError, lastNodeError, wasAborted, startTime);
+                } finally {
+                    cleanup.run();
+                }
+            } catch (Exception e) {
+                if (!hadSendError.get()) {
+                    result.success = false;
+                    result.error = e.getMessage();
+                    callback.onError(result.error);
+                }
+                return result;
+            }
+        });
+    }
+
+    private SDKResult runTurn(
+            DaemonBridge daemon,
+            String channelId,
+            JsonObject params,
+            MessageCallback callback,
+            SDKResult result,
+            StringBuilder assistantContent,
+            AtomicBoolean hadSendError,
+            AtomicReference<String> lastNodeError,
+            AtomicBoolean wasAborted,
+            long startTime
+    ) throws Exception {
+        try {
+            log.info("[CodexDaemonExecutor] Sending via daemon: codex.send");
+
+                CompletableFuture<Boolean> cmdFuture = daemon.sendCommand(
+                        "codex.send",
+                        params,
+                        new DaemonBridge.DaemonOutputCallback() {
+                            @Override
+                            public void onLine(String line) {
+                                if (line.startsWith("[UNCAUGHT_ERROR]")
+                                        || line.startsWith("[UNHANDLED_REJECTION]")
+                                        || line.startsWith("[COMMAND_ERROR]")
+                                        || line.startsWith("[STARTUP_ERROR]")
+                                        || line.startsWith("[ERROR]")) {
+                                    log.warn("[Codex Node ERROR] " + line);
+                                    lastNodeError.set(line);
+                                }
+                                bridge.processOutputLine(
+                                        line,
+                                        callback,
+                                        result,
+                                        assistantContent,
+                                        hadSendError,
+                                        lastNodeError
+                                );
+                            }
+
+                            @Override
+                            public void onStderr(String text) {
+                                if (text != null && (text.contains("[SEND_ERROR]")
+                                        || text.contains("[DEBUG] Error"))) {
+                                    bridge.processOutputLine(
+                                            text,
+                                            callback,
+                                            result,
+                                            assistantContent,
+                                            hadSendError,
+                                            lastNodeError
+                                    );
+                                    return;
+                                }
+                                log.debug("[CodexDaemon:stderr] " + text);
+                            }
+
+                            @Override
+                            public void onError(String error) {
+                                if (!hadSendError.get()) {
+                                    result.success = false;
+                                    result.error = error;
+                                }
+                            }
+
+                            @Override
+                            public void onAbort() {
+                                wasAborted.set(true);
+                            }
+
+                            @Override
+                            public void onComplete(boolean success) {
+                            }
+                        }
+                );
+
+                Boolean success;
+                long waitStart = System.currentTimeMillis();
+                long lastProgressLogAt = waitStart;
+                while (true) {
+                    try {
+                        success = cmdFuture.get(30, TimeUnit.SECONDS);
+                        break;
+                    } catch (TimeoutException timeout) {
+                        if (!daemon.isAlive()) {
+                            throw new RuntimeException("Codex daemon not alive", timeout);
+                        }
+                        long now = System.currentTimeMillis();
+                        if (now - lastProgressLogAt >= 60_000) {
+                            long elapsedSec = (now - waitStart) / 1000;
+                            log.info("[CodexDaemonExecutor] still running (" + elapsedSec + "s)...");
+                            lastProgressLogAt = now;
+                        }
+                    }
+                }
+
+                result.finalResult = assistantContent.toString();
+                result.messageCount = result.messages.size();
+
+                if (!hadSendError.get()) {
+                    result.success = success != null && success;
+                    if (result.success) {
+                        callback.onComplete(result);
+                    } else if (wasAborted.get()) {
+                        long elapsed = System.currentTimeMillis() - startTime;
+                        log.info("[CodexDaemonExecutor] aborted by user (" + elapsed + "ms)");
+                        result.error = "User interrupted";
+                        callback.onComplete(result);
+                    } else {
+                        String errorMsg = "Codex daemon command failed";
+                        String nodeErr = lastNodeError.get();
+                        if (nodeErr != null) {
+                            errorMsg += "\n\nDetails: " + nodeErr;
+                        }
+                        if (result.error == null) {
+                            result.error = errorMsg;
+                        }
+                        callback.onError(result.error);
+                    }
+                } else {
+                    callback.onError(result.error != null ? result.error : "Codex send error");
+                }
+
+                return result;
+            } catch (Exception e) {
+                log.debug("[CodexDaemonExecutor] runTurn exception: " + e.getMessage());
+                throw e;
+            }
+        }
+}

--- a/src/main/java/com/github/claudecodegui/provider/codex/CodexSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/codex/CodexSDKBridge.java
@@ -12,6 +12,7 @@ import com.github.claudecodegui.dependency.DependencyManager;
 import com.github.claudecodegui.bridge.NodeDetector;
 import com.github.claudecodegui.bridge.ProcessManager;
 import com.github.claudecodegui.provider.common.BaseSDKBridge;
+import com.github.claudecodegui.provider.common.DaemonBridge;
 import com.github.claudecodegui.provider.common.MessageCallback;
 import com.github.claudecodegui.provider.common.SDKResult;
 import com.github.claudecodegui.util.PlatformUtils;
@@ -57,6 +58,8 @@ public class CodexSDKBridge extends BaseSDKBridge {
     private static final int MAX_ENV_VAR_VALUE_LENGTH = 16 * 1024;
     private final CodexHistoryReader historyReader;
     private final CodemossSettingsService settingsService = new CodemossSettingsService();
+    private final CodexDaemonCoordinator daemonCoordinator;
+    private final CodexDaemonRequestExecutor daemonRequestExecutor;
 
     private static final Set<String> PROTECTED_ENV_KEYS = new HashSet<>();
     static {
@@ -99,11 +102,58 @@ public class CodexSDKBridge extends BaseSDKBridge {
     public CodexSDKBridge() {
         super(CodexSDKBridge.class);
         this.historyReader = new CodexHistoryReader();
+        this.daemonCoordinator = new CodexDaemonCoordinator(
+                LOG,
+                nodeDetector,
+                this::getDirectoryResolver,
+                envConfigurator,
+                envConfigurator::configureCodexEnv
+        );
+        this.daemonRequestExecutor = new CodexDaemonRequestExecutor(LOG, this);
     }
 
     CodexSDKBridge(Path sessionsDir) {
         super(CodexSDKBridge.class);
         this.historyReader = new CodexHistoryReader(sessionsDir, gson);
+        this.daemonCoordinator = new CodexDaemonCoordinator(
+                LOG,
+                nodeDetector,
+                this::getDirectoryResolver,
+                envConfigurator,
+                envConfigurator::configureCodexEnv
+        );
+        this.daemonRequestExecutor = new CodexDaemonRequestExecutor(LOG, this);
+    }
+
+    /**
+     * Interrupt a channel. In daemon mode, sends an abort command so the live
+     * Codex turn's AbortController fires; also delegates to ProcessManager for
+     * the one-shot fallback.
+     */
+    @Override
+    public void interruptChannel(String channelId) {
+        DaemonBridge db = daemonCoordinator.getCurrentDaemonBridge();
+        if (db != null && db.isAlive()) {
+            LOG.info("[CodexSDKBridge] Sending daemon abort for channel: " + channelId);
+            try {
+                db.sendAbort();
+            } catch (Exception e) {
+                LOG.error("[CodexSDKBridge] Daemon abort failed: " + e.getMessage());
+            }
+        }
+        // Also try per-process interrupt (covers one-shot fallback)
+        super.interruptChannel(channelId);
+    }
+
+    @Override
+    public void cleanupAllProcesses() {
+        shutdownDaemon();
+        super.cleanupAllProcesses();
+    }
+
+    /** Stops the Codex daemon if running (idempotent). */
+    public void shutdownDaemon() {
+        daemonCoordinator.shutdownDaemon();
     }
 
     // ============================================================================
@@ -451,14 +501,102 @@ public class CodexSDKBridge extends BaseSDKBridge {
                     LOG.info("[Codex] ✓ Prepared " + attachmentsArray.size() + " image attachment(s)");
                 }
 
+                File processTempDir = processManager.prepareClaudeTempDir();
+
+                // Build the request env once — both transports need the same
+                // variables: as child-process env for the one-shot spawn and
+                // as params.env for the daemon (applied per request).
+                Map<String, String> requestEnv = new java.util.LinkedHashMap<>();
+                envConfigurator.configureTempDir(requestEnv, processTempDir);
+                requestEnv.put("CODEX_USE_STDIN", "true");
+
+                // Set model via environment variable if specified
+                if (model != null && !model.isEmpty()) {
+                    requestEnv.put("CODEX_MODEL", model);
+                }
+
+                // Override user's ~/.codex/config.toml sandbox and approval settings via environment variables
+                if (permissionMode != null && !permissionMode.isEmpty()) {
+                    String sandboxMode = resolveCodexSandboxMode(cwd);
+
+                    switch (permissionMode) {
+                        case "auto":
+                            // Codex native auto review requires the guarded workspace-write/on-request pair.
+                            requestEnv.put(ENV_CODEX_SANDBOX_MODE, SANDBOX_MODE_WORKSPACE_WRITE);
+                            requestEnv.put(ENV_CODEX_SANDBOX, SANDBOX_MODE_WORKSPACE_WRITE);
+                            requestEnv.put(ENV_CODEX_APPROVAL_POLICY, APPROVAL_POLICY_ON_REQUEST);
+                            break;
+                        case "bypassPermissions":
+                            requestEnv.put(ENV_CODEX_SANDBOX_MODE, sandboxMode);
+                            requestEnv.put(ENV_CODEX_SANDBOX, sandboxMode);
+                            requestEnv.put(ENV_CODEX_APPROVAL_POLICY, APPROVAL_POLICY_NEVER);
+                            break;
+                        case "acceptEdits":
+                        case "autoEdit":
+                            requestEnv.put(ENV_CODEX_SANDBOX_MODE, sandboxMode);
+                            requestEnv.put(ENV_CODEX_SANDBOX, sandboxMode);
+                            requestEnv.put(ENV_CODEX_APPROVAL_POLICY, APPROVAL_POLICY_ON_REQUEST);
+                            break;
+                        case "plan":
+                            requestEnv.put(ENV_CODEX_SANDBOX_MODE, sandboxMode);
+                            requestEnv.put(ENV_CODEX_SANDBOX, sandboxMode);
+                            requestEnv.put(ENV_CODEX_APPROVAL_POLICY, APPROVAL_POLICY_ON_REQUEST);
+                            break;
+                        default:
+                            // Default mode: use configured sandbox mode with confirmation
+                            requestEnv.put(ENV_CODEX_SANDBOX_MODE, sandboxMode);
+                            requestEnv.put(ENV_CODEX_SANDBOX, sandboxMode);
+                            requestEnv.put(ENV_CODEX_APPROVAL_POLICY, APPROVAL_POLICY_ON_REQUEST);
+                            break;
+                    }
+                    LOG.info("[Codex] Permission env override: SANDBOX_MODE=" +
+                            requestEnv.get(ENV_CODEX_SANDBOX_MODE) + ", SANDBOX=" +
+                            requestEnv.get(ENV_CODEX_SANDBOX) + ", APPROVAL_POLICY=" +
+                            requestEnv.get(ENV_CODEX_APPROVAL_POLICY) + " (from permissionMode=" + permissionMode +
+                            ")");
+                }
+
+                // Configure Codex-specific env vars from ~/.codex/config.toml
+                envConfigurator.configureCodexEnv(requestEnv);
+
+                // Inject custom "message" env vars from active provider
+                injectCustomEnvVars(requestEnv, "message");
+
+                LOG.info("[Codex] Final Node permission env snapshot: CODEX_SANDBOX_MODE=" +
+                        requestEnv.get(ENV_CODEX_SANDBOX_MODE) + ", CODEX_SANDBOX=" +
+                        requestEnv.get(ENV_CODEX_SANDBOX) + ", CODEX_CI=" + requestEnv.get(ENV_CODEX_CI) +
+                        ", CODEX_SANDBOX_NETWORK_DISABLED=" + requestEnv.get(ENV_CODEX_SANDBOX_NETWORK_DISABLED) +
+                        ", CLAUDE_SESSION_ID=" + requestEnv.get("CLAUDE_SESSION_ID") +
+                        ", CLAUDE_PERMISSION_DIR=" + requestEnv.get("CLAUDE_PERMISSION_DIR"));
+
+                // Daemon path first: the warm process skips the per-message
+                // node + SDK cold start. The coordinator returns null while the
+                // daemon is down (60s retry backoff) — fall through to one-shot.
+                DaemonBridge daemon = daemonCoordinator.getDaemonBridge();
+                if (daemon != null) {
+                    JsonObject envJson = new JsonObject();
+                    for (Map.Entry<String, String> entry : requestEnv.entrySet()) {
+                        envJson.addProperty(entry.getKey(), entry.getValue() != null ? entry.getValue() : "");
+                    }
+                    stdinInput.add("env", envJson);
+                    LOG.info("[CodexSDKBridge] Sending via daemon (codex.send)");
+                    SDKResult daemonResult = daemonRequestExecutor.sendMessageViaDaemon(
+                            daemon, channelId, stdinInput, callback,
+                            () -> cleanupTempImages(tempImageFiles)).join();
+                    if (daemonResult == null) {
+                        daemonResult = new SDKResult();
+                        daemonResult.success = false;
+                        daemonResult.error = "Codex daemon returned no result";
+                    }
+                    return daemonResult;
+                }
+
                 String stdinJson = gson.toJson(stdinInput);
 
                 String scriptPath = new File(bridgeDir, CHANNEL_SCRIPT).getAbsolutePath();
                 List<String> command = NodeDetector.buildNodeScriptCommand(node, scriptPath);
                 command.add("codex");
                 command.add("send");
-
-                File processTempDir = processManager.prepareClaudeTempDir();
 
                 ProcessBuilder pb = new ProcessBuilder(command);
 
@@ -474,72 +612,9 @@ public class CodexSDKBridge extends BaseSDKBridge {
                     pb.directory(bridgeDir);
                 }
 
-                // Configure environment variables
-                Map<String, String> env = pb.environment();
-                envConfigurator.configureTempDir(env, processTempDir);
-                env.put("CODEX_USE_STDIN", "true");
-
-                // Set model via environment variable if specified
-                if (model != null && !model.isEmpty()) {
-                    env.put("CODEX_MODEL", model);
-                }
-
-                // Override user's ~/.codex/config.toml sandbox and approval settings via environment variables
-                if (permissionMode != null && !permissionMode.isEmpty()) {
-                    String sandboxMode = resolveCodexSandboxMode(cwd);
-
-                    switch (permissionMode) {
-                        case "auto":
-                            // Codex native auto review requires the guarded workspace-write/on-request pair.
-                            env.put(ENV_CODEX_SANDBOX_MODE, SANDBOX_MODE_WORKSPACE_WRITE);
-                            env.put(ENV_CODEX_SANDBOX, SANDBOX_MODE_WORKSPACE_WRITE);
-                            env.put(ENV_CODEX_APPROVAL_POLICY, APPROVAL_POLICY_ON_REQUEST);
-                            break;
-                        case "bypassPermissions":
-                            env.put(ENV_CODEX_SANDBOX_MODE, sandboxMode);
-                            env.put(ENV_CODEX_SANDBOX, sandboxMode);
-                            env.put(ENV_CODEX_APPROVAL_POLICY, APPROVAL_POLICY_NEVER);
-                            break;
-                        case "acceptEdits":
-                        case "autoEdit":
-                            env.put(ENV_CODEX_SANDBOX_MODE, sandboxMode);
-                            env.put(ENV_CODEX_SANDBOX, sandboxMode);
-                            env.put(ENV_CODEX_APPROVAL_POLICY, APPROVAL_POLICY_ON_REQUEST);
-                            break;
-                        case "plan":
-                            env.put(ENV_CODEX_SANDBOX_MODE, sandboxMode);
-                            env.put(ENV_CODEX_SANDBOX, sandboxMode);
-                            env.put(ENV_CODEX_APPROVAL_POLICY, APPROVAL_POLICY_ON_REQUEST);
-                            break;
-                        default:
-                            // Default mode: use configured sandbox mode with confirmation
-                            env.put(ENV_CODEX_SANDBOX_MODE, sandboxMode);
-                            env.put(ENV_CODEX_SANDBOX, sandboxMode);
-                            env.put(ENV_CODEX_APPROVAL_POLICY, APPROVAL_POLICY_ON_REQUEST);
-                            break;
-                    }
-                    LOG.info("[Codex] Permission env override: SANDBOX_MODE=" +
-                            env.get(ENV_CODEX_SANDBOX_MODE) + ", SANDBOX=" +
-                            env.get(ENV_CODEX_SANDBOX) + ", APPROVAL_POLICY=" +
-                            env.get(ENV_CODEX_APPROVAL_POLICY) + " (from permissionMode=" + permissionMode +
-                            ")");
-                }
-
                 pb.redirectErrorStream(true);
                 envConfigurator.updateProcessEnvironment(pb, node);
-
-                // Configure Codex-specific env vars from ~/.codex/config.toml
-                envConfigurator.configureCodexEnv(env);
-
-                // Inject custom "message" env vars from active provider
-                injectCustomEnvVars(env, "message");
-
-                LOG.info("[Codex] Final Node permission env snapshot: CODEX_SANDBOX_MODE=" +
-                        env.get(ENV_CODEX_SANDBOX_MODE) + ", CODEX_SANDBOX=" +
-                        env.get(ENV_CODEX_SANDBOX) + ", CODEX_CI=" + env.get(ENV_CODEX_CI) +
-                        ", CODEX_SANDBOX_NETWORK_DISABLED=" + env.get(ENV_CODEX_SANDBOX_NETWORK_DISABLED) +
-                        ", CLAUDE_SESSION_ID=" + env.get("CLAUDE_SESSION_ID") +
-                        ", CLAUDE_PERMISSION_DIR=" + env.get("CLAUDE_PERMISSION_DIR"));
+                pb.environment().putAll(requestEnv);
 
                 LOG.info("Command: " + String.join(" ", command));
 


### PR DESCRIPTION
## Why

`CodexSDKBridge` spawned a fresh node + channel-manager process for every chat message. End-to-end benchmarking with real codex turns (median of 4) showed the dominant turn cost is the codex CLI + model roundtrip (~3.1s in both modes), so this is **not** a seconds-per-message win — the daemon eliminates the fixed per-message process overhead only:

| transport | fixed overhead per message (measured, `codex listModels`) |
|---|---|
| one-shot (before) | 155 ms median |
| daemon (after) | 1 ms |

Net: ~150 ms (~5%) per chat message, plus one fewer node process spawn per message (startup/AV-scan/memory churn), and codex gains daemon lifecycle parity with Claude/Grok.

## Design (mirrors GrokDaemonCoordinator / GrokDaemonRequestExecutor)

- `CodexDaemonCoordinator` owns the DaemonBridge lifecycle (60s retry backoff after a failed start).
- `CodexSDKBridge` builds the request env once (`requestEnv`) and shares it across transports: ProcessBuilder child env (one-shot) and `params.env` (daemon applies it per request and restores afterwards).
- `CodexDaemonRequestExecutor` adapts daemon NDJSON output to the same `processOutputLine` streaming path; `interruptChannel` forwards a daemon abort; codex turns gained an `AbortController`-based abort (required because the daemon process is shared and cannot be killed per turn).
- One-shot remains the fallback whenever the daemon is unavailable.

## Verification

- Real daemon turns return the threadId + result payload with correctly request-id-tagged NDJSON output lines.
- Resume turns on the same thread work through the daemon.
- `compileJava` and `checkstyleMain` pass.

## Follow-up finding

The remaining ~3s per codex turn is the CLI binary + model roundtrip (identical in both modes; resume turns save ~1s of session rebuild). A persistent app-server runtime would be the next lever if codex send latency ever needs a real reduction.