### PR TITLE
feat(webview): dedicated findings card for ReportFindings tool calls

### DIFF
--- a/webview/src/components/MessageItem/ContentBlockRenderer.test.tsx
+++ b/webview/src/components/MessageItem/ContentBlockRenderer.test.tsx
@@ -21,6 +21,12 @@ vi.mock('../toolBlocks', () => ({
   BashToolBlock: () => null,
   EditToolBlock: () => null,
   GenericToolBlock: () => null,
+  ReportFindingsToolBlock: ({ data }: { data: { findings: unknown[] } }) => (
+    <div data-testid="report-findings-block">{data.findings.length}</div>
+  ),
+  parseReportFindingsInput: (input?: { findings?: unknown }) => (
+    Array.isArray(input?.findings) ? { findings: input.findings } : null
+  ),
   TaskExecutionBlock: () => null,
 }));
 
@@ -50,7 +56,36 @@ function renderTextBlock({ isStreaming, isLastBlock }: { isStreaming: boolean; i
   );
 }
 
+function reportFindingsBlock(): ClaudeContentBlock {
+  return {
+    type: 'tool_use',
+    name: 'ReportFindings',
+    input: { findings: [{ summary: 'A structured finding' }] },
+  } as ClaudeContentBlock;
+}
+
 describe('ContentBlockRenderer block-level streaming', () => {
+  it('routes a valid ReportFindings tool call to its structured renderer', () => {
+    render(
+      <ContentBlockRenderer
+        block={reportFindingsBlock()}
+        messageIndex={0}
+        messageType="assistant"
+        isStreaming={false}
+        isThinkingExpanded={false}
+        isThinking={false}
+        isLastMessage={true}
+        isLastBlock={true}
+        t={t}
+        onToggleThinking={() => {}}
+        findToolResult={() => null}
+      />,
+    );
+
+    expect(document.querySelector('[data-testid="report-findings-block"]')?.textContent).toBe('1');
+    expect(document.querySelector('[data-testid="content-block-tool_use"]')).toBeNull();
+  });
+
   it('keeps the last block streaming while the message is still streaming', () => {
     renderTextBlock({ isStreaming: true, isLastBlock: true });
     expect(markdownProps.isStreaming).toBe(true);

--- a/webview/src/components/MessageItem/blocks/ToolUseBlock.tsx
+++ b/webview/src/components/MessageItem/blocks/ToolUseBlock.tsx
@@ -1,12 +1,14 @@
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import {
   BashToolBlock,
   EditToolBlock,
   GenericToolBlock,
+  ReportFindingsToolBlock,
   TaskExecutionBlock,
+  parseReportFindingsInput,
 } from '../../toolBlocks';
 import type { EditToolItem } from '../../toolBlocks/EditToolBlock';
-import { EDIT_TOOL_NAMES, BASH_TOOL_NAMES, TASK_MANAGE_TOOL_NAMES, AGENT_TOOL_NAMES, isToolName, isTransientInternalToolName, normalizeToolName } from '../../../utils/toolConstants';
+import { EDIT_TOOL_NAMES, BASH_TOOL_NAMES, TASK_MANAGE_TOOL_NAMES, AGENT_TOOL_NAMES, REPORT_FINDINGS_TOOL_NAMES, isToolName, isTransientInternalToolName, normalizeToolName } from '../../../utils/toolConstants';
 import type { ClaudeContentBlock, ToolResultBlock } from '../../../types';
 
 /**
@@ -35,6 +37,9 @@ interface ToolUseBlockProps {
 
 export function ToolUseBlock({ block, messageIndex, isStreaming, findToolResult }: ToolUseBlockProps) {
   const toolName = normalizeToolName(block.name ?? '');
+  // Parse once per input snapshot: rebuilding the findings array on every
+  // streaming re-render would defeat the memo on the specialized block.
+  const report = useMemo(() => parseReportFindingsInput(block.input), [block.input]);
 
   if (toolName === 'todowrite' || toolName === 'update_plan' || TASK_MANAGE_TOOL_NAMES.has(toolName)) {
     return null;
@@ -42,6 +47,16 @@ export function ToolUseBlock({ block, messageIndex, isStreaming, findToolResult 
 
   if (!isStreaming && isTransientInternalToolName(block.name)) {
     return null;
+  }
+
+  if (REPORT_FINDINGS_TOOL_NAMES.has(toolName) && report) {
+    return (
+      <ReportFindingsToolBlock
+        data={report}
+        result={findToolResult(block.id, messageIndex)}
+        toolId={block.id}
+      />
+    );
   }
 
   if (AGENT_TOOL_NAMES.has(toolName)) {

--- a/webview/src/components/toolBlocks/ReportFindingsToolBlock.test.tsx
+++ b/webview/src/components/toolBlocks/ReportFindingsToolBlock.test.tsx
@@ -1,0 +1,175 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ToolInput } from '../../types';
+import ReportFindingsToolBlock, { parseReportFindingsInput } from './ReportFindingsToolBlock';
+
+const bridgeMocks = vi.hoisted(() => ({
+  openFile: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number; filePath?: string; level?: string }) => {
+      const translations: Record<string, string> = {
+        'tools.reportFindings.title': 'Report Findings',
+        'tools.reportFindings.confirmed': 'Confirmed',
+        'tools.reportFindings.plausible': 'To review',
+        'tools.reportFindings.fixed': 'Fixed',
+        'tools.reportFindings.skipped': 'Skipped',
+        'tools.reportFindings.noChangeNeeded': 'No change needed',
+        'tools.reportFindings.empty': 'No findings',
+        'tools.reportFindings.summaryLabel': 'Review summary',
+        'tools.reportFindings.summary': 'Summary',
+        'tools.reportFindings.failureScenario': 'Failure scenario',
+        'tools.reportFindings.expandFinding': 'Expand finding',
+        'tools.reportFindings.collapseFinding': 'Collapse finding',
+        'tools.reportFindings.expandReport': 'Expand findings report',
+        'tools.reportFindings.collapseReport': 'Collapse findings report',
+        'tools.reportFindings.untitled': 'Untitled finding',
+      };
+      if (key === 'tools.reportFindings.findingsCount') {
+        return `${options?.count ?? 0} findings`;
+      }
+      if (key === 'tools.reportFindings.confirmedCount') {
+        return `${options?.count ?? 0} confirmed`;
+      }
+      if (key === 'tools.reportFindings.plausibleCount') {
+        return `${options?.count ?? 0} to review`;
+      }
+      if (key === 'tools.reportFindings.reviewLevel') {
+        return `Review level: ${options?.level ?? ''}`;
+      }
+      if (key === 'tools.reportFindings.openFile') {
+        return `Open ${options?.filePath ?? ''}`;
+      }
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('../../hooks/useIsToolDenied', () => ({
+  useIsToolDenied: () => false,
+}));
+
+vi.mock('../../utils/bridge', () => ({
+  openFile: bridgeMocks.openFile,
+}));
+
+vi.mock('../MarkdownBlock', () => ({
+  default: ({ content }: { content: string }) => <div data-testid="finding-markdown">{content}</div>,
+}));
+
+describe('parseReportFindingsInput', () => {
+  it('normalizes the structured findings payload', () => {
+    const data = parseReportFindingsInput({
+      level: 'high',
+      findings: [{
+        category: 'security',
+        failure_scenario: 'An attacker can submit an unauthenticated request.',
+        file: 'src/MetaInit.java',
+        line: 747,
+        short_summary: 'Unauthenticated entity creation',
+        summary: 'The endpoint can create an entity without checking the caller.',
+        verdict: 'CONFIRMED',
+        outcome: 'fixed',
+      }],
+    });
+
+    expect(data).toEqual({
+      level: 'high',
+      findings: [{
+        category: 'security',
+        failureScenario: 'An attacker can submit an unauthenticated request.',
+        file: 'src/MetaInit.java',
+        line: 747,
+        shortSummary: 'Unauthenticated entity creation',
+        summary: 'The endpoint can create an entity without checking the caller.',
+        verdict: 'CONFIRMED',
+        outcome: 'fixed',
+      }],
+    });
+  });
+
+  it('rejects malformed payloads so the generic renderer can take over', () => {
+    expect(parseReportFindingsInput({ findings: '{not-json' })).toBeNull();
+    expect(parseReportFindingsInput({ findings: { file: 'src/App.tsx' } })).toBeNull();
+    expect(parseReportFindingsInput({})).toBeNull();
+  });
+});
+
+describe('ReportFindingsToolBlock', () => {
+  it('renders findings as readable rows and opens their file location', () => {
+    const data = parseReportFindingsInput({
+      findings: [
+        {
+          category: 'security',
+          failure_scenario: 'An attacker can submit an unauthenticated request.',
+          file: 'src/MetaInit.java',
+          line: 747,
+          short_summary: 'Unauthenticated entity creation',
+          summary: 'The endpoint can create an entity without checking the caller.',
+          verdict: 'CONFIRMED',
+        },
+        {
+          category: 'correctness',
+          file: 'src/SessionState.java',
+          line: 42,
+          short_summary: 'Stale state survives a reset',
+          verdict: 'PLAUSIBLE',
+        },
+      ],
+    });
+
+    render(<ReportFindingsToolBlock data={data!} result={{ type: 'tool_result' }} />);
+
+    expect(screen.getByText('Report Findings')).toBeTruthy();
+    expect(screen.getByText('2 findings')).toBeTruthy();
+    expect(screen.getByText('Unauthenticated entity creation')).toBeTruthy();
+    expect(screen.getByText('Stale state survives a reset')).toBeTruthy();
+    expect(screen.getByText('security')).toBeTruthy();
+    expect(screen.getByText('Confirmed')).toBeTruthy();
+    expect(screen.getByText('To review')).toBeTruthy();
+    expect(screen.getByText('src/MetaInit.java')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open src/MetaInit.java' }));
+    expect(bridgeMocks.openFile).toHaveBeenCalledWith('src/MetaInit.java', 747);
+  });
+
+  it('reveals the summary and failure scenario only after expanding a finding', () => {
+    const data = parseReportFindingsInput({
+      findings: [{
+        file: 'src/App.tsx',
+        short_summary: 'Invalid state transition',
+        summary: 'The state transition accepts an invalid input.',
+        failure_scenario: 'When the callback runs twice, the second call uses stale data.',
+      }],
+    });
+
+    render(<ReportFindingsToolBlock data={data!} result={{ type: 'tool_result' }} />);
+
+    expect(screen.queryByText('The state transition accepts an invalid input.')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Expand finding' }));
+    expect(screen.getByText('Summary')).toBeTruthy();
+    expect(screen.getByText('The state transition accepts an invalid input.')).toBeTruthy();
+    expect(screen.getByText('Failure scenario')).toBeTruthy();
+    expect(screen.getByText('When the callback runs twice, the second call uses stale data.')).toBeTruthy();
+  });
+
+  it('shows an explicit empty state and can collapse the report', () => {
+    render(
+      <ReportFindingsToolBlock
+        data={{ findings: [] }}
+        result={{ type: 'tool_result' }}
+      />,
+    );
+
+    expect(screen.getByText('No findings')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse findings report' }));
+    expect(screen.queryByText('No findings')).toBeNull();
+  });
+
+  it('keeps malformed input available to the generic renderer', () => {
+    const malformedInput = { findings: 42 } as unknown as ToolInput;
+    expect(parseReportFindingsInput(malformedInput)).toBeNull();
+  });
+});

--- a/webview/src/components/toolBlocks/ReportFindingsToolBlock.tsx
+++ b/webview/src/components/toolBlocks/ReportFindingsToolBlock.tsx
@@ -1,0 +1,282 @@
+import { memo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { ToolInput, ToolResultBlock } from '../../types';
+import { useIsToolDenied } from '../../hooks/useIsToolDenied';
+import { openFile } from '../../utils/bridge';
+import { truncate, truncatePathFromStart } from '../../utils/helpers';
+import MarkdownBlock from '../MarkdownBlock';
+
+export interface ReportFinding {
+  category?: string;
+  failureScenario?: string;
+  file?: string;
+  line?: number;
+  shortSummary?: string;
+  summary?: string;
+  verdict?: 'CONFIRMED' | 'PLAUSIBLE';
+  outcome?: 'fixed' | 'skipped' | 'no_change_needed';
+}
+
+export interface ReportFindingsData {
+  findings: ReportFinding[];
+  level?: string;
+}
+
+type RecordValue = Record<string, unknown>;
+
+const isRecord = (value: unknown): value is RecordValue =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const readText = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+};
+
+const readLine = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : undefined;
+
+// Parser output is normalized to the schema's own enum values, so these maps
+// double as both the label i18n key tail and the row/verdict class name.
+const VERDICT_LABEL_KEYS = { CONFIRMED: 'confirmed', PLAUSIBLE: 'plausible' } as const;
+const OUTCOME_LABEL_KEYS = { fixed: 'fixed', skipped: 'skipped', no_change_needed: 'noChangeNeeded' } as const;
+
+const readVerdict = (value: unknown): ReportFinding['verdict'] => {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.toUpperCase() as keyof typeof VERDICT_LABEL_KEYS;
+  return normalized in VERDICT_LABEL_KEYS ? normalized : undefined;
+};
+
+const readOutcome = (value: unknown): ReportFinding['outcome'] => {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.toLowerCase() as keyof typeof OUTCOME_LABEL_KEYS;
+  return normalized in OUTCOME_LABEL_KEYS ? normalized : undefined;
+};
+
+const parseFinding = (value: unknown): ReportFinding | null => {
+  if (!isRecord(value)) return null;
+
+  const finding: ReportFinding = {
+    category: readText(value.category),
+    failureScenario: readText(value.failure_scenario),
+    file: readText(value.file),
+    line: readLine(value.line),
+    shortSummary: readText(value.short_summary),
+    summary: readText(value.summary),
+    verdict: readVerdict(value.verdict),
+    outcome: readOutcome(value.outcome),
+  };
+
+  // Drop fully empty entries: a row with no text and no location is pure noise.
+  return finding.shortSummary || finding.summary || finding.failureScenario || finding.file
+    ? finding
+    : null;
+};
+
+/**
+ * Parse the structured input accepted by the ReportFindings tool.
+ * Invalid payloads return null so callers can preserve the generic tool view.
+ */
+export function parseReportFindingsInput(input?: ToolInput): ReportFindingsData | null {
+  if (!input || !Array.isArray(input.findings)) return null;
+
+  const findings = input.findings.map(parseFinding).filter((finding): finding is ReportFinding => finding !== null);
+  // Every entry unusable means the payload is garbage; the generic card shows the raw input.
+  if (input.findings.length > 0 && findings.length === 0) return null;
+
+  return {
+    findings,
+    level: readText(input.level),
+  };
+}
+
+interface ReportFindingRowProps {
+  finding: ReportFinding;
+}
+
+const ReportFindingRow = memo(function ReportFindingRow({ finding }: ReportFindingRowProps) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const title = truncate(
+    finding.shortSummary ?? finding.summary ?? finding.failureScenario ?? finding.file ?? t('tools.reportFindings.untitled'),
+    140,
+  );
+  const hasDetails = Boolean(finding.summary || finding.failureScenario);
+  const verdictKey = finding.verdict ? VERDICT_LABEL_KEYS[finding.verdict] : undefined;
+  const outcomeKey = finding.outcome ? OUTCOME_LABEL_KEYS[finding.outcome] : undefined;
+  // No verdict is the norm for inline reviews (verdict is set only after a verify
+  // pass), so unverified findings get a neutral outline instead of a warning icon.
+  const verdictIcon = verdictKey === 'confirmed'
+    ? 'codicon-pass'
+    : verdictKey === 'plausible'
+      ? 'codicon-warning'
+      : 'codicon-circle-outline';
+
+  const handleOpenFile = () => {
+    if (finding.file) {
+      openFile(finding.file, finding.line);
+    }
+  };
+
+  return (
+    <article className={`report-finding-row ${verdictKey ?? 'unverified'}`}>
+      <div className="report-finding-main">
+        <div className="report-finding-title-row">
+          <span className={`codicon ${verdictIcon} report-finding-verdict-icon`} aria-hidden="true" />
+          <span className="report-finding-title" title={finding.shortSummary ?? finding.summary}>
+            {title}
+          </span>
+          {finding.category && (
+            <span className="report-finding-category">{finding.category}</span>
+          )}
+          {verdictKey && (
+            <span className={`report-finding-verdict report-finding-verdict-${verdictKey}`}>
+              {t(`tools.reportFindings.${verdictKey}`)}
+            </span>
+          )}
+          {outcomeKey && (
+            <span className={`report-finding-outcome report-finding-outcome-${finding.outcome}`}>
+              {t(`tools.reportFindings.${outcomeKey}`)}
+            </span>
+          )}
+        </div>
+
+        {finding.file && (
+          <button
+            type="button"
+            className="report-finding-location"
+            onClick={handleOpenFile}
+            title={t('tools.reportFindings.openFile', { filePath: finding.file })}
+            aria-label={t('tools.reportFindings.openFile', { filePath: finding.file })}
+          >
+            <span className="codicon codicon-file-code" aria-hidden="true" />
+            <span className="report-finding-path">{truncatePathFromStart(finding.file, 64)}</span>
+            {finding.line !== undefined && (
+              <span className="report-finding-line">:{finding.line}</span>
+            )}
+          </button>
+        )}
+      </div>
+
+      {hasDetails && (
+        <button
+          type="button"
+          className="report-finding-toggle"
+          onClick={() => setExpanded((previous) => !previous)}
+          aria-expanded={expanded}
+          aria-label={expanded
+            ? t('tools.reportFindings.collapseFinding')
+            : t('tools.reportFindings.expandFinding')}
+          title={expanded
+            ? t('tools.reportFindings.collapseFinding')
+            : t('tools.reportFindings.expandFinding')}
+        >
+          <span className={`codicon codicon-chevron-${expanded ? 'up' : 'down'}`} aria-hidden="true" />
+        </button>
+      )}
+
+      {expanded && (
+        <div className="report-finding-details">
+          {finding.summary && (
+            <div className="report-finding-detail">
+              <div className="report-finding-detail-label">{t('tools.reportFindings.summary')}</div>
+              <MarkdownBlock content={finding.summary} />
+            </div>
+          )}
+          {finding.failureScenario && (
+            <div className="report-finding-detail">
+              <div className="report-finding-detail-label">{t('tools.reportFindings.failureScenario')}</div>
+              <MarkdownBlock content={finding.failureScenario} />
+            </div>
+          )}
+        </div>
+      )}
+    </article>
+  );
+});
+
+interface ReportFindingsToolBlockProps {
+  data: ReportFindingsData;
+  result?: ToolResultBlock | null;
+  toolId?: string;
+}
+
+const ReportFindingsToolBlock = memo(function ReportFindingsToolBlock({
+  data,
+  result,
+  toolId,
+}: ReportFindingsToolBlockProps) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(true);
+  const isDenied = useIsToolDenied(toolId);
+  const isCompleted = result !== undefined && result !== null;
+  const isError = isDenied || (isCompleted && result?.is_error === true);
+  const confirmedCount = data.findings.filter((finding) => finding.verdict === 'CONFIRMED').length;
+  const plausibleCount = data.findings.filter((finding) => finding.verdict === 'PLAUSIBLE').length;
+
+  return (
+    <div className="task-container report-findings-container">
+      <button
+        type="button"
+        className={`task-header report-findings-header ${expanded ? 'task-header-expanded' : ''}`}
+        onClick={() => setExpanded((previous) => !previous)}
+        aria-expanded={expanded}
+        aria-label={expanded
+          ? t('tools.reportFindings.collapseReport')
+          : t('tools.reportFindings.expandReport')}
+      >
+        <span className="task-title-section">
+          <span className="codicon codicon-checklist tool-title-icon" aria-hidden="true" />
+          <span className="tool-title-text">{t('tools.reportFindings.title')}</span>
+          <span className="report-findings-count">
+            {t('tools.reportFindings.findingsCount', { count: data.findings.length })}
+          </span>
+        </span>
+        <span className="task-header-right">
+          <span className={`tool-status-indicator ${isError ? 'error' : isCompleted ? 'completed' : 'pending'}`} />
+          <span className={`codicon codicon-chevron-${expanded ? 'up' : 'down'} report-findings-chevron`} aria-hidden="true" />
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="report-findings-content">
+          {data.findings.length === 0 ? (
+            <div className="report-findings-empty" role="status">
+              {t('tools.reportFindings.empty')}
+            </div>
+          ) : (
+            <>
+              <div className="report-findings-summary" aria-label={t('tools.reportFindings.summaryLabel')}>
+                {confirmedCount > 0 && (
+                  <span className="report-findings-summary-item confirmed">
+                    <span className="codicon codicon-pass" aria-hidden="true" />
+                    {t('tools.reportFindings.confirmedCount', { count: confirmedCount })}
+                  </span>
+                )}
+                {plausibleCount > 0 && (
+                  <span className="report-findings-summary-item plausible">
+                    <span className="codicon codicon-warning" aria-hidden="true" />
+                    {t('tools.reportFindings.plausibleCount', { count: plausibleCount })}
+                  </span>
+                )}
+                {data.level && (
+                  <span className="report-findings-level">
+                    {t('tools.reportFindings.reviewLevel', { level: data.level })}
+                  </span>
+                )}
+              </div>
+
+              <div className="report-findings-list">
+                {data.findings.map((finding, index) => (
+                  <ReportFindingRow key={index} finding={finding} />
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});
+
+export default ReportFindingsToolBlock;

--- a/webview/src/components/toolBlocks/index.ts
+++ b/webview/src/components/toolBlocks/index.ts
@@ -1,4 +1,5 @@
 export { default as GenericToolBlock } from './GenericToolBlock';
+export { default as ReportFindingsToolBlock, parseReportFindingsInput } from './ReportFindingsToolBlock';
 export { default as TaskExecutionBlock } from './TaskExecutionBlock';
 export { default as ReadToolBlock } from './ReadToolBlock';
 export { default as ReadToolGroupBlock } from './ReadToolGroupBlock';

--- a/webview/src/i18n/locales/en.json
+++ b/webview/src/i18n/locales/en.json
@@ -1792,7 +1792,32 @@
     "bashGroupFailed": "failed",
     "promptLabel": "Prompt",
     "updatePlan": "Update Plan",
-    "applyPatch": "Apply Patch"
+    "applyPatch": "Apply Patch",
+    "reportFindings": {
+      "title": "Report Findings",
+      "findingsCount_one": "{{count}} finding",
+      "findingsCount_other": "{{count}} findings",
+      "confirmedCount_one": "{{count}} confirmed",
+      "confirmedCount_other": "{{count}} confirmed",
+      "plausibleCount_one": "{{count}} to review",
+      "plausibleCount_other": "{{count}} to review",
+      "confirmed": "Confirmed",
+      "plausible": "To review",
+      "fixed": "Fixed",
+      "skipped": "Skipped",
+      "noChangeNeeded": "No change needed",
+      "empty": "No findings",
+      "summaryLabel": "Review summary",
+      "summary": "Summary",
+      "failureScenario": "Failure scenario",
+      "reviewLevel": "Review level: {{level}}",
+      "openFile": "Open {{filePath}}",
+      "expandFinding": "Expand finding",
+      "collapseFinding": "Collapse finding",
+      "expandReport": "Expand findings report",
+      "collapseReport": "Collapse findings report",
+      "untitled": "Untitled finding"
+    }
   },
   "todo": {
     "inProgress": "In Progress {{completed}}/{{total}} tasks",

--- a/webview/src/i18n/locales/es.json
+++ b/webview/src/i18n/locales/es.json
@@ -1349,7 +1349,32 @@
     "bashGroupBatchExecution": "Batch Execution",
     "bashGroupCompleted": "completed",
     "bashGroupAllCompleted": "All Completed",
-    "bashGroupFailed": "failed"
+    "bashGroupFailed": "failed",
+    "reportFindings": {
+      "title": "Hallazgos de la revisión",
+      "findingsCount_one": "{{count}} hallazgo",
+      "findingsCount_other": "{{count}} hallazgos",
+      "confirmedCount_one": "{{count}} confirmado",
+      "confirmedCount_other": "{{count}} confirmados",
+      "plausibleCount_one": "{{count}} por revisar",
+      "plausibleCount_other": "{{count}} por revisar",
+      "confirmed": "Confirmado",
+      "plausible": "Por revisar",
+      "fixed": "Corregido",
+      "skipped": "Omitido",
+      "noChangeNeeded": "Sin cambios necesarios",
+      "empty": "Sin hallazgos",
+      "summaryLabel": "Resumen de la revisión",
+      "summary": "Resumen",
+      "failureScenario": "Escenario de fallo",
+      "reviewLevel": "Nivel de revisión: {{level}}",
+      "openFile": "Abrir {{filePath}}",
+      "expandFinding": "Expandir hallazgo",
+      "collapseFinding": "Contraer hallazgo",
+      "expandReport": "Expandir informe de hallazgos",
+      "collapseReport": "Contraer informe de hallazgos",
+      "untitled": "Hallazgo sin título"
+    }
   },
   "todo": {
     "inProgress": "En progreso {{completed}}/{{total}} tareas",

--- a/webview/src/i18n/locales/fr.json
+++ b/webview/src/i18n/locales/fr.json
@@ -1349,7 +1349,32 @@
     "bashGroupBatchExecution": "Batch Execution",
     "bashGroupCompleted": "completed",
     "bashGroupAllCompleted": "All Completed",
-    "bashGroupFailed": "failed"
+    "bashGroupFailed": "failed",
+    "reportFindings": {
+      "title": "Constats de la revue",
+      "findingsCount_one": "{{count}} constat",
+      "findingsCount_other": "{{count}} constats",
+      "confirmedCount_one": "{{count}} confirmé",
+      "confirmedCount_other": "{{count}} confirmés",
+      "plausibleCount_one": "{{count}} à vérifier",
+      "plausibleCount_other": "{{count}} à vérifier",
+      "confirmed": "Confirmé",
+      "plausible": "À vérifier",
+      "fixed": "Corrigé",
+      "skipped": "Ignoré",
+      "noChangeNeeded": "Aucune modification requise",
+      "empty": "Aucun constat",
+      "summaryLabel": "Résumé de la revue",
+      "summary": "Résumé",
+      "failureScenario": "Scénario d'échec",
+      "reviewLevel": "Niveau de revue : {{level}}",
+      "openFile": "Ouvrir {{filePath}}",
+      "expandFinding": "Déplier le constat",
+      "collapseFinding": "Replier le constat",
+      "expandReport": "Déplier les constats",
+      "collapseReport": "Replier les constats",
+      "untitled": "Constat sans titre"
+    }
   },
   "todo": {
     "inProgress": "En cours {{completed}}/{{total}} tâches",

--- a/webview/src/i18n/locales/hi.json
+++ b/webview/src/i18n/locales/hi.json
@@ -1349,7 +1349,32 @@
     "bashGroupBatchExecution": "Batch Execution",
     "bashGroupCompleted": "completed",
     "bashGroupAllCompleted": "All Completed",
-    "bashGroupFailed": "failed"
+    "bashGroupFailed": "failed",
+    "reportFindings": {
+      "title": "समीक्षा निष्कर्ष",
+      "findingsCount_one": "{{count}} निष्कर्ष",
+      "findingsCount_other": "{{count}} निष्कर्ष",
+      "confirmedCount_one": "{{count}} पुष्ट",
+      "confirmedCount_other": "{{count}} पुष्ट",
+      "plausibleCount_one": "{{count}} समीक्षा शेष",
+      "plausibleCount_other": "{{count}} समीक्षा शेष",
+      "confirmed": "पुष्ट",
+      "plausible": "समीक्षा शेष",
+      "fixed": "ठीक किया गया",
+      "skipped": "छोड़ा गया",
+      "noChangeNeeded": "कोई बदलाव आवश्यक नहीं",
+      "empty": "कोई निष्कर्ष नहीं",
+      "summaryLabel": "समीक्षा सारांश",
+      "summary": "सारांश",
+      "failureScenario": "विफलता परिदृश्य",
+      "reviewLevel": "समीक्षा स्तर: {{level}}",
+      "openFile": "{{filePath}} खोलें",
+      "expandFinding": "निष्कर्ष विस्तृत करें",
+      "collapseFinding": "निष्कर्ष संक्षिप्त करें",
+      "expandReport": "समीक्षा निष्कर्ष विस्तृत करें",
+      "collapseReport": "समीक्षा निष्कर्ष संक्षिप्त करें",
+      "untitled": "शीर्षकहीन निष्कर्ष"
+    }
   },
   "todo": {
     "inProgress": "{{completed}}/{{total}} कार्य प्रगति में",

--- a/webview/src/i18n/locales/ja.json
+++ b/webview/src/i18n/locales/ja.json
@@ -1354,7 +1354,32 @@
     "bashGroupBatchExecution": "Batch Execution",
     "bashGroupCompleted": "completed",
     "bashGroupAllCompleted": "All Completed",
-    "bashGroupFailed": "failed"
+    "bashGroupFailed": "failed",
+    "reportFindings": {
+      "title": "レビュー指摘",
+      "findingsCount_one": "{{count}} 件の指摘",
+      "findingsCount_other": "{{count}} 件の指摘",
+      "confirmedCount_one": "確認済み {{count}} 件",
+      "confirmedCount_other": "確認済み {{count}} 件",
+      "plausibleCount_one": "要確認 {{count}} 件",
+      "plausibleCount_other": "要確認 {{count}} 件",
+      "confirmed": "確認済み",
+      "plausible": "要確認",
+      "fixed": "修正済み",
+      "skipped": "スキップ",
+      "noChangeNeeded": "修正不要",
+      "empty": "指摘はありません",
+      "summaryLabel": "レビュー概要",
+      "summary": "概要",
+      "failureScenario": "発生シナリオ",
+      "reviewLevel": "レビューレベル: {{level}}",
+      "openFile": "{{filePath}} を開く",
+      "expandFinding": "指摘の詳細を展開",
+      "collapseFinding": "指摘の詳細を折りたたむ",
+      "expandReport": "レビュー指摘を展開",
+      "collapseReport": "レビュー指摘を折りたたむ",
+      "untitled": "無題の指摘"
+    }
   },
   "todo": {
     "inProgress": "進行中 {{completed}}/{{total}} タスク",

--- a/webview/src/i18n/locales/ko.json
+++ b/webview/src/i18n/locales/ko.json
@@ -1445,7 +1445,32 @@
     "bashGroupAllCompleted": "모두 완료",
     "bashGroupFailed": "실패",
     "updatePlan": "계획 업데이트",
-    "applyPatch": "패치 적용"
+    "applyPatch": "패치 적용",
+    "reportFindings": {
+      "title": "리뷰 지적 사항",
+      "findingsCount_one": "지적 {{count}}건",
+      "findingsCount_other": "지적 {{count}}건",
+      "confirmedCount_one": "확인됨 {{count}}건",
+      "confirmedCount_other": "확인됨 {{count}}건",
+      "plausibleCount_one": "검토 필요 {{count}}건",
+      "plausibleCount_other": "검토 필요 {{count}}건",
+      "confirmed": "확인됨",
+      "plausible": "검토 필요",
+      "fixed": "수정됨",
+      "skipped": "건너뜀",
+      "noChangeNeeded": "수정 불필요",
+      "empty": "지적 사항 없음",
+      "summaryLabel": "리뷰 요약",
+      "summary": "요약",
+      "failureScenario": "발생 시나리오",
+      "reviewLevel": "리뷰 수준: {{level}}",
+      "openFile": "{{filePath}} 열기",
+      "expandFinding": "지적 사항 펼치기",
+      "collapseFinding": "지적 사항 접기",
+      "expandReport": "리뷰 지적 사항 펼치기",
+      "collapseReport": "리뷰 지적 사항 접기",
+      "untitled": "제목 없는 지적"
+    }
   },
   "todo": {
     "inProgress": "진행 중 {{completed}}/{{total}} 작업",

--- a/webview/src/i18n/locales/pt-BR.json
+++ b/webview/src/i18n/locales/pt-BR.json
@@ -1500,7 +1500,32 @@
     "bashGroupAllCompleted": "Todos Concluídos",
     "bashGroupFailed": "falhou",
     "updatePlan": "Atualizar Plano",
-    "applyPatch": "Aplicar Patch"
+    "applyPatch": "Aplicar Patch",
+    "reportFindings": {
+      "title": "Constatações da revisão",
+      "findingsCount_one": "{{count}} constatação",
+      "findingsCount_other": "{{count}} constatações",
+      "confirmedCount_one": "{{count}} confirmada",
+      "confirmedCount_other": "{{count}} confirmadas",
+      "plausibleCount_one": "{{count}} a revisar",
+      "plausibleCount_other": "{{count}} a revisar",
+      "confirmed": "Confirmada",
+      "plausible": "A revisar",
+      "fixed": "Corrigida",
+      "skipped": "Ignorada",
+      "noChangeNeeded": "Nenhuma alteração necessária",
+      "empty": "Nenhuma constatação",
+      "summaryLabel": "Resumo da revisão",
+      "summary": "Resumo",
+      "failureScenario": "Cenário de falha",
+      "reviewLevel": "Nível de revisão: {{level}}",
+      "openFile": "Abrir {{filePath}}",
+      "expandFinding": "Expandir constatação",
+      "collapseFinding": "Recolher constatação",
+      "expandReport": "Expandir constatações",
+      "collapseReport": "Recolher constatações",
+      "untitled": "Constatação sem título"
+    }
   },
   "todo": {
     "inProgress": "Em Andamento {{completed}}/{{total}} tarefas",

--- a/webview/src/i18n/locales/ru.json
+++ b/webview/src/i18n/locales/ru.json
@@ -1376,7 +1376,32 @@
     "bashGroupCompleted": "завершено",
     "bashGroupAllCompleted": "Все завершены",
     "bashGroupFailed": "ошибка",
-    "promptLabel": "Промпт"
+    "promptLabel": "Промпт",
+    "reportFindings": {
+      "title": "Результаты ревью",
+      "findingsCount_one": "{{count}} замечание",
+      "findingsCount_other": "{{count}} замечаний",
+      "confirmedCount_one": "{{count}} подтверждено",
+      "confirmedCount_other": "{{count}} подтверждено",
+      "plausibleCount_one": "{{count}} требует проверки",
+      "plausibleCount_other": "{{count}} требует проверки",
+      "confirmed": "Подтверждено",
+      "plausible": "Требует проверки",
+      "fixed": "Исправлено",
+      "skipped": "Пропущено",
+      "noChangeNeeded": "Изменения не требуются",
+      "empty": "Замечаний нет",
+      "summaryLabel": "Сводка ревью",
+      "summary": "Описание",
+      "failureScenario": "Сценарий сбоя",
+      "reviewLevel": "Уровень ревью: {{level}}",
+      "openFile": "Открыть {{filePath}}",
+      "expandFinding": "Развернуть замечание",
+      "collapseFinding": "Свернуть замечание",
+      "expandReport": "Развернуть результаты ревью",
+      "collapseReport": "Свернуть результаты ревью",
+      "untitled": "Замечание без названия"
+    }
   },
   "todo": {
     "inProgress": "В процессе {{completed}}/{{total}} задач",

--- a/webview/src/i18n/locales/zh-TW.json
+++ b/webview/src/i18n/locales/zh-TW.json
@@ -1378,7 +1378,32 @@
     "bashGroupBatchExecution": "Batch Execution",
     "bashGroupCompleted": "completed",
     "bashGroupAllCompleted": "All Completed",
-    "bashGroupFailed": "failed"
+    "bashGroupFailed": "failed",
+    "reportFindings": {
+      "title": "審查發現",
+      "findingsCount_one": "{{count}} 項發現",
+      "findingsCount_other": "{{count}} 項發現",
+      "confirmedCount_one": "{{count}} 項已確認",
+      "confirmedCount_other": "{{count}} 項已確認",
+      "plausibleCount_one": "{{count}} 項待複核",
+      "plausibleCount_other": "{{count}} 項待複核",
+      "confirmed": "已確認",
+      "plausible": "待複核",
+      "fixed": "已修復",
+      "skipped": "已略過",
+      "noChangeNeeded": "無需修改",
+      "empty": "未發現問題",
+      "summaryLabel": "審查摘要",
+      "summary": "問題摘要",
+      "failureScenario": "觸發情境",
+      "reviewLevel": "審查層級：{{level}}",
+      "openFile": "開啟 {{filePath}}",
+      "expandFinding": "展開問題詳情",
+      "collapseFinding": "收合問題詳情",
+      "expandReport": "展開審查發現",
+      "collapseReport": "收合審查發現",
+      "untitled": "未命名問題"
+    }
   },
   "todo": {
     "inProgress": "進行中 {{completed}}/{{total}} 個任務",

--- a/webview/src/i18n/locales/zh.json
+++ b/webview/src/i18n/locales/zh.json
@@ -1797,7 +1797,32 @@
     "bashGroupAllCompleted": "全部完成",
     "bashGroupFailed": "失败",
     "updatePlan": "更新计划",
-    "applyPatch": "应用补丁"
+    "applyPatch": "应用补丁",
+    "reportFindings": {
+      "title": "审查发现",
+      "findingsCount_one": "{{count}} 条发现",
+      "findingsCount_other": "{{count}} 条发现",
+      "confirmedCount_one": "{{count}} 条已确认",
+      "confirmedCount_other": "{{count}} 条已确认",
+      "plausibleCount_one": "{{count}} 条待复核",
+      "plausibleCount_other": "{{count}} 条待复核",
+      "confirmed": "已确认",
+      "plausible": "待复核",
+      "fixed": "已修复",
+      "skipped": "已跳过",
+      "noChangeNeeded": "无需修改",
+      "empty": "未发现问题",
+      "summaryLabel": "审查摘要",
+      "summary": "问题摘要",
+      "failureScenario": "触发场景",
+      "reviewLevel": "审查级别：{{level}}",
+      "openFile": "打开 {{filePath}}",
+      "expandFinding": "展开问题详情",
+      "collapseFinding": "收起问题详情",
+      "expandReport": "展开审查发现",
+      "collapseReport": "收起审查发现",
+      "untitled": "未命名问题"
+    }
   },
   "todo": {
     "inProgress": "进行中 {{completed}}/{{total}} 个任务",

--- a/webview/src/styles/less/components/tools.less
+++ b/webview/src/styles/less/components/tools.less
@@ -467,3 +467,261 @@
 [data-theme="light"] .bash-timeline-content.expanded {
     background-color: rgba(0, 0, 0, 0.04);
 }
+
+/* Report findings card: keep the review actionable without exposing its raw JSON payload. */
+.report-findings-container {
+    border-color: var(--color-link);
+}
+
+.report-findings-header {
+    width: 100%;
+    border: 0;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+}
+
+.report-findings-header:focus-visible,
+.report-finding-toggle:focus-visible,
+.report-finding-location:focus-visible {
+    outline: 1px solid var(--color-link);
+    outline-offset: -2px;
+}
+
+.report-findings-count {
+    margin-left: 8px;
+    color: var(--text-tertiary);
+    font-size: 12px;
+    white-space: nowrap;
+}
+
+.report-findings-chevron {
+    color: var(--text-tertiary);
+    font-size: 12px;
+}
+
+.report-findings-content {
+    background: var(--bg-primary);
+}
+
+.report-findings-summary {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--border-primary);
+    color: var(--text-tertiary);
+    font-size: 12px;
+}
+
+.report-findings-summary-item,
+.report-findings-level {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    min-height: 20px;
+    padding: 2px 6px;
+    border: 1px solid var(--border-primary);
+    border-radius: 4px;
+}
+
+.report-findings-summary-item.confirmed {
+    color: var(--color-success);
+}
+
+.report-findings-summary-item.plausible {
+    color: var(--color-warning);
+}
+
+.report-findings-level {
+    color: var(--text-tertiary);
+    margin-left: auto;
+}
+
+.report-findings-empty {
+    padding: 8px 12px;
+    color: var(--color-success);
+}
+
+.report-findings-list {
+    max-height: 520px;
+    overflow-y: auto;
+    padding: 4px 8px 8px;
+    scrollbar-width: thin;
+    scrollbar-color: var(--scrollbar-thumb, rgba(128, 128, 128, 0.4)) transparent;
+}
+
+.report-findings-list::-webkit-scrollbar {
+    width: 6px;
+}
+
+.report-findings-list::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.report-findings-list::-webkit-scrollbar-thumb {
+    background-color: var(--scrollbar-thumb, rgba(128, 128, 128, 0.4));
+    border-radius: 3px;
+}
+
+.report-finding-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 6px;
+    padding: 9px 4px;
+    border-bottom: 1px solid var(--border-primary);
+}
+
+.report-finding-row:last-child {
+    border-bottom: 0;
+}
+
+.report-finding-main {
+    min-width: 0;
+}
+
+.report-finding-title-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    min-width: 0;
+    line-height: 1.35;
+}
+
+.report-finding-verdict-icon {
+    flex: 0 0 auto;
+    font-size: 14px;
+}
+
+.report-finding-row.confirmed .report-finding-verdict-icon,
+.report-finding-verdict-confirmed {
+    color: var(--color-success);
+}
+
+.report-finding-row.plausible .report-finding-verdict-icon,
+.report-finding-verdict-plausible {
+    color: var(--color-warning);
+}
+
+.report-finding-row.unverified .report-finding-verdict-icon {
+    color: var(--text-tertiary);
+}
+
+.report-finding-title {
+    min-width: 0;
+    flex: 1 1 180px;
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 500;
+    overflow-wrap: anywhere;
+}
+
+.report-finding-category,
+.report-finding-verdict,
+.report-finding-outcome {
+    display: inline-flex;
+    align-items: center;
+    min-height: 18px;
+    padding: 1px 5px;
+    border: 1px solid var(--border-primary);
+    border-radius: 4px;
+    color: var(--text-tertiary);
+    font-size: 11px;
+    line-height: 1.3;
+    white-space: nowrap;
+}
+
+.report-finding-category {
+    color: var(--text-secondary);
+}
+
+.report-finding-verdict,
+.report-finding-outcome-fixed {
+    border-color: transparent;
+}
+
+.report-finding-outcome-fixed {
+    color: var(--color-success);
+}
+
+.report-finding-outcome-skipped,
+.report-finding-outcome-no_change_needed {
+    color: var(--text-tertiary);
+}
+
+.report-finding-location {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    max-width: 100%;
+    margin-top: 5px;
+    padding: 2px 0 2px 20px;
+    border: 0;
+    background: transparent;
+    color: var(--color-link);
+    cursor: pointer;
+    font: inherit;
+    font-size: 11px;
+    text-align: left;
+}
+
+.report-finding-location:hover {
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
+.report-finding-path {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.report-finding-line {
+    flex: 0 0 auto;
+    color: var(--text-secondary);
+    font-family: var(--cc-gui-code-font-family, var(--idea-editor-font-family, 'JetBrains Mono', 'Consolas', monospace));
+}
+
+.report-finding-toggle {
+    align-self: start;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-tertiary);
+    cursor: pointer;
+}
+
+.report-finding-toggle:hover {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+}
+
+.report-finding-details {
+    grid-column: 1 / -1;
+    margin: 2px 0 0 20px;
+    padding: 8px 0 0;
+    border-top: 1px solid var(--border-primary);
+}
+
+.report-finding-detail + .report-finding-detail {
+    margin-top: 8px;
+}
+
+.report-finding-detail-label {
+    margin-bottom: 3px;
+    color: var(--text-tertiary);
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.report-finding-detail .markdown-content {
+    color: var(--text-primary);
+    font-size: 12px;
+    line-height: 1.5;
+}

--- a/webview/src/utils/toolConstants.ts
+++ b/webview/src/utils/toolConstants.ts
@@ -29,6 +29,10 @@ export const SEARCH_TOOL_NAMES = new Set(['grep', 'glob', 'search', 'find', 'sea
 // Agent/subagent spawning tools
 export const AGENT_TOOL_NAMES = new Set(['task', 'agent', 'spawn_agent']);
 
+// Structured code-review report tool. CamelCase names normalize to reportfindings;
+// snake_case aliases keep custom integrations compatible with the same renderer.
+export const REPORT_FINDINGS_TOOL_NAMES = new Set(['reportfindings', 'report_findings']);
+
 // Task management tools (new structured Task API)
 export const TASK_MANAGE_TOOL_NAMES = new Set(['taskcreate', 'taskupdate', 'taskget', 'tasklist']);
 

--- a/webview/src/utils/toolPresentation.test.ts
+++ b/webview/src/utils/toolPresentation.test.ts
@@ -20,7 +20,7 @@ describe('toolPresentation', () => {
     });
   });
 
-  it('prefers structured line metadata over path suffix', () => {
+  it('treats read offset as a 1-based starting line number', () => {
     const target = resolveToolTarget({
       file_path: 'src/main.ts:1-10',
       offset: 19,
@@ -31,7 +31,21 @@ describe('toolPresentation', () => {
       file_path: 'src/main.ts:1-10',
       offset: 19,
       limit: 5,
-    }, target)).toEqual({ start: 20, end: 24 });
+    }, target)).toEqual({ start: 19, end: 23 });
+  });
+
+  it('covers the first page when reading from the top', () => {
+    const input = { file_path: 'src/main.ts', offset: 1, limit: 100 };
+    const target = resolveToolTarget(input, 'read');
+
+    expect(getToolLineInfo(input, target)).toEqual({ start: 1, end: 100 });
+  });
+
+  it('clamps a zero read offset to the first line', () => {
+    const input = { file_path: 'src/main.ts', offset: 0, limit: 50 };
+    const target = resolveToolTarget(input, 'read');
+
+    expect(getToolLineInfo(input, target)).toEqual({ start: 1, end: 50 });
   });
 
   it('summarizes shell-wrapped multiline commands like the TUI', () => {

--- a/webview/src/utils/toolPresentation.ts
+++ b/webview/src/utils/toolPresentation.ts
@@ -305,10 +305,14 @@ export const getToolLineInfo = (
 ): { start?: number; end?: number } => {
   const offset = parseNumber(input.offset);
   const limit = parseNumber(input.limit);
+  // Read-tool offset is a 1-based starting line number (defaults to 1), so the
+  // range covers lines [offset, offset + limit - 1]. Clamp 0 to 1 — the schema
+  // still allows 0 and the tool treats it the same as 1.
   if (offset !== undefined && limit !== undefined) {
+    const startLine = Math.max(offset, 1);
     return {
-      start: offset + 1,
-      end: offset + limit,
+      start: startLine,
+      end: startLine + limit - 1,
     };
   }
 


### PR DESCRIPTION
## Summary

`ReportFindings` tool calls previously fell through to the generic tool card, which printed the findings array as raw JSON. This PR adds a dedicated findings card for code-review reports.

### Card layout
- Header: tool title, finding count, and the standard completed/error/pending status indicator; the whole card collapses like other tool cards.
- Summary strip: confirmed / to-review counts and the review level.
- Each finding row shows the verdict icon (CONFIRMED = pass, PLAUSIBLE = warning, unverified = neutral outline), short summary, category, outcome tag, and a clickable `file:line` location that opens the IDE editor at that line.
- Per-finding `summary` and `failure_scenario` render as expandable Markdown details; `findings: []` shows an explicit "no findings" state.
- Malformed payloads fall back to the generic tool card, so raw JSON stays visible when the model output is garbage.

### Implementation notes
- Parsing lives in `ReportFindingsToolBlock.tsx` and runs once per input snapshot (`useMemo` in `ToolUseBlock`), so streaming re-renders do not defeat the row memos.
- Routing uses `REPORT_FINDINGS_TOOL_NAMES` (`reportfindings` / `report_findings` after name normalization) in `ToolUseBlock`, following the existing block dispatch style.
- No Java/bridge protocol changes: findings arrive as a standard assistant `tool_use` block and reuse the existing `openFile` bridge.
- i18n strings added for all 10 locales.

Also includes a small fix: `getToolLineInfo` now treats the read tool's `offset` as a 1-based starting line (`[offset, offset + limit - 1]`, clamping 0 to 1), so read tool line links no longer land one line low.

## Tests

- `cd webview && npm run test` — 173 files / 1504 tests passing
- `npx tsc -p tsconfig.test.json --noEmit` — clean

<img width="625" height="534" alt="image" src="https://github.com/user-attachments/assets/d1e51b48-34c6-42df-9282-58e28d7db469" />
