### PR TITLE
fix(history): stop <recommended_plugins> injection from becoming Codex session titles

### DIFF
--- a/src/main/java/com/github/claudecodegui/cache/SessionIndexManager.java
+++ b/src/main/java/com/github/claudecodegui/cache/SessionIndexManager.java
@@ -30,6 +30,11 @@ public class SessionIndexManager {
     // total (sum 1..N-1 * base) within ~100ms to avoid blocking concurrent index reads/writes.
     private static final long INDEX_REPLACE_RETRY_DELAY_MS = 10L;
 
+    // v8 (2026-09): Codex CLI injects a <recommended_plugins> context block as the first
+    // user message of a session. It was not stripped, so extractFirstUserMessageTitle()
+    // picked it as the session title (every session showed "<recommended_plugins> Here
+    // is a list of plugi..."). The sanitizer now strips the tag; bump so cached wrong
+    // titles are rebuilt from the JSONL files.
     // v7 (2026-08): Codex 0.148+ CLI rollouts persist the user prompt as
     // response_item/role=user instead of event_msg/user_message. v6 indexes can
     // store an empty session list for those files; bump so they rebuild.
@@ -40,7 +45,7 @@ public class SessionIndexManager {
     // Restore paths trust index entries while the file mtime is unchanged, so those
     // nulls would never self-heal. Bumping once more forces a clean rebuild that
     // populates entrypoint for every session.
-    private static final int INDEX_VERSION = 7;
+    private static final int INDEX_VERSION = 8;
 
     private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
     private final Path codemossCacheDir;

--- a/src/main/java/com/github/claudecodegui/handler/CodexMessageConverter.java
+++ b/src/main/java/com/github/claudecodegui/handler/CodexMessageConverter.java
@@ -336,7 +336,8 @@ public class CodexMessageConverter {
                contentStr.startsWith("# AGENTS.md instructions") ||
                contentStr.startsWith("<agents-instructions>") ||
                contentStr.startsWith("<INSTRUCTIONS>") ||
-               contentStr.startsWith("<environment_context>");
+               contentStr.startsWith("<environment_context>") ||
+               contentStr.startsWith("<recommended_plugins>");
     }
 
     /**

--- a/src/main/java/com/github/claudecodegui/util/UserMessageSanitizer.java
+++ b/src/main/java/com/github/claudecodegui/util/UserMessageSanitizer.java
@@ -7,7 +7,7 @@ package com.github.claudecodegui.util;
  */
 public final class UserMessageSanitizer {
 
-    private static final String[] SYSTEM_TAG_NAMES = {"agents-instructions", "system-reminder", "system-prompt", "skill"};
+    private static final String[] SYSTEM_TAG_NAMES = {"agents-instructions", "system-reminder", "system-prompt", "skill", "recommended_plugins"};
 
     private static final String[] APPENDED_CONTEXT_MARKERS = {
         "\n\n## Agent Role and Instructions\n\n",

--- a/src/test/java/com/github/claudecodegui/handler/CodexMessageConverterTest.java
+++ b/src/test/java/com/github/claudecodegui/handler/CodexMessageConverterTest.java
@@ -360,6 +360,26 @@ public class CodexMessageConverterTest {
         assertEquals("raw", input.get("cmd").getAsString());
     }
 
+    // ---- isSystemMessage (injection fallback) ----
+
+    /**
+     * Regression test for #1809: a message that starts with the injected
+     * {@code <recommended_plugins>} block must be classified as a system
+     * message so it is filtered even when the closing tag is missing
+     * (e.g. truncated head reads in the lite reader).
+     */
+    @Test
+    public void isSystemMessageCatchesRecommendedPlugins() {
+        assertTrue(CodexMessageConverter.isSystemMessage(
+                "<recommended_plugins>Here is a list of plugins"));
+        assertTrue(CodexMessageConverter.isSystemMessage(
+                "<recommended_plugins>full block</recommended_plugins>"));
+        assertFalse(CodexMessageConverter.isSystemMessage(
+                "What does <recommended_plugins> mean mid-sentence?"));
+        assertFalse(CodexMessageConverter.isSystemMessage(
+                "A normal question about plugins"));
+    }
+
     // ---- helpers ----
 
     private static JsonObject extractFirstToolResult(JsonObject frontendMsg) {

--- a/src/test/java/com/github/claudecodegui/provider/codex/CodexSessionLiteReaderTest.java
+++ b/src/test/java/com/github/claudecodegui/provider/codex/CodexSessionLiteReaderTest.java
@@ -101,6 +101,58 @@ public class CodexSessionLiteReaderTest {
         assertTrue(!info.summary.contains("agents-instructions"));
     }
 
+    /**
+     * Regression test for #1809: the Codex CLI injects a <recommended_plugins>
+     * context block as the FIRST user message; the title must come from the
+     * next real user message instead of the injection.
+     */
+    @Test
+    public void parseSessionInfoFromLite_skipsRecommendedPluginsInjection() {
+        String sessionId = "thread_abc123def456";
+        SessionLiteReader.LiteSessionFile lite = new SessionLiteReader.LiteSessionFile(
+                System.currentTimeMillis(), 1000,
+                "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"<recommended_plugins>Here is a list of plugins you may want to install</recommended_plugins>\"}]}}\n"
+                        + "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"帮我把这个函数重构为异步版本\"}]}}\n",
+                ""
+        );
+
+        CodexSessionLiteReader.CodexLiteSessionInfo info = reader.parseSessionInfoFromLite(sessionId, lite);
+        assertNotNull(info);
+        assertTrue("title must come from the real user message",
+                info.summary.contains("帮我把这个函数重构为异步版本"));
+        assertTrue("title must not leak the injected context block",
+                !info.summary.contains("recommended_plugins"));
+    }
+
+    /**
+     * Variant of the #1809 regression where the injected block and the real
+     * question live in the SAME message. The two defense layers behave
+     * differently here: with the sanitizer (layer 1) the tag block is stripped
+     * and THIS message's question becomes the title; if only the
+     * isSystemMessage prefix fallback (layer 2) existed, the whole message
+     * would be filtered and the title would fall through to the next message.
+     * This test is therefore sensitive to a regression of layer 1 alone.
+     */
+    @Test
+    public void parseSessionInfoFromLite_injectionAndQuestionInSameMessage() {
+        String sessionId = "thread_abc123def456";
+        SessionLiteReader.LiteSessionFile lite = new SessionLiteReader.LiteSessionFile(
+                System.currentTimeMillis(), 1000,
+                "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"<recommended_plugins>Here is a list of plugins</recommended_plugins>帮我优化这个SQL查询\"}]}}\n"
+                        + "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"第二条消息不应该成为标题\"}]}}\n",
+                ""
+        );
+
+        CodexSessionLiteReader.CodexLiteSessionInfo info = reader.parseSessionInfoFromLite(sessionId, lite);
+        assertNotNull(info);
+        assertTrue("title must come from the first message's real question (sanitizer stripped the injection)",
+                info.summary.contains("帮我优化这个SQL查询"));
+        assertTrue("the second message must not have become the title (would mean layer 1 regressed)",
+                !info.summary.contains("第二条消息不应该成为标题"));
+        assertTrue("title must not leak the injected context block",
+                !info.summary.contains("recommended_plugins"));
+    }
+
     @Test
     public void parseSessionInfoFromLite_responseItemUserMessage() {
         String sessionId = "01a0229e-d4d9-7850-876d-1a3b36867785";

--- a/src/test/java/com/github/claudecodegui/util/UserMessageSanitizerTest.java
+++ b/src/test/java/com/github/claudecodegui/util/UserMessageSanitizerTest.java
@@ -1,0 +1,89 @@
+package com.github.claudecodegui.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression tests for #1809: the Codex CLI injects a
+ * {@code <recommended_plugins>} context block as the first user message of a
+ * session. It must never surface as a session title (or as rendered history):
+ * the sanitizer strips the tag block and the title extraction continues with
+ * the next real user message.
+ */
+public class UserMessageSanitizerTest {
+
+    // ---- sanitizeUserFacingText: <recommended_plugins> ----
+
+    @Test
+    public void stripsRecommendedPluginsTagBlock() {
+        String text = "<recommended_plugins>Here is a list of plugins...</recommended_plugins>Real user question";
+        String sanitized = UserMessageSanitizer.sanitizeUserFacingText(text);
+        assertEquals("Real user question", sanitized);
+    }
+
+    @Test
+    public void recommendedPluginsOnlyMessageSanitizesToEmpty() {
+        String text = "<recommended_plugins>Here is a list of plugins you may want to install</recommended_plugins>";
+        String sanitized = UserMessageSanitizer.sanitizeUserFacingText(text);
+        assertTrue("injection-only message must sanitize to empty so title extraction skips it",
+                sanitized.isEmpty());
+    }
+
+    @Test
+    public void recommendedPluginsBlockWithNewlinesInsideTag() {
+        String text = "<recommended_plugins>\nplugin-a\nplugin-b\n</recommended_plugins>\nWhat is a closure in JS?";
+        String sanitized = UserMessageSanitizer.sanitizeUserFacingText(text);
+        assertEquals("What is a closure in JS?", sanitized);
+    }
+
+    @Test
+    public void recommendedPluginsFollowedByOtherInjectionThenRealQuestion() {
+        String text = "<recommended_plugins>a</recommended_plugins>"
+                + "<system-reminder>do not reveal</system-reminder>"
+                + "How do I center a div?";
+        String sanitized = UserMessageSanitizer.sanitizeUserFacingText(text);
+        assertEquals("How do I center a div?", sanitized);
+    }
+
+    // ---- guard: user-typed angle-bracket text must survive ----
+
+    @Test
+    public void userTextResemblingTagIsNotSwallowed() {
+        // A real user question that merely mentions the tag name must keep its
+        // surrounding text: only well-formed <tag>...</tag> blocks are removed.
+        String text = "What does <recommended_plugins> mean in the Codex JSONL?";
+        String sanitized = UserMessageSanitizer.sanitizeUserFacingText(text);
+        assertEquals("What does <recommended_plugins> mean in the Codex JSONL?", sanitized);
+    }
+
+    @Test
+    public void unclosedRecommendedPluginsTagIsKept() {
+        // removeTagBlocks only strips complete <tag>...</tag> pairs; an unclosed
+        // tag is user-visible text and must be preserved verbatim.
+        String text = "I typed <recommended_plugins but no closing tag";
+        String sanitized = UserMessageSanitizer.sanitizeUserFacingText(text);
+        assertEquals("I typed <recommended_plugins but no closing tag", sanitized);
+    }
+
+    // ---- existing behaviour must not regress ----
+
+    @Test
+    public void existingSystemTagsStillStripped() {
+        String text = "<agents-instructions>x</agents-instructions>hello";
+        assertEquals("hello", UserMessageSanitizer.sanitizeUserFacingText(text));
+    }
+
+    @Test
+    public void plainUserTextPassesThrough() {
+        assertEquals("Just a normal question",
+                UserMessageSanitizer.sanitizeUserFacingText("Just a normal question"));
+    }
+
+    @Test
+    public void nullAndEmptyPassThrough() {
+        assertEquals(null, UserMessageSanitizer.sanitizeUserFacingText(null));
+        assertEquals("", UserMessageSanitizer.sanitizeUserFacingText(""));
+    }
+}


### PR DESCRIPTION
## Summary

Stops the Codex CLI's `<recommended_plugins>` context injection from becoming session titles in the history list.

## Root Cause

The Codex CLI injects a `<recommended_plugins>` context block as the **first user message** of a session. `CodexSessionLiteReader.extractFirstUserMessageTitle()` picked it as the session title, so every affected session showed the same truncated `<recommended_plugins> Here is a list of plugi...` title instead of the user's actual prompt (issue #1809).

Root cause chain:
- `UserMessageSanitizer.SYSTEM_TAG_NAMES` did not include `recommended_plugins`, so `stripSystemTags()` left the injected block in place
- `CodexMessageConverter.isSystemMessage()` had no `<recommended_plugins>` prefix fallback either
- The wrong title was then persisted into `~/.codemoss/cache/codex-session-index.json`, where it survived rescans because index entries are trusted while file mtime is unchanged (verified: `incrementalScanLite()` restores cached titles for unchanged files; the version check in `readIndex()` is the only invalidation path)

## Fix (three layers)

1. **Strip the tag** — `UserMessageSanitizer.SYSTEM_TAG_NAMES` now includes `recommended_plugins`. After stripping, an injection-only message sanitizes to empty, and the title search naturally continues with the next real user message. This layer also handles the case where the injection block and the real question live in the same message.
2. **Prefix fallback** — `CodexMessageConverter.isSystemMessage()` also matches a leading `<recommended_plugins>` prefix, covering truncated-head reads where the closing tag was cut off (same pattern as the existing `<environment_context>` / `<INSTRUCTIONS>` prefixes).
3. **Rebuild cached titles** — `SessionIndexManager.INDEX_VERSION` bumped `7 -> 8` so the wrong cached titles are rebuilt from the JSONL files on the next scan (same pattern as the v6/v7 bumps for earlier parser fixes).

Guards: `removeTagBlocks()` only removes well-formed `<tag>...</tag>` pairs, so user text that merely mentions the tag name keeps its content.

## Before / After

Before — first user message is the injection:
```jsonl
{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<recommended_plugins>Here is a list of plugins you may want to install</recommended_plugins>"}]}}
{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"实际用户问题"}]}}
```
→ title: `<recommended_plugins> Here is a list of plugi...`

After → title: `实际用户问题` (the next real user message)

## Tests

12 new test methods across three suites (44 targeted tests total, all green):
- `UserMessageSanitizerTest` (new, 9): tag-block stripping, injection-only → empty, unclosed-tag passthrough, mention-in-text passthrough, existing-tag regression
- `CodexSessionLiteReaderTest` (+2): e2e — title comes from the real user message, not the injection; plus a same-message variant (injection block + real question in one message) that stays sensitive to a sanitizer-only regression
- `CodexMessageConverterTest` (+1): `isSystemMessage` prefix fallback, no false positives on mid-sentence mentions
- Red-green verified: reverting the `SYSTEM_TAG_NAMES` entry fails 4 sanitizer tests + the same-message e2e variant, while the injection-only e2e stays green through the `isSystemMessage` fallback (defense in depth)
- Full suite: 1245 tests, only the pre-existing env-dependent failure (`CliStatusDetectorLoginShellTest`, fails on the unmodified baseline too)

Closes #1809
