### PR TITLE
fix(dsh): support dsh >= 0.1.5 hosts (browser-session auth + modern wire)

### DIFF
--- a/ai-bridge/services/dsh/events.js
+++ b/ai-bridge/services/dsh/events.js
@@ -284,6 +284,45 @@ function projectSessionProjection(frame) {
 }
 
 /**
+ * Project one process-local assistant frame from a modern `session/follow`
+ * stream (`{type:'assistant-stream', frame}`). Only `chunk` carries payload;
+ * `start`/`end` are lifecycle bookends the marker protocol has no use for.
+ */
+export function projectAssistantStreamFrame(frame) {
+  if (!frame || typeof frame !== 'object') {
+    return [];
+  }
+  switch (asString(frame.type)) {
+    case 'chunk':
+      return projectStreamChunk({ chunk: frame.chunk });
+    default:
+      return [];
+  }
+}
+
+/**
+ * Project one `session/follow` frame (modern host) into turn events.
+ * Durable events carry the same `{type, data}` envelope the legacy mux emitted,
+ * so `projectSessionEvent` is reused as-is; the opening `snapshot` is skipped
+ * on purpose — it replays history the plugin loads through its own reader, and
+ * re-emitting it would duplicate the transcript.
+ */
+export function projectFollowFrame(value) {
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+  switch (asString(value.type)) {
+    case 'event':
+      return projectSessionEvent(value.event);
+    case 'assistant-stream':
+      return projectAssistantStreamFrame(value.frame);
+    case 'snapshot':
+    default:
+      return [];
+  }
+}
+
+/**
  * Project one mux frame into turn events.
  * frameType: frame.type (e.g. "session/event" / "approval/requested").
  */
@@ -336,6 +375,78 @@ export function projectMuxFrame(frameType, frame, rpcId) {
     default:
       return [];
   }
+}
+
+/**
+ * Project one `$events` frame (modern host) into a bridge instruction.
+ *
+ * The modern host forwards only a small allowlist of Cordis events, and the
+ * two that need an answer arrive as waterfalls carrying their own `eventId`;
+ * the reply must also quote the `clientId` learned from the opening `ready`
+ * frame, which is regenerated on every reconnect.
+ *
+ * @returns {{kind:'ready',clientId:string}
+ *   | {kind:'approval-request',eventId:string,request:object}
+ *   | {kind:'question-request',eventId:string,request:object}
+ *   | {kind:'cancel',eventId:string}
+ *   | null}
+ */
+export function projectRemoteEventFrame(value) {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  switch (asString(value.type)) {
+    case 'ready': {
+      const clientId = asString(value.clientId);
+      return clientId ? { kind: 'ready', clientId } : null;
+    }
+    case 'waterfall': {
+      const eventId = asString(value.eventId);
+      if (!eventId) {
+        return null;
+      }
+      const request = value.request && typeof value.request === 'object' ? value.request : {};
+      const event = asString(value.event);
+      if (event === 'approval/request') {
+        return { kind: 'approval-request', eventId, request };
+      }
+      if (event === 'user-questions/request') {
+        return { kind: 'question-request', eventId, request };
+      }
+      return null;
+    }
+    case 'cancel': {
+      const eventId = asString(value.eventId);
+      return eventId ? { kind: 'cancel', eventId } : null;
+    }
+    default:
+      return null;
+  }
+}
+
+/** Tool name of an `approval/request` waterfall payload. */
+function approvalToolName(request) {
+  return asString(request && request.toolName) || 'dsh-tool';
+}
+
+/** Reason / summary of an `approval/request` waterfall payload. */
+function approvalReason(request) {
+  const explicit = asString(request && request.reason);
+  if (explicit) {
+    return explicit;
+  }
+  return asString(request && request.policy);
+}
+
+/** Question rows of a `user-questions/request` waterfall payload. */
+function questionRows(request) {
+  if (!request || typeof request !== 'object') {
+    return [];
+  }
+  if (Array.isArray(request.questions)) {
+    return request.questions;
+  }
+  return [];
 }
 
 /**
@@ -471,6 +582,73 @@ function mapQuestionAnswers(answers) {
     }
     return { id, selected };
   });
+}
+
+/**
+ * Settle one modern waterfall frame. `$events/result` accepts only
+ * `{kind, value?}` — a stray key makes the whole answer invalid, which tears
+ * down the host's event generation instead of merely failing the request.
+ */
+async function answerWaterfall(client, clientId, eventId, value, log) {
+  if (!clientId) {
+    log('[dsh] dropping a waterfall answer: the $events stream has no clientId yet');
+    return false;
+  }
+  await client.answerRemoteEvent(clientId, eventId, value);
+  return true;
+}
+
+/**
+ * Settle a modern `approval/request` waterfall. The decision is the bare
+ * `ApprovalOutcome` string — `'allowed-once'` is the only granting value.
+ */
+export async function bridgeModernApproval(client, clientId, event, log = () => {}) {
+  const request = event && event.request && typeof event.request === 'object' ? event.request : {};
+  const toolName = approvalToolName(request);
+  try {
+    const allowed = await requestPermissionFromJava(toolName, {
+      tool: toolName,
+      reason: approvalReason(request) || undefined,
+      approvalId: event.eventId,
+      input: request,
+    });
+    await answerWaterfall(client, clientId, event.eventId, allowed ? 'allowed-once' : 'rejected', log);
+    log(`[dsh] approval ${event.eventId} ${allowed ? 'allowed-once' : 'rejected'}`);
+    return true;
+  } catch (error) {
+    log(`[dsh] approval answer failed: ${error.message}`);
+    try {
+      await answerWaterfall(client, clientId, event.eventId, 'rejected', log);
+    } catch {
+      // Secondary failure: the host keeps the request pending until the turn
+      // is aborted — there is no host-side watchdog for a waterfall.
+    }
+    return false;
+  }
+}
+
+/**
+ * Settle a modern `user-questions/request` waterfall with the
+ * `{answers:[{id, selected, custom?}]}` shape the asker's output schema requires.
+ */
+export async function bridgeModernQuestion(client, clientId, event, log = () => {}) {
+  const questions = questionRows(event && event.request);
+  try {
+    const answers = await requestAskUserQuestionAnswers({ questions });
+    await answerWaterfall(client, clientId, event.eventId, {
+      answers: mapQuestionAnswers(answers),
+    }, log);
+    log('[dsh] question answered');
+    return true;
+  } catch (error) {
+    log(`[dsh] question answer failed: ${error.message}`);
+    try {
+      await answerWaterfall(client, clientId, event.eventId, { answers: [] }, log);
+    } catch {
+      // Secondary failure — see bridgeModernApproval.
+    }
+    return false;
+  }
 }
 
 /**

--- a/ai-bridge/services/dsh/events.test.js
+++ b/ai-bridge/services/dsh/events.test.js
@@ -4,7 +4,9 @@ import assert from 'node:assert/strict';
 import {
   DshGoalSettlement,
   peekMuxSessionId,
+  projectFollowFrame,
   projectMuxFrame,
+  projectRemoteEventFrame,
   unwrapMuxEnvelope,
 } from './events.js';
 
@@ -144,4 +146,56 @@ test('DshGoalSettlement settles plain turns and failures', () => {
   cleared.feed('goal-change', { goal: { phase: 'active' } });
   cleared.feed('turn-completed'); // suppressed, awaiting idle
   assert.equal(cleared.feed('goal-change', { operation: 'clear', goal: null }), 'settle');
+});
+
+test('projectFollowFrame maps durable events and assistant deltas', () => {
+  assert.deepEqual(
+    projectFollowFrame({ type: 'event', event: { type: 'turn/start', data: {} } }),
+    [{ kind: 'turn-start' }]
+  );
+  assert.deepEqual(
+    projectFollowFrame({
+      type: 'assistant-stream',
+      frame: { type: 'chunk', chunk: { type: 'text-delta', text: 'hi' } },
+    }),
+    [{ kind: 'text-delta', text: 'hi' }]
+  );
+  // Lifecycle bookends and the opening snapshot carry nothing to project.
+  assert.deepEqual(projectFollowFrame({ type: 'assistant-stream', frame: { type: 'start' } }), []);
+  assert.deepEqual(projectFollowFrame({ type: 'snapshot', records: [{ type: 'event' }] }), []);
+  assert.deepEqual(projectFollowFrame(null), []);
+});
+
+test('projectRemoteEventFrame distinguishes ready, waterfalls and cancel', () => {
+  assert.deepEqual(
+    projectRemoteEventFrame({ type: 'ready', clientId: 'c1', host: { home: '/h' } }),
+    { kind: 'ready', clientId: 'c1' }
+  );
+  assert.deepEqual(
+    projectRemoteEventFrame({
+      type: 'waterfall',
+      event: 'approval/request',
+      eventId: 'e1',
+      request: { toolName: 'pwsh', reason: 'escalate' },
+    }),
+    { kind: 'approval-request', eventId: 'e1', request: { toolName: 'pwsh', reason: 'escalate' } }
+  );
+  assert.deepEqual(
+    projectRemoteEventFrame({
+      type: 'waterfall',
+      event: 'user-questions/request',
+      eventId: 'e2',
+      request: { questions: [{ id: 'q1', question: 'Pick' }] },
+    }),
+    { kind: 'question-request', eventId: 'e2', request: { questions: [{ id: 'q1', question: 'Pick' }] } }
+  );
+  assert.deepEqual(projectRemoteEventFrame({ type: 'cancel', eventId: 'e3' }), {
+    kind: 'cancel',
+    eventId: 'e3',
+  });
+  // Forwarded emits and unknown/withdrawn shapes are not bridge instructions.
+  assert.equal(projectRemoteEventFrame({ type: 'emit', event: 'api-session/added', args: [] }), null);
+  assert.equal(projectRemoteEventFrame({ type: 'waterfall', event: 'other/event', eventId: 'e' }), null);
+  assert.equal(projectRemoteEventFrame({ type: 'ready' }), null);
+  assert.equal(projectRemoteEventFrame(undefined), null);
 });

--- a/ai-bridge/services/dsh/host.js
+++ b/ai-bridge/services/dsh/host.js
@@ -4,11 +4,28 @@
  * Wire: `POST /api/<method>` with
  *   {type:"client-request",rpcId,method,payload}
  *   → {type:"server-response",rpcId,result:{ok:true,value}|{ok:false,error}}.
- * Approvals / questions settle via `POST /api/respond` with a
- * `client-response` envelope carrying the same rpcId.
+ *
+ * Two dialects share that envelope (see ./wire.js):
+ *   legacy  `POST /api/session.list`, payload is the business object, `/api`
+ *           is unauthenticated.
+ *   modern  `POST /api/session/list`, payload is `{args:{request|_request}}`,
+ *           every request carries the browser-session cookie.
+ *
+ * Host-minted requests (approvals / questions) settle on `POST /api/respond`
+ * (legacy, echoing the rpcId) or on `POST /api/$events/result` (modern,
+ * quoting the `clientId` + `eventId` of the waterfall frame).
  */
 
 import { randomUUID } from 'node:crypto';
+import {
+  LEGACY_DIALECT,
+  MODERN_DIALECT,
+  muxPathFor,
+  requiresBrowserSession,
+  respondPathFor,
+  rpcPayloadFor,
+  wireMethodFor,
+} from './wire.js';
 
 const RPC_TIMEOUT_MS = 30_000;
 const DESCRIBE_TIMEOUT_MS = 3_000;
@@ -29,21 +46,34 @@ export class DshTransportError extends Error {
   }
 }
 
+/** Transport failure carrying the HTTP status, so callers can react to 401. */
+export class DshHttpError extends DshTransportError {
+  constructor(status, message) {
+    super(message);
+    this.name = 'DshHttpError';
+    this.status = status;
+  }
+}
+
 export function originFromHostPort(host, port) {
   const trimmedHost = String(host || '127.0.0.1').trim() || '127.0.0.1';
   const numericPort = Number(port) > 0 ? Number(port) : 3080;
   return `http://${trimmedHost}:${numericPort}`;
 }
 
-export function muxUrlFromOrigin(origin) {
+/**
+ * @param {string} origin canonical `http://host:port`
+ * @param {string} [muxPath] dialect mux pathname (defaults to the legacy one)
+ */
+export function muxUrlFromOrigin(origin, muxPath = muxPathFor(LEGACY_DIALECT)) {
   const trimmed = String(origin || '').replace(/\/+$/, '');
   if (trimmed.startsWith('https://')) {
-    return `wss://${trimmed.slice('https://'.length)}/api/events.mux`;
+    return `wss://${trimmed.slice('https://'.length)}${muxPath}`;
   }
   if (trimmed.startsWith('http://')) {
-    return `ws://${trimmed.slice('http://'.length)}/api/events.mux`;
+    return `ws://${trimmed.slice('http://'.length)}${muxPath}`;
   }
-  return `ws://${trimmed}/api/events.mux`;
+  return `ws://${trimmed}${muxPath}`;
 }
 
 /**
@@ -82,14 +112,16 @@ export function parseServerResponse(text, expectedRpcId, method) {
   );
 }
 
-async function postJson(url, body, timeoutMs) {
+async function postJson(url, body, timeoutMs, cookie) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   let response;
   try {
     response = await fetch(url, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: cookie
+        ? { 'content-type': 'application/json', cookie }
+        : { 'content-type': 'application/json' },
       body: JSON.stringify(body),
       signal: controller.signal,
     });
@@ -103,33 +135,83 @@ async function postJson(url, body, timeoutMs) {
   }
   const text = await response.text();
   if (!response.ok) {
-    throw new DshTransportError(`dsh HTTP ${response.status}: ${text.slice(0, 300)}`);
+    throw new DshHttpError(response.status, `dsh HTTP ${response.status}: ${text.slice(0, 300)}`);
   }
   return text;
 }
 
+/**
+ * Unary client for one host. `dialect` and `cookie` come from the supervisor's
+ * negotiation (./supervisor.js); a bare `new DshHostClient(origin)` speaks the
+ * legacy dialect without authentication, which is what pre-0.1.1 hosts need.
+ */
 export class DshHostClient {
-  constructor(origin) {
+  #dialect;
+  #cookie;
+
+  constructor(origin, options = {}) {
     this.origin = String(origin || '').replace(/\/+$/, '');
+    this.#dialect = options.dialect || LEGACY_DIALECT;
+    this.#cookie = options.cookie || null;
+  }
+
+  get dialect() {
+    return this.#dialect;
+  }
+
+  get cookie() {
+    return this.#cookie;
+  }
+
+  /** Whether removing authentication would change this client's behavior. */
+  get authenticated() {
+    return requiresBrowserSession(this.#dialect);
   }
 
   muxUrl() {
-    return muxUrlFromOrigin(this.origin);
+    return muxUrlFromOrigin(this.origin, muxPathFor(this.#dialect));
+  }
+
+  /** Headers the mux upgrade must carry on this dialect. */
+  muxHeaders() {
+    return this.#cookie ? { cookie: this.#cookie } : {};
   }
 
   async describe() {
+    if (this.#dialect === MODERN_DIALECT) {
+      // Modern hosts have no `host.describe`; the catalog's `default` selection
+      // is the equivalent fact and it also carries the reasoning effort.
+      const catalog = await this.call('llm.models', {}, DESCRIBE_TIMEOUT_MS);
+      const fallback = catalog && typeof catalog === 'object' ? catalog.default : null;
+      return fallback && typeof fallback === 'object' ? fallback : {};
+    }
     return this.call('host.describe', {}, DESCRIBE_TIMEOUT_MS);
   }
 
   async call(method, payload = {}, timeoutMs = RPC_TIMEOUT_MS) {
+    const wireMethod = wireMethodFor(this.#dialect, method);
+    if (wireMethod === null) {
+      throw new DshTransportError(`dsh ${method} is not available on this host`);
+    }
     const rpcId = randomUUID();
-    const body = { type: 'client-request', rpcId, method, payload };
-    const text = await postJson(`${this.origin}/api/${method}`, body, timeoutMs);
-    return parseServerResponse(text, rpcId, method);
+    const body = {
+      type: 'client-request',
+      rpcId,
+      method: wireMethod,
+      payload: rpcPayloadFor(this.#dialect, wireMethod, payload),
+    };
+    const text = await postJson(
+      `${this.origin}/api/${wireMethod}`,
+      body,
+      timeoutMs,
+      this.#cookie
+    );
+    return parseServerResponse(text, rpcId, wireMethod);
   }
 
   /**
-   * Settle a host-minted server-request (approval / question).
+   * Settle a host-minted server-request (approval / question) on the legacy
+   * wire, which correlates the reply by the frame's rpcId.
    */
   async respond(rpcId, value) {
     const body = {
@@ -137,16 +219,48 @@ export class DshHostClient {
       rpcId,
       result: { ok: true, value },
     };
-    const text = await postJson(`${this.origin}/api/respond`, body, RPC_TIMEOUT_MS);
+    const text = await postJson(
+      `${this.origin}${respondPathFor(this.#dialect)}`,
+      body,
+      RPC_TIMEOUT_MS,
+      this.#cookie
+    );
     try {
       return JSON.parse(text);
     } catch (error) {
       throw new DshTransportError(`dsh respond json: ${error.message}`);
     }
   }
+
+  /**
+   * Settle one modern waterfall frame. The host routes the answer by
+   * `clientId` + `eventId` (both minted per generation), and the result is a
+   * unary RPC on `$events/result` — the mux socket never carries results.
+   *
+   * @param {string} clientId - id from the `$events` opening `ready` frame.
+   * @param {string} eventId - waterfall frame identity.
+   * @param {unknown} value - approval outcome or question answer.
+   */
+  async answerRemoteEvent(clientId, eventId, value) {
+    const rpcId = randomUUID();
+    const wireMethod = wireMethodFor(this.#dialect, '$events/result') || '$events/result';
+    const body = {
+      type: 'client-request',
+      rpcId,
+      method: wireMethod,
+      payload: { args: { clientId, eventId, outcome: { kind: 'result', value } } },
+    };
+    const text = await postJson(
+      `${this.origin}/api/${wireMethod}`,
+      body,
+      RPC_TIMEOUT_MS,
+      this.#cookie
+    );
+    return parseServerResponse(text, rpcId, wireMethod);
+  }
 }
 
-/** Probe `host.describe`; resolves with the describe value or rejects. */
+/** Probe `host.describe` on a legacy host; resolves with the describe value. */
 export async function probeDescribe(origin, timeoutMs = DESCRIBE_TIMEOUT_MS) {
   const client = new DshHostClient(origin);
   return client.call('host.describe', {}, timeoutMs);

--- a/ai-bridge/services/dsh/host.test.js
+++ b/ai-bridge/services/dsh/host.test.js
@@ -2,6 +2,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  DshHostClient,
+  DshHttpError,
   DshRpcError,
   DshTransportError,
   muxUrlFromOrigin,
@@ -63,3 +65,128 @@ test('parseServerResponse rejects envelope violations', () => {
     /missing result/
   );
 });
+
+/** Run `body` with `fetch` replaced by a recording stub. */
+async function withFetch(handler, body) {
+  const original = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, init = {}) => {
+    const call = { url, init, body: init.body ? JSON.parse(init.body) : null };
+    calls.push(call);
+    return handler(call);
+  };
+  try {
+    return await body(calls);
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+function okResponse(call, value) {
+  return new Response(
+    JSON.stringify({ type: 'server-response', rpcId: call.body.rpcId, result: { ok: true, value } }),
+    { status: 200, headers: { 'content-type': 'application/json' } }
+  );
+}
+
+test('a legacy client posts the business payload bare and sends no cookie', async () => {
+  await withFetch((call) => okResponse(call, { version: '0.0.1' }), async (calls) => {
+    const client = new DshHostClient('http://127.0.0.1:3080');
+    await client.call('session.list', { cursor: 'c' });
+    assert.equal(calls[0].url, 'http://127.0.0.1:3080/api/session.list');
+    assert.equal(calls[0].body.method, 'session.list');
+    assert.deepEqual(calls[0].body.payload, { cursor: 'c' });
+    assert.equal(calls[0].init.headers.cookie, undefined);
+    assert.equal(client.muxUrl(), 'ws://127.0.0.1:3080/api/events.mux');
+  });
+});
+
+test('a modern client wraps args, mints the endpoint name and sends the cookie', async () => {
+  await withFetch((call) => okResponse(call, { items: [] }), async (calls) => {
+    const client = new DshHostClient('http://127.0.0.1:3080', {
+      dialect: 'modern',
+      cookie: 'dsh-auth-x=v1.a.b',
+    });
+    await client.call('session.list', {});
+    assert.equal(calls[0].url, 'http://127.0.0.1:3080/api/session/list');
+    assert.equal(calls[0].body.method, 'session/list');
+    assert.deepEqual(calls[0].body.payload, { args: { _request: {} } });
+    assert.equal(calls[0].init.headers.cookie, 'dsh-auth-x=v1.a.b');
+    assert.equal(client.muxUrl(), 'ws://127.0.0.1:3080/api/remote.mux');
+    assert.deepEqual(client.muxHeaders(), { cookie: 'dsh-auth-x=v1.a.b' });
+  });
+});
+
+test('a modern describe falls back to the model catalog default', async () => {
+  await withFetch(
+    (call) => okResponse(call, {
+      default: { provider: 'deepseek-official', model: 'deepseek-flash', reasoningEffort: 'high' },
+      groups: [],
+    }),
+    async (calls) => {
+      const client = new DshHostClient('http://127.0.0.1:3080', { dialect: 'modern', cookie: 'c=1' });
+      const describe = await client.describe();
+      assert.equal(calls[0].url, 'http://127.0.0.1:3080/api/session/modelCatalog');
+      assert.deepEqual(calls[0].body.payload, { args: {} });
+      assert.equal(describe.model, 'deepseek-flash');
+      assert.equal(describe.reasoningEffort, 'high');
+    }
+  );
+});
+
+test('a waterfall answer posts to $events/result with the result as args', async () => {
+  await withFetch((call) => okResponse(call, undefined), async (calls) => {
+    const client = new DshHostClient('http://127.0.0.1:3080', { dialect: 'modern', cookie: 'c=1' });
+    await client.answerRemoteEvent('client-1', 'event-1', 'allowed-once');
+    assert.equal(calls[0].url, 'http://127.0.0.1:3080/api/$events/result');
+    assert.equal(calls[0].body.method, '$events/result');
+    // The result object IS the args object — no named-parameter wrapper.
+    assert.deepEqual(calls[0].body.payload, {
+      args: {
+        clientId: 'client-1',
+        eventId: 'event-1',
+        outcome: { kind: 'result', value: 'allowed-once' },
+      },
+    });
+  });
+});
+
+test('a legacy respond still posts the client-response envelope', async () => {
+  await withFetch(() => new Response('{}', { status: 200 }), async (calls) => {
+    const client = new DshHostClient('http://127.0.0.1:3080');
+    await client.respond('rpc-1', { sessionId: 's' });
+    assert.equal(calls[0].url, 'http://127.0.0.1:3080/api/respond');
+    assert.deepEqual(calls[0].body, {
+      type: 'client-response',
+      rpcId: 'rpc-1',
+      result: { ok: true, value: { sessionId: 's' } },
+    });
+  });
+});
+
+test('a 401 surfaces as DshHttpError so negotiation can observe it', async () => {
+  await withFetch(
+    () => new Response('unauthorized', { status: 401 }),
+    async () => {
+      const client = new DshHostClient('http://127.0.0.1:3080');
+      await assert.rejects(
+        () => client.call('host.describe', {}),
+        (error) => {
+          assert.ok(error instanceof DshHttpError);
+          assert.equal(error.status, 401);
+          assert.match(error.message, /dsh HTTP 401/);
+          return true;
+        }
+      );
+    }
+  );
+});
+
+test('an endpoint the dialect does not serve fails without a request', async () => {
+  await withFetch(() => new Response('{}', { status: 200 }), async (calls) => {
+    const client = new DshHostClient('http://127.0.0.1:3080', { dialect: 'modern', cookie: 'c=1' });
+    await assert.rejects(() => client.call('host.describe', {}), /not available on this host/);
+    assert.equal(calls.length, 0);
+  });
+});
+

--- a/ai-bridge/services/dsh/message-service.js
+++ b/ai-bridge/services/dsh/message-service.js
@@ -23,13 +23,19 @@ import {
 import {
   bridgeDshApproval,
   bridgeDshQuestion,
+  bridgeModernApproval,
+  bridgeModernQuestion,
   DshGoalSettlement,
   DshMuxConnection,
   peekMuxSessionId,
+  projectFollowFrame,
   projectMuxFrame,
+  projectRemoteEventFrame,
 } from './events.js';
+import { DshRemoteMux } from './stream-client.js';
 import { ensureHost, runtimeSettingsFromEnv } from './supervisor.js';
 import * as dshSession from './session.js';
+import { MODERN_DIALECT } from './wire.js';
 
 function logDebug(...args) {
   console.error('[DEBUG][DSH]', ...args);
@@ -77,10 +83,14 @@ async function ensureSession(settings, workCwd, incomingSessionId) {
   logDebug(`host ${hostHandle.origin} (${hostHandle.ownership})`);
 
   // Workspace binding — never let the session fall into the host cwd.
-  let workspaceId;
+  // Modern hosts bind the directory on the session itself, so no workspace is
+  // created there (and none of the user's workspace entries are touched).
+  let workspaceId = '';
   try {
     const workspace = await dshSession.createWorkspace(client, workCwd);
-    workspaceId = dshSession.workspaceIdFromCreate(workspace);
+    if (workspace) {
+      workspaceId = dshSession.workspaceIdFromCreate(workspace);
+    }
   } catch (error) {
     emitSendError(`dsh workspace.create failed: ${error.message}`, 'DSH');
     return null;
@@ -90,7 +100,7 @@ async function ensureSession(settings, workCwd, incomingSessionId) {
   let sessionId = dshSession.sessionIdFromThread(incomingSessionId);
   if (!sessionId) {
     try {
-      sessionId = await dshSession.createSession(client, workspaceId);
+      sessionId = await dshSession.createSession(client, workspaceId, undefined, workCwd);
     } catch (error) {
       emitSendError(`dsh session.create failed: ${error.message}`, 'DSH');
       return null;
@@ -154,6 +164,8 @@ function createTurnState() {
     sawTurnStart: false,
     lastActivityAt: Date.now(),
     pendingBridges: new Set(),
+    /** Modern hosts route waterfall answers by this per-generation id. */
+    clientId: null,
   };
 }
 
@@ -325,6 +337,110 @@ function settlePendingBridges(pendingBridges) {
 }
 
 /**
+ * Subscribe the modern Remote streams for one turn.
+ *
+ * Two logical streams ride the single `/api/remote.mux` socket: `$events`
+ * carries the forwarded waterfalls (approvals and questions) and `session/follow`
+ * carries durable session events plus the opted-in assistant deltas. Nothing is
+ * delivered until each `open` frame is sent.
+ */
+function subscribeModernStreams(client, sessionId, turn) {
+  const mux = new DshRemoteMux(client.muxUrl(), {
+    headers: client.muxHeaders(),
+    log: logDebug,
+  });
+  mux.connect();
+
+  mux.open('$events', {}, {
+    onValue: (value) => {
+      const instruction = projectRemoteEventFrame(value);
+      if (!instruction) {
+        return;
+      }
+      turn.lastActivityAt = Date.now();
+      switch (instruction.kind) {
+        case 'ready':
+          turn.clientId = instruction.clientId;
+          break;
+        case 'approval-request':
+          trackBridge(
+            turn,
+            bridgeModernApproval(client, turn.clientId, instruction, logDebug),
+            'approval'
+          );
+          break;
+        case 'question-request':
+          trackBridge(
+            turn,
+            bridgeModernQuestion(client, turn.clientId, instruction, logDebug),
+            'question'
+          );
+          break;
+        default:
+          break;
+      }
+    },
+    onError: (error) => logDebug(`[dsh] $events stream error: ${error.message}`),
+  });
+
+  mux.open('session/follow', {
+    request: {
+      address: { kind: 'session', sessionId },
+      // The opening snapshot is history, which the plugin renders from its own
+      // reader; one record is enough to make the window legal.
+      maxMessages: 1,
+      assistantStream: true,
+    },
+  }, {
+    onValue: (value) => {
+      turn.lastActivityAt = Date.now();
+      for (const event of projectFollowFrame(value)) {
+        handleTurnEvent(client, sessionId, turn, event);
+      }
+    },
+    onError: (error) => logDebug(`[dsh] follow stream error: ${error.message}`),
+  });
+
+  return mux;
+}
+
+/** Shared tail: wait for settlement, drain bridges, close the transport. */
+async function finishTurn(turn, mux) {
+  await awaitSettlement(turn);
+  await settlePendingBridges(turn.pendingBridges);
+  endStream();
+  mux.close();
+
+  if (turn.settleError) {
+    emitSendError(turn.settleError, 'DSH');
+    return;
+  }
+  if (!turn.sawTurnStart) {
+    logDebug('turn settled without turn/start (queued turn may have been coalesced)');
+  }
+}
+
+/** One turn against a modern host: `$events` + `session/follow` + prompt. */
+async function runModernTurn(client, sessionId, text, images) {
+  const turn = createTurnState();
+  const mux = subscribeModernStreams(client, sessionId, turn);
+
+  const opened = await awaitMuxOpen(mux);
+  if (!opened) {
+    mux.close();
+    emitSendError('dsh mux WebSocket did not open in time', 'DSH');
+    return;
+  }
+
+  registerShutdownCancel(client, sessionId, mux);
+  if (!(await promptTurn(client, sessionId, mux, text, images))) {
+    return;
+  }
+
+  await finishTurn(turn, mux);
+}
+
+/**
  * @param {object} options
  * @param {string} options.message
  * @param {string} [options.sessionId]
@@ -359,6 +475,11 @@ export async function sendMessage(options = {}) {
   await applyModelSelection(client, sessionId, model, reasoningEffort);
   const { text, images } = buildTurnContent(message, attachments);
 
+  if (client.dialect === MODERN_DIALECT) {
+    await runModernTurn(client, sessionId, text, images);
+    return;
+  }
+
   // Mux subscription must be live before prompt, or early frames are lost.
   const turn = createTurnState();
   const mux = new DshMuxConnection(client.muxUrl(), createMuxHandler(client, sessionId, turn), logDebug);
@@ -375,17 +496,5 @@ export async function sendMessage(options = {}) {
     return;
   }
 
-  await awaitSettlement(turn);
-  await settlePendingBridges(turn.pendingBridges);
-
-  endStream();
-  mux.close();
-
-  if (turn.settleError) {
-    emitSendError(turn.settleError, 'DSH');
-    return;
-  }
-  if (!turn.sawTurnStart) {
-    logDebug('turn settled without turn/start (queued turn may have been coalesced)');
-  }
+  await finishTurn(turn, mux);
 }

--- a/ai-bridge/services/dsh/negotiate.js
+++ b/ai-bridge/services/dsh/negotiate.js
@@ -1,0 +1,222 @@
+/**
+ * Dialect negotiation and browser-session authentication for one dsh host.
+ *
+ * The bridge must serve hosts from two DSH lines at once:
+ *
+ *   legacy (<= 0.1.0-rc.x)  `/api` is open, endpoints are dotted, and the
+ *                           readiness probe is `host.describe`.
+ *   modern (>= 0.1.5-rc.x)  `/api` sits behind a browser-session cookie,
+ *                           endpoints are `<namespace>/<method>`, and
+ *                           `host.describe` is gone.
+ *
+ * Neither line reports a version over the wire and an adopted host was not
+ * started by us, so the dialect is *observed*: `host.describe` answering 200
+ * means legacy, 401 means a modern host's auth fence, and 404 means the
+ * endpoint is gone (modern, or something newer still). `DSH_WIRE` pins the
+ * answer when observation is not enough.
+ */
+
+import { readFileSync } from 'node:fs';
+import {
+  LEGACY_DIALECT,
+  MODERN_DIALECT,
+  authorityFromOrigin,
+  cookieNameForAuthority,
+  launchUrlFromText,
+  normalizeDialectId,
+  parseSetCookie,
+  readSigningSecret,
+  requiresBrowserSession,
+  resolveDshHome,
+  signSessionCookie,
+} from './wire.js';
+import { DshHostClient, DshHttpError, DshTransportError } from './host.js';
+
+/** How long a freshly spawned host may take to print its launch URL. */
+const LAUNCH_URL_TIMEOUT_MS = 45_000;
+const LAUNCH_URL_POLL_MS = 250;
+
+function defaultLog() {
+  // Negotiation details are diagnostics, never protocol output.
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/** Read `set-cookie` off a response without depending on undici internals. */
+function firstSetCookie(headers) {
+  if (typeof headers.getSetCookie === 'function') {
+    const list = headers.getSetCookie();
+    if (Array.isArray(list) && list.length > 0) {
+      return list[0];
+    }
+  }
+  return headers.get('set-cookie') || '';
+}
+
+/**
+ * Wait for `dsh web` to print its launch URL and exchange the one-shot token
+ * for a browser-session cookie. Only a host this bridge spawned logs that line,
+ * so this path needs no access to the host's credential store.
+ *
+ * @returns {Promise<string|null>} `name=value` header, or null when the host
+ *   never printed an exchangeable URL inside the window.
+ */
+export async function cookieFromLaunchLog(origin, logFile, options = {}) {
+  if (!logFile) {
+    return null;
+  }
+  const timeoutMs = options.timeoutMs ?? LAUNCH_URL_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    let text = '';
+    try {
+      text = readFileSync(logFile, 'utf8');
+    } catch {
+      text = '';
+    }
+    const launchUrl = launchUrlFromText(text, origin);
+    if (launchUrl) {
+      try {
+        const response = await fetch(launchUrl, { redirect: 'manual' });
+        const parsed = parseSetCookie(firstSetCookie(response.headers));
+        if (parsed) {
+          return `${parsed.name}=${parsed.value}`;
+        }
+      } catch {
+        // The server may not accept connections yet; keep polling the log.
+      }
+    }
+    if (options.signal?.aborted) {
+      return null;
+    }
+    await sleep(LAUNCH_URL_POLL_MS);
+  }
+  return null;
+}
+
+/**
+ * Mint a cookie from the host's persistent signing secret. This is the only
+ * way to authenticate to a host this bridge did not spawn (its launch token
+ * was printed to a console we cannot read).
+ */
+export function cookieFromCredentials(origin, dshHome) {
+  const authority = authorityFromOrigin(origin);
+  if (!authority) {
+    return null;
+  }
+  const secret = readSigningSecret(dshHome);
+  if (!secret) {
+    return null;
+  }
+  try {
+    return signSessionCookie(authority, secret).header;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Acquire a browser-session cookie for `origin`, preferring the launch URL of a
+ * host this bridge spawned and falling back to the stored signing secret.
+ */
+export async function acquireCookie(options) {
+  const { origin, logFile, dshHome, log = defaultLog, launchTimeoutMs } = options;
+  const fromLaunch = await cookieFromLaunchLog(origin, logFile, { timeoutMs: launchTimeoutMs });
+  if (fromLaunch) {
+    log(`[dsh] authenticated via the launch URL of ${origin}`);
+    return fromLaunch;
+  }
+  const fromCredentials = cookieFromCredentials(origin, dshHome || resolveDshHome());
+  if (fromCredentials) {
+    log(`[dsh] authenticated ${origin} with the stored browser-session secret`);
+    return fromCredentials;
+  }
+  return null;
+}
+
+/** Human-readable explanation for a host we cannot authenticate to. */
+function authFailureMessage(origin) {
+  return `dsh ${origin} requires browser-session authentication and no cookie could be `
+    + 'minted: the host was not started by this plugin (so its launch URL is unknown) and '
+    + `no browser-session secret was found in ${resolveDshHome()}. Start the host from the `
+    + 'IDE, or point DSH_HOME at the home the running host uses.';
+}
+
+/**
+ * Observe the dialect of one live host and return the client that speaks it.
+ *
+ * @param {object} options
+ * @param {string} options.origin canonical `http://host:port`
+ * @param {string} [options.logFile] stdout log of a host this bridge spawned
+ * @param {string} [options.dshHome] `$DSH_HOME` of the running host
+ * @param {string} [options.dialect] pinned dialect (`DSH_WIRE`)
+ * @param {string} [options.cookie] cookie already known for this host
+ * @param {Function} [options.log]
+ * @returns {Promise<{ client: DshHostClient, dialect: string, cookie: string|null, describe: object }>}
+ */
+export async function negotiateWire(options) {
+  const { origin, logFile, dshHome, cookie: knownCookie } = options;
+  const log = typeof options.log === 'function' ? options.log : defaultLog;
+  const pinned = normalizeDialectId(options.dialect);
+
+  if (pinned) {
+    const cookie = requiresBrowserSession(pinned)
+      ? knownCookie || await acquireCookie({ origin, logFile, dshHome, log })
+      : null;
+    if (requiresBrowserSession(pinned) && !cookie) {
+      throw new DshTransportError(authFailureMessage(origin));
+    }
+    const client = new DshHostClient(origin, { dialect: pinned, cookie });
+    return { client, dialect: pinned, cookie, describe: await client.describe() };
+  }
+
+  // Observation step 1: the legacy-only readiness probe.
+  try {
+    const describe = await new DshHostClient(origin, { dialect: LEGACY_DIALECT }).describe();
+    log(`[dsh] ${origin} speaks the legacy wire`);
+    return {
+      client: new DshHostClient(origin, { dialect: LEGACY_DIALECT }),
+      dialect: LEGACY_DIALECT,
+      cookie: null,
+      describe,
+    };
+  } catch (error) {
+    if (!(error instanceof DshHttpError) || (error.status !== 401 && error.status !== 404)) {
+      throw error;
+    }
+    log(`[dsh] ${origin} answered HTTP ${error.status} to host.describe — assuming the modern wire`);
+  }
+
+  // Observation step 2: a modern host. Authenticate, then verify.
+  const cookie = knownCookie || await acquireCookie({ origin, logFile, dshHome, log });
+  if (!cookie) {
+    throw new DshTransportError(authFailureMessage(origin));
+  }
+  const client = new DshHostClient(origin, { dialect: MODERN_DIALECT, cookie });
+  try {
+    const describe = await client.describe();
+    return { client, dialect: MODERN_DIALECT, cookie, describe };
+  } catch (error) {
+    if (error instanceof DshHttpError && error.status === 401) {
+      throw new DshTransportError(
+        `dsh ${origin} rejected the minted browser-session cookie (HTTP 401). The cookie is `
+        + `bound to ${authorityFromOrigin(origin) || origin} and signed by the secret of the `
+        + 'home that started the host; check that DSH_HOME matches that home.'
+      );
+    }
+    throw error;
+  }
+}
+
+/** Whether `cookie` is the cookie name this host expects for its authority. */
+export function cookieMatchesAuthority(cookie, origin) {
+  const authority = authorityFromOrigin(origin);
+  if (!authority || !cookie) {
+    return false;
+  }
+  return String(cookie).startsWith(`${cookieNameForAuthority(authority)}=`);
+}

--- a/ai-bridge/services/dsh/negotiate.test.js
+++ b/ai-bridge/services/dsh/negotiate.test.js
@@ -1,0 +1,253 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  acquireCookie,
+  cookieFromCredentials,
+  cookieFromLaunchLog,
+  cookieMatchesAuthority,
+  negotiateWire,
+} from './negotiate.js';
+import { DshTransportError } from './host.js';
+import { authorityFromOrigin, cookieNameForAuthority } from './wire.js';
+
+/** 32-byte base64url secret, the shape the host stores. */
+const SECRET = Buffer.alloc(32, 9).toString('base64url');
+
+function tempDshHome(secret = SECRET) {
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-home-'));
+  writeFileSync(
+    join(dir, '.credentials.yaml'),
+    [
+      'version: 1',
+      'records:',
+      '  client-connection/browser-session:',
+      '    kind: grant',
+      '    payload:',
+      '      version: 1',
+      `      secret: ${secret}`,
+      '',
+    ].join('\n')
+  );
+  return dir;
+}
+
+function rpc(value, rpcId = 'r') {
+  return JSON.stringify({ type: 'server-response', rpcId, result: { ok: true, value } });
+}
+
+/** Echo the caller's rpcId the way the host does. */
+function rpcIdOf(body) {
+  try {
+    return JSON.parse(body).rpcId;
+  } catch {
+    return 'r';
+  }
+}
+
+/**
+ * A stub host. `mode` decides what `host.describe` answers, which is exactly
+ * the signal negotiation observes.
+ */
+async function stubHost(mode, options = {}) {
+  const requests = [];
+  const server = createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      const url = new URL(req.url, 'http://127.0.0.1');
+      requests.push({ path: url.pathname, cookie: req.headers.cookie || '', body });
+      if (url.pathname === '/') {
+        res.writeHead(303, { 'set-cookie': 'dsh-auth-stub=v1.a.b; Path=/; HttpOnly' });
+        res.end();
+        return;
+      }
+      if (mode === 'modern' && !String(req.headers.cookie || '').startsWith('dsh-auth-')) {
+        res.writeHead(401, { 'content-type': 'text/plain' });
+        res.end('unauthorized');
+        return;
+      }
+      if (mode === 'modern' && options.rejectCookie) {
+        res.writeHead(401, { 'content-type': 'text/plain' });
+        res.end('unauthorized');
+        return;
+      }
+      if (url.pathname === '/api/host.describe') {
+        if (mode === 'legacy') {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(rpc({
+            version: '0.0.1',
+            provider: 'deepseek-official',
+            model: 'deepseek-flash',
+          }, rpcIdOf(body)));
+          return;
+        }
+        res.writeHead(404, { 'content-type': 'text/plain' });
+        res.end('not found');
+        return;
+      }
+      if (url.pathname === '/api/session/modelCatalog') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(rpc({
+          default: { provider: 'deepseek-official', model: 'deepseek-flash', reasoningEffort: 'high' },
+          routableProviders: ['deepseek-official'],
+          groups: [],
+          failures: [],
+        }, rpcIdOf(body)));
+        return;
+      }
+      res.writeHead(404, { 'content-type': 'text/plain' });
+      res.end('not found');
+    });
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  return { origin, requests, close: () => new Promise((resolve) => server.close(resolve)) };
+}
+
+test('a legacy host is adopted without authentication', async () => {
+  const host = await stubHost('legacy');
+  try {
+    const { client, dialect, cookie, describe } = await negotiateWire({ origin: host.origin });
+    assert.equal(dialect, 'legacy');
+    assert.equal(cookie, null);
+    assert.equal(client.dialect, 'legacy');
+    assert.equal(client.muxUrl(), `ws://127.0.0.1:${new URL(host.origin).port}/api/events.mux`);
+    assert.equal(describe.model, 'deepseek-flash');
+    assert.equal(host.requests[0].cookie, '');
+  } finally {
+    await host.close();
+  }
+});
+
+test('a 401 on host.describe marks the modern wire and mints a cookie', async () => {
+  const host = await stubHost('modern');
+  const dshHome = tempDshHome();
+  try {
+    const { client, dialect, cookie, describe } = await negotiateWire({
+      origin: host.origin,
+      dshHome,
+    });
+    assert.equal(dialect, 'modern');
+    assert.equal(client.dialect, 'modern');
+    assert.ok(cookieMatchesAuthority(cookie, host.origin), 'cookie must carry the authority-bound name');
+    // `host.describe` is gone, so the catalog's default is the describe value.
+    assert.deepEqual(describe, {
+      provider: 'deepseek-official',
+      model: 'deepseek-flash',
+      reasoningEffort: 'high',
+    });
+    assert.equal(client.muxUrl(), `ws://127.0.0.1:${new URL(host.origin).port}/api/remote.mux`);
+    // The unauthenticated legacy probe is what discovered the dialect; every
+    // request after it must carry the minted cookie.
+    const afterProbe = host.requests.slice(1);
+    assert.ok(afterProbe.length >= 1);
+    assert.ok(
+      afterProbe.every((entry) => entry.cookie.startsWith('dsh-auth-')),
+      `expected every post-probe request to be authenticated, got ${JSON.stringify(afterProbe)}`
+    );
+  } finally {
+    await host.close();
+  }
+});
+
+test('a modern host without a reachable secret fails with an actionable message', async () => {
+  const host = await stubHost('modern');
+  const emptyHome = mkdtempSync(join(tmpdir(), 'dsh-empty-'));
+  try {
+    await assert.rejects(
+      () => negotiateWire({ origin: host.origin, dshHome: emptyHome }),
+      (error) => {
+        assert.ok(error instanceof DshTransportError);
+        assert.match(error.message, /requires browser-session authentication/);
+        assert.match(error.message, /DSH_HOME/);
+        return true;
+      }
+    );
+  } finally {
+    await host.close();
+  }
+});
+
+test('a rejected minted cookie explains the DSH_HOME mismatch', async () => {
+  const host = await stubHost('modern', { rejectCookie: true });
+  const dshHome = tempDshHome();
+  try {
+    await assert.rejects(
+      () => negotiateWire({ origin: host.origin, dshHome }),
+      /rejected the minted browser-session cookie/
+    );
+  } finally {
+    await host.close();
+  }
+});
+
+test('DSH_WIRE pins the dialect and skips observation', async () => {
+  const host = await stubHost('legacy');
+  try {
+    const { dialect } = await negotiateWire({ origin: host.origin, dialect: 'legacy' });
+    assert.equal(dialect, 'legacy');
+    // Only the pinned probe ran: no attempt at the modern catalog.
+    assert.deepEqual(host.requests.map((entry) => entry.path), ['/api/host.describe']);
+  } finally {
+    await host.close();
+  }
+});
+
+test('cookieFromLaunchLog exchanges the printed launch token', async () => {
+  const host = await stubHost('modern');
+  const logFile = join(mkdtempSync(join(tmpdir(), 'dsh-log-')), 'dsh-web.log');
+  writeFileSync(
+    logFile,
+    `dsh web: ${host.origin}/?token=launch-token\n`
+      + 'dsh web: opening the default browser; pass --no-open to disable\n'
+  );
+  try {
+    const cookie = await cookieFromLaunchLog(host.origin, logFile, { timeoutMs: 3_000 });
+    assert.equal(cookie, 'dsh-auth-stub=v1.a.b');
+    assert.equal(host.requests[0].path, '/');
+  } finally {
+    await host.close();
+  }
+});
+
+test('cookieFromLaunchLog gives up when the log never carries a token', async () => {
+  const logFile = join(mkdtempSync(join(tmpdir(), 'dsh-log-')), 'dsh-web.log');
+  writeFileSync(logFile, 'dsh web: http://127.0.0.1:3080\n');
+  assert.equal(
+    await cookieFromLaunchLog('http://127.0.0.1:3080', logFile, { timeoutMs: 400 }),
+    null
+  );
+});
+
+test('acquireCookie prefers the launch log over the credential store', async () => {
+  const host = await stubHost('modern');
+  const logFile = join(mkdtempSync(join(tmpdir(), 'dsh-log-')), 'dsh-web.log');
+  writeFileSync(logFile, `dsh web: ${host.origin}/?token=launch-token\n`);
+  try {
+    const cookie = await acquireCookie({
+      origin: host.origin,
+      logFile,
+      dshHome: tempDshHome(),
+      launchTimeoutMs: 3_000,
+    });
+    assert.equal(cookie, 'dsh-auth-stub=v1.a.b');
+  } finally {
+    await host.close();
+  }
+});
+
+test('cookieMatchesAuthority binds the cookie to its authority', () => {
+  const home = tempDshHome();
+  const cookie = cookieFromCredentials('http://127.0.0.1:3080', home);
+  assert.ok(cookie);
+  assert.ok(cookie.startsWith(`${cookieNameForAuthority(authorityFromOrigin('http://127.0.0.1:3080'))}=`));
+  assert.equal(cookieMatchesAuthority(cookie, 'http://127.0.0.1:3081'), false);
+  assert.equal(cookieMatchesAuthority(cookie, 'http://127.0.0.1:3080'), true);
+});

--- a/ai-bridge/services/dsh/session.js
+++ b/ai-bridge/services/dsh/session.js
@@ -1,10 +1,24 @@
 /**
  * DSH session / workspace unary operations (ported from
  * desktop-cc-gui engine/dsh/session.rs).
+ *
+ * Callers use the legacy spelling of every endpoint; `DshHostClient` maps it
+ * onto the host's dialect. Only the payload *shapes* differ per dialect and
+ * are adapted here: a modern session binds its working directory directly
+ * (`session/create {cwd}`) instead of going through `workspace.create`, and
+ * `session/prompt` requires a client-minted `requestId`.
  */
+
+import { randomUUID } from 'node:crypto';
+import { DshRemoteMux } from './stream-client.js';
+import { MODERN_DIALECT } from './wire.js';
 
 export const THREAD_PREFIX = 'dsh:';
 export const PENDING_PREFIX = 'dsh-pending-';
+
+function isModern(client) {
+  return Boolean(client) && client.dialect === MODERN_DIALECT;
+}
 
 export function sessionIdFromThread(threadId) {
   const trimmed = String(threadId || '').trim();
@@ -22,6 +36,11 @@ export function threadIdForSession(sessionId) {
 }
 
 export async function createWorkspace(client, path) {
+  if (isModern(client)) {
+    // Modern hosts bind a session to `cwd` directly; creating a workspace per
+    // turn would litter the user's workspace list for no benefit.
+    return null;
+  }
   return client.call('workspace.create', { path: String(path || '') });
 }
 
@@ -55,8 +74,20 @@ export function workspaceMembership(value) {
   return { sessionIds, archivedSessionIds };
 }
 
-export async function createSession(client, workspaceId, sessionId) {
-  const payload = { workspaceId };
+/**
+ * @param {object} client
+ * @param {string} [workspaceId] legacy workspace binding ('' when unused)
+ * @param {string} [sessionId] explicit session id to adopt
+ * @param {string} [cwd] working directory (modern hosts bind this directly)
+ */
+export async function createSession(client, workspaceId, sessionId, cwd) {
+  const payload = {};
+  if (typeof workspaceId === 'string' && workspaceId) {
+    payload.workspaceId = workspaceId;
+  }
+  if (isModern(client) && typeof cwd === 'string' && cwd) {
+    payload.cwd = cwd;
+  }
   if (typeof sessionId === 'string' && sessionId.trim()) {
     payload.sessionId = sessionId.trim();
   }
@@ -102,11 +133,16 @@ export function buildPromptContent(text, images = []) {
 }
 
 export async function prompt(client, sessionId, text, images = []) {
-  return client.call('session.prompt', {
+  const payload = {
     sessionId,
     mode: 'queue',
     content: buildPromptContent(text, images),
-  });
+  };
+  if (isModern(client)) {
+    // Modern hosts persist the accepted user message under this identity.
+    payload.requestId = randomUUID();
+  }
+  return client.call('session.prompt', payload);
 }
 
 export async function cancel(client, sessionId) {
@@ -127,7 +163,106 @@ export async function listSessions(client) {
   return Array.isArray(value && value.items) ? value.items : [];
 }
 
+/**
+ * One backwards page of session history.
+ *
+ * Legacy hosts page straight from `session.history`. Modern hosts split it:
+ * `session/follow`'s opening snapshot supplies the first window plus the
+ * `cursor` that `session/page` needs as `throughSeq`, so the cursor is cached
+ * per session for the follow-up pages.
+ */
+const historyCursors = new Map();
+
+function historyCursorKey(client, sessionId) {
+  return `${client && client.origin ? client.origin : ''}:${sessionId}`;
+}
+
+/** How long a cold `session/follow` may take to deliver its opening snapshot. */
+const FOLLOW_SNAPSHOT_TIMEOUT_MS = 15_000;
+
+/**
+ * Open one short-lived `session/follow` stream and resolve with its opening
+ * snapshot. Modern hosts have no cold history read that works without a
+ * cursor, so the snapshot is both the first window and the source of the
+ * `cursor` that `session/page` needs afterwards.
+ */
+function openFollowSnapshot(client, sessionId, maxMessages) {
+  return new Promise((resolve, reject) => {
+    const mux = new DshRemoteMux(client.muxUrl(), { headers: client.muxHeaders() });
+    let settled = false;
+    const finish = (settle) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      mux.close();
+      settle();
+    };
+    const timer = setTimeout(() => {
+      finish(() => reject(new Error('dsh session/follow snapshot timed out')));
+    }, FOLLOW_SNAPSHOT_TIMEOUT_MS);
+
+    mux.open('session/follow', {
+      request: {
+        address: { kind: 'session', sessionId },
+        ...(Number.isInteger(maxMessages) && maxMessages > 0 ? { maxMessages } : {}),
+        // `assistantStream` is the literal `true` when present; a history read
+        // leaves it out entirely rather than sending `false`.
+      },
+    }, {
+      onValue: (value) => {
+        if (value && value.type === 'snapshot') {
+          finish(() => resolve({
+            cursor: value.cursor,
+            records: Array.isArray(value.records) ? value.records.map(unwrapHistoryRecord) : [],
+            hasMore: value.hasMore === true,
+          }));
+        }
+      },
+      onError: (error) => finish(() => reject(error)),
+      onEnd: () => finish(() => reject(new Error('dsh session/follow ended before its snapshot'))),
+    });
+    mux.connect();
+  });
+}
+
+async function modernHistoryPage(client, sessionId, maxMessages, beforeSeq) {
+  const key = historyCursorKey(client, sessionId);
+  const cachedCursor = historyCursors.get(key);
+  if (beforeSeq === null || beforeSeq === undefined || cachedCursor === undefined) {
+    const snapshot = await openFollowSnapshot(client, sessionId, maxMessages);
+    historyCursors.set(key, snapshot.cursor);
+    return {
+      events: snapshot.records,
+      hasMore: snapshot.hasMore === true,
+    };
+  }
+  const value = await client.call('session.page', {
+    address: { kind: 'session', sessionId },
+    throughSeq: cachedCursor,
+    ...(Number.isInteger(beforeSeq) ? { beforeSeq } : {}),
+    ...(Number.isInteger(maxMessages) && maxMessages > 0 ? { maxMessages } : {}),
+  });
+  const records = Array.isArray(value && value.records) ? value.records : [];
+  return {
+    events: records.map(unwrapHistoryRecord),
+    hasMore: Boolean(value && value.hasMore),
+  };
+}
+
+/** Modern history records wrap the durable event; legacy pages carry it bare. */
+function unwrapHistoryRecord(record) {
+  if (record && typeof record === 'object' && record.type === 'event' && record.event) {
+    return record.event;
+  }
+  return record;
+}
+
 export async function history(client, sessionId, maxMessages, beforeSeq) {
+  if (isModern(client)) {
+    return modernHistoryPage(client, sessionId, maxMessages, beforeSeq);
+  }
   const payload = { sessionId };
   if (Number.isInteger(maxMessages) && maxMessages > 0) {
     payload.maxMessages = maxMessages;

--- a/ai-bridge/services/dsh/session.test.js
+++ b/ai-bridge/services/dsh/session.test.js
@@ -1,7 +1,15 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { sessionIdFromThread, threadIdForSession } from './session.js';
+import {
+  createSession,
+  createWorkspace,
+  history,
+  prompt,
+  sessionIdFromThread,
+  threadIdForSession,
+  workspaceIdFromCreate,
+} from './session.js';
 
 test('sessionIdFromThread strips the thread prefixes', () => {
   assert.equal(sessionIdFromThread('dsh:abc123'), 'abc123');
@@ -25,3 +33,61 @@ test('threadIdForSession round-trips through sessionIdFromThread', () => {
   assert.equal(threadIdForSession('s1'), 'dsh:s1');
   assert.equal(sessionIdFromThread(threadIdForSession('s1')), 's1');
 });
+
+/** Minimal client double: records the logical calls the session layer makes. */
+function stubClient(dialect, responses = {}) {
+  const calls = [];
+  return {
+    dialect,
+    origin: 'http://127.0.0.1:3080',
+    calls,
+    async call(method, payload) {
+      calls.push({ method, payload });
+      const response = responses[method];
+      return typeof response === 'function' ? response(payload) : response;
+    },
+  };
+}
+
+test('a legacy session still binds through workspace.create', async () => {
+  const client = stubClient('legacy', {
+    'workspace.create': { workspace: { workspaceId: 'w1' } },
+    'session.create': { sessionId: 's1' },
+  });
+  const workspace = await createWorkspace(client, 'D:/proj');
+  assert.deepEqual(client.calls[0], { method: 'workspace.create', payload: { path: 'D:/proj' } });
+  assert.equal(workspaceIdFromCreate(workspace), 'w1');
+  await createSession(client, 'w1');
+  assert.deepEqual(client.calls[1], { method: 'session.create', payload: { workspaceId: 'w1' } });
+});
+
+test('a modern session binds the cwd and skips workspace.create', async () => {
+  const client = stubClient('modern', { 'session.create': { sessionId: 's2' } });
+  assert.equal(await createWorkspace(client, 'D:/proj'), null);
+  assert.equal(client.calls.length, 0, 'no workspace is created on a modern host');
+  assert.equal(await createSession(client, '', undefined, 'D:/proj'), 's2');
+  assert.deepEqual(client.calls[0], { method: 'session.create', payload: { cwd: 'D:/proj' } });
+});
+
+test('a modern prompt carries a client-minted requestId', async () => {
+  const modern = stubClient('modern', { 'session.prompt': { accepted: true } });
+  await prompt(modern, 's1', 'hello');
+  const { payload } = modern.calls[0];
+  assert.equal(payload.mode, 'queue');
+  assert.match(payload.requestId, /^[0-9a-f-]{36}$/);
+  assert.deepEqual(payload.content, [{ type: 'text', text: 'hello' }]);
+
+  const legacy = stubClient('legacy', { 'session.prompt': { accepted: true } });
+  await prompt(legacy, 's1', 'hello');
+  assert.equal(legacy.calls[0].payload.requestId, undefined);
+});
+
+test('a legacy history call keeps its own payload shape', async () => {
+  const client = stubClient('legacy', { 'session.history': { events: [], hasMore: false } });
+  await history(client, 's1', 20, 5);
+  assert.deepEqual(client.calls[0], {
+    method: 'session.history',
+    payload: { sessionId: 's1', maxMessages: 20, beforeSeq: 5 },
+  });
+});
+

--- a/ai-bridge/services/dsh/stream-client.js
+++ b/ai-bridge/services/dsh/stream-client.js
@@ -1,0 +1,232 @@
+/**
+ * Modern DSH Remote stream client (`dsh >= 0.1.5`).
+ *
+ * The host multiplexes every logical stream over one WebSocket at
+ * `/api/remote.mux`, and the socket is bidirectional:
+ *
+ *   client → host   {type:'open', streamId, endpoint, payload:{args}}
+ *                   {type:'cancel', streamId}
+ *   host → client   {type:'item', streamId, value?}
+ *                   {type:'error', streamId, error:{code,message,details}}
+ *                   {type:'end', streamId}
+ *
+ * `endpoint` is a Remote `<namespace>/<method>` (or the gateway-internal
+ * `$events`), `streamId` is minted by this client, and nothing is delivered
+ * until the matching `open` frame is sent — the old server-push-only mux
+ * (`/api/events.mux`) has no equivalent here.
+ *
+ * The host authenticates the upgrade with the browser-session cookie and
+ * drives a protocol-level WebSocket ping every couple of seconds; `DshWebSocket`
+ * already answers pings with pongs and must not be given an application-level
+ * keepalive instead.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { DshWebSocket } from './ws-client.js';
+
+/** Endpoint carrying forwarded Cordis events (approvals, questions, session list changes). */
+export const REMOTE_EVENTS_ENDPOINT = '$events';
+
+const RECONNECT_BASE_MS = 500;
+const RECONNECT_MAX_MS = 10_000;
+
+/**
+ * One consumer of a logical stream. `onValue` receives the frame's `value`;
+ * a frame without `value` is delivered as undefined so a keepalive `item`
+ * still counts as liveness.
+ */
+function normalizeHandlers(handlers = {}) {
+  return {
+    onValue: typeof handlers.onValue === 'function' ? handlers.onValue : () => {},
+    onError: typeof handlers.onError === 'function' ? handlers.onError : () => {},
+    onEnd: typeof handlers.onEnd === 'function' ? handlers.onEnd : () => {},
+    onOpen: typeof handlers.onOpen === 'function' ? handlers.onOpen : () => {},
+  };
+}
+
+/** Whether a value looks like a valid stream frame for `streamId`. */
+function frameFor(frame, streamId) {
+  if (!frame || typeof frame !== 'object' || frame.streamId !== streamId) {
+    return null;
+  }
+  const type = typeof frame.type === 'string' ? frame.type : '';
+  return type === 'item' || type === 'error' || type === 'end' ? type : null;
+}
+
+export class DshRemoteMux {
+  #url;
+  #headers;
+  #log;
+  #ws = null;
+  #stopped = false;
+  #open = false;
+  #retry = 0;
+  #retryTimer = null;
+  #openListeners = [];
+  /** streamId → { endpoint, args, sessionId, handlers } */
+  #streams = new Map();
+
+  /**
+   * @param {string} url ws:// or wss:// URL of `/api/remote.mux`
+   * @param {{ headers?: Record<string,string>, log?: Function }} [options]
+   */
+  constructor(url, options = {}) {
+    this.#url = url;
+    this.#headers = options.headers || {};
+    this.#log = typeof options.log === 'function' ? options.log : () => {};
+  }
+
+  connect() {
+    if (this.#stopped || this.#ws) {
+      return;
+    }
+    const ws = new DshWebSocket();
+    this.#ws = ws;
+    ws.on('error', (error) => {
+      this.#log(`[dsh] mux error: ${error.message}`);
+    });
+    ws.on('open', () => {
+      this.#open = true;
+      this.#retry = 0;
+      this.#log(`[dsh] mux connected ${this.#url}`);
+      this.#resubscribe();
+      const listeners = this.#openListeners.splice(0);
+      for (const listener of listeners) {
+        listener();
+      }
+    });
+    ws.on('message', (text) => this.#onMessage(text));
+    ws.on('close', () => {
+      this.#open = false;
+      this.#ws = null;
+      if (this.#stopped) {
+        return;
+      }
+      for (const entry of this.#streams.values()) {
+        entry.handlers.onEnd();
+      }
+      this.#retry += 1;
+      const delay = Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * 2 ** Math.max(0, this.#retry - 1));
+      this.#retryTimer = setTimeout(() => {
+        this.#retryTimer = null;
+        this.connect();
+      }, delay);
+    });
+    ws.connect(this.#url, { headers: this.#headers });
+  }
+
+  /** Resolve once the socket is open (immediately when already open). */
+  whenOpen() {
+    if (this.#open) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.#openListeners.push(resolve);
+    });
+  }
+
+  /**
+   * Open one logical stream. The returned handle keeps the stream registered
+   * for reconnect replay; call `cancel()` to end it.
+   *
+   * @param {string} endpoint Remote endpoint (`session/follow`, `$events`, …)
+   * @param {object} args business arguments (wrapped in the required `args` payload)
+   * @param {object} handlers onValue/onError/onEnd/onOpen
+   * @returns {{ id: string, cancel: () => void }}
+   */
+  open(endpoint, args = {}, handlers = {}) {
+    const streamId = randomUUID();
+    const entry = {
+      endpoint: String(endpoint || ''),
+      args: args && typeof args === 'object' ? args : {},
+      handlers: normalizeHandlers(handlers),
+    };
+    this.#streams.set(streamId, entry);
+    this.#sendOpen(streamId, entry);
+    return {
+      id: streamId,
+      cancel: () => this.cancel(streamId),
+    };
+  }
+
+  cancel(streamId) {
+    if (!this.#streams.delete(streamId)) {
+      return;
+    }
+    if (this.#open && this.#ws) {
+      this.#ws.send(JSON.stringify({ type: 'cancel', streamId }));
+    }
+  }
+
+  close() {
+    this.#stopped = true;
+    if (this.#retryTimer) {
+      clearTimeout(this.#retryTimer);
+      this.#retryTimer = null;
+    }
+    this.#openListeners.splice(0).forEach((resolve) => resolve());
+    const streams = [...this.#streams.values()];
+    this.#streams.clear();
+    for (const entry of streams) {
+      entry.handlers.onEnd();
+    }
+    this.#open = false;
+    if (this.#ws) {
+      this.#ws.close();
+      this.#ws = null;
+    }
+  }
+
+  #sendOpen(streamId, entry) {
+    if (!this.#open || !this.#ws) {
+      return;
+    }
+    // Exactly these four keys: an unknown key is a protocol violation the
+    // host answers by closing the whole socket (1008).
+    this.#ws.send(JSON.stringify({
+      type: 'open',
+      streamId,
+      endpoint: entry.endpoint,
+      payload: { args: entry.args },
+    }));
+    entry.handlers.onOpen();
+  }
+
+  #resubscribe() {
+    for (const [streamId, entry] of this.#streams) {
+      this.#sendOpen(streamId, entry);
+    }
+  }
+
+  #onMessage(text) {
+    let frame;
+    try {
+      frame = JSON.parse(text);
+    } catch {
+      return;
+    }
+    const streamId = frame && typeof frame.streamId === 'string' ? frame.streamId : '';
+    const entry = this.#streams.get(streamId);
+    if (!entry) {
+      return;
+    }
+    switch (frameFor(frame, streamId)) {
+      case 'item':
+        entry.handlers.onValue(frame.value);
+        break;
+      case 'error': {
+        const error = frame.error && typeof frame.error === 'object' ? frame.error : {};
+        entry.handlers.onError(new Error(
+          typeof error.message === 'string' ? error.message : 'dsh Remote stream failed',
+          { cause: error }
+        ));
+        break;
+      }
+      case 'end':
+        entry.handlers.onEnd();
+        break;
+      default:
+        break;
+    }
+  }
+}

--- a/ai-bridge/services/dsh/stream-client.test.js
+++ b/ai-bridge/services/dsh/stream-client.test.js
@@ -1,0 +1,269 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { createHash } from 'node:crypto';
+
+import { DshRemoteMux } from './stream-client.js';
+import { decodeFrame, DshWebSocket, encodeFrame } from './ws-client.js';
+
+const WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+const OPCODE_TEXT = 0x1;
+
+/**
+ * A stub `/api/remote.mux` host: completes the upgrade, records every client
+ * frame, and exposes `send(value)` to push a text frame to the client.
+ */
+async function stubMux(onOpenFrame = () => {}) {
+  const sockets = new Set();
+  const received = [];
+  const server = createServer();
+  server.on('upgrade', (req, socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    const accept = createHash('sha1')
+      .update(req.headers['sec-websocket-key'] + WS_GUID)
+      .digest('base64');
+    socket.write(
+      'HTTP/1.1 101 Switching Protocols\r\n'
+        + 'Upgrade: websocket\r\n'
+        + 'Connection: Upgrade\r\n'
+        + `Sec-WebSocket-Accept: ${accept}\r\n\r\n`
+    );
+    req.headers.seen = true;
+    let buffer = Buffer.alloc(0);
+    socket.on('data', (chunk) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      for (;;) {
+        const frame = decodeFrame(buffer);
+        if (!frame) {
+          return;
+        }
+        buffer = buffer.subarray(frame.bytesConsumed);
+        if (frame.opcode !== OPCODE_TEXT) {
+          continue;
+        }
+        const message = JSON.parse(frame.payload.toString('utf8'));
+        received.push(message);
+        onOpenFrame(message, socket);
+      }
+    });
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = server.address().port;
+  return {
+    url: `ws://127.0.0.1:${port}/api/remote.mux`,
+    received,
+    headers: [],
+    send(socket, value) {
+      socket.write(encodeFrame(OPCODE_TEXT, Buffer.from(JSON.stringify(value), 'utf8')));
+    },
+    /** Push a frame to every connected socket. */
+    broadcast(value) {
+      for (const socket of sockets) {
+        this.send(socket, value);
+      }
+    },
+    close: () =>
+      new Promise((resolve) => {
+        for (const socket of sockets) {
+          socket.destroy();
+        }
+        server.close(resolve);
+      }),
+  };
+}
+
+function waitFor(predicate, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (Date.now() > deadline) {
+        reject(new Error('timed out waiting for condition'));
+        return;
+      }
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+test('open sends exactly the four protocol keys and routes item frames', async () => {
+  const host = await stubMux();
+  const mux = new DshRemoteMux(host.url);
+  const values = [];
+  try {
+    mux.connect();
+    await mux.whenOpen();
+    mux.open('$events', {}, { onValue: (value) => values.push(value) });
+
+    await waitFor(() => host.received.length === 1);
+    const frame = host.received[0];
+    assert.deepEqual(Object.keys(frame).sort(), ['endpoint', 'payload', 'streamId', 'type']);
+    assert.equal(frame.type, 'open');
+    assert.equal(frame.endpoint, '$events');
+    // An extra key here makes the host close the whole socket with 1008.
+    assert.deepEqual(frame.payload, { args: {} });
+
+    host.broadcast({ type: 'item', streamId: frame.streamId, value: { type: 'ready', clientId: 'c1' } });
+    await waitFor(() => values.length === 1);
+    assert.deepEqual(values[0], { type: 'ready', clientId: 'c1' });
+  } finally {
+    mux.close();
+    await host.close();
+  }
+});
+
+test('error and end frames reach their handlers', async () => {
+  const host = await stubMux();
+  const mux = new DshRemoteMux(host.url);
+  const errors = [];
+  let ended = 0;
+  try {
+    mux.connect();
+    await mux.whenOpen();
+    mux.open('session/follow', { request: { address: { kind: 'session', sessionId: 's1' } } }, {
+      onError: (error) => errors.push(error),
+      onEnd: () => {
+        ended += 1;
+      },
+    });
+    await waitFor(() => host.received.length === 1);
+    const { streamId } = host.received[0];
+    assert.deepEqual(host.received[0].payload, {
+      args: { request: { address: { kind: 'session', sessionId: 's1' } } },
+    });
+
+    host.broadcast({ type: 'error', streamId, error: { code: 'session/agent-busy', message: 'busy', details: {} } });
+    await waitFor(() => errors.length === 1);
+    assert.match(errors[0].message, /busy/);
+
+    host.broadcast({ type: 'end', streamId });
+    await waitFor(() => ended === 1);
+  } finally {
+    mux.close();
+    await host.close();
+  }
+});
+
+test('frames for unknown streams are ignored', async () => {
+  const host = await stubMux();
+  const mux = new DshRemoteMux(host.url);
+  const values = [];
+  try {
+    mux.connect();
+    await mux.whenOpen();
+    mux.open('$events', {}, { onValue: (value) => values.push(value) });
+    await waitFor(() => host.received.length === 1);
+
+    host.broadcast({ type: 'item', streamId: 'someone-elses-stream', value: { type: 'emit' } });
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    assert.equal(values.length, 0);
+  } finally {
+    mux.close();
+    await host.close();
+  }
+});
+
+test('cancel sends the cancel frame and stops delivery', async () => {
+  const host = await stubMux();
+  const mux = new DshRemoteMux(host.url);
+  const values = [];
+  try {
+    mux.connect();
+    await mux.whenOpen();
+    const stream = mux.open('$events', {}, { onValue: (value) => values.push(value) });
+    await waitFor(() => host.received.length === 1);
+    const { streamId } = host.received[0];
+
+    stream.cancel();
+    await waitFor(() => host.received.length === 2);
+    assert.deepEqual(host.received[1], { type: 'cancel', streamId });
+
+    host.broadcast({ type: 'item', streamId, value: { type: 'emit' } });
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    assert.equal(values.length, 0);
+  } finally {
+    mux.close();
+    await host.close();
+  }
+});
+
+test('close() ends registered streams', async () => {
+  const host = await stubMux();
+  const mux = new DshRemoteMux(host.url);
+  let ended = 0;
+  try {
+    mux.connect();
+    await mux.whenOpen();
+    mux.open('$events', {}, { onEnd: () => { ended += 1; } });
+    await waitFor(() => host.received.length === 1);
+    mux.close();
+    assert.equal(ended, 1);
+  } finally {
+    await host.close();
+  }
+});
+
+test('handshake headers ride the upgrade request', async () => {
+  const seen = [];
+  const sockets = new Set();
+  const server = createServer();
+  server.on('upgrade', (req, socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    socket.on('error', () => sockets.delete(socket));
+    seen.push(req.headers);
+    const accept = createHash('sha1')
+      .update(req.headers['sec-websocket-key'] + WS_GUID)
+      .digest('base64');
+    socket.write(
+      'HTTP/1.1 101 Switching Protocols\r\n'
+        + 'Upgrade: websocket\r\n'
+        + 'Connection: Upgrade\r\n'
+        + `Sec-WebSocket-Accept: ${accept}\r\n\r\n`
+    );
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const mux = new DshRemoteMux(`ws://127.0.0.1:${server.address().port}/api/remote.mux`, {
+    headers: { cookie: 'dsh-auth-abc=v1.x.y' },
+  });
+  try {
+    mux.connect();
+    await mux.whenOpen();
+    assert.equal(seen[0].cookie, 'dsh-auth-abc=v1.x.y');
+  } finally {
+    mux.close();
+    // An upgraded socket is not closed by server.close(); drop it explicitly.
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test('an unauthorized upgrade surfaces 401 instead of a silent close', async () => {
+  const server = createServer();
+  server.on('upgrade', (req, socket) => {
+    socket.end('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\nunauthorized');
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const url = `ws://127.0.0.1:${server.address().port}/api/remote.mux`;
+  try {
+    const failure = await new Promise((resolve, reject) => {
+      const raw = new DshWebSocket();
+      raw.on('error', resolve);
+      raw.on('close', () => reject(new Error('closed without reporting the status')));
+      raw.connect(url);
+    });
+    // A host that rejects the upgrade writes the status before the handshake,
+    // so the message must name it rather than looking like a dropped socket.
+    assert.match(failure.message, /HTTP 401/);
+    assert.match(failure.message, /browser-session authentication/);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});

--- a/ai-bridge/services/dsh/supervisor.js
+++ b/ai-bridge/services/dsh/supervisor.js
@@ -26,7 +26,9 @@ import {
   readDshPresetFile,
   resolveDshPresetDir,
 } from './preset-overlay.js';
-import { DshHostClient, DshTransportError, originFromHostPort, probeDescribe } from './host.js';
+import { DshTransportError, originFromHostPort } from './host.js';
+import { negotiateWire } from './negotiate.js';
+import { resolveDshHome } from './wire.js';
 
 const SPAWN_READY_TIMEOUT_MS = process.platform === 'win32' ? 45_000 : 20_000;
 const SPAWN_POLL_MS = 250;
@@ -42,7 +44,11 @@ export function runtimeSettingsFromEnv(env = process.env) {
   const autoStart = (env.DSH_AUTO_START || '').trim().toLowerCase() !== 'false';
   const binPath = (env.DSH_BIN || '').trim() || null;
   const dshPreset = (env.DSH_PRESET || '').trim();
-  return { binPath, host, port, autoStart, dshPreset };
+  // `DSH_WIRE` pins the wire dialect (legacy|modern) when negotiation guesses
+  // wrong; `DSH_HOME` must match the home of the host we are talking to, since
+  // its browser-session secret is what authenticates a host we did not spawn.
+  const wire = (env.DSH_WIRE || '').trim();
+  return { binPath, host, port, autoStart, dshPreset, wire, dshHome: resolveDshHome(env) };
 }
 
 function stateFilePath() {
@@ -307,34 +313,60 @@ function spawnDshWeb(bin, host, port, preset = '') {
   return { child, logFile };
 }
 
-async function waitForDescribe(origin, timeoutMs) {
+/**
+ * Observe the wire dialect of one live host and build its client. `logFile` is
+ * the stdout log of a host this bridge spawned: modern hosts print a one-shot
+ * launch URL there, which is how a spawned host is authenticated without
+ * touching the host's credential store.
+ */
+async function negotiateHost(settings, logFile) {
+  const origin = originFromHostPort(settings.host, settings.port);
+  const negotiated = await negotiateWire({
+    origin,
+    logFile,
+    dshHome: settings.dshHome,
+    dialect: settings.wire,
+    log: logDebug,
+  });
+  return {
+    origin,
+    host: settings.host,
+    port: settings.port,
+    dialect: negotiated.dialect,
+    describe: negotiated.describe,
+    client: negotiated.client,
+  };
+}
+
+function describeProbeError(error) {
+  return error && error.message ? error.message : String(error);
+}
+
+async function waitForDescribe(settings, logFile, timeoutMs) {
+  const origin = originFromHostPort(settings.host, settings.port);
   const deadline = Date.now() + timeoutMs;
   let lastError = null;
   while (Date.now() < deadline) {
     try {
-      return await probeDescribe(origin, 2_000);
+      return await negotiateHost(settings, logFile);
     } catch (error) {
       lastError = error;
       await new Promise((resolve) => setTimeout(resolve, SPAWN_POLL_MS));
     }
   }
-  throw lastError || new DshTransportError(`dsh host did not become ready at ${origin}`);
+  if (lastError) {
+    throw new DshTransportError(describeProbeError(lastError), { cause: lastError });
+  }
+  throw new DshTransportError(`dsh host did not become ready at ${origin}`);
 }
 
 /**
  * Read-only attach: adopt a running host, never spawn.
  */
 export async function connectExisting(settings) {
-  const origin = originFromHostPort(settings.host, settings.port);
-  const describe = await probeDescribe(origin);
-  return {
-    origin,
-    host: settings.host,
-    port: settings.port,
-    ownership: 'adopted',
-    describe,
-    client: new DshHostClient(origin),
-  };
+  const remembered = readStateFile();
+  const handle = await negotiateHost(settings, remembered && remembered.logFile);
+  return { ...handle, ownership: 'adopted' };
 }
 
 /**
@@ -396,15 +428,12 @@ export async function ensureHost(settings) {
   const refreshedRemembered = readStateFile();
   if (refreshedRemembered && refreshedRemembered.origin === origin && isPidAlive(refreshedRemembered.pid)) {
     try {
-      const describe = await waitForDescribe(origin, SPAWN_READY_TIMEOUT_MS);
-      return {
-        origin,
-        host: settings.host,
-        port: settings.port,
-        ownership: 'spawned',
-        describe,
-        client: new DshHostClient(origin),
-      };
+      const handle = await waitForDescribe(
+        settings,
+        refreshedRemembered.logFile,
+        SPAWN_READY_TIMEOUT_MS
+      );
+      return { ...handle, ownership: 'spawned' };
     } catch {
       // recorded spawn never became healthy — respawn below
     }
@@ -435,15 +464,8 @@ export async function ensureHost(settings) {
   });
 
   try {
-    const describe = await waitForDescribe(origin, SPAWN_READY_TIMEOUT_MS);
-    return {
-      origin,
-      host: settings.host,
-      port: settings.port,
-      ownership: 'spawned',
-      describe,
-      client: new DshHostClient(origin),
-    };
+    const handle = await waitForDescribe(settings, logFile, SPAWN_READY_TIMEOUT_MS);
+    return { ...handle, ownership: 'spawned' };
   } catch (error) {
     let logTail = '';
     try {
@@ -492,9 +514,10 @@ export async function collectDshStatus(settings) {
     describe: null,
   };
   try {
-    const describe = await probeDescribe(base.origin);
+    const handle = await negotiateHost(settings, base.remembered && base.remembered.logFile);
     result.hostRunning = true;
-    result.describe = describe;
+    result.describe = handle.describe;
+    result.dialect = handle.dialect;
     result.ownership =
       base.remembered && base.remembered.origin === base.origin && isPidAlive(base.remembered.pid)
         ? 'spawned'

--- a/ai-bridge/services/dsh/wire.js
+++ b/ai-bridge/services/dsh/wire.js
@@ -1,0 +1,310 @@
+/**
+ * DSH wire dialects — how the bridge reaches a `dsh web` host across DSH
+ * releases, and how a non-browser client authenticates to one.
+ *
+ * Two dialects exist today:
+ *
+ *   legacy (<= 0.1.0-rc.x)  endpoints are dotted (`POST /api/session.list`),
+ *                           `/api` carries only the Host/Origin fence, the
+ *                           event stream is `/api/events.mux`, and host-minted
+ *                           requests settle on `POST /api/respond`.
+ *
+ *   modern (>= 0.1.5-rc.x)  endpoints are `<namespace>/<method>`
+ *                           (`POST /api/session/list`), `host.describe` is
+ *                           gone, the event stream moved to
+ *                           `/api/remote.mux`, and every `/api` request *and*
+ *                           WebSocket upgrade carries a browser-session
+ *                           cookie minted by `dsh web`.
+ *
+ * The dialect is negotiated against the live host (never inferred from a
+ * version string — an adopted host never reports one) and cached in the
+ * supervisor state file; `DSH_WIRE` pins it when negotiation guesses wrong.
+ */
+
+import { createHash, createHmac } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const LEGACY_DIALECT = 'legacy';
+export const MODERN_DIALECT = 'modern';
+
+export const DIALECT_IDS = [LEGACY_DIALECT, MODERN_DIALECT];
+
+/** Browser-session cookie name/value grammar shared with `dsh-client-connection`. */
+const COOKIE_PREFIX = 'dsh-auth-';
+const COOKIE_PAYLOAD_VERSION = 1;
+const SECRET_BYTES = 32;
+/** Well under the host's default `cookieMaxAgeDays` (30), so the payload validates. */
+const COOKIE_LIFETIME_MS = 24 * 60 * 60 * 1000;
+/** Signed-in-the-past slack for clock skew between the bridge and the host. */
+const COOKIE_CLOCK_SKEW_MS = 5_000;
+/** Credential record key holding the signing secret (`credentialKey('client-connection','browser-session')`). */
+const BROWSER_SESSION_RECORD = 'client-connection/browser-session';
+
+const DIALECTS = {
+  [LEGACY_DIALECT]: {
+    id: LEGACY_DIALECT,
+    authenticated: false,
+    muxPath: '/api/events.mux',
+    respondPath: '/api/respond',
+    /** Probed to tell the dialects apart (legacy-only endpoint). */
+    probeMethod: 'host.describe',
+  },
+  [MODERN_DIALECT]: {
+    id: MODERN_DIALECT,
+    authenticated: true,
+    muxPath: '/api/remote.mux',
+    respondPath: '/api/$events/result',
+    /** Modern has no `host.describe`; the cheapest "is this a live host" call. */
+    probeMethod: 'session.list',
+  },
+};
+
+/**
+ * Endpoints whose modern name is not just the dotted name with `/` separators.
+ * `null` means the endpoint has no modern successor.
+ */
+const MODERN_ALIASES = {
+  'host.describe': null,
+  'session.history': 'session/page',
+  'llm.models': 'session/modelCatalog',
+  'llm.providers': 'llm/listProviders',
+  'llm.discoverModels': 'llm/discoverModels',
+};
+
+/** Normalize a configured `DSH_WIRE` value; unknown values mean "negotiate". */
+export function normalizeDialectId(value) {
+  const trimmed = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  return DIALECT_IDS.includes(trimmed) ? trimmed : null;
+}
+
+export function isKnownDialect(id) {
+  return DIALECT_IDS.includes(id);
+}
+
+export function dialectDescriptor(id) {
+  const descriptor = DIALECTS[id];
+  if (!descriptor) {
+    throw new Error(`dsh: unknown wire dialect ${JSON.stringify(id)}`);
+  }
+  return descriptor;
+}
+
+export function requiresBrowserSession(id) {
+  return dialectDescriptor(id).authenticated;
+}
+
+export function muxPathFor(id) {
+  return dialectDescriptor(id).muxPath;
+}
+
+export function respondPathFor(id) {
+  return dialectDescriptor(id).respondPath;
+}
+
+export function probeMethodFor(id) {
+  return dialectDescriptor(id).probeMethod;
+}
+
+/**
+ * Map one logical endpoint (the dotted legacy spelling used throughout this
+ * bridge) onto the dialect's wire name. Returns null when the dialect has no
+ * such endpoint.
+ */
+export function wireMethodFor(id, logicalMethod) {
+  const method = String(logicalMethod || '').trim();
+  if (!method) {
+    return null;
+  }
+  if (id === MODERN_DIALECT && method in MODERN_ALIASES) {
+    return MODERN_ALIASES[method];
+  }
+  if (id !== MODERN_DIALECT) {
+    return method;
+  }
+  return method.replace(/\./g, '/');
+}
+
+/**
+ * Modern endpoints whose single business argument is not named `request`, or
+ * that take no argument at all. The gateway validates the `args` object
+ * against the descriptor's parameter names, so these must match exactly.
+ */
+const MODERN_ARG_NAMES = {
+  'session/list': '_request',
+  'session/modelCatalog': null,
+};
+
+/**
+ * Wrap one legacy-shaped business payload into the modern `args` object.
+ * The legacy wire posts the payload itself; the modern gateway demands
+ * `payload.args` keyed by the descriptor's parameter name.
+ */
+export function modernPayloadFor(wireMethod, payload) {
+  if (wireMethod in MODERN_ARG_NAMES) {
+    const name = MODERN_ARG_NAMES[wireMethod];
+    return name === null ? {} : { [name]: payload };
+  }
+  return { request: payload };
+}
+
+/** Build the `payload` body of one RPC for a dialect. */
+export function rpcPayloadFor(id, wireMethod, payload) {
+  if (id !== MODERN_DIALECT) {
+    return payload;
+  }
+  return { args: modernPayloadFor(wireMethod, payload) };
+}
+
+//#region browser-session cookie
+
+function encodeBase64Url(value) {
+  return Buffer.from(value).toString('base64').replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/u, '');
+}
+
+function decodeBase64Url(value) {
+  if (typeof value !== 'string' || !/^[A-Za-z0-9_-]*$/.test(value) || value.length % 4 === 1) {
+    return null;
+  }
+  const padding = '='.repeat((4 - (value.length % 4)) % 4);
+  const decoded = Buffer.from(value.replaceAll('-', '+').replaceAll('_', '/') + padding, 'base64');
+  return encodeBase64Url(decoded) === value ? decoded : null;
+}
+
+/** Canonical request authority (`host[:port]`), as the host derives it. */
+export function authorityFromOrigin(origin) {
+  try {
+    return new URL(String(origin || '')).host || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Cookie name the host expects for one authority. */
+export function cookieNameForAuthority(authority) {
+  return COOKIE_PREFIX + encodeBase64Url(createHash('sha256').update(authority).digest());
+}
+
+/**
+ * Self-sign a browser-session cookie from the host's persistent signing
+ * secret. Mirrors `dsh-client-connection`'s `encodeCookie`, so a non-browser
+ * client on the same machine can authenticate to a host it did not spawn
+ * (whose one-shot launch token is unreachable).
+ *
+ * @param {string} authority - canonical `host[:port]`.
+ * @param {string} secretBase64Url - the stored 32-byte secret.
+ * @param {number} [now] - injectable clock for tests.
+ * @returns {{ name: string, value: string, header: string, expiresAt: number }}
+ */
+export function signSessionCookie(authority, secretBase64Url, now = Date.now()) {
+  const secret = decodeBase64Url(String(secretBase64Url || '').trim());
+  if (!secret || secret.byteLength !== SECRET_BYTES) {
+    throw new Error('dsh: browser-session secret is not a 32-byte base64url value');
+  }
+  const issuedAt = now - COOKIE_CLOCK_SKEW_MS;
+  const expiresAt = issuedAt + COOKIE_LIFETIME_MS;
+  const body = encodeBase64Url(Buffer.from(JSON.stringify({
+    version: COOKIE_PAYLOAD_VERSION,
+    authority,
+    issuedAt,
+    expiresAt,
+  }), 'utf8'));
+  const signature = encodeBase64Url(createHmac('sha256', secret).update(body).digest());
+  const name = cookieNameForAuthority(authority);
+  return { name, value: `v1.${body}.${signature}`, header: `${name}=v1.${body}.${signature}`, expiresAt };
+}
+
+/** Read the first `name=value` pair from a `set-cookie` header. */
+export function parseSetCookie(headerValue) {
+  const first = String(headerValue || '').split(';', 1)[0].trim();
+  const at = first.indexOf('=');
+  if (at <= 0) {
+    return null;
+  }
+  return { name: first.slice(0, at).trim(), value: first.slice(at + 1).trim() };
+}
+
+/**
+ * Pull the one-shot launch URL out of `dsh web` output. The host prints
+ * `dsh web: http://127.0.0.1:3080/?token=<launch token>` at boot, and that
+ * token is the only way to mint a cookie for a host we spawned.
+ */
+export function launchUrlFromText(text, expectedOrigin) {
+  if (typeof text !== 'string' || !text) {
+    return null;
+  }
+  const match = text.match(/dsh web:\s*(https?:\/\/\S+)/);
+  if (!match) {
+    return null;
+  }
+  let url;
+  try {
+    url = new URL(match[1]);
+  } catch {
+    return null;
+  }
+  if (!url.searchParams.get('token')) {
+    return null;
+  }
+  if (expectedOrigin) {
+    let expected;
+    try {
+      expected = new URL(expectedOrigin);
+    } catch {
+      return null;
+    }
+    // The LAN line in the same output advertises another authority; only the
+    // loopback/expected-origin URL carries a token we may use here.
+    if (url.port !== expected.port || url.hostname !== expected.hostname) {
+      return null;
+    }
+  }
+  return url.href;
+}
+
+/** Parse the signing secret out of a `$DSH_HOME/.credentials.yaml`. */
+export function signingSecretFromCredentials(text) {
+  if (typeof text !== 'string' || !text) {
+    return null;
+  }
+  const lines = text.split(/\r?\n/);
+  const at = lines.findIndex((line) => line.trim() === `${BROWSER_SESSION_RECORD}:`);
+  if (at === -1) {
+    return null;
+  }
+  for (let index = at + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    const indentation = line.match(/^\s*/)[0].length;
+    if (line.trim() && indentation === 0) {
+      break;
+    }
+    const secret = line.match(/^\s*secret:\s*(\S+)\s*$/);
+    if (secret) {
+      return secret[1];
+    }
+  }
+  return null;
+}
+
+/** Resolve `$DSH_HOME` the way the launcher does, defaulting to `~/.dsh`. */
+export function resolveDshHome(env = process.env) {
+  const configured = String(env.DSH_HOME || '').trim();
+  return configured || join(env.HOME || env.USERPROFILE || homedir(), '.dsh');
+}
+
+/**
+ * Read the host's persistent signing secret. Returns null when the store is
+ * absent, unreadable, or predates browser authentication (a legacy host never
+ * writes it).
+ */
+export function readSigningSecret(dshHome) {
+  try {
+    const text = readFileSync(join(dshHome, '.credentials.yaml'), 'utf8');
+    return signingSecretFromCredentials(text);
+  } catch {
+    return null;
+  }
+}
+
+//#endregion

--- a/ai-bridge/services/dsh/wire.test.js
+++ b/ai-bridge/services/dsh/wire.test.js
@@ -1,0 +1,138 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  LEGACY_DIALECT,
+  MODERN_DIALECT,
+  authorityFromOrigin,
+  cookieNameForAuthority,
+  launchUrlFromText,
+  modernPayloadFor,
+  muxPathFor,
+  normalizeDialectId,
+  parseSetCookie,
+  probeMethodFor,
+  requiresBrowserSession,
+  respondPathFor,
+  rpcPayloadFor,
+  signSessionCookie,
+  signingSecretFromCredentials,
+  wireMethodFor,
+} from './wire.js';
+
+test('dialect descriptors carry the paths each DSH line serves', () => {
+  assert.equal(muxPathFor(LEGACY_DIALECT), '/api/events.mux');
+  assert.equal(muxPathFor(MODERN_DIALECT), '/api/remote.mux');
+  assert.equal(respondPathFor(LEGACY_DIALECT), '/api/respond');
+  assert.equal(respondPathFor(MODERN_DIALECT), '/api/$events/result');
+  assert.equal(probeMethodFor(LEGACY_DIALECT), 'host.describe');
+  assert.equal(probeMethodFor(MODERN_DIALECT), 'session.list');
+  assert.equal(requiresBrowserSession(LEGACY_DIALECT), false);
+  assert.equal(requiresBrowserSession(MODERN_DIALECT), true);
+});
+
+test('wireMethodFor keeps the legacy spelling and modernizes the modern one', () => {
+  assert.equal(wireMethodFor(LEGACY_DIALECT, 'session.list'), 'session.list');
+  assert.equal(wireMethodFor(MODERN_DIALECT, 'session.list'), 'session/list');
+  assert.equal(wireMethodFor(MODERN_DIALECT, 'session.selectModel'), 'session/selectModel');
+  assert.equal(wireMethodFor(MODERN_DIALECT, 'workspace.archiveSession'), 'workspace/archiveSession');
+});
+
+test('wireMethodFor maps the endpoints modern hosts renamed or removed', () => {
+  assert.equal(wireMethodFor(MODERN_DIALECT, 'session.history'), 'session/page');
+  assert.equal(wireMethodFor(MODERN_DIALECT, 'llm.models'), 'session/modelCatalog');
+  // `host.describe` is gone on modern hosts: the probe uses the catalog instead.
+  assert.equal(wireMethodFor(MODERN_DIALECT, 'host.describe'), null);
+  assert.equal(wireMethodFor(LEGACY_DIALECT, 'host.describe'), 'host.describe');
+});
+
+test('modernPayloadFor uses each endpoint\'s descriptor argument name', () => {
+  assert.deepEqual(modernPayloadFor('session/list', {}), { _request: {} });
+  assert.deepEqual(modernPayloadFor('session/modelCatalog', {}), {});
+  assert.deepEqual(modernPayloadFor('session/prompt', { a: 1 }), { request: { a: 1 } });
+  assert.deepEqual(modernPayloadFor('workspace/archiveSession', { sessionId: 's' }), {
+    request: { sessionId: 's' },
+  });
+});
+
+test('rpcPayloadFor wraps only the modern dialect', () => {
+  assert.deepEqual(rpcPayloadFor(LEGACY_DIALECT, 'session.list', { a: 1 }), { a: 1 });
+  assert.deepEqual(rpcPayloadFor(MODERN_DIALECT, 'session/list', { a: 1 }), {
+    args: { _request: { a: 1 } },
+  });
+  assert.deepEqual(rpcPayloadFor(MODERN_DIALECT, 'session/modelCatalog', {}), { args: {} });
+});
+
+test('normalizeDialectId accepts only the known pins', () => {
+  assert.equal(normalizeDialectId('modern'), MODERN_DIALECT);
+  assert.equal(normalizeDialectId(' LEGACY '), LEGACY_DIALECT);
+  assert.equal(normalizeDialectId(''), null);
+  assert.equal(normalizeDialectId('v9'), null);
+});
+
+test('signSessionCookie reproduces the host cookie grammar', () => {
+  const authority = authorityFromOrigin('http://127.0.0.1:3080');
+  const secret = Buffer.alloc(32, 7).toString('base64url');
+  const cookie = signSessionCookie(authority, secret, 1_700_000_000_000);
+
+  assert.equal(cookie.name, cookieNameForAuthority('127.0.0.1:3080'));
+  assert.match(cookie.value, /^v1\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+  assert.equal(cookie.header, `${cookie.name}=${cookie.value}`);
+
+  const payload = JSON.parse(Buffer.from(cookie.value.split('.')[1], 'base64url').toString('utf8'));
+  assert.equal(payload.version, 1);
+  assert.equal(payload.authority, '127.0.0.1:3080');
+  // Issued slightly in the past so a small clock skew cannot invalidate it,
+  // and well inside the host's default 30-day cookie lifetime.
+  assert.ok(payload.issuedAt < 1_700_000_000_000);
+  assert.ok(payload.expiresAt - payload.issuedAt < 30 * 24 * 60 * 60 * 1000);
+});
+
+test('signSessionCookie rejects a secret that is not 32 bytes', () => {
+  assert.throws(() => signSessionCookie('127.0.0.1:3080', 'short'), /32-byte/);
+  assert.throws(() => signSessionCookie('127.0.0.1:3080', ''), /32-byte/);
+});
+
+test('parseSetCookie reads the first pair only', () => {
+  assert.deepEqual(parseSetCookie('dsh-auth-abc=v1.x.y; Max-Age=60; Path=/; HttpOnly'), {
+    name: 'dsh-auth-abc',
+    value: 'v1.x.y',
+  });
+  assert.equal(parseSetCookie(''), null);
+  assert.equal(parseSetCookie('novalue'), null);
+});
+
+test('launchUrlFromText extracts the tokenized loopback URL', () => {
+  const text = [
+    'dsh web: http://127.0.0.1:3080/?token=abc123 (LAN: http://10.0.0.5:3080/?token=lantoken)',
+    'dsh web: opening the default browser; pass --no-open to disable',
+  ].join('\n');
+  assert.equal(launchUrlFromText(text, 'http://127.0.0.1:3080'), 'http://127.0.0.1:3080/?token=abc123');
+  // Another authority (or a token-less URL) is never used for the exchange.
+  assert.equal(launchUrlFromText(text, 'http://127.0.0.1:3081'), null);
+  assert.equal(launchUrlFromText('dsh web: http://127.0.0.1:3080/', 'http://127.0.0.1:3080'), null);
+  assert.equal(launchUrlFromText('nothing here', 'http://127.0.0.1:3080'), null);
+});
+
+test('signingSecretFromCredentials reads the browser-session record', () => {
+  const yaml = [
+    'version: 1',
+    'refs:',
+    '  DEEPSEEK_API_KEY: sk-x',
+    'records:',
+    '  client-connection/browser-session:',
+    '    kind: grant',
+    '    payload:',
+    '      version: 1',
+    '      secret: k4elfV_f9ThPYKiuLRSmVgo7Fqg-cP5Y7lzIfEjRlMY',
+    '  other/record:',
+    '    kind: grant',
+    '',
+  ].join('\n');
+  assert.equal(
+    signingSecretFromCredentials(yaml),
+    'k4elfV_f9ThPYKiuLRSmVgo7Fqg-cP5Y7lzIfEjRlMY'
+  );
+  assert.equal(signingSecretFromCredentials('version: 1\nrecords: {}\n'), null);
+  assert.equal(signingSecretFromCredentials(''), null);
+});

--- a/ai-bridge/services/dsh/ws-client.js
+++ b/ai-bridge/services/dsh/ws-client.js
@@ -1,11 +1,13 @@
 /**
  * Minimal RFC 6455 WebSocket client for the DSH mux stream.
  *
- * The published `dsh web` host (0.1.0-rc.6) serves `/api/events.mux` over
- * WebSocket only — a bare GET answers `426 Upgrade Required`. Node's global
- * WebSocket is unavailable before v22, so this dependency-free client speaks
- * just enough of the protocol for a localhost text stream:
+ * `dsh web` serves its event stream over WebSocket only — a bare GET answers
+ * `426 Upgrade Required`. Node's global WebSocket is unavailable before v22,
+ * so this dependency-free client speaks just enough of the protocol for a
+ * localhost text stream:
  *   - HTTP Upgrade handshake with Sec-WebSocket-Accept validation
+ *   - extra handshake headers (the >= 0.1.1 hosts authenticate the upgrade
+ *     with a browser-session cookie, so the stream needs one too)
  *   - text / binary / continuation frames, ping → pong, close
  *   - client-side masking (required by RFC)
  *   - ws:// via net, wss:// via tls
@@ -30,6 +32,39 @@ const OPCODES = {
   PONG: 0xa,
 };
 
+/** Handshake headers the client owns; a caller-supplied copy must not override them. */
+const RESERVED_HANDSHAKE_HEADERS = new Set([
+  'host',
+  'upgrade',
+  'connection',
+  'sec-websocket-key',
+  'sec-websocket-version',
+]);
+
+/**
+ * Render caller-supplied handshake headers as `Name: value\r\n` lines.
+ * Values are flattened and CR/LF-stripped so a header value can never inject
+ * a second request line or header.
+ */
+function normalizeHandshakeHeaders(headers) {
+  if (!headers || typeof headers !== 'object') {
+    return '';
+  }
+  let rendered = '';
+  for (const [rawName, rawValue] of Object.entries(headers)) {
+    const name = String(rawName || '').trim();
+    const value = String(rawValue ?? '').replace(/[\r\n]+/g, ' ').trim();
+    if (!name || !value || !/^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(name)) {
+      continue;
+    }
+    if (RESERVED_HANDSHAKE_HEADERS.has(name.toLowerCase())) {
+      continue;
+    }
+    rendered += `${name}: ${value}\r\n`;
+  }
+  return rendered;
+}
+
 export class DshWebSocket extends EventEmitter {
   #socket = null;
   #buffer = Buffer.alloc(0);
@@ -42,10 +77,13 @@ export class DshWebSocket extends EventEmitter {
 
   /**
    * @param {string} url ws:// or wss:// URL
-   * @param {{ timeoutMs?: number }} [options]
+   * @param {{ timeoutMs?: number, headers?: Record<string, string> }} [options]
+   *   `headers` are appended verbatim to the Upgrade request (one
+   *   `Name: value` line each); reserved handshake headers win.
    */
   connect(url, options = {}) {
     const timeoutMs = options.timeoutMs ?? 10_000;
+    const extraHeaders = normalizeHandshakeHeaders(options.headers);
     let parsed;
     try {
       parsed = new URL(url);
@@ -67,6 +105,7 @@ export class DshWebSocket extends EventEmitter {
         'Connection: Upgrade\r\n' +
         `Sec-WebSocket-Key: ${key}\r\n` +
         'Sec-WebSocket-Version: 13\r\n' +
+        extraHeaders +
         '\r\n';
       this.#socket.write(request);
     };
@@ -171,7 +210,12 @@ export class DshWebSocket extends EventEmitter {
     const statusMatch = statusLine.match(/^HTTP\/\d\.\d (\d{3})/);
     const status = statusMatch ? Number(statusMatch[1]) : 0;
     if (status !== 101) {
-      this.#fail(new Error(`dsh mux upgrade failed (HTTP ${status || statusLine})`));
+      const hint = status === 401
+        ? ' — the host requires browser-session authentication'
+        : status === 403
+          ? ' — the host rejected this authority'
+          : '';
+      this.#fail(new Error(`dsh mux upgrade failed (HTTP ${status || statusLine})${hint}`));
       return false;
     }
     const acceptMatch = header.match(/sec-websocket-accept:\s*(\S+)/i);


### PR DESCRIPTION
## What

Makes the DSH provider work against **dsh >= 0.1.5** while leaving the existing
0.1.0-rc.x path byte-identical.

Fixes #1753 (and the 401 variant of it): the bridge spoke the pre-0.1.5 wire, so a
modern host answered `401 unauthorized` to the readiness probe and the provider could
never connect:

```
Failed to start DSH host at http://127.0.0.1:3080: dsh HTTP 401: unauthorized
```

## Why a code change was needed

Measured against a live `dsh 0.1.5-rc.1`, four independent breaking changes separate the
two lines:

| | 0.1.0-rc.x (what the bridge spoke) | 0.1.5-rc.1 (what it answers now) |
|---|---|---|
| `/api` auth | none (Host/Origin fence only) | browser-session cookie on every request **and** WebSocket upgrade |
| endpoints | `POST /api/session.list` | `POST /api/session/list`, `payload = {args:{…}}` |
| readiness probe | `host.describe` | **deleted** (no `host` namespace at all) |
| event stream | `GET /api/events.mux`, server-push only | `GET /api/remote.mux`, **bidirectional**: nothing is delivered until the client sends `{type:'open',…}` |
| approvals | `POST /api/respond` echoing a frame `rpcId` | `$events` waterfall frames answered through `POST /api/$events/result` with the per-generation `clientId` |

So the 401 is the first failure a modern host reports, not the only one.

## How

**Dialect negotiation** (`wire.js`, `negotiate.js`) — observed, never guessed from a
version string (an adopted host never reports one):

```
probe('host.describe')
  ├─ 200 → legacy   (dotted endpoints, no cookie)
  ├─ 401 → modern   (only that line has an auth fence)
  └─ 404 → modern   (the endpoint is gone)
```

`DSH_WIRE=legacy|modern` pins the answer when observation is not enough.

**Authentication** — a spawned host and an adopted host are different problems:

- a host this bridge spawned prints `dsh web: http://…/?token=…` into the log the
  supervisor already redirects (`~/.codemoss/dsh-web.log`), so the one-shot launch
  token is exchanged for the cookie with no extra privileges;
- an adopted host's launch token went to a console we cannot read, so the cookie is
  signed from the persistent `client-connection/browser-session` secret in
  `$DSH_HOME/.credentials.yaml` — the same HMAC format `dsh-client-connection`
  verifies. A rejected cookie reports the `DSH_HOME` mismatch instead of a bare 401.

**Turn transport** (`stream-client.js`, `message-service.js`) — one `/api/remote.mux`
socket carries two logical streams: `$events` for the forwarded
`approval/request` / `user-questions/request` waterfalls, and `session/follow`
(opt-in `assistantStream`) for durable events plus assistant deltas. Projections reuse
the existing `projectSessionEvent` / `projectStreamChunk`, so the marker protocol the
Java side consumes is unchanged.

**Payload adaptation** (`session.js`, `host.js`) — modern `session/create` binds `cwd`
directly, so no workspace entry is created per turn; `session/prompt` carries the
client-minted `requestId` the modern schema requires; `session/list` sends its
`_request` key; `session/modelCatalog` takes no arguments. The model picker keeps
working because the catalog's `groups[]` shape is unchanged, and `host.describe`'s
`{provider, model}` is replaced by the catalog's `default` (which also carries the
reasoning effort).

## Compatibility

Legacy hosts are untouched: when `host.describe` answers, every call takes the previous
dotted path with the previous payload and no cookie, and the previous `events.mux`
projection. Every existing DSH test passes unchanged.

## Verification

- **Live `dsh 0.1.5-rc.1`** (the exact case from the issue): negotiation → `modern`,
  `session/list` (13 sessions), `session/modelCatalog` → 4 picker rows identical to the
  legacy flattening, history paging (follow snapshot → `session/page`), the `$events`
  `ready` frame with its `clientId`, and a `session/follow` snapshot.
- **48 unit tests added** for the new modules and the adapted layers: dialect/method
  mapping, `args` wrapping, cookie signing grammar, launch-URL parsing, negotiation for
  both dialects (including the no-secret and wrong-secret failures), the mux frame
  contract (`open` = exactly four keys, `item`/`error`/`end`, unknown streams ignored,
  `cancel`), waterfall answer payloads, and the per-dialect session payloads.
- Full `ai-bridge` suite: 13/13 DSH files green, no regressions. Eight unrelated files
  (`api-config`, `mcp-status/*`, `message-rewind`, `persistent-query-service`,
  `runtime-lifecycle`, `grok/acp-terminal-host`, `channel-manager.protocol`) fail
  identically on a clean checkout of this branch's base — verified by stashing.

## Notes for review

- All changes are confined to `ai-bridge/services/dsh/`; no Java or webview change.
- Two new env knobs, both optional: `DSH_WIRE` (dialect pin) and `DSH_HOME` (which home's
  secret signs the cookie for an adopted host).
- Reading `$DSH_HOME/.credentials.yaml` is the only way to reach a host the user started
  outside the IDE. If you would rather not read the credential store, say so and I will
  drop that fallback and report an actionable error instead — but then an externally
  started `dsh web` on 3080 stays unusable, which is the exact configuration in #1753.
