### PR TITLE
fix(history): make the node-service timeout actually reachable

### DIFF
--- a/src/main/java/com/github/claudecodegui/handler/NodeJsServiceCaller.java
+++ b/src/main/java/com/github/claudecodegui/handler/NodeJsServiceCaller.java
@@ -31,9 +31,15 @@ public class NodeJsServiceCaller {
     );
 
     private final HandlerContext context;
+    private final int processTimeoutSeconds;
 
     public NodeJsServiceCaller(HandlerContext context) {
+        this(context, PROCESS_TIMEOUT_SECONDS);
+    }
+
+    NodeJsServiceCaller(HandlerContext context, int processTimeoutSeconds) {
         this.context = context;
+        this.processTimeoutSeconds = processTimeoutSeconds;
     }
 
     /**
@@ -158,10 +164,14 @@ public class NodeJsServiceCaller {
     }
 
     /**
-     * Execute a Node.js script via ProcessBuilder, read its output, enforce a timeout,
-     * and return the last line of stdout (expected to be JSON).
+     * Execute a Node.js script via ProcessBuilder, enforce a timeout, and
+     * return the last line of stdout (expected to be JSON).
+     *
+     * <p>Stdout is drained on a daemon thread so the timeout below is the real
+     * deadline: the previous read-to-EOF-then-wait ordering let a hung child
+     * holding the pipe open block forever with the timeout never reached.
      */
-    private String executeNodeScript(ProcessBuilder pb) throws Exception {
+    String executeNodeScript(ProcessBuilder pb) throws Exception {
         // L8 fix: register with ProcessManager so cleanupAllProcesses sees this child.
         ProcessManager processManager = context.getClaudeSDKBridge().getProcessManager();
         String channelId = ProcessManager.newChannelId("node-service");
@@ -170,27 +180,41 @@ public class NodeJsServiceCaller {
             process = pb.start();
             processManager.registerProcess(channelId, process);
 
+            final Process started = process;
             StringBuilder output = new StringBuilder();
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    output.append(line).append("\n");
+            Thread readerThread = new Thread(() -> {
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(started.getInputStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        synchronized (output) {
+                            output.append(line).append("\n");
+                        }
+                    }
+                } catch (Exception ignored) {
                 }
-            }
+            });
+            readerThread.setDaemon(true);
+            readerThread.start();
 
-            boolean finished = process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            boolean finished = process.waitFor(processTimeoutSeconds, TimeUnit.SECONDS);
             if (!finished) {
                 PlatformUtils.terminateProcess(process);
-                throw new Exception("Node.js process timed out after " + PROCESS_TIMEOUT_SECONDS + " seconds");
+                throw new Exception("Node.js process timed out after " + processTimeoutSeconds + " seconds");
             }
+            // Process exited; the reader hits EOF promptly — join for the final lines.
+            readerThread.join(2000L);
 
             int exitCode = process.exitValue();
+            String outputText;
+            synchronized (output) {
+                outputText = output.toString();
+            }
             if (exitCode != 0) {
-                throw new Exception("Node.js process exited with code " + exitCode + ": " + output);
+                throw new Exception("Node.js process exited with code " + exitCode + ": " + outputText);
             }
 
-            String[] lines = output.toString().split("\n");
+            String[] lines = outputText.split("\n");
             return lines.length > 0 ? lines[lines.length - 1] : "{}";
         } finally {
             if (process != null) {

--- a/src/test/java/com/github/claudecodegui/handler/NodeJsServiceCallerTimeoutTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/NodeJsServiceCallerTimeoutTest.java
@@ -1,0 +1,87 @@
+package com.github.claudecodegui.handler;
+
+import com.github.claudecodegui.handler.core.HandlerContext;
+import com.github.claudecodegui.provider.claude.ClaudeSDKBridge;
+import com.github.claudecodegui.bridge.ProcessManager;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Regression tests for the executeNodeScript timeout: stdout used to be
+ * drained to EOF BEFORE the timeout was checked, so a hung child holding the
+ * pipe open blocked forever and the 30s timeout was unreachable dead code.
+ */
+public class NodeJsServiceCallerTimeoutTest {
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final long TEST_TIMEOUT_SECONDS = 2;
+
+    @Test(timeout = 20_000)
+    public void hungChildTimesOutInsteadOfBlockingForever() throws Exception {
+        TestClaudeSDKBridge bridge = new TestClaudeSDKBridge();
+        NodeJsServiceCaller caller = new NodeJsServiceCaller(bridge.context, (int) TEST_TIMEOUT_SECONDS);
+
+        // Child prints nothing and stays alive holding the pipe open.
+        ProcessBuilder pb = new ProcessBuilder(List.of(
+                "node", "-e", "setTimeout(() => {}, 60_000);"));
+        pb.redirectErrorStream(true);
+
+        long start = System.currentTimeMillis();
+        try {
+            caller.executeNodeScript(pb);
+            fail("expected the hung child to be terminated by the timeout");
+        } catch (Exception e) {
+            assertTrue("expected a timeout error, got: " + e.getMessage(),
+                    e.getMessage().contains("timed out"));
+        }
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertTrue("timeout should fire promptly (took " + elapsed + " ms)",
+                elapsed < TEST_TIMEOUT_SECONDS * 1000 + 5_000);
+        assertEquals("child should be unregistered after the timeout",
+                0, bridge.getProcessManager().getActiveProcessCount());
+    }
+
+    private static final class TestClaudeSDKBridge extends ClaudeSDKBridge {
+        private final ProcessManager processManager = new ProcessManager();
+        private final HandlerContext context;
+
+        private TestClaudeSDKBridge() {
+            this.context = new HandlerContext(null, this, null, null, new HandlerContext.JsCallback() {
+                @Override
+                public void callJavaScript(String functionName, String... args) {
+                }
+
+                @Override
+                public String escapeJs(String str) {
+                    return str;
+                }
+            });
+        }
+
+        @Override
+        public File getSdkTestDir() {
+            return new File(".");
+        }
+
+        @Override
+        public String getNodeExecutable() {
+            return "node";
+        }
+
+        @Override
+        public ProcessManager getProcessManager() {
+            return processManager;
+        }
+    }
+}


### PR DESCRIPTION
## Bug

`NodeJsServiceCaller.executeNodeScript` drained the child's stdout to EOF **before** checking the 30s timeout. A child that hangs while holding the pipe open (favorites-service / session-titles-service / input-history-service calls — favorites toggle, session title load/rename/delete, input-history save/load) therefore blocked forever: the `waitFor(30s)` deadline was unreachable dead code.

## Fix

Stdout is now drained on a daemon thread and `waitFor(timeout)` is the real deadline (the same pattern `CliModelsHandler` already uses); the reader is joined briefly after a clean exit. The child is terminated and unregistered on timeout as before.

## Test

New regression test (`NodeJsServiceCallerTimeoutTest`) spawns a genuinely hung child (prints nothing, sleeps 60s, holds the pipe open) with a 2s budget and asserts:

- a timeout error is raised (instead of blocking forever)
- it fires promptly (< timeout + 5s)
- the child is unregistered from `ProcessManager`

Before this change that test would hang indefinitely. All handler-package suites pass (52 test classes, 0 failures).