### PR TITLE
fix: keep webview startup work off the EDT

### DIFF
--- a/src/main/java/com/github/claudecodegui/provider/common/BaseSDKBridge.java
+++ b/src/main/java/com/github/claudecodegui/provider/common/BaseSDKBridge.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -30,6 +31,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public abstract class BaseSDKBridge {
 
     protected static final String CHANNEL_SCRIPT = "channel-manager.js";
+    private static final long ENVIRONMENT_CHECK_TIMEOUT_SECONDS = 5L;
 
     protected final Logger LOG;
     protected final Gson gson = new Gson();
@@ -185,12 +187,21 @@ public abstract class BaseSDKBridge {
      * Check if the environment is ready.
      */
     public boolean checkEnvironment() {
+        Process process = null;
         try {
             String node = nodeDetector.findNodeExecutable();
             List<String> versionCmd = NodeDetector.buildNodeScriptCommand(node, "--version");
             ProcessBuilder pb = new ProcessBuilder(versionCmd);
             envConfigurator.updateProcessEnvironment(pb, node);
-            Process process = pb.start();
+            process = pb.start();
+
+            boolean finished = process.waitFor(
+                    ENVIRONMENT_CHECK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!finished) {
+                LOG.warn("Node.js environment check timed out; terminating probe process");
+                process.destroyForcibly();
+                return false;
+            }
 
             try (BufferedReader reader = new BufferedReader(
                     new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
@@ -198,15 +209,14 @@ public abstract class BaseSDKBridge {
                 LOG.debug("Node.js version: " + version);
             }
 
-            int exitCode = process.waitFor();
-            if (exitCode != 0) {
+            if (process.exitValue() != 0) {
                 return false;
             }
 
             // Check bridge directory
             File bridgeDir = getDirectoryResolver().findSdkDir();
             if (bridgeDir == null) {
-                // Bridge extraction is in progress (EDT thread scenario)
+                // Bridge extraction is in progress (background initialization scenario)
                 LOG.info("Bridge directory not ready yet (extraction in progress)");
                 return false;
             }
@@ -219,9 +229,17 @@ public abstract class BaseSDKBridge {
 
             LOG.info("Environment check passed for " + getProviderName());
             return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Environment check was interrupted");
+            return false;
         } catch (Exception e) {
             LOG.warn("Environment check failed: " + e.getMessage());
             return false;
+        } finally {
+            if (process != null && process.isAlive()) {
+                process.destroyForcibly();
+            }
         }
     }
 

--- a/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
+++ b/src/main/java/com/github/claudecodegui/ui/ChatWindowDelegate.java
@@ -193,36 +193,16 @@ public class ChatWindowDelegate {
             if (savedNodePath != null && !savedNodePath.trim().isEmpty()) {
                 String path = savedNodePath.trim();
                 applyNodePathToBridges(path);
-                claudeSDKBridge.verifyAndCacheNodePath(path);
-                LOG.info("Using manually configured Node.js path: " + path);
+                // The webview initializer performs the authoritative verification on its
+                // preparation worker before creating the browser. Avoid starting a duplicate
+                // subprocess here; this constructor path must remain non-blocking.
+                LOG.info("Using manually configured Node.js path: " + path
+                        + " (verification deferred to webview preparation)");
             } else {
-                // Auto-detection spawns shell processes which block the calling thread for several
-                // seconds per attempt. Running this on the EDT freezes the entire IDE. Offload to
-                // a pooled thread; the bridges fall back to invoking "node" by name until the
-                // detection completes and updates them.
-                LOG.info("No saved Node.js path found, scheduling auto-detection on background thread...");
-                ApplicationManager.getApplication().executeOnPooledThread(() -> {
-                    try {
-                        com.github.claudecodegui.model.NodeDetectionResult detected =
-                            claudeSDKBridge.detectNodeWithDetails();
-
-                        if (detected != null && detected.isFound() && detected.getNodePath() != null) {
-                            String detectedPath = detected.getNodePath();
-                            String detectedVersion = detected.getNodeVersion();
-
-                            props.setValue(NODE_PATH_PROPERTY_KEY, detectedPath);
-                            applyNodePathToBridges(detectedPath);
-                            claudeSDKBridge.verifyAndCacheNodePath(detectedPath);
-
-                            LOG.info("Auto-detected Node.js: " + detectedPath + " (" + detectedVersion + ")");
-                        } else {
-                            LOG.warn("Failed to auto-detect Node.js path. Error: " +
-                                (detected != null ? detected.getErrorMessage() : "Unknown error"));
-                        }
-                    } catch (Exception e) {
-                        LOG.error("Failed to auto-detect Node.js path: " + e.getMessage(), e);
-                    }
-                });
+                // WebviewInitializer owns the startup preparation and performs the single
+                // background detection there. Keeping construction free of a second probe
+                // avoids duplicate shell processes and competing writes to the shared cache.
+                LOG.info("No saved Node.js path; deferring detection to webview preparation...");
             }
         } catch (Exception e) {
             LOG.error("Failed to load Node.js path: " + e.getMessage(), e);

--- a/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
+++ b/src/main/java/com/github/claudecodegui/ui/WebviewInitializer.java
@@ -47,6 +47,7 @@ import java.awt.dnd.DropTargetDropEvent;
 import java.io.File;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 import java.util.function.IntPredicate;
@@ -106,6 +107,10 @@ public class WebviewInitializer {
     private final WebviewHost host;
 
     private final Object bridgeLock = new Object();
+    /** Invalidates background preparation when the browser lifecycle advances. */
+    private final AtomicInteger initializationGeneration = new AtomicInteger();
+    /** Prevents duplicate background preparation for one browser lifecycle. */
+    private final AtomicBoolean initializationInProgress = new AtomicBoolean();
 
     private static void applyNodePathToCliBridges(Map<String, MarkerCliBridge> cliBridges, String path) {
         if (cliBridges == null) {
@@ -135,6 +140,10 @@ public class WebviewInitializer {
      * Create and configure UI components (browser, JS bridge, drag-and-drop).
      */
     public void createUIComponents() {
+        if (!SwingUtilities.isEventDispatchThread()) {
+            invokeLaterForToolWindow(this::createUIComponents);
+            return;
+        }
         if (this.host.isDisposed()) {
             return;
         }
@@ -146,135 +155,248 @@ public class WebviewInitializer {
             LOG.debug("Skip duplicate webview initialization: browser is already active");
             return;
         }
+        if (!this.initializationInProgress.compareAndSet(false, true)) {
+            LOG.debug("Skip duplicate webview initialization: preparation is already running");
+            return;
+        }
 
-        // Use the shared resolver from BridgePreloader for consistent state
-        com.github.claudecodegui.bridge.BridgeDirectoryResolver sharedResolver = BridgePreloader.getSharedResolver();
+        int initializationId = this.initializationGeneration.incrementAndGet();
+        // Use the shared resolver from BridgePreloader for consistent state.
+        com.github.claudecodegui.bridge.BridgeDirectoryResolver sharedResolver =
+                BridgePreloader.getSharedResolver();
 
-        // Check if bridge extraction is in progress (non-blocking check)
+        // Check extraction state without blocking the EDT. The future continuation releases
+        // this initialization only after it schedules a fresh attempt.
         if (sharedResolver.isExtractionInProgress()) {
             LOG.info("[ClaudeSDKToolWindow] Bridge extraction in progress, showing loading panel...");
             showLoadingPanel();
-
-            // Register async callback to reinitialize when extraction completes
-            sharedResolver.getExtractionFuture().thenAcceptAsync(ready -> {
-                if (ready) {
-                    reinitializeAfterExtraction();
-                } else {
-                    invokeLaterForToolWindow(this::showErrorPanel);
-                }
-            });
+            waitForBridgeExtraction(initializationId, sharedResolver);
             return;
         }
 
         ClaudeSDKBridge claudeSDKBridge = host.getClaudeSDKBridge();
         CodexSDKBridge codexSDKBridge = host.getCodexSDKBridge();
         Map<String, MarkerCliBridge> cliBridges = host.getCliBridges();
-
         PropertiesComponent props = PropertiesComponent.getInstance();
         String savedNodePath = props.getValue(NODE_PATH_PROPERTY_KEY);
 
+        // Setting an already-known path is cheap; verification is deliberately deferred to
+        // the preparation worker because it starts a subprocess and may wait several seconds.
         if (savedNodePath != null && !savedNodePath.trim().isEmpty()) {
             String trimmed = savedNodePath.trim();
             claudeSDKBridge.setNodeExecutable(trimmed);
             codexSDKBridge.setNodeExecutable(trimmed);
             applyNodePathToCliBridges(cliBridges, trimmed);
-            NodeDetectionResult nodeResult = claudeSDKBridge.verifyAndCacheNodePath(trimmed);
-            if (nodeResult == null || !nodeResult.isFound()) {
-                showInvalidNodePathPanel(trimmed, nodeResult != null ? nodeResult.getErrorMessage() : null);
-                return;
-            }
-            continueCreateUIComponentsAfterNodeSetup(nodeResult);
-            return;
         }
 
-        // No saved path: auto-detection spawns shell probes that block the calling
-        // thread for several seconds per attempt (and may hang instead of exiting in
-        // VM/container environments), so it must never run on the EDT. Detect on a
-        // pooled thread, then continue initialization back on the EDT.
-        LOG.info("No saved Node.js path found, scheduling auto-detection on background thread...");
         showLoadingPanel();
-        ApplicationManager.getApplication().executeOnPooledThread(() -> {
-            NodeDetectionResult detected;
-            try {
-                detected = claudeSDKBridge.detectNodeWithDetails();
-            } catch (Exception e) {
-                LOG.error("Failed to auto-detect Node.js path: " + e.getMessage(), e);
-                detected = null;
-            }
+        LOG.info("Preparing webview environment and HTML on a background thread...");
+        ApplicationManager.getApplication().executeOnPooledThread(() -> prepareUIComponents(
+                initializationId,
+                savedNodePath,
+                props,
+                claudeSDKBridge,
+                codexSDKBridge,
+                cliBridges,
+                sharedResolver));
+    }
 
-            if (detected != null && detected.isFound() && detected.getNodePath() != null) {
-                props.setValue(NODE_PATH_PROPERTY_KEY, detected.getNodePath());
-                claudeSDKBridge.setNodeExecutable(detected.getNodePath());
-                codexSDKBridge.setNodeExecutable(detected.getNodePath());
-                applyNodePathToCliBridges(cliBridges, detected.getNodePath());
-                claudeSDKBridge.verifyAndCacheNodePath(detected.getNodePath());
-                LOG.info("Auto-detected Node.js: " + detected.getNodePath()
-                    + " (" + detected.getNodeVersion() + ")");
-            } else {
-                // Fall back to invoking "node" by name (the same fallback
-                // NodeDetector.findNodeExecutable uses) so checkEnvironment can
-                // still pass when node is reachable on PATH but the probes failed.
-                LOG.warn("Failed to auto-detect Node.js path. Error: " +
-                    (detected != null ? detected.getErrorMessage() : "Unknown error"));
-                claudeSDKBridge.setNodeExecutable("node");
-                codexSDKBridge.setNodeExecutable("node");
-                applyNodePathToCliBridges(cliBridges, "node");
-            }
+    private void waitForBridgeExtraction(
+            int initializationId,
+            com.github.claudecodegui.bridge.BridgeDirectoryResolver sharedResolver
+    ) {
+        sharedResolver.getExtractionFuture()
+                .thenAcceptAsync(ready -> {
+                    if (ready) {
+                        reinitializeAfterExtraction(initializationId);
+                    } else {
+                        completePreparedInitialization(
+                                initializationId, InitializationResult.environmentUnavailable());
+                    }
+                })
+                .exceptionally(error -> {
+                    LOG.warn("Bridge extraction future failed: " + error.getMessage(), error);
+                    completePreparedInitialization(
+                            initializationId, InitializationResult.environmentUnavailable());
+                    return null;
+                });
+    }
 
-            final NodeDetectionResult nodeResult = detected;
-            invokeLaterForToolWindow(() -> {
-                if (host.isDisposed()) {
+    /** Resolves blocking startup inputs before the EDT creates the native browser. */
+    private void prepareUIComponents(
+            int initializationId,
+            String savedNodePath,
+            PropertiesComponent props,
+            ClaudeSDKBridge claudeSDKBridge,
+            CodexSDKBridge codexSDKBridge,
+            Map<String, MarkerCliBridge> cliBridges,
+            com.github.claudecodegui.bridge.BridgeDirectoryResolver sharedResolver
+    ) {
+        try {
+            if (!isCurrentInitialization(initializationId)) {
+                return;
+            }
+            NodeDetectionResult nodeResult;
+            if (savedNodePath != null && !savedNodePath.trim().isEmpty()) {
+                String trimmed = savedNodePath.trim();
+                nodeResult = claudeSDKBridge.verifyAndCacheNodePath(trimmed);
+                if (nodeResult == null || !nodeResult.isFound()) {
+                    completePreparedInitialization(
+                            initializationId,
+                            InitializationResult.invalidNodePath(
+                                    trimmed,
+                                    nodeResult != null ? nodeResult.getErrorMessage() : null));
                     return;
                 }
-                continueCreateUIComponentsAfterNodeSetup(nodeResult);
-            });
+            } else {
+                // Auto-detection spawns shell probes and can hang in VM/container environments.
+                NodeDetectionResult detected;
+                try {
+                    detected = claudeSDKBridge.detectNodeWithDetails();
+                } catch (Exception e) {
+                    LOG.error("Failed to auto-detect Node.js path: " + e.getMessage(), e);
+                    detected = null;
+                }
+
+                if (detected != null && detected.isFound() && detected.getNodePath() != null) {
+                    if (!isCurrentInitialization(initializationId)) {
+                        return;
+                    }
+                    String detectedPath = detected.getNodePath();
+                    props.setValue(NODE_PATH_PROPERTY_KEY, detectedPath);
+                    claudeSDKBridge.setNodeExecutable(detectedPath);
+                    codexSDKBridge.setNodeExecutable(detectedPath);
+                    applyNodePathToCliBridges(cliBridges, detectedPath);
+                    // Cache the verified version for dependency and session handlers. This extra
+                    // probe remains off the EDT and preserves the previous cache contract.
+                    claudeSDKBridge.verifyAndCacheNodePath(detectedPath);
+                    nodeResult = detected;
+                    LOG.info("Auto-detected Node.js: " + detectedPath
+                            + " (" + detected.getNodeVersion() + ")");
+                } else {
+                    // Fall back to invoking "node" by name so checkEnvironment can still pass
+                    // when the executable is reachable on PATH but discovery probes failed.
+                    LOG.warn("Failed to auto-detect Node.js path. Error: "
+                            + (detected != null ? detected.getErrorMessage() : "Unknown error"));
+                    claudeSDKBridge.setNodeExecutable("node");
+                    codexSDKBridge.setNodeExecutable("node");
+                    applyNodePathToCliBridges(cliBridges, "node");
+                    nodeResult = detected;
+                }
+            }
+
+            if (!isCurrentInitialization(initializationId)) {
+                return;
+            }
+            if (!claudeSDKBridge.checkEnvironment()) {
+                if (sharedResolver.isExtractionInProgress()) {
+                    LOG.info("Environment check is waiting for bridge extraction");
+                    completePreparedInitialization(
+                            initializationId, InitializationResult.waitForExtraction());
+                    return;
+                }
+                if (sharedResolver.isExtractionComplete()) {
+                    LOG.info("Environment check observed a just-completed extraction; retrying...");
+                    completePreparedInitialization(
+                            initializationId, InitializationResult.retryEnvironment());
+                    return;
+                }
+                completePreparedInitialization(
+                        initializationId, InitializationResult.environmentUnavailable());
+                return;
+            }
+
+            // This reads and transforms the approximately 10 MB bundled page. Keep it off the
+            // EDT even when the Node.js path was already cached.
+            if (!isCurrentInitialization(initializationId)) {
+                return;
+            }
+            String htmlContent = loadChatHtmlWithInitialTabState();
+            completePreparedInitialization(
+                    initializationId, InitializationResult.ready(nodeResult, htmlContent));
+        } catch (Exception e) {
+            LOG.error("Failed to prepare webview initialization: " + e.getMessage(), e);
+            completePreparedInitialization(
+                    initializationId, InitializationResult.failure(e.getMessage()));
+        }
+    }
+
+    private void completePreparedInitialization(
+            int initializationId,
+            InitializationResult result
+    ) {
+        if (host.isDisposed()) {
+            releaseInitialization(initializationId);
+            return;
+        }
+        invokeLaterForToolWindow(() -> {
+            if (!isCurrentInitialization(initializationId) || host.isDisposed()) {
+                releaseInitialization(initializationId);
+                return;
+            }
+
+            switch (result.status) {
+                case WAIT_FOR_EXTRACTION:
+                    waitForBridgeExtraction(initializationId, BridgePreloader.getSharedResolver());
+                    return;
+                case RETRY_ENVIRONMENT:
+                    retryCheckEnvironmentWithBackoff(0, initializationId);
+                    return;
+                case INVALID_NODE_PATH:
+                    releaseInitialization(initializationId);
+                    showInvalidNodePathPanel(result.nodePath, result.errorMessage);
+                    return;
+                case READY:
+                    try {
+                        continueCreateUIComponentsAfterNodeSetup(result.nodeResult, result.htmlContent);
+                    } finally {
+                        releaseInitialization(initializationId);
+                    }
+                    return;
+                case ENVIRONMENT_UNAVAILABLE:
+                case FAILURE:
+                default:
+                    // default guards future enum values: skipping the release would leave
+                    // initializationInProgress latched and block every later browser creation.
+                    releaseInitialization(initializationId);
+                    if (result.errorMessage != null) {
+                        LOG.warn("Webview preparation failed: " + result.errorMessage);
+                    }
+                    showErrorPanel();
+                    return;
+            }
         });
     }
 
+    private boolean isCurrentInitialization(int initializationId) {
+        return this.initializationGeneration.get() == initializationId
+                && this.initializationInProgress.get();
+    }
+
+    private void releaseInitialization(int initializationId) {
+        if (this.initializationGeneration.get() == initializationId) {
+            this.initializationInProgress.set(false);
+        }
+    }
+
     /**
-     * Continue UI initialization once the Node.js path has been resolved: environment
-     * check, version gate, then browser creation. Must be called on the EDT.
+     * Continue UI initialization after Node.js, environment, and HTML preparation completed.
+     * Browser creation and Swing/JCEF registration must remain on the EDT.
      */
-    private void continueCreateUIComponentsAfterNodeSetup(NodeDetectionResult nodeResult) {
+    private void continueCreateUIComponentsAfterNodeSetup(
+            NodeDetectionResult nodeResult,
+            String htmlContent
+    ) {
         ClaudeSDKBridge claudeSDKBridge = host.getClaudeSDKBridge();
         JPanel mainPanel = host.getMainPanel();
         JBCefBrowser browser = null;
 
-        // The async detection path shows a loading panel while probing; clear it so
-        // it cannot linger next to the browser component added below (BorderLayout
-        // keeps only CENTER in its map, it does not remove stale children).
+        // The preparation path shows a loading panel; clear it before adding the browser so
+        // stale components cannot remain next to the new CENTER component.
         mainPanel.removeAll();
 
-        // Use the shared resolver from BridgePreloader for consistent state
-        com.github.claudecodegui.bridge.BridgeDirectoryResolver sharedResolver = BridgePreloader.getSharedResolver();
-
-        if (!claudeSDKBridge.checkEnvironment()) {
-            if (sharedResolver.isExtractionInProgress()) {
-                LOG.info("[ClaudeSDKToolWindow] checkEnvironment failed but extraction in progress, showing loading panel...");
-                showLoadingPanel();
-                sharedResolver.getExtractionFuture().thenAcceptAsync(ready -> {
-                    if (ready) {
-                        reinitializeAfterExtraction();
-                    } else {
-                        invokeLaterForToolWindow(this::showErrorPanel);
-                    }
-                });
-                return;
-            }
-
-            if (sharedResolver.isExtractionComplete()) {
-                LOG.info("[ClaudeSDKToolWindow] checkEnvironment failed but extraction just completed, retrying initialization with exponential backoff...");
-                retryCheckEnvironmentWithBackoff(0);
-                showLoadingPanel();
-                return;
-            }
-
-            showErrorPanel();
-            return;
-        }
-
-        // nodeResult is always the resolved verify/detection result here; a failure
-        // result (or null) simply skips the version gate, matching prior behavior.
+        // nodeResult is the result resolved by the background preparation. A failed discovery
+        // result simply skips the version gate, matching the previous fallback behavior.
         if (nodeResult != null && nodeResult.isFound() && nodeResult.getNodeVersion() != null) {
             if (!NodeDetector.isVersionSupported(nodeResult.getNodeVersion())) {
                 showVersionErrorPanel(nodeResult.getNodeVersion());
@@ -394,7 +516,6 @@ public class WebviewInitializer {
             int initialPageGeneration = beginPageLoad(currentBridges, initialPageLoadKind);
             host.activatePageGeneration(initialPageGeneration);
             host.setFrontendReady(false);
-            String htmlContent = loadChatHtmlWithInitialTabState();
 
             // LoadHandler must be registered before loadHTML, otherwise the
             // first frame's onLoadEnd is missed and the JS bridge injection
@@ -577,6 +698,67 @@ public class WebviewInitializer {
                     ? JBCefBrowserFactory.JcefSupportStatus.OUTDATED_JBR
                     : JBCefBrowserFactory.JcefSupportStatus.UNAVAILABLE;
             showJcefNotSupportedPanel(status);
+        }
+    }
+
+    private enum InitializationStatus {
+        READY,
+        INVALID_NODE_PATH,
+        WAIT_FOR_EXTRACTION,
+        RETRY_ENVIRONMENT,
+        ENVIRONMENT_UNAVAILABLE,
+        FAILURE
+    }
+
+    private static final class InitializationResult {
+        private final InitializationStatus status;
+        private final NodeDetectionResult nodeResult;
+        private final String htmlContent;
+        private final String nodePath;
+        private final String errorMessage;
+
+        private InitializationResult(
+                InitializationStatus status,
+                NodeDetectionResult nodeResult,
+                String htmlContent,
+                String nodePath,
+                String errorMessage
+        ) {
+            this.status = status;
+            this.nodeResult = nodeResult;
+            this.htmlContent = htmlContent;
+            this.nodePath = nodePath;
+            this.errorMessage = errorMessage;
+        }
+
+        private static InitializationResult ready(NodeDetectionResult nodeResult, String htmlContent) {
+            return new InitializationResult(
+                    InitializationStatus.READY, nodeResult, htmlContent, null, null);
+        }
+
+        private static InitializationResult invalidNodePath(String nodePath, String errorMessage) {
+            return new InitializationResult(
+                    InitializationStatus.INVALID_NODE_PATH, null, null, nodePath, errorMessage);
+        }
+
+        private static InitializationResult waitForExtraction() {
+            return new InitializationResult(
+                    InitializationStatus.WAIT_FOR_EXTRACTION, null, null, null, null);
+        }
+
+        private static InitializationResult retryEnvironment() {
+            return new InitializationResult(
+                    InitializationStatus.RETRY_ENVIRONMENT, null, null, null, null);
+        }
+
+        private static InitializationResult environmentUnavailable() {
+            return new InitializationResult(
+                    InitializationStatus.ENVIRONMENT_UNAVAILABLE, null, null, null, null);
+        }
+
+        private static InitializationResult failure(String errorMessage) {
+            return new InitializationResult(
+                    InitializationStatus.FAILURE, null, null, null, errorMessage);
         }
     }
 
@@ -957,13 +1139,14 @@ public class WebviewInitializer {
 
     public void showErrorPanel() {
         ClaudeSDKBridge claudeSDKBridge = host.getClaudeSDKBridge();
+        String nodePath = knownNodePath(claudeSDKBridge);
         String message = ClaudeCodeGuiBundle.message(
-            "error.nodeNotFound.message", claudeSDKBridge.getNodeExecutable());
+            "error.nodeNotFound.message", nodePath);
 
         JPanel errorPanel = ErrorPanelBuilder.build(
             ClaudeCodeGuiBundle.message("error.nodeNotFound.title"),
             message,
-            claudeSDKBridge.getNodeExecutable(),
+            nodePath,
             this::handleNodePathSave
         );
         replaceMainContent(errorPanel);
@@ -972,17 +1155,22 @@ public class WebviewInitializer {
     private void showVersionErrorPanel(String currentVersion) {
         ClaudeSDKBridge claudeSDKBridge = host.getClaudeSDKBridge();
         int minVersion = NodeDetector.MIN_NODE_MAJOR_VERSION;
+        String nodePath = knownNodePath(claudeSDKBridge);
         String message = ClaudeCodeGuiBundle.message(
-            "error.nodeVersionTooOld.message",
-            currentVersion, String.valueOf(minVersion), claudeSDKBridge.getNodeExecutable());
+            "error.nodeVersionTooOld.message", currentVersion, String.valueOf(minVersion), nodePath);
 
         JPanel errorPanel = ErrorPanelBuilder.build(
             ClaudeCodeGuiBundle.message("error.nodeVersionTooOld.title"),
             message,
-            claudeSDKBridge.getNodeExecutable(),
+            nodePath,
             this::handleNodePathSave
         );
         replaceMainContent(errorPanel);
+    }
+
+    private static String knownNodePath(ClaudeSDKBridge claudeSDKBridge) {
+        String nodePath = claudeSDKBridge.getCachedNodePath();
+        return nodePath == null || nodePath.trim().isEmpty() ? "node" : nodePath;
     }
 
     private void showInvalidNodePathPanel(String path, String errMsg) {
@@ -1123,49 +1311,68 @@ public class WebviewInitializer {
     /**
      * Reinitialize UI after bridge extraction completes.
      */
-    private void reinitializeAfterExtraction() {
+    private void reinitializeAfterExtraction(int expectedInitializationId) {
         invokeLaterForToolWindow(() -> {
+            if (host.isDisposed() || !isCurrentInitialization(expectedInitializationId)) {
+                releaseInitialization(expectedInitializationId);
+                return;
+            }
+            if (host.getBrowser() != null) {
+                releaseInitialization(expectedInitializationId);
+                return;
+            }
             LOG.info("[ClaudeSDKToolWindow] Bridge extraction complete, reinitializing UI...");
-            JPanel mainPanel = host.getMainPanel();
-            mainPanel.removeAll();
+            releaseInitialization(expectedInitializationId);
             createUIComponents();
-            mainPanel.revalidate();
-            mainPanel.repaint();
         });
     }
 
     /**
-     * Retry environment check with exponential backoff strategy.
+     * Retry the environment check without occupying the EDT while the bridge directory settles.
      */
-    private void retryCheckEnvironmentWithBackoff(int attempt) {
-        final int MAX_RETRIES = 3;
-        final int[] BACKOFF_DELAYS_MS = {100, 200, 400};
+    private void retryCheckEnvironmentWithBackoff(int attempt, int expectedInitializationId) {
+        final int maxRetries = 3;
+        final int[] backoffDelaysMs = {100, 200, 400};
 
-        if (attempt >= MAX_RETRIES) {
-            LOG.warn("[ClaudeSDKToolWindow] All " + MAX_RETRIES + " retry attempts failed after extraction completion");
-            invokeLaterForToolWindow(this::showErrorPanel);
+        if (!isCurrentInitialization(expectedInitializationId) || host.isDisposed()) {
+            return;
+        }
+        if (attempt >= maxRetries) {
+            LOG.warn("[ClaudeSDKToolWindow] All " + maxRetries
+                    + " retry attempts failed after extraction completion");
+            invokeLaterForToolWindow(() -> {
+                if (!isCurrentInitialization(expectedInitializationId) || host.isDisposed()) {
+                    return;
+                }
+                releaseInitialization(expectedInitializationId);
+                showErrorPanel();
+            });
             return;
         }
 
-        int delayMs = BACKOFF_DELAYS_MS[attempt];
-        LOG.info("[ClaudeSDKToolWindow] Retry attempt " + (attempt + 1) + "/" + MAX_RETRIES + ", waiting " + delayMs + "ms...");
-
-        CompletableFuture.runAsync(() -> {
-            try {
-                Thread.sleep(delayMs);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        }).thenRun(() -> {
-            invokeLaterForToolWindow(() -> {
-                if (host.getClaudeSDKBridge().checkEnvironment()) {
-                    LOG.info("[ClaudeSDKToolWindow] Retry attempt " + (attempt + 1) + " succeeded after extraction completion");
-                    reinitializeAfterExtraction();
-                } else {
-                    retryCheckEnvironmentWithBackoff(attempt + 1);
-                }
-            });
-        });
+        int delayMs = backoffDelaysMs[attempt];
+        LOG.info("[ClaudeSDKToolWindow] Retry attempt " + (attempt + 1) + "/" + maxRetries
+                + ", waiting " + delayMs + "ms...");
+        CompletableFuture.delayedExecutor(delayMs, java.util.concurrent.TimeUnit.MILLISECONDS)
+                .execute(() -> {
+                    if (!isCurrentInitialization(expectedInitializationId) || host.isDisposed()) {
+                        return;
+                    }
+                    boolean environmentReady;
+                    try {
+                        environmentReady = host.getClaudeSDKBridge().checkEnvironment();
+                    } catch (Exception e) {
+                        LOG.warn("Environment retry failed: " + e.getMessage(), e);
+                        environmentReady = false;
+                    }
+                    if (environmentReady) {
+                        LOG.info("[ClaudeSDKToolWindow] Retry attempt " + (attempt + 1)
+                                + " succeeded after extraction completion");
+                        reinitializeAfterExtraction(expectedInitializationId);
+                    } else {
+                        retryCheckEnvironmentWithBackoff(attempt + 1, expectedInitializationId);
+                    }
+                });
     }
 
     /**
@@ -1310,11 +1517,11 @@ public class WebviewInitializer {
                 ? host.getHandlerContext().getSession() : null;
         String tabProvider = session != null ? session.getProvider() : null;
         String tabModel = session != null ? session.getModel() : null;
-        String htmlWithTabState = htmlLoader.injectInitialTabState(htmlContent, tabProvider, tabModel);
-        String htmlWithDshPresets = htmlLoader.injectInitialDshPresets(
-                htmlWithTabState,
+        return htmlLoader.injectInitialPageState(
+                htmlContent,
+                tabProvider,
+                tabModel,
                 SessionState.discoverUserDshPresetIds());
-        return htmlLoader.injectPageContextBootstrap(htmlWithDshPresets);
     }
 
     /**
@@ -1323,6 +1530,11 @@ public class WebviewInitializer {
     public void recreateWebview(String reason) {
         runOnEventDispatchThread(() -> {
             if (host.isDisposed()) { return; }
+
+            // Invalidate a preparation worker even when the old browser is already absent.
+            // Otherwise a stale worker can publish its HTML after this recreate request.
+            this.initializationGeneration.incrementAndGet();
+            this.initializationInProgress.set(false);
 
             synchronized (this.bridgeLock) {
                 this.nextBrowserPageLoadKind = recoveryPageLoadKind();
@@ -1383,6 +1595,12 @@ public class WebviewInitializer {
      * callback handles do not outlive the browser.
      */
     public void disposeBridges() {
+        // A preparation worker may still be reading the bundled page when the browser is
+        // replaced or the window is disposed. Invalidate its EDT continuation so it cannot
+        // attach stale HTML to a later browser lifecycle.
+        this.initializationGeneration.incrementAndGet();
+        this.initializationInProgress.set(false);
+
         BrowserBridges currentBridges;
         synchronized (this.bridgeLock) {
             currentBridges = this.bridges;

--- a/src/main/java/com/github/claudecodegui/util/HtmlLoader.java
+++ b/src/main/java/com/github/claudecodegui/util/HtmlLoader.java
@@ -6,6 +6,8 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * HTML loader.
@@ -14,6 +16,8 @@ import java.util.List;
 public class HtmlLoader {
 
     private static final Logger LOG = Logger.getInstance(HtmlLoader.class);
+    private static final Map<String, String> CHAT_HTML_CACHE = new ConcurrentHashMap<>();
+    private static final Object CHAT_HTML_CACHE_LOCK = new Object();
     private final Class<?> resourceClass;
 
     public HtmlLoader(Class<?> resourceClass) {
@@ -25,96 +29,179 @@ public class HtmlLoader {
      * @return the HTML content, or fallback HTML if loading fails
      */
     public String loadChatHtml() {
-        try {
-            InputStream is = resourceClass.getResourceAsStream("/html/claude-chat.html");
-            if (is != null) {
-                String html = new String(is.readAllBytes(), StandardCharsets.UTF_8);
-                is.close();
+        // Read the theme once: theme and background color are both derived from the same
+        // observation, so a mid-read theme switch cannot produce a mixed dark/light injection.
+        boolean isDark = ThemeConfigService.getIdeThemeConfig().get("isDark").getAsBoolean();
+        String theme = isDark ? "dark" : "light";
+        String bgColor = isDark ? ThemeConfigService.DARK_BG_HEX : ThemeConfigService.LIGHT_BG_HEX;
+        String cacheKey = resourceClass.getName() + "\n" + theme;
+        String cachedHtml = CHAT_HTML_CACHE.get(cacheKey);
+        if (cachedHtml != null) {
+            return cachedHtml;
+        }
 
-                if (html.contains("<!-- LOCAL_LIBRARY_INJECTION_POINT -->")) {
-                    html = injectLocalLibraries(html);
-                } else {
-                    LOG.info("Detected bundled modern frontend assets; no additional library injection needed");
-                }
-
-                // Inject the IDE theme into the HTML to prevent flash of unstyled content on initial load
-                html = injectIdeTheme(html);
-
-                return html;
+        // Several tabs can initialize concurrently. Serialize the one-time 10 MB resource
+        // transformation so a burst of tabs does not duplicate the same allocation and I/O.
+        synchronized (CHAT_HTML_CACHE_LOCK) {
+            cachedHtml = CHAT_HTML_CACHE.get(cacheKey);
+            if (cachedHtml != null) {
+                return cachedHtml;
             }
-        } catch (Exception e) {
-            LOG.error("Failed to load claude-chat.html: " + e.getMessage());
+
+            try (InputStream is = resourceClass.getResourceAsStream("/html/claude-chat.html")) {
+                if (is != null) {
+                    String html = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+
+                    if (html.contains("<!-- LOCAL_LIBRARY_INJECTION_POINT -->")) {
+                        html = injectLocalLibraries(html);
+                    } else {
+                        LOG.info("Detected bundled modern frontend assets; no additional library injection needed");
+                    }
+
+                    // Prepare the complete static page once per theme. Per-tab state is added
+                    // later, after this shared result is returned.
+                    html = injectIdeTheme(html, theme, bgColor);
+                    CHAT_HTML_CACHE.put(cacheKey, html);
+                    return html;
+                }
+            } catch (Exception e) {
+                LOG.error("Failed to load claude-chat.html: " + e.getMessage(), e);
+            }
         }
 
         return generateFallbackHtml();
     }
 
     /**
-     * Inject the IDE theme into the HTML.
+     * Injects theme bootstrap data with one linear pass over the static document.
      *
-     * Strategy: add inline style attributes directly on HTML tags to ensure the background
-     * color is applied on the very first render frame.
-     * 1. Modify the &lt;html&gt; tag to add style="background-color:..."
-     * 2. Modify the &lt;body&gt; tag to add style="background-color:..."
-     * 3. Inject a theme variable script into &lt;head&gt;
+     * The bundled JavaScript contains HTML examples, so the body lookup uses the last body
+     * before the document's closing tag and cannot accidentally modify an embedded string.
      *
-     * Inline styles are parsed faster than CSS rules, ensuring the correct color appears
-     * on the first CEF render frame.
+     * @param html the static HTML document.
+     * @param theme the IDE theme name.
+     * @param bgColor the background color to apply.
+     * @return the HTML with the initial theme bootstrap.
      */
-    private String injectIdeTheme(String html) {
-        try {
-            boolean isDark = ThemeConfigService.getIdeThemeConfig().get("isDark").getAsBoolean();
-            String theme = isDark ? "dark" : "light";
-            // Use the unified color values to ensure consistency with Swing component backgrounds
-            String bgColor = ThemeConfigService.getBackgroundColorHex();
+    static String injectIdeTheme(String html, String theme, String bgColor) {
+        int htmlTagEnd = findOpeningTagEnd(html, "<html", 0);
+        int headTagEnd = findOpeningTagEnd(html, "<head", htmlTagEnd + 1);
+        int htmlClosingTagStart = html.lastIndexOf("</html>");
+        int bodyTagEnd = findLastOpeningTagEnd(
+                html, "<body", htmlClosingTagStart >= 0 ? htmlClosingTagStart : html.length());
 
-            // 1. Modify the <html> tag to add inline styles
-            html = html.replaceFirst(
-                "<html([^>]*)>",
-                "<html$1 style=\"background-color:" + bgColor + ";\">"
-            );
+        String styleAttribute = " style=\"background-color:" + bgColor + ";\"";
+        String scriptInjection = "\n    <script>window.__INITIAL_IDE_THEME__ = '"
+                + theme + "';</script>";
+        StringBuilder result = new StringBuilder(html.length() + styleAttribute.length() * 2
+                + scriptInjection.length());
+        int cursor = 0;
 
-            // 2. Modify the <body> tag to add inline styles
-            html = html.replaceFirst(
-                "<body([^>]*)>",
-                "<body$1 style=\"background-color:" + bgColor + ";\">"
-            );
-
-            // 3. Inject a theme variable script after the <head> tag
-            String scriptInjection = "\n    <script>window.__INITIAL_IDE_THEME__ = '" + theme + "';</script>";
-            int headIndex = html.indexOf("<head>");
-            if (headIndex != -1) {
-                int insertPos = headIndex + "<head>".length();
-                html = html.substring(0, insertPos) + scriptInjection + html.substring(insertPos);
-            }
-
-            LOG.info("Successfully injected IDE theme (inline styles): " + theme + ", background: " + bgColor);
-        } catch (Exception e) {
-            LOG.error("Failed to inject IDE theme: " + e.getMessage(), e);
+        if (htmlTagEnd >= cursor) {
+            result.append(html, cursor, htmlTagEnd);
+            result.append(styleAttribute);
+            cursor = htmlTagEnd;
         }
+        if (headTagEnd >= cursor) {
+            result.append(html, cursor, headTagEnd + 1);
+            result.append(scriptInjection);
+            cursor = headTagEnd + 1;
+        }
+        if (bodyTagEnd >= cursor) {
+            result.append(html, cursor, bodyTagEnd);
+            result.append(styleAttribute);
+            cursor = bodyTagEnd;
+        }
+        result.append(html, cursor, html.length());
 
-        return html;
+        LOG.info("Successfully injected IDE theme (inline styles): " + theme + ", background: " + bgColor);
+        return result.toString();
+    }
+
+    private static int findOpeningTagEnd(String html, String tagPrefix, int fromIndex) {
+        int tagStart = html.indexOf(tagPrefix, Math.max(0, fromIndex));
+        while (tagStart >= 0) {
+            int nameEnd = tagStart + tagPrefix.length();
+            if (nameEnd >= html.length()
+                    || Character.isWhitespace(html.charAt(nameEnd))
+                    || html.charAt(nameEnd) == '>') {
+                return html.indexOf('>', nameEnd);
+            }
+            tagStart = html.indexOf(tagPrefix, nameEnd);
+        }
+        return -1;
+    }
+
+    private static int findLastOpeningTagEnd(String html, String tagPrefix, int beforeIndex) {
+        int tagStart = html.lastIndexOf(tagPrefix, Math.max(0, beforeIndex - 1));
+        while (tagStart >= 0) {
+            int nameEnd = tagStart + tagPrefix.length();
+            if (nameEnd >= html.length()
+                    || Character.isWhitespace(html.charAt(nameEnd))
+                    || html.charAt(nameEnd) == '>') {
+                return html.indexOf('>', nameEnd);
+            }
+            tagStart = html.lastIndexOf(tagPrefix, tagStart - 1);
+        }
+        return -1;
     }
 
     /**
-     * Inject per-tab provider/model into the HTML so the WebView can prefer
-     * the backend-restored values over the global localStorage snapshot.
+     * Injects all page-start state in one rewrite of the large HTML document.
      *
-     * Without this, every tab in a multi-tab setup hydrates from the same
-     * localStorage key ("model-selection-state") and clobbers the per-tab
-     * provider that ClaudeChatWindow.restorePersistedTabSessionState already
-     * applied to the session — see issue #1353.
+     * Combining the snippets avoids creating three additional full-size strings when a tab
+     * starts or a watchdog recreates the browser.
      *
-     * Both arguments may be null/empty. Null/empty values are injected as
-     * empty strings; the frontend treats an empty string as "no backend
-     * preference" and falls back to localStorage. Only non-empty values
-     * override the global localStorage snapshot.
+     * The provider/model pair is injected so each tab can prefer the backend-restored values
+     * over the shared localStorage snapshot ("model-selection-state") — without it, every tab
+     * in a multi-tab setup hydrates from the same key and clobbers the per-tab provider that
+     * ClaudeChatWindow.restorePersistedTabSessionState already applied to the session
+     * (issue #1353). Null/empty values are injected as empty strings; the frontend treats an
+     * empty string as "no backend preference" and falls back to localStorage.
+     *
+     * @param html the static HTML document.
+     * @param provider the restored provider, or {@code null}.
+     * @param model the restored model, or {@code null}.
+     * @param presetIds locally available DSH preset IDs.
+     * @return the HTML with all page-start state injected.
      */
-    public String injectInitialTabState(String html, String provider, String model) {
+    public String injectInitialPageState(
+            String html,
+            String provider,
+            String model,
+            List<String> presetIds
+    ) {
         try {
             String safeProvider = escapeForSingleQuotedJs(provider == null ? "" : provider);
             String safeModel = escapeForSingleQuotedJs(model == null ? "" : model);
+            StringBuilder presetValues = new StringBuilder("[");
+            if (presetIds != null) {
+                boolean first = true;
+                for (String presetId : presetIds) {
+                    if (presetId == null || presetId.isBlank()) {
+                        continue;
+                    }
+                    if (!first) {
+                        presetValues.append(',');
+                    }
+                    presetValues.append('\'')
+                            .append(escapeForSingleQuotedJs(presetId.trim()))
+                            .append('\'');
+                    first = false;
+                }
+            }
+            presetValues.append(']');
+
             String scriptInjection = "\n    <script>"
+                    + "window.__CCG_PAGE_GENERATION__ = undefined;"
+                    + "window.__CCGUI_PAGE_CONTEXT_READY__ = false;"
+                    + "window.__CCGUI_PAGE_LOAD_KIND__ = undefined;"
+                    + "window.__CCGUI_RECOVERY_RELOAD__ = undefined;"
+                    + "window.__CCGUI_RECOVERY_STATE_APPLIED__ = false;"
+                    + "</script>"
+                    + "\n    <script>window.__INITIAL_DSH_PRESETS__ = "
+                    + presetValues + ";</script>"
+                    + "\n    <script>"
                     + "window.__INITIAL_TAB_PROVIDER__ = '" + safeProvider + "';"
                     + "window.__INITIAL_TAB_MODEL__ = '" + safeModel + "';"
                     + "</script>";
@@ -124,65 +211,9 @@ public class HtmlLoader {
                 return html.substring(0, insertPos) + scriptInjection + html.substring(insertPos);
             }
         } catch (Exception e) {
-            LOG.error("Failed to inject initial tab state: " + e.getMessage(), e);
+            LOG.error("Failed to inject initial page state: " + e.getMessage(), e);
         }
         return html;
-    }
-
-    /**
-     * Inject locally installed DSH preset ids before the frontend bundle starts.
-     */
-    public String injectInitialDshPresets(String html, List<String> presetIds) {
-        try {
-            StringBuilder values = new StringBuilder("[");
-            if (presetIds != null) {
-                boolean first = true;
-                for (String presetId : presetIds) {
-                    if (presetId == null || presetId.isBlank()) {
-                        continue;
-                    }
-                    if (!first) {
-                        values.append(',');
-                    }
-                    values.append('\'')
-                            .append(escapeForSingleQuotedJs(presetId.trim()))
-                            .append('\'');
-                    first = false;
-                }
-            }
-            values.append(']');
-            String scriptInjection = "\n    <script>window.__INITIAL_DSH_PRESETS__ = "
-                    + values + ";</script>";
-            int headIndex = html.indexOf("<head>");
-            if (headIndex != -1) {
-                int insertPos = headIndex + "<head>".length();
-                return html.substring(0, insertPos) + scriptInjection + html.substring(insertPos);
-            }
-        } catch (Exception e) {
-            LOG.error("Failed to inject initial DSH presets: " + e.getMessage(), e);
-        }
-        return html;
-    }
-
-    /**
-     * Marks the Java-owned page context as unavailable before the frontend bundle executes.
-     * The active runtime generation is injected later by {@code WebviewInitializer}, immediately
-     * before the page-specific bridge becomes visible.
-     */
-    public String injectPageContextBootstrap(String html) {
-        String scriptInjection = "\n    <script>"
-                + "window.__CCG_PAGE_GENERATION__ = undefined;"
-                + "window.__CCGUI_PAGE_CONTEXT_READY__ = false;"
-                + "window.__CCGUI_PAGE_LOAD_KIND__ = undefined;"
-                + "window.__CCGUI_RECOVERY_RELOAD__ = undefined;"
-                + "window.__CCGUI_RECOVERY_STATE_APPLIED__ = false;"
-                + "</script>";
-        int headIndex = html.indexOf("<head>");
-        if (headIndex == -1) {
-            return html;
-        }
-        int insertPos = headIndex + "<head>".length();
-        return html.substring(0, insertPos) + scriptInjection + html.substring(insertPos);
     }
 
     private static String escapeForSingleQuotedJs(String value) {
@@ -266,25 +297,23 @@ public class HtmlLoader {
      * Load a resource file as a string.
      */
     private String loadResourceAsString(String resourcePath) throws Exception {
-        InputStream is = resourceClass.getResourceAsStream(resourcePath);
-        if (is == null) {
-            throw new Exception("Resource not found: " + resourcePath);
+        try (InputStream is = resourceClass.getResourceAsStream(resourcePath)) {
+            if (is == null) {
+                throw new Exception("Resource not found: " + resourcePath);
+            }
+            return new String(is.readAllBytes(), StandardCharsets.UTF_8);
         }
-        String content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
-        is.close();
-        return content;
     }
 
     /**
      * Load a resource file as a Base64-encoded string.
      */
     private String loadResourceAsBase64(String resourcePath) throws Exception {
-        InputStream is = resourceClass.getResourceAsStream(resourcePath);
-        if (is == null) {
-            throw new Exception("Resource not found: " + resourcePath);
+        try (InputStream is = resourceClass.getResourceAsStream(resourcePath)) {
+            if (is == null) {
+                throw new Exception("Resource not found: " + resourcePath);
+            }
+            return Base64.getEncoder().encodeToString(is.readAllBytes());
         }
-        byte[] bytes = is.readAllBytes();
-        is.close();
-        return Base64.getEncoder().encodeToString(bytes);
     }
 }

--- a/src/test/java/com/github/claudecodegui/util/HtmlLoaderTest.java
+++ b/src/test/java/com/github/claudecodegui/util/HtmlLoaderTest.java
@@ -1,7 +1,11 @@
 package com.github.claudecodegui.util;
 
+import org.junit.Assume;
 import org.junit.Test;
 
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -9,18 +13,61 @@ import static org.junit.Assert.assertTrue;
  */
 public class HtmlLoaderTest {
 
-    /** Verifies that runtime page state starts unavailable and does not embed a generation. */
+    /** Verifies that theme injection ignores HTML examples embedded in the JavaScript bundle. */
     @Test
-    public void injectsPendingPageContextBeforeFrontendBundle() {
+    public void injectsThemeIntoDocumentRootTags() {
+        String html = "<!doctype html><html lang=\"zh-CN\"><head>"
+                + "<script>const sample = '<body class=\\\"embedded\\\">';</script>"
+                + "</head><body></body></html>";
+
+        String injected = HtmlLoader.injectIdeTheme(html, "dark", "#1e1e1e");
+
+        assertTrue(injected.contains("<html lang=\"zh-CN\" style=\"background-color:#1e1e1e;\">"));
+        assertTrue(injected.contains("<body style=\"background-color:#1e1e1e;\"></body>"));
+        assertTrue(injected.contains("const sample = '<body class=\\\"embedded\\\">'"));
+        assertTrue(injected.contains("window.__INITIAL_IDE_THEME__ = 'dark'"));
+    }
+
+    /** Verifies that all page-start variables are added with one ordered head injection. */
+    @Test
+    public void injectsInitialPageStateBeforeFrontendBundle() {
         HtmlLoader loader = new HtmlLoader(HtmlLoaderTest.class);
         String html = "<html><head><script src=\"main.js\"></script></head><body></body></html>";
 
-        String injected = loader.injectPageContextBootstrap(html);
+        String injected = loader.injectInitialPageState(
+                html, "codex", "gpt-5.6-sol", List.of("custom"));
 
-        int generationIndex = injected.indexOf("window.__CCG_PAGE_GENERATION__ = undefined");
+        int contextIndex = injected.indexOf("window.__CCG_PAGE_GENERATION__ = undefined");
+        int presetsIndex = injected.indexOf("window.__INITIAL_DSH_PRESETS__ = ['custom']");
+        int providerIndex = injected.indexOf("window.__INITIAL_TAB_PROVIDER__ = 'codex'");
         int bundleIndex = injected.indexOf("main.js");
-        assertTrue(generationIndex > 0);
-        assertTrue(generationIndex < bundleIndex);
+        assertTrue(contextIndex > 0);
+        assertTrue(contextIndex < presetsIndex);
+        assertTrue(presetsIndex < providerIndex);
+        assertTrue(providerIndex < bundleIndex);
         assertTrue(injected.contains("window.__CCGUI_PAGE_CONTEXT_READY__ = false"));
+        assertFalse(injected.contains("\\n    <script>"));
+    }
+
+    /** Verifies that the bundled single-file page receives styles on its real document roots. */
+    @Test
+    public void loadsBundledHtmlWithRootThemeInjection() {
+        String html = new HtmlLoader(HtmlLoaderTest.class).loadChatHtml();
+        // claude-chat.html is a build artifact (gitignored) and absent until the webview is
+        // built; loadChatHtml silently falls back to a minimal error page in that case.
+        Assume.assumeTrue("bundled webview page has not been built in this workspace",
+                html.contains("<div id=\"app\">"));
+
+        int documentEnd = html.lastIndexOf("</html>");
+        int htmlStart = html.indexOf("<html");
+        int bodyStart = html.lastIndexOf("<body", documentEnd);
+        int bodyEnd = html.indexOf('>', bodyStart);
+
+        assertTrue(htmlStart >= 0);
+        assertTrue(html.substring(htmlStart, html.indexOf('>', htmlStart))
+                .contains("style=\"background-color:"));
+        assertTrue(bodyStart >= 0);
+        assertTrue(bodyEnd > bodyStart);
+        assertTrue(html.substring(bodyStart, bodyEnd).contains("style=\"background-color:"));
     }
 }

--- a/webview/index.html
+++ b/webview/index.html
@@ -10,7 +10,7 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data: https://cc-gui-font.local; connect-src 'self'; frame-src 'none';" />
     <title>Claude Chat Webview</title>
     <!-- Set theme data-theme attribute immediately before React loads -->
-    <!-- Note: Background color is injected as inline style on the HTML tag by Java; only data-theme needs to be set here -->
+    <!-- Note: Java injects the initial background color on the root HTML and body tags; only data-theme needs to be set here -->
     <script>
       (function() {
         try {


### PR DESCRIPTION
## Problem

IDEA reported **"Freeze in EDT for 17 seconds"** with the following stack, both on first tool window open and on every `WebviewWatchdog` recreation:

```
java.util.regex.Matcher.replaceFirst
java.lang.String.replaceFirst
HtmlLoader.injectIdeTheme
HtmlLoader.loadChatHtml
WebviewInitializer.createUIComponents
```

A second freeze trace showed the same path also running `ProcessBuilder.start` / `NodeDetector.verifyNodePath` / `Inflater.inflate` on the EDT: Node.js detection, environment checks, the ~10 MB single-file HTML read/decompression, and regex-based theme replacement all executed on the event dispatch thread.

## Root causes

1. `createUIComponents` ran Node.js path verification, auto-detection, `checkEnvironment` (subprocess), DSH preset directory scan, and the full HTML load + theme injection on the EDT.
2. `String.replaceFirst` over the ~10 MB bundle — O(document) regex scan per call, called twice per initialization.
3. `ChatWindowDelegate` and `WebviewInitializer` each launched their own Node.js detection, spawning duplicate shell probes that competed for the shared `NodeDetector` cache.
4. `checkEnvironment` waited on the probe process indefinitely — a hung `node` wedged initialization forever.

## Changes

- **`WebviewInitializer`**: Node.js verification/auto-detection, environment check, DSH preset discovery, and HTML preparation now run on a pooled thread. Only JCEF browser creation, JS bridge registration, `loadHTML`, and Swing mounting remain on the EDT. Preparation results are guarded by an initialization generation so a disposed/recreated webview ignores stale background HTML; error panels read the cached node path instead of re-triggering a synchronous probe.
- **`HtmlLoader`**: theme injection is now a single linear pass over the document's real root tags (no regex), and it locates the true `<body>` so `<body>` strings embedded in the JS bundle can no longer be modified by mistake. The themed static HTML is cached per theme (double-checked, shared across concurrently initializing tabs), and the per-tab provider/model, DSH preset, and page-context injections are merged into one rewrite of the document.
- **`BaseSDKBridge.checkEnvironment`**: the `node --version` probe is bounded by a 5s timeout and the process is force-killed on timeout/interrupt.
- **`ChatWindowDelegate`**: the duplicate Node.js detection is removed; the webview preparation worker owns the single probe.

## Verification

- `./gradlew checkstyleMain` — pass
- `HtmlLoaderTest` / `WebviewInitializerTest` / `ChatWindowDelegateTest` — pass (new regression tests cover root-tag theme injection, embedded-string immunity, injection ordering on the real bundled page, and graceful skip when the webview build artifact is absent)