### PR TITLE
docs: add macOS scrolling performance tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ A powerful IntelliJ IDEA plugin that provides a visual interface for **Claude Co
 
 ---
 
+## Performance Tips
+
+### macOS Scrolling Performance
+
+If you experience laggy scrolling in the chat panel or settings on macOS (especially with Retina displays), disable GPU acceleration:
+
+**Add to VM options** (Help → Edit Custom VM Options):
+```
+-Dide.browser.jcef.gpu.disable=true
+```
+
+Then restart the IDE.
+
+---
+
 ## Key Features
 
 ### Multi AI Engine Support


### PR DESCRIPTION
Fixes laggy scrolling in the chat panel and settings on macOS with Retina displays by disabling JCEF GPU acceleration.

**Changes:**
- Added Performance Tips section to README
- Documents the  VM option fix

This significantly improves scroll performance on macOS where GPU acceleration can cause stuttering in embedded Chromium (JCEF).

### Testing
Before:

https://github.com/user-attachments/assets/847f8cc0-44eb-4b50-90cc-41fe9593aac3



After:

https://github.com/user-attachments/assets/36c02766-e892-4e63-8d3f-7dbaab05e5b0

