### PR TITLE
fix(history): detect session file changes without relying on directory mtime

### DIFF
--- a/src/main/java/com/github/claudecodegui/cache/SessionIndexManager.java
+++ b/src/main/java/com/github/claudecodegui/cache/SessionIndexManager.java
@@ -8,10 +8,13 @@ import com.intellij.openapi.diagnostic.Logger;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /**
@@ -29,6 +32,10 @@ public class SessionIndexManager {
     // Linear backoff base. Sleeps happen while holding indexFileLock, so keep the worst-case
     // total (sum 1..N-1 * base) within ~100ms to avoid blocking concurrent index reads/writes.
     private static final long INDEX_REPLACE_RETRY_DELAY_MS = 10L;
+    private static final Pattern CLAUDE_SESSION_FILE_PATTERN = Pattern.compile(
+            "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\.jsonl$",
+            Pattern.CASE_INSENSITIVE
+    );
 
     // v7 (2026-08): Codex 0.148+ CLI rollouts persist the user prompt as
     // response_item/role=user instead of event_msg/user_message. v6 indexes can
@@ -54,7 +61,12 @@ public class SessionIndexManager {
         this(defaultCacheDir());
     }
 
-    SessionIndexManager(Path codemossCacheDir) {
+    /**
+     * Creates an index manager that stores files under the given cache directory.
+     *
+     * @param codemossCacheDir cache directory for index files
+     */
+    public SessionIndexManager(Path codemossCacheDir) {
         this.codemossCacheDir = codemossCacheDir;
         ensureCacheDir();
     }
@@ -101,7 +113,7 @@ public class SessionIndexManager {
      */
     public enum UpdateType {
         NONE,           // No update needed
-        INCREMENTAL,    // Incremental update (new files only)
+        INCREMENTAL,    // Incremental update (new or modified files)
         FULL            // Full rebuild
     }
 
@@ -178,10 +190,15 @@ public class SessionIndexManager {
     }
 
     /**
-     * Saves the Claude index.
+     * Saves one Claude project entry while preserving concurrent updates to other projects.
+     *
+     * @param projectPath  the Claude project path used as the index key
+     * @param projectIndex the refreshed project index
      */
-    public void saveClaudeIndex(SessionIndex index) {
+    public void saveClaudeProjectIndex(String projectPath, ProjectIndex projectIndex) {
         synchronized (indexFileLock) {
+            SessionIndex index = readIndex(getClaudeIndexPath());
+            index.projects.put(projectPath, projectIndex);
             saveIndex(getClaudeIndexPath(), index);
         }
     }
@@ -336,38 +353,112 @@ public class SessionIndexManager {
      * @return the update type
      */
     public UpdateType getUpdateType(ProjectIndex projectIndex, Path projectDir) {
-        if (projectIndex == null || projectIndex.sessions.isEmpty()) {
+        if (projectIndex == null || projectIndex.sessions == null) {
+            return UpdateType.FULL;
+        }
+        if (projectDir == null || !Files.isDirectory(projectDir)) {
             return UpdateType.FULL;
         }
 
         try {
-            // Check file count
-            long currentFileCount;
+            List<Path> currentFiles = new ArrayList<>();
             try (Stream<Path> paths = Files.list(projectDir)) {
-                currentFileCount = paths.filter(p -> p.toString().endsWith(".jsonl")).count();
+                paths.filter(Files::isRegularFile)
+                        .filter(p -> p.toString().endsWith(".jsonl"))
+                        .forEach(currentFiles::add);
             }
 
-            if (currentFileCount == projectIndex.fileCount) {
-                // File count unchanged; check directory modification time
-                long currentDirModified = Files.getLastModifiedTime(projectDir).toMillis();
-                if (currentDirModified <= projectIndex.lastDirScanTime) {
-                    return UpdateType.NONE;
-                }
-                // Directory timestamp changed but file count is the same -- content may have changed, requiring a full update
-                return UpdateType.FULL;
-            } else if (currentFileCount > projectIndex.fileCount) {
-                // File count increased; an incremental update is sufficient
-                LOG.info("[SessionIndexManager] File count increased: " + projectIndex.fileCount + " -> " + currentFileCount + ", incremental update");
+            long currentFileCount = currentFiles.size();
+            if (currentFileCount > projectIndex.fileCount) {
+                // New files can be added without re-reading unchanged sessions.
+                LOG.info("[SessionIndexManager] File count increased: " + projectIndex.fileCount
+                        + " -> " + currentFileCount + ", incremental update");
                 return UpdateType.INCREMENTAL;
-            } else {
-                // File count decreased; a full update is needed
-                LOG.info("[SessionIndexManager] File count decreased: " + projectIndex.fileCount + " -> " + currentFileCount + ", full update");
+            }
+            if (currentFileCount < projectIndex.fileCount) {
+                // A deleted file must be removed from the index, so rebuild the project.
+                LOG.info("[SessionIndexManager] File count decreased: " + projectIndex.fileCount
+                        + " -> " + currentFileCount + ", full update");
                 return UpdateType.FULL;
             }
+
+            Map<String, BasicFileAttributes> currentFileAttributes = new HashMap<>();
+            for (Path currentFile : currentFiles) {
+                String relativePath = normalizeRelativePath(currentFile.getFileName().toString());
+                currentFileAttributes.put(
+                        relativePath,
+                        Files.readAttributes(currentFile, BasicFileAttributes.class)
+                );
+            }
+
+            Set<String> indexedPaths = new HashSet<>();
+            boolean hasChangedFile = false;
+            for (SessionIndexEntry entry : projectIndex.sessions) {
+                if (entry == null || entry.sessionId == null || entry.sessionId.isEmpty()) {
+                    return UpdateType.FULL;
+                }
+
+                String indexedPath = entry.fileRelativePath;
+                if (indexedPath == null || indexedPath.isEmpty()) {
+                    indexedPath = entry.sessionId + ".jsonl";
+                }
+                indexedPath = normalizeRelativePath(indexedPath);
+                indexedPaths.add(indexedPath);
+
+                BasicFileAttributes currentAttributes = currentFileAttributes.get(indexedPath);
+                if (currentAttributes == null) {
+                    // Rebuild the index when a session file disappears, matching a reduced file count.
+                    return UpdateType.FULL;
+                }
+                if (entry.fileLastModified <= 0
+                        || entry.fileLastModified != currentAttributes.lastModifiedTime().toMillis()
+                        || entry.fileSize != currentAttributes.size()
+                        || entry.entrypoint == null) {
+                    hasChangedFile = true;
+                }
+            }
+
+            if (hasChangedFile) {
+                // Claude appends to existing JSONL files, which changes file metadata but not
+                // the project directory mtime. Let the existing incremental scanner refresh them.
+                return UpdateType.INCREMENTAL;
+            }
+
+            long currentDirModified = Files.getLastModifiedTime(projectDir).toMillis();
+            if (currentDirModified > projectIndex.lastDirScanTime) {
+                // Detect a new Claude session that replaced another file while the total file
+                // count stayed constant. Non-UUID JSONL files are intentionally ignored by
+                // Claude's reader. Gated on the directory mtime so a file that exists but never
+                // produces an index entry (single-message, warmup, or truncated session) does
+                // not trigger a rescan on every read.
+                for (String currentPath : currentFileAttributes.keySet()) {
+                    if (!indexedPaths.contains(currentPath)
+                            && isClaudeSessionFile(currentPath)
+                            && currentFileAttributes.get(currentPath).size() > 0) {
+                        return UpdateType.INCREMENTAL;
+                    }
+                }
+                // A directory change not explained by a known session requires a full rebuild.
+                return UpdateType.FULL;
+            }
+            return UpdateType.NONE;
+        } catch (UncheckedIOException e) {
+            LOG.warn("[SessionIndexManager] Failed to check update type: " + e.getMessage());
+            return UpdateType.FULL;
         } catch (IOException e) {
             LOG.warn("[SessionIndexManager] Failed to check update type: " + e.getMessage());
             return UpdateType.FULL;
         }
+    }
+
+    private static String normalizeRelativePath(String path) {
+        return path.replace('\\', '/').toLowerCase(Locale.ROOT);
+    }
+
+    private static boolean isClaudeSessionFile(String relativePath) {
+        int separator = relativePath.lastIndexOf('/');
+        String fileName = separator >= 0 ? relativePath.substring(separator + 1) : relativePath;
+        return CLAUDE_SESSION_FILE_PATTERN.matcher(fileName).matches();
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/provider/claude/ClaudeHistoryIndexService.java
+++ b/src/main/java/com/github/claudecodegui/provider/claude/ClaudeHistoryIndexService.java
@@ -6,6 +6,7 @@ import com.github.claudecodegui.util.PathUtils;
 import com.intellij.openapi.diagnostic.Logger;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -46,11 +47,21 @@ class ClaudeHistoryIndexService {
     private final Path projectsDir;
     private final ClaudeHistoryParser parser;
     private final ClaudeSessionLiteReader liteReader;
+    private final SessionIndexManager indexManager;
 
     ClaudeHistoryIndexService(Path projectsDir, ClaudeHistoryParser parser) {
+        this(projectsDir, parser, SessionIndexManager.getInstance());
+    }
+
+    ClaudeHistoryIndexService(
+            Path projectsDir,
+            ClaudeHistoryParser parser,
+            SessionIndexManager indexManager
+    ) {
         this.projectsDir = projectsDir;
         this.parser = parser;
         this.liteReader = new ClaudeSessionLiteReader();
+        this.indexManager = indexManager;
     }
 
     /**
@@ -74,9 +85,15 @@ class ClaudeHistoryIndexService {
             return new ArrayList<>();
         }
 
-        // 1. Check memory cache (only for non-paginated requests)
+        // Claude appends messages without changing the parent directory mtime, so inspect files
+        // before trusting the in-memory cache.
+        SessionIndexManager.SessionIndex index = this.indexManager.readClaudeIndex();
+        SessionIndexManager.ProjectIndex projectIndex = index.projects.get(projectPath);
+        SessionIndexManager.UpdateType updateType = this.indexManager.getUpdateType(projectIndex, projectDir);
+
+        // Use the memory cache only after the per-file index check confirms that no session changed.
         SessionIndexCache cache = SessionIndexCache.getInstance();
-        if (limit == 0 && offset == 0) {
+        if (limit == 0 && offset == 0 && updateType == SessionIndexManager.UpdateType.NONE) {
             List<ClaudeHistoryReader.SessionInfo> cachedSessions = cache.getClaudeSessions(projectPath, projectDir);
             if (cachedSessions != null) {
                 LOG.info("[ClaudeHistoryIndexService] Using memory cache for " + projectPath + ", sessions: " + cachedSessions.size());
@@ -84,18 +101,17 @@ class ClaudeHistoryIndexService {
             }
         }
 
-        // 2. Check index file and determine update type
-        SessionIndexManager indexManager = SessionIndexManager.getInstance();
-        SessionIndexManager.SessionIndex index = indexManager.readClaudeIndex();
-        SessionIndexManager.ProjectIndex projectIndex = index.projects.get(projectPath);
-        SessionIndexManager.UpdateType updateType = indexManager.getUpdateType(projectIndex, projectDir);
-
         if (updateType == SessionIndexManager.UpdateType.NONE) {
             // Index is valid, restore from index
             LOG.info("[ClaudeHistoryIndexService] Using file index for " + projectPath + ", sessions: " + projectIndex.sessions.size());
             List<ClaudeHistoryReader.SessionInfo> restored = restoreSessionsFromIndex(projectIndex);
             // Apply pagination if needed
-            List<ClaudeHistoryReader.SessionInfo> paged = applySortAndLimit(restored, limit, offset);
+            List<ClaudeHistoryReader.SessionInfo> paged = applySortAndLimit(
+                    restored,
+                    limit,
+                    offset,
+                    getIndexedMtimes(projectIndex)
+            );
             // Update memory cache (full list, reuse already-restored list)
             if (limit == 0 && offset == 0) {
                 cache.updateClaudeCache(projectPath, projectDir, restored);
@@ -107,11 +123,15 @@ class ClaudeHistoryIndexService {
 
         ScanResult scanResult;
         if (updateType == SessionIndexManager.UpdateType.INCREMENTAL && projectIndex != null) {
-            // 3a. Incremental update: only scan new files using lite-read
+            // Incremental scanning preserves unchanged summaries and refreshes only new or modified files.
             LOG.info("[ClaudeHistoryIndexService] Incremental scan for " + projectPath);
-            scanResult = incrementalScanLite(projectDir, projectIndex);
+            ScanResult incremental = incrementalScanLite(projectDir, projectIndex);
+            scanResult = new ScanResult(
+                    applySortAndLimit(incremental.sessions, limit, offset, incremental.sessionMtimes),
+                    incremental.sessionMtimes
+            );
         } else {
-            // 3b. Full scan using lite-read with pagination support
+            // Full scan using lite-read with pagination support
             LOG.info("[ClaudeHistoryIndexService] Full scan for " + projectPath);
             scanResult = scanProjectSessionsLite(projectDir, limit, offset);
         }
@@ -119,11 +139,15 @@ class ClaudeHistoryIndexService {
         long scanTime = System.currentTimeMillis() - startTime;
         LOG.info("[ClaudeHistoryIndexService] Scan completed in " + scanTime + "ms, sessions: " + scanResult.sessions.size());
 
-        // 4. Update index (for non-paginated full scans)
+        // Persist the refreshed index only for non-paginated requests.
         if (limit == 0 && offset == 0) {
-            updateProjectIndex(index, projectPath, projectDir, scanResult.sessions, scanResult.sessionMtimes);
-            indexManager.saveClaudeIndex(index);
-            // 5. Update memory cache
+            SessionIndexManager.ProjectIndex refreshedProjectIndex = updateProjectIndex(
+                    projectDir,
+                    scanResult.sessions,
+                    scanResult.sessionMtimes
+            );
+            this.indexManager.saveClaudeProjectIndex(projectPath, refreshedProjectIndex);
+            // Update the in-memory cache
             cache.updateClaudeCache(projectPath, projectDir, scanResult.sessions);
         }
 
@@ -156,7 +180,7 @@ class ClaudeHistoryIndexService {
         Map<String, SessionIndexManager.SessionIndexEntry> indexedById = new HashMap<>();
         for (SessionIndexManager.SessionIndexEntry entry : existingIndex.sessions) {
             if (entry != null && entry.sessionId != null) {
-                indexedById.put(entry.sessionId, entry);
+                indexedById.put(normalizeSessionId(entry.sessionId), entry);
             }
         }
 
@@ -183,7 +207,7 @@ class ClaudeHistoryIndexService {
                             skipped.incrementAndGet();
                             return;
                         }
-                        if (attrs.size() <= 0) {
+                        if (!attrs.isRegularFile() || attrs.size() <= 0) {
                             skipped.incrementAndGet();
                             return;
                         }
@@ -193,8 +217,9 @@ class ClaudeHistoryIndexService {
                         if (indexed == null) {
                             newFiles.add(p);
                         } else if (indexed.fileLastModified <= 0 || indexed.fileLastModified != mtime
+                                || indexed.fileSize != attrs.size()
                                 || indexed.entrypoint == null) {
-                            // Re-read when the mtime drifted (active session appended, or legacy
+                            // Re-read when file metadata drifted (active session appended, or legacy
                             // entry without mtime) or when entrypoint was never extracted (entry
                             // persisted by a writer predating extraction) -- restoring such an
                             // entry verbatim would freeze the missing field forever.
@@ -205,11 +230,14 @@ class ClaudeHistoryIndexService {
                             sessionMtimes.put(sessionId, mtime);
                         }
                     });
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
         }
 
         List<ClaudeHistoryReader.SessionInfo> sessions = new ArrayList<>();
         for (SessionIndexManager.SessionIndexEntry entry : existingIndex.sessions) {
-            if (entry != null && entry.sessionId != null && restoredIds.contains(entry.sessionId)) {
+            String sessionId = entry != null ? normalizeSessionId(entry.sessionId) : null;
+            if (sessionId != null && restoredIds.contains(sessionId)) {
                 sessions.add(restoreEntry(entry));
             }
         }
@@ -228,7 +256,7 @@ class ClaudeHistoryIndexService {
                 + newSessions.size() + " new, " + restoredIds.size() + " unchanged, "
                 + skipped.get() + " skipped");
 
-        sessions.sort((a, b) -> Long.compare(b.lastTimestamp, a.lastTimestamp));
+        sessions.sort((a, b) -> compareSessions(a, b, sessionMtimes));
         return new ScanResult(sessions, sessionMtimes);
     }
 
@@ -273,7 +301,7 @@ class ClaudeHistoryIndexService {
                         if (doStat) {
                             try {
                                 BasicFileAttributes attrs = Files.readAttributes(p, BasicFileAttributes.class);
-                                if (attrs.size() <= 0) {
+                                if (!attrs.isRegularFile() || attrs.size() <= 0) {
                                     return;
                                 }
                                 mtime = attrs.lastModifiedTime().toMillis();
@@ -284,9 +312,39 @@ class ClaudeHistoryIndexService {
 
                         candidates.add(new SessionCandidate(sessionId, p, mtime));
                     });
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
         }
 
         return candidates;
+    }
+
+    private static int compareSessions(
+            ClaudeHistoryReader.SessionInfo first,
+            ClaudeHistoryReader.SessionInfo second,
+            Map<String, Long> sessionMtimes
+    ) {
+        long firstTimestamp = getSortTimestamp(first, sessionMtimes);
+        long secondTimestamp = getSortTimestamp(second, sessionMtimes);
+        int timestampComparison = Long.compare(secondTimestamp, firstTimestamp);
+        if (timestampComparison != 0) {
+            return timestampComparison;
+        }
+        String firstId = first.sessionId != null ? first.sessionId : "";
+        String secondId = second.sessionId != null ? second.sessionId : "";
+        return secondId.compareTo(firstId);
+    }
+
+    private static long getSortTimestamp(
+            ClaudeHistoryReader.SessionInfo session,
+            Map<String, Long> sessionMtimes
+    ) {
+        Long mtime = sessionMtimes.get(normalizeSessionId(session.sessionId));
+        return mtime != null && mtime > 0 ? mtime : session.lastTimestamp;
+    }
+
+    private static String normalizeSessionId(String sessionId) {
+        return sessionId != null ? sessionId.toLowerCase(Locale.ROOT) : null;
     }
 
     /**
@@ -302,7 +360,7 @@ class ClaudeHistoryIndexService {
         if (!UUID_PATTERN.matcher(sessionId).matches()) {
             return null;
         }
-        return sessionId.toLowerCase(); // Normalize to lowercase for consistency
+        return normalizeSessionId(sessionId);
     }
 
     /**
@@ -361,8 +419,7 @@ class ClaudeHistoryIndexService {
             i = batchEnd;
         }
 
-        // Final sort by lastTimestamp to ensure correct order
-        sessions.sort((a, b) -> Long.compare(b.lastTimestamp, a.lastTimestamp));
+        sessions.sort((a, b) -> compareSessions(a, b, sessionMtimes));
 
         return sessions;
     }
@@ -384,14 +441,10 @@ class ClaudeHistoryIndexService {
                         return new ReadResult(convertToSessionInfo(liteInfo), liteInfo.lastModified);
                     }
                     // Fallback to full scan if lite-read fails.
-                    ClaudeHistoryReader.SessionInfo info = fallbackFullScan(path);
-                    long mtime = info != null ? safeStatMillis(path) : 0L;
-                    return new ReadResult(info, mtime);
+                    return readFallback(path);
                 } catch (Exception e) {
                     LOG.debug("[ClaudeHistoryIndexService] Lite-read failed for " + path + ", trying fallback: " + e.getMessage());
-                    ClaudeHistoryReader.SessionInfo info = fallbackFullScan(path);
-                    long mtime = info != null ? safeStatMillis(path) : 0L;
-                    return new ReadResult(info, mtime);
+                    return readFallback(path);
                 }
             }, LITE_READ_POOL));
         }
@@ -411,11 +464,18 @@ class ClaudeHistoryIndexService {
         return results;
     }
 
-    private static long safeStatMillis(Path path) {
+    private ReadResult readFallback(Path path) {
+        ClaudeHistoryReader.SessionInfo info = fallbackFullScan(path);
+        if (info == null) {
+            return new ReadResult(null, 0L);
+        }
+        info.sessionId = normalizeSessionId(info.sessionId);
         try {
-            return Files.getLastModifiedTime(path).toMillis();
+            BasicFileAttributes attrs = Files.readAttributes(path, BasicFileAttributes.class);
+            info.fileSize = attrs.size();
+            return new ReadResult(info, attrs.lastModifiedTime().toMillis());
         } catch (IOException e) {
-            return 0L;
+            return new ReadResult(info, 0L);
         }
     }
 
@@ -458,9 +518,10 @@ class ClaudeHistoryIndexService {
     private List<ClaudeHistoryReader.SessionInfo> applySortAndLimit(
             List<ClaudeHistoryReader.SessionInfo> sessions,
             int limit,
-            int offset
+            int offset,
+            Map<String, Long> sessionMtimes
     ) {
-        sessions.sort((a, b) -> Long.compare(b.lastTimestamp, a.lastTimestamp));
+        sessions.sort((a, b) -> compareSessions(a, b, sessionMtimes));
 
         if (offset > 0) {
             sessions = sessions.subList(Math.min(offset, sessions.size()), sessions.size());
@@ -471,6 +532,16 @@ class ClaudeHistoryIndexService {
         }
 
         return new ArrayList<>(sessions);
+    }
+
+    private Map<String, Long> getIndexedMtimes(SessionIndexManager.ProjectIndex projectIndex) {
+        Map<String, Long> sessionMtimes = new HashMap<>();
+        for (SessionIndexManager.SessionIndexEntry entry : projectIndex.sessions) {
+            if (entry != null && entry.sessionId != null && entry.fileLastModified > 0) {
+                sessionMtimes.put(normalizeSessionId(entry.sessionId), entry.fileLastModified);
+            }
+        }
+        return sessionMtimes;
     }
 
     /**
@@ -489,7 +560,7 @@ class ClaudeHistoryIndexService {
      */
     private ClaudeHistoryReader.SessionInfo restoreEntry(SessionIndexManager.SessionIndexEntry entry) {
         ClaudeHistoryReader.SessionInfo session = new ClaudeHistoryReader.SessionInfo();
-        session.sessionId = entry.sessionId;
+        session.sessionId = normalizeSessionId(entry.sessionId);
         session.title = entry.title;
         session.messageCount = entry.messageCount;
         session.lastTimestamp = entry.lastTimestamp;
@@ -504,9 +575,7 @@ class ClaudeHistoryIndexService {
      * Update project index. Uses mtimes captured during the scan phase so no second
      * stat call is required.
      */
-    private void updateProjectIndex(
-            SessionIndexManager.SessionIndex index,
-            String projectPath,
+    private SessionIndexManager.ProjectIndex updateProjectIndex(
             Path projectDir,
             List<ClaudeHistoryReader.SessionInfo> sessions,
             Map<String, Long> sessionMtimes
@@ -515,7 +584,10 @@ class ClaudeHistoryIndexService {
         projectIndex.lastDirScanTime = System.currentTimeMillis();
 
         try (Stream<Path> paths = Files.list(projectDir)) {
-            projectIndex.fileCount = (int) paths.filter(p -> p.toString().endsWith(".jsonl")).count();
+            projectIndex.fileCount = (int) paths.filter(p -> p.toString().endsWith(".jsonl"))
+                    .filter(Files::isRegularFile).count();
+        } catch (UncheckedIOException e) {
+            projectIndex.fileCount = sessions.size();
         } catch (IOException e) {
             projectIndex.fileCount = sessions.size();
         }
@@ -538,7 +610,7 @@ class ClaudeHistoryIndexService {
             projectIndex.sessions.add(entry);
         }
 
-        index.projects.put(projectPath, projectIndex);
+        return projectIndex;
     }
 
     /**

--- a/src/test/java/com/github/claudecodegui/cache/SessionIndexManagerUpdateTest.java
+++ b/src/test/java/com/github/claudecodegui/cache/SessionIndexManagerUpdateTest.java
@@ -1,0 +1,196 @@
+package com.github.claudecodegui.cache;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Verifies that Claude index update detection follows individual session-file changes instead of
+ * relying only on the project directory timestamp.
+ */
+public class SessionIndexManagerUpdateTest {
+
+    private static final String SESSION_ID = "aaaaaaaa-1111-4111-8111-111111111111";
+    private static final long INDEXED_FILE_MTIME = 1_700_000_000_000L;
+    private static final long DIRECTORY_MTIME = 1_700_000_100_000L;
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void getUpdateType_detectsModifiedSessionWhenDirectoryMtimeIsUnchanged() throws IOException {
+        Path projectDir = tmp.newFolder("claude-project").toPath();
+        Path sessionFile = projectDir.resolve(SESSION_ID + ".jsonl");
+        Files.writeString(sessionFile, "initial\n");
+        Files.setLastModifiedTime(sessionFile, FileTime.fromMillis(INDEXED_FILE_MTIME));
+        Files.setLastModifiedTime(projectDir, FileTime.fromMillis(DIRECTORY_MTIME));
+
+        SessionIndexManager.ProjectIndex projectIndex = projectIndex(INDEXED_FILE_MTIME);
+        SessionIndexManager manager = new SessionIndexManager(tmp.newFolder("codemoss-cache").toPath());
+
+        assertEquals(SessionIndexManager.UpdateType.NONE, manager.getUpdateType(projectIndex, projectDir));
+
+        Files.writeString(sessionFile, "appended\n", java.nio.file.StandardOpenOption.APPEND);
+        Files.setLastModifiedTime(sessionFile, FileTime.fromMillis(INDEXED_FILE_MTIME + 2_000));
+        Files.setLastModifiedTime(projectDir, FileTime.fromMillis(DIRECTORY_MTIME));
+
+        assertEquals(SessionIndexManager.UpdateType.INCREMENTAL, manager.getUpdateType(projectIndex, projectDir));
+    }
+
+    @Test
+    public void getUpdateType_detectsSizeChangeWhenMtimeIsUnchanged() throws IOException {
+        Path projectDir = tmp.newFolder("claude-project-size").toPath();
+        Path sessionFile = projectDir.resolve(SESSION_ID + ".jsonl");
+        Files.writeString(sessionFile, "initial\n");
+        Files.setLastModifiedTime(sessionFile, FileTime.fromMillis(INDEXED_FILE_MTIME));
+        Files.setLastModifiedTime(projectDir, FileTime.fromMillis(DIRECTORY_MTIME));
+
+        SessionIndexManager.ProjectIndex projectIndex = projectIndex(INDEXED_FILE_MTIME);
+        SessionIndexManager manager = new SessionIndexManager(tmp.newFolder("codemoss-cache-size").toPath());
+
+        assertEquals(SessionIndexManager.UpdateType.NONE, manager.getUpdateType(projectIndex, projectDir));
+
+        Files.writeString(
+                sessionFile,
+                "appended\n",
+                java.nio.file.StandardOpenOption.APPEND
+        );
+        Files.setLastModifiedTime(sessionFile, FileTime.fromMillis(INDEXED_FILE_MTIME));
+        Files.setLastModifiedTime(projectDir, FileTime.fromMillis(DIRECTORY_MTIME));
+
+        assertEquals(SessionIndexManager.UpdateType.INCREMENTAL, manager.getUpdateType(projectIndex, projectDir));
+    }
+
+    @Test
+    public void getUpdateType_rechecksLegacyEntrypointEntries() throws IOException {
+        Path projectDir = tmp.newFolder("claude-project-legacy").toPath();
+        Path sessionFile = projectDir.resolve(SESSION_ID + ".jsonl");
+        Files.writeString(sessionFile, "session\n");
+        Files.setLastModifiedTime(sessionFile, FileTime.fromMillis(INDEXED_FILE_MTIME));
+        Files.setLastModifiedTime(projectDir, FileTime.fromMillis(DIRECTORY_MTIME));
+
+        SessionIndexManager.ProjectIndex projectIndex = projectIndex(INDEXED_FILE_MTIME);
+        projectIndex.sessions.get(0).entrypoint = null;
+        SessionIndexManager manager = new SessionIndexManager(tmp.newFolder("codemoss-cache-legacy").toPath());
+
+        assertEquals(SessionIndexManager.UpdateType.INCREMENTAL, manager.getUpdateType(projectIndex, projectDir));
+    }
+
+    @Test
+    public void getUpdateType_rebuildsWhenSessionIsReplacedAtTheSameFileCount() throws IOException {
+        Path projectDir = tmp.newFolder("replaced-session").toPath();
+        Files.writeString(projectDir.resolve("bbbbbbbb-2222-4222-8222-222222222222.jsonl"), "new session\n");
+        Files.setLastModifiedTime(projectDir, FileTime.fromMillis(DIRECTORY_MTIME));
+        SessionIndexManager manager = new SessionIndexManager(tmp.newFolder("replaced-cache").toPath());
+
+        assertEquals(SessionIndexManager.UpdateType.FULL, manager.getUpdateType(projectIndex(INDEXED_FILE_MTIME), projectDir));
+    }
+
+    @Test
+    public void getUpdateType_acceptsUppercaseFilenameAndLegacyMissingPath() throws IOException {
+        Path projectDir = tmp.newFolder("uppercase-session").toPath();
+        Path sessionFile = projectDir.resolve(SESSION_ID.toUpperCase(java.util.Locale.ROOT) + ".jsonl");
+        Files.writeString(sessionFile, "session\n");
+        Files.setLastModifiedTime(sessionFile, FileTime.fromMillis(INDEXED_FILE_MTIME));
+        Files.setLastModifiedTime(projectDir, FileTime.fromMillis(DIRECTORY_MTIME));
+        SessionIndexManager.ProjectIndex index = projectIndex(INDEXED_FILE_MTIME);
+        index.sessions.get(0).fileRelativePath = null;
+        SessionIndexManager manager = new SessionIndexManager(tmp.newFolder("uppercase-cache").toPath());
+
+        assertEquals(SessionIndexManager.UpdateType.NONE, manager.getUpdateType(index, projectDir));
+        index.sessions.get(0).fileLastModified = 0;
+        assertEquals(SessionIndexManager.UpdateType.INCREMENTAL, manager.getUpdateType(index, projectDir));
+    }
+
+    @Test
+    public void getUpdateType_acceptsAnUnchangedEmptyProject() throws IOException {
+        Path projectDir = tmp.newFolder("empty-project").toPath();
+        Files.setLastModifiedTime(projectDir, FileTime.fromMillis(DIRECTORY_MTIME));
+        SessionIndexManager.ProjectIndex projectIndex = new SessionIndexManager.ProjectIndex();
+        projectIndex.lastDirScanTime = DIRECTORY_MTIME;
+        projectIndex.fileCount = 0;
+        SessionIndexManager manager = new SessionIndexManager(tmp.newFolder("empty-cache").toPath());
+
+        assertEquals(SessionIndexManager.UpdateType.NONE, manager.getUpdateType(projectIndex, projectDir));
+    }
+
+    @Test
+    public void getUpdateType_doesNotRescanPersistentEmptySessionFile() throws IOException {
+        Path projectDir = tmp.newFolder("empty-session-file").toPath();
+        Files.createFile(projectDir.resolve(SESSION_ID + ".jsonl"));
+        Files.setLastModifiedTime(projectDir, FileTime.fromMillis(DIRECTORY_MTIME));
+
+        SessionIndexManager.ProjectIndex projectIndex = new SessionIndexManager.ProjectIndex();
+        projectIndex.lastDirScanTime = DIRECTORY_MTIME;
+        projectIndex.fileCount = 1;
+        SessionIndexManager manager = new SessionIndexManager(tmp.newFolder("empty-session-cache").toPath());
+
+        assertEquals(SessionIndexManager.UpdateType.NONE, manager.getUpdateType(projectIndex, projectDir));
+    }
+
+    @Test
+    public void getUpdateType_ignoresUnindexedSessionFileWhenDirectoryIsUnchanged() throws IOException {
+        // A non-empty session file that never produces an index entry (single-message or
+        // truncated session) must not trigger a rescan on every read while the directory
+        // itself is unchanged; a later directory change still surfaces it as incremental.
+        Path projectDir = tmp.newFolder("unindexed-session").toPath();
+        Path indexedFile = projectDir.resolve(SESSION_ID + ".jsonl");
+        Files.writeString(indexedFile, "initial\n");
+        Files.setLastModifiedTime(indexedFile, FileTime.fromMillis(INDEXED_FILE_MTIME));
+        Files.writeString(projectDir.resolve("bbbbbbbb-2222-4222-8222-222222222222.jsonl"), "single line\n");
+        Files.setLastModifiedTime(projectDir, FileTime.fromMillis(DIRECTORY_MTIME));
+
+        SessionIndexManager.ProjectIndex projectIndex = projectIndex(INDEXED_FILE_MTIME);
+        projectIndex.fileCount = 2;
+        SessionIndexManager manager = new SessionIndexManager(tmp.newFolder("unindexed-cache").toPath());
+
+        assertEquals(SessionIndexManager.UpdateType.NONE, manager.getUpdateType(projectIndex, projectDir));
+
+        Files.setLastModifiedTime(projectDir, FileTime.fromMillis(DIRECTORY_MTIME + 1_000));
+        assertEquals(SessionIndexManager.UpdateType.INCREMENTAL, manager.getUpdateType(projectIndex, projectDir));
+    }
+
+    @Test
+    public void saveClaudeProjectIndex_preservesOtherProjects() throws IOException {
+        SessionIndexManager manager = new SessionIndexManager(tmp.newFolder("project-merge-cache").toPath());
+        SessionIndexManager.ProjectIndex firstProject = new SessionIndexManager.ProjectIndex();
+        SessionIndexManager.ProjectIndex secondProject = new SessionIndexManager.ProjectIndex();
+
+        manager.saveClaudeProjectIndex("first", firstProject);
+        manager.saveClaudeProjectIndex("second", secondProject);
+
+        SessionIndexManager.SessionIndex saved = manager.readClaudeIndex();
+        assertNotNull(saved.projects.get("first"));
+        assertNotNull(saved.projects.get("second"));
+        assertEquals(0, saved.projects.get("first").sessions.size());
+        assertEquals(0, saved.projects.get("second").sessions.size());
+    }
+
+    private SessionIndexManager.ProjectIndex projectIndex(long fileMtime) {
+        SessionIndexManager.ProjectIndex projectIndex = new SessionIndexManager.ProjectIndex();
+        projectIndex.lastDirScanTime = DIRECTORY_MTIME;
+        projectIndex.fileCount = 1;
+        SessionIndexManager.SessionIndexEntry entry = SessionIndexManager.createEntry(
+                SESSION_ID,
+                "Existing session",
+                1,
+                1_700_000_000_000L,
+                1_700_000_000_000L,
+                8L,
+                fileMtime,
+                null,
+                ""
+        );
+        entry.fileRelativePath = SESSION_ID + ".jsonl";
+        projectIndex.sessions.add(entry);
+        return projectIndex;
+    }
+}

--- a/src/test/java/com/github/claudecodegui/provider/claude/ClaudeHistoryIndexServiceTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/claude/ClaudeHistoryIndexServiceTest.java
@@ -1,5 +1,6 @@
 package com.github.claudecodegui.provider.claude;
 
+import com.github.claudecodegui.cache.SessionIndexCache;
 import com.github.claudecodegui.cache.SessionIndexManager;
 import org.junit.Rule;
 import org.junit.Test;
@@ -8,6 +9,8 @@ import org.junit.rules.TemporaryFolder;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -44,8 +47,14 @@ public class ClaudeHistoryIndexServiceTest {
         SessionIndexManager.ProjectIndex existing = new SessionIndexManager.ProjectIndex();
         existing.lastDirScanTime = System.currentTimeMillis();
         existing.fileCount = 2;
-        existing.sessions.add(entry(UUID_1, "STALE A", 1, mtimeA + 1000, mtimeA + 1000, UUID_1 + ".jsonl"));
-        existing.sessions.add(entry(UUID_2, "Hello B", 1, mtimeB, mtimeB, UUID_2 + ".jsonl"));
+        SessionIndexManager.SessionIndexEntry staleA =
+                entry(UUID_1, "STALE A", 1, mtimeA + 1000, mtimeA + 1000, UUID_1 + ".jsonl");
+        staleA.fileSize = Files.size(fileA);
+        SessionIndexManager.SessionIndexEntry unchangedB =
+                entry(UUID_2, "Hello B", 1, mtimeB, mtimeB, UUID_2 + ".jsonl");
+        unchangedB.fileSize = Files.size(fileB);
+        existing.sessions.add(staleA);
+        existing.sessions.add(unchangedB);
 
         ClaudeHistoryIndexService service = newService(projectDir);
         ClaudeHistoryIndexService.ScanResult result = service.incrementalScanLite(projectDir, existing);
@@ -72,7 +81,10 @@ public class ClaudeHistoryIndexServiceTest {
         SessionIndexManager.ProjectIndex existing = new SessionIndexManager.ProjectIndex();
         existing.lastDirScanTime = System.currentTimeMillis();
         existing.fileCount = 1;
-        existing.sessions.add(entry(UUID_1, "Existing A", 1, mtimeA, mtimeA, UUID_1 + ".jsonl"));
+        SessionIndexManager.SessionIndexEntry existingEntry =
+                entry(UUID_1, "Existing A", 1, mtimeA, mtimeA, UUID_1 + ".jsonl");
+        existingEntry.fileSize = Files.size(fileA);
+        existing.sessions.add(existingEntry);
 
         writeSession(projectDir, UUID_3, "Brand New", "2026-04-21T11:00:00Z");
 
@@ -104,6 +116,69 @@ public class ClaudeHistoryIndexServiceTest {
 
         assertEquals(1, result.sessions().size());
         assertEquals("legacy entry should be refreshed from file", "Fresh A", result.sessions().get(0).title);
+    }
+
+    @Test
+    public void incrementalScan_refreshesSizeChangedFileWhenMtimeIsUnchanged() throws IOException {
+        Path projectDir = tmp.newFolder("claude-index-size").toPath();
+        Path file = writeSession(projectDir, UUID_1, "Original", "2026-04-21T10:00:00Z");
+        long mtime = Files.getLastModifiedTime(file).toMillis();
+
+        SessionIndexManager.ProjectIndex existing = new SessionIndexManager.ProjectIndex();
+        existing.fileCount = 1;
+        SessionIndexManager.SessionIndexEntry indexed = entry(
+                UUID_1, "Original", 1, mtime, mtime, UUID_1 + ".jsonl");
+        indexed.fileSize = Files.size(file);
+        existing.sessions.add(indexed);
+
+        Files.writeString(
+                file,
+                "{\"type\":\"assistant\",\"customTitle\":\"Updated\"}\n",
+                java.nio.file.StandardOpenOption.APPEND
+        );
+        Files.setLastModifiedTime(file, FileTime.fromMillis(mtime));
+
+        ClaudeHistoryIndexService.ScanResult result = newService(projectDir)
+                .incrementalScanLite(projectDir, existing);
+
+        assertEquals(1, result.sessions().size());
+        assertEquals("Updated", result.sessions().get(0).title);
+    }
+
+    @Test
+    public void incrementalScan_usesSessionIdToBreakTimestampTies() throws IOException {
+        Path projectDir = tmp.newFolder("claude-index-tie-order").toPath();
+        Path first = writeSession(projectDir, UUID_1, "First", "2026-04-21T10:00:00Z");
+        Path second = writeSession(projectDir, UUID_2, "Second", "2026-04-21T10:00:00Z");
+        long mtime = 1_700_000_000_000L;
+        Files.setLastModifiedTime(first, FileTime.fromMillis(mtime));
+        Files.setLastModifiedTime(second, FileTime.fromMillis(mtime));
+
+        SessionIndexManager.ProjectIndex existing = new SessionIndexManager.ProjectIndex();
+        existing.fileCount = 2;
+        SessionIndexManager.SessionIndexEntry secondEntry = entry(
+                UUID_2, "Second", 1, mtime, mtime, UUID_2 + ".jsonl");
+        secondEntry.fileSize = Files.size(second);
+        SessionIndexManager.SessionIndexEntry firstEntry = entry(
+                UUID_1, "First", 1, mtime, mtime, UUID_1 + ".jsonl");
+        firstEntry.fileSize = Files.size(first);
+        existing.sessions.add(secondEntry);
+        existing.sessions.add(firstEntry);
+
+        Files.writeString(
+                second,
+                "{\"type\":\"assistant\",\"customTitle\":\"Updated second\"}\n",
+                java.nio.file.StandardOpenOption.APPEND
+        );
+        Files.setLastModifiedTime(second, FileTime.fromMillis(mtime));
+
+        ClaudeHistoryIndexService.ScanResult result = newService(projectDir)
+                .incrementalScanLite(projectDir, existing);
+
+        assertEquals(2, result.sessions().size());
+        assertEquals("equal timestamps must use a stable descending ID order",
+                UUID_2, result.sessions().get(0).sessionId);
+        assertEquals(UUID_1, result.sessions().get(1).sessionId);
     }
 
     @Test
@@ -140,7 +215,10 @@ public class ClaudeHistoryIndexServiceTest {
         SessionIndexManager.ProjectIndex existing = new SessionIndexManager.ProjectIndex();
         existing.lastDirScanTime = System.currentTimeMillis();
         existing.fileCount = 1;
-        existing.sessions.add(entry(UUID_1, "RESTORED TITLE", 1, mtime, mtime, UUID_1 + ".jsonl"));
+        SessionIndexManager.SessionIndexEntry restoredEntry =
+                entry(UUID_1, "RESTORED TITLE", 1, mtime, mtime, UUID_1 + ".jsonl");
+        restoredEntry.fileSize = Files.size(file);
+        existing.sessions.add(restoredEntry);
 
         ClaudeHistoryIndexService service = newService(projectDir);
         ClaudeHistoryIndexService.ScanResult result = service.incrementalScanLite(projectDir, existing);
@@ -195,6 +273,125 @@ public class ClaudeHistoryIndexServiceTest {
         assertEquals(UUID_1, result.sessions().get(0).sessionId);
         assertTrue("mtime map should use normalized lowercase key",
                 result.sessionMtimes().containsKey(UUID_1));
+    }
+
+    @Test
+    public void incrementalScan_matchesUppercaseIndexedSessionId() throws IOException {
+        Path projectDir = tmp.newFolder("claude-index-uppercase-index").toPath();
+        String uppercaseUuid = UUID_1.toUpperCase(java.util.Locale.ROOT);
+        Path file = writeSession(projectDir, uppercaseUuid, "Upper Case", "2026-04-21T10:00:00Z");
+        long mtime = Files.getLastModifiedTime(file).toMillis();
+
+        SessionIndexManager.ProjectIndex existing = new SessionIndexManager.ProjectIndex();
+        existing.lastDirScanTime = System.currentTimeMillis();
+        existing.fileCount = 1;
+        SessionIndexManager.SessionIndexEntry uppercaseEntry =
+                entry(uppercaseUuid, "Upper Case", 1, mtime, mtime, uppercaseUuid + ".jsonl");
+        uppercaseEntry.fileSize = Files.size(file);
+        existing.sessions.add(uppercaseEntry);
+
+        ClaudeHistoryIndexService.ScanResult result = newService(projectDir).incrementalScanLite(projectDir, existing);
+
+        assertEquals(1, result.sessions().size());
+        assertEquals(UUID_1, result.sessions().get(0).sessionId);
+        assertEquals("Upper Case", result.sessions().get(0).title);
+    }
+
+    @Test
+    public void readProjectSessions_reloadsChangedFileWhenDirectoryMtimeIsUnchanged() throws IOException {
+        Path projectsDir = tmp.newFolder("claude-projects").toPath();
+        String projectPath = "claude-index-reload-" + tmp.getRoot().getName();
+        Path projectDir = projectsDir.resolve(projectPath);
+        Files.createDirectories(projectDir);
+        Path sessionFile = writeSession(projectDir, UUID_1, "Original title", "2026-04-21T10:00:00Z");
+
+        long indexedFileMtime = Files.getLastModifiedTime(sessionFile).toMillis();
+        long directoryMtime = Files.getLastModifiedTime(projectDir).toMillis();
+        SessionIndexCache cache = SessionIndexCache.getInstance();
+        SessionIndexManager indexManager = new SessionIndexManager(tmp.newFolder("reload-index-cache").toPath());
+        cache.clearProject(projectPath);
+
+        try {
+            ClaudeHistoryIndexService service = new ClaudeHistoryIndexService(
+                    projectsDir, new ClaudeHistoryParser(), indexManager);
+            List<ClaudeHistoryReader.SessionInfo> initial = service.readProjectSessions(projectPath);
+            assertEquals(1, initial.size());
+            assertEquals("Original title", initial.get(0).title);
+            assertEquals(1, initial.get(0).messageCount);
+
+            Files.writeString(
+                    sessionFile,
+                    "{\"type\":\"assistant\",\"customTitle\":\"Updated title\"}\n",
+                    java.nio.file.StandardOpenOption.APPEND
+            );
+            Files.setLastModifiedTime(sessionFile, FileTime.fromMillis(indexedFileMtime + 2_000));
+            Files.setLastModifiedTime(projectDir, FileTime.fromMillis(directoryMtime));
+
+            List<ClaudeHistoryReader.SessionInfo> updated = service.readProjectSessions(projectPath);
+            assertEquals(1, updated.size());
+            assertEquals("Updated title", updated.get(0).title);
+            assertEquals(2, updated.get(0).messageCount);
+        } finally {
+            cache.clearProject(projectPath);
+            indexManager.clearProjectIndex("claude", projectPath);
+        }
+    }
+
+    @Test
+    public void readProjectSessions_appliesPaginationAfterIncrementalRefresh() throws IOException {
+        Path projectsDir = tmp.newFolder("paginated-projects").toPath();
+        String projectPath = "paginated-" + tmp.getRoot().getName();
+        Path projectDir = Files.createDirectory(projectsDir.resolve(projectPath));
+        Path first = writeSession(projectDir, UUID_1, "First", "2026-04-21T10:00:00Z");
+        Path second = writeSession(projectDir, UUID_2, "Second", "2026-04-21T11:00:00Z");
+        Files.setLastModifiedTime(first, FileTime.fromMillis(1_700_000_000_000L));
+        Files.setLastModifiedTime(second, FileTime.fromMillis(1_700_000_002_000L));
+        long directoryMtime = Files.getLastModifiedTime(projectDir).toMillis();
+        SessionIndexManager indexManager = new SessionIndexManager(tmp.newFolder("isolated-index-cache").toPath());
+        SessionIndexCache cache = SessionIndexCache.getInstance();
+        cache.clearProject(projectPath);
+        try {
+            ClaudeHistoryIndexService service = new ClaudeHistoryIndexService(
+                    projectsDir, new ClaudeHistoryParser(), indexManager);
+            assertEquals(2, service.readProjectSessions(projectPath).size());
+            Files.setLastModifiedTime(first, FileTime.fromMillis(1_700_000_004_000L));
+            Files.setLastModifiedTime(projectDir, FileTime.fromMillis(directoryMtime));
+
+            List<ClaudeHistoryReader.SessionInfo> page = service.readProjectSessions(projectPath, 1, 0);
+            assertEquals(1, page.size());
+            assertEquals(UUID_1, page.get(0).sessionId);
+            page = service.readProjectSessions(projectPath, 1, 1);
+            assertEquals(1, page.size());
+            assertEquals(UUID_2, page.get(0).sessionId);
+            assertTrue(service.readProjectSessions(projectPath, 1, 2).isEmpty());
+            assertEquals(2, service.readProjectSessions(projectPath).size());
+        } finally {
+            cache.clearProject(projectPath);
+            indexManager.clearProjectIndex("claude", projectPath);
+        }
+    }
+
+    @Test
+    public void readProjectSessions_ignoresJsonlDirectoriesInPersistedFileCount() throws IOException {
+        Path projectsDir = tmp.newFolder("directory-projects").toPath();
+        String projectPath = "directory-" + tmp.getRoot().getName();
+        Path projectDir = Files.createDirectory(projectsDir.resolve(projectPath));
+        writeSession(projectDir, UUID_1, "Real session", "2026-04-21T10:00:00Z");
+        Files.createDirectory(projectDir.resolve(UUID_2 + ".jsonl"));
+        SessionIndexManager indexManager = new SessionIndexManager(tmp.newFolder("isolated-index-cache").toPath());
+        SessionIndexCache cache = SessionIndexCache.getInstance();
+        cache.clearProject(projectPath);
+        try {
+            ClaudeHistoryIndexService service = new ClaudeHistoryIndexService(
+                    projectsDir, new ClaudeHistoryParser(), indexManager);
+            assertEquals(1, service.readProjectSessions(projectPath).size());
+            SessionIndexManager.ProjectIndex index = indexManager.readClaudeIndex().projects.get(projectPath);
+            assertEquals(1, index.fileCount);
+            assertEquals(SessionIndexManager.UpdateType.NONE, indexManager.getUpdateType(index, projectDir));
+        } finally {
+            cache.clearProject(projectPath);
+            indexManager.clearProjectIndex("claude", projectPath);
+        }
     }
 
     // --- helpers -----------------------------------------------------------


### PR DESCRIPTION
## Problem

Claude appends new messages to the existing session `.jsonl` file without updating the parent project directory's mtime. The previous cache-invalidation logic relied on directory mtime plus file count, which caused:

- Active sessions kept serving stale index entries (title / lastTimestamp / messageCount) until something else happened to touch the directory.
- Any file-count change (new or deleted session) triggered a full rescan of every session file in the project, even though the incremental scanner only needs the new/changed files.
- Paginated history requests (`limit`/`offset`) bypassed the persisted index entirely and always performed a lite full scan; their ordering (sort by `lastTimestamp` only) was unstable, so page boundaries could shift between requests.
- `saveClaudeIndex` rewrote the whole index file, so refreshing one project could discard concurrent index updates written for other projects.

## Solution

- `SessionIndexManager.getUpdateType` now compares per-file `mtime`/`size` against the persisted index: appended files go through the incremental scanner, removed files trigger a full rebuild, and same-count replacements (a new session file replacing another) are detected by combining file attributes with a directory-mtime gate. The "unindexed UUID file" detection is gated on directory mtime so files that can never produce an index entry (single-message, warmup, truncated sessions) cannot trigger a rescan on every read.
- New `saveClaudeProjectIndex` persists a single project entry under the existing lock, re-reading the file first so concurrent updates to other projects survive.
- `ClaudeHistoryIndexService` consults the per-file index check before trusting the in-memory cache, restores paginated requests from the persisted index, and sorts with a stable tie-break (file mtime, then session id) so page boundaries stay consistent.
- Session ids and relative paths are normalized to lowercase so index entries match disk files regardless of case; fallback reads now also populate `fileSize` so appended-session detection works for restored sessions.

## Testing

- New `SessionIndexManagerUpdateTest` covers append / remove / replace / no-op update detection, including a regression test for the rescan loop caused by unindexable session files.
- `ClaudeHistoryIndexServiceTest` extended for paginated index restoration and stable ordering.
- `./gradlew test --tests "com.github.claudecodegui.cache.*" --tests "...ClaudeHistoryIndexServiceTest"` all green; `./gradlew checkstyleMain` clean; `./gradlew buildPlugin` succeeds.