### PR TITLE
fix(remote-dev): make Git4Idea dependency optional — action-in-fragment breaks descriptor resolution on 2025.3

### DIFF
--- a/src/main/java/com/github/claudecodegui/action/vcs/GenerateCommitMessageAction.java
+++ b/src/main/java/com/github/claudecodegui/action/vcs/GenerateCommitMessageAction.java
@@ -86,7 +86,15 @@ public class GenerateCommitMessageAction extends AnAction implements DumbAware {
         // Cancel any in-flight generation (double-click / re-trigger).
         cancelInFlight(project);
 
-        final GitCommitMessageService service = new GitCommitMessageService(project);
+        final GitCommitMessageService service;
+        try {
+            service = new GitCommitMessageService(project);
+        } catch (NoClassDefFoundError error) {
+            // 兜底: update() 已按 Git4Idea 可用性隐藏入口, 这里防御极端时序
+            // (如运行中被禁用插件)。git4idea 缺失时 CommitDiffProvider 无法加载。
+            LOG.warn("Git4Idea became unavailable; aborting commit message generation", error);
+            return;
+        }
         setActive(project, service);
 
         // Preserve the user's existing draft; restored on error.
@@ -289,6 +297,13 @@ public class GenerateCommitMessageAction extends AnAction implements DumbAware {
 
     @Override
     public void update(@NotNull AnActionEvent e) {
+        // Git4Idea 是可选依赖 (见 plugin.xml): 提交信息生成走 git4idea 的 git diff。
+        // 没有它的环境 (如 Remote Development 的前端客户端) 直接隐藏入口。
+        if (!isGit4IdeaAvailable()) {
+            e.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
+
         Project project = e.getProject();
         boolean enabled = project != null;
 
@@ -307,6 +322,23 @@ public class GenerateCommitMessageAction extends AnAction implements DumbAware {
         e.getPresentation().setText(ClaudeCodeGuiBundle.message("action.generateCommitMessage.text"));
         e.getPresentation().setDescription(ClaudeCodeGuiBundle.message("action.generateCommitMessage.description"));
         e.getPresentation().setEnabledAndVisible(enabled);
+    }
+
+    /**
+     * Whether the optional Git4Idea plugin's classes are loadable. The commit
+     * message generator needs its {@code git diff}; without it (e.g. the Remote
+     * Development frontend client) the action hides itself instead of crashing.
+     * Class-loadability is exactly the condition {@link GitCommitMessageService}
+     * (via {@code CommitDiffProvider}) needs, and it also covers the
+     * installed-but-disabled case.
+     */
+    private static boolean isGit4IdeaAvailable() {
+        try {
+            Class.forName("git4idea.repo.GitRepositoryManager");
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/ui/WebviewWatchdog.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewWatchdog.java
@@ -1,5 +1,6 @@
 package com.github.claudecodegui.ui;
 
+import com.github.claudecodegui.util.PlatformUtils;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.application.ApplicationManager;
@@ -28,7 +29,13 @@ public class WebviewWatchdog {
     private static final long HEARTBEAT_TIMEOUT_MS = 45_000L;
     private static final long WATCHDOG_INTERVAL_MS = 10_000L;
     private static final long RECOVERY_COOLDOWN_MS = 60_000L;
-    private static final long STARTUP_READY_TIMEOUT_MS = 15_000L;
+    // Remote Development backends render via Linux/OSR JCEF, whose first page
+    // load (CEF cold start + the ~10MB single-file webview) takes ~60s on
+    // typical hosts. A 15s startup budget reloads the page mid-load and adds
+    // ~40s of restart churn per reconnect (observed 2026-09), so the pre-ready
+    // budget is platform-adaptive: tight 15s locally, 150s where OSR applies.
+    // Frontend readiness exits the startup phase as soon as the page finishes.
+    private static final long STARTUP_READY_TIMEOUT_MS = PlatformUtils.isLinux() ? 150_000L : 15_000L;
     private static final long STARTUP_RECOVERY_COOLDOWN_MS = 15_000L;
     private static final int MAX_STARTUP_RECOVERY_ATTEMPTS = 2;
 
@@ -278,6 +285,11 @@ public class WebviewWatchdog {
             return STARTUP_READY_TIMEOUT_MS;
         }
         return streaming ? STREAMING_HEARTBEAT_TIMEOUT_MS : HEARTBEAT_TIMEOUT_MS;
+    }
+
+    /** Whether the pre-ready startup budget uses the extended remote/OSR value. */
+    static boolean isRemoteStartupBudget() {
+        return PlatformUtils.isLinux();
     }
 
     static long recoveryCooldownMs(boolean frontendReady) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -64,9 +64,12 @@
     ]]></description>
 
     <depends>com.intellij.modules.platform</depends>
-    <!-- Git support — required for Commit AI to run a real `git diff`.
-         Git4Idea is bundled in all JetBrains IDEs that support Git. -->
-    <depends>Git4Idea</depends>
+  <!-- Git support — only needed by the Commit AI feature (a real `git diff`
+       via git4idea). Optional so the plugin also loads in environments without
+       Git4Idea, e.g. the Remote Development frontend client, where VCS runs on
+       the remote backend instead. The commit-message action hides itself via
+       GenerateCommitMessageAction#update when Git4Idea is absent. -->
+  <depends optional="true">Git4Idea</depends>
     <!-- JCEF is a separate platform module in IntelliJ IDEA 2026.2+, but older
          IDEs may provide JCEF from the platform without exposing this module. -->
     <depends optional="true" config-file="jcef-features.xml">com.intellij.modules.jcef</depends>
@@ -181,7 +184,8 @@
             <add-to-group group-id="ConsoleView.PopupMenu" anchor="last"/>
         </action>
 
-        <!-- Generate Commit Message with AI Action -->
+        <!-- Generate Commit Message with AI Action. Requires the optional
+             Git4Idea dependency; the action hides itself when it is absent. -->
         <action id="ClaudeCodeGUI.GenerateCommitMessageAction"
                 class="com.github.claudecodegui.action.vcs.GenerateCommitMessageAction"
                 icon="/icons/logo-16.png">

--- a/src/test/java/com/github/claudecodegui/ui/WebviewWatchdogTest.java
+++ b/src/test/java/com/github/claudecodegui/ui/WebviewWatchdogTest.java
@@ -17,13 +17,23 @@ import static org.junit.Assert.assertTrue;
  */
 public class WebviewWatchdogTest {
 
-    /** Verifies that an unready frontend uses the bounded startup timeout. */
+    /**
+     * Verifies that an unready frontend uses the bounded startup timeout.
+     * On Linux (Remote Development backends render via OSR) the startup budget
+     * is intentionally larger than the post-ready heartbeat timeout, because
+     * the first page load legitimately takes about a minute; on desktop
+     * platforms it stays tighter than the runtime timeout.
+     */
     @Test
     public void usesShortTimeoutBeforeFrontendReady() {
         long startupTimeout = WebviewWatchdog.heartbeatTimeoutMs(false, false);
 
         assertEquals(startupTimeout, WebviewWatchdog.heartbeatTimeoutMs(false, true));
-        assertTrue(startupTimeout < WebviewWatchdog.heartbeatTimeoutMs(true, false));
+        if (WebviewWatchdog.isRemoteStartupBudget()) {
+            assertTrue(startupTimeout >= WebviewWatchdog.heartbeatTimeoutMs(true, false));
+        } else {
+            assertTrue(startupTimeout < WebviewWatchdog.heartbeatTimeoutMs(true, false));
+        }
     }
 
     /** Verifies that active streaming only extends the timeout after frontend readiness. */


### PR DESCRIPTION
## 问题

Remote Development (SSH) 场景下,插件安装到后端后完全不加载(工具窗口、设置页均不出现),且日志无任何报错。

## 根因

2025.3(253)平台上,`<action>` 声明在 optional depends 的 config-file 片段中,会导致**整个插件描述符解析静默失败**——插件不注册、不加载、日志零提及。

隔离实例 A/B 实验(同一环境,仅替换 lib jar):

| 片段/主文件组合 | 结果 |
|---|---|
| 市场 0.5.5 jar(plugin.xml 无片段) | ✅ 注册 |
| 市场版 plugin.xml + depends 改 `optional="true" config-file="..."` | ❌ 静默丢弃 |
| 真实 plugin.xml + 最小化片段(`<idea-plugin/>`) | ✅ 注册 |
| 真实 plugin.xml + 含 `<action>` 的片段 | ❌ 静默丢弃 |

## 修复

- `plugin.xml`:`<depends optional="true">Git4Idea</depends>`(平台 tasks 插件有 optional 无 config-file 的先例)
- Action 注册回主 plugin.xml;`GenerateCommitMessageAction.update()` 通过 `Class.forName("git4idea.repo.GitRepositoryManager")` 探测 git4idea 类可载性,不可载(如 Remote Dev 前端客户端)时自动隐藏按钮;`actionPerformed` 兜底 `NoClassDefFoundError`

## 附带:看门狗启动超时平台自适应

Remote Linux/OSR 后端首屏加载实测 ~57s(CEF 冷启动 + ~10MB 单文件 webview,主页面上无外部网络请求),而启动看门狗 15s 即强制 reload、连续两次,每次把快完成的加载归零(时间线:浏览器#1 22:12:48 → 重载 22:13:08 → #2 22:13:28 → #3 → frontend_ready 22:14:25)。启动就绪超时改为平台自适应:Linux/OSR 150s,桌面平台保持 15s;`WebviewWatchdogTest` 断言已按平台自适应语义更新。

## 验证

- 后端(Linux/OSR,IU-253.33813.55):插件正常加载,CCG 工具窗口与全部功能可用
- 前端客户端(无 Git4Idea):插件正常加载,提交 AI 按钮按预期隐藏
- 既有测试全部通过
