### PR TITLE
fix(claude): preserve large images for provider aliases

### DIFF
--- a/ai-bridge/services/claude/attachment-service.js
+++ b/ai-bridge/services/claude/attachment-service.js
@@ -4,13 +4,11 @@
  */
 
 import fs from 'fs';
-import { mkdir, writeFile, readdir, stat as statAsync, unlink } from 'fs/promises';
+import { readdir, stat as statAsync, unlink } from 'fs/promises';
 import path from 'path';
 import os from 'os';
-import crypto from 'crypto';
-import { modelSupportsVision } from '../../utils/model-utils.js';
 
-// Image temp directory shared across the daemon's lifetime.
+// Retain cleanup for image files written by older plugin versions.
 const TEMP_IMAGE_SUBDIR = 'cc-gui-images';
 // Files older than 24h are removed at daemon startup to bound disk growth.
 const TEMP_IMAGE_TTL_MS = 24 * 60 * 60 * 1000;
@@ -106,49 +104,6 @@ export async function loadAttachments(stdinData) {
 }
 
 /**
- * Save base64 image data to a temporary file for cross-model compatibility.
- *
- * Some models (e.g. mimo-v2.5-pro, deepseek, qwen) do not handle Anthropic
- * vision content blocks reliably — especially when routed through third-party
- * proxies that may strip image blocks during translation. Saving to a file and
- * referencing the path lets the model use the Read tool to load the image,
- * matching Claude Code CLI's universal image handling approach.
- *
- * @param {string} base64Data - Base64-encoded image data (no "data:" prefix)
- * @param {string} mediaType - MIME type (e.g. "image/png")
- * @param {string} fileName - Original file name (optional)
- * @returns {string|null} Absolute path to the saved file, or null on failure
- */
-async function saveImageToTemp(base64Data, mediaType, fileName) {
-  try {
-    if (!base64Data || typeof base64Data !== 'string') {
-      return null;
-    }
-    const ext = (typeof mediaType === 'string' && mediaType.split('/')[1])
-      ? mediaType.split('/')[1].toLowerCase()
-      : 'png';
-    const tempDir = path.join(os.tmpdir(), TEMP_IMAGE_SUBDIR);
-    await mkdir(tempDir, { recursive: true });
-
-    let safeName;
-    const uniqueId = crypto.randomUUID();
-    if (fileName && typeof fileName === 'string') {
-      const baseName = path.basename(fileName).replace(/[^a-zA-Z0-9._-]/g, '_');
-      safeName = `${uniqueId}-${baseName}`;
-    } else {
-      safeName = `image-${uniqueId}.${ext}`;
-    }
-
-    const filePath = path.join(tempDir, safeName);
-    await writeFile(filePath, Buffer.from(base64Data, 'base64'));
-    return filePath;
-  } catch (e) {
-    console.error('[ATTACHMENTS] Failed to save image to temp:', e.message);
-    return null;
-  }
-}
-
-/**
  * Best-effort cleanup of old temp image files (>24h old). Called at daemon
  * startup so failed/abandoned writes from previous sessions don't accumulate.
  * Errors are swallowed — cleanup is non-critical.
@@ -178,50 +133,24 @@ export async function cleanupStaleTempImages() {
 /**
  * Build user message content blocks (supports images and text).
  *
- * Image transmission strategy depends on the target model:
- * - Claude models: Inline base64 vision content blocks (most efficient,
- *   natively supported by the Anthropic API).
- * - Non-Claude models (mimo, deepseek, qwen, etc.): Save images to temp files
- *   and reference paths in the message text. The model is asked to use the
- *   Read tool to load them, matching Claude Code CLI behavior. This avoids
- *   issues where third-party proxies silently drop vision content blocks.
+ * Preserve structured image input for every model. Provider aliases do not
+ * describe vision capabilities, and replacing images with file paths loses
+ * visual input on endpoints that only accept images in user content blocks.
  *
  * @param {Array} attachments - Attachment array
  * @param {string} message - User message text
- * @param {string|null} modelId - Resolved model ID actually sent to the API
- *                                  (e.g. "claude-sonnet-4-5", "mimo-v2.5-pro").
- *                                  Used to decide image transmission strategy.
  * @returns {Array} Content block array
  */
-export async function buildContentBlocks(attachments, message, modelId = null) {
+export async function buildContentBlocks(attachments, message) {
   const contentBlocks = [];
-  const useNativeVision = modelSupportsVision(modelId);
-  const imagePathRefs = [];
 
   for (const a of attachments) {
     const mt = typeof a.mediaType === 'string' ? a.mediaType : '';
     if (mt.startsWith('image/')) {
-      if (useNativeVision) {
-        contentBlocks.push({
-          type: 'image',
-          source: {
-            type: 'base64',
-            media_type: mt || 'image/png',
-            data: a.data
-          }
-        });
-      } else {
-        const tempPath = await saveImageToTemp(a.data, mt, a.fileName);
-        if (tempPath) {
-          imagePathRefs.push(tempPath);
-          console.log('[ATTACHMENTS] Saved image to temp for non-vision model:', tempPath);
-        } else {
-          contentBlocks.push({
-            type: 'image',
-            source: { type: 'base64', media_type: mt || 'image/png', data: a.data }
-          });
-        }
-      }
+      contentBlocks.push({
+        type: 'image',
+        source: { type: 'base64', media_type: mt, data: a.data }
+      });
     } else {
       const name = a.fileName || 'Attachment';
       contentBlocks.push({ type: 'text', text: `[Attachment: ${name}]` });
@@ -230,9 +159,7 @@ export async function buildContentBlocks(attachments, message, modelId = null) {
 
   let userText = message;
   if (!userText || userText.trim() === '') {
-    const totalImages = useNativeVision
-      ? contentBlocks.filter(b => b.type === 'image').length
-      : imagePathRefs.length;
+    const totalImages = contentBlocks.filter(b => b.type === 'image').length;
     const textCount = contentBlocks.filter(b => b.type === 'text').length;
     if (totalImages > 0) {
       userText = `[Uploaded ${totalImages} image(s)]`;
@@ -241,13 +168,6 @@ export async function buildContentBlocks(attachments, message, modelId = null) {
     } else {
       userText = '[Empty message]';
     }
-  }
-
-  if (imagePathRefs.length > 0) {
-    const refs = imagePathRefs
-      .map((p, idx) => `[Image #${idx + 1}: ${p}]`)
-      .join('\n');
-    userText = `${refs}\n\nThe user has attached the image(s) above. Please use the Read tool to view them.\n\n${userText}`;
   }
 
   contentBlocks.push({ type: 'text', text: userText });

--- a/ai-bridge/services/claude/attachment-service.test.js
+++ b/ai-bridge/services/claude/attachment-service.test.js
@@ -1,0 +1,117 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { buildContentBlocks, loadAttachments, cleanupStaleTempImages } from './attachment-service.js';
+
+test('keeps image bytes and MIME types intact across the reported size boundary', async () => {
+  for (const size of [1024, 49 * 1024, 51 * 1024, 1024 * 1024, 12 * 1024 * 1024]) {
+    const data = Buffer.alloc(size, 0xab).toString('base64');
+    for (const mediaType of ['image/png', 'image/jpeg', 'image/gif', 'image/webp']) {
+      const attachments = await loadAttachments(JSON.parse(JSON.stringify({
+        attachments: [{ fileName: 'photo', mediaType, data }],
+      })));
+      const blocks = await buildContentBlocks(attachments, 'Describe this image');
+      assert.equal(blocks[0].type, 'image');
+      assert.equal(blocks[0].source.type, 'base64');
+      assert.equal(blocks[0].source.media_type, mediaType);
+      assert.equal(blocks[0].source.data === data, true, `${size} bytes must survive unchanged`);
+      assert.deepEqual(blocks[1], { type: 'text', text: 'Describe this image' });
+    }
+  }
+});
+
+test('preserves multiple images and provides text for image-only messages', async () => {
+  const attachments = [
+    { fileName: 'first.png', mediaType: 'image/png', data: 'AQ==' },
+    { fileName: 'second.jpg', mediaType: 'image/jpeg', data: 'Ag==' },
+  ];
+  assert.deepEqual(await loadAttachments(attachments), attachments);
+  const blocks = await buildContentBlocks(attachments, '  ');
+  assert.deepEqual(blocks.map(block => block.type), ['image', 'image', 'text']);
+  assert.equal(blocks[2].text, '[Uploaded 2 image(s)]');
+});
+
+test('preserves non-image attachment and empty-message fallbacks', async () => {
+  assert.deepEqual(await buildContentBlocks([], ''), [{ type: 'text', text: '[Empty message]' }]);
+  assert.deepEqual(await buildContentBlocks([{ fileName: 'notes.txt' }, {}], ''), [
+    { type: 'text', text: '[Attachment: notes.txt]' },
+    { type: 'text', text: '[Attachment: Attachment]' },
+    { type: 'text', text: '[Uploaded attachment(s)]' },
+  ]);
+});
+
+test('reads a large attachment through the bridge stdin protocol without truncation', () => {
+  const data = Buffer.alloc(1024 * 1024, 0xab).toString('base64');
+  const moduleUrl = new URL('./attachment-service.js', import.meta.url).href;
+  const stdinModuleUrl = new URL('../../utils/stdin-utils.js', import.meta.url).href;
+  const child = spawnSync(process.execPath, ['--input-type=module', '-e', `
+    import { loadAttachments, buildContentBlocks } from ${JSON.stringify(moduleUrl)};
+    import { readStdinData } from ${JSON.stringify(stdinModuleUrl)};
+    const input = await readStdinData();
+    const blocks = await buildContentBlocks(await loadAttachments(input), input.message);
+    process.stdout.write(JSON.stringify(blocks));
+  `], {
+    env: { ...process.env, CLAUDE_USE_STDIN: 'true' },
+    input: JSON.stringify({
+      message: 'Describe the image',
+      attachments: [{ mediaType: 'image/png', data }],
+    }),
+    encoding: 'utf8',
+    maxBuffer: 4 * 1024 * 1024,
+    timeout: 10000,
+  });
+  assert.ifError(child.error);
+  assert.equal(child.status, 0, child.stderr);
+  const blocks = JSON.parse(child.stdout);
+  assert.equal(blocks[0].type, 'image');
+  assert.equal(blocks[0].source.data === data, true);
+});
+
+test('retains legacy attachment-file loading while preferring explicit stdin attachments', async t => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-gui-attachment-test-'));
+  const file = path.join(directory, 'attachments.json');
+  const previous = process.env.CLAUDE_ATTACHMENTS_FILE;
+  t.after(async () => {
+    if (previous === undefined) delete process.env.CLAUDE_ATTACHMENTS_FILE;
+    else process.env.CLAUDE_ATTACHMENTS_FILE = previous;
+    await fs.unlink(file);
+    await fs.rmdir(directory);
+  });
+  delete process.env.CLAUDE_ATTACHMENTS_FILE;
+  assert.deepEqual(await loadAttachments(null), []);
+  process.env.CLAUDE_ATTACHMENTS_FILE = file;
+  const attachments = [{ mediaType: 'image/png', data: 'AQ==' }];
+  await fs.writeFile(file, JSON.stringify(attachments));
+  assert.deepEqual(await loadAttachments(null), attachments);
+  assert.deepEqual(await loadAttachments({ attachments: [] }), []);
+  await fs.writeFile(file, '{}');
+  assert.deepEqual(await loadAttachments({}), []);
+  await fs.writeFile(file, '{');
+  assert.deepEqual(await loadAttachments(null), []);
+});
+
+test('cleans legacy temporary images without deleting recent uploads', async t => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'cc-gui-image-cleanup-test-'));
+  const images = path.join(directory, 'cc-gui-images');
+  const stale = path.join(images, 'stale.png');
+  const recent = path.join(images, 'recent.png');
+  t.mock.method(os, 'tmpdir', () => directory);
+  t.after(async () => {
+    await fs.unlink(stale).catch(() => {});
+    await fs.unlink(recent).catch(() => {});
+    await fs.rmdir(images);
+    await fs.rmdir(directory);
+  });
+  await cleanupStaleTempImages();
+  await fs.mkdir(images);
+  await fs.writeFile(stale, 'old image');
+  await fs.writeFile(recent, 'recent image');
+  const oldTime = new Date(Date.now() - 48 * 60 * 60 * 1000);
+  await fs.utimes(stale, oldTime, oldTime);
+  await cleanupStaleTempImages();
+  await assert.rejects(fs.stat(stale), { code: 'ENOENT' });
+  assert.equal(await fs.readFile(recent, 'utf8'), 'recent image');
+});

--- a/ai-bridge/services/claude/message-sender-anthropic.js
+++ b/ai-bridge/services/claude/message-sender-anthropic.js
@@ -81,7 +81,7 @@ export async function sendMessageWithAnthropicSDK(message, resumeSessionId, cwd,
     console.log('[DEBUG] Auth type:', authType || 'api_key (default)');
 
     const userContent = (Array.isArray(attachments) && attachments.length > 0)
-      ? await buildContentBlocks(attachments, message, modelId)
+      ? await buildContentBlocks(attachments, message)
       : [{ type: 'text', text: message }];
 
     persistJsonlMessage(sessionId, cwd, {

--- a/ai-bridge/services/claude/message-sender.js
+++ b/ai-bridge/services/claude/message-sender.js
@@ -586,7 +586,7 @@ export async function sendMessageWithAttachments(message, resumeSessionId = null
     console.log('[DEBUG] (withAttachments) Model:', model, '->', resolvedAttachModel);
     setModelEnvironmentVariables(resolvedAttachModel, model);
 
-    const contentBlocks = await buildContentBlocks(attachments, message, resolvedAttachModel);
+    const contentBlocks = await buildContentBlocks(attachments, message);
     const userMessage = {
       type: 'user', session_id: '', parent_tool_use_id: null,
       message: { role: 'user', content: contentBlocks }

--- a/ai-bridge/services/claude/persistent-query-service.images.integration.test.mjs
+++ b/ai-bridge/services/claude/persistent-query-service.images.integration.test.mjs
@@ -1,0 +1,140 @@
+import { testHomeDir } from './testing/cli-login-home.js';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { __testing } from './persistent-query-service.js';
+import { createImageFixture } from './testing/image-fixture.js';
+
+const sdkPath = process.env.CLAUDE_IMAGE_TEST_SDK_PATH;
+
+// The optional SDK lives outside this repository. Only use an explicitly selected
+// installation, with isolated settings, a dummy key and a loopback API endpoint.
+test('sends uploads and @ Read results through the real persistent SDK to the API', {
+  skip: !sdkPath && 'Set CLAUDE_IMAGE_TEST_SDK_PATH to an installed sdk.mjs',
+  timeout: 60000,
+}, async t => {
+  const { query } = await import(pathToFileURL(sdkPath).href);
+  const originalCwd = process.cwd();
+  const previousCliPath = process.env.CLAUDE_CODE_PATH;
+  // Exercise isolation even on machines without a custom CLI configured.
+  process.env.CLAUDE_CODE_PATH = path.join(testHomeDir, 'unrelated-cli');
+  t.after(() => {
+    if (previousCliPath === undefined) delete process.env.CLAUDE_CODE_PATH;
+    else process.env.CLAUDE_CODE_PATH = previousCliPath;
+  });
+  let requests = [];
+  let referencePath;
+  const server = createServer(async (req, res) => {
+    let raw = '';
+    for await (const part of req) raw += part;
+    res.setHeader('Content-Type', 'application/json');
+    if (!req.url.startsWith('/v1/messages') || req.url.includes('count_tokens')) {
+      res.end(JSON.stringify({ input_tokens: 1 }));
+      return;
+    }
+    const payload = JSON.parse(raw);
+    requests.push(payload);
+    const requestRead = referencePath && requests.length === 1;
+    const block = requestRead
+      ? { type: 'tool_use', id: 'tool_image_test', name: 'Read', input: { file_path: referencePath } }
+      : { type: 'text', text: 'ok' };
+    const message = {
+      id: 'msg_image_test', type: 'message', role: 'assistant', model: payload.model,
+      content: [block], stop_reason: requestRead ? 'tool_use' : 'end_turn', stop_sequence: null,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    if (!payload.stream) {
+      res.end(JSON.stringify(message));
+      return;
+    }
+    res.setHeader('Content-Type', 'text/event-stream');
+    const events = [
+      { type: 'message_start', message: { ...message, content: [], stop_reason: null } },
+      { type: 'content_block_start', index: 0, content_block: requestRead
+        ? { ...block, input: {} } : { type: 'text', text: '' } },
+      { type: 'content_block_delta', index: 0, delta: requestRead
+        ? { type: 'input_json_delta', partial_json: JSON.stringify(block.input) }
+        : { type: 'text_delta', text: 'ok' } },
+      { type: 'content_block_stop', index: 0 },
+      { type: 'message_delta', delta: { stop_reason: message.stop_reason, stop_sequence: null },
+        usage: { output_tokens: 1 } },
+      { type: 'message_stop' },
+    ];
+    for (const event of events) res.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
+    res.end();
+  });
+  t.after(async () => {
+    await __testing.resetState();
+    process.chdir(originalCwd);
+    server.closeAllConnections();
+    await new Promise(resolve => server.close(resolve));
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const env = {
+    PATH: process.env.PATH, SystemRoot: process.env.SystemRoot,
+    TEMP: testHomeDir, TMP: testHomeDir, HOME: testHomeDir, USERPROFILE: testHomeDir,
+    CLAUDE_CONFIG_DIR: testHomeDir,
+    ANTHROPIC_API_KEY: 'local-image-test-key',
+    ANTHROPIC_BASE_URL: `http://127.0.0.1:${server.address().port}`,
+    ANTHROPIC_DEFAULT_SONNET_MODEL: 'custom-vision-model',
+    CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: '1', CLAUDE_CODE_ENTRYPOINT: 'cli', USER_TYPE: 'external',
+    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1', DISABLE_TELEMETRY: '1', DISABLE_ERROR_REPORTING: '1',
+  };
+
+  const imageDirectory = path.join(testHomeDir, 'issue 1725 image fixtures');
+  await mkdir(imageDirectory, { recursive: true });
+  for (const width of [128, 132, 600, 2100]) {
+    const png = createImageFixture(width);
+    const filename = path.join(imageDirectory, `photo-${width}.png`);
+    await writeFile(filename, png);
+    for (const kind of ['upload', 'reference']) {
+      await t.test(`${kind}: ${png.length} byte PNG through a provider model alias`, { timeout: 15000 }, async () => {
+        requests = [];
+        referencePath = kind === 'reference' ? filename : undefined;
+        const context = await __testing.buildRequestContext({
+          cwd: testHomeDir, model: 'claude-sonnet-4-6', disableThinking: true,
+          message: kind === 'reference' ? `@${filename} Describe this image` : 'Describe this image',
+          attachments: kind === 'upload' ? [{ mediaType: 'image/png', data: png.toString('base64') }] : [],
+        }, kind === 'upload', { settings: { env } });
+        const abortController = new AbortController();
+        const timeout = setTimeout(() => abortController.abort(), 12000);
+        __testing.setQueryFn(args => query({ ...args, options: {
+          ...args.options, env, settingSources: [], persistSession: false, enableFileCheckpointing: false,
+          // Keep a developer's custom CLI override from replacing the selected SDK's binary.
+          pathToClaudeCodeExecutable: undefined,
+          tools: ['Read'], mcpServers: {}, maxTurns: 2, abortController,
+        } }));
+        try {
+          const runtime = await __testing.acquireRuntime(context);
+          await __testing.executeTurn(runtime, context);
+          assert.equal(requests.length, kind === 'reference' ? 2 : 1);
+          const lastRequest = requests.at(-1);
+          assert.equal(lastRequest.model, 'custom-vision-model');
+          const blocks = lastRequest.messages.flatMap(message => message.content);
+          const images = kind === 'reference'
+            ? blocks.filter(block => block.type === 'tool_result' && block.tool_use_id === 'tool_image_test')
+              .flatMap(block => block.content).filter(block => block.type === 'image')
+            : blocks.filter(block => block.type === 'image');
+          assert.equal(images.length, 1, 'The API must receive visual content, not just a file path');
+          const image = images[0].source;
+          assert.equal(image.type, 'base64');
+          const bytes = Buffer.from(image.data, 'base64');
+          assert.ok(bytes.length > 0);
+          if (image.media_type === 'image/png') {
+            assert.deepEqual(bytes.subarray(0, 8), png.subarray(0, 8));
+          } else {
+            assert.equal(image.media_type, 'image/jpeg');
+            assert.equal(bytes.subarray(0, 2).toString('hex'), 'ffd8');
+            assert.equal(bytes.subarray(-2).toString('hex'), 'ffd9');
+          }
+        } finally {
+          clearTimeout(timeout);
+          await __testing.resetState();
+        }
+      });
+    }
+  }
+});

--- a/ai-bridge/services/claude/persistent-query-service.images.test.mjs
+++ b/ai-bridge/services/claude/persistent-query-service.images.test.mjs
@@ -1,0 +1,56 @@
+// Keep request construction independent of the developer's credentials.
+import './testing/cli-login-home.js';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { __testing } from './persistent-query-service.js';
+import { createScriptedQuery, RESULT_OK } from './testing/scripted-query.js';
+
+for (const resolvedModel of ['claude-sonnet-4-6', 'custom-vision-model', 'qwen-vl', 'sonnet']) {
+  test(`delivers image blocks to the SDK when the provider maps to ${resolvedModel}`, async () => {
+    const data = Buffer.alloc(128 * 1024, 0xab).toString('base64');
+    const context = await __testing.buildRequestContext({
+      model: 'claude-sonnet-4-6',
+      message: 'Describe the photo',
+      attachments: [{ fileName: 'photo.png', mediaType: 'image/png', data }],
+    }, true, {
+      settings: { env: { ANTHROPIC_DEFAULT_SONNET_MODEL: resolvedModel } },
+    });
+
+    assert.equal(context.resolvedModelId, resolvedModel);
+    const blocks = context.userMessage.message.content;
+    assert.equal(blocks[0].type, 'image', 'provider aliases must not turn images into file paths');
+    assert.equal(blocks[0].source.data === data, true, 'image data must remain complete');
+    assert.deepEqual(blocks[1], { type: 'text', text: 'Describe the photo' });
+  });
+}
+
+test('preserves @ reference text when constructing plain messages', async () => {
+  const message = '@"/tmp/photo with spaces.jpg" Describe this image';
+  const context = await __testing.buildRequestContext({ message }, false);
+  assert.deepEqual(context.userMessage.message.content, [{ type: 'text', text: message }]);
+});
+
+test('passes image-only uploads through the persistent runtime input stream', { timeout: 5000 }, async () => {
+  const data = Buffer.alloc(1024 * 1024, 0xab).toString('base64');
+  let query;
+  __testing.setQueryFn(args => {
+    query = createScriptedQuery(args, [[RESULT_OK]]);
+    return query;
+  });
+  try {
+    const context = await __testing.buildRequestContext({
+      model: 'custom-vision-model',
+      attachments: [{ mediaType: 'image/jpeg', fileName: 'photo.jpg', data }],
+    }, true, { settings: { env: {} } });
+    const runtime = await __testing.acquireRuntime(context);
+    await __testing.executeTurn(runtime, context);
+
+    assert.equal(query.inputs.length, 1);
+    const blocks = query.inputs[0].message.content;
+    assert.equal(blocks[0].type, 'image');
+    assert.equal(blocks[0].source.data === data, true);
+    assert.deepEqual(blocks[1], { type: 'text', text: '[Uploaded 1 image(s)]' });
+  } finally {
+    await __testing.resetState();
+  }
+});

--- a/ai-bridge/services/claude/persistent-query-service.js
+++ b/ai-bridge/services/claude/persistent-query-service.js
@@ -161,10 +161,10 @@ function buildQueryOptions(workingDirectory, sdkModelName, permissionMode, maxTh
   };
 }
 
-async function buildUserMessage(params, withAttachments, requestedSessionId, resolvedModelId = null) {
+async function buildUserMessage(params, withAttachments, requestedSessionId) {
   if (withAttachments) {
     const attachments = await loadAttachments({ attachments: params.attachments || [] });
-    const contentBlocks = await buildContentBlocks(attachments, params.message || '', resolvedModelId);
+    const contentBlocks = await buildContentBlocks(attachments, params.message || '');
     return {
       type: 'user',
       session_id: requestedSessionId || '',
@@ -223,7 +223,7 @@ async function buildRequestContext(params, withAttachments, overrides = {}) {
     mcpServers, modelId
   );
 
-  const userMessage = await buildUserMessage(params, withAttachments, requestedSessionId, resolvedModelId);
+  const userMessage = await buildUserMessage(params, withAttachments, requestedSessionId);
 
   const runtimeSignature = buildRuntimeSignature(options, systemPromptAppend, streamingEnabled, runtimeSessionEpoch, modelId);
   console.log('[LIFECYCLE] buildRequestContext sessionId=' + (requestedSessionId || '(new)')

--- a/ai-bridge/services/claude/testing/image-fixture.js
+++ b/ai-bridge/services/claude/testing/image-fixture.js
@@ -1,0 +1,42 @@
+import { deflateSync } from 'node:zlib';
+
+function crc32(bytes) {
+  let crc = -1;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit++) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return (crc ^ -1) >>> 0;
+}
+
+function chunk(type, data) {
+  const body = Buffer.concat([Buffer.from(type), data]);
+  const size = Buffer.alloc(4);
+  size.writeUInt32BE(data.length);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(body));
+  return Buffer.concat([size, body, crc]);
+}
+
+// Deterministic noise keeps valid PNG fixtures large enough to exercise SDK resizing.
+export function createImageFixture(width) {
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0);
+  header.writeUInt32BE(width, 4);
+  header[8] = 8;
+  header[9] = 2;
+  const pixels = Buffer.alloc((width * 3 + 1) * width);
+  let seed = 123456;
+  for (let row = 0; row < width; row++) {
+    for (let col = 1; col <= width * 3; col++) {
+      seed ^= seed << 13;
+      seed ^= seed >>> 17;
+      seed ^= seed << 5;
+      pixels[row * (width * 3 + 1) + col] = seed & 255;
+    }
+  }
+  return Buffer.concat([
+    Buffer.from('89504e470d0a1a0a', 'hex'), chunk('IHDR', header),
+    chunk('IDAT', deflateSync(pixels)), chunk('IEND', Buffer.alloc(0)),
+  ]);
+}

--- a/ai-bridge/utils/model-utils.js
+++ b/ai-bridge/utils/model-utils.js
@@ -143,37 +143,6 @@ export function setModelEnvironmentVariables(modelId, baseModelId) {
   }
 }
 
-/**
- * Determine whether the model natively supports Anthropic vision content blocks.
- *
- * Different models have different vision input capabilities:
- * - Claude models (claude-*): Support Anthropic's standard vision format
- *   via {type: "image", source: {type: "base64", media_type, data}}.
- * - Third-party models (mimo, deepseek, qwen, glm, etc.): Many do not properly
- *   handle Anthropic vision content blocks, especially when routed through
- *   third-party Anthropic-compatible proxies. The image blocks may be silently
- *   dropped during proxy translation, causing the model to report "no image attached".
- *
- * For non-Claude models, the caller should fall back to saving images as temp
- * files and referencing them in the message text, mimicking Claude Code CLI
- * behavior which uses the Read tool to load images from disk.
- *
- * @param {string} modelId - The resolved model name actually sent to the API.
- *                            Examples: "claude-sonnet-4-5", "mimo-v2.5-pro", "MiniMax-M2.5"
- * @returns {boolean} True if the model natively supports Anthropic vision blocks.
- */
-export function modelSupportsVision(modelId) {
-  if (!modelId || typeof modelId !== 'string') {
-    return true;
-  }
-  const lower = modelId.toLowerCase();
-  // Anchor to the canonical "claude-" prefix to avoid matching third-party
-  // model names that merely contain the substring "claude" (e.g.
-  // "claude-compatible-proxy"), which historically yielded false positives
-  // and dropped images for proxies that don't speak Anthropic vision blocks.
-  return lower.startsWith('claude-');
-}
-
 // Note: getClaudeCliPath() has been removed.
 // Now using the SDK's built-in cli.js (at node_modules/@anthropic-ai/claude-agent-sdk/cli.js).
 // This avoids system CLI path issues on Windows (ENOENT errors) and keeps the version aligned with the SDK.

--- a/ai-bridge/utils/model-utils.test.mjs
+++ b/ai-bridge/utils/model-utils.test.mjs
@@ -5,7 +5,6 @@ import {
   mapModelIdToSdkName,
   resolveModelFromSettings,
   setModelEnvironmentVariables,
-  modelSupportsVision,
 } from './model-utils.js';
 
 // --- mapModelIdToSdkName ------------------------------------------------
@@ -199,21 +198,4 @@ test('setModelEnvironmentVariables routes haiku base to haiku env', () => {
       else process.env[key] = value;
     }
   }
-});
-
-// --- modelSupportsVision -------------------------------------------------
-
-test('modelSupportsVision only matches the canonical claude- prefix', () => {
-  assert.equal(modelSupportsVision('claude-sonnet-4-6'), true);
-  assert.equal(modelSupportsVision('claude-fable-5'), true);
-  assert.equal(modelSupportsVision('claude-opus-5'), true);
-  assert.equal(modelSupportsVision('claude-opus-4-8'), true);
-  // Third-party proxies that merely contain "claude" must NOT be treated as
-  // native vision-capable models.
-  assert.equal(modelSupportsVision('claude-compatible-proxy'), true); // starts with 'claude-'
-  assert.equal(modelSupportsVision('mimo-claude-bridge'), false);
-  assert.equal(modelSupportsVision('glm-4.7'), false);
-  assert.equal(modelSupportsVision('deepseek-v4-pro[1m]'), false);
-  assert.equal(modelSupportsVision(''), true);
-  assert.equal(modelSupportsVision(null), true);
 });


### PR DESCRIPTION
## Summary

Fix image input for Claude Code requests routed through third-party model aliases. Issue #1725 reported that images above roughly 50 KB failed in the plugin while the official CLI worked.

## What changed

- Preserve every image attachment as an Anthropic base64 image content block instead of inferring vision support from the model name.
- Remove the non-Claude temporary-file and Read-prompt fallback that discarded structured image input for provider aliases.
- Apply the same content construction to persistent daemon requests, per-process requests, and the direct Anthropic SDK fallback.
- Keep stale-image cleanup for files created by older plugin versions.

## Validation

- Full Claude bridge regression suite: 375 tests, 373 passed, 2 skipped, 0 failed.
- Real Claude Agent SDK loopback integration: 9 passed, covering 49 KB, 52 KB, 1 MB, and 13 MB valid PNGs, upload and Read flows, provider model mapping, and paths containing spaces.
- `git diff --check` and JavaScript syntax checks passed.

The original macOS and third-party relay environment was not available for reproduction, so the tests validate the plugin-side transport and SDK/API request shape without claiming a specific relay's limits.

Refs #1725