### PR TITLE
fix(webview): stop edit cards from rendering code in the UI font

### DIFF
--- a/webview/src/components/toolBlocks/EditDiffView.tsx
+++ b/webview/src/components/toolBlocks/EditDiffView.tsx
@@ -17,7 +17,11 @@ const TASK_DETAILS_STYLE: React.CSSProperties = {
 };
 
 const DIFF_CONTAINER_STYLE: React.CSSProperties = {
-  // Use monospace font to ensure consistent tab and space widths
+  // Use monospace font to ensure consistent tab and space widths. Declaring it on
+  // the container alone is not enough: the global `* { font-family }` UI-font rule
+  // in base.less matches every descendant directly and beats inheritance, so the
+  // container also carries the .code-font-surface class (see base.less) to push the
+  // code font back onto all of them.
   fontFamily: 'var(--idea-editor-font-family, monospace)',
   fontSize: '12px',
   lineHeight: 1.5,
@@ -149,7 +153,7 @@ interface EditDiffViewProps {
 const EditDiffView = function EditDiffView({ diff }: EditDiffViewProps) {
   return (
     <div className="task-details" style={TASK_DETAILS_STYLE}>
-      <div style={DIFF_CONTAINER_STYLE}>
+      <div className="code-font-surface" style={DIFF_CONTAINER_STYLE}>
         {/* Inner wrapper stretches to scrollWidth so row backgrounds fill the full width */}
         <div style={INNER_WRAPPER_STYLE}>
         {diff.lines.map((line, index) => {

--- a/webview/src/components/toolBlocks/EditFileHeader.tsx
+++ b/webview/src/components/toolBlocks/EditFileHeader.tsx
@@ -96,7 +96,7 @@ const EditFileHeader = function EditFileHeader({
           {displayPath}
         </span>
         {lineInfo.start && (
-          <span className="tool-title-summary" style={LINE_INFO_STYLE}>
+          <span className="tool-title-summary code-font-surface" style={LINE_INFO_STYLE}>
             {lineInfo.end && lineInfo.end !== lineInfo.start
               ? t('tools.lineRange', { start: lineInfo.start, end: lineInfo.end })
               : t('tools.lineSingle', { line: lineInfo.start })}
@@ -104,13 +104,13 @@ const EditFileHeader = function EditFileHeader({
           </span>
         )}
         {!lineInfo.start && extraEditCount > 0 && (
-          <span className="tool-title-summary" style={LINE_INFO_STYLE}>
+          <span className="tool-title-summary code-font-surface" style={LINE_INFO_STYLE}>
             +{extraEditCount}{t('tools.editLocationsSuffix')}
           </span>
         )}
 
         {(additions > 0 || deletions > 0) && (
-          <span style={STATS_STYLE}>
+          <span className="code-font-surface" style={STATS_STYLE}>
             {additions > 0 && <span style={ADDED_TEXT_STYLE}>+{additions}</span>}
             {additions > 0 && deletions > 0 && <span style={STATS_SPACER_STYLE} />}
             {deletions > 0 && <span style={DELETED_TEXT_STYLE}>-{deletions}</span>}

--- a/webview/src/components/toolBlocks/EditToolGroupBlock.tsx
+++ b/webview/src/components/toolBlocks/EditToolGroupBlock.tsx
@@ -249,7 +249,7 @@ const EditFileItem = ({ item, onFileClick, onShowDiff, onRefresh, t }: EditFileI
       </span>
 
       {(item.lineStart || item.additions > 0 || item.deletions > 0) && (
-        <span style={ITEM_STATS_STYLE}>
+        <span className="code-font-surface" style={ITEM_STATS_STYLE}>
           {item.lineStart && (
             <span style={LINE_INFO_STYLE}>
               {item.lineEnd && item.lineEnd !== item.lineStart
@@ -382,7 +382,7 @@ const EditToolGroupBlock = ({ items }: EditToolGroupBlockProps) => {
           </span>
 
           {(totalAdditions > 0 || totalDeletions > 0) && (
-            <span style={TOTAL_STATS_STYLE}>
+            <span className="code-font-surface" style={TOTAL_STATS_STYLE}>
               {totalAdditions > 0 && <span style={ADDED_TEXT_STYLE}>+{totalAdditions}</span>}
               {totalAdditions > 0 && totalDeletions > 0 && <span style={STATS_SPACER_STYLE} />}
               {totalDeletions > 0 && <span style={DELETED_TEXT_STYLE}>-{totalDeletions}</span>}

--- a/webview/src/styles/less/base.less
+++ b/webview/src/styles/less/base.less
@@ -92,6 +92,17 @@ html {
     font-family: var(--cc-gui-ui-font-family, 'Inter', system-ui, sans-serif);
 }
 
+/* 代码字体作用域 - 给代码/等宽内容容器加 .code-font-surface，作用域内的每个后代
+ * 都使用当前生效的代码字体（即用户在设置里选的编辑器/代码字体）。
+ * 上面的全局 UI 字体通配符会命中作用域内的每个元素并截断继承链，仅靠容器继承
+ * 拿不到代码字体，故这里用后代选择器把代码字体重新压到每个元素上（特异性 0,1,0
+ * 高于通配符的 0,0,0）。这样 diff 行、符号列以及后续可能加入的语法高亮 span 都
+ * 无需逐个声明字体。 */
+.code-font-surface,
+.code-font-surface * {
+    font-family: var(--cc-gui-code-font-family, var(--idea-editor-font-family, 'JetBrains Mono', 'Consolas', monospace));
+}
+
 /* 保护字体图标 - 确保 codicon 图标正常显示 */
 .codicon,
 .codicon[class*='codicon-'],


### PR DESCRIPTION
## Problem

Edit tool cards render their code blocks in the UI font instead of the editor/code font picked in settings.

Root cause: the global UI-font wildcard in `base.less` (`*:not(:where(.tt-dashboard, .tt-dashboard *))`) matches **every** element directly, which cuts the `font-family` inheritance chain. The diff container declares the code font, but each child — row, glyph column, `<pre>` — still comes out in the UI font, because a directly matched rule always beats an inherited value.

## Fix

- Add a `.code-font-surface` scope in `base.less` whose descendant selector re-applies the code font to every element inside it (specificity `0,1,0` beats the wildcard's `0,0,0`). Nested rows, glyphs and any syntax-highlight spans added later need no per-element font declaration.
- Apply the scope to the diff view container in `EditDiffView`, and to the line/stats badges in `EditFileHeader` / `EditToolGroupBlock`, whose child spans were picking up the UI font for the same reason.

Write tool content is unaffected: `.task-field-content` already declares the code font on the element that holds the text, so it never lost it.

## Verification

- `npx tsc -p tsconfig.test.json --noEmit` clean
- `npm run test`: 175 files / 1514 tests pass
- Rebuilt the webview and inspected computed `font-family` on the real rendered DOM in headless Chrome — every element inside the diff view (wrapper, rows, glyph column, `<pre>`, nested syntax span) and the line/stats badges now resolve to the code font. File names/paths intentionally keep the UI font, matching the existing convention across tool cards.