### PR TITLE
fix(webview): stop queued messages from being silently dropped between turns

### DIFF
--- a/webview/src/hooks/useMessageQueue.test.ts
+++ b/webview/src/hooks/useMessageQueue.test.ts
@@ -1,0 +1,147 @@
+import { act, renderHook } from '@testing-library/react';
+import { useState } from 'react';
+import { useMessageQueue } from './useMessageQueue';
+import type { Attachment } from '../components/ChatInputBox/types';
+
+describe('useMessageQueue', () => {
+  const renderQueue = (initialLoading: boolean) => {
+    const onExecute = vi.fn();
+    const hook = renderHook(() => {
+      // Drive `isLoading` through real component state so the auto-execute
+      // path sees the same setState semantics as production, where
+      // executeMessage flips loading back on via setLoading(true).
+      const [loading, setLoading] = useState(initialLoading);
+      const queueApi = useMessageQueue({
+        isLoading: loading,
+        onExecute: (content: string, attachments?: Attachment[]) => {
+          onExecute(content, attachments);
+          setLoading(true);
+        },
+      });
+      return { queueApi, setLoading };
+    });
+    return { ...hook, onExecute };
+  };
+
+  it('executes the queued message once loading finishes', () => {
+    const { result, onExecute } = renderQueue(true);
+
+    act(() => {
+      result.current.queueApi.enqueue('queued message');
+    });
+    expect(onExecute).not.toHaveBeenCalled();
+
+    // Regression: the old implementation deferred execution behind a 50ms
+    // timer whose cleanup ran on the dequeue's own re-render, cancelling the
+    // timer and silently dropping the already-dequeued message.
+    act(() => {
+      result.current.setLoading(false);
+    });
+
+    expect(onExecute).toHaveBeenCalledTimes(1);
+    expect(onExecute).toHaveBeenCalledWith('queued message', undefined);
+    expect(result.current.queueApi.queue).toHaveLength(0);
+    expect(result.current.queueApi.hasQueuedMessages).toBe(false);
+  });
+
+  it('keeps queued messages waiting while loading', () => {
+    const { result, onExecute } = renderQueue(true);
+
+    act(() => {
+      result.current.queueApi.enqueue('first');
+    });
+    act(() => {
+      result.current.queueApi.enqueue('second');
+    });
+
+    expect(onExecute).not.toHaveBeenCalled();
+    expect(result.current.queueApi.queue).toHaveLength(2);
+  });
+
+  it('executes queued messages one by one across turns', () => {
+    const { result, onExecute } = renderQueue(true);
+
+    act(() => {
+      result.current.queueApi.enqueue('first');
+    });
+    act(() => {
+      result.current.queueApi.enqueue('second');
+    });
+
+    act(() => {
+      result.current.setLoading(false);
+    });
+    expect(onExecute).toHaveBeenCalledTimes(1);
+    expect(onExecute).toHaveBeenCalledWith('first', undefined);
+    expect(result.current.queueApi.queue).toHaveLength(1);
+
+    act(() => {
+      result.current.setLoading(false);
+    });
+    expect(onExecute).toHaveBeenCalledTimes(2);
+    expect(onExecute).toHaveBeenLastCalledWith('second', undefined);
+    expect(result.current.queueApi.queue).toHaveLength(0);
+  });
+
+  it('executes a message enqueued while already idle', () => {
+    // Covers the race where the enqueue closure still sees loading=true but
+    // the state has already flipped to false — the message must not strand.
+    const { result, onExecute } = renderQueue(false);
+
+    act(() => {
+      result.current.queueApi.enqueue('late arrival');
+    });
+
+    expect(onExecute).toHaveBeenCalledTimes(1);
+    expect(onExecute).toHaveBeenCalledWith('late arrival', undefined);
+    expect(result.current.queueApi.queue).toHaveLength(0);
+  });
+
+  it('passes attachments through to onExecute', () => {
+    const { result, onExecute } = renderQueue(true);
+    const attachment: Attachment = { id: 'att-1', fileName: 'notes.txt', mediaType: 'text/plain', data: 'aGk=' };
+
+    act(() => {
+      result.current.queueApi.enqueue('with file', [attachment]);
+    });
+    act(() => {
+      result.current.setLoading(false);
+    });
+
+    expect(onExecute).toHaveBeenCalledWith('with file', [attachment]);
+  });
+
+  it('does not execute messages removed from the queue', () => {
+    const { result, onExecute } = renderQueue(true);
+
+    act(() => {
+      result.current.queueApi.enqueue('to be removed');
+    });
+    act(() => {
+      result.current.queueApi.dequeue(result.current.queueApi.queue[0].id);
+    });
+    act(() => {
+      result.current.setLoading(false);
+    });
+
+    expect(onExecute).not.toHaveBeenCalled();
+  });
+
+  it('clearQueue empties the queue', () => {
+    const { result, onExecute } = renderQueue(true);
+
+    act(() => {
+      result.current.queueApi.enqueue('doomed');
+    });
+    act(() => {
+      result.current.queueApi.clearQueue();
+    });
+    act(() => {
+      result.current.setLoading(false);
+    });
+
+    expect(result.current.queueApi.queue).toHaveLength(0);
+    expect(result.current.queueApi.hasQueuedMessages).toBe(false);
+    expect(onExecute).not.toHaveBeenCalled();
+  });
+});

--- a/webview/src/hooks/useMessageQueue.ts
+++ b/webview/src/hooks/useMessageQueue.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import type { Attachment } from '../components/ChatInputBox/types';
 
 export interface QueuedMessage {
@@ -37,8 +37,6 @@ export function useMessageQueue({
   onExecute,
 }: UseMessageQueueOptions): UseMessageQueueReturn {
   const [queue, setQueue] = useState<QueuedMessage[]>([]);
-  const prevLoadingRef = useRef(isLoading);
-  const isExecutingFromQueueRef = useRef(false);
 
   // Generate unique ID
   const generateId = useCallback(() => {
@@ -66,31 +64,19 @@ export function useMessageQueue({
     setQueue([]);
   }, []);
 
-  // Auto-execute next message when loading completes
+  // Auto-execute next message whenever the chat is idle. Dequeue and execute
+  // must stay atomic inside this effect: deferring the execution behind a
+  // timer let the very next re-render (the dequeue's own state update) run
+  // effect cleanup, cancel the timer, and silently drop the already-dequeued
+  // message. Checking "idle && non-empty" instead of a loading transition also
+  // covers messages enqueued while `isLoading` was already flipping to false.
   useEffect(() => {
-    // Detect transition from loading to not loading
-    const wasLoading = prevLoadingRef.current;
-    prevLoadingRef.current = isLoading;
-
-    // If just finished loading and queue has items, execute next
-    if (wasLoading && !isLoading && !isExecutingFromQueueRef.current && queue.length > 0) {
-      const nextMessage = queue[0];
-      isExecutingFromQueueRef.current = true;
-
-      // Remove from queue first
-      setQueue(prev => prev.slice(1));
-
-      // Execute with small delay to ensure state updates
-      const timer = setTimeout(() => {
-        onExecute(nextMessage.content, nextMessage.attachments);
-        isExecutingFromQueueRef.current = false;
-      }, 50);
-      return () => {
-        clearTimeout(timer);
-        isExecutingFromQueueRef.current = false;
-      };
+    if (isLoading || queue.length === 0) {
+      return;
     }
-    return undefined;
+    const nextMessage = queue[0];
+    setQueue(prev => prev.slice(1));
+    onExecute(nextMessage.content, nextMessage.attachments);
   }, [isLoading, queue, onExecute]);
 
   return {

--- a/webview/src/hooks/useSessionManagement.test.ts
+++ b/webview/src/hooks/useSessionManagement.test.ts
@@ -66,6 +66,31 @@ describe('useSessionManagement', () => {
     expect(window.sendToJava).toHaveBeenCalledWith('create_new_session:');
   });
 
+  it('discards queued messages when the session transitions', () => {
+    const mocks = createMocks();
+    const clearQueuedMessages = vi.fn();
+
+    const { result } = renderHook(() =>
+      useSessionManagement({
+        messages: [],
+        loading: false,
+        historyData: null,
+        currentSessionId: 'old-session',
+        ...mocks,
+        t,
+        clearQueuedMessages,
+      })
+    );
+
+    act(() => {
+      result.current.createNewSession();
+    });
+
+    // Queued messages belong to the outgoing session; the transition must
+    // drop them before the next session's queue-auto-execute can see them.
+    expect(clearQueuedMessages).toHaveBeenCalledTimes(1);
+  });
+
   it('clears stale ui state before loading history', () => {
     const historyData = {
       success: true,

--- a/webview/src/hooks/useSessionManagement.ts
+++ b/webview/src/hooks/useSessionManagement.ts
@@ -43,6 +43,12 @@ interface UseSessionManagementOptions {
    * matches the session being opened.
    */
   applyHistoryModel?: (provider: string, model: string, agent?: string | null) => void;
+  /**
+   * Discards messages still waiting in the send queue. Queued messages belong
+   * to the session they were typed in, so they must not leak into the next
+   * session when the user switches away.
+   */
+  clearQueuedMessages?: () => void;
 }
 
 interface UseSessionManagementReturn {
@@ -94,6 +100,7 @@ export function useSessionManagement({
   addToast,
   t,
   applyHistoryModel,
+  clearQueuedMessages,
 }: UseSessionManagementOptions): UseSessionManagementReturn {
   const [showNewSessionConfirm, setShowNewSessionConfirm] = useState(false);
   const [showInterruptConfirm, setShowInterruptConfirm] = useState(false);
@@ -133,6 +140,16 @@ export function useSessionManagement({
       setStreamingActive(false);
     }
     setMessages([]);
+    // Queued messages were typed against the outgoing session — dropping them
+    // here keeps them from firing into the freshly opened one. The reset via
+    // window.__resetTransientUiState above already clears the queue too (it
+    // also covers the Java-driven clearMessages path); this explicit call only
+    // guards the fallback branch where that global isn't registered yet.
+    // A plain interrupt (no transition) intentionally keeps the queue so the
+    // pending messages still get sent once the turn ends.
+    if (clearQueuedMessages) {
+      clearQueuedMessages();
+    }
     // Drop async subagent events from the prior session: tool_use_ids are
     // globally unique so stale entries cannot mislabel the new session's
     // agents, but leaving them would grow the map without bound.
@@ -176,7 +193,7 @@ export function useSessionManagement({
         }
       }
     }, 15_000); // 15 seconds — generous enough for slow history loads
-  }, [clearToasts, currentSessionIdRef, setStatus, setLoadingState, setIsThinking, setStreamingActive, setMessages, setCurrentSessionId, setCustomSessionTitle, setUsagePercentage, setUsageUsedTokens, setUsageMaxTokens, setTaskEvents, setSubagentHistories]);
+  }, [clearToasts, currentSessionIdRef, setStatus, setLoadingState, setIsThinking, setStreamingActive, setMessages, setCurrentSessionId, setCustomSessionTitle, setUsagePercentage, setUsageUsedTokens, setUsageMaxTokens, setTaskEvents, setSubagentHistories, clearQueuedMessages]);
 
   // Create new session
   const createNewSession = useCallback(() => {

--- a/webview/src/hooks/useWindowCallbacks.ts
+++ b/webview/src/hooks/useWindowCallbacks.ts
@@ -121,6 +121,15 @@ export interface UseWindowCallbacksOptions {
   updateHistoryTitle: (sessionId: string, newTitle: string) => void;
   applyHistoryTitleLocal: (sessionId: string, newTitle: string) => void;
 
+  /**
+   * Discards messages waiting in the send queue; wired into
+   * resetTransientUiState so every session-reset path (beginSessionTransition
+   * and the Java-driven clearMessages callback) drops them. Resolved through a
+   * ref by the caller because registration happens once on mount, before the
+   * message queue hook has been created.
+   */
+  clearQueuedMessages?: () => void;
+
   // AI title generation: update the displayed session title when backend generates one
   setCustomSessionTitle: React.Dispatch<React.SetStateAction<string | null>>;
 }

--- a/webview/src/hooks/windowCallbacks/registerCallbacks.ts
+++ b/webview/src/hooks/windowCallbacks/registerCallbacks.ts
@@ -88,6 +88,7 @@ export function registerWindowCallbacks(
     contentUpdateTimeoutRef: options.contentUpdateTimeoutRef,
     thinkingUpdateTimeoutRef: options.thinkingUpdateTimeoutRef,
     streamingTurnIdRef: options.streamingTurnIdRef,
+    clearQueuedMessages: options.clearQueuedMessages,
   });
 
   // Expose as single entry point for session transition cleanup.

--- a/webview/src/hooks/windowCallbacks/sessionTransition.test.ts
+++ b/webview/src/hooks/windowCallbacks/sessionTransition.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildResetTransientUiState } from './sessionTransition';
+import type { ResetTransientUiStateOptions } from './sessionTransition';
+
+describe('buildResetTransientUiState', () => {
+  const buildOptions = (
+    overrides: Partial<ResetTransientUiStateOptions> = {}
+  ): ResetTransientUiStateOptions => ({
+    clearToasts: vi.fn(),
+    setStatus: vi.fn(),
+    setLoading: vi.fn(),
+    setLoadingStartTime: vi.fn(),
+    setIsThinking: vi.fn(),
+    setStreamingActive: vi.fn(),
+    isStreamingRef: { current: true },
+    useBackendStreamingRenderRef: { current: true },
+    streamingMessageIndexRef: { current: 3 },
+    streamingContentRef: { current: 'partial' },
+    streamingThinkingRef: { current: 'thinking' },
+    autoExpandedThinkingKeysRef: { current: new Set(['k1']) },
+    contentUpdateTimeoutRef: { current: null },
+    thinkingUpdateTimeoutRef: { current: null },
+    streamingTurnIdRef: { current: 7 },
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    window.__streamEndProcessedTurnId = undefined;
+    window.__deferredTransitionUpdateMessages = null;
+    window.__cancelPendingUpdateMessages = undefined;
+  });
+
+  it('drops queued messages as part of the transient reset', () => {
+    // The Java-driven clearMessages callback funnels through this reset, so
+    // this is the guard that keeps queued messages from firing into a
+    // freshly cleared/replaced session.
+    const clearQueuedMessages = vi.fn();
+    const reset = buildResetTransientUiState(buildOptions({ clearQueuedMessages }));
+
+    reset();
+
+    expect(clearQueuedMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets without a queue clearer when the option is absent', () => {
+    const reset = buildResetTransientUiState(buildOptions());
+
+    expect(() => {
+      reset();
+    }).not.toThrow();
+  });
+});

--- a/webview/src/hooks/windowCallbacks/sessionTransition.ts
+++ b/webview/src/hooks/windowCallbacks/sessionTransition.ts
@@ -29,6 +29,14 @@ export interface ResetTransientUiStateOptions {
 
   // Turn tracking ref (for streaming assistant isolation)
   streamingTurnIdRef: MutableRefObject<number>;
+
+  /**
+   * Discards messages still waiting in the send queue. Every session-reset
+   * path funnels through this reset (beginSessionTransition AND the
+   * Java-driven clearMessages callback), so queueing the cleanup here keeps
+   * queued messages from firing into a freshly cleared/replaced session.
+   */
+  clearQueuedMessages?: () => void;
 }
 
 /**
@@ -44,6 +52,11 @@ export const buildResetTransientUiState = (opts: ResetTransientUiStateOptions) =
     opts.setLoadingStartTime(null);
     opts.setIsThinking(false);
     opts.setStreamingActive(false);
+    // Dropping the queue alongside loading keeps the queue-auto-execute effect
+    // (idle && non-empty) from dispatching stale entries into the reset session.
+    if (opts.clearQueuedMessages) {
+      opts.clearQueuedMessages();
+    }
     opts.isStreamingRef.current = false;
     opts.useBackendStreamingRenderRef.current = false;
     opts.streamingMessageIndexRef.current = -1;

--- a/webview/src/useAppChatController.ts
+++ b/webview/src/useAppChatController.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -175,6 +175,16 @@ export const useAppChatController = ({
     getOrCreateStreamingAssistantIndex, patchAssistantForStreaming,
   } = useStreamingMessages();
 
+  // Ref indirection breaks a hook-ordering cycle: useSessionManagement wants the
+  // message queue's clearQueue, but that hook sits further down the chain
+  // (useMessageQueue needs executeMessage, which needs forceCreateNewSession
+  // from useSessionManagement). The stable wrapper keeps beginSessionTransition's
+  // useCallback from re-creating on every render.
+  const clearMessageQueueRef = useRef<() => void>(() => {});
+  const clearQueuedMessages = useCallback(() => {
+    clearMessageQueueRef.current();
+  }, []);
+
   // ── Session management ──
   const {
     showNewSessionConfirm, showInterruptConfirm,
@@ -194,6 +204,7 @@ export const useAppChatController = ({
     setSubagentHistories,
     clearToasts, addToast, t,
     applyHistoryModel,
+    clearQueuedMessages,
   });
 
   useHistoryLoader({ currentView, currentProvider });
@@ -233,6 +244,7 @@ export const useAppChatController = ({
     customSessionTitleRef, currentSessionIdRef, updateHistoryTitle, applyHistoryTitleLocal,
     setCustomSessionTitle,
     setPermissionDialogTimeoutSeconds,
+    clearQueuedMessages,
   });
 
   // ── Message processing ──
@@ -274,7 +286,13 @@ export const useAppChatController = ({
     queue: messageQueue,
     enqueue: enqueueMessage,
     dequeue: dequeueMessage,
+    clearQueue,
   } = useMessageQueue({ isLoading: loading, onExecute: executeMessage });
+
+  // Point the session-transition indirection at the real clearQueue.
+  useEffect(() => {
+    clearMessageQueueRef.current = clearQueue;
+  }, [clearQueue]);
 
   // handleSubmit with queue support (new session and local commands bypass loading check)
   const handleSubmit = useCallback((content: string, attachments?: Attachment[]) => {


### PR DESCRIPTION
## Problem

Messages sent while a turn was still running are queued in the webview. When the running turn finished or was cancelled, queued messages could silently disappear instead of being sent.

Two root causes:

1. **Timer cancellation race in `useMessageQueue`.** The old auto-execute path dequeued the next message and deferred executing it behind a 50ms `setTimeout`, with `clearTimeout` in the effect cleanup. The dequeue's own state update triggered the next re-render, whose cleanup cancelled the timer — the message was already out of the queue, so it was gone.
2. **Queue leak across session resets.** Session transitions (new session, history load) and the Java-driven `clearMessages` callback reset `isLoading` but left the queue intact, so a stale queued message could fire into the freshly reset session.

## Fix

- `useMessageQueue`: dequeue and execute atomically inside the effect, keyed on `idle && queue non-empty` instead of a loading down-transition. This also covers entries enqueued while `isLoading` was already flipping to false.
- `beginSessionTransition` and the shared `resetTransientUiState` (the funnel for both webview-driven transitions and the Java-driven `clearMessages`) now drop queued messages — they belong to the session they were typed in. A plain interrupt (no transition) intentionally keeps its queue so pending messages still go out once the turn ends.
- A ref indirection in `useAppChatController` breaks the hook-ordering cycle: `useSessionManagement` needs the queue's `clearQueue`, while `useMessageQueue` needs `executeMessage`, which needs `forceCreateNewSession` from session management.

## Testing

- New `useMessageQueue.test.ts` (7 cases): the turn-end execution regression, no execution while loading, sequential multi-message drain, idle-enqueue, attachment passthrough, manual dequeue, and `clearQueue`.
- New `sessionTransition.test.ts`: the `clearMessages`-driven reset drops the queue; missing option does not throw.
- `useSessionManagement.test.ts`: a session transition discards queued messages.
- `npx tsc -p tsconfig.test.json --noEmit` clean; full webview suite green (175 files / 1514 tests).