### PR TITLE
fix(commit): recover empty commit-message responses from reasoning models

### DIFF
--- a/ai-bridge/services/commit-message.js
+++ b/ai-bridge/services/commit-message.js
@@ -43,6 +43,18 @@ let claudeSdk = null;
 let codexSdk = null;
 
 /**
+ * Output-token budget for one commit message.
+ *
+ * Reasoning models (e.g. deepseek-v4.1-flash) emit a `thinking` block before the
+ * `text` block, and those thinking tokens count against `max_tokens`. With a
+ * small budget (1024) a large diff made thinking consume the whole budget, so
+ * the response ended with stop_reason=max_tokens and NO text block - surfacing
+ * as "Claude commit response is empty" on every attempt. 4096 leaves room for
+ * thinking plus the message itself (verified against oversized diffs).
+ */
+const MAX_OUTPUT_TOKENS = 4096;
+
+/**
  * Lazy-load and cache the Claude Agent SDK (same pattern as ensureCodexSdk).
  */
 async function ensureClaudeSdk() {
@@ -153,7 +165,7 @@ async function generateWithClaudeAsk(prompt, model, config) {
   let streamedText = '';
   const stream = client.messages.stream({
     model: modelId,
-    max_tokens: 1024,
+    max_tokens: MAX_OUTPUT_TOKENS,
     messages: [{ role: 'user', content: prompt }],
   });
 
@@ -204,7 +216,7 @@ async function askClaudeNonStreaming(client, modelId, prompt) {
     console.log(`[CommitMessage] Non-streaming messages.create() attempt ${attempt}/${ATTEMPTS}...`);
     const response = await client.messages.create({
       model: modelId,
-      max_tokens: 1024,
+      max_tokens: MAX_OUTPUT_TOKENS,
       messages: [{ role: 'user', content: prompt }],
     });
     let text = '';

--- a/ai-bridge/services/commit-message.js
+++ b/ai-bridge/services/commit-message.js
@@ -177,10 +177,53 @@ async function generateWithClaudeAsk(prompt, model, config) {
   }
 
   console.log(`[CommitMessage] Claude response text length: ${streamedText.length}`);
+
+  // Third-party Anthropic-compatible endpoints (e.g. DeepSeek) intermittently
+  // return empty text on the streaming protocol even though the plain JSON path
+  // is reliable. Fall back to a non-streaming create() call before giving up,
+  // so a transient empty stream no longer fails the whole generation.
+  if (!streamedText.trim()) {
+    streamedText = await askClaudeNonStreaming(client, modelId, prompt);
+  }
+
   if (streamedText.trim()) {
     return streamedText.trim();
   }
   throw new Error('Claude commit response is empty');
+}
+
+/**
+ * Non-streaming one-shot "ask" via messages.create(). Third-party
+ * Anthropic-compatible endpoints (DeepSeek) intermittently return empty text on
+ * the streaming protocol; the plain create() JSON response maps text blocks
+ * reliably. Retries once on an empty result to absorb transient flakiness.
+ */
+async function askClaudeNonStreaming(client, modelId, prompt) {
+  const ATTEMPTS = 2;
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt += 1) {
+    console.log(`[CommitMessage] Non-streaming messages.create() attempt ${attempt}/${ATTEMPTS}...`);
+    const response = await client.messages.create({
+      model: modelId,
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    let text = '';
+    if (response && Array.isArray(response.content)) {
+      for (const block of response.content) {
+        if (block && block.type === 'text' && block.text) {
+          text += block.text;
+        }
+      }
+    }
+    console.log(`[CommitMessage] Non-streaming attempt ${attempt} text length: ${text.length}`);
+    if (text.trim()) {
+      return text;
+    }
+    if (attempt < ATTEMPTS) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+  return '';
 }
 
 /**


### PR DESCRIPTION
## Problem

AI commit-message generation fails with `Claude commit response is empty` when the
configured provider routes to a **reasoning model** (e.g. `deepseek-v4-flash`,
`deepseek-v4.1-flash`) behind an Anthropic-compatible endpoint.

The failure appears on larger diffs, is reproducible every time, and switching to a
different model does not help.

## Root cause

Reasoning models emit a `thinking` content block **before** the `text` block, and
thinking tokens **count against `max_tokens`**. The commit request used a 1024-token
budget, so on a large diff the thinking block consumed the entire allowance:

- the response ends with `stop_reason=max_tokens`
- **no `text` block is ever emitted**
- every extraction path (stream `text` events plus the `finalMessage().content`
  fallback) returns an empty string, surfacing as `Claude commit response is empty`

Because the cause is the token budget rather than transient flakiness, the failure is
**deterministic** - retrying with the same budget hits the same wall every time.

## Changes

Two commits, both in `ai-bridge/services/commit-message.js`:

1. **`raise max_tokens so reasoning models emit text`** - the actual fix. Raises the
   output budget from 1024 to 4096 for both the streaming (`messages.stream`) and the
   non-streaming (`messages.create`) paths, via a documented `MAX_OUTPUT_TOKENS`
   constant. Thinking now completes with room left for the message itself.
2. **`fall back to non-streaming create() on empty stream`** - defensive. When the
   stream yields no text, retry once via the non-streaming path instead of failing
   immediately. Kept because it still helps genuinely transient empty responses.

## Measured (real endpoint, ~490k-char prompt)

| model | max_tokens | stop_reason | blocks | text length |
|---|---|---|---|---|
| deepseek-v4-flash | 1024 | `max_tokens` | `[thinking]` | **0** |
| deepseek-v4-flash | 4096 | `end_turn` | `[thinking,text]` | 248 |
| deepseek-v4.1-flash | 1024 | `max_tokens` | `[thinking]` | **0** |
| deepseek-v4.1-flash | 4096 | `end_turn` | `[thinking,text]` | 204 |
| deepseek-v4.1-flash | 8192 | `end_turn` | `[thinking,text]` | 243 |

## Verification

- **Probe**: both models emit a `text` block at 4096 across an oversized diff; at 1024
  no text block is produced at all.
- **End-to-end** against the real endpoint with a ~490k-char prompt: 3/3 runs returned
  a commit message, with no non-streaming fallback needed.
- **Production**: after installing the rebuilt plugin, a commit generation streamed
  403 chars directly (`response text length: 403`) and returned a full message - no
  empty stream, no fallback.
